### PR TITLE
BaseRecalibrator speedup >20%

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -150,13 +150,13 @@ public final class BaseRecalibrator extends ReadWalker {
 
     @Override
     public CountingReadFilter makeReadFilter() {
-        return super.makeReadFilter()
-                .and(makeBQSRSpecificReadFilters());
+        //Note: the order is deliberate - we first check the cheap conditions that do not require decoding the read
+        return makeBQSRSpecificReadFilters().and(super.makeReadFilter());
     }
 
     public static CountingReadFilter getStandardBQSRReadFilter( final SAMFileHeader header ) {
-        return new CountingReadFilter("Wellformed", new WellformedReadFilter(header))
-                .and(makeBQSRSpecificReadFilters());
+        //Note: the order is deliberate - we first check the cheap conditions that do not require decoding the read
+        return makeBQSRSpecificReadFilters().and(new CountingReadFilter("Wellformed", new WellformedReadFilter(header)));
     }
 
     private static CountingReadFilter makeBQSRSpecificReadFilters() {

--- a/src/main/java/org/broadinstitute/hellbender/transformers/BQSRReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/BQSRReadTransformer.java
@@ -135,7 +135,7 @@ public final class BQSRReadTransformer implements ReadTransformer {
         // the rg key is constant over the whole read, the global deltaQ is too
         final int rgKey = fullReadKeySet[0][0];
 
-        final RecalDatum empiricalQualRG = recalibrationTables.getReadGroupTable().get2(rgKey, BASE_SUBSTITUTION_INDEX);
+        final RecalDatum empiricalQualRG = recalibrationTables.getReadGroupTable().get2Keys(rgKey, BASE_SUBSTITUTION_INDEX);
 
         if (empiricalQualRG == null) {
             return read;
@@ -159,11 +159,11 @@ public final class BQSRReadTransformer implements ReadTransformer {
             final int[] keySet = fullReadKeySet[offset];
 
 
-            final RecalDatum empiricalQualQS = qualityScoreTable.get3(keySet[0], keySet[1], BASE_SUBSTITUTION_INDEX);
+            final RecalDatum empiricalQualQS = qualityScoreTable.get3Keys(keySet[0], keySet[1], BASE_SUBSTITUTION_INDEX);
 
             for (int i = specialCovariateCount; i < totalCovariateCount; i++) {
                 if (keySet[i] >= 0) {
-                    empiricalQualCovsArgs[i - specialCovariateCount] = recalibrationTables.getTable(i).get4(keySet[0], keySet[1], keySet[i], BASE_SUBSTITUTION_INDEX);
+                    empiricalQualCovsArgs[i - specialCovariateCount] = recalibrationTables.getTable(i).get4Keys(keySet[0], keySet[1], keySet[i], BASE_SUBSTITUTION_INDEX);
                 }
             }
             final double recalibratedQualDouble = hierarchicalBayesianQualityEstimate(epsilon, empiricalQualRG, empiricalQualQS, empiricalQualCovsArgs);

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArray.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArray.java
@@ -84,10 +84,12 @@ public final class NestedIntegerArray<T extends Serializable> implements Seriali
 
     @SuppressWarnings("unchecked")
     private T leaf(final int key, final Object[] array){
+        //Note: bounds check is done in the caller
         return array == null ? null : (T) array[key];
     }
 
-    private Object[] unroll(final int key, final Object[] array){
+    private Object[] nextDimension(final int key, final Object[] array){
+        //Note: bounds check is done in the caller
         return array == null ? null : (Object[]) array[key];
     }
 
@@ -97,7 +99,7 @@ public final class NestedIntegerArray<T extends Serializable> implements Seriali
      * Using a specialized method eliminates that performance problem.
      */
     @SuppressWarnings("unchecked")
-    public T get1(final int key0) {
+    public T get1Key(final int key0) {
         return leaf(key0, data);
     }
 
@@ -107,11 +109,11 @@ public final class NestedIntegerArray<T extends Serializable> implements Seriali
      * Using a specialized method eliminates that performance problem.
      */
     @SuppressWarnings("unchecked")
-    public T get2(final int key0, final int key1) {
-        if ( key0 >= dimensions[0] ) {
+    public T get2Keys(final int key0, final int key1) {
+        if ( key0 >= dimensions[0] || key1 >= dimensions[1] ) {
             return null;
         }
-        return leaf(key1, unroll(key0, data));
+        return leaf(key1, nextDimension(key0, data));
     }
 
     /**
@@ -120,11 +122,11 @@ public final class NestedIntegerArray<T extends Serializable> implements Seriali
      * Using a specialized method eliminates that performance problem.
      */
     @SuppressWarnings("unchecked")
-    public T get3(final int key0, final int key1, final int key2) {
-        if (key0 >= dimensions[0] || key1 >= dimensions[1]) {
+    public T get3Keys(final int key0, final int key1, final int key2) {
+        if (key0 >= dimensions[0] || key1 >= dimensions[1] || key2 >= dimensions[2] ) {
             return null;
         }
-        return leaf(key2, unroll(key1, unroll(key0, data)));
+        return leaf(key2, nextDimension(key1, nextDimension(key0, data)));
     }
 
     /**
@@ -133,13 +135,12 @@ public final class NestedIntegerArray<T extends Serializable> implements Seriali
      * Using a specialized method eliminates that performance problem.
      */
     @SuppressWarnings("unchecked")
-    public T get4(final int key0, final int key1, final int key2, final int key3) {
-        if (key0 >= dimensions[0] || key1 >= dimensions[1] || key2 >= dimensions[2]) {
+    public T get4Keys(final int key0, final int key1, final int key2, final int key3) {
+        if (key0 >= dimensions[0] || key1 >= dimensions[1] || key2 >= dimensions[2] || key3 >= dimensions[3]) {
             return null;
         }
-        return leaf(key3, unroll(key2, unroll(key1, unroll(key0, data))));
+        return leaf(key3, nextDimension(key2, nextDimension(key1, nextDimension(key0, data))));
     }
-
 
     /**
      * Insert a value at the position specified by the given keys.

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
@@ -563,20 +563,74 @@ public final class RecalUtils {
      * Increments the RecalDatum at the specified position in the specified table, or put a new item there
      * if there isn't already one.
      *
+     * Note: we intentionally do not use varargs here to avoid the performance cost of allocating an array on every call. It showed on the profiler.
+     *
      * @param table the table that holds/will hold our item
      * @param qual qual for this event
      * @param isError error value for this event
-     * @param keys location in table of our item
+     * @param key0, key1 location in table of our item
      */
-    public static void incrementDatumOrPutIfNecessary( final NestedIntegerArray<RecalDatum> table,
-                                                          final byte qual,
-                                                          final double isError,
-                                                          final int... keys ) {
-        final RecalDatum existingDatum = table.get(keys);
+    public static void incrementDatumOrPutIfNecessary2keys( final NestedIntegerArray<RecalDatum> table,
+                                                            final byte qual,
+                                                            final double isError,
+                                                            final int key0, final int key1) {
+        final RecalDatum existingDatum = table.get2Keys(key0, key1);
 
         if ( existingDatum == null ) {
             // No existing item, put a new one
-            table.put(createDatumObject(qual, isError), keys);
+            table.put(createDatumObject(qual, isError), key0, key1);
+        } else {
+            // Easy case: already an item here, so increment it
+            existingDatum.increment(1L, isError);
+        }
+    }
+
+    /**
+     * Increments the RecalDatum at the specified position in the specified table, or put a new item there
+     * if there isn't already one.
+     *
+     * Note: we intentionally do not use varargs here to avoid the performance cost of allocating an array on every call. It showed on the profiler.
+     *
+     * @param table the table that holds/will hold our item
+     * @param qual qual for this event
+     * @param isError error value for this event
+     * @param key0, key1, key2 location in table of our item
+     */
+    public static void incrementDatumOrPutIfNecessary3keys( final NestedIntegerArray<RecalDatum> table,
+                                                            final byte qual,
+                                                            final double isError,
+                                                            final int key0, final int key1, final int key2) {
+        final RecalDatum existingDatum = table.get3Keys(key0, key1, key2);
+
+        if ( existingDatum == null ) {
+            // No existing item, put a new one
+            table.put(createDatumObject(qual, isError), key0, key1, key2);
+        } else {
+            // Easy case: already an item here, so increment it
+            existingDatum.increment(1L, isError);
+        }
+    }
+
+    /**
+     * Increments the RecalDatum at the specified position in the specified table, or put a new item there
+     * if there isn't already one.
+     *
+     * Note: we intentionally do not use varargs here to avoid the performance cost of allocating an array on every call. It showed on the profiler.
+     *
+     * @param table the table that holds/will hold our item
+     * @param qual qual for this event
+     * @param isError error value for this event
+     * @param key0, key1, key2, key3 location in table of our item
+     */
+    public static void incrementDatumOrPutIfNecessary4keys( final NestedIntegerArray<RecalDatum> table,
+                                                            final byte qual,
+                                                            final double isError,
+                                                            final int key0,  final int key1, final int key2, final int key3) {
+        final RecalDatum existingDatum = table.get4Keys(key0, key1, key2, key3);
+
+        if ( existingDatum == null ) {
+            // No existing item, put a new one
+            table.put(createDatumObject(qual, isError), key0, key1, key2, key3);
         } else {
             // Easy case: already an item here, so increment it
             existingDatum.increment(1L, isError);

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
@@ -163,6 +163,8 @@ public final class ContextCovariate implements Covariate {
     private static IntList contextWith(final byte[] bases, final int contextSize, final int mask) {
 
         final int readLength = bases.length;
+
+        //Note: we use a specialized collection to avoid the cost of boxing and unboxing that otherwise comes up on the profiler.
         final IntList keys = new IntArrayList(readLength);
 
         // the first contextSize-1 bases will not have enough previous context

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateList.java
@@ -52,7 +52,7 @@ public final class StandardCovariateList implements Iterable<Covariate>, Seriali
     }
 
     /**
-     * Returns 2. ReadGroupCovariate and  QualityScoreCovariate are special
+     * Returns 2. ReadGroupCovariate and QualityScoreCovariate are special
      */
     public int numberOfSpecialCovariates() {
         return 2;
@@ -127,10 +127,8 @@ public final class StandardCovariateList implements Iterable<Covariate>, Seriali
      * record the values in the provided storage object.
       */
     public void recordAllValuesInStorage(final GATKRead read, final SAMFileHeader header, final ReadCovariates resultsStorage, final boolean recordIndelValues) {
-        //Note: extracting the field to a temp because this is a very tight loop and field lookup came up on the profile
-        final List<Covariate> allCovs = allCovariates;
-        for (int i = 0, n = allCovs.size(); i < n; i++) {
-            final Covariate cov = allCovs.get(i);
+        for (int i = 0, n = allCovariates.size(); i < n; i++) {
+            final Covariate cov = allCovariates.get(i);
             resultsStorage.setCovariateIndex(i);
             cov.recordValues(read, header, resultsStorage, recordIndelValues);
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArrayUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArrayUnitTest.java
@@ -51,7 +51,7 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
     }
 
     @Test
-    public void testPutGet1() throws Exception {
+    public void testPutget1Key() throws Exception {
         NestedIntegerArray<String> arr= new NestedIntegerArray<>(2);
         arr.put("fred", 0);
         arr.put("bozo", 1);
@@ -60,15 +60,15 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
         Assert.assertEquals(Sets.newHashSet("fred", "bozo"), new HashSet<>(arr.getAllValues()));
 
         Assert.assertEquals("fred", arr.get(0));
-        Assert.assertEquals("fred", arr.get1(0));
+        Assert.assertEquals("fred", arr.get1Key(0));
 
         Assert.assertEquals("bozo", arr.get(1));
-        Assert.assertEquals("bozo", arr.get1(1));
+        Assert.assertEquals("bozo", arr.get1Key(1));
 
     }
 
     @Test
-    public void testPutGet2() throws Exception {
+    public void testPutget2Keys() throws Exception {
         NestedIntegerArray<String> arr= new NestedIntegerArray<>(2, 2);
         arr.put("fred", 0, 1);
         arr.put("bozo", 1, 0);
@@ -77,18 +77,18 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
         Assert.assertEquals(Sets.newHashSet("fred", "bozo"), new HashSet<>(arr.getAllValues()));
 
         Assert.assertEquals("fred", arr.get(0, 1));
-        Assert.assertEquals("fred", arr.get2(0, 1));
+        Assert.assertEquals("fred", arr.get2Keys(0, 1));
 
         Assert.assertEquals("bozo", arr.get(1, 0));
-        Assert.assertEquals("bozo", arr.get2(1, 0));
+        Assert.assertEquals("bozo", arr.get2Keys(1, 0));
 
         Assert.assertNull(arr.get(0, 0));
-        Assert.assertNull(arr.get2(0, 0));
+        Assert.assertNull(arr.get2Keys(0, 0));
 
     }
 
     @Test
-    public void testPutGet2null() throws Exception {
+    public void testPutget2Keysnull() throws Exception {
         NestedIntegerArray<String> arr= new NestedIntegerArray<>(2, 2);
         arr.put("fred", 0, 1);
         arr.put("bozo", 1, 0);
@@ -98,14 +98,14 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
         Assert.assertEquals(Sets.newHashSet("fred", "bozo"), new HashSet<>(arr.getAllValues()));
 
         Assert.assertEquals("fred", arr.get(0, 1));
-        Assert.assertEquals("fred", arr.get2(0, 1));
+        Assert.assertEquals("fred", arr.get2Keys(0, 1));
 
         Assert.assertEquals("bozo", arr.get(1, 0));
-        Assert.assertEquals("bozo", arr.get2(1, 0));
+        Assert.assertEquals("bozo", arr.get2Keys(1, 0));
     }
 
     @Test
-    public void testPutGet3() throws Exception {
+    public void testPutget3Keys() throws Exception {
         NestedIntegerArray<String> arr= new NestedIntegerArray<>(2, 2, 42);
         arr.put("fred", 0, 1, 13);
         arr.put("bozo", 1, 0, 0);
@@ -115,23 +115,23 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
         Assert.assertEquals(Sets.newHashSet("fred", "bozo", "mike"), new HashSet<>(arr.getAllValues()));
 
         Assert.assertEquals("fred", arr.get(0, 1, 13));
-        Assert.assertEquals("fred", arr.get3(0, 1, 13));
+        Assert.assertEquals("fred", arr.get3Keys(0, 1, 13));
 
         Assert.assertEquals("bozo", arr.get(1, 0, 0));
-        Assert.assertEquals("bozo", arr.get3(1, 0, 0));
+        Assert.assertEquals("bozo", arr.get3Keys(1, 0, 0));
 
         Assert.assertEquals("mike", arr.get(1, 0, 17));
-        Assert.assertEquals("mike", arr.get3(1, 0, 17));
+        Assert.assertEquals("mike", arr.get3Keys(1, 0, 17));
 
         Assert.assertNull(arr.get(0, 0, 0));
-        Assert.assertNull(arr.get3(0, 0, 0));
+        Assert.assertNull(arr.get3Keys(0, 0, 0));
 
         Assert.assertNull(arr.get(1, 2, 3));
-        Assert.assertNull(arr.get3(1, 2, 3));
+        Assert.assertNull(arr.get3Keys(1, 2, 3));
     }
 
     @Test
-    public void testPutGet4() throws Exception {
+    public void testPutget4Keys() throws Exception {
         NestedIntegerArray<String> arr= new NestedIntegerArray<>(2, 2, 42, 91);
         arr.put("fred", 0, 1, 13, 41);
         arr.put("bozo", 1, 0, 0, 90);
@@ -141,19 +141,19 @@ public class NestedIntegerArrayUnitTest extends BaseTest{
         Assert.assertEquals(Sets.newHashSet("fred", "bozo", "mike"), new HashSet<>(arr.getAllValues()));
 
         Assert.assertEquals("fred", arr.get(0, 1, 13, 41));
-        Assert.assertEquals("fred", arr.get4(0, 1, 13, 41));
+        Assert.assertEquals("fred", arr.get4Keys(0, 1, 13, 41));
 
         Assert.assertEquals("bozo", arr.get(1, 0, 0, 90));
-        Assert.assertEquals("bozo", arr.get4(1, 0, 0, 90));
+        Assert.assertEquals("bozo", arr.get4Keys(1, 0, 0, 90));
 
         Assert.assertEquals("mike", arr.get(1, 0, 17, 0));
-        Assert.assertEquals("mike", arr.get4(1, 0, 17, 0));
+        Assert.assertEquals("mike", arr.get4Keys(1, 0, 17, 0));
 
         Assert.assertNull(arr.get(1, 2, 3, 4));
-        Assert.assertNull(arr.get4(1, 2, 3, 4));
+        Assert.assertNull(arr.get4Keys(1, 2, 3, 4));
 
         Assert.assertNull(arr.get(0, 0, 0, 0));
-        Assert.assertNull(arr.get4(0, 0, 0, 0));
+        Assert.assertNull(arr.get4Keys(0, 0, 0, 0));
 
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationTablesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationTablesUnitTest.java
@@ -1,9 +1,8 @@
 package org.broadinstitute.hellbender.utils.recalibration;
 
-import org.broadinstitute.hellbender.utils.recalibration.*;
+import org.broadinstitute.hellbender.utils.collections.NestedIntegerArray;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.Covariate;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
-import org.broadinstitute.hellbender.utils.collections.NestedIntegerArray;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -34,13 +33,13 @@ public final class RecalibrationTablesUnitTest extends BaseTest {
             for ( final EventType et : EventType.values() ) {
                 for ( final int rg : combineStates) {
                     final double error = rg % 2 == 0 ? 1 : 0;
-                    RecalUtils.incrementDatumOrPutIfNecessary(tables.getReadGroupTable(), qualByte, error, rg, et.ordinal());
+                    RecalUtils.incrementDatumOrPutIfNecessary2keys(tables.getReadGroupTable(), qualByte, error, rg, et.ordinal());
                     for ( final int qual : combineStates) {
-                        RecalUtils.incrementDatumOrPutIfNecessary(tables.getQualityScoreTable(), qualByte, error, rg, qual, et.ordinal());
+                        RecalUtils.incrementDatumOrPutIfNecessary3keys(tables.getQualityScoreTable(), qualByte, error, rg, qual, et.ordinal());
                         for ( final int cycle : combineStates)
-                            RecalUtils.incrementDatumOrPutIfNecessary(tables.getTable(2), qualByte, error, rg, qual, cycle, et.ordinal());
+                            RecalUtils.incrementDatumOrPutIfNecessary4keys(tables.getTable(2), qualByte, error, rg, qual, cycle, et.ordinal());
                         for ( final int context : combineStates)
-                            RecalUtils.incrementDatumOrPutIfNecessary(tables.getTable(3), qualByte, error, rg, qual, context, et.ordinal());
+                            RecalUtils.incrementDatumOrPutIfNecessary4keys(tables.getTable(3), qualByte, error, rg, qual, context, et.ordinal());
                     }
                 }
             }
@@ -132,7 +131,7 @@ public final class RecalibrationTablesUnitTest extends BaseTest {
     public void testCombinePartial() {
         final RecalibrationTables merged = new RecalibrationTables(covariates, numReadGroups);
         for ( final int rg : combineStates) {
-            RecalUtils.incrementDatumOrPutIfNecessary(merged.getTable(3), qualByte, 1, rg, 0, 0, 0);
+            RecalUtils.incrementDatumOrPutIfNecessary4keys(merged.getTable(3), qualByte, 1, rg, 0, 0, 0);
         }
 
         merged.combine(tables);


### PR DESCRIPTION
Simple code changes that improve performance of BaseRecalibrator by ~20%. 

NOTE: this is not related to removing indels. That will come later and is expected to improve performance further.

According to my tests, we now beat GATK3 on the infamous first 10Mb of chr1 in CEUTrio.HiSeq.WGS.b37.NA12878.bam

@droazen  can you review? some of those changes are similar to those in #1099 