### PR TITLE
fix and test for missing contig in seq dict

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -2,9 +2,11 @@ package org.broadinstitute.hellbender.exceptions;
 
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.ValidateVariants;
 import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -345,6 +347,14 @@ public class UserException extends RuntimeException {
             this.type = type;
         }
     }
+
+    public static class MissingContigInSequenceDictionary extends UserException {
+        public MissingContigInSequenceDictionary(String contigName, SAMSequenceDictionary dict1) {
+            super(String.format("Contig %s not present in the sequence dictionary %s\n",
+                    contigName, ReadUtils.prettyPrintSequenceRecords(dict1)));
+        }
+    }
+
 }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
@@ -282,6 +282,9 @@ public class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceFile {
         } else {
             // todo -- potential optimization is to check if contig.name == contig, as this in general will be true
             SAMSequenceRecord contigInfo = super.getSequenceDictionary().getSequence(contig);
+            if (contigInfo == null){
+                throw new UserException.MissingContigInSequenceDictionary(contig, super.getSequenceDictionary());
+            }
 
             if (stop > contigInfo.getSequenceLength())
                 throw new SAMException("Query asks for data past end of contig. Query contig " + contig + " start:" + start + " stop:" + stop + " contigLength:" +  contigInfo.getSequenceLength());

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -60,6 +60,15 @@ public class ReadUtils {
         return read.getReadBases() == null || read.getReadLength() == 0;
     }
 
+    public static String prettyPrintSequenceRecords ( SAMSequenceDictionary sequenceDictionary ) {
+        String[] sequenceRecordNames = new String[sequenceDictionary.size()];
+        int sequenceRecordIndex = 0;
+        for (SAMSequenceRecord sequenceRecord : sequenceDictionary.getSequences()) {
+            sequenceRecordNames[sequenceRecordIndex++] = sequenceRecord.getSequenceName();
+        }
+        return Arrays.deepToString(sequenceRecordNames);
+    }
+
     /**
      * A marker to tell which end of the read has been clipped
      */

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
@@ -88,4 +88,19 @@ public class BaseRecalibratorIntegrationTest extends CommandLineProgramTest{
                 UserException.CommandLineException.class);
         spec.executeTest("testBQSRFailWithoutDBSNP", this);
     }
+
+    @Test
+    public void testBQSRFailWithIncompatibleReference() throws IOException {
+        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+
+        final String HiSeqBam_Hg18 = resourceDir + "HiSeq.1mb.1RG.2k_lines.bam";
+
+        final String  NO_ARGS = "";
+        final BQSRTest params = new BQSRTest(hg19MiniReference, HiSeqBam_Hg18, hg19_chr1_1M_dbSNP, NO_ARGS, resourceDir + "expected.txt");
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                params.getCommandLine(),
+                1,
+                UserException.MissingContigInSequenceDictionary.class);
+        spec.executeTest("testBQSRFailWithIncompatibleReference", this);
+    }
 }


### PR DESCRIPTION
Fixed bug #355.
The problem was that reads and reference file had incompatible sequence dictionaries. 
@jean-philippe-martin please review and confirm that the NPE is fixed. @lbergelson please review for merging. 

The result now is something like this:
`A USER ERROR has occurred: Contig chr1 not present in the sequence dictionary [17]`
