### PR TITLE
Expose Feature headers, and provide convenient VCFHeader access in VariantWalker

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -84,6 +84,17 @@ public final class FeatureContext {
     }
 
     /**
+     * Gets the header associated with the provided FeatureInput
+     *
+     * @param featureDescriptor FeatureInput whose header we want to retrieve
+     * @param <T> type of Feature in our FeatureInput
+     * @return header for the provided FeatureInput (null if we have no backing data sources)
+     */
+    public <T extends Feature> Object getHeader( final FeatureInput<T> featureDescriptor ) {
+        return featureManager != null ? featureManager.getHeader(featureDescriptor) : null;
+    }
+
+    /**
      * Gets all Features from the source represented by the provided FeatureInput argument that overlap
      * this FeatureContext's query interval. Will return an empty List if this FeatureContext has
      * no backing source of Features and/or interval.

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -477,6 +477,15 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
     }
 
     /**
+     * Gets the header associated with this data source
+     *
+     * @return header associated with this data source as an Object
+     */
+    public Object getHeader() {
+        return featureReader.getHeader();
+    }
+
+    /**
      * Permanently close this data source, invalidating any open iteration over it, and making it invalid for future
      * iterations and queries.
      */

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -224,6 +224,35 @@ public final class FeatureManager implements AutoCloseable {
      *         the provided interval (may be empty if there are none, but never null)
      */
     public <T extends Feature> List<T> getFeatures( final FeatureInput<T> featureDescriptor, final SimpleInterval interval ) {
+        final FeatureDataSource<T> dataSource = lookupDataSource(featureDescriptor);
+
+        // No danger of a ClassCastException here, since we verified that the FeatureDataSource for this
+        // FeatureInput will return Features of the expected type T when we first created the data source
+        // in initializeFeatureSources()
+        return dataSource.queryAndPrefetch(interval);
+    }
+
+    /**
+     * Get the header associated with a particular FeatureInput
+     *
+     * @param featureDescriptor the FeatureInput whose header we want to retrieve
+     * @param <T> type of Feature in our FeatureInput
+     * @return header for the provided FeatureInput
+     */
+    public <T extends Feature> Object getHeader( final FeatureInput<T> featureDescriptor ) {
+        final FeatureDataSource<T> dataSource = lookupDataSource(featureDescriptor);
+        return dataSource.getHeader();
+    }
+
+    /**
+     * Retrieve the data source for a particular FeatureInput. Throws an exception if the provided
+     * FeatureInput is not among our discovered sources of Features.
+     *
+     * @param featureDescriptor FeatureInput whose data source to retrieve
+     * @param <T> type of Feature in our FeatureInput
+     * @return query-able data source for the provided FeatureInput, if it was found
+     */
+    private <T extends Feature> FeatureDataSource<T> lookupDataSource( final FeatureInput<T> featureDescriptor ) {
         @SuppressWarnings("unchecked")
         FeatureDataSource<T> dataSource = (FeatureDataSource<T>)featureSources.get(featureDescriptor);
 
@@ -236,10 +265,7 @@ public final class FeatureManager implements AutoCloseable {
                                                   featureDescriptor.getName(), toolInstance.getClass().getSimpleName()));
         }
 
-        // No danger of a ClassCastException here, since we verified that the FeatureDataSource for this
-        // FeatureInput will return Features of the expected type T when we first created the data source
-        // in initializeFeatureSources()
-        return dataSource.queryAndPrefetch(interval);
+        return dataSource;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.engine;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.SimpleInterval;
+import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
@@ -213,6 +214,17 @@ public abstract class GATKTool extends CommandLineProgram {
      */
     public SAMFileHeader getHeaderForReads() {
         return hasReads() ? reads.getHeader() : null;
+    }
+
+    /**
+     * Returns the header for the specified source of Features
+     *
+     * @param featureDescriptor FeatureInput whose header to retrieve
+     * @param <T> type of Feature in our FeatureInput
+     * @return header for the provided FeatureInput (null if we have no sources of Features)
+     */
+    public <T extends Feature> Object getHeaderForFeatures( final FeatureInput<T> featureDescriptor ) {
+        return hasFeatures() ? features.getHeader(featureDescriptor) : null;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -4,10 +4,12 @@ import htsjdk.samtools.util.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.filters.VariantFilter;
 import org.broadinstitute.hellbender.engine.filters.VariantFilterLibrary;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 
 import java.io.File;
@@ -78,6 +80,21 @@ public abstract class VariantWalker extends GATKTool {
                           new ReferenceContext(reference, variantInterval),
                           new FeatureContext(features, variantInterval));
                 });
+    }
+
+    /**
+     * Gets the header associated with our driving source of variants as a VCFHeader
+     *
+     * @return VCFHeader for our driving source of variants
+     */
+    public VCFHeader getHeaderForVariants() {
+        Object header = drivingVariants.getHeader();
+
+        if ( ! (header instanceof VCFHeader) ) {
+            throw new GATKException("Header for " + drivingVariantFile.getAbsolutePath() + " is not in VCF header format");
+        }
+
+        return (VCFHeader)header;
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.util.SimpleInterval;
 import htsjdk.tribble.Feature;
+import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
@@ -53,4 +54,15 @@ public class FeatureContextUnitTest extends BaseTest {
         Assert.assertTrue(featureContext.getValues(Arrays.<FeatureInput<Feature>>asList(toolInstance.featureArgument), 1).isEmpty(), "Empty FeatureContext should have returned an empty List from getValues()");
     }
 
+    @Test
+    public void testGetHeader() {
+        final ArtificialFeatureContainingCommandLineProgram toolInstance = new ArtificialFeatureContainingCommandLineProgram();
+        final FeatureManager featureManager = new FeatureManager(toolInstance);
+        final FeatureContext featureContext = new FeatureContext(featureManager, new SimpleInterval("1", 1, 1));
+        final Object header = featureContext.getHeader(toolInstance.featureArgument);
+        featureManager.close();
+
+        Assert.assertTrue(header instanceof VCFHeader, "Header for " + toolInstance.featureArgument.getFeatureFile().getAbsolutePath() +
+                                                       " not a VCFHeader");
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.util.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -65,6 +66,15 @@ public class FeatureDataSourceUnitTest extends BaseTest {
         FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>(QUERY_TEST_VCF, new VCFCodec(), "CustomName");
         Assert.assertEquals(featureSource.getName(), "CustomName", "Wrong name returned from getName()");
         featureSource.close();
+    }
+
+    @Test
+    public void testGetHeader() {
+        FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>(QUERY_TEST_VCF, new VCFCodec(), "CustomName");
+        final Object header = featureSource.getHeader();
+        featureSource.close();
+
+        Assert.assertTrue(header instanceof VCFHeader, "Header for " + QUERY_TEST_VCF.getAbsolutePath() + " not a VCFHeader");
     }
 
     @DataProvider(name = "CompleteIterationTestData")


### PR DESCRIPTION
-Within a tool, Feature headers can now be obtained from a FeatureContext within apply(),
 or from the inherited method getHeaderForFeatures() outside of apply() (eg., in onTraversalStart()).

-VariantWalkers have the additional inherited convenience method getHeaderForVariants()
 that returns the header for the driving source of variants typed as a VCFHeader.

-Engine-facing classes FeatureManager and FeatureDataSource now also expose headers.

Requested by Adam
