### PR TITLE
Allow reference window in ReferenceContext objects to be set dynamically by tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -89,7 +89,9 @@ public abstract class ReadWalker extends GATKTool {
      * TODO: discourage statefulness in walkers, but how this value should be handled is TBD.
      *
      * @param read current read
-     * @param referenceContext reference bases spanning the current read (null if no reference was specified)
+     * @param referenceContext Reference bases spanning the current read (null if no reference was specified).
+     *                         Can request extra bases of context around the current read's interval by invoking
+     *                         {@link ReferenceContext#setWindow} on this object before calling {@link ReferenceContext#getBases}
      */
     public abstract void apply(final SAMRecord read, final ReferenceContext referenceContext);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
@@ -56,8 +56,8 @@ public class ReferenceContextUnitTest extends BaseTest {
         checkReferenceContextBases(refContext, expectedBases);
         Assert.assertEquals(refContext.getInterval(), interval, "Wrong interval in reference context");
         Assert.assertEquals(refContext.getWindow(), interval, "Window in windowless reference context not equal to original interval");
-        Assert.assertEquals(refContext.getLeadingWindowSize(), 0, "Non-zero leading window size in windowless reference context");
-        Assert.assertEquals(refContext.getTrailingWindowSize(), 0, "Non-zero trailing window size in windowless reference context");
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 0, "Non-zero leading window size in windowless reference context");
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 0, "Non-zero trailing window size in windowless reference context");
 
         reference.close();
     }
@@ -70,17 +70,17 @@ public class ReferenceContextUnitTest extends BaseTest {
 
         return new Object[][] {
                 // Window off the start of the contig:
-                { genomeLocParser.createGenomeLoc("1", 1, 3), -5, 5, genomeLocParser.createGenomeLoc("1", 1, 8), "NNNNNNNN" },
+                { genomeLocParser.createGenomeLoc("1", 1, 3), 5, 5, genomeLocParser.createGenomeLoc("1", 1, 8), "NNNNNNNN" },
                 // Window in middle of contig with equal, non-zero start and stop offsets
-                { genomeLocParser.createGenomeLoc("1", 11041, 11045), -5, 5, genomeLocParser.createGenomeLoc("1", 11036, 11050), "CAGGAGCAAAGTCGC" },
+                { genomeLocParser.createGenomeLoc("1", 11041, 11045), 5, 5, genomeLocParser.createGenomeLoc("1", 11036, 11050), "CAGGAGCAAAGTCGC" },
                 // Window in middle of contig with start offset only
-                { genomeLocParser.createGenomeLoc("1", 11210, 11220), -3, 0, genomeLocParser.createGenomeLoc("1", 11207, 11220), "TCACGGTGCTGTGC" },
+                { genomeLocParser.createGenomeLoc("1", 11210, 11220), 3, 0, genomeLocParser.createGenomeLoc("1", 11207, 11220), "TCACGGTGCTGTGC" },
                 // Window in middle of contig with stop offset only
                 { genomeLocParser.createGenomeLoc("2", 9995, 10005), 0, 3, genomeLocParser.createGenomeLoc("2", 9995, 10008), "NNNNNNCGTATCCC" },
                 // Window in middle of contig with unequal, non-zero start and stop offsets
-                { genomeLocParser.createGenomeLoc("2", 10005, 10084), -3, 8, genomeLocParser.createGenomeLoc("2", 10002, 10092), "GTATCCCACACACCACACCCACACACCACACCCACACACACCCACACCCACACCCACACACACCACACCCACACACCACACCCACACCCAC" },
+                { genomeLocParser.createGenomeLoc("2", 10005, 10084), 3, 8, genomeLocParser.createGenomeLoc("2", 10002, 10092), "GTATCCCACACACCACACCCACACACCACACCCACACACACCCACACCCACACCCACACACACCACACCCACACACCACACCCACACCCAC" },
                 // Window off the end of the contig
-                { genomeLocParser.createGenomeLoc("2", 15995, 16000), -2, 5, genomeLocParser.createGenomeLoc("2", 15993, 16000), "TGTGTCAG" }
+                { genomeLocParser.createGenomeLoc("2", 15995, 16000), 2, 5, genomeLocParser.createGenomeLoc("2", 15993, 16000), "TGTGTCAG" }
         };
     }
 
