### PR TITLE
several very minor updates to help improve coverage

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationArgumentCollection.java
@@ -342,16 +342,16 @@ public class RecalibrationArgumentCollection implements Cloneable {
         if (intersect.size() == 0) { // In practice this is not possible due to required covariates but...
             diffMessage = String.format("There are no common covariates between '%s' and '%s'"
                             + " recalibrator reports. Covariates in '%s': {%s}. Covariates in '%s': {%s}.", thisRole, otherRole,
-                    thisRole, Utils.join(", ", this.COVARIATES),
-                    otherRole, Utils.join(",", other.COVARIATES));
+                    thisRole, String.join(", ", this.COVARIATES),
+                    otherRole, String.join(",", other.COVARIATES));
         } else if (intersect.size() != beforeNames.size() || intersect.size() != afterNames.size()) {
             beforeNames.removeAll(intersect);
             afterNames.removeAll(intersect);
             diffMessage = String.format("There are differences in the set of covariates requested in the"
                             + " '%s' and '%s' recalibrator reports. "
                             + " Exclusive to '%s': {%s}. Exclusive to '%s': {%s}.", thisRole, otherRole,
-                    thisRole, Utils.join(", ", beforeNames),
-                    otherRole, Utils.join(", ", afterNames));
+                    thisRole, String.join(", ", beforeNames),
+                    otherRole, String.join(", ", afterNames));
         }
         if (diffMessage != null) {
             diffs.put("covariate",diffMessage);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
@@ -444,7 +444,7 @@ public final class AnalyzeCovariates extends CommandLineProgram {
                 throw new UserException.IncompatibleRecalibrationTableParameters("There are differences in relevant arguments of"
                         + " two or more input recalibration reports. Please make sure"
                         + " they have been created using the same recalibration parameters."
-                        + " " + Utils.join("// ", reportDifferencesStringArray(diffs)));
+                        + " " + String.join("// ", reportDifferencesStringArray(diffs)));
             }
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -179,65 +179,16 @@ public class Utils {
         for (L key : map.keySet()) {
             joinedKeyValues[index++] = String.format("%s%s%s",key.toString(),keyValueSeperator,map.get(key).toString());
         }
-        return join(recordSeperator,joinedKeyValues);
+        return String.join(recordSeperator, joinedKeyValues);
     }
 
     /**
-     * Splits a String using indexOf instead of regex to speed things up.
+     * Returns a string of the values in ints joined by separator, such as A,B,C
      *
-     * @param str the string to split.
-     * @param delimiter the delimiter used to split the string.
-     * @return an array of tokens.
+     * @param separator separator character
+     * @param ints   the array with values
+     * @return a string with the values separated by the separator
      */
