### PR TITLE
Change BQSR_REFERENCE_WINDOW_FUNCTION to use a static class instead of a lambda

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
@@ -34,9 +34,18 @@ public final class BaseRecalibrationEngine implements Serializable {
     /**
      * Reference window function for BQSR. For each read, returns an interval representing the span of
      * reference bases required by the BQSR algorithm for that read.
+     *
+     * Implemented as a static class rather than an anonymous class or lambda due to serialization issues in spark.
      */
-    public static final SerializableFunction<GATKRead, SimpleInterval> BQSR_REFERENCE_WINDOW_FUNCTION =
-            read -> BAQ.getReferenceWindowForRead(read, BAQ.DEFAULT_BANDWIDTH, BAQ.DEFAULT_INCLUDE_CLIPPED_BASES);
+    public static final class BQSRReferenceWindowFunction implements SerializableFunction<GATKRead, SimpleInterval> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public SimpleInterval apply( GATKRead read ) {
+            return BAQ.getReferenceWindowForRead(read, BAQ.DEFAULT_BANDWIDTH, BAQ.DEFAULT_INCLUDE_CLIPPED_BASES);
+        }
+    }
+    public static final SerializableFunction<GATKRead, SimpleInterval> BQSR_REFERENCE_WINDOW_FUNCTION = new BQSRReferenceWindowFunction();
 
     private RecalibrationArgumentCollection recalArgs;
 


### PR DESCRIPTION
We were having trouble serializing this lambda when using the BROADCAST strategy
in BQSR for reasons we still don't understand. This fixes the issue for now and
enables us to test out BROADCAST.