### PR TITLE
improving output of command line inputs

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -149,9 +149,9 @@ public class CommandLineParserTest {
         Assert.assertEquals(clp.getCommandLine(),
                 "org.broadinstitute.hellbender.cmdline.CommandLineParserTest$FrobnicateArguments  " +
                         "positional1 positional2 --FROBNICATION_THRESHOLD 17 --FROBNICATION_FLAVOR BAR " +
-                        "--SHMIGGLE_TYPE [shmiggle1, shmiggle2] --TRUTHINESS true    --help false --version false");
+                        "--SHMIGGLE_TYPE shmiggle1 --SHMIGGLE_TYPE shmiggle2 --TRUTHINESS true  --help false " +
+                        "--version false");
     }
-
 
     @Test
     public void testDefault() {


### PR DESCRIPTION
`CommandLineParser.getCommandLine()` now outputs arguments that have collection values as
a list of pairs in the form `--name value1 --name value2 ...`
previously it was `--name [value1,value2,...]`

this allows the command line to be copy/pasted for ease of use

this should close #318 
