### PR TITLE
adding a packaging command to build a single super jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ task wrapper(type: Wrapper) {
 
 task fatJar(type: Jar) {
   manifest {
-        attributes 'Implementation-Title': 'Hellbender'
+        attributes 'Implementation-Title': 'Hellbender',
           'Implementation-Version': version,
           'Main-Class': 'org.broadinstitute.hellbender.Main'
     }


### PR DESCRIPTION
`gradle fatJar` will build a new jar build/libs/called hellbender-all-1.0.jar

It seems to work, but I haven't tested it in any systematic way.  
