### PR TITLE
Use a custom Spark (Kryo) serializer for reads.

### DIFF
--- a/src/main/java/htsjdk/samtools/GATKReadSparkCodec.java
+++ b/src/main/java/htsjdk/samtools/GATKReadSparkCodec.java
@@ -1,0 +1,196 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.BinaryCodec;
+import htsjdk.samtools.util.RuntimeEOFException;
+import htsjdk.samtools.util.SortingCollection;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+/**
+ * Class for translating between in-memory and disk representation of BAMRecord.
+ * <b>GATK: Renamed copy of BAMRecordCodec, changed to remove calls to SAMRecord#getReferenceIndex and
+ * SAMRecord#getMateReferenceIndex, since they throw exceptions for headerless records.</b>
+ */
+public class GATKReadSparkCodec implements SortingCollection.Codec<SAMRecord> {
+    private final SAMFileHeader header;
+    private final BinaryCodec binaryCodec = new BinaryCodec();
+    private final BinaryTagCodec binaryTagCodec = new BinaryTagCodec(binaryCodec);
+    private final SAMRecordFactory samRecordFactory;
+
+    public GATKReadSparkCodec(final SAMFileHeader header) {
+        this(header, new DefaultSAMRecordFactory());
+    }
+
+    public GATKReadSparkCodec(final SAMFileHeader header, final SAMRecordFactory factory) {
+        this.header = header;
+        this.samRecordFactory = factory;
+    }
+
+    public BAMRecordCodec clone() {
+        // Do not clone the references to codecs, as they must be distinct for each instance.
+        return new BAMRecordCodec(this.header, this.samRecordFactory);
+    }
+
+
+    /** Sets the output stream that records will be written to. */
+    public void setOutputStream(final OutputStream os) {
+        this.binaryCodec.setOutputStream(os);
+    }
+
+    /** Sets the output stream that records will be written to. */
+    public void setOutputStream(final OutputStream os, final String filename) {
+        this.binaryCodec.setOutputStream(os);
+        this.binaryCodec.setOutputFileName(filename);
+    }
+
+    /** Sets the input stream that records will be read from. */
+    public void setInputStream(final InputStream is) {
+        this.binaryCodec.setInputStream(is);
+    }
+
+    /** Sets the input stream that records will be read from. */
+    public void setInputStream(final InputStream is, final String filename) {
+        this.binaryCodec.setInputStream(is);
+        this.binaryCodec.setInputFileName(filename);
+    }
+
+    /**
+     * Write object to OutputStream.
+     *
+     * @param alignment Record to be written.
+     */
+    public void encode(final SAMRecord alignment) {
+        // Compute block size, as it is the first element of the file representation of SAMRecord
+        final int readLength = alignment.getReadLength();
+
+        final int cigarLength = alignment.getCigarLength();
+
+        int blockSize = BAMFileConstants.FIXED_BLOCK_SIZE + alignment.getReadNameLength() + 1  + // null terminated
+                        cigarLength * 4 +
+                        (readLength + 1) / 2 + // 2 bases per byte, round up
+                        readLength;
+
+        final int attributesSize = alignment.getAttributesBinarySize();
+        if (attributesSize != -1) {
+            // binary attribute size already known, don't need to compute.
+            blockSize += attributesSize;
+        } else {
+            SAMBinaryTagAndValue attribute = alignment.getBinaryAttributes();
+            while (attribute != null) {
+                blockSize += (BinaryTagCodec.getTagSize(attribute.value));
+                attribute = attribute.getNext();
+            }
+        }
+
+        // Blurt out the elements
+        this.binaryCodec.writeInt(blockSize);
+        this.binaryCodec.writeInt(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX); // reference index is not used
+        // 0-based!!
+        this.binaryCodec.writeInt(alignment.getAlignmentStart() - 1);
+        this.binaryCodec.writeUByte((short)(alignment.getReadNameLength() + 1));
+        this.binaryCodec.writeUByte((short) alignment.getMappingQuality());
+        this.binaryCodec.writeUShort(0); // index bin is not used
+        this.binaryCodec.writeUShort(cigarLength);
+        this.binaryCodec.writeUShort(alignment.getFlags());
+        this.binaryCodec.writeInt(alignment.getReadLength());
+        this.binaryCodec.writeInt(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);  // mate reference index is not used
+        this.binaryCodec.writeInt(alignment.getMateAlignmentStart() - 1);
+        this.binaryCodec.writeInt(alignment.getInferredInsertSize());
+        final byte[] variableLengthBinaryBlock = alignment.getVariableBinaryRepresentation();
+        if (variableLengthBinaryBlock != null) {
+            // Don't need to encode variable-length block, because it is unchanged from
+            // when the record was read from a BAM file.
+            this.binaryCodec.writeBytes(variableLengthBinaryBlock);
+        } else {
+            if (alignment.getReadLength() != alignment.getBaseQualities().length &&
+                alignment.getBaseQualities().length != 0) {
+                throw new RuntimeException("Mismatch between read length and quals length writing read " +
+                alignment.getReadName() + "; read length: " + alignment.getReadLength() +
+                "; quals length: " + alignment.getBaseQualities().length);
+            }
+            this.binaryCodec.writeString(alignment.getReadName(), false, true);
+            final int[] binaryCigar = BinaryCigarCodec.encode(alignment.getCigar());
+            for (final int cigarElement : binaryCigar) {
+                // Assumption that this will fit into an integer, despite the fact
+                // that it is specced as a uint.
+                this.binaryCodec.writeInt(cigarElement);
+            }
+            this.binaryCodec.writeBytes(SAMUtils.bytesToCompressedBases(alignment.getReadBases()));
+            byte[] qualities = alignment.getBaseQualities();
+            if (qualities.length == 0) {
+                qualities = new byte[alignment.getReadLength()];
+                Arrays.fill(qualities, (byte) 0xFF);
+            }
+            this.binaryCodec.writeBytes(qualities);
+            SAMBinaryTagAndValue attribute = alignment.getBinaryAttributes();
+            while (attribute != null) {
+                this.binaryTagCodec.writeTag(attribute.tag, attribute.value, attribute.isUnsignedArray());
+                attribute = attribute.getNext();
+            }
+        }
+    }
+
+    /**
+     * Read the next record from the input stream and convert into a java object.
+     *
+     * @return null if no more records.  Should throw exception if EOF is encountered in the middle of
+     *         a record.
+     */
+    public SAMRecord decode() {
+        int recordLength = 0;
+        try {
+            recordLength = this.binaryCodec.readInt();
+        }
+        catch (RuntimeEOFException e) {
+            return null;
+        }
+
+        if (recordLength < BAMFileConstants.FIXED_BLOCK_SIZE) {
+            throw new SAMFormatException("Invalid record length: " + recordLength);
+        }
+        
+        final int referenceID = this.binaryCodec.readInt();
+        final int coordinate = this.binaryCodec.readInt() + 1;
+        final short readNameLength = this.binaryCodec.readUByte();
+        final short mappingQuality = this.binaryCodec.readUByte();
+        final int bin = this.binaryCodec.readUShort();
+        final int cigarLen = this.binaryCodec.readUShort();
+        final int flags = this.binaryCodec.readUShort();
+        final int readLen = this.binaryCodec.readInt();
+        final int mateReferenceID = this.binaryCodec.readInt();
+        final int mateCoordinate = this.binaryCodec.readInt() + 1;
+        final int insertSize = this.binaryCodec.readInt();
+        final byte[] restOfRecord = new byte[recordLength - BAMFileConstants.FIXED_BLOCK_SIZE];
+        this.binaryCodec.readBytes(restOfRecord);
+        final BAMRecord ret = this.samRecordFactory.createBAMRecord(
+                header, referenceID, coordinate, readNameLength, mappingQuality,
+                bin, cigarLen, flags, readLen, mateReferenceID, mateCoordinate, insertSize, restOfRecord);
+        ret.setHeader(header); 
+        return ret;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -5,6 +5,7 @@ import com.google.api.services.genomics.model.Read;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 
 import java.util.Collections;
 
@@ -35,9 +36,7 @@ public class GATKRegistrator implements KryoRegistrator {
 
         kryo.register(Collections.unmodifiableList(Collections.EMPTY_LIST).getClass(), new UnmodifiableCollectionsSerializer());
 
-        // SAMRecordToGATKReadAdapterSerializer is not currently being used until we are sure that headers are being
-        // properly handled (https://github.com/broadinstitute/hellbender/issues/900)
-        //kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
+        kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
 
         // register the ADAM data types using Avro serialization, including:
         //     AlignmentRecord

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 
 public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordToGATKReadAdapter> {
 
-    private GATKReadSparkCodec lazyCodec = new GATKReadSparkCodec(null, new LazyBAMRecordFactory());
+    private SAMRecordSparkCodec lazyCodec = new SAMRecordSparkCodec();
 
     @Override
     public void write(Kryo kryo, Output output, SAMRecordToGATKReadAdapter adapter) {
@@ -40,54 +40,5 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
         record.setMateReferenceName(mateReferenceName);
 
         return SAMRecordToGATKReadAdapter.headerlessReadAdapter(record);
-    }
-
-
-    static class LazyBAMRecordFactory implements SAMRecordFactory {
-        @Override public SAMRecord createSAMRecord(SAMFileHeader hdr) {
-            throw new UnsupportedOperationException(
-                    "LazyBAMRecordFactory can only create BAM records");
-        }
-
-        @Override public BAMRecord createBAMRecord(
-                SAMFileHeader hdr,
-                int referenceSequenceIndex, int alignmentStart,
-                short readNameLength, short mappingQuality,
-                int indexingBin, int cigarLen, int flags, int readLen,
-                int mateReferenceSequenceIndex, int mateAlignmentStart,
-                int insertSize, byte[] variableLengthBlock)
-        {
-            return new LazyBAMRecord(
-                    hdr, referenceSequenceIndex, alignmentStart, readNameLength,
-                    mappingQuality, indexingBin, cigarLen, flags, readLen,
-                    mateReferenceSequenceIndex, mateAlignmentStart, insertSize,
-                    variableLengthBlock);
-        }
-    }
-
-    static class LazyBAMRecord extends BAMRecord {
-        private static final long serialVersionUID = 1L;
-
-        public LazyBAMRecord(
-                SAMFileHeader hdr, int referenceID, int coordinate, short readNameLength,
-                short mappingQuality, int indexingBin, int cigarLen, int flags,
-                int readLen, int mateReferenceID, int mateCoordinate, int insertSize,
-                byte[] restOfData)
-        {
-            super(
-                    hdr, referenceID, coordinate, readNameLength, mappingQuality,
-                    indexingBin, cigarLen, flags, readLen, mateReferenceID,
-                    mateCoordinate, insertSize, restOfData);
-        }
-
-        @Override
-        public void setReferenceIndex(final int referenceIndex) {
-            mReferenceIndex = null; // null out
-        }
-
-        @Override
-        public void setMateReferenceIndex(final int referenceIndex) {
-            mMateReferenceIndex = null; // null out
-        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
@@ -9,11 +9,12 @@ import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 
 public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordToGATKReadAdapter> {
 
-    private BAMRecordCodec lazyCodec = new BAMRecordCodec(null, new LazyBAMRecordFactory());
+    private GATKReadSparkCodec lazyCodec = new GATKReadSparkCodec(null, new LazyBAMRecordFactory());
 
     @Override
     public void write(Kryo kryo, Output output, SAMRecordToGATKReadAdapter adapter) {
         SAMRecord record = adapter.getEncapsulatedSamRecord();
+
         // serialize reference names to avoid having to have a header at read time
         output.writeString(record.getReferenceName());
         output.writeString(record.getMateReferenceName());
@@ -34,14 +35,9 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
         // clear indexing bin after decoding to ensure all SAMRecords compare properly
         record.setFlags(record.getFlags());
 
-        final int referenceIndex = record.getReferenceIndex();
-        final int mateReferenceIndex = record.getMateReferenceIndex();
+        // set reference names (and indexes to null)
         record.setReferenceName(referenceName);
         record.setMateReferenceName(mateReferenceName);
-
-        // set reference indexes again since setting reference names without a header will unset indexes
-        record.setReferenceIndex(referenceIndex);
-        record.setMateReferenceIndex(mateReferenceIndex);
 
         return SAMRecordToGATKReadAdapter.headerlessReadAdapter(record);
     }
@@ -86,12 +82,12 @@ public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordTo
 
         @Override
         public void setReferenceIndex(final int referenceIndex) {
-            mReferenceIndex = referenceIndex;
+            mReferenceIndex = null; // null out
         }
 
         @Override
         public void setMateReferenceIndex(final int referenceIndex) {
-            mMateReferenceIndex = referenceIndex;
+            mMateReferenceIndex = null; // null out
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -210,6 +210,24 @@ public final class ArtificialReadUtils {
     }
 
     /**
+     * Creates an artificial GATKRead backed by a SAMRecord with no header.
+     *
+     * The read will consist of the specified number of Q30 'A' bases, and will be
+     * mapped to the specified contig at the specified start position.
+     *
+     * @param name name of the new read
+     * @param contig contig the new read is mapped to
+     * @param start start position of the new read
+     * @param length number of bases in the new read
+     * @return an artificial GATKRead backed by a SAMRecord.
+     */
+    public static GATKRead createHeaderlessSamBackedRead( final String name, final String contig, final int start, final int length ) {
+        GATKRead read = createSamBackedRead(name, contig, start, length);
+        ((SAMRecordToGATKReadAdapter) read).getEncapsulatedSamRecord().setHeader(null);
+        return read;
+    }
+
+    /**
      * Creates an artificial GATKRead backed by a Google Genomics read.
      *
      * The read will consist of the specified number of Q30 'A' bases, and will be

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
@@ -149,7 +149,7 @@ public class ReadsPreprocessingPipelineSparkTestData {
         if (clazz == Read.class) {
             return ArtificialReadUtils.createGoogleBackedRead(Integer.toString(i), contig, start, length);
         } else if (clazz == SAMRecord.class) {
-            return ArtificialReadUtils.createSamBackedRead(Integer.toString(i), contig, start, length);
+            return ArtificialReadUtils.createHeaderlessSamBackedRead(Integer.toString(i), contig, start, length);
         } else {
             throw new GATKException("invalid GATKRead type");
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 import com.esotericsoftware.kryo.Kryo;
+import htsjdk.samtools.SAMRecord;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.apache.spark.serializer.KryoSerializer;
@@ -30,12 +31,21 @@ public class SAMRecordToGATKReadAdapterSerializerUnitTest {
         KryoSerializer kryoSerializer = new KryoSerializer(conf);
         SerializerInstance sparkSerializer = kryoSerializer.newInstance();
 
-        // check round trip with header set
-        GATKRead read = ArtificialReadUtils.createSamBackedRead("read1", "1", 100, 50);
+        // check round trip with no header
+        GATKRead read = ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50);
+        check(sparkSerializer, read);
+    }
+
+    @Test
+    public void testChangingContigsOnHeaderlessGATKRead(){
+        final SparkConf conf = new SparkConf().set("spark.kryo.registrator",
+                "org.broadinstitute.hellbender.engine.spark.SAMRecordToGATKReadAdapterSerializerUnitTest$TestGATKRegistrator");
+        final KryoSerializer kryoSerializer = new KryoSerializer(conf);
+        final SerializerInstance sparkSerializer = kryoSerializer.newInstance();
+        final GATKRead read = ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50);
         check(sparkSerializer, read);
 
-        // check round trip with no header
-        ((SAMRecordToGATKReadAdapter) read).getEncapsulatedSamRecord().setHeader(null);
+        read.setPosition("2", 1);
         check(sparkSerializer, read);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -24,8 +24,8 @@ public class SAMRecordToGATKReadAdapterSerializerUnitTest {
         }
     }
 
-    @Test(enabled = false)
-    public void test() {
+    @Test
+    public void testSerializerRoundTripHeaderlessRead() {
         SparkConf conf = new SparkConf().set("spark.kryo.registrator",
                 "org.broadinstitute.hellbender.engine.spark.SAMRecordToGATKReadAdapterSerializerUnitTest$TestGATKRegistrator");
         KryoSerializer kryoSerializer = new KryoSerializer(conf);


### PR DESCRIPTION
This change enables SAMRecordToGATKReadAdapterSerializer, which has been in the codebase for a while now, just not explicitly enabled. We've been using it for manual testing and haven't seen any problems with it. All unit tests pass. The performance improvement is striking: running mark duplicates locally went from ~120s to ~36s (https://github.com/broadinstitute/gatk/issues/1047).

In terms of the change this makes, it means that the header is not present on SAMRecord, but since operations on reads go through the GATKRead interface (which does not need the header), the change is safe. Note also that SAMRecordToGATKReadAdapterSerializer explicitly serializes the reference name (and the mate reference name) so that the round trip serialization/deserialization works.