### PR TITLE
Move SimpleInterval to hellbender, and add overlaps()/contains()/size() methods

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -2,7 +2,7 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 
 import java.util.ArrayList;

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.*;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import org.apache.commons.lang3.tuple.Pair;

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKDataSource.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.util.Iterator;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;

--- a/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 /**
  * An IntervalWalker is a tool that processes a single interval at a time, with the ability to query

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.util.Collections;
 import java.util.Iterator;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.engine;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceContext.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.reference.ReferenceSequence;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.iterators.ByteArrayIterator;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.iterators.ByteArrayIterator;

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.variant.variantcontext.VariantContext;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.tools.examples;
 
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -1,11 +1,13 @@
-package htsjdk.samtools.util;
+package org.broadinstitute.hellbender.utils;
 
+
+import htsjdk.samtools.util.Locatable;
 
 /**
  * Minimal immutable class representing a 1-based closed ended genomic interval
  * SimpleInterval does not allow null contig names.  It cannot represent an unmapped Locatable.
  *
- *@warning 0 length intervals are allowed, which are represented as end = start-1
+ *@warning 0 length intervals are NOT currently allowed, but support may be added in the future
  */
 public class SimpleInterval implements Locatable {
 
@@ -20,14 +22,14 @@ public class SimpleInterval implements Locatable {
      * @param end  1-based inclusive end position
      */
     public SimpleInterval(final String contig, final int start, final int end){
-        if(contig == null){
+        if ( contig == null ) {
             throw new IllegalArgumentException("contig cannot be null");
         }
-        if (start <= 0 ){
+        if ( start <= 0 ) {
             throw new IllegalArgumentException("SimpleInterval is 1 based, so start must be >= 1, start:%d" + start);
         }
-        if (end < start -1){
-            throw new IllegalArgumentException( String.format("end must be >= start -1 . start:%d end:%d", start, end));
+        if ( end < start ) {
+            throw new IllegalArgumentException(String.format("end must be >= start. start:%d end:%d", start, end));
         }
         this.contig = contig;
         this.start = start;
@@ -75,8 +77,43 @@ public class SimpleInterval implements Locatable {
 
     /**
      * @return the 1-based closed-ended end position of the interval on the contig.
-     * @warning in the case of a 0-length interval getEnd() == getStart - 1 */
+     */
     public final int getEnd(){
         return end;
+    }
+
+    /**
+     * @return number of bases covered by this interval (will always be > 0)
+     */
+    public final int size() {
+        return end - start + 1;
+    }
+
+    /**
+     * Determines whether this interval overlaps the provided interval.
+     *
+     * @param other interval to check
+     * @return true if this interval overlaps other, otherwise false
+     */
+    public final boolean overlaps( final SimpleInterval other ) {
+        if ( other == null ) {
+            return false;
+        }
+
+        return this.contig.equals(other.contig) && this.start <= other.end && other.start <= this.end;
+    }
+
+    /**
+     * Determines whether this interval contains the entire region represented by other
+     *
+     * @param other interval to check
+     * @return true if this interval contains all of the bases spanned by other, otherwise false
+     */
+    public final boolean contains( final SimpleInterval other ) {
+        if ( other == null ) {
+            return false;
+        }
+
+        return this.contig.equals(other.contig) && this.start <= other.start && this.end >= other.end;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.GenomeLoc;

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.hellbender.cmdline.Argument;

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
@@ -14,7 +14,6 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.codecs.hapmap.RawHapMapCodec;
-import org.broadinstitute.hellbender.utils.codecs.table.TableCodec;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
@@ -2,11 +2,9 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
-import htsjdk.samtools.util.SimpleInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.GenomeLoc;
-import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
@@ -1,0 +1,133 @@
+package org.broadinstitute.hellbender.utils;
+
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SimpleIntervalUnitTest extends BaseTest {
+
+    @DataProvider(name = "badIntervals")
+    public Object[][] badIntervals(){
+        return new Object[][]{
+                {null,1,12, "null contig"},
+                {"1", 0, 10, "start==0"},
+                {"1", -10, 10, "negative start"},
+                {"1", 10, 9, "end < start"}
+        };
+    }
+
+    @Test(dataProvider = "badIntervals", expectedExceptions = IllegalArgumentException.class)
+    public void badIntervals(String contig, int start, int end, String name){
+        SimpleInterval interval = new SimpleInterval(contig, start, end);
+    }
+
+    @Test
+    public void testEquality(){
+        final SimpleInterval i1 = new SimpleInterval("1",1,100);
+        final SimpleInterval i2 = new SimpleInterval("1",1,100);
+        final SimpleInterval i3 = new SimpleInterval("chr1", 1, 100);
+        final SimpleInterval i4 = new SimpleInterval("chr1", 2, 100);
+        final SimpleInterval i5 = new SimpleInterval("chr1", 1, 200);
+
+        Assert.assertTrue(i1.equals(i1));
+        Assert.assertTrue(i1.equals(i2));
+        Assert.assertTrue(i2.equals(i1));
+        Assert.assertFalse(i1.equals(i3));
+        Assert.assertFalse(i1.equals(i4));
+        Assert.assertFalse(i1.equals(i5));
+    }
+
+    @Test
+    public void testToString(){
+        final SimpleInterval i1 = new SimpleInterval("1",1,100);
+        Assert.assertEquals(i1.toString(), "1:1-100");
+    }
+
+    @DataProvider(name = "IntervalSizeData")
+    public Object[][] getIntervalSizeData() {
+        // Intervals + expected sizes
+        return new Object[][]{
+                { new SimpleInterval("1", 1, 1), 1 },
+                { new SimpleInterval("1", 1, 2), 2 },
+                { new SimpleInterval("1", 1, 10), 10 },
+                { new SimpleInterval("1", 2, 10), 9 }
+        };
+    }
+
+    @Test(dataProvider = "IntervalSizeData")
+    public void testGetSize( final SimpleInterval interval, final int expectedSize ) {
+        Assert.assertEquals(interval.size(), expectedSize, "size() incorrect for interval " + interval);
+    }
+
+    @DataProvider(name = "IntervalOverlapData")
+    public Object[][] getIntervalOverlapData() {
+        final SimpleInterval standardInterval = new SimpleInterval("1", 10, 20);
+        final SimpleInterval oneBaseInterval = new SimpleInterval("1", 10, 10);
+
+        return new Object[][] {
+                { standardInterval, new SimpleInterval("2", 10, 20), false },
+                { standardInterval, new SimpleInterval("1", 1, 5), false },
+                { standardInterval, new SimpleInterval("1", 1, 9), false },
+                { standardInterval, new SimpleInterval("1", 1, 10), true },
+                { standardInterval, new SimpleInterval("1", 1, 15), true },
+                { standardInterval, new SimpleInterval("1", 10, 10), true },
+                { standardInterval, new SimpleInterval("1", 10, 15), true },
+                { standardInterval, new SimpleInterval("1", 10, 20), true },
+                { standardInterval, new SimpleInterval("1", 15, 20), true },
+                { standardInterval, new SimpleInterval("1", 15, 25), true },
+                { standardInterval, new SimpleInterval("1", 20, 20), true },
+                { standardInterval, new SimpleInterval("1", 20, 25), true },
+                { standardInterval, new SimpleInterval("1", 21, 25), false },
+                { standardInterval, new SimpleInterval("1", 25, 30), false },
+                { oneBaseInterval, new SimpleInterval("2", 10, 10), false },
+                { oneBaseInterval, new SimpleInterval("1", 1, 5), false },
+                { oneBaseInterval, new SimpleInterval("1", 1, 9), false },
+                { oneBaseInterval, new SimpleInterval("1", 1, 10), true },
+                { oneBaseInterval, new SimpleInterval("1", 10, 10), true },
+                { oneBaseInterval, new SimpleInterval("1", 10, 15), true },
+                { oneBaseInterval, new SimpleInterval("1", 11, 15), false },
+                { oneBaseInterval, new SimpleInterval("1", 15, 20), false },
+                { standardInterval, null, false },
+                { standardInterval, standardInterval, true }
+        };
+    }
+
+    @Test(dataProvider = "IntervalOverlapData")
+    public void testOverlap( final SimpleInterval firstInterval, final SimpleInterval secondInterval, final boolean expectedOverlapResult ) {
+        Assert.assertEquals(firstInterval.overlaps(secondInterval), expectedOverlapResult,
+                            "overlap() returned incorrect result for intervals " + firstInterval + " and " + secondInterval);
+    }
+
+    @DataProvider(name = "IntervalContainsData")
+    public Object[][] getIntervalContainsData() {
+        final SimpleInterval containingInterval = new SimpleInterval("1", 10, 20);
+
+        return new Object[][] {
+                { containingInterval, new SimpleInterval("2", 10, 20), false },
+                { containingInterval, new SimpleInterval("1", 1, 5), false },
+                { containingInterval, new SimpleInterval("1", 1, 10), false },
+                { containingInterval, new SimpleInterval("1", 5, 15), false },
+                { containingInterval, new SimpleInterval("1", 9, 10), false },
+                { containingInterval, new SimpleInterval("1", 9, 20), false },
+                { containingInterval, new SimpleInterval("1", 10, 10), true },
+                { containingInterval, new SimpleInterval("1", 10, 15), true },
+                { containingInterval, new SimpleInterval("1", 10, 20), true },
+                { containingInterval, new SimpleInterval("1", 10, 21), false },
+                { containingInterval, new SimpleInterval("1", 15, 25), false },
+                { containingInterval, new SimpleInterval("1", 20, 20), true },
+                { containingInterval, new SimpleInterval("1", 20, 21), false },
+                { containingInterval, new SimpleInterval("1", 20, 25), false },
+                { containingInterval, new SimpleInterval("1", 21, 25), false },
+                { containingInterval, new SimpleInterval("1", 25, 30), false },
+                { containingInterval, null, false },
+                { containingInterval, containingInterval, true }
+        };
+    }
+
+    @Test(dataProvider = "IntervalContainsData")
+    public void testContains( final SimpleInterval firstInterval, final SimpleInterval secondInterval, final boolean expectedContainsResult ) {
+        Assert.assertEquals(firstInterval.contains(secondInterval), expectedContainsResult,
+                            "contains() returned incorrect result for intervals " + firstInterval + " and " + secondInterval);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.utils.test;
 
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.util.SimpleInterval;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.variantcontext.Genotype;


### PR DESCRIPTION
-We've decided to develop SimpleInterval in hellbender for now so that we don't
 have to deal with the tricky politics of standardization across htsjdk (though
 we will eventually address this when we're ready).

-Locatable interface remains in htsjdk, so a small victory there.

-Added overlaps()/contains()/size() methods to SimpleInterval.

-Removed support for zero-length intervals for now, since none of our current
 query interfaces support it, and it complicates basic interval operations.
 Will open a ticket to investigate whether support for zero-length intervals
 will be needed given GA4GH query interfaces, future representation of
 insertions, etc.

Resolves #305
