### PR TITLE
changing where require GATK spark settings are applied

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 
 
 public abstract class SparkCommandLineProgram extends CommandLineProgram implements Serializable {
-    private static final long serialVersionUID = 1l;
+    private static final long serialVersionUID = 1L;
 
 
     @Argument(doc = "API Key for google cloud authentication",
@@ -20,7 +20,7 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
 
 
     @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
-    protected String sparkMaster = "local[2]";
+    protected String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
 
     @Argument(
             doc = "Name of the program running",
@@ -33,12 +33,6 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
     @Override
     protected Object doWork() {
         final JavaSparkContext ctx = SparkContextFactory.getSparkContext(getProgramName(), sparkMaster);
-        ctx.getConf().set("spark.driver.maxResultSize", "0")
-                .set("spark.driver.userClassPathFirst", "true")
-                .set("spark.executor.userClassPathFirst", "true")
-                .set("spark.io.compression.codec", "lzf")
-                .set("spark.yarn.executor.memoryOverhead", "600");
-
         try{
             runPipeline(ctx);
             return null;
@@ -56,7 +50,7 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
             return null;
         }
 
-        GCSOptions options = PipelineOptionsFactory.as(GCSOptions.class);
+        final GCSOptions options = PipelineOptionsFactory.as(GCSOptions.class);
         options.setApiKey(apiKey);
         return options;
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactoryUnitTest.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.SparkConf;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class SparkContextFactoryUnitTest extends BaseTest {
+
+    @Test
+    public void testSetupSparkConf(){
+        final String appName = "appName";
+        final String master = "master";
+        final SparkConf sparkConf = SparkContextFactory.setupSparkConf(appName, master, SparkContextFactory.TEST_ATTRIBUTES);
+        Assert.assertEquals(sparkConf.get("spark.master"), master);
+        Assert.assertEquals(sparkConf.get("spark.app.name"), appName);
+        for(Map.Entry<String,String> entry: SparkContextFactory.TEST_ATTRIBUTES.entrySet()){
+            Assert.assertEquals(sparkConf.get(entry.getKey()), entry.getValue());
+        }
+    }
+
+}


### PR DESCRIPTION
moving settings from SparkCommandLineProgram to SparkContextFactory
the settings that were being applied to SparkContext.getConf were pointless since getConf is a copy of the configuration
instead they're applied to the SparkConfig in SparkContextFactory.getSparkContext

fixes #1096

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/broadinstitute/gatk/1097)
<!-- Reviewable:end -->
