### PR TITLE
setting test jvm maximum memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   global:
   #gradle needs this
   - TERM=dumb
+  #limit gradle jvm memory
+  - GRADLE_OPTS=-Xmx1024m
   #google cloud stuff
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
   - GCLOUD=$HOME/gcloud/google-cloud-sdk/bin 

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,8 @@ task testAll(type: Test){
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"
-    maxHeapSize = "2G"
+    maxHeapSize = "1.5G"
+    jvmArgs '-Xmx2G'
 
     // show standard out and standard error of the test JVM(s) on the console
     testLogging.showStandardStreams = true


### PR DESCRIPTION
set the maximum memory used by the test jvm to 2g

should prevent at least 1 cause of travis from falling over at random (fixes #1113), but since it's intermittent it's hard to tell if it's really fixed or not

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/broadinstitute/gatk/1124)
<!-- Reviewable:end -->