@@ -92,14 +92,53 @@ public class ReferenceContextUnitTest extends BaseTest {
         checkReferenceContextBases(refContext, expectedBases);
         Assert.assertEquals(refContext.getInterval(), interval, "Wrong interval in reference context");
         Assert.assertEquals(refContext.getWindow(), expectedWindow, "Window in windowed reference context not equal to expected window");
-        Assert.assertEquals(refContext.getLeadingWindowSize(), interval.getStart() - expectedWindow.getStart(),
+        Assert.assertEquals(refContext.numWindowLeadingBases(), interval.getStart() - expectedWindow.getStart(),
                             "Leading window size in windowed reference context not equal to expected value");
-        Assert.assertEquals(refContext.getTrailingWindowSize(), 0, expectedWindow.getStop() - interval.getStop(),
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 0, expectedWindow.getStop() - interval.getStop(),
                             "Trailing window size in windowed reference context not equal to expected value");
 
         reference.close();
     }
 
+    @Test
+    public void testDynamicallyChangingWindow() {
+        final ReferenceDataSource reference = new ReferenceDataSource(TEST_REFERENCE);
+        final GenomeLocParser parser = new GenomeLocParser(reference.getSequenceDictionary());
+        final GenomeLoc interval = parser.createGenomeLoc("1", 11210, 11220);
+        final ReferenceContext refContext = new ReferenceContext(reference, interval);
+        final String intervalBases = "CGGTGCTGTGC";
+
+        Assert.assertEquals(interval, refContext.getWindow());
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 0);
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 0);
+        checkReferenceContextBases(refContext, intervalBases);
+
+        refContext.setWindow(5, 5);
+        Assert.assertEquals(refContext.getWindow(), parser.createGenomeLoc(interval.getContig(), interval.getStart() - 5, interval.getStop() + 5));
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 5);
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 5);
+        checkReferenceContextBases(refContext, "GCTCA" + intervalBases + "CAGGG");
+
+        refContext.setWindow(0, 10);
+        Assert.assertEquals(refContext.getWindow(), parser.createGenomeLoc(interval.getContig(), interval.getStart(), interval.getStop() + 10));
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 0);
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 10);
+        checkReferenceContextBases(refContext, intervalBases + "CAGGGCGCCC");
+
+        refContext.setWindow(20, 3);
+        Assert.assertEquals(refContext.getWindow(), parser.createGenomeLoc(interval.getContig(), interval.getStart() - 20, interval.getStop() + 3));
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 20);
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 3);
+        checkReferenceContextBases(refContext, "CTACAGGACCCGCTTGCTCA" + intervalBases + "CAG");
+
+        refContext.setWindow(0, 0);
+        Assert.assertEquals(interval, refContext.getWindow());
+        Assert.assertEquals(refContext.numWindowLeadingBases(), 0);
+        Assert.assertEquals(refContext.numWindowTrailingBases(), 0);
+        checkReferenceContextBases(refContext, intervalBases);
+
+        reference.close();
+    }
 
     private void checkReferenceContextBases( final ReferenceContext refContext, final String expectedBases ) {
         byte[] contextBases = refContext.getBases();
@@ -123,20 +162,29 @@ public class ReferenceContextUnitTest extends BaseTest {
     @DataProvider(name = "InvalidWindowDataProvider")
     public Object[][] getInvalidWindows() {
         return new Object[][] {
-                // window start offset > 0
-                {1, 1},
+                // window start offset < 0
+                {-1, 1},
                 // window stop offset < 0
-                {-1, -1},
-                // window start offset > 0 && window stop offset < 0
-                {1, -1}
+                {1, -1},
+                // window start offset < 0 && window stop offset < 0
+                {-1, -1}
         };
     }
 
     @Test(dataProvider = "InvalidWindowDataProvider", expectedExceptions = GATKException.class)
-    public void testInvalidWindowHandling( final int windowStartOffset, final int windowStopOffset ) {
+    public void testInvalidWindowHandlingAtConstruction( final int windowStartOffset, final int windowStopOffset ) {
         try ( ReferenceDataSource reference = new ReferenceDataSource(TEST_REFERENCE) ) {
             GenomeLoc interval = new GenomeLocParser(reference.getSequenceDictionary()).createGenomeLoc("1", 5, 10);
             ReferenceContext refContext = new ReferenceContext(reference, interval, windowStartOffset, windowStopOffset);
+        }
+    }
+
+    @Test(dataProvider = "InvalidWindowDataProvider", expectedExceptions = GATKException.class)
+    public void testInvalidWindowHandlingPostConstruction( final int windowStartOffset, final int windowStopOffset ) {
+        try ( ReferenceDataSource reference = new ReferenceDataSource(TEST_REFERENCE) ) {
+            GenomeLoc interval = new GenomeLocParser(reference.getSequenceDictionary()).createGenomeLoc("1", 5, 10);
+            ReferenceContext refContext = new ReferenceContext(reference, interval);
+            refContext.setWindow(windowStartOffset, windowStopOffset);
         }
     }
 }


### PR DESCRIPTION
Some tools need to dynamically resize the reference context window based upon other
input. This commit exposes a setWindow() method to allow tools to do this.

-To change the reference context size, tools should invoke setWindow() on the
 ReferenceContext provided by the engine before invoking getBases()/getBasesIterator().

-Hopefully eliminates the need for tools to create their own reference readers

-ReferenceContext still caches previous query results, but cache gets invalidated
 every time the window size changes.

Resolves #131
