### PR TITLE
Removing UUID from reads and variants

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
@@ -43,7 +43,7 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
         record.setReferenceIndex(referenceIndex);
         record.setMateReferenceIndex(mateReferenceIndex);
 
-        return (SAMRecordToGATKReadAdapter) SAMRecordToGATKReadAdapter.sparkReadAdapter(record);
+        return new SAMRecordToGATKReadAdapter(record);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -67,7 +67,7 @@ public class ReadsSparkSource implements Serializable {
             SAMRecord sam = v1._2().get();
             if (samRecordOverlaps(sam, intervals)) {
                 try {
-                    return SAMRecordToGATKReadAdapter.sparkReadAdapter(sam);
+                    return (GATKRead) new SAMRecordToGATKReadAdapter(sam);
                 } catch (SAMException e) {
                     // TODO: add stringency
                 }            

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -162,40 +162,42 @@ public final class ArtificialReadUtils {
         return new SAMRecordToGATKReadAdapter(createArtificialSAMRecord(cigar));
     }
 
+    public static GATKRead createArtificialRead(final Cigar cigar, final String name) {
+        return new SAMRecordToGATKReadAdapter(createArtificialSAMRecord(createArtificialSamHeader(), cigar, name));
+    }
+
     public static GATKRead createArtificialRead(final String cigarString) {
         return new SAMRecordToGATKReadAdapter(createArtificialSAMRecord(TextCigarCodec.decode(cigarString)));
     }
 
     /**
-     * Creates an artificial GATKRead backed by a SAMRecord, with the specified UUID.
+     * Creates an artificial GATKRead backed by a SAMRecord.
      *
      * The read will consist of the specified number of Q30 'A' bases, and will be
      * mapped to contig "1" at the specified start position.
      *
-     * @param uuid UUID of the new read
      * @param name name of the new read
      * @param start start position of the new read
      * @param length number of bases in the new read
-     * @return an artificial GATKRead backed by a SAMRecord, with the specified UUID.
+     * @return an artificial GATKRead backed by a SAMRecord.
      */
-    public static GATKRead createSamBackedReadWithUUID( final UUID uuid, final String name, final int start, final int length ) {
-        return createSamBackedReadWithUUID(uuid, name, "1", start, length);
+    public static GATKRead createSamBackedRead( final String name, final int start, final int length ) {
+        return createSamBackedRead(name, "1", start, length);
     }
 
     /**
-     * Creates an artificial GATKRead backed by a SAMRecord, with the specified UUID.
+     * Creates an artificial GATKRead backed by a SAMRecord.
      *
      * The read will consist of the specified number of Q30 'A' bases, and will be
      * mapped to the specified contig at the specified start position.
      *
-     * @param uuid UUID of the new read
      * @param name name of the new read
      * @param contig contig the new read is mapped to
      * @param start start position of the new read
      * @param length number of bases in the new read
-     * @return an artificial GATKRead backed by a SAMRecord, with the specified UUID.
+     * @return an artificial GATKRead backed by a SAMRecord.
      */
-    public static GATKRead createSamBackedReadWithUUID( final UUID uuid, final String name, final String contig, final int start, final int length ) {
+    public static GATKRead createSamBackedRead( final String name, final String contig, final int start, final int length ) {
         final SAMFileHeader header = createArtificialSamHeader();
         final byte[] bases = Utils.dupBytes((byte)'A', length);
         final byte[] quals = Utils.dupBytes((byte) 30, length);
@@ -204,44 +206,27 @@ public final class ArtificialReadUtils {
         sam.setReadName(name);
         sam.setReferenceName(contig);
         sam.setAlignmentStart(start);
-        return new SAMRecordToGATKReadAdapter(sam, uuid);
+        return new SAMRecordToGATKReadAdapter(sam);
     }
 
     /**
-     * Creates an artificial GATKRead backed by a Google Genomics read, with the specified UUID.
-     *
-     * The read will consist of the specified number of Q30 'A' bases, and will be
-     * mapped to contig "1" at the specified start position.
-     *
-     * @param uuid UUID of the new read
-     * @param name name of the new read
-     * @param start start position of the new read
-     * @param length number of bases in the new read
-     * @return an artificial GATKRead backed by a Google Genomics read, with the specified UUID.
-     */
-    public static GATKRead createGoogleBackedReadWithUUID( final UUID uuid, final String name, final int start, final int length ) {
-        return createGoogleBackedReadWithUUID(uuid, name, "1", start, length);
-    }
-
-    /**
-     * Creates an artificial GATKRead backed by a Google Genomics read, with the specified UUID.
+     * Creates an artificial GATKRead backed by a Google Genomics read.
      *
      * The read will consist of the specified number of Q30 'A' bases, and will be
      * mapped to the specified contig at the specified start position.
      *
-     * @param uuid UUID of the new read
      * @param name name of the new read
      * @param contig contig the new read is mapped to
      * @param start start position of the new read
      * @param length number of bases in the new read
-     * @return an artificial GATKRead backed by a Google Genomics read, with the specified UUID.
+     * @return an artificial GATKRead backed by a Google Genomics read.
      */
-    public static GATKRead createGoogleBackedReadWithUUID( final UUID uuid, final String name, final String contig, final int start, final int length ) {
-        final byte[] bases = Utils.dupBytes((byte)'A', length);
+    public static GATKRead createGoogleBackedRead( final String name, final String contig, final int start, final int length ) {
+        final byte[] bases = Utils.dupBytes((byte) 'A', length);
         final byte[] quals = Utils.dupBytes((byte) 30, length);
 
         final Read googleRead = createArtificialGoogleGenomicsRead(name, contig, start, bases, quals, length + "M");
-        return new GoogleGenomicsReadToGATKReadAdapter(googleRead, uuid);
+        return new GoogleGenomicsReadToGATKReadAdapter(googleRead);
     }
 
     /**
@@ -352,18 +337,22 @@ public final class ArtificialReadUtils {
         return createArtificialSAMRecord(header, "default_read", 0, 10000, bases, qual, cigar);
     }
 
-    public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar) {
+    public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar, final String name) {
         int length = cigar.getReadLength();
         byte base = 'A';
         byte qual = 30;
         byte [] bases = Utils.dupBytes(base, length);
         byte [] quals = Utils.dupBytes(qual, length);
-        return createArtificialSAMRecord(header, "default_read", 0, 10000, bases, quals, cigar.toString());
+        return createArtificialSAMRecord(header, name, 0, 10000, bases, quals, cigar.toString());
+    }
+
+    public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar) {
+        return createArtificialSAMRecord(header, cigar, "default_read");
     }
 
     public static SAMRecord createArtificialSAMRecord(final Cigar cigar) {
         final SAMFileHeader header = createArtificialSamHeader();
-        return createArtificialSAMRecord(header, cigar);
+        return createArtificialSAMRecord(header, cigar, "default_read");
     }
 
     public static Read createArtificialGoogleGenomicsRead( final String name, final String contig, final int start, final byte[] bases, final byte[] quals, final String cigar ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/BDGAlignmentRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/BDGAlignmentRecordToGATKReadAdapter.java
@@ -6,10 +6,6 @@ import org.bdgenomics.adam.converters.AlignmentRecordConverter;
 import org.bdgenomics.adam.models.SAMFileHeaderWritable;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
-
 /**
  * Implementation of the {@link GATKRead} interface for the {@link AlignmentRecord} class.
  *
@@ -29,42 +25,20 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class BDGAlignmentRecordToGATKReadAdapter extends SAMRecordToGATKReadAdapter {
     private static final long serialVersionUID = 1L;
-    private final static long uuidHighWord = new Random().nextLong();
-    private final static AtomicLong uuidLowWord = new AtomicLong(0);
 
     private final AlignmentRecord alignmentRecord;
 
-    public BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord) {
-        this(alignmentRecord, null);
-    }
-
-    public BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord, final SAMFileHeader header) {
-        // this is 100x faster than UUID.randomUUID()
-        this(alignmentRecord, header, new UUID(uuidHighWord, uuidLowWord.incrementAndGet()));
-    }
-
-    /**
-     * Constructor that allows an explicit UUID to be passed in -- only meant
-     * for internal use and test class use, which is why it's package protected.
-     */
-    BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord, final SAMFileHeader header, final UUID uuid ) {
-        super(new AlignmentRecordConverter().convert(alignmentRecord, SAMFileHeaderWritable.apply(header)), uuid);
+    public BDGAlignmentRecordToGATKReadAdapter(final AlignmentRecord alignmentRecord, final SAMFileHeader header) {
+        super(new AlignmentRecordConverter().convert(alignmentRecord, SAMFileHeaderWritable.apply(header)));
         this.alignmentRecord = alignmentRecord;
     }
 
-    /**
-     * Produces a BDGAlignmentRecordToGATKReadAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
-     * and loading the reads twice (which can happen when caching is missing) prevents joining.
-     * @param record Read to adapt
-     * @param header SAMFileHeaderWritable corresponding to the underlying SAMRecord object
-     * @return adapted Read
-     */
     public static GATKRead sparkReadAdapter(final AlignmentRecord record, final SAMFileHeader header) {
-        return new BDGAlignmentRecordToGATKReadAdapter(record, header, new UUID(0L, 0L));
+        return new BDGAlignmentRecordToGATKReadAdapter(record, header);
     }
 
     public static GATKRead sparkReadAdapter(final AlignmentRecord record) {
-        return new BDGAlignmentRecordToGATKReadAdapter(record, null, new UUID(0L, 0L));
+        return new BDGAlignmentRecordToGATKReadAdapter(record, null);
     }
 
     public AlignmentRecord convertToBDGAlignmentRecord() { return alignmentRecord; }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -8,8 +8,6 @@ import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.StringUtil;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
-import java.util.UUID;
-
 /**
  * Unified read interface for use throughout the GATK.
  *
@@ -24,11 +22,6 @@ import java.util.UUID;
  * of the conversion methods {@link #convertToSAMRecord} and {@link #convertToGoogleGenomicsRead}.
  */
 public interface GATKRead extends Locatable {
-
-    /**
-     * @return A globally unique identifier for this read, suitable for use as a key
-     */
-    UUID getUUID();
 
     /**
      * @return The name of the read (equivalent to QNAME in SAM), or {@code null} if the read has no name.
@@ -540,12 +533,6 @@ public interface GATKRead extends Locatable {
      * @return This read as a Google Genomics model read.
      */
     Read convertToGoogleGenomicsRead();
-
-    /**
-     * @param other Object to compare against
-     * @return True if this is the same class as other and the underlying reads are equal, ignoring UUIDs in the comparison
-     */
-    boolean equalsIgnoreUUID( final Object other );
 
 }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -23,24 +23,11 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Serializable {
     private static final long serialVersionUID = 1L;
-    private final static long uuidHighWord = new Random().nextLong();
-    private final static AtomicLong uuidLowWord = new AtomicLong(0);
 
     private final Read genomicsRead;
-    private final UUID uuid;
 
     public GoogleGenomicsReadToGATKReadAdapter( final Read genomicsRead ) {
-        // this is 100x faster than UUID.randomUUID()
-        this(genomicsRead, new UUID(uuidHighWord, uuidLowWord.incrementAndGet()));
-    }
-
-    /**
-     * Constructor that allows an explicit UUID to be passed in -- only meant
-     * for internal use and test class use, which is why it's package protected.
-     */
-    public GoogleGenomicsReadToGATKReadAdapter( final Read genomicsRead, final UUID uuid ) {
         this.genomicsRead = genomicsRead;
-        this.uuid = uuid;
     }
 
     private static <T> T assertFieldValueNotNull( final T fieldValue, final String fieldName ) {
@@ -83,11 +70,6 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
         if ( genomicsRead.getNextMatePosition() == null ) {
             genomicsRead.setNextMatePosition(new Position());
         }
-    }
-
-    @Override
-    public UUID getUUID() {
-        return uuid;
     }
 
     @Override
@@ -625,7 +607,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
     }
 
     @Override
-    public boolean equalsIgnoreUUID( final Object other ) {
+    public boolean equals( Object other ) {
         if ( this == other ) return true;
         if ( other == null || getClass() != other.getClass() ) return false;
 
@@ -636,16 +618,8 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
     }
 
     @Override
-    public boolean equals( Object other ) {
-        return equalsIgnoreUUID(other) && uuid.equals(((GoogleGenomicsReadToGATKReadAdapter)other).uuid);
-    }
-
-    @Override
     public int hashCode() {
-        int result = genomicsRead != null ? genomicsRead.hashCode() : 0;
-        result = 31 * result + uuid.hashCode();
-
-        return result;
+        return genomicsRead != null ? genomicsRead.hashCode() : 0;
     }
 
     // TODO: Remove once https://github.com/broadinstitute/hellbender/issues/650 is solved.

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -856,29 +856,4 @@ public final class ReadUtils {
         return read.isUnmapped() || read.getStart() <= contigHeader.getSequenceLength();
     }
 
-    /**
-     * Returns true if both Lists contain the same reads in the same order, ignoring UUIDs in the comparison.
-     *
-     * @param first first List of GATKReads to check
-     * @param second second List of GATKReads to check
-     * @return true if both Lists contain the same reads in the same order, ignoring UUIDs in the comparison,
-     *         otherwise false
-     */
-    public static boolean readListsAreEqualIgnoreUUID( final List<GATKRead> first, final List<GATKRead> second ) {
-        if ( first == null || second == null ) {
-            return first == null && second == null;
-        }
-
-        if ( first.size() != second.size() ) {
-            return false;
-        }
-
-        for ( int i = 0; i < first.size(); ++i ) {
-            if ( ! first.get(i).equalsIgnoreUUID(second.get(i)) ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ReadsPreprocessingPipelineTestData.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ReadsPreprocessingPipelineTestData.java
@@ -7,7 +7,6 @@ import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.ReferenceShard;
 import org.broadinstitute.hellbender.engine.VariantShard;
-import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -101,14 +100,14 @@ public class ReadsPreprocessingPipelineTestData {
         );
 
         variants = Lists.newArrayList(
-                new MinimalVariant(new SimpleInterval("1", 170, 180), true, false, new UUID(1001, 1001)),
-                new MinimalVariant(new SimpleInterval("1", 210, 220), false, true, new UUID(1002, 1002)),
+                new MinimalVariant(new SimpleInterval("1", 170, 180), true, false),
+                new MinimalVariant(new SimpleInterval("1", 210, 220), false, true),
                 new MinimalVariant(new SimpleInterval("1", ReferenceShard.REFERENCE_SHARD_SIZE,
-                        ReferenceShard.REFERENCE_SHARD_SIZE), true, false, new UUID(1003, 1003)),
+                        ReferenceShard.REFERENCE_SHARD_SIZE), true, false),
                 new MinimalVariant(new SimpleInterval("1", 3 * ReferenceShard.REFERENCE_SHARD_SIZE - 2,
-                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true, new UUID(1004, 1004)),
+                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true),
                 new MinimalVariant(new SimpleInterval("2", ReferenceShard.REFERENCE_SHARD_SIZE,
-                        ReferenceShard.REFERENCE_SHARD_SIZE), false, true, new UUID(1005, 1005))
+                        ReferenceShard.REFERENCE_SHARD_SIZE), false, true)
         );
 
         kvVariantShardRead = Arrays.asList(
@@ -174,7 +173,7 @@ public class ReadsPreprocessingPipelineTestData {
     /**
      * makeRead creates a read backed by either SAMRecord or Google model Read.
      * @param startLength the key is the start of the read, the value is the length.
-     * @param i name and id (UUID), note that if a different i is used, then two otherwise identical reads are not equal.
+     * @param i name
      * @param clazz either Google model Read or SAMRecord
      * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
      */
@@ -186,15 +185,15 @@ public class ReadsPreprocessingPipelineTestData {
      * makeRead creates a read backed by either SAMRecord or Google model Read.
      * @param start start position of the read
      * @param length length of the read
-     * @param i name and id (UUID), note that if a different i is used, then two otherwise identical reads are not equal.
+     * @param i name
      * @param clazz either Google model Read or SAMRecord
      * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
      */
     public static GATKRead makeRead(String contig, int start, int length, int i, Class<?> clazz) {
         if (clazz == Read.class) {
-            return ArtificialReadUtils.createGoogleBackedReadWithUUID(new UUID(0, i), Integer.toString(i), contig, start, length);
+            return ArtificialReadUtils.createGoogleBackedRead(Integer.toString(i), contig, start, length);
         } else if (clazz == SAMRecord.class) {
-            return ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, i), Integer.toString(i), contig, start, length);
+            return ArtificialReadUtils.createSamBackedRead(Integer.toString(i), contig, start, length);
         } else {
             throw new GATKException("invalid GATKRead type");
         }
@@ -203,8 +202,7 @@ public class ReadsPreprocessingPipelineTestData {
     /**
      * Generates a List of artificial reads located in significant positions relative to reference shard
      * boundaries. For each reference shard, places a read at the start of the shard, 1 base after the
-     * start, at the middle of the shard, 1 base before the end, and at the end. Each read has a length of 100,
-     * with consecutive UUIDs starting at 1.
+     * start, at the middle of the shard, 1 base before the end, and at the end. Each read has a length of 100.
      *
      * @param numContigs Generate reads for this many contigs (starting at "1" and increasing numerically)
      * @param numShardsPerContig Generate reads for this many reference shards within each contig. Each shard will have 5 reads, as described above.
@@ -213,7 +211,7 @@ public class ReadsPreprocessingPipelineTestData {
      */
     public static List<GATKRead> makeReferenceShardBoundaryReads( final int numContigs, final int numShardsPerContig, final Class<?> readImplementation ) {
         final List<GATKRead> reads = new ArrayList<>();
-        int uuid = 0;
+        int id = 0;
 
         for ( int contig = 1; contig <= numContigs; ++contig ) {
             for ( int shardNum = 0; shardNum < numShardsPerContig; ++shardNum ) {
@@ -223,7 +221,7 @@ public class ReadsPreprocessingPipelineTestData {
                 final int shardMiddle = shardEnd - (ReferenceShard.REFERENCE_SHARD_SIZE / 2);
 
                 for ( int readStart : Arrays.asList(shardStart, shardStart + 1, shardMiddle, shardEnd - 1, shardEnd) ) {
-                    reads.add(makeRead(Integer.toString(contig), readStart, 100, ++uuid, readImplementation));
+                    reads.add(makeRead(Integer.toString(contig), readStart, 100, ++id, readImplementation));
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/MinimalVariant.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/MinimalVariant.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.utils.variant;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 /**
  * MinimalVariant is a minimal implementation of the Variant interface.
@@ -14,7 +13,6 @@ public class MinimalVariant implements Variant, Serializable {
     private final SimpleInterval interval;
     private final boolean snp;
     private final boolean indel;
-    private final UUID uuid;
 
     @Override
     public boolean equals(Object o) {
@@ -25,25 +23,22 @@ public class MinimalVariant implements Variant, Serializable {
 
         if (isSnp() != that.isSnp()) return false;
         if (isIndel() != that.isIndel()) return false;
-        if (!interval.equals(that.interval)) return false;
-        return uuid.equals(that.uuid);
+        return !(interval != null ? !interval.equals(that.interval) : that.interval != null);
 
     }
 
     @Override
     public int hashCode() {
-        int result = interval.hashCode();
+        int result = interval != null ? interval.hashCode() : 0;
         result = 31 * result + (isSnp() ? 1 : 0);
         result = 31 * result + (isIndel() ? 1 : 0);
-        result = 31 * result + uuid.hashCode();
         return result;
     }
 
-    public MinimalVariant(SimpleInterval interval, boolean isSNP, boolean isIndel, UUID uuid) {
+    public MinimalVariant(SimpleInterval interval, boolean isSNP, boolean isIndel) {
         this.interval = interval;
         this.snp = isSNP;
         this.indel = isIndel;
-        this.uuid = uuid;
     }
 
     @Override
@@ -56,11 +51,6 @@ public class MinimalVariant implements Variant, Serializable {
     public boolean isSnp() { return snp; }
     @Override
     public boolean isIndel() { return indel; }
-
-    @Override
-    public UUID getUUID() {
-        return uuid;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/Variant.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/Variant.java
@@ -2,8 +2,6 @@ package org.broadinstitute.hellbender.utils.variant;
 
 import htsjdk.samtools.util.Locatable;
 
-import java.util.UUID;
-
 /**
  * Variant is (currently) a minimal variant interface needed by the Hellbender pipeline.
  * This will be expanded as more methods are needed.
@@ -13,5 +11,4 @@ import java.util.UUID;
 public interface Variant extends Locatable {
     boolean isSnp();
     boolean isIndel();
-    UUID getUUID();
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
@@ -4,7 +4,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 /**
  * VariantContextVariantAdapter wraps the existing htsjdk VariantContext class so it can be
@@ -14,34 +13,14 @@ public class VariantContextVariantAdapter implements Variant, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final VariantContext variantContext;
-    private final UUID uuid;
 
     public VariantContextVariantAdapter(VariantContext vc) {
         this.variantContext = vc;
-        this.uuid = UUID.randomUUID();
     }
 
-    VariantContextVariantAdapter(VariantContextVariantAdapter vcvc, UUID uuid) {
-        this.variantContext = vcvc.variantContext;
-        this.uuid = uuid;
-    }
-
-    VariantContextVariantAdapter(VariantContext vc, UUID uuid) {
-        this.variantContext = vc;
-        this.uuid = uuid;
-    }
-
-    /**
-     * Produces a VariantContextVariantAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
-     * and loading the variants twice (which can happen when caching is missing) prevents joining.
-     * @param vc VariantContext to adapt
-     * @return adapted VariantContext.
-     */
     public static Variant sparkVariantAdapter(VariantContext vc) {
-        return new MinimalVariant(new SimpleInterval(vc.getContig(),vc.getStart(),vc.getEnd()), vc.isSNP(), vc.isIndel(), new UUID(0L, 0L));
+        return new MinimalVariant(new SimpleInterval(vc.getContig(),vc.getStart(),vc.getEnd()), vc.isSNP(), vc.isIndel());
     }
-
-
 
     @Override
     public String getContig() { return variantContext.getContig(); }
@@ -53,11 +32,6 @@ public class VariantContextVariantAdapter implements Variant, Serializable {
     public boolean isSnp() { return variantContext.isSNP(); }
     @Override
     public boolean isIndel() { return variantContext.isIndel(); }
-
-    @Override
-    public UUID getUUID() {
-        return uuid;
-    }
 
     @Override
     public boolean equals(Object o) {
@@ -79,22 +53,17 @@ public class VariantContextVariantAdapter implements Variant, Serializable {
         if (isSnp() != that.isSnp()) {
             return false;
         }
-        if (isIndel() != that.isIndel()) {
-            return false;
-        }
-        return uuid.equals(that.uuid);
+        return isIndel() != that.isIndel();
     }
 
     @Override
     public int hashCode() {
-        int result = variantContext.hashCode();
-        result = 31 * result + uuid.hashCode();
-        return result;
+        return variantContext.hashCode();
     }
 
     @Override
     public String toString() {
-        return String.format("VariantContextVariantAdapter -- interval(%s:%d-%d), snp(%b), indel(%b), uuid(%d,%d)",
-                getContig(), getStart(), getEnd(), isSnp(), isIndel(), getUUID().getLeastSignificantBits(), getUUID().getMostSignificantBits());
+        return String.format("VariantContextVariantAdapter -- interval(%s:%d-%d), snp(%b), indel(%b)",
+                getContig(), getStart(), getEnd(), isSnp(), isIndel());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * ReadsPreprocessingPipelineTestData contains coordinated test data that can be used in the many transforms that
@@ -84,14 +83,14 @@ public class ReadsPreprocessingPipelineSparkTestData {
         );
 
         variants = Lists.newArrayList(
-                new MinimalVariant(new SimpleInterval("1", 170, 180), true, false, new UUID(1001, 1001)),
-                new MinimalVariant(new SimpleInterval("1", 210, 220), false, true, new UUID(1002, 1002)),
+                new MinimalVariant(new SimpleInterval("1", 170, 180), true, false),
+                new MinimalVariant(new SimpleInterval("1", 210, 220), false, true),
                 new MinimalVariant(new SimpleInterval("1", ReferenceShard.REFERENCE_SHARD_SIZE,
-                        ReferenceShard.REFERENCE_SHARD_SIZE), true, false, new UUID(1003, 1003)),
+                        ReferenceShard.REFERENCE_SHARD_SIZE), true, false),
                 new MinimalVariant(new SimpleInterval("1", 3 * ReferenceShard.REFERENCE_SHARD_SIZE - 2,
-                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true, new UUID(1004, 1004)),
+                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true),
                 new MinimalVariant(new SimpleInterval("2", ReferenceShard.REFERENCE_SHARD_SIZE,
-                        ReferenceShard.REFERENCE_SHARD_SIZE), false, true, new UUID(1005, 1005))
+                        ReferenceShard.REFERENCE_SHARD_SIZE), false, true)
         );
 
         kvReadVariant = Arrays.asList(
@@ -148,9 +147,9 @@ public class ReadsPreprocessingPipelineSparkTestData {
      */
     public static GATKRead makeRead(String contig, int start, int length, int i, Class<?> clazz) {
         if (clazz == Read.class) {
-            return ArtificialReadUtils.createGoogleBackedReadWithUUID(new UUID(0, 0), Integer.toString(i), contig, start, length);
+            return ArtificialReadUtils.createGoogleBackedRead(Integer.toString(i), contig, start, length);
         } else if (clazz == SAMRecord.class) {
-            return ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, 0), Integer.toString(i), contig, start, length);
+            return ArtificialReadUtils.createSamBackedRead(Integer.toString(i), contig, start, length);
         } else {
             throw new GATKException("invalid GATKRead type");
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -10,11 +10,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
-
-import java.util.UUID;
 
 public class SAMRecordToGATKReadAdapterSerializerUnitTest {
 
@@ -34,7 +31,7 @@ public class SAMRecordToGATKReadAdapterSerializerUnitTest {
         SerializerInstance sparkSerializer = kryoSerializer.newInstance();
 
         // check round trip with header set
-        GATKRead read = ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, 0), "read1", "1", 100, 50);
+        GATKRead read = ArtificialReadUtils.createSamBackedRead("read1", "1", 100, 50);
         check(sparkSerializer, read);
 
         // check round trip with no header

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualitySumPerAlleleBySampleUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualitySumPerAlleleBySampleUnitTest.java
@@ -22,7 +22,6 @@ public final class BaseQualitySumPerAlleleBySampleUnitTest {
     public void testUsableRead() {
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(5, 1, 10000);
         final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "myRead", 0, 1, 76);
-
         read.setMappingQuality(60);
         Assert.assertTrue(BaseQualitySumPerAlleleBySample.isUsableRead(read));
 
@@ -59,14 +58,14 @@ public final class BaseQualitySumPerAlleleBySampleUnitTest {
         final int readLen = 10;
 
         for (int i = 0; i < readDepthAlt; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"), "read1_" + i);
             read.setBaseQualities(Utils.dupBytes(baseQual, readLen));
             read.setMappingQuality(20);
             map.add(read, A, -10.0);
             map.add(read, C, -1.0);      //try to fool it - add another likelihood to same read
         }
         for (int i = 0; i < readDepthRef; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"), "read2_" + i);
             read.setBaseQualities(Utils.dupBytes(baseQual, readLen));
             read.setMappingQuality(20);
             map.add(read, A, -1.0);
@@ -74,7 +73,7 @@ public final class BaseQualitySumPerAlleleBySampleUnitTest {
         }
 
         //throw in one non-informative read
-        final GATKRead badRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"));
+        final GATKRead badRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(readLen + "M"), "read3");
         badRead.setBaseQualities(Utils.dupBytes(baseQual, readLen));
         badRead.setMappingQuality(20);
         map.add(badRead, A, -1.0);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/CoverageUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/CoverageUnitTest.java
@@ -66,11 +66,11 @@ public final class CoverageUnitTest extends BaseTest {
         final int n1A= 3;
         final int n1T= 5;
         for (int i = 0; i < n1A; i++) {
-            map.add(ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M")), alleleA, lik);
+            map.add(ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "n1A_" + i), alleleA, lik);
         }
         for (int i = 0; i < n1T; i++) {
             //try to fool it - add 2 alleles for same read
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "n1T_" + i);
             map.add(read, alleleA, lik);
             map.add(read, alleleT, lik);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySampleUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySampleUnitTest.java
@@ -45,20 +45,20 @@ public final class DepthPerAlleleBySampleUnitTest extends BaseTest {
         final double log10PError = -5;
 
         for (int i = 0; i < readDepthAlt; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "readDepthAlt_" + i);
             read.setMappingQuality(20);
             map.add(read, A, -10.0);
             map.add(read, C, -1.0);      //try to fool it - add another likelihood to same read
         }
         for (int i = 0; i < readDepthRef; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "readDepthRef_" + i);
             read.setMappingQuality(20);
             map.add(read, A, -1.0);
             map.add(read, C, -100.0);  //try to fool it - add another likelihood to same read
         }
 
         //throw in one non-informative read
-        final GATKRead badRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+        final GATKRead badRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "non-informative");
         badRead.setMappingQuality(20);
         map.add(badRead, A, -1.0);
         map.add(badRead, C, -1.1); //maybe it's ref, maybe it's alt, too close to call -> not informative

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/LikelihoodRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/LikelihoodRankSumTestUnitTest.java
@@ -35,9 +35,9 @@ public final class LikelihoodRankSumTestUnitTest extends BaseTest {
                 .alleles(Arrays.asList(refAllele, altAllele)).chr(contig).start(position).stop(position).genotypes(testGC).make();
     }
 
-    private GATKRead makeRead(final String contig, final int start, final int mq) {
+    private GATKRead makeRead(final String contig, final int start, final int mq, final String name) {
         Cigar cigar = TextCigarCodec.decode("10M");
-        final GATKRead read = ArtificialReadUtils.createArtificialRead(cigar);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(cigar, name);
         read.setMappingQuality(mq);
         read.setPosition(contig, start);
         return read;
@@ -56,10 +56,10 @@ public final class LikelihoodRankSumTestUnitTest extends BaseTest {
 
         final double[] altBadAlleleLL =  {-100.0, -100.0};
         final double[] refBestAlleleLL = {-5.0, -7.0};
-        final GATKRead read1 = makeRead(contig, 1,  30);
-        final GATKRead read2 = makeRead(contig, 1, 30);
-        final GATKRead read3 = makeRead(contig, 1, 30);
-        final GATKRead read4 = makeRead(contig, 1, 30);
+        final GATKRead read1 = makeRead(contig, 1,  30, "read1");
+        final GATKRead read2 = makeRead(contig, 1, 30, "read2");
+        final GATKRead read3 = makeRead(contig, 1, 30, "read3");
+        final GATKRead read4 = makeRead(contig, 1, 30, "read4");
         map.add(read1, alleleAlt, altBestAlleleLL[0]);
         map.add(read1, alleleRef, refBadAlleleLL[0]);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZeroUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZeroUnitTest.java
@@ -61,13 +61,13 @@ public final class MappingQualityZeroUnitTest {
         final int n1A= 3;
         final int n1T= 5;
         for (int i = 0; i < n1A; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "n1A_" + i);
             read.setMappingQuality(10);
             map.add(read, alleleA, lik);
         }
         for (int i = 0; i < n1T; i++) {
             //try to fool it - add 2 alleles for same read
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "n1T_" + i);
             read.setMappingQuality(0);
             map.add(read, alleleA, lik);
             map.add(read, alleleT, lik);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/OxoGReadCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/OxoGReadCountsUnitTest.java
@@ -50,8 +50,8 @@ public final class OxoGReadCountsUnitTest {
         );
     }
 
-    private GATKRead makeRead(final Allele ref, final Allele alt, final boolean isRefRead, final boolean isF1R2Read, final PerReadAlleleLikelihoodMap map){
-        final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(10 + "M"));
+    private GATKRead makeRead(final Allele ref, final Allele alt, final boolean isRefRead, final boolean isF1R2Read, final PerReadAlleleLikelihoodMap map, int name){
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(10 + "M"), "random_read_" + isRefRead + "_" + isF1R2Read + "_" + name);
         read.setMappingQuality(20);
         if (isF1R2Read){
             F1R2(read);
@@ -135,16 +135,16 @@ public final class OxoGReadCountsUnitTest {
 
     private VariantContext makeReads(int alt_F1R2, int alt_F2R1, int ref_F1R2, int ref_F2R1, PerReadAlleleLikelihoodMap map, Allele refAllele, Allele altAllele, List<Allele> alleles, Genotype g) {
         for (int i = 0; i < alt_F1R2; i++) {
-            makeRead(refAllele, altAllele, false, true, map);
+            makeRead(refAllele, altAllele, false, true, map, i);
         }
         for (int i = 0; i < alt_F2R1; i++) {
-            makeRead(refAllele, altAllele, false, false, map);
+            makeRead(refAllele, altAllele, false, false, map, i);
         }
         for (int i = 0; i < ref_F1R2; i++) {
-            makeRead(refAllele, altAllele, true, true, map);
+            makeRead(refAllele, altAllele, true, true, map, i);
         }
         for (int i = 0; i < ref_F2R1; i++) {
-            makeRead(refAllele, altAllele, true, false, map);
+            makeRead(refAllele, altAllele, true, false, map, i);
         }
         //throw in one non-informative read
         final GATKRead badRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(10 + "M"));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepthUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepthUnitTest.java
@@ -105,7 +105,7 @@ public class QualByDepthUnitTest extends BaseTest {
 
         final int n1A= readDepth;
         for (int i = 0; i < n1A; i++) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"));
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("10M"), "n1A_" + i);
             read.setMappingQuality(20);
             map.add(read, A, -1.0);
             map.add(read, C, -100.0);  //try to fool it - add another likelihood to same read

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandOddsRatioUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandOddsRatioUnitTest.java
@@ -87,9 +87,9 @@ public final class StrandOddsRatioUnitTest {
         Assert.assertEquals(Double.valueOf(sor), expectedSOR, 0.001);
     }
 
-    private GATKRead makeRead(final boolean forward) {
+    private GATKRead makeRead(final boolean forward, final String name) {
         Cigar cigar = TextCigarCodec.decode("10M");
-        final GATKRead read = ArtificialReadUtils.createArtificialRead(cigar);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(cigar, name);
         read.setIsReverseStrand(!forward);
         return read;
     }
@@ -116,10 +116,10 @@ public final class StrandOddsRatioUnitTest {
         final int[][] table= {{1, 1},  // alt: one read in each direction,
                               {2, 0}}; //ref: 2 reads fwd, 0 reads back
 
-        final GATKRead read1 = makeRead(true);
-        final GATKRead read2 = makeRead(true);
-        final GATKRead read3 = makeRead(false);
-        final GATKRead read4 = makeRead(true);
+        final GATKRead read1 = makeRead(true, "read1");
+        final GATKRead read2 = makeRead(true, "read2");
+        final GATKRead read3 = makeRead(false, "read3");
+        final GATKRead read4 = makeRead(true, "read4");
         map.add(read1, alleleAlt, -1.0);
         map.add(read1, alleleRef, -100.0);
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/downsampling/AlleleBiasedDownsamplingUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/downsampling/AlleleBiasedDownsamplingUtilsUnitTest.java
@@ -116,7 +116,7 @@ public class AlleleBiasedDownsamplingUtilsUnitTest extends BaseTest {
             readMap.put(nonRefAllele, new ArrayList<>());
             for (int i = 0; i < actualCounts[idx]; i++) {
                 final byte[] readBases = {(byte) bases[idx]};
-                final GATKRead newRead = ArtificialReadUtils.createArtificialRead(header, UUID.randomUUID().toString(), 0, 1, readBases, quals, "1M");
+                final GATKRead newRead = ArtificialReadUtils.createArtificialRead(header, "read" + i, 0, 1, readBases, quals, "1M");
                 readMap.get(nonRefAllele).add(newRead);
             }
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/genotyper/PerReadAlleleLikelihoodMapUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/genotyper/PerReadAlleleLikelihoodMapUnitTest.java
@@ -24,7 +24,7 @@ public final class PerReadAlleleLikelihoodMapUnitTest extends BaseTest {
 
     @Test()
     public void testMultiAlleleWithHomLiks() {
-        final ReadPileup pileup = makeArtificialPileup();
+        final ReadPileup pileup = makeArtificialPileup("first");
 
         Allele base_A = Allele.create(BaseUtils.Base.A.base);
         Allele base_C = Allele.create(BaseUtils.Base.C.base);
@@ -57,7 +57,7 @@ public final class PerReadAlleleLikelihoodMapUnitTest extends BaseTest {
         Assert.assertEquals(likMap.get(base_A), likA);
         Assert.assertEquals(likMap.get(base_C), likNotA);
 
-        ReadPileup newPileup = makeArtificialPileup();
+        ReadPileup newPileup = makeArtificialPileup("second");
         Assert.assertNull(perReadAlleleLikelihoodMap.getLikelihoods(newPileup.get(0)));
 
         Assert.assertNotNull(perReadAlleleLikelihoodMap.toString()); //checking blowup
@@ -68,7 +68,7 @@ public final class PerReadAlleleLikelihoodMapUnitTest extends BaseTest {
         Assert.assertNotNull(perReadAlleleLikelihoodMap.toString()); //checking blowup
     }
 
-    private ReadPileup makeArtificialPileup() {
+    private ReadPileup makeArtificialPileup(final String prefix) {
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
         final Locatable myLocation = new SimpleInterval("1", 10, 10);
 
@@ -76,7 +76,7 @@ public final class PerReadAlleleLikelihoodMapUnitTest extends BaseTest {
         final int readLength = 10;
         final List<GATKRead> reads = new LinkedList<>();
         for ( int i = 0; i < pileupSize; i++ ) {
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "myRead" + i, 0, 1, readLength);
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(header, prefix + "_myRead" + i, 0, 1, readLength);
             final byte[] bases = Utils.dupBytes((byte) 'A', readLength);
             bases[0] = (byte)(i % 2 == 0 ? 'A' : 'C'); // every other read the first base is a C
 
@@ -92,7 +92,7 @@ public final class PerReadAlleleLikelihoodMapUnitTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadLikelihood(){
-        final ReadPileup pileup = makeArtificialPileup();
+        final ReadPileup pileup = makeArtificialPileup("first");
         PerReadAlleleLikelihoodMap perReadAlleleLikelihoodMap = new PerReadAlleleLikelihoodMap();
         Allele base_A = Allele.create(BaseUtils.Base.A.base);
         final Allele allele = base_A;

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
@@ -17,10 +17,6 @@ public class VariantContextVariantAdapterTest extends BaseTest {
     private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
     private static final File QUERY_TEST_VCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "feature_data_source_test.vcf");
 
-    UUID defaultUUID() {
-        return new UUID(0L, 0L);
-    }
-
     @Test(dataProvider = "VariantDataProvider")
     public void testVariantAdapter(final List<Variant> expectedVariantList) {
         // The test suite for reading in VCF files is FeatureDataSourceUnitTest.
@@ -46,35 +42,33 @@ public class VariantContextVariantAdapterTest extends BaseTest {
 
     @DataProvider(name = "VariantDataProvider")
     public Object[][] getVariantData() {
-        // We use the defaultUUID because we want to have be able to use equals (without clearing, we'd see items
-        // aren't the same because of UUIDs).
         List<Variant> variantSet = new ArrayList<>();
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 100, 100), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 199, 200), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 200, 200), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 203, 206), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 280, 280), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 284, 286), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 285, 285), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 286, 286), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 999, 999), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1000, 1000), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1000, 1003), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1076, 1076), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1150, 1150), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1176, 1176), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("2", 200, 200), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("2", 525, 525), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("2", 548, 550), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("2", 640, 640), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("2", 700, 700), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("3", 1, 1), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("3", 300, 300), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("3", 300, 303), false, true, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("3", 400, 400), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("4", 600, 600), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("4", 775, 775), true, false, defaultUUID()));
-        variantSet.add(new MinimalVariant(new SimpleInterval("4", 776, 779), false, true, defaultUUID()));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 100, 100), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 199, 200), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 200, 200), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 203, 206), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 280, 280), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 284, 286), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 285, 285), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 286, 286), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 999, 999), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1000, 1000), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1000, 1003), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1076, 1076), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1150, 1150), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("1", 1176, 1176), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("2", 200, 200), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("2", 525, 525), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("2", 548, 550), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("2", 640, 640), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("2", 700, 700), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("3", 1, 1), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("3", 300, 300), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("3", 300, 303), false, true));
+        variantSet.add(new MinimalVariant(new SimpleInterval("3", 400, 400), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("4", 600, 600), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("4", 775, 775), true, false));
+        variantSet.add(new MinimalVariant(new SimpleInterval("4", 776, 779), false, true));
         return new Object[][]{
                 { variantSet }
         };


### PR DESCRIPTION
We needed UUIDs for Dataflow, but they are just a hinderance in Spark.
In this PR, I removed every reference to UUID that was related to the original Dataflow code. I also fixed some unit tests that were implicitly depending on the UUIDs to have test reads not equal. The fix was to give the test reads different names.