### PR TITLE
Disable test suite parallelism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,6 @@ test {
     String runRTests = "$System.env.RUNR"
     if (CI == "true") {
         int count = 0
-        maxParallelForks = 2
         // listen to events in the test execution lifecycle
         testLogging {
             events "skipped", "failed"
@@ -143,7 +142,6 @@ test {
     } else {
         // show standard out and standard error of the test JVM(s) on the console
         testLogging.showStandardStreams = true
-        maxParallelForks = 4 
         beforeTest { descriptor ->
             logger.lifecycle("Running Test: " + descriptor)
         }


### PR DESCRIPTION
We've been experiencing intermittent, inexplicable failures in the test suite.
In a recent travis build, an assertion in MisencodedBaseQualityReadTransformerUnitTest
failed for no reason at all, then passed on the re-run (with no code changes).

My initial suspect is the new test suite parallelism, which based on my experience
with TestNG is a potentially inexhaustible source of weird, impossible-to-reproduce errors.
Let's turn this off for now and see if these intermittent failures go away. The
extra speed isn't worth it if we can't trust the results of our travis builds!