-    public static ArrayList<String> split(String str, String delimiter) {
-        return split(str, delimiter, 10);
-    }
-
-    /**
-     * Splits a String using indexOf instead of regex to speed things up.
-     *
-     * @param str the string to split.
-     * @param delimiter the delimiter used to split the string.
-     * @param expectedNumTokens The number of tokens expected. This is used to initialize the ArrayList.
-     * @return an array of tokens.
-     */
-    public static ArrayList<String> split(String str, String delimiter, int expectedNumTokens) {
-        final ArrayList<String> result =  new ArrayList<String>(expectedNumTokens);
-
-        int delimiterIdx = -1;
-        do {
-            final int tokenStartIdx = delimiterIdx + 1;
-            delimiterIdx = str.indexOf(delimiter, tokenStartIdx);
-            final String token = (delimiterIdx != -1 ? str.substring(tokenStartIdx, delimiterIdx) : str.substring(tokenStartIdx) );
-            result.add(token);
-        } while( delimiterIdx != -1 );
-
-        return result;
-    }
-
-
-    /**
-     * join an array of strings given a seperator
-     * @param separator the string to insert between each array element
-     * @param strings the array of strings
-     * @return a string, which is the joining of all array values with the separator
-     */
-    public static String join(String separator, String[] strings) {
-        return join(separator, strings, 0, strings.length);
-    }
-
-    public static String join(String separator, String[] strings, int start, int end) {
-        if ((end - start) == 0) {
-            return "";
-        }
-        StringBuilder ret = new StringBuilder(strings[start]);
-        for (int i = start + 1; i < end; ++i) {
-            ret.append(separator);
-            ret.append(strings[i]);
-        }
-        return ret.toString();
-    }
-
     public static String join(String separator, int[] ints) {
         if ( ints == null || ints.length == 0)
             return "";
@@ -390,22 +341,6 @@ public class Utils {
         byte[] bytes = new byte[nCopies];
         Arrays.fill(bytes, b);
         return bytes;
-    }
-
-    // trim a string for the given character (i.e. not just whitespace)
-    public static String trim(String str, char ch) {
-        char[] array = str.toCharArray();
-
-
-        int start = 0;
-        while ( start < array.length && array[start] == ch )
-            start++;
-
-        int end = array.length - 1;
-        while ( end > start && array[end] == ch )
-            end--;
-
-        return str.substring(start, end+1);
     }
 
     /**
@@ -727,25 +662,6 @@ public class Utils {
     }
 
     /**
-     * Divides the input list into a list of sublists, which contains group size elements (except potentially the last one)
-     *
-     * list = [A, B, C, D, E]
-     * groupSize = 2
-     * result = [[A, B], [C, D], [E]]
-     *
-     */
-    public static <T> List<List<T>> groupList(final List<T> list, final int groupSize) {
-        if ( groupSize < 1 ) throw new IllegalArgumentException("groupSize >= 1");
-
-        final List<List<T>> subLists = new LinkedList<List<T>>();
-        int n = list.size();
-        for ( int i = 0; i < n; i += groupSize ) {
-            subLists.add(list.subList(i, Math.min(i + groupSize, n)));
-        }
-        return subLists;
-    }
-
-    /**
      * @see #calcMD5(byte[])
      */
     public static String calcMD5(final String s) {
@@ -887,7 +803,7 @@ public class Utils {
     }
 
     /**
-     * Skims out positions of an array returning a shorter one with the remaning positions in the same order.
+     * Skims out positions of an array returning a shorter one with the remaining positions in the same order.
      * @param original the original array to splice.
      * @param remove for each position in {@code original} indicates whether it should be spliced away ({@code true}),
      *               or retained ({@code false})

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessController.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessController.java
@@ -279,7 +279,7 @@ public class ProcessController {
         if (po.getExitValue() != 0) {
             String message = String.format("Process exited with %d\nCommand Line: %s",
                     po.getExitValue(),
-                    Utils.join(" ", settings.getCommand()));
+                    String.join(" ", settings.getCommand()));
             throw new IOException(message);
         }
         return po;

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -26,6 +26,7 @@
 package org.broadinstitute.hellbender.utils;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -109,6 +110,38 @@ public class UtilsUnitTest extends BaseTest {
         map.put("six",2);
         String joined = Utils.joinMap("-",";",map);
         Assert.assertTrue("one-1;two-2;three-1;four-2;five-1;six-2".equals(joined));
+    }
+
+    @Test
+    public void testWarnUserLines(){
+        String message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut" +
+                " labore et dolore magna aliqua.";
+        Assert.assertEquals(Utils.warnUserLines(message), new ArrayList<>(Arrays.asList(
+                "**********************************************************************",
+                "* WARNING:",
+                "* ",
+                "* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do",
+                "* eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "**********************************************************************")));
+    }
+
+    @Test
+    public void testListFromPrimitives(){
+        int[] ints = {1,2,3,4};
+        Assert.assertEquals(Utils.listFromPrimitives(ints), Arrays.asList(ArrayUtils.toObject(ints)));
+    }
+
+    @Test
+    public void testJoin(){
+        int[] ints = {1,2,3,4};
+        int[] nullints = null;
+        Assert.assertEquals(Utils.join(",", ints),"1,2,3,4");
+        Assert.assertEquals(Utils.join(",", nullints), "");
+
+        double[] dbls = {1.0,2.0,3.0,4.0};
+        double[] emptydbl = null;
+        Assert.assertEquals(Utils.join(",", emptydbl), "");
+        Assert.assertEquals(Utils.join(",",dbls), "1.0,2.0,3.0,4.0");
     }
 
     @Test


### PR DESCRIPTION
deleting a few methods with have been deprecated by java 8

removed `getCigarOperatorForAllBases()`
  it is only used in CountReadEvents which isn't coming over

remove getBothReadToLociMappings() which is never used anywhere in hellbender or gatk

adding tests to some trivial methods so coverage looks less bad
