### PR TITLE
Re-enable ReferenceTwoBitSourceUnitTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     }
 
     compile 'org.bdgenomics.bdg-formats:bdg-formats:0.5.0'
-    compile('org.bdgenomics.adam:adam-core_2.10:0.17.1') {
+    compile('org.bdgenomics.adam:adam-core_2.10:0.18.0') {
         exclude group: 'org.slf4j'
         exclude group: 'org.apache.hadoop'
         exclude group: 'org.scala-lang'

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSourceUnitTest.java
@@ -27,7 +27,7 @@ public class ReferenceTwoBitSourceUnitTest extends BaseTest {
         };
     }
 
-    @Test(dataProvider = "goodIntervals", enabled = false)
+    @Test(dataProvider = "goodIntervals")
     public void testIntervalConversion(ReferenceSource fastaRef, ReferenceSource twoBitRef, String intervalString) throws IOException {
         SimpleInterval interval = new SimpleInterval(intervalString);
         ReferenceBases expected = fastaRef.getReferenceBases(null, interval);


### PR DESCRIPTION
Now that ADAM 0.18 has been released.

Fixes #957.