### PR TITLE
improving cli treatment of collection arguments

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
@@ -59,12 +59,6 @@ public @interface Argument {
      */
     String[] mutex() default {};
 
-    /** The minimum number of times that this option is required. */
-    int minElements() default 0;
-
-    /** The maximum number of times this option is allowed. */
-    int maxElements() default Integer.MAX_VALUE;
-
     /**
      * Is this an Option common to all command line programs.  If it is then it will only
      * be displayed in usage info when H or STDHELP is used to display usage.

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/SpecialArgumentsCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/SpecialArgumentsCollection.java
@@ -20,7 +20,7 @@ public class SpecialArgumentsCollection implements ArgumentCollectionDefinition 
     @Argument(fullName = VERSION_FULLNAME, doc="display the version number for this tool", special = true)
     public boolean VERSION = false;
 
-    @Argument(fullName = ARGUMENTS_FILE_FULLNAME, doc="read one or more arguments files and add them to the command line", special = true)
+    @Argument(fullName = ARGUMENTS_FILE_FULLNAME, doc="read one or more arguments files and add them to the command line", optional = true, special = true)
     public List<File> ARGUMENTS_FILE = new ArrayList<>();
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -20,7 +20,7 @@ public class IntervalArgumentCollection implements ArgumentCollectionDefinition 
      * You can use samtools-style intervals either explicitly on the command line (e.g. -L 1 or -L 1:100-200) or
      * by loading in a file containing a list of intervals (e.g. -L myFile.intervals).
      */
-    @Argument(fullName = "intervals", shortName = "L", doc = "One or more genomic intervals over which to operate")
+    @Argument(fullName = "intervals", shortName = "L", doc = "One or more genomic intervals over which to operate", optional = true)
     final protected List<String> intervalStrings = new ArrayList<>();
 
     /**
@@ -30,7 +30,7 @@ public class IntervalArgumentCollection implements ArgumentCollectionDefinition 
      * (e.g. -XL myFile.intervals).
      *
      * */
-    @Argument(fullName = "excludeIntervals", shortName = "XL", doc = "One or more genomic intervals to exclude from processing")
+    @Argument(fullName = "excludeIntervals", shortName = "XL", doc = "One or more genomic intervals to exclude from processing", optional = true)
     final protected List<String> excludeIntervalStrings = new ArrayList<>();
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -27,7 +27,7 @@ public abstract class VariantWalker extends GATKTool {
 
     // NOTE: using File rather than FeatureInput<VariantContext> here so that we can keep this driving source
     //       of variants separate from any other potential sources of Features
-    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "A VCF/BCF file containing variants", common = false, optional = false, minElements = 1)
+    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "A VCF/BCF file containing variants", common = false, optional = false)
     public File drivingVariantFile;
 
     // NOTE: keeping the driving source of variants separate from other, supplementary FeatureInputs in our FeatureManager in GATKTool

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignment.java
@@ -3,8 +3,10 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.SamPairUtil;
-import htsjdk.samtools.util.Log;
-import org.broadinstitute.hellbender.cmdline.*;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.sam.mergealignment.*;
@@ -96,12 +98,14 @@ public class MergeBamAlignment extends PicardCommandLineProgram {
     public int MAX_INSERTIONS_OR_DELETIONS = 1;
 
     @Argument(doc = "Reserved alignment attributes (tags starting with X, Y, or Z) that should be " +
-            "brought over from the alignment data when merging.")
-    public List<String> ATTRIBUTES_TO_RETAIN = new ArrayList<String>();
+            "brought over from the alignment data when merging.",
+             optional = true)
+    public List<String> ATTRIBUTES_TO_RETAIN = new ArrayList<>();
 
     @Argument(doc = "Attributes from the alignment record that should be removed when merging." +
-            "  This overrides ATTRIBUTES_TO_RETAIN if they share common tags.")
-    public List<String> ATTRIBUTES_TO_REMOVE = new ArrayList<String>();
+            "  This overrides ATTRIBUTES_TO_RETAIN if they share common tags.",
+            optional = true)
+    public List<String> ATTRIBUTES_TO_REMOVE = new ArrayList<>();
 
     @Argument(shortName = "R1_TRIM",
             doc = "The number of bases trimmed from the beginning of read 1 prior to alignment")
