### PR TITLE
Suppressing warnings

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParseException.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParseException.java
@@ -26,6 +26,7 @@ package org.broadinstitute.hellbender.cmdline;
 import org.broadinstitute.hellbender.exceptions.ReviewedHellbenderException;
 
 public class CommandLineParseException extends ReviewedHellbenderException {
+    private static final long serialVersionUID = 0L;
     public CommandLineParseException(final String s) {
         super(s);
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -465,6 +465,7 @@ public class CommandLineParser {
 
     }
 
+    @SuppressWarnings("unchecked")
     private boolean parsePositionalArgument(final String stringValue) {
         if (positionalArguments == null) {
             messageStream.println("ERROR: Invalid argument '" + stringValue + "'.");
@@ -497,6 +498,7 @@ public class CommandLineParser {
         return parseOption(key, stringValue, optionsFile, false);
     }
 
+    @SuppressWarnings("unchecked")
     private boolean parseOption(String key, final String stringValue, final boolean optionsFile,
                                 boolean precedenceSet) {
         key = key.toUpperCase();
@@ -942,6 +944,7 @@ public class CommandLineParser {
         }
     }
 
+    @SuppressWarnings({"unchecked","rawtypes"})
     private Object constructFromString(final Class clazz, final String s) {
         try {
             if (clazz.isEnum()) {

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParserDefinitionException.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParserDefinitionException.java
@@ -26,6 +26,7 @@ package org.broadinstitute.hellbender.cmdline;
 import org.broadinstitute.hellbender.exceptions.ReviewedHellbenderException;
 
 public class CommandLineParserDefinitionException extends ReviewedHellbenderException {
+    private static final long serialVersionUID = 0L;
     public CommandLineParserDefinitionException(final String s) {
         super(s);
     }

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/HellbenderException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/HellbenderException.java
@@ -32,6 +32,8 @@ package org.broadinstitute.hellbender.exceptions;
  * This exception allows us to filter out exceptions that come from us.
  */
 public class HellbenderException extends RuntimeException {
+    private static final long serialVersionUID = 0L;
+
     public HellbenderException(String msg) {
         super(msg);
     }

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/ReviewedHellbenderException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/ReviewedHellbenderException.java
@@ -31,6 +31,8 @@ package org.broadinstitute.hellbender.exceptions;
  * is now just a catch all for lazy users.
  */
 public class ReviewedHellbenderException extends HellbenderException {
+    private static final long serialVersionUID = 0L;
+
     public ReviewedHellbenderException(String msg) {
         super(msg);
     }


### PR DESCRIPTION
I suppressed the warnings we were getting.   If we can't fix them lets at least not see them.
It seemed like it was ok to suppress the serialization warnings rather than provide a UUID, since java will fill one in for us.  We can add a hash value instead if that's better.
