### PR TITLE
allow MD Spark to write metrics to hdfs and gcs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
     }
-    compile('org.apache.hadoop:hadoop-client:2.2.0') // should be a 'provided' dependency
+    compile('org.apache.hadoop:hadoop-client:2.7.1') // should be a 'provided' dependency
 
     compile('org.apache.spark:spark-core_2.10:1.4.1') {
         // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
@@ -145,7 +145,7 @@ dependencies {
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.hadoop:hadoop-minicluster:2.7.1'
+    testCompile 'org.apache.hadoop:hadoop-minicluster:2.7.1' //the version of minicluster should match the version of hadoop
     testCompile "org.mockito:mockito-core:1.10.19"
 }
 

--- a/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
@@ -1,0 +1,32 @@
+package org.broadinstitute.hellbender.metrics;
+
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.metrics.MetricsFile;
+import org.broadinstitute.hellbender.engine.AuthHolder;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+
+import java.io.PrintWriter;
+
+/**
+ * Utility methods for dealing with {@link MetricsFile} and related classes.
+ */
+public final class MetricsUtils {
+
+    private MetricsUtils(){} //don't instantiate this utility class
+
+    /**
+     * Write a {@link MetricsFile} to the given path, can be any destination supported by {@link BucketUtils#createFile(String, AuthHolder)}
+     * @param metricsFile a {@link MetricsFile} object to write to disk
+     * @param metricsOutputPath the path (or uri) to write the metrics to
+     * @param authHolder authentication for remote paths, can be null if the path is not remote
+     */
+    public static void saveMetrics(final MetricsFile<?, ?> metricsFile, String metricsOutputPath, AuthHolder authHolder) {
+        try(PrintWriter out = new PrintWriter(BucketUtils.createFile(metricsOutputPath, authHolder))) {
+            metricsFile.write(out);
+        } catch (SAMException e ){
+            throw new UserException.CouldNotCreateOutputFile("Could not write metrics to file: " + metricsOutputPath, e);
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSpark.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines.metrics;
 
-import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
@@ -15,16 +14,16 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.metrics.MetricsUtils;
 import org.broadinstitute.hellbender.tools.picard.analysis.MeanQualityByCycle;
 import org.broadinstitute.hellbender.utils.R.RScriptExecutor;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.Resource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
-import java.io.*;
+import java.io.File;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -219,12 +218,7 @@ public final class MeanQualityByCycleSpark extends GATKSparkTool {
     }
 
     private void saveResults(final MetricsFile<?, Integer> metrics, final SAMFileHeader readsHeader, final String inputFileName){
-        final GCSOptions gcsOptions = getAuthenticatedGCSOptions(); // null if we have no api key
-        try(OutputStream outputStream = BucketUtils.createFile(out, gcsOptions)) {
-            metrics.write(new PrintWriter(outputStream));
-        } catch (final IOException e){
-            throw new GATKException("Could not write metrics to file: " + out, e);
-        }
+        MetricsUtils.saveMetrics(metrics, out, getAuthHolder());
 
         if (metrics.getAllHistograms().isEmpty()) {
             logger.warn("No valid bases found in input file.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSpark.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines.metrics;
 
-import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
@@ -15,15 +14,15 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.metrics.MetricsUtils;
 import org.broadinstitute.hellbender.tools.picard.analysis.QualityScoreDistribution;
 import org.broadinstitute.hellbender.utils.R.RScriptExecutor;
-import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.Resource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
-import java.io.*;
+import java.io.File;
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -153,12 +152,8 @@ public final class QualityScoreDistributionSpark extends GATKSparkTool {
     }
 
     private void saveResults(final MetricsFile<?, Byte> metrics,  final SAMFileHeader readsHeader, final String inputFileName) {
-        final GCSOptions gcsOptions = getAuthenticatedGCSOptions(); // null if we have no api key
-        try(OutputStream outputStream = BucketUtils.createFile(out, gcsOptions)) {
-            metrics.write(new PrintWriter(outputStream));
-        } catch (final IOException e){
-            throw new GATKException("Could not write metrics to file: " + out, e);
-        }
+        MetricsUtils.saveMetrics(metrics, out, getAuthHolder());
+
         if (metrics.getAllHistograms().isEmpty()) {
             logger.warn("No valid bases found in input file.");
         } else if(chartOutput != null){

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -18,7 +18,6 @@ import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.read.markduplicates.DuplicationMetrics;
 import org.broadinstitute.hellbender.utils.read.markduplicates.OpticalDuplicateFinder;
 
-import java.io.File;
 import java.io.IOException;
 
 @CommandLineProgramProperties(
@@ -35,9 +34,9 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     protected String output;
 
-    @Argument(doc = "File to write duplication metrics to.", optional=true,
+    @Argument(doc = "Path to write duplication metrics to.", optional=true,
             shortName = "M", fullName = "METRICS_FILE")
-    protected File metricsFile;
+    protected String metricsFile;
 
     @ArgumentCollection
     protected OpticalDuplicatesArgumentCollection opticalDuplicatesArgumentCollection = new OpticalDuplicatesArgumentCollection();
@@ -84,7 +83,7 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
 
         if (metricsFile != null) {
             final JavaPairRDD<String, DuplicationMetrics> metrics = MarkDuplicatesSparkUtils.generateMetrics(getHeaderForReads(), finalReads);
-            MarkDuplicatesSparkUtils.writeMetricsToFile(metrics, metricsFile);
+            MarkDuplicatesSparkUtils.saveMetricsRDD(metrics, metricsFile, getAuthHolder());
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -1,18 +1,27 @@
 package org.broadinstitute.hellbender.tools.spark.transforms.markduplicates;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimaps;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
-import org.broadinstitute.hellbender.utils.read.markduplicates.*;
+import org.broadinstitute.hellbender.metrics.MetricsUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.read.markduplicates.DuplicationMetrics;
+import org.broadinstitute.hellbender.utils.read.markduplicates.LibraryIdGenerator;
+import org.broadinstitute.hellbender.utils.read.markduplicates.MarkDuplicatesUtils;
+import org.broadinstitute.hellbender.utils.read.markduplicates.OpticalDuplicateFinder;
+import org.broadinstitute.hellbender.utils.read.markduplicates.PairedEnds;
+import org.broadinstitute.hellbender.utils.read.markduplicates.ReadsKey;
 import scala.Tuple2;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
@@ -233,13 +242,13 @@ public class MarkDuplicatesSparkUtils {
                 });
     }
 
-    public static void writeMetricsToFile(final JavaPairRDD<String, DuplicationMetrics> metrics, final File dest) {
-        final MetricsFile<DuplicationMetrics, Double> file = new MetricsFile<>();
-        Map<String, DuplicationMetrics> stringDuplicationMetricsMap = metrics.collectAsMap();
-        for (final Map.Entry<String, DuplicationMetrics> entry : metrics.collectAsMap().entrySet()) {
-            file.addMetric(entry.getValue());
+    public static void saveMetricsRDD(final JavaPairRDD<String, DuplicationMetrics> metricsRDD, final String metricsOutputPath, AuthHolder authHolder) {
+        final MetricsFile<DuplicationMetrics, Double> metrics = new MetricsFile<>();
+        for (final Map.Entry<String, DuplicationMetrics> entry : metricsRDD.collectAsMap().entrySet()) {
+            metrics.addMetric(entry.getValue());
         }
-        file.write(dest);
+
+        MetricsUtils.saveMetrics(metrics, metricsOutputPath, authHolder );
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -9,6 +9,7 @@ import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.vcf.VCFConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.GenomeLoc;
@@ -25,7 +26,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 
@@ -150,6 +158,9 @@ public abstract class BaseTest {
         return popts;
     }
 
+    public static AuthHolder getAuthentication(){
+        return new AuthHolder("test-app",getGCPTestApiKey());
+    }
     @BeforeClass
     public void initGenomeLocParser() throws FileNotFoundException {
         hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
@@ -1,0 +1,73 @@
+package org.broadinstitute.hellbender.metrics;
+
+import htsjdk.samtools.metrics.MetricBase;
+import htsjdk.samtools.metrics.MetricsFile;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class MetricsUtilsTest extends BaseTest {
+    private MiniDFSCluster cluster;
+    private String hdfsWorkingDir;
+
+    @BeforeClass(alwaysRun = true)
+    private void setupMiniCluster() throws IOException {
+        cluster = new MiniDFSCluster.Builder(new Configuration()).build();
+        hdfsWorkingDir = cluster.getFileSystem().getWorkingDirectory().toString();
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void shutdownMiniCluster() {
+        if (cluster != null) {
+            cluster.shutdown();
+        }
+    }
+
+    @DataProvider(name = "metricsPaths")
+    public Object[][] getMetricsPaths(){
+        return new Object[][]{
+                {"metrics"},
+                {getGCPTestStaging()},
+                {hdfsWorkingDir}
+        };
+    }
+
+    public static class TestMetric extends MetricBase {
+        public Integer value1 = 0;
+        public Integer value2 = 0;
+    }
+
+    @Test(dataProvider = "metricsPaths", groups = "cloud")
+    public void testSaveMetrics(String destinationPrefix) throws IOException {
+        final String outputPath = BucketUtils.getTempFilePath(destinationPrefix, ".txt", getAuthentication());
+        TestMetric testMetric = new TestMetric();
+        testMetric.value1 = 10;
+        testMetric.value2 = 5;
+
+        final MetricsFile<TestMetric, ?> metrics = new MetricsFile<>();
+        metrics.addMetric(testMetric);
+        MetricsUtils.saveMetrics(metrics, outputPath,getAuthentication());
+        Assert.assertTrue(BucketUtils.fileExists(outputPath, getAuthenticatedPipelineOptions()));
+        File localCopy = copyFileToLocalTmpFile(outputPath);
+
+        final File expectedMetrics = createTempFile("expectedMetrics", ".txt");
+        metrics.write(expectedMetrics);
+
+        Assert.assertTrue(MetricsFile.areMetricsEqual(localCopy, expectedMetrics));
+    }
+
+    private File copyFileToLocalTmpFile(String outputPath) throws IOException {
+        File localCopy = createTempFile("local_metrics_copy",".txt");
+        BucketUtils.copyFile(outputPath, getAuthenticatedPipelineOptions(), localCopy.getAbsolutePath());
+        return localCopy;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -52,9 +52,7 @@ public final class BucketUtilsTest extends BaseTest {
             fw.write("Goodbye, cruel world!");
         }
         BucketUtils.deleteFile(dest.getPath(), null);
-        if (dest.exists()) {
-            Assert.fail("File '"+dest.getPath()+"' was not properly deleted as it should.");
-        }
+        Assert.assertFalse(dest.exists(), "File '"+dest.getPath()+"' was not properly deleted as it should.");
     }
 
     @Test(groups={"bucket"})
@@ -97,4 +95,5 @@ public final class BucketUtilsTest extends BaseTest {
             }
         }
     }
+
 }


### PR DESCRIPTION
change MarkDuplicatesSpark and MarkDuplicatesSparkUtils so that metrics can be written to hdfs:// and gs:// paths.

Fixes #1025 
Fixes #1026

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/broadinstitute/gatk/1044)
<!-- Reviewable:end -->
