### PR TITLE
D.R.Y. with filter for GATKReads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/GatkReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/GatkReadFilter.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.tools.spark.pipelines.metrics;
+
+import org.apache.spark.api.java.function.Function;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+class GatkReadFilter {
+  /** 
+   * @param aligned_reads_only If set to true calculate mean quality over
+   * aligned reads only.
+   * @param pf_read_only If set to true calculate mean quality over passing
+   * filter reads only.
+   */
+  public static Function<GATKRead, Boolean> by(final boolean pf_read_only,
+      final boolean aligned_reads_only) {
+    return read -> (!pf_read_only || !read.failsVendorQualityCheck()) &&
+        (!aligned_reads_only || !read.isUnmapped()) &&
+        !read.isSecondaryAlignment() &&
+        !read.isSupplementaryAlignment();
+  }
+}


### PR DESCRIPTION
Fixes #1027 

This follows google java style guide. Not sure why `pf_read_only` and `aligned_reads_only` are not
camel-cased, but I'm all for that style of casing.

---

The following test passes:

> gradle test --tests org.broadinstitute.hellbender.tools.spark.pipelines.metrics.MeanQualityByCycleSparkIntegrationTest

It seems that there is no need for a unit test here, but please let me
know if you would prefer one. I have a skeleton test class to verify
that GatkReadFilter blocks secondary alignment reads,
blocks supplementary alignment reads, can restrict to passing filter
reads only, and can restrict to aligned reads only.