### PR TITLE
fixing an issue where flags would consume an adjacent positional argumen...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ dependencies {
     compile 'org.apache.commons:commons-collections4:4.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.reflections:reflections:0.9.9'
-    compile 'net.sf.jopt-simple:jopt-simple:4.8'
+    compile 'net.sf.jopt-simple:jopt-simple:4.9-beta-1'
+
 
     testCompile 'org.testng:testng:6.8.8'
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -24,10 +24,7 @@
 package org.broadinstitute.hellbender.cmdline;
 
 import htsjdk.samtools.util.StringUtil;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
-import joptsimple.OptionSpecBuilder;
+import joptsimple.*;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -220,7 +217,6 @@ public class CommandLineParser {
                     .forEach(argumentDefinition -> printArgumentUsage(stream, argumentDefinition));
     }
 
-
     /**
      * Parse command-line arguments, and store values in callerArguments object passed to ctor.
      *
@@ -234,10 +230,11 @@ public class CommandLineParser {
         this.messageStream = messageStream;
 
         OptionParser parser = new OptionParser();
+
         for (ArgumentDefinition arg : argumentDefinitions){
             OptionSpecBuilder bld = parser.acceptsAll(arg.getNames(), arg.doc);
             if (arg.isFlag()) {
-                bld.withOptionalArg();
+                bld.withOptionalArg().withValuesConvertedBy(new StrictBooleanConverter());
             } else {
                 bld.withRequiredArg();
             }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StrictBooleanConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StrictBooleanConverter.java
@@ -1,0 +1,27 @@
+package org.broadinstitute.hellbender.cmdline;
+
+import joptsimple.ValueConversionException;
+import joptsimple.ValueConverter;
+
+/**
+ * converts values case insensitively matching T, True, F, or False to true or false
+ * throws {@link joptsimple.ValueConversionException} otherwise
+ */
+public class StrictBooleanConverter implements ValueConverter<String> {
+    public String convert( String value ) {
+        if ( value.equalsIgnoreCase("true") || value.equalsIgnoreCase("t")) {
+            return "true";
+        } else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("f")) {
+            return "false";
+        } else {
+            throw new ValueConversionException(value + " does not match one of T|True|F|False");
+        }
+    }
+    public Class<? extends String> valueType() {
+        return String.class;
+    }
+
+    public String valuePattern() {
+        return "[T|True|F|False]";
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -24,8 +24,6 @@
 package org.broadinstitute.hellbender.cmdline;
 
 import htsjdk.samtools.util.CollectionUtil;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -585,6 +583,15 @@ public class CommandLineParserTest {
 
         @PositionalArguments()
         List<Integer> positionals = new ArrayList<>();
+    }
+
+    @Test
+    public void testFlagWithPositionalFollowing(){
+        PrivateArgument o = new PrivateArgument();
+        final CommandLineParser clp = new CommandLineParser(o);
+        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--flag1","1","2" }));
+        Assert.assertTrue(o.booleanFlags.flag1);
+        Assert.assertEquals(o.positionals, Arrays.asList(1,2));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/StrictBooleanConverterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/StrictBooleanConverterTest.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.hellbender.cmdline;
+
+import joptsimple.ValueConversionException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StrictBooleanConverterTest {
+    @Test
+    public void recognizedValues(){
+        StrictBooleanConverter converter = new StrictBooleanConverter();
+        Assert.assertEquals("true", converter.convert("true"));
+        Assert.assertEquals("true", converter.convert("T"));
+        Assert.assertEquals("true",converter.convert("TRUE"));
+        Assert.assertEquals("false",converter.convert("F"));
+        Assert.assertEquals("false", converter.convert("False"));
+    }
+
+    @Test(expectedExceptions = ValueConversionException.class)
+    public void unrecognizedValues(){
+        StrictBooleanConverter converter = new StrictBooleanConverter();
+        converter.convert("unprovable");
+    }
+
+}


### PR DESCRIPTION
Currently command line boolean flags can optionally accept an argument.  This plays poorly with PositionalArguments in the current version of our parser.  

`--flag 1 2` is currently parsed as `(--flag 1) 2` which is then fails
it can be worked around by specifying  `--flag true 1 2`, but this is suboptimal

A solution to this has been introduced in the 4.9 snapshot build of jopt-simple see here https://github.com/pholser/jopt-simple/issues/76.  
