### PR TITLE
setting RScriptExecutor to output useful messages on failure

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalUtils.java
@@ -578,7 +578,6 @@ public class RecalUtils {
     public static void generatePlots(final File csvFile, final File maybeGzipedExampleReportFile, final File output) {
         final File exampleReportFile = IOUtils.gunzipToTempIfNeeded(maybeGzipedExampleReportFile);
         final RScriptExecutor executor = new RScriptExecutor();
-        executor.setExceptOnError(true);
         executor.addScript(new Resource(SCRIPT_FILE, RecalUtils.class));
         executor.addArgs(csvFile.getAbsolutePath());
         executor.addArgs(exampleReportFile.getAbsolutePath());

--- a/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptExecutorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptExecutorUnitTest.java
@@ -26,8 +26,8 @@
 package org.broadinstitute.hellbender.utils.R;
 
 import org.apache.commons.io.FileUtils;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -52,7 +52,6 @@ public class RScriptExecutorUnitTest extends BaseTest {
         try {
             RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(script);
-            executor.setExceptOnError(true);
             Assert.assertTrue(executor.exec(), "Exec failed");
         } finally {
             FileUtils.deleteQuietly(script);
@@ -62,7 +61,6 @@ public class RScriptExecutorUnitTest extends BaseTest {
     @Test(dependsOnMethods = "testRscriptExists", expectedExceptions = RScriptExecutorException.class)
     public void testNonExistantScriptException() {
         RScriptExecutor executor = new RScriptExecutor();
-        executor.setExceptOnError(true);
         executor.addScript(new File("does_not_exists.R"));
         executor.exec();
     }
@@ -71,8 +69,8 @@ public class RScriptExecutorUnitTest extends BaseTest {
     public void testNonExistantScriptNoException() {
         logger.warn("Testing that warning is printed an no exception thrown for missing script.");
         RScriptExecutor executor = new RScriptExecutor();
-        executor.setExceptOnError(false);
         executor.addScript(new File("does_not_exists.R"));
+        executor.setIgnoreExceptions(true);
         Assert.assertFalse(executor.exec(), "Exec should have returned false when the job failed");
     }
 
@@ -83,7 +81,6 @@ public class RScriptExecutorUnitTest extends BaseTest {
             RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(script);
             executor.addLibrary(RScriptLibrary.GSALIB);
-            executor.setExceptOnError(true);
             Assert.assertTrue(executor.exec(), "Exec failed");
         } finally {
             FileUtils.deleteQuietly(script);
@@ -97,7 +94,6 @@ public class RScriptExecutorUnitTest extends BaseTest {
             RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(script);
             // GSALIB is not added nor imported in the script
-            executor.setExceptOnError(true);
             executor.exec();
         } finally {
             FileUtils.deleteQuietly(script);


### PR DESCRIPTION
changing the default behavior of `RScriptExecutor` from logging a warning on a failure to crashing on failure

the exception message will include output from the failed Rscript
closes #223 
