### PR TITLE
remove fastutil as a direct dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     compile 'org.reflections:reflections:0.9.10'
     compile 'net.sf.jopt-simple:jopt-simple:4.9'
     compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:0.4.150727'
-    compile 'it.unimi.dsi:fastutil:7.0.6'
     compile ('com.google.apis:google-api-services-genomics:v1beta2-rev56-1.20.0') {
         exclude module: 'guava-jdk5'
     }


### PR DESCRIPTION
fixes #1117
note though that removing fastutil as a direct dependency does not remove it as a indirect one and so the code still compiles and runs. Removing the indirect dependency would be a much more heroic task