@@ -146,8 +150,6 @@ public class MergeBamAlignment extends PicardCommandLineProgram {
 
     @Argument(shortName = "MC", optional = true, doc = "Adds the mate CIGAR tag (MC) if true, does not if false.")
     public Boolean ADD_MATE_CIGAR = true;
-
-    private static final Log log = Log.getInstance(MergeBamAlignment.class);
 
     /**
      * Mechanism to bridge between command line option and PrimaryAlignmentSelectionStrategy implementation.

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFiles.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class MergeSamFiles extends PicardCommandLineProgram {
     private static final Log log = Log.getInstance(MergeSamFiles.class);
 
-    @Argument(shortName = "I", doc = "SAM or BAM input file", minElements = 1)
+    @Argument(shortName = "I", doc = "SAM or BAM input file", optional=false)
     public List<File> INPUT = new ArrayList<File>();
 
     @Argument(shortName = "O", doc = "SAM or BAM file to write merged result to")

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFile.java
@@ -41,8 +41,8 @@ public class ValidateSamFile extends PicardCommandLineProgram {
             doc = "Mode of output")
     public Mode MODE = Mode.VERBOSE;
 
-    @Argument(doc = "List of validation error types to ignore.")
-    public List<SAMValidationError.Type> IGNORE = new ArrayList<SAMValidationError.Type>();
+    @Argument(doc = "List of validation error types to ignore.", optional = true)
+    public List<SAMValidationError.Type> IGNORE = new ArrayList<>();
 
     @Argument(shortName = "MO",
             doc = "The maximum number of lines output in verbose mode")

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -36,7 +36,7 @@ public class CommandLineParserTest {
         @Argument
         public FrobnicationFlavor FROBNICATION_FLAVOR;
 
-        @Argument(doc="Allowed shmiggle types.", minElements=1, maxElements = 3)
+        @Argument(doc="Allowed shmiggle types.", optional = false)
         public List<String> SHMIGGLE_TYPE = new ArrayList<>();
 
         @Argument
@@ -55,7 +55,7 @@ public class CommandLineParserTest {
         @Argument
         public FrobnicationFlavor FROBNICATION_FLAVOR;
 
-        @Argument(doc="Allowed shmiggle types.", minElements=1, maxElements = 3)
+        @Argument(doc="Allowed shmiggle types.", optional = false)
         public List<String> SHMIGGLE_TYPE = new ArrayList<>();
 
         @Argument
@@ -186,9 +186,6 @@ public class CommandLineParserTest {
     class CollectionRequired{
         @Argument(optional = false)
         List<Integer> ints;
-
-        @Argument
-        String something;
     }
 
     @Test(expectedExceptions = UserException.MissingArgument.class)
@@ -197,7 +194,6 @@ public class CommandLineParserTest {
         final CollectionRequired cr = new CollectionRequired();
         final CommandLineParser clp = new CommandLineParser(cr);
         clp.parseArguments(System.err, args);
-        Assert.fail("Should have thrown a MissingArgument");
     }
 
     @Test( expectedExceptions = UserException.BadArgumentValue.class)
@@ -236,23 +232,6 @@ public class CommandLineParserTest {
         final String[] args = {
                 "--FROBNICATION_FLAVOR","BAR",
                 "--TRUTHINESS","False",
-                "positional1",
-                "positional2",
-        };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
-    }
-
-    @Test( expectedExceptions = UserException.CommandLineException.class)
-    public void testTooManyListArgument() {
-        final String[] args = {
-                "--FROBNICATION_FLAVOR","BAR",
-                "--TRUTHINESS","False",
-                "--SHMIGGLE_TYPE","shmiggle1",
-                "--SHMIGGLE_TYPE","shmiggle2",
-                "--SHMIGGLE_TYPE","shmiggle3",
-                "--SHMIGGLE_TYPE","shmiggle4",
                 "positional1",
                 "positional2",
         };
@@ -557,7 +536,7 @@ public class CommandLineParserTest {
         @Argument
         private boolean privateArgument = false;
 
-        @Argument
+        @Argument(optional = true)
         private List<Integer> privateCollection = new ArrayList<>();
 
         @ArgumentCollection


### PR DESCRIPTION
removing min/max element options in argument
  these sound nice, but they were only ever used to indicate that an argument was required or not.
  they did not play nicely with optional, which is already confusing enough

fixed a broken test that wasn't actually testing anything

closes #315 
