### PR TITLE
A basic progress meter for walker-based tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
@@ -55,6 +55,8 @@ public abstract class IntervalWalker extends GATKTool {
                   new ReadsContext(reads, interval),
                   new ReferenceContext(reference, interval),
                   new FeatureContext(features, interval));
+
+            progressMeter.update(interval);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ProgressMeter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ProgressMeter.java
@@ -1,0 +1,243 @@
+package org.broadinstitute.hellbender.engine;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.util.Locatable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.function.LongSupplier;
+
+/**
+ * A basic progress meter to print out the number of records processed (and other metrics) during a traversal
+ * at a configurable time interval.
+ *
+ * Clients set the update interval at construction, which controls how many seconds must elapse
+ * before printing an update. Then call {@link #start} at traversal start, {@link #update(Locatable)}
+ * after processing each record from the primary input, and {@link #stop} at traversal end to print
+ * summary statistics.
+ *
+ * All output is made at INFO level via log4j.
+ */
+public final class ProgressMeter {
+    protected static final Logger logger = LogManager.getLogger(ProgressMeter.class);
+
+    /**
+     * By default, we output a line to the logger after this many seconds have elapsed
+     */
+    public static final double DEFAULT_SECONDS_BETWEEN_UPDATES = 10.0;
+
+    /**
+     * We check the current time every time we process this many records
+     * (to cut down on the number of system calls)
+     */
+    public static final long RECORDS_BETWEEN_TIME_CHECKS = 1000l;
+
+    /**
+     * By default, we use this function to get the current time
+     */
+    public static final LongSupplier DEFAULT_TIME_FUNCTION = System::currentTimeMillis;
+
+    /**
+     * Number of milliseconds in a second
+     */
+    public static final long MILLISECONDS_PER_SECOND = 1000l;
+
+    /**
+     * Number of milliseconds in a minute
+     */
+    public static final long MILLISECONDS_PER_MINUTE = MILLISECONDS_PER_SECOND * 60l;
+
+    /**
+     * We output a line to the logger after this many seconds have elapsed
+     */
+    private final double secondsBetweenUpdates;
+
+    /**
+     * Total records processed
+     */
+    private long numRecordsProcessed = 0l;
+
+    /**
+     * Our start timestamp in milliseconds as returned by our {@link #timeFunction}
+     */
+    private long startTimeMs = 0l;
+
+    /**
+     * Current timestamp in milliseconds as returned by our {@link #timeFunction}.
+     *
+     * Updated only every {@link #RECORDS_BETWEEN_TIME_CHECKS} records to cut down
+     * on system calls.
+     */
+    private long currentTimeMs = 0l;
+
+    /**
+     * Timestamp in milliseconds as returned by our {@link #timeFunction} of the last time
+     * we outputted a progress line to the logger
+     */
+    private long lastPrintTimeMs = 0l;
+
+    /**
+     * The genomic location of the most recently processed record, or null if the most recent record had no location.
+     * Updated only when we actually output a line to the logger.
+     */
+    private Locatable currentLocus = null;
+
+    /**
+     * The number of times we've outputted a status line to the logger via {@link #printProgress}.
+     * We keep track of this only for unit-testing purposes.
+     */
+    private long numLoggerUpdates = 0l;
+
+    /**
+     * Function that returns the current time in milliseconds (defaults to {@link #DEFAULT_TIME_FUNCTION}).
+     * Should only be customized for unit testing purposes.
+     */
+    private LongSupplier timeFunction;
+
+    /**
+     * Create a progress meter with the default update interval of {@link #DEFAULT_SECONDS_BETWEEN_UPDATES} seconds
+     * and the default time function {@link #DEFAULT_TIME_FUNCTION}.
+     */
+    public ProgressMeter() {
+        this(DEFAULT_SECONDS_BETWEEN_UPDATES);
+    }
+
+    /**
+     * Create a progress meter with a custom update interval and the default time function {@link #DEFAULT_TIME_FUNCTION}
+     *
+     * @param secondsBetweenUpdates number of seconds that should elapse before outputting a line to the logger
+     */
+    public ProgressMeter( final double secondsBetweenUpdates ) {
+        this(secondsBetweenUpdates, DEFAULT_TIME_FUNCTION);
+    }
+
+    /**
+     * Create a progress meter with a custom update interval and a custom function for getting the current
+     * time in milliseconds.
+     *
+     * Providing your own time function is only useful in unit tests -- in normal usage
+     * clients should call one of the other constructors.
+     *
+     * @param secondsBetweenUpdates number of seconds that should elapse before outputting a line to the logger
+     * @param timeFunction function that returns the current time in milliseconds.
+     */
+    @VisibleForTesting
+    ProgressMeter( final double secondsBetweenUpdates, final LongSupplier timeFunction ) {
+        Utils.nonNull(timeFunction);
+        if ( secondsBetweenUpdates <= 0.0 ) {
+            throw new IllegalArgumentException("secondsBetweenUpdates must be > 0.0");
+        }
+
+        this.secondsBetweenUpdates = secondsBetweenUpdates;
+        this.timeFunction = timeFunction;
+    }
+
+    /**
+     * Start the progress meter and produce preliminary output such as column headings.
+     */
+    public void start() {
+        logger.info("Starting traversal");
+        printHeader();
+
+        startTimeMs = timeFunction.getAsLong();
+        currentTimeMs = startTimeMs;
+        lastPrintTimeMs = startTimeMs;
+        numRecordsProcessed = 0l;
+        numLoggerUpdates = 0l;
+        currentLocus = null;
+    }
+
+    /**
+     * Signal to the progress meter that an additional record has been processed. Will output
+     * statistics to the logger roughly every {@link #secondsBetweenUpdates} seconds.
+     *
+     * @param currentLocus the genomic location of the record just processed
+     */
+    public void update( final Locatable currentLocus ) {
+        ++numRecordsProcessed;
+        if ( numRecordsProcessed % RECORDS_BETWEEN_TIME_CHECKS == 0 ) {
+            currentTimeMs = timeFunction.getAsLong();
+            this.currentLocus = currentLocus;
+
+            if ( secondsSinceLastPrint() >= secondsBetweenUpdates ) {
+                printProgress();
+                lastPrintTimeMs = currentTimeMs;
+            }
+        }
+    }
+
+    /**
+     * Stop the progress meter and output summary statistics to the logger
+     */
+    public void stop() {
+        currentTimeMs = timeFunction.getAsLong();
+        logger.info(String.format("Traversal complete. Processed %d total records in %.1f minutes.", numRecordsProcessed, elapsedTimeInMinutes()));
+    }
+
+    /**
+     * Print column headings labelling the output from {@link #printProgress}
+     */
+    private void printHeader() {
+        logger.info(String.format("%20s  %15s  %20s  %15s",
+                                  "Current Locus", "Elapsed Minutes", "Records Processed", "Records/Minute"));
+    }
+
+    /**
+     * Output traversal statistics to the logger.
+     */
+    private void printProgress() {
+        ++numLoggerUpdates;
+        logger.info(String.format("%20s  %15.1f  %20d  %15.1f",
+                                  currentLocusString(), elapsedTimeInMinutes(), numRecordsProcessed, processingRate()));
+    }
+
+    /**
+     * @return the total minutes elapsed since we called {@link #start}
+     *
+     * This is only accurate at set polling intervals and should not be
+     * called directly except in tests.
+     */
+    @VisibleForTesting
+    double elapsedTimeInMinutes() {
+        return (currentTimeMs - startTimeMs) / (double)MILLISECONDS_PER_MINUTE;
+    }
+
+    /**
+     * @return the number of seconds that have elapsed since our last progress output to the logger
+     *
+     * This is only accurate at set polling intervals and should not be
+     * called directly except in tests.
+     */
+    @VisibleForTesting
+    double secondsSinceLastPrint() {
+        return (currentTimeMs - lastPrintTimeMs) / (double)MILLISECONDS_PER_SECOND;
+    }
+
+    /**
+     * @return number of records we're processing per minute, on average
+     *
+     * This is only accurate at set polling intervals and should not be
+     * called directly except in tests.
+     */
+    @VisibleForTesting
+    double processingRate() {
+        return numRecordsProcessed / elapsedTimeInMinutes();
+    }
+
+    /**
+     * @return number of times we've outputted a progress line to the logger (for unit testing purposes)
+     */
+    @VisibleForTesting
+    long numLoggerUpdates() {
+        return numLoggerUpdates;
+    }
+
+    /**
+     * @return genomic location of the most recent record formatted for output to the logger
+     */
+    private String currentLocusString() {
+        return currentLocus != null ? currentLocus.getContig() + ":" + currentLocus.getStart() :
+                                      "unmapped";
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -66,6 +66,8 @@ public abstract class ReadWalker extends GATKTool {
                     apply(read,
                           new ReferenceContext(reference, readInterval), // Will create an empty ReferenceContext if reference or readInterval == null
                           new FeatureContext(features, readInterval));   // Will create an empty FeatureContext if features or readInterval == null
+
+                    progressMeter.update(readInterval);
                 });
 
         logger.info(countedFilter.getSummaryLine());

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -5,7 +5,6 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.IOUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.utils.logging.BunnyLog;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -152,10 +151,8 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
             if ( ! indicesAvailable ) {
                 raiseExceptionForMissingIndex("Traversal by intervals was requested but some input files are not indexed.");
             }
-            BunnyLog bl = new BunnyLog(logger);
-            bl.start("Preparing intervals for traversal");
+            logger.info("Preparing intervals for traversal");
             preparedIntervals = prepareIntervalsForTraversal();
-            bl.end();
         }
         else {
             preparedIntervals = null;
@@ -181,10 +178,8 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
      */
     @Override
     public Iterator<GATKRead> iterator() {
-        BunnyLog bunny = new BunnyLog(logger);
-        bunny.start("Preparing readers for traversal");
+        logger.debug("Preparing readers for traversal");
         final Iterator<GATKRead> traversalIter = prepareIteratorsForTraversal(preparedIntervals);
-        bunny.end();
 
         return traversalIter;
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -94,6 +94,8 @@ public abstract class VariantWalker extends GATKTool {
                           new ReadsContext(reads, variantInterval),
                           new ReferenceContext(reference, variantInterval),
                           new FeatureContext(features, variantInterval));
+
+                    progressMeter.update(variantInterval);
                 });
     }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{1} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
