### PR TITLE
Refactor *Context classes to return empty Collections/iterators when there is no backing data source

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.utils.GenomeLoc;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -22,11 +23,16 @@ import java.util.List;
  *
  * Feature sources are lazily queried, so there's no overhead if the client chooses not to examine
  * the FeatureContext it's passed.
+ *
+ * A FeatureContext may have no backing data source. In this case, queries on it will always
+ * return empty Lists. You can determine whether there is a backing source of Features via
+ * {@link #hasBackingDataSource()}
  */
-public class FeatureContext {
+public final class FeatureContext {
 
     /**
-     * FeatureManager containing backing data sources for all discovered Feature arguments
+     * FeatureManager containing backing data sources for all discovered Feature arguments.
+     * Null if there are no sources of Features.
      */
     private final FeatureManager featureManager;
 
@@ -36,14 +42,40 @@ public class FeatureContext {
     private final GenomeLoc interval;
 
     /**
-     * Creates a new FeatureContext given a FeatureManager and query interval
+     * Creates an empty FeatureContext with no backing data source. All queries on this context will
+     * return an empty List.
+     */
+    public FeatureContext() {
+        this(null, null);
+    }
+
+    /**
+     * Creates a new FeatureContext given a FeatureManager and a query interval. These may be null if
+     * no sources of Features are available, but if you provide a FeatureManager you must also provide
+     * a query interval.
      *
-     * @param featureManager FeatureManager containing backing data sources for all discovered Feature arguments
-     * @param interval interval to constrain queries on this FeatureContext
+     * @param featureManager FeatureManager containing backing data sources for all discovered Feature arguments. Null if there are no sources of Features.
+     * @param interval Interval to constrain queries on this FeatureContext. May be null if there are no sources of Features.
      */
     public FeatureContext( final FeatureManager featureManager, final GenomeLoc interval ) {
+        // If we have a backing FeatureManager, we must also have a query interval. If there's no source of Features,
+        // we don't care about the interval (may be null or non-null).
+        if ( featureManager != null && interval == null ) {
+            throw new IllegalArgumentException("Must provide a non-null query interval for a FeatureContext that has a backing FeatureManager");
+        }
+
         this.featureManager = featureManager;
         this.interval = interval;
+    }
+
+    /**
+     * Determines whether this FeatureContext has a backing source of Features. A FeatureContext with
+     * no backing data source will always return an empty List in response to a query.
+     *
+     * @return true if this FeatureContext has a backing source of Features, otherwise false
+     */
+    public boolean hasBackingDataSource() {
+        return featureManager != null;
     }
 
     /**
@@ -57,22 +89,28 @@ public class FeatureContext {
 
     /**
      * Gets all Features from the source represented by the provided FeatureInput argument that overlap
-     * this FeatureContext's query interval.
+     * this FeatureContext's query interval. Will return an empty List if this FeatureContext has
+     * no backing source of Features.
      *
      * Returned Features are not guaranteed to be in any particular order.
      *
      * @param featureDescriptor FeatureInput argument for which to fetch Features
      * @param <T> type of Feature in the data source backing the provided FeatureInput
-     * @return all Features in the data source backing the provided FeatureInput that overlap
-     *         this FeatureContext's query interval
+     * @return All Features in the data source backing the provided FeatureInput that overlap
+     *         this FeatureContext's query interval. Empty List if there is no backing data source.
      */
     public <T extends Feature> List<T> getValues( final FeatureInput<T> featureDescriptor ) {
+        if ( featureManager == null ) {
+            return Collections.<T>emptyList();
+        }
+
         return featureManager.getFeatures(featureDescriptor, interval);
     }
 
     /**
      * Gets all Features from the source represented by the provided FeatureInput argument that overlap
      * this FeatureContext's query interval AND that start at the specified start position.
+     * Will return an empty List if this FeatureContext has no backing source of Features.
      *
      * Returned Features are not guaranteed to be in any particular order.
      *
@@ -80,26 +118,36 @@ public class FeatureContext {
      * @param featureStart All returned Features must start at this position, in addition to overlapping this
      *                     FeatureContext's query interval
      * @param <T> type of Feature in the data source backing the provided FeatureInput
-     * @return all Features in the data source backing the provided FeatureInput that overlap
-     *         this FeatureContext's query interval AND that start at the specified start position
+     * @return All Features in the data source backing the provided FeatureInput that overlap
+     *         this FeatureContext's query interval AND that start at the specified start position.
+     *         Empty List if there is no backing data source.
      */
     public <T extends Feature> List<T> getValues( final FeatureInput<T> featureDescriptor, final int featureStart ) {
+        if ( featureManager == null ) {
+            return Collections.<T>emptyList();
+        }
+
         return subsetToStartPosition(getValues(featureDescriptor), featureStart);
     }
 
     /**
      * Gets all Features from the sources represented by the provided FeatureInput arguments that overlap
-     * this FeatureContext's query interval.
+     * this FeatureContext's query interval. Will return an empty List if this FeatureContext has no
+     * backing source of Features.
      *
      * Returned Features are not guaranteed to be in any particular order, or to be globally unique
      * across all sources of Features.
      *
      * @param featureDescriptors FeatureInput arguments for which to fetch Features
      * @param <T> type of Feature in the data sources backing the provided FeatureInputs
-     * @return all Features in the data sources backing the provided FeatureInputs that overlap
-     *         this FeatureContext's query interval
+     * @return All Features in the data sources backing the provided FeatureInputs that overlap
+     *         this FeatureContext's query interval. Empty List if there is no backing data source.
      */
     public <T extends Feature> List<T> getValues( final Collection<FeatureInput<T>> featureDescriptors ) {
+        if ( featureManager == null ) {
+            return Collections.<T>emptyList();
+        }
+
         List<T> features = new ArrayList<>();
         for ( FeatureInput<T> featureSource : featureDescriptors ) {
             features.addAll(getValues(featureSource));
@@ -109,7 +157,8 @@ public class FeatureContext {
 
     /**
      * Gets all Features from the sources represented by the provided FeatureInput arguments that overlap
-     * this FeatureContext's query interval, AND that start at the specified start position.
+     * this FeatureContext's query interval, AND that start at the specified start position. Will return
+     * an empty List if this FeatureContext has no backing source of Features.
      *
      * Returned Features are not guaranteed to be in any particular order, or to be globally unique
      * across all sources of Features.
@@ -118,10 +167,15 @@ public class FeatureContext {
      * @param featureStart All returned Features must start at this position, in addition to overlapping this
      *                     FeatureContext's query interval
      * @param <T> type of Feature in the data sources backing the provided FeatureInputs
-     * @return all Features in the data sources backing the provided FeatureInputs that overlap
-     *         this FeatureContext's query interval, AND that start at the specified start position
+     * @return All Features in the data sources backing the provided FeatureInputs that overlap
+     *         this FeatureContext's query interval, AND that start at the specified start position.
+     *         Empty List if there is no backing data source.
      */
     public <T extends Feature> List<T> getValues( final Collection<FeatureInput<T>> featureDescriptors, final int featureStart ) {
+        if ( featureManager == null ) {
+            return Collections.<T>emptyList();
+        }
+
         return subsetToStartPosition(getValues(featureDescriptors), featureStart);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -31,7 +31,7 @@ import java.util.*;
  *
  * @param <T> The type of Feature returned by this data source
  */
-public class FeatureDataSource<T extends Feature> implements GATKDataSource<T>, AutoCloseable {
+public final class FeatureDataSource<T extends Feature> implements GATKDataSource<T>, AutoCloseable {
 
     /**
      * File backing this data source. Used mainly for error messages.

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -24,7 +24,7 @@ import java.io.File;
  *
  * @param <T> the type of Feature that this FeatureInput file contains (eg., VariantContext, BEDFeature, etc.)
  */
-public class FeatureInput<T extends Feature> {
+public final class FeatureInput<T extends Feature> {
 
     /**
      * Logical name for this source of Features optionally provided by the user on the command line

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -35,7 +35,7 @@ import java.util.*;
  * Clients can then call {@link #getFeatures(FeatureInput, GenomeLoc)} to query the data source for
  * a particular FeatureInput over a specific interval.
  */
-public class FeatureManager {
+public final class FeatureManager implements AutoCloseable {
     private static final Logger logger = LogManager.getLogger(FeatureManager.class);
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * -Iteration over all reads, optionally restricted to reads that overlap a set of intervals
  * -Targeted queries by one interval at a time
  */
-public class ReadsDataSource implements GATKDataSource<SAMRecord>, AutoCloseable {
+public final class ReadsDataSource implements GATKDataSource<SAMRecord>, AutoCloseable {
 
     /**
      * Mapping from SamReaders to iterators over the reads from each reader. Only one

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
@@ -17,7 +17,7 @@ import java.util.Iterator;
  * Supports targeted queries over the reference by interval, but does not
  * yet support complete iteration over the entire reference.
  */
-public class ReferenceDataSource implements GATKDataSource<Byte>, AutoCloseable {
+public final class ReferenceDataSource implements GATKDataSource<Byte>, AutoCloseable {
 
     /**
      * Our reference file. Uses the caching version of IndexedFastaSequenceFile

--- a/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSR.java
@@ -16,7 +16,6 @@ import org.broadinstitute.hellbender.tools.recalibration.BaseRecalibration;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 
 import java.io.File;
-import java.util.Optional;
 import java.util.function.Function;
 
 @CommandLineProgramProperties(
@@ -101,7 +100,7 @@ public final class ApplyBQSR extends ReadWalker{
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         outputWriter.addAlignment(bqsrTransform.apply(read));
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
@@ -314,7 +314,7 @@ public final class ClipReads extends ReadWalker {
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> ref, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext ref, FeatureContext featureContext ) {
         if ( onlyDoRead == null || read.getReadName().equals(onlyDoRead) ) {
             if ( clippingRepresentation == ClippingRepresentation.HARDCLIP_BASES || clippingRepresentation == ClippingRepresentation.REVERT_SOFTCLIPPED_BASES )
                 read = ReadClipper.revertSoftClippedBases(read);

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -7,8 +7,6 @@ import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 
-import java.util.Optional;
-
 @CommandLineProgramProperties(
 	usage = "Walks over the input data set, calculating the number of bases seen for diagnostic purposes.",
 	usageShort = "Count bases",
@@ -19,7 +17,7 @@ public class CountBases extends ReadWalker {
     private long count = 0;
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         count += read.getReadLength();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -7,8 +7,6 @@ import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 
-import java.util.Optional;
-
 @CommandLineProgramProperties(
 	usage = "Count reads.",
 	usageShort = "Count reads",
@@ -18,7 +16,7 @@ public class CountReads extends ReadWalker {
 
     private long count = 0;
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         ++count;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -9,7 +9,6 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.Optional;
 
 @CommandLineProgramProperties(
 	usage = "Walks over all input data, accumulating statistics such as total number of read\n" +
@@ -22,7 +21,7 @@ public class FlagStat extends ReadWalker {
     private FlagStatus sum = new FlagStatus();
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         sum.add(read);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -64,7 +64,6 @@ import org.broadinstitute.hellbender.utils.sam.CigarUtils;
 import org.broadinstitute.hellbender.utils.sam.AlignmentUtils;
 
 import java.io.File;
-import java.util.Optional;
 
 /**
  * Left-aligns indels from reads in a bam file.
@@ -118,7 +117,7 @@ public class LeftAlignIndels extends ReadWalker {
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> ref, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext ref, FeatureContext featureContext ) {
         // we can not deal with screwy records
         if ( read.getReadUnmappedFlag() || read.getCigar().numCigarElements() == 0 ) {
             outputWriter.addAlignment(read);
@@ -129,7 +128,7 @@ public class LeftAlignIndels extends ReadWalker {
         int numBlocks = AlignmentUtils.getNumAlignmentBlocks(read);
         if ( numBlocks == 2 ) {
             // We checked in onTraversalStart() that a reference is present, so ref.get() is safe
-            Cigar newCigar = AlignmentUtils.leftAlignIndel(CigarUtils.unclipCigar(read.getCigar()), ref.get().getBases(), read.getReadBases(), 0, 0, true);
+            Cigar newCigar = AlignmentUtils.leftAlignIndel(CigarUtils.unclipCigar(read.getCigar()), ref.getBases(), read.getReadBases(), 0, 0, true);
             newCigar = CigarUtils.reclipCigar(newCigar, read);
             read.setCigar(newCigar);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -9,7 +9,6 @@ import org.broadinstitute.hellbender.engine.ReadWalker;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 
 import java.io.File;
-import java.util.Optional;
 
 @CommandLineProgramProperties(
 	usage = "Prints reads from the input to the output.",
@@ -30,7 +29,7 @@ public class PrintReads extends ReadWalker {
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         outputWriter.addAlignment(read);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -64,7 +64,7 @@ public class SplitReads extends ReadWalker {
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         outs.get(getKey(splitters, read)).addAlignment(read);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
@@ -13,7 +13,6 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
-import java.util.Optional;
 
 /**
  * Example/toy program that prints reads from the provided file or files with corresponding reference bases
@@ -42,10 +41,10 @@ public class PrintReadsWithReference extends ReadWalker {
     }
 
     @Override
-    public void apply( SAMRecord read, Optional<ReferenceContext> referenceContext, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         outputStream.printf("Read at %s:%d-%d:\n%s\n", read.getReferenceName(), read.getAlignmentStart(), read.getAlignmentEnd(), read.getReadString());
-        if ( referenceContext.isPresent() )
-            outputStream.println("Reference Context:\n" + new String(referenceContext.get().getBases()));
+        if ( referenceContext.hasBackingDataSource() )
+            outputStream.println("Reference Context:\n" + new String(referenceContext.getBases()));
         outputStream.println();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -324,7 +324,7 @@ public class BaseRecalibrator extends ReadWalker {
      * whether or not the base matches the reference at this particular location
      */
     @Override
-    public void apply( SAMRecord originalRead, Optional<ReferenceContext> ref, Optional<FeatureContext> featureContext ) {
+    public void apply( SAMRecord originalRead, ReferenceContext ref, FeatureContext featureContext ) {
         ReadTransformer transform = makeReadTransform();
         final SAMRecord read = transform.apply(originalRead);
 
@@ -336,7 +336,7 @@ public class BaseRecalibrator extends ReadWalker {
         }
 
         // We've checked in onTraversalStart() that we have a reference, so ref.get() is safe
-        final int[] isSNP = calculateIsSNP(read, ref.get(), originalRead);
+        final int[] isSNP = calculateIsSNP(read, ref, originalRead);
         final int[] isInsertion = calculateIsIndel(read, EventType.BASE_INSERTION);
         final int[] isDeletion = calculateIsIndel(read, EventType.BASE_DELETION);
         final int nErrors = nEvents(isSNP, isInsertion, isDeletion);
@@ -376,10 +376,10 @@ public class BaseRecalibrator extends ReadWalker {
         return n;
     }
 
-    private boolean[] calculateSkipArray( final SAMRecord read, final Optional<FeatureContext> featureContext ) {
+    private boolean[] calculateSkipArray( final SAMRecord read, final FeatureContext featureContext ) {
         final byte[] bases = read.getReadBases();
         final boolean[] skip = new boolean[bases.length];
-        final boolean[] knownSites = calculateKnownSites(read, featureContext.isPresent() ? featureContext.get().getValues(RAC.knownSites) : Collections.<Feature>emptyList());
+        final boolean[] knownSites = calculateKnownSites(read, featureContext.getValues(RAC.knownSites));
         for( int iii = 0; iii < bases.length; iii++ ) {
             skip[iii] = !BaseUtils.isRegularBase(bases[iii]) || isLowQualityBase(read, iii) || knownSites[iii] || badSolidOffset(read, iii);
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.tribble.Feature;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+public class FeatureContextUnitTest extends BaseTest {
+
+    @CommandLineProgramProperties(usage = "", usageShort = "")
+    private static class ArtificialFeatureContainingCommandLineProgram extends CommandLineProgram {
+        @Argument(fullName = "featureArgument", shortName = "f")
+        FeatureInput<Feature> featureArgument;
+
+        public ArtificialFeatureContainingCommandLineProgram() {
+            featureArgument = new FeatureInput<>(publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test.vcf");
+        }
+
+        @Override
+        protected Object doWork() {
+            return null;
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNullIntervalWithNonNullFeatureManager() {
+        // If we provide a backing data source, we must also provide a query interval
+        try ( FeatureManager featureManager = new FeatureManager(new ArtificialFeatureContainingCommandLineProgram()) ) {
+            FeatureContext featureContext = new FeatureContext(featureManager, null);
+        }
+    }
+
+    @DataProvider(name = "EmptyFeatureContextDataProvider")
+    public Object[][] getEmptyFeatureContextData() {
+        // Default-constructed FeatureContexts and FeatureContexts constructed from null FeatureManagers
+        // should behave as empty context objects.
+        return new Object[][] {
+                { new FeatureContext() },
+                { new FeatureContext(null, null) },
+                { new FeatureContext(null, hg19GenomeLocParser.createGenomeLoc("1", 1, 1) ) }
+        };
+    }
+
+    @Test(dataProvider = "EmptyFeatureContextDataProvider")
+    public void testFeatureContextWithNoBackingDataSource( final FeatureContext featureContext) {
+        ArtificialFeatureContainingCommandLineProgram toolInstance = new ArtificialFeatureContainingCommandLineProgram();
+
+        Assert.assertFalse(featureContext.hasBackingDataSource(), "Empty FeatureContext reports having a backing data source");
+        Assert.assertTrue(featureContext.getValues(toolInstance.featureArgument).isEmpty(), "Empty FeatureContext should have returned an empty List from getValues()");
+        Assert.assertTrue(featureContext.getValues(toolInstance.featureArgument, 1).isEmpty(), "Empty FeatureContext should have returned an empty List from getValues()");
+        Assert.assertTrue(featureContext.getValues(Arrays.<FeatureInput<Feature>>asList(toolInstance.featureArgument)).isEmpty(), "Empty FeatureContext should have returned an empty List from getValues()");
+        Assert.assertTrue(featureContext.getValues(Arrays.<FeatureInput<Feature>>asList(toolInstance.featureArgument), 1).isEmpty(), "Empty FeatureContext should have returned an empty List from getValues()");
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
@@ -18,17 +18,29 @@ public class ReferenceContextUnitTest extends BaseTest {
     private static final File TEST_REFERENCE = new File(hg19MiniReference);
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNullDataSource() {
-        try ( ReferenceDataSource reference = new ReferenceDataSource(TEST_REFERENCE) ) {
-            ReferenceContext refContext = new ReferenceContext(null, new GenomeLocParser(reference.getSequenceDictionary()).createGenomeLoc("1", 1, 5));
-        }
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNullInterval() {
+    public void testNullIntervalWithNonNullDataSource() {
+        // If we provide a backing data source, we must also provide a query interval
         try ( ReferenceDataSource reference = new ReferenceDataSource(TEST_REFERENCE) ) {
             ReferenceContext refContext = new ReferenceContext(reference, null);
         }
+    }
+
+    @DataProvider(name = "EmptyReferenceContextDataProvider")
+    public Object[][] getEmptyReferenceContextData() {
+        // Default-constructed ReferenceContexts and ReferenceContexts constructed from null ReferenceDataSources
+        // should behave as empty context objects.
+        return new Object[][] {
+                { new ReferenceContext() },
+                { new ReferenceContext(null, null) },
+                { new ReferenceContext(null, hg19GenomeLocParser.createGenomeLoc("1", 1, 1) ) }
+        };
+    }
+
+    @Test(dataProvider = "EmptyReferenceContextDataProvider")
+    public void testReferenceContextWithNoBackingDataSource( final ReferenceContext refContext) {
+        Assert.assertFalse(refContext.hasBackingDataSource(), "Empty ReferenceContext reports having a backing data source");
+        Assert.assertEquals(refContext.getBases().length, 0, "Empty ReferenceContext should have returned an empty bases array from getBases()");
+        Assert.assertFalse(refContext.getBasesIterator().hasNext(), "Empty ReferenceContext should have returned an empty bases iterator from getBasesIterator()");
     }
 
     @DataProvider(name = "WindowlessReferenceIntervalDataProvider")


### PR DESCRIPTION
-ReferenceContext and FeatureContext are now guaranteed to be non-null in ReadWalker.apply(),
 and simply return empty Collections/iterators when there is no backing data source (previously,
 these were wrapped in Optional objects, and would be Optional.empty() if there was no source
 of reference and/or Feature data)

 This spares tool authors from having to explicitly check for the existence of reference/Feature
 contextual data before using it.

-For tools that care about the distinction between the "no data source" case and the "no records
 overlapping the current interval" case, there is now a hasBackingDataSource() method in both
 ReferenceContext and FeatureContext.

Requested by Valentin!

Resolves #244
