### PR TITLE
improving build process in several ways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ hellbender-tools/repos/
 testSortingFile.txt
 gsalib.tar.gz
 gradlew*
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,16 @@ env:
   matrix:
   - TERM=dumb
   global:
-    secure: RA4LKD82cW+0xPayPVAWSpYqJu5uoPcz7oXXYtYNVuilFmS8PGYx0g/BXs4QMvQsGMt6aMLN8m7lMAPN5XTH/8JSeM3VmQ3mdpgNdP+p3CVlwrapZ2lTq27Wb/E8J1CGEHOg76z716t//FUElyC/gdhS+tfBmXk3YanM5fMXEHs=
+    - secure: RA4LKD82cW+0xPayPVAWSpYqJu5uoPcz7oXXYtYNVuilFmS8PGYx0g/BXs4QMvQsGMt6aMLN8m7lMAPN5XTH/8JSeM3VmQ3mdpgNdP+p3CVlwrapZ2lTq27Wb/E8J1CGEHOg76z716t//FUElyC/gdhS+tfBmXk3YanM5fMXEHs=
+cache:
+  directories:
+    - ~/.gradle
+    - ~/site-library
 before_install:
-  - wget https://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+  - sudo mkdir -p /usr/local/lib/R/
+  - mkdir -p site-library
+  - sudo ln -sFv ~/site-library /usr/local/lib/R/site-library
+  - wget -N https://downloads.gradle.org/distributions/gradle-2.2.1-bin.zip
   - unzip gradle-2.2.1-bin.zip
   - "export PATH=`pwd`/gradle-2.2.1/bin:$PATH"
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
@@ -15,7 +22,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y r-base-dev=3.1.3-1precise2
   - sudo apt-get install -y --force-yes r-base-core=3.1.3-1precise2
-  - sudo Rscript scripts/install_R_packages.R
   - R --version
+  - sudo Rscript scripts/install_R_packages.R
 after_success:
 - gradle jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ General guidelines for Hellbender developers
 
 * Don't accept pull requests that significantly decrease coverage (less than 1% decrease is sort of tolerable). 
 
