### PR TITLE
Port most existing hellbender tools to ReadWalker interface

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -112,7 +112,8 @@ public class Main {
      * Override this if you want to include different java packages to search for classes that extend CommandLineProgram. *
      */
     public static void main(final String[] args) {
-        new Main().instanceMain(args, getPackageList(), COMMAND_LINE_NAME);
+        Object result = new Main().instanceMain(args, getPackageList(), COMMAND_LINE_NAME);
+        System.out.println("Tool returned:\n" + result);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -29,17 +29,19 @@ public abstract class GATKTool extends CommandLineProgram {
 
     /**
      * Operations performed immediately after traversal. Should be overridden by tool authors who
-     * need to close local resources, etc., after traversal.
+     * need to close local resources, etc., after traversal. Also allows tools to return a value
+     * representing the traversal result, which is printed by the engine.
      *
-     * Default implementation does nothing.
+     * Default implementation does nothing and returns null.
+     *
+     * @return Object representing the traversal result, or null if a tool does not return a value
      */
-    public void onTraversalDone() {}
+    public Object onTraversalDone() { return null; }
 
     @Override
     protected Object doWork() {
         onTraversalStart();
         traverse();
-        onTraversalDone();
-        return 0;
+        return onTraversalDone();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.engine;
 
+import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.cmdline.Option;
 import org.broadinstitute.hellbender.cmdline.StandardOptionDefinitions;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
@@ -40,6 +42,26 @@ public abstract class ReadWalker extends GATKTool {
         // Need to delay initialization of members until after the argument-parsing system has injected argument values
         reads = new ReadsDataSource(READS_FILES);
         reference = REFERENCE_FILE != null ? new ReferenceDataSource(REFERENCE_FILE) : null;
+    }
+
+    /**
+     * Returns the SAM header for this reads traversal. Will be a merged header if there are multiple inputs for
+     * the reads. If there is only a single input, returns its header directly.
+     *
+     * @return SAM header for this reads traversal
+     */
+    public SAMFileHeader getHeaderForReads() {
+        return reads.getHeader();
+    }
+
+    /**
+     * Returns the sequence dictionary for the reference, if a reference is present. If there is no
+     * reference, returns null.
+     *
+     * @return sequence dictionary for the reference, or null if there is no reference
+     */
+    public SAMSequenceDictionary getReferenceDictionary() {
+        return reference != null ? reference.getSequenceDictionary() : null;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -1,46 +1,27 @@
 package org.broadinstitute.hellbender.tools;
 
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOUtil;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
-import org.broadinstitute.hellbender.cmdline.Option;
-import org.broadinstitute.hellbender.cmdline.StandardOptionDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
-
-import java.io.File;
+import org.broadinstitute.hellbender.engine.ReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
 
 @CommandLineProgramProperties(
 	usage = "Walks over the input data set, calculating the number of bases seen for diagnostic purposes.",
 	usageShort = "Count bases",
-        programGroup = ReadProgramGroup.class
+    programGroup = ReadProgramGroup.class
 )
-public class CountBases extends CommandLineProgram {
+public class CountBases extends ReadWalker {
 
-    @Option(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="The SAM or BAM file to count bases.")
-    public File INPUT;
+    private long count = 0;
 
     @Override
-    protected Long doWork() {
-        final long count = countBases();
-        System.out.println(count + " bases");
-        return count;
+    public void apply( SAMRecord read, ReferenceContext referenceContext ) {
+        count += read.getReadLength();
     }
 
-    /**
-     * This is factored out of doWork only for unit testing.
-     */
-    long countBases() {
-        long count=0;
-        IOUtil.assertFileIsReadable(INPUT);
-        final SamReader in = SamReaderFactory.makeDefault().open(INPUT);
-        for (final SAMRecord rec : in) {
-            count += rec.getReadLength();
-        }
-        CloserUtil.close(in);
+    @Override
+    public Object onTraversalDone() {
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -1,46 +1,27 @@
 package org.broadinstitute.hellbender.tools;
 
-import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOUtil;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
-import org.broadinstitute.hellbender.cmdline.Option;
-import org.broadinstitute.hellbender.cmdline.StandardOptionDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
-
-import java.io.File;
+import org.broadinstitute.hellbender.engine.ReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
 
 @CommandLineProgramProperties(
 	usage = "Count reads.",
 	usageShort = "Count reads",
-        programGroup = ReadProgramGroup.class
+    programGroup = ReadProgramGroup.class
 )
-public class CountReads extends CommandLineProgram {
+public class CountReads extends ReadWalker {
 
-    @Option(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="The SAM or BAM file to count reads.")
-    public File INPUT;
+    private long count = 0;
 
     @Override
-    protected Long doWork() {
-        final long count = countReads();
-        System.out.println(count + " reads");
-        return count;
+    public void apply( SAMRecord read, ReferenceContext referenceContext ) {
+        ++count;
     }
 
-    /**
-     * This is factored out of doWork only for unit testing.
-     */
-    long countReads() {
-        long count=0;
-        IOUtil.assertFileIsReadable(INPUT);
-        final SamReader in = SamReaderFactory.makeDefault().open(INPUT);
-        for (final SAMRecord rec : in) {
-            count++;
-        }
-        CloserUtil.close(in);
+    @Override
+    public Object onTraversalDone() {
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -2,41 +2,39 @@ package org.broadinstitute.hellbender.tools;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.engine.ReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
 
 import java.io.File;
 
 @CommandLineProgramProperties(
 	usage = "Prints reads from the input to the output.",
-        usageShort = "Print reads",
-        programGroup = ReadProgramGroup.class
+    usageShort = "Print reads",
+    programGroup = ReadProgramGroup.class
 )
-public class PrintReads extends CommandLineProgram {
-
-    @Option(fullName = "input", shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="The file to print reads from.")
-    public File INPUT;
+public class PrintReads extends ReadWalker {
 
     @Option(fullName = "output", shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
     public File OUTPUT;
 
-    /**
-     * Does the work of the tool, ie prints the reads from the inout to the output.
-     * Returns null.
-     */
-    @Override
-    public Object doWork() {
-        IOUtil.assertFileIsReadable(INPUT);
-        final SamReader in = SamReaderFactory.makeDefault().open(INPUT);
-        final SAMFileHeader outputHeader = in.getFileHeader().clone();
-        System.out.print(outputHeader);
+    private SAMFileWriter outputWriter;
 
-        final SAMFileWriter outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, REFERENCE_SEQUENCE);
-        in.forEach(outputWriter::addAlignment);
-        CloserUtil.close(in);
+    @Override
+    public void onTraversalStart() {
+        final SAMFileHeader outputHeader = getHeaderForReads().clone();
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, REFERENCE_FILE);
+    }
+
+    @Override
+    public void apply( SAMRecord read, ReferenceContext referenceContext ) {
+        outputWriter.addAlignment(read);
+    }
+
+    @Override
+    public Object onTraversalDone() {
         CloserUtil.close(outputWriter);
         return null;
     }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
@@ -48,8 +48,10 @@ public class PrintReadsWithReference extends ReadWalker {
     }
 
     @Override
-    public void onTraversalDone() {
+    public Object onTraversalDone() {
         if ( outputStream != null )
             outputStream.close();
+
+        return null;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
@@ -45,8 +45,25 @@ public class ReadsDataSourceUnitTest extends BaseTest {
     }
 
     @Test(expectedExceptions = UserException.class)
-    public void testHandleUnindexedFile() {
+    public void testHandleUnindexedFileWithIntervals() {
+        ReferenceDataSource refDataSource = new ReferenceDataSource(TEST_REFERENCE);
+        GenomeLocParser parser = new GenomeLocParser(refDataSource.getSequenceDictionary());
+        refDataSource.close();
+
+        // Cannot initialize a reads source with intervals unless all files are indexed
+        ReadsDataSource readsSource = new ReadsDataSource(new File(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam"),
+                                                          Arrays.asList(parser.createGenomeLoc("1", 1, 5)));
+    }
+
+    @Test(expectedExceptions = UserException.class)
+    public void testHandleUnindexedFileQuery() {
+        ReferenceDataSource refDataSource = new ReferenceDataSource(TEST_REFERENCE);
+        GenomeLocParser parser = new GenomeLocParser(refDataSource.getSequenceDictionary());
+        refDataSource.close();
+
+        // Construction should succeed, since we don't pass in any intervals, but the query should throw.
         ReadsDataSource readsSource = new ReadsDataSource(new File(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam"));
+        readsSource.query(parser.createGenomeLoc("1", 1, 5));
     }
 
     @DataProvider(name = "SingleFileCompleteTraversalData")

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountBasesTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountBasesTest.java
@@ -36,7 +36,7 @@ public class CountBasesTest extends CommandLineProgramTest {
     public void testCountBases(String fileIn) throws Exception {
         final File ORIG_BAM = new File(getTestDataDir(), fileIn);
         final String[] args = new String[]{
-                "INPUT=" + ORIG_BAM.getAbsolutePath(),
+                "I=" + ORIG_BAM.getAbsolutePath(),
         };
         final Object res = this.runCommandLine(args);
         Assert.assertEquals(res, 808l);

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountReadsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountReadsTest.java
@@ -35,7 +35,7 @@ public class CountReadsTest extends CommandLineProgramTest {
     public void testCountBases(String fileIn) throws Exception {
         final File ORIG_BAM = new File(getTestDataDir(), fileIn);
         final String[] args = new String[]{
-                "INPUT=" + ORIG_BAM.getAbsolutePath(),
+                "I=" + ORIG_BAM.getAbsolutePath(),
         };
         final Object res = this.runCommandLine(args);
         Assert.assertEquals(res, 8l);

--- a/src/test/java/org/broadinstitute/hellbender/tools/FlagStatTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/FlagStatTest.java
@@ -36,7 +36,7 @@ public class FlagStatTest extends CommandLineProgramTest{
     public void testSamCount(String fileIn) throws Exception {
         final File ORIG_BAM = new File(getTestDataDir(), fileIn);
         final String[] args = new String[]{
-                "INPUT=" + ORIG_BAM.getAbsolutePath(),
+                "I=" + ORIG_BAM.getAbsolutePath(),
         };
         final Object res = this.runCommandLine(args);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsTest.java
@@ -48,8 +48,8 @@ public class PrintReadsTest extends CommandLineProgramTest{
         outFile.deleteOnExit();
         File ORIG_BAM = new File(TEST_DATA_DIR, samFile);
         final String[] args = new String[]{
-                "INPUT=" + ORIG_BAM.getAbsolutePath(),
-                "OUTPUT=" + outFile.getAbsolutePath()
+                "I=" + ORIG_BAM.getAbsolutePath(),
+                "O=" + outFile.getAbsolutePath()
         };
         Assert.assertEquals(runCommandLine(args), null);
 


### PR DESCRIPTION
-CompareSAMs not ported because ReadWalker traversal is not suited
 for it

-SplitNCigarReads not ported because of the way it uses the reference
 (could be ported to ReadWalker with some refactoring, however)

There were a few engine changes as well to accomodate the new ReadWalker tools:

-Method to allow walkers to access the SAM header from the reads data source

-No longer require an index for BAM/SAM files when no intervals are
 provided and no queries are performed.

-onTraversalDone() now allows tools to return a value, which is printed
 out by the engine

Resolves #113
