### PR TITLE
Fix regression in ReadSparkSource: null out SAMFileHeaders when loading reads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
@@ -13,7 +13,7 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
 
     @Override
     public void write(Kryo kryo, Output output, SAMRecordToGATKReadAdapter adapter) {
-        SAMRecord record = adapter.getSamRecord();
+        SAMRecord record = adapter.getEncapsulatedSamRecord();
         // serialize reference names to avoid having to have a header at read time
         output.writeString(record.getReferenceName());
         output.writeString(record.getMateReferenceName());
@@ -43,7 +43,7 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
         record.setReferenceIndex(referenceIndex);
         record.setMateReferenceIndex(mateReferenceIndex);
 
-        return new SAMRecordToGATKReadAdapter(record);
+        return SAMRecordToGATKReadAdapter.headerlessReadAdapter(record);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -79,7 +79,7 @@ public class ReadsSparkSource implements Serializable {
             SAMRecord sam = v1._2().get();
             if (samRecordOverlaps(sam, intervals)) {
                 try {
-                    return (GATKRead) new SAMRecordToGATKReadAdapter(sam);
+                    return (GATKRead)SAMRecordToGATKReadAdapter.headerlessReadAdapter(sam);
                 } catch (SAMException e) {
                     // TODO: add stringency
                 }            

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -27,6 +27,20 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
         this.samRecord = samRecord;
     }
 
+    /**
+     * Produces a SAMRecordToGATKReadAdapter wrapping the provided SAMRecord,
+     * and nulls out the header in the encapsulated read. This is useful for
+     * Spark tools, in order to avoid serializing the SAMFileHeader for each
+     * record.
+     *
+     * @param samRecord read to adapt (header will be stripped)
+     * @return SAMRecordToGATKReadAdapter wrapping the headerless samRecord
+     */
+    public static SAMRecordToGATKReadAdapter headerlessReadAdapter( final SAMRecord samRecord ) {
+        samRecord.setHeader(null);
+        return new SAMRecordToGATKReadAdapter(samRecord);
+    }
+
     @Override
     public String getName() {
         return samRecord.getReadName();
@@ -488,7 +502,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
         return samRecord;
     }
 
-    public SAMRecord getSamRecord() {
+    public SAMRecord getEncapsulatedSamRecord() {
         return samRecord;
     }
 
@@ -505,13 +519,13 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
         SAMRecordToGATKReadAdapter that = (SAMRecordToGATKReadAdapter) o;
 
-        return !(getSamRecord() != null ? !getSamRecord().equals(that.getSamRecord()) : that.getSamRecord() != null);
+        return !(samRecord != null ? !samRecord.equals(that.samRecord) : that.samRecord != null);
 
     }
 
     @Override
     public int hashCode() {
-        return getSamRecord() != null ? getSamRecord().hashCode() : 0;
+        return samRecord != null ? samRecord.hashCode() : 0;
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -35,7 +35,7 @@ public class SAMRecordToGATKReadAdapterSerializerUnitTest {
         check(sparkSerializer, read);
 
         // check round trip with no header
-        ((SAMRecordToGATKReadAdapter) read).getSamRecord().setHeader(null);
+        ((SAMRecordToGATKReadAdapter) read).getEncapsulatedSamRecord().setHeader(null);
         check(sparkSerializer, read);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -42,6 +43,17 @@ public class ReadsSparkSourceUnitTest extends BaseTest {
         List<GATKRead> serialReads = rddSerialReads.collect();
         List<GATKRead> parallelReads = rddParallelReads.collect();
         Assert.assertEquals(serialReads.size(), parallelReads.size());
+    }
+
+    @Test(groups = "spark")
+    public void testHeadersAreStripped() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        final List<GATKRead> reads = readSource.getParallelReads(dir + "HiSeq.1mb.1RG.2k_lines.alternate.bam").collect();
+
+        for ( final GATKRead read : reads ) {
+            Assert.assertNull(((SAMRecordToGATKReadAdapter)read).getEncapsulatedSamRecord().getHeader(), "ReadSparkSource failed to null out header for read");
+        }
     }
 
     @Test


### PR DESCRIPTION
PR #1068 had the unintended side effect of removing the method responsible for
stripping out SAMFileHeaders on Spark. This commit restores that method, and adds
a unit test to verify that all reads emitted by ReadSparkSource are headerless.