### PR TITLE
removing irrelevant builds from each travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ jdk:
 env:
   matrix:
   - CLOUD=mandatory
-  - CLOUD=todo
   - CLOUD=false
-  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false SPARK=false
   global:
   #gradle needs this
   - TERM=dumb
@@ -32,7 +30,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false SPARK=false
     - env: CLOUD=todo
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -234,13 +234,10 @@ test {
             excludeGroups 'cloud', 'bucket', 'cloud_todo', 'bucket_todo'
         }
         if (SPARK == "false") {
-            // exclude Spark (but not Spark Dataflow, see DATAFLOW_RUNNER env variable) if explicitly requested
+            // exclude Spark tests
             excludeGroups 'spark'
         }
     }
-
-    // ensure dataflowRunner is passed to the test VM if specified on the command line
-    systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"


### PR DESCRIPTION
Removing the spark dataflow runner build and the cloud_todo_build from travis.

Left in the logic for dealing with the cloud_todo in case we have similar problems in the future.  I can strip it out of if th