+R Dependency
+----------------
+Certain Hellbender tools rely on R for generating plots. **R v3.1.3** must be installed for all unit tests to work (other versions of R may work, but there is no guarantee).  
+
+R installation is not part of the gradle build.  See http://cran.r-project.org/ for general information on installing R for your system.
+* for [ubuntu specific instructions](http://cran.r-project.org/bin/linux/ubuntu/README))
+* for OSX we recommend installation through [homebrew](http://brew.sh/)
+
+* For more information on R see http://www.ihater.org/
+
+Gradle installApp will attempt to install R packages, this may potentially fail if your R library is not writable.  If this happens, the package installation script is the package installation script is `scripts/install_R_packages.R`.  Either run it as superuser to force installation into the sites library or run interactively and create a local library.
+```
+sudo Rscript scripts/install_R_packages.R
+```
+**or**
+```
+R 
+source("scripts/install_R_packages.R")
+```
 
 Creating a Hellbender project in the IntelliJ IDE:
 ----------------

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ task downloadGsaLibFile(type: Download) {
     overwrite false
 }
 
+task installRPackages(type: Exec){
+  executable 'Rscript'
+  args 'scripts/install_R_packages.R'
+  ignoreExitValue true
+}
+
 repositories {
     mavenCentral()
 }
@@ -56,7 +62,7 @@ compileTestJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all']
 }
 
-compileJava.dependsOn downloadGsaLibFile
+installApp.dependsOn downloadGsaLibFile, installRPackages
 build.dependsOn installApp
 check.dependsOn installApp
 
@@ -103,16 +109,25 @@ jar {
 }
 
 test {
+    dependsOn installRPackages
     // enable TestNG support (default is JUnit)
     useTestNG()
 
+    beforeSuite {
+        boolean ROk = installRPackages.execResult.exitValue == 0
+        if (!ROk) {
+            logger.warn( "R package installation failed" )
+        }
+    }
     // set heap size for the test JVM(s)
     minHeapSize = "1G"
     maxHeapSize = "2G"
-
+  
     String CI = "$System.env.CI"
+    String runRTests = "$System.env.RUNR"
     if (CI == "true") {
         int count = 0
+        maxParallelForks = 2
         // listen to events in the test execution lifecycle
         testLogging {
             events "skipped", "failed"
@@ -128,7 +143,7 @@ test {
     } else {
         // show standard out and standard error of the test JVM(s) on the console
         testLogging.showStandardStreams = true
-
+        maxParallelForks = 4 
         beforeTest { descriptor ->
             logger.lifecycle("Running Test: " + descriptor)
         }

--- a/scripts/install_R_packages.R
+++ b/scripts/install_R_packages.R
@@ -1,2 +1,5 @@
-install.packages(c("ggplot2","gplots","reshape","gsalib"), repos="http://cran.cnr.Berkeley.edu" )
+dependencies = c("ggplot2","gplots","reshape","gsalib")
+if (length(setdiff(dependencies, rownames(installed.packages()))) > 0) {
+  install.packages(setdiff(dependencies, rownames(installed.packages())), repos="http://cran.cnr.Berkeley.edu")  
+}
 q(save="no")

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/MarkDuplicates.java
@@ -49,6 +49,10 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             "some of the sorting collections.  If you are running out of memory, try reducing this number.")
     public double SORTING_COLLECTION_SIZE_RATIO = 0.25;
 
+    @Argument(doc = "Report Memory Stats at various times during the run")
+    public boolean reportMemoryStats = false;
+
+
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;
     private SortingCollection<ReadEndsForMarkDuplicates> fragSort;
     private SortingLongCollection duplicateIndexes;
@@ -180,10 +184,12 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
     /** Print out some quick JVM memory stats. */
     private void reportMemoryStats(final String stage) {
-        System.gc();
-        final Runtime runtime = Runtime.getRuntime();
-        log.info(stage + " freeMemory: " + runtime.freeMemory() + "; totalMemory: " + runtime.totalMemory() +
-                "; maxMemory: " + runtime.maxMemory());
+        if(reportMemoryStats) {
+            System.gc();
+            final Runtime runtime = Runtime.getRuntime();
+            log.info(stage + " freeMemory: " + runtime.freeMemory() + "; totalMemory: " + runtime.totalMemory() +
+                    "; maxMemory: " + runtime.maxMemory());
+        }
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
@@ -73,7 +73,7 @@ public class AnalyzeCovariatesIntegrationTest extends CommandLineProgramTest{
      * @throws java.io.IOException should never happen. It would be an
      *    indicator of a problem with the testing environment.
      */
-    @Test
+    @Test(groups = {"R"})
     public void testPdfGeneration()
             throws IOException {
         final File pdfFile = createTempFile("ACTest", ".pdf");
@@ -139,7 +139,7 @@ public class AnalyzeCovariatesIntegrationTest extends CommandLineProgramTest{
      * @param useAfterFile  whether to include the -after input file.
      * @throws java.io.IOException never thrown, unless there is a problem with the testing environment.
      */
-    @Test(dataProvider="alternativeInOutAbsenceCombinations")
+    @Test(groups = {"R"}, dataProvider="alternativeInOutAbsenceCombinations")
     public void testInOutAbsence(final boolean useCsvFile, final boolean usePdfFile,
             final boolean useBQSRFile, final boolean useBeforeFile, final boolean useAfterFile)
             throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptExecutorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptExecutorUnitTest.java
@@ -16,12 +16,12 @@ public class RScriptExecutorUnitTest extends BaseTest {
     private static final String HELLO_WORLD_SCRIPT = "print('hello, world')";
     private static final String GSALIB_LOADED_SCRIPT = "if (!'package:gsalib' %in% search()) stop('gsalib not loaded')";
 
-    @Test
+    @Test(groups = {"R"})
     public void testRscriptExists() {
         Assert.assertTrue(RScriptExecutor.RSCRIPT_EXISTS, "Rscript not found in environment ${PATH}");
     }
 
-    @Test(dependsOnMethods = "testRscriptExists")
+    @Test(groups = {"R"}, dependsOnMethods = "testRscriptExists")
     public void testExistingScript() {
         File script = writeScript(HELLO_WORLD_SCRIPT);
         try {
@@ -33,14 +33,14 @@ public class RScriptExecutorUnitTest extends BaseTest {
         }
     }
 
-    @Test(dependsOnMethods = "testRscriptExists", expectedExceptions = RScriptExecutorException.class)
+    @Test(groups = {"R"}, dependsOnMethods = "testRscriptExists", expectedExceptions = RScriptExecutorException.class)
     public void testNonExistantScriptException() {
         RScriptExecutor executor = new RScriptExecutor();
         executor.addScript(new File("does_not_exists.R"));
         executor.exec();
     }
 
-    @Test(dependsOnMethods = "testRscriptExists")
+    @Test(groups = {"R"}, dependsOnMethods = "testRscriptExists")
     public void testNonExistantScriptNoException() {
         logger.warn("Testing that warning is printed an no exception thrown for missing script.");
         RScriptExecutor executor = new RScriptExecutor();
@@ -49,7 +49,7 @@ public class RScriptExecutorUnitTest extends BaseTest {
         Assert.assertFalse(executor.exec(), "Exec should have returned false when the job failed");
     }
 
-    @Test(dependsOnMethods = "testRscriptExists")
+    @Test(groups = {"R"}, dependsOnMethods = "testRscriptExists")
     public void testLibrary() {
         File script = writeScript(GSALIB_LOADED_SCRIPT);
         try {
@@ -62,7 +62,7 @@ public class RScriptExecutorUnitTest extends BaseTest {
         }
     }
 
-    @Test(dependsOnMethods = "testRscriptExists", expectedExceptions = RScriptExecutorException.class)
+    @Test(groups = {"R"}, dependsOnMethods = "testRscriptExists", expectedExceptions = RScriptExecutorException.class)
     public void testLibraryMissing() {
         File script = writeScript(GSALIB_LOADED_SCRIPT);
         try {

--- a/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptLibraryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/R/RScriptLibraryUnitTest.java
@@ -7,13 +7,13 @@ import org.testng.annotations.Test;
 import java.io.File;
 
 public class RScriptLibraryUnitTest {
-    @Test
+    @Test(groups = {"R"})
     public void testProperties() {
         Assert.assertEquals(RScriptLibrary.GSALIB.getLibraryName(), "gsalib");
         Assert.assertEquals(RScriptLibrary.GSALIB.getResourcePath(), "gsalib.tar.gz");
     }
 
-    @Test
+    @Test(groups = {"R"})
     public void testWriteTemp() {
         File file = RScriptLibrary.GSALIB.writeTemp();
         Assert.assertTrue(file.exists(), "R library was not written to temp file: " + file);


### PR DESCRIPTION
changes to build.gradle
  R package installation is now part of the gradle build
    install_R_packages.R no longer reinstalls existing packages
    a warning will be emitted if this fails

  compilation no longer depends on R installation, installation does

  test run in parallel now
     this is set to use 2 cores on travis and 4 locally

adding a note about our R dependency to the readme

travis changes
  adding caching to travis for dramatic R installation speedup
  updating gradle download because it was using an out of date link

misc changes:
  adding an additional flag to mark duplicates to avoid the garbage collection statistics while integration testing
  tagging tests that depend on R for future use
