### PR TITLE
changing gsalib to only redownload when necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ mainClassName = "org.broadinstitute.hellbender.Main"
 task downloadGsaLibFile(type: Download) {
     src 'http://cran.r-project.org/src/contrib/gsalib_2.1.tar.gz'
     dest "src/main/resources/org/broadinstitute/hellbender/utils/R/gsalib.tar.gz"
-    overwrite true
+    overwrite false
 }
 
 repositories {


### PR DESCRIPTION
lets avoid those 5-10 seconds of waiting for cran on every build
