### PR TITLE
Fix for #309

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
@@ -43,10 +43,11 @@ public @interface Argument {
     String doc() default "Undocumented option";
 
     /**
-     * If set to false, an exception will be thrown if the option is not specified.
-     * If 2 options are mutually exclusive and both are required it will be
-     * interpreted as one or the other is required and an exception will only be thrown if
-     * neither are specified.
+     * If set to false, a {@link org.broadinstitute.hellbender.exceptions.UserException.MissingArgument} will be thrown
+     * if the option is not specified.
+     * If 2 options are mutually exclusive and both are required it will be interpreted as one or the other is required
+     * and an exception will only be thrown if neither are specified.
+     * An argument with a non-null default value specified will ignore this flag and always be treated as optional
      */
     boolean optional() default false;
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.cmdline;
 
 import htsjdk.samtools.util.StringUtil;
-import joptsimple.*;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -657,7 +660,7 @@ public class CommandLineParser {
                         field.getName());
             }
 
-            // If the Collection's parameterized type is itself parameterized (eg., List<Foo<Bar>>),
+            // If the Collection's parametrized type is itself parametrized (eg., List<Foo<Bar>>),
             // return the raw type of the outer parameter (Foo.class, in this example) to avoid a
             // ClassCastException. Otherwise, return the Collection's type parameter directly as a Class.
             return (Class<?>) (genericTypes[0] instanceof ParameterizedType ?
@@ -756,7 +759,6 @@ public class CommandLineParser {
             this.fullName = annotation.fullName();
             this.shortName = annotation.shortName();
             this.doc = annotation.doc();
-            this.optional = annotation.optional() || getFieldValue() != null ;
             this.isCollection = isCollectionField(field);
 
             if ( this.isFlag()){
@@ -769,7 +771,6 @@ public class CommandLineParser {
             this.isCommon = annotation.common();
             this.isSpecial = annotation.special();
 
-
             this.mutuallyExclusive = new HashSet<>(Arrays.asList(annotation.mutex()));
 
             Object tmpDefault = getFieldValue();
@@ -778,12 +779,16 @@ public class CommandLineParser {
                     //treat empty collections the same as uninitialized primitive types
                     this.defaultValue = NULL_STRING;
                 } else {
-                    //this is an intialized primitive type or a non-empty collection
+                    //this is an initialized primitive type or a non-empty collection
                     this.defaultValue = tmpDefault.toString();
                 }
             } else {
                 this.defaultValue = NULL_STRING;
             }
+
+            //null collections have been initialized by createCollection which is called in handleArgumentAnnotation
+            //this is optional if it's specified as being optional or if there is a default value specified
+            this.optional = annotation.optional() || ! this.defaultValue.equals(NULL_STRING);
         }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -183,6 +183,23 @@ public class CommandLineParserTest {
         clp.parseArguments(System.err, args);
     }
 
+    class CollectionRequired{
+        @Argument(optional = false)
+        List<Integer> ints;
+
+        @Argument
+        String something;
+    }
+
+    @Test(expectedExceptions = UserException.MissingArgument.class)
+    public void testMissingRequiredCollectionArgument(){
+        final String[] args = {};
+        final CollectionRequired cr = new CollectionRequired();
+        final CommandLineParser clp = new CommandLineParser(cr);
+        clp.parseArguments(System.err, args);
+        Assert.fail("Should have thrown a MissingArgument");
+    }
+
     @Test( expectedExceptions = UserException.BadArgumentValue.class)
     public void testBadValue() {
         final String[] args = {
@@ -416,7 +433,6 @@ public class CommandLineParserTest {
     public void testCollectionThatCannotBeAutoInitialized() {
         final UninitializedCollectionThatCannotBeAutoInitializedArguments o = new UninitializedCollectionThatCannotBeAutoInitializedArguments();
         new CommandLineParser(o);
-        Assert.fail("Exception should have been thrown");
     }
 
     class CollectionWithDefaultValuesArguments {
@@ -535,7 +551,6 @@ public class CommandLineParserTest {
     public void testBadFieldCausesException(){
         WithBadField o = new WithBadField();
         final CommandLineParser clp = new CommandLineParser(o);
-        Assert.fail(); //shouldn't reach here
     }
 
     class PrivateArgument{


### PR DESCRIPTION
Argument parser was incorrectly marking collection arguments as optional.
To maintain campatibility with picard style arguments it marks any argument with a default value as optional.
This was incorrectly flagging empty lists as having a default because they were non-null.
