### PR TITLE
Updating build.gradle so that it outputs failed test results on travis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,7 @@ test {
     // enable TestNG support (default is JUnit)
     useTestNG()
 
-    // show standard out and standard error of the test JVM(s) on the console
-    testLogging.showStandardStreams = true
+
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"
@@ -90,19 +89,34 @@ test {
     if (CI == "true") {
         int count = 0
         // listen to events in the test execution lifecycle
+        testLogging {
+            events "skipped", "failed"
+            exceptionFormat = "full"
+        }
+
         beforeTest { descriptor ->
-            logger.lifecycle(Integer.toString(count++))
+            count++
+            if( count % 10000 == 0) {
+                logger.lifecycle("Finished "+ Integer.toString(count++) + " tests")
+            }
         }
     } else {
+        // show standard out and standard error of the test JVM(s) on the console
+        testLogging.showStandardStreams = true
+
         beforeTest { descriptor ->
             logger.lifecycle("Running Test: " + descriptor)
         }
+
+        // listen to standard out and standard error of the test JVM(s)
+        onOutput { descriptor, event ->
+            logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message )
+        }
     }
 
-    // listen to standard out and standard error of the test JVM(s)
-    onOutput { descriptor, event ->
-        logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message )
-    }
+
+
+
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
@akiezun This should fix it so that it prints the stacktraces of the failing tests on travis in a readable way.
