### PR TITLE
misencoded quals transformer

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
@@ -1,0 +1,51 @@
+package org.broadinstitute.hellbender.tools;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.CloserUtil;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.ReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.transformers.MisencodedBaseQualityReadTransformer;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+
+import java.io.File;
+
+@CommandLineProgramProperties(
+	usage = "Fixes Illumina base quality scores.",
+    usageShort = "Fix Illumina base quality scores.",
+    programGroup = ReadProgramGroup.class
+)
+public class FixMisencodedBaseQualityReads extends ReadWalker {
+
+    @Argument(fullName = "output", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    public File OUTPUT;
+
+    private SAMFileWriter outputWriter;
+
+    private ReadTransformer transform;
+
+    @Override
+    public void onTraversalStart() {
+        final SAMFileHeader outputHeader = getHeaderForReads().clone();
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, REFERENCE_FILE);
+        transform = new MisencodedBaseQualityReadTransformer();
+    }
+
+    @Override
+    public void apply( SAMRecord read, ReferenceContext referenceContext, FeatureContext featureContext ) {
+        outputWriter.addAlignment(transform.apply(read));
+    }
+
+    @Override
+    public Object onTraversalDone() {
+        CloserUtil.close(outputWriter);
+        return null;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/transformers/BQSRReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/BQSRReadTransformer.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.tools.recalibration.BaseRecalibration;
+
+import java.io.File;
+
+public final class BQSRReadTransformer implements ReadTransformer{
+    private final BaseRecalibration bqsr;
+
+    public BQSRReadTransformer(File bqsrRecalFile, int quantizationLevels, boolean disableIndelQuals, final int preserveQLessThan, final boolean emitOriginalQuals, final double globalQScorePrior) {
+        this.bqsr = new BaseRecalibration(bqsrRecalFile, quantizationLevels, disableIndelQuals, preserveQLessThan, emitOriginalQuals, globalQScorePrior);
+    }
+
+    @Override
+    public SAMRecord apply(SAMRecord read) {
+        bqsr.recalibrateRead(read);
+        return read;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2012 The Broad Institute
+* 
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+* 
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+/**
+ * Checks for and errors out (or fixes if requested) when it detects reads with base qualities that are not encoded with
+ * phred-scaled quality scores.  Q0 == ASCII 33 according to the SAM specification, whereas Illumina encoding starts at
+ * Q64.  The idea here is simple: if we are asked to fix the scores then we just subtract 31 from every quality score.
+ */
+public final class MisencodedBaseQualityReadTransformer implements ReadTransformer {
+
+    private static final int ILLUMINA_ENCODING_FIX_VALUE = 31;  // Illumina_64 - PHRED_33
+
+    @Override
+    public SAMRecord apply(final SAMRecord read) {
+        final byte[] quals = read.getBaseQualities();
+        for ( int i = 0; i < quals.length; i++ ) {
+            quals[i] -= ILLUMINA_ENCODING_FIX_VALUE;
+            if ( quals[i] < 0 )
+                throw new UserException.BadInput("while fixing mis-encoded base qualities we encountered a read that was correctly encoded; we cannot handle such a mixture of reads so unfortunately the BAM must be fixed with some other tool");
+        }
+        read.setBaseQualities(quals);
+        return read;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
@@ -1,0 +1,82 @@
+/*
+* Copyright (c) 2012 The Broad Institute
+* 
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+* 
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package org.broadinstitute.hellbender.transformers;
+
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.sam.ArtificialSAMUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Basic unit test for misencoded quals
+ */
+public class MisencodedBaseQualityReadTransformerUnitTest extends BaseTest {
+
+    private static final byte[] badQuals = { 59, 60, 62, 63, 64, 61, 62, 58, 57, 56 };
+    private static final byte[] goodQuals = { 60, 60, 60, 60, 60, 60, 60, 60, 60, 60 };
+    private static final byte[] fixedQuals = { 28, 29, 31, 32, 33, 30, 31, 27, 26, 25 };
+    private SAMFileHeader header;
+
+    @BeforeMethod
+    public void before() {
+        header = ArtificialSAMUtils.createArtificialSamHeader(1, 1, 1000);
+    }
+
+    private SAMRecord createRead(final byte[] quals) {
+        final String readBases = "AAAAAAAAAA";
+        SAMRecord read = ArtificialSAMUtils.createArtificialRead(header, "foo", 0, 10, readBases.getBytes(), quals);
+        read.setCigarString("10M");
+        return read;
+    }
+
+    @Test(enabled = true)
+    public void testGoodQuals() {
+        final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
+        SAMRecord read = createRead(goodQuals);
+        SAMRecord newRead = tr.apply(read);
+        Assert.assertEquals(read, newRead);
+    }
+
+    @Test(enabled = true)
+    public void testFixBadQuals() {
+        final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
+        final SAMRecord read = createRead(badQuals);
+        final SAMRecord fixedRead = tr.apply(read);
+        Assert.assertEquals(fixedQuals, fixedRead.getBaseQualities());
+    }
+
+    @Test(expectedExceptions = UserException.BadInput.class)
+    public void testFixGoodQualsBlowUp() {
+        final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
+        final SAMRecord read = createRead(fixedQuals);
+        tr.apply(read);
+    }
+}


### PR DESCRIPTION
ported the FixMisencodedQualsReadTransformer and added a trivial walker to plug the transformer into (we dont have magic engine-wide transformers so (for now) have silly walkers that just transform a read and print it. In the dataflow world, those walkers will be useless but the transformer classes will be more prominent so i think it's ok to keep those walkers for now.

The MisencodedBaseQualityReadTransformer now longer blows up on high quality scores. There's nothing to transform so that code does not belong here. If the functionality is needed, then a different class need to exist (either a filter or some other thing that checks reads and blows up - transformers are not it).

Small cleanup in ApplyBQSR (and extracted a transformers from it).
