### PR TITLE
BaseRecalibratorDataflowIntegrationTest on SparkPipelineRunner

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/HadoopReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/HadoopReferenceSequenceFileFactory.java
@@ -20,15 +20,20 @@ public class HadoopReferenceSequenceFileFactory {
 
     public static ReferenceSequenceFile getReferenceSequenceFile(Path fastaFile) throws IOException {
         Path fastaIndexFile = getFastaIndexFileName(fastaFile);
+        Path fastaDictFile = getFastaDictFileName(fastaFile);
 
         File tempDir = Files.createTempDir();
         File localFakeFastaFile = new File(tempDir, fastaFile.getName());
         File localFastaIndexFile = new File(tempDir, fastaIndexFile.getName());
+        File localFastaDictFile = new File(tempDir, fastaDictFile.getName());
 
         localFakeFastaFile.createNewFile(); // create empty file to satisfy IndexedFastaSequenceFile; we'll actually read from HDFS
 
         FileSystem fs = fastaFile.getFileSystem(new Configuration());
         fs.copyToLocalFile(fastaIndexFile, new Path(localFastaIndexFile.toString()));
+        if (fs.exists(fastaDictFile)) {
+            fs.copyToLocalFile(fastaDictFile, new Path(localFastaDictFile.toString()));
+        }
 
         HadoopFastaSequenceIndex index = new HadoopFastaSequenceIndex(localFastaIndexFile);
         FastaSequenceIndex indexCopy = new FastaSequenceIndex(localFastaIndexFile);
@@ -37,6 +42,10 @@ public class HadoopReferenceSequenceFileFactory {
 
     private static Path getFastaIndexFileName(Path fastaFile) {
         return new Path(fastaFile.toUri().toString() + ".fai");
+    }
+
+    private static Path getFastaDictFileName(Path fastaFile) {
+        return new Path(fastaFile.toUri().toString().replaceFirst(".fasta$", ".dict"));
     }
 
     static class HadoopIndexedFastaSequenceFile extends IndexedFastaSequenceFile {


### PR DESCRIPTION
This gets BaseRecalibratorDataflowIntegrationTest running on Spark.

I noticed that the test with "-knownSites" from BaseRecalibratorIntegrationTest (i.e. the non-dataflow version) fails with both the Direct and Spark runners. I had a look at the file output and there are a few discrepancies (see diff below). Any thoughts on how to fix this? I've commented out the test in this PR.

```
diff /var/folders/d1/8f5_j4hx04z72w6wgqxkb2l40000gn/T/walktest.tmp_param.02172067147450353519.tmp src/test/resources/org/broadinstitute/hellbender/tools/BQSR/expected.NA12878.chr17_69k_70k.2inputs.txt
60c60
<           34   3051              34
---
>           34   3050              34
71c71
<           45  46942              45
---
>           45  46940              45
124,126c124,126
< 809R9ABXX101220.5  D                   45.0000             45.0000         23471    0.00
< 809R9ABXX101220.5  I                   45.0000             45.0000         23471    0.00
< 809R9ABXX101220.5  M                   27.0000             27.0494         23471   49.13
---
> 809R9ABXX101220.5  D                   45.0000             45.0000         23470    0.00
> 809R9ABXX101220.5  I                   45.0000             45.0000         23470    0.00
> 809R9ABXX101220.5  M                   27.0000             27.0493         23470   49.13
155c155
< 809R9ABXX101220.5            34  M                   34.0000          3051    2.96
---
> 809R9ABXX101220.5            34  M                   34.0000          3050    2.96
161,162c161,162
< 809R9ABXX101220.5            45  D                   45.0000         23471    0.00
< 809R9ABXX101220.5            45  I                   45.0000         23471    0.00
---
> 809R9ABXX101220.5            45  D                   45.0000         23470    0.00
> 809R9ABXX101220.5            45  I                   45.0000         23470    0.00
2714c2714
< 809R9ABXX101220.5            34  29              Cycle          M                   34.0000            20    0.00
---
> 809R9ABXX101220.5            34  29              Cycle          M                   34.0000            19    0.00
2773c2773
< 809R9ABXX101220.5            34  CA              Context        M                   34.0000           506    0.00
---
> 809R9ABXX101220.5            34  CA              Context        M                   34.0000           505    0.00
3464,3465c3464,3465
< 809R9ABXX101220.5            45  29              Cycle          D                   45.0000           180    0.00
< 809R9ABXX101220.5            45  29              Cycle          I                   45.0000           180    0.00
---
> 809R9ABXX101220.5            45  29              Cycle          D                   45.0000           179    0.00
> 809R9ABXX101220.5            45  29              Cycle          I                   45.0000           179    0.00
3634,3635c3634,3635
< 809R9ABXX101220.5            45  GCA             Context        D                   45.0000           278    0.00
< 809R9ABXX101220.5            45  GCA             Context        I                   45.0000           278    0.00
---
> 809R9ABXX101220.5            45  GCA             Context        D                   45.0000           277    0.00
> 809R9ABXX101220.5            45  GCA             Context        I                   45.0000           277    0.00
```