@@ -1,0 +1,143 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.LongSupplier;
+
+public class ProgressMeterUnitTest extends BaseTest {
+
+    private static class ListBasedTimeFunction implements LongSupplier {
+        private final List<Long> values;
+        private int currentIndex = 0;
+
+        public ListBasedTimeFunction( final List<Long> values ) {
+            this.values = values;
+        }
+
+        @Override
+        public long getAsLong() {
+            if ( currentIndex >= values.size() ) {
+                throw new NoSuchElementException();
+            }
+
+            return values.get(currentIndex++);
+        }
+
+        public int size() {
+            return values.size();
+        }
+    }
+
+    @DataProvider(name = "UpdateIntervalTestData")
+    public Object[][] getUpdateIntervalTestData() {
+        return new Object[][] {
+                // Seconds between logger updates, time function, total number of records to process, and expected number of progress updates
+                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS, 1 },
+                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS * 2, 2 },
+                { 1.5, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS, 0 },
+                { 2.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l, 4000l, 5000l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS * 4, 2 },
+                { 2.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l, 4000l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS * 3, 1 },
+                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2500l, 3500l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS * 3, 2 },
+                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2500l, 3400l)), ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS * 3, 1 },
+        };
+    }
+
+    @Test(dataProvider = "UpdateIntervalTestData")
+    public void testUpdateInterval( final double secondsBetweenUpdates, final ListBasedTimeFunction timeFunction, final long numRecords, final int expectedUpdates ) {
+        final ProgressMeter meter = new ProgressMeter(secondsBetweenUpdates, timeFunction);
+        meter.start();
+        for ( int i = 1; i <= numRecords; ++i ) {
+            meter.update(new SimpleInterval("1", 1, 1));
+        }
+
+        Assert.assertEquals(meter.numLoggerUpdates(), expectedUpdates, "Wrong number of logger updates given secondsBetweenUpdates = " + secondsBetweenUpdates);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidUpdateInterval() {
+        final ProgressMeter meter = new ProgressMeter(0.0);
+    }
+
+    @DataProvider(name = "ElapsedTimeInMinutesTestData")
+    public Object[][] getElapsedTimeInMinutesTestData() {
+        return new Object[][] {
+                // 600,000ms = 10 minutes
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l * 10l + 1000l)), 10.0 },
+                // 60,000ms = 1 minute
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l + 1000l)), 1.0 },
+                // 30,000ms = 0.5 minutes
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 30000l + 1000l)), 0.5 },
+                // 0ms = 0 minutes
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 1000l)), 0.0 },
+                // 10,000ms = 1.0/6.0 minutes
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 3000l, 6000l, 10000l, 11000l)), 1.0 / 6.0 }
+        };
+    }
+
+    @Test(dataProvider = "ElapsedTimeInMinutesTestData")
+    public void testElapsedTimeInMinutes( final ListBasedTimeFunction timeFunction, final double expectedElapsedMinutes ) {
+        final ProgressMeter meter = new ProgressMeter(1l, timeFunction);
+
+        meter.start();
+        // The start() call consumes one value from the time function, so we need to process
+        // (timeFunction.size() - 1) * ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS in order
+        // to consume the rest of the values in the time function
+        for ( int i = 1; i <= (timeFunction.size() - 1) * ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS; ++i ) {
+            meter.update(new SimpleInterval("1", 1, 1));
+        }
+
+        Assert.assertEquals(meter.elapsedTimeInMinutes(), expectedElapsedMinutes, "elapsed minutes differs from expected value");
+    }
+
+    @DataProvider(name = "ProcessingRateTestData")
+    public Object[][] getProcessingRateTestData() {
+        // We need to base the number of records we process on the time check interval (to ensure that
+        // the progress meter pulls all values from the time function and gets updated properly).
+        final long timeCheckRecords = ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS;
+        return new Object[][] {
+                // If we process timeCheckRecords records in 1 minute, rate should be timeCheckRecords
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l + 1000l)), timeCheckRecords, timeCheckRecords },
+                // If we process timeCheckRecords records in 2 minutes, rate should be timeCheckRecords / 2
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l * 2l + 1000l)), timeCheckRecords, timeCheckRecords / 2},
+                // timeCheckRecords records in 15 seconds should give timeCheckRecords * 4 records/minute
+                { new ListBasedTimeFunction(Arrays.asList(1000l, 15000l + 1000l)), timeCheckRecords, timeCheckRecords * 4 }
+        };
+    }
+
+    @Test(dataProvider = "ProcessingRateTestData")
+    public void testProcessingRate( final ListBasedTimeFunction timeFunction, final long recordsToProcess, final double expectedProcessingRate ) {
+        final ProgressMeter meter = new ProgressMeter(1.0, timeFunction);
+
+        meter.start();
+        for ( int i = 1; i <= recordsToProcess; ++i ) {
+            meter.update(new SimpleInterval("1", 1, 1));
+        }
+
+        Assert.assertEquals(meter.processingRate(), expectedProcessingRate, "actual processing rate differs from expected value");
+    }
+
+    @Test
+    public void testSecondsSinceLastPrint() {
+        final ListBasedTimeFunction timeFunction = new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2000l, 2500l, 3000l));
+        final ProgressMeter meter = new ProgressMeter(1.0, timeFunction);
+        final List<Double> expectedSecondsSinceLastPrint = Arrays.asList(0.5, 0.0, 0.5, 0.0);
+
+        meter.start();
+        // start() consumes one timestamp from our function, so we need to process size() - 1 more timestamps
+        for ( int i = 1; i <= timeFunction.size() - 1; ++i ) {
+            for ( int j = 1; j <= ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS; ++j ) {
+                meter.update(new SimpleInterval("1", 1, 1));
+            }
+
+            Assert.assertEquals(meter.secondsSinceLastPrint(), expectedSecondsSinceLastPrint.get(i - 1), "Wrong number of seconds reported since last print");
+        }
+
+    }
+}


### PR DESCRIPTION
-Prints the current locus, the elapsed time, number of records processed,
 and the rate at which records are being processed.

-Hooked up for ReadWalkers, VariantWalkers, and IntervalWalkers

-A new command-line arg in GATKTool allows control over the frequency of
 progress meter updates

-Tweaked the log4j output format to create more screen space for logger output.

Resolves #974 (for alpha purposes)