### PR TITLE
adding a defensive copy to the byte[] in ArtificialSamUtils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
@@ -1,28 +1,3 @@
-/*
-* Copyright (c) 2012 The Broad Institute
-* 
-* Permission is hereby granted, free of charge, to any person
-* obtaining a copy of this software and associated documentation
-* files (the "Software"), to deal in the Software without
-* restriction, including without limitation the rights to use,
-* copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following
-* conditions:
-* 
-* The above copyright notice and this permission notice shall be
-* included in all copies or substantial portions of the Software.
-* 
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 package org.broadinstitute.hellbender.transformers;
 
 import htsjdk.samtools.SAMRecord;

--- a/src/main/java/org/broadinstitute/hellbender/utils/sam/ArtificialSAMUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/sam/ArtificialSAMUtils.java
@@ -95,8 +95,8 @@ public class ArtificialSAMUtils {
             throw new IllegalArgumentException("Passed in read string is different length then the quality array");
         }
         SAMRecord rec = createArtificialRead(header, name, refIndex, alignmentStart, bases.length);
-        rec.setReadBases(bases);
-        rec.setBaseQualities(qual);
+        rec.setReadBases(Arrays.copyOf(bases, bases.length));
+        rec.setBaseQualities(Arrays.copyOf(qual, qual.length));
         rec.setAttribute(SAMTag.PG.name(), new SAMReadGroupRecord("x").getId());
         if (refIndex == -1) {
             rec.setReadUnmappedFlag(true);
@@ -155,7 +155,7 @@ public class ArtificialSAMUtils {
     }
 
 
-    public final static List<SAMRecord> createPair(SAMFileHeader header, String name, int readLen, int leftStart, int rightStart, boolean leftIsFirst, boolean leftIsNegative) {
+    public static List<SAMRecord> createPair(SAMFileHeader header, String name, int readLen, int leftStart, int rightStart, boolean leftIsFirst, boolean leftIsNegative) {
         SAMRecord left = ArtificialSAMUtils.createArtificialRead(header, name, 0, leftStart, readLen);
         SAMRecord right = ArtificialSAMUtils.createArtificialRead(header, name, 0, rightStart, readLen);
 

--- a/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
@@ -1,28 +1,3 @@
-/*
-* Copyright (c) 2012 The Broad Institute
-* 
-* Permission is hereby granted, free of charge, to any person
-* obtaining a copy of this software and associated documentation
-* files (the "Software"), to deal in the Software without
-* restriction, including without limitation the rights to use,
-* copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following
-* conditions:
-* 
-* The above copyright notice and this permission notice shall be
-* included in all copies or substantial portions of the Software.
-* 
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 package org.broadinstitute.hellbender.transformers;
 
 
@@ -40,9 +15,6 @@ import org.testng.annotations.Test;
  */
 public class MisencodedBaseQualityReadTransformerUnitTest extends BaseTest {
 
-    private static final byte[] badQuals = { 59, 60, 62, 63, 64, 61, 62, 58, 57, 56 };
-    private static final byte[] goodQuals = { 60, 60, 60, 60, 60, 60, 60, 60, 60, 60 };
-    private static final byte[] fixedQuals = { 28, 29, 31, 32, 33, 30, 31, 27, 26, 25 };
     private SAMFileHeader header;
 
     @BeforeMethod
@@ -57,16 +29,19 @@ public class MisencodedBaseQualityReadTransformerUnitTest extends BaseTest {
         return read;
     }
 
-    @Test(enabled = true)
+    @Test
     public void testGoodQuals() {
+        final byte[] goodQuals = { 60, 60, 60, 60, 60, 60, 60, 60, 60, 60 };
         final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
         SAMRecord read = createRead(goodQuals);
         SAMRecord newRead = tr.apply(read);
         Assert.assertEquals(read, newRead);
     }
 
-    @Test(enabled = true)
+    @Test
     public void testFixBadQuals() {
+        final byte[] fixedQuals = { 28, 29, 31, 32, 33, 30, 31, 27, 26, 25 };
+        final byte[] badQuals = { 59, 60, 62, 63, 64, 61, 62, 58, 57, 56 };
         final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
         final SAMRecord read = createRead(badQuals);
         final SAMRecord fixedRead = tr.apply(read);
@@ -75,6 +50,7 @@ public class MisencodedBaseQualityReadTransformerUnitTest extends BaseTest {
 
     @Test(expectedExceptions = UserException.BadInput.class)
     public void testFixGoodQualsBlowUp() {
+        final byte[] fixedQuals = { 28, 29, 31, 32, 33, 30, 31, 27, 26, 25 };
         final ReadTransformer tr = new MisencodedBaseQualityReadTransformer();
         final SAMRecord read = createRead(fixedQuals);
         tr.apply(read);


### PR DESCRIPTION
hopeful this will fix transient errors in MisencodedBaseQualityReadTransformerTest (see #311)
