### PR TITLE
improving help output and improving CommandLineParser

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
@@ -60,12 +60,6 @@ public @interface Argument {
     String[] mutex() default {};
 
     /**
-     * Is this an Option common to all command line programs.  If it is then it will only
-     * be displayed in usage info when H or STDHELP is used to display usage.
-     */
-    boolean common() default false;
-
-    /**
      * Does this option have special treatment in the argument parsing system.
      * Some examples are arguments_file and help, which have special behavior in the parser.
      * This is intended for documenting these options.

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -9,6 +9,7 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 
 import java.io.File;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -41,17 +41,17 @@ import java.util.List;
 public abstract class CommandLineProgram {
     protected final Logger logger = LogManager.getLogger(this.getClass());
 
-    @Argument(common=true, optional=true)
+    @Argument(optional=true)
     public List<File> TMP_DIR = new ArrayList<>();
 
     @ArgumentCollection(doc="Special Arguments that have meaning to the argument parsing system.  " +
             "It is unlikely these will ever need to be accessed by the command line program")
     public SpecialArgumentsCollection specialArgumentsCollection = new SpecialArgumentsCollection();
 
-    @Argument(doc = "Control verbosity of logging.", common=true)
+    @Argument(doc = "Control verbosity of logging.")
     public Log.LogLevel VERBOSITY = Log.LogLevel.INFO;
 
-    @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)
+    @Argument(doc = "Whether to suppress job-summary info on System.err.")
     public Boolean QUIET = false;
 
     /**
@@ -194,7 +194,7 @@ public abstract class CommandLineProgram {
             for (final String msg : customErrorMessages) {
                 System.err.println(msg);
             }
-            commandLineParser.usage(System.err, false);
+            commandLineParser.usage(System.err);
             return false;
         }
         return true;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -185,7 +185,7 @@ public abstract class CommandLineProgram {
 
         commandLineParser = new CommandLineParser(this);
         final boolean ret = commandLineParser.parseArguments(System.err, argv);
-        commandLine = commandLineParser.getCommandLine();
+        commandLine = commandLineParser.getFullySpecifiedCommandLine();
         if (!ret) {
             return false;
         }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -53,7 +53,6 @@ public abstract class CommandLineProgram {
 
     @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)
     public Boolean QUIET = false;
-    private final String standardUsagePreamble = CommandLineParser.getStandardUsagePreamble(getClass());
 
     /**
     * Initialized in parseArgs.  Subclasses may want to access this to do their
@@ -209,10 +208,6 @@ public abstract class CommandLineProgram {
         }
 
         return file;
-    }
-
-    public String getStandardUsagePreamble() {
-        return standardUsagePreamble;
     }
 
     public CommandLineParser getCommandLineParser() {

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/PicardCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/PicardCommandLineProgram.java
@@ -14,23 +14,23 @@ public abstract class PicardCommandLineProgram extends CommandLineProgram {
 
     @Argument(doc = "Validation stringency for all SAM files read by this program.  Setting stringency to SILENT " +
             "can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) " +
-            "do not otherwise need to be decoded.", common=true)
+            "do not otherwise need to be decoded.")
     public ValidationStringency VALIDATION_STRINGENCY = ValidationStringency.DEFAULT_STRINGENCY;
 
-    @Argument(doc = "Compression level for all compressed files created (e.g. BAM and GELI).", common=true)
+    @Argument(doc = "Compression level for all compressed files created (e.g. BAM and GELI).")
     public int COMPRESSION_LEVEL = BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
 
-    @Argument(doc = "When writing SAM files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a SAM file, and increases the amount of RAM needed.", optional=true, common=true)
+    @Argument(doc = "When writing SAM files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a SAM file, and increases the amount of RAM needed.", optional=true)
     public Integer MAX_RECORDS_IN_RAM = SAMFileWriterImpl.getDefaultMaxRecordsInRam();
 
-    @Argument(doc = "Whether to create a BAM index when writing a coordinate-sorted BAM file.", common=true)
+    @Argument(doc = "Whether to create a BAM index when writing a coordinate-sorted BAM file.")
     public Boolean CREATE_INDEX = Defaults.CREATE_INDEX;
 
-    @Argument(doc="Whether to create an MD5 digest for any BAM or FASTQ files created.  ", common=true)
+    @Argument(doc="Whether to create an MD5 digest for any BAM or FASTQ files created.")
     public boolean CREATE_MD5_FILE = Defaults.CREATE_MD5;
 
     @Argument(fullName =  StandardArgumentDefinitions.REFERENCE_LONG_NAME,
-            shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file.", common = true, optional = true)
+            shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file.", optional = true)
     public File REFERENCE_SEQUENCE = Defaults.REFERENCE_FASTA;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -25,7 +25,6 @@ final class ArgumentDefinition {
     private final String shortName;
     private final String doc;
     private final String defaultValue;
-    private final boolean isCommon;
     private final Set<String> mutuallyExclusive;
     private final Object parent;
     private final boolean isSensitive;
@@ -45,7 +44,6 @@ final class ArgumentDefinition {
         this.doc = annotation.doc();
         this.isCollection = CommandLineParser.isCollectionField(field);
 
-        this.isCommon = annotation.common();
         this.isSensitive = annotation.sensitive();
 
         this.mutuallyExclusive = new HashSet<>(Arrays.asList(annotation.mutex()));
@@ -295,10 +293,6 @@ final class ArgumentDefinition {
 
     public String getDefaultValue() {
         return defaultValue;
-    }
-
-    public boolean isCommon() {
-        return isCommon;
     }
 
     public Set<String> getMutuallyExclusive() {

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -137,7 +137,10 @@ final class ArgumentDefinition {
     }
 
     @SuppressWarnings("unchecked")
-    protected void setArgument(final List<String> values) {
+    /**
+     * Sets the value of the field associated to this argument definition
+     */
+    public void setArgument(final List<String> values) {
         //special treatment for flags
         if (isFlag() && values.isEmpty()) {
             hasBeenSet = true;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -71,7 +71,6 @@ final class ArgumentDefinition {
         }
     }
 
-
     public String getArgumentParamUsage(final Map<String, ArgumentDefinition> argumentMap) {
         final StringBuilder output = new StringBuilder();
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -277,7 +277,7 @@ final class ArgumentDefinition {
             return mutuallyExclusiveArguments.stream()
                     .map(arg -> arg.getArgumentParamUsage(argumentDefinitionMap))
                     .sorted()
-                    .collect(Collectors.joining("\n", "one of the following required arguments must be specified:\n", "\n"));
+                    .collect(Collectors.joining("\n", "exactly one of the following arguments is required:\n", "\n"));
         }
     }
 
@@ -304,4 +304,5 @@ final class ArgumentDefinition {
     public Set<String> getMutuallyExclusive() {
         return mutuallyExclusive;
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -1,0 +1,313 @@
+package org.broadinstitute.hellbender.cmdline.parser;
+
+import htsjdk.samtools.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+final class ArgumentDefinition {
+    private final Field field;
+    private final String fieldName;
+    private final String fullName;
+    private final String shortName;
+    private final String doc;
+    private final String defaultValue;
+    private final boolean isCommon;
+    private final Set<String> mutuallyExclusive;
+    private final Object parent;
+    private final boolean isSensitive;
+    private final boolean isCollection;
+
+    private final boolean optional;
+
+
+    private boolean hasBeenSet = false;
+
+    public ArgumentDefinition(final Field field, final Argument annotation, final Object parent) {
+        this.field = field;
+        this.fieldName = field.getName();
+        this.parent = parent;
+        this.fullName = annotation.fullName();
+        this.shortName = annotation.shortName();
+        this.doc = annotation.doc();
+        this.isCollection = CommandLineParser.isCollectionField(field);
+
+        this.isCommon = annotation.common();
+        this.isSensitive = annotation.sensitive();
+
+        this.mutuallyExclusive = new HashSet<>(Arrays.asList(annotation.mutex()));
+
+        this.defaultValue = getDefaultValueString(isCollection);
+
+        //null collections have been initialized by createCollection which is called in handleArgumentAnnotation
+        //this is optional if it's specified as being optional or if there is a default value specified
+        this.optional = annotation.optional() || !this.defaultValue.equals(CommandLineParser.NULL_STRING);
+    }
+
+    private String getDefaultValueString(boolean isCollection) {
+        final Object tmpDefault = getFieldValue();
+        if (tmpDefault != null) {
+            if (isCollection && ((Collection) tmpDefault).isEmpty()) {
+                //treat empty collections the same as uninitialized primitive types
+                return CommandLineParser.NULL_STRING;
+            } else {
+                //this is an initialized primitive type or a non-empty collection
+                return tmpDefault.toString();
+            }
+        } else {
+            return CommandLineParser.NULL_STRING;
+        }
+    }
+
+
+    public String getArgumentParamUsage(final Map<String, ArgumentDefinition> argumentMap) {
+        final StringBuilder output = new StringBuilder();
+
+        final String argumentLabel = getPrettyNameAndType();
+        output.append(argumentLabel);
+
+        int numSpaces = CommandLineParser.ARGUMENT_COLUMN_WIDTH - argumentLabel.length();
+        if (argumentLabel.length() > CommandLineParser.ARGUMENT_COLUMN_WIDTH) {
+            output.append(System.lineSeparator());
+            numSpaces = CommandLineParser.ARGUMENT_COLUMN_WIDTH;
+        }
+        output.append(StringUtils.repeat(' ', numSpaces));
+        final String wrappedDescription = StringUtil.wordWrap(makeArgumentDescription(argumentMap), CommandLineParser.DESCRIPTION_COLUMN_WIDTH);
+        final String[] descriptionLines = wrappedDescription.split("\n");
+        for (int i = 0; i < descriptionLines.length; ++i) {
+            if (i > 0) {
+                output.append(StringUtils.repeat(' ', CommandLineParser.ARGUMENT_COLUMN_WIDTH));
+            }
+            output.append(descriptionLines[i]).append(System.lineSeparator());
+        }
+        output.append(System.lineSeparator());
+        return output.toString();
+    }
+
+    public String getPrettyNameAndType() {
+        final StringBuilder output = new StringBuilder();
+        output.append("--").append(getLongName());
+
+        if (!shortName.isEmpty() && !shortName.equals(getLongName())) {
+            output.append(",-").append(shortName);
+        }
+        output.append(':').append(CommandLineParser.getUnderlyingType(field).getSimpleName());
+        return output.toString();
+    }
+
+    private String makeArgumentDescription(Map<String, ArgumentDefinition> argumentMap) {
+        final StringBuilder sb = new StringBuilder();
+        if (!doc.isEmpty()) {
+            sb.append(doc);
+            sb.append("  ");
+        }
+        if (isCollection) {
+            if (optional) {
+                sb.append("This argument may be specified 0 or more times. ");
+            } else {
+                sb.append("This argument must be specified at least once. ");
+            }
+        }
+        if (optional) {
+            sb.append("Default: ");
+            sb.append(defaultValue);
+        }
+        sb.append(CommandLineParser.getOptions(CommandLineParser.getUnderlyingType(field)));
+        if (!mutuallyExclusive.isEmpty()) {
+            sb.append(" Cannot be used in conjuction with argument(s)");
+            for (final String argument : mutuallyExclusive) {
+                final ArgumentDefinition mutextArgumentDefinition = argumentMap.get(argument);
+
+                if (mutextArgumentDefinition == null) {
+                    throw new GATKException("Invalid argument definition in source code.  " + argument +
+                            " doesn't match any known argument.");
+                }
+
+                sb.append(' ').append(mutextArgumentDefinition.fieldName);
+                if (!mutextArgumentDefinition.shortName.isEmpty()) {
+                    sb.append(" (").append(mutextArgumentDefinition.shortName).append(')');
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void setArgument(final List<String> values) {
+        //special treatment for flags
+        if (isFlag() && values.isEmpty()) {
+            hasBeenSet = true;
+            setFieldValue(true);
+            return;
+        }
+
+        if (!isCollection && (hasBeenSet || values.size() > 1)) {
+            throw new UserException.CommandLineException("Argument '" + getNames() + "' cannot be specified more than once.");
+        }
+
+        for (String stringValue : values) {
+            final Object value;
+            if (stringValue.equals(CommandLineParser.NULL_STRING)) {
+                //"null" is a special value that allows the user to override any default
+                //value set for this arg
+                if (optional) {
+                    value = null;
+                } else {
+                    throw new UserException.CommandLineException("Non \"null\" value must be provided for '" + getNames() + "'.");
+                }
+            } else {
+                value = CommandLineParser.constructFromString(CommandLineParser.getUnderlyingType(field), stringValue, getLongName());
+            }
+
+            if (isCollection) {
+                @SuppressWarnings("rawtypes")
+                final Collection c = (Collection) getFieldValue();
+                if (value == null) {
+                    //user specified this arg=null which is interpreted as empty list
+                    c.clear();
+                } else {
+                    c.add(value);
+                }
+                hasBeenSet = true;
+            } else {
+                setFieldValue(value);
+                hasBeenSet = true;
+            }
+        }
+    }
+
+
+    public Object getFieldValue() {
+        try {
+            field.setAccessible(true);
+            return field.get(parent);
+        } catch (IllegalAccessException e) {
+            throw new GATKException.ShouldNeverReachHereException("This shouldn't happen since we setAccessible(true).", e);
+        }
+    }
+
+    public void setFieldValue(final Object value) {
+        try {
+            field.setAccessible(true);
+            field.set(parent, value);
+        } catch (IllegalAccessException e) {
+            throw new GATKException.ShouldNeverReachHereException("BUG: couldn't set field value. For "
+                    + fieldName + " in " + parent + " with value " + value
+                    + " This shouldn't happen since we setAccessible(true)", e);
+        }
+    }
+
+    public boolean isFlag() {
+        return field.getType().equals(boolean.class) || field.getType().equals(Boolean.class);
+    }
+
+    public List<String> getNames() {
+        final List<String> names = new ArrayList<>();
+        if (!shortName.isEmpty()) {
+            names.add(shortName);
+        }
+        if (!fullName.isEmpty()) {
+            names.add(fullName);
+        } else {
+            names.add(fieldName);
+        }
+        return names;
+    }
+
+    public String getLongName() {
+        return !fullName.isEmpty() ? fullName : fieldName;
+    }
+
+    /**
+     * Helper for pretty printing this option.
+     *
+     * @param value A value this argument was given
+     * @return a string
+     */
+    private String prettyNameValue(Object value) {
+        if (value != null) {
+            if (isSensitive) {
+                return String.format("--%s ***********", getLongName());
+            } else {
+                return String.format("--%s %s", getLongName(), value);
+            }
+        }
+        return "";
+    }
+
+    /**
+     * @return A string representation of this argument and it's value(s) which would be valid if copied and pasted
+     * back as a command line argument
+     */
+    public String toCommandLineString() {
+        final Object value = getFieldValue();
+        if (this.isCollection) {
+            final Collection<?> collect = (Collection<?>) value;
+            return collect.stream()
+                    .map(this::prettyNameValue)
+                    .collect(Collectors.joining(" "));
+
+        } else {
+            return prettyNameValue(value);
+        }
+    }
+
+    /**
+     * @param argumentDefinitionMap a map from argument names to {@link ArgumentDefinition}
+     * @return the set of arguments that this argument is mutually exclusive with (including itself in the set)
+     */
+    public Set<ArgumentDefinition> getMutuallyExclusiveArguments(Map<String, ArgumentDefinition> argumentDefinitionMap) {
+        final Set<ArgumentDefinition> mutexArguments = mutuallyExclusive.stream().map(argumentDefinitionMap::get).collect(Collectors.toSet());
+        mutexArguments.add(this);
+        return mutexArguments;
+    }
+
+    public String composeMissingArgumentMessage(Map<String, ArgumentDefinition> argumentDefinitionMap) {
+        if (mutuallyExclusive.isEmpty()) {
+            return String.format("required argument --%s was not specified", getLongName());
+        } else {
+            final Set<ArgumentDefinition> mutuallyExclusiveArguments = getMutuallyExclusiveArguments(argumentDefinitionMap);
+            return mutuallyExclusiveArguments.stream()
+                    .map(ArgumentDefinition::getLongName)
+                    .sorted()
+                    .map(name -> "--" + name)
+                    .collect(Collectors.joining(", ", "one of the following required arguments must be specified: ", ""));
+        }
+    }
+
+    public boolean isOptional() {
+        return optional;
+    }
+
+    public boolean hasBeenSet() {
+        return hasBeenSet;
+    }
+
+    public String getDoc() {
+        return doc;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public boolean isCommon() {
+        return isCommon;
+    }
+
+    public Set<String> getMutuallyExclusive() {
+        return mutuallyExclusive;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/ArgumentDefinition.java
@@ -97,9 +97,6 @@ final class ArgumentDefinition {
             output.append(",-").append(shortName);
         }
         output.append(':').append(CommandLineParser.getUnderlyingType(field).getSimpleName());
-        if (isCollection) {
-            output.append("[]");
-        }
         return output.toString();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -216,6 +216,13 @@ public final class CommandLineParser {
         }
     }
 
+    private String generateUsageFromRequiredArguments(){
+        return argumentDefinitions.stream()
+                .filter(arg -> !arg.isOptional())
+                .map(ArgumentDefinition::getPrettyNameAndType)
+                .collect(Collectors.joining(" ", "Usage: " + callerArguments.getClass().getSimpleName(), " [options]"));
+    }
+
     /**
      * Parse command-line arguments, and store values in callerArguments object passed to ctor.
      * @param messageStream Where to write error messages.
@@ -843,4 +850,5 @@ public final class CommandLineParser {
 
         return argumentValues;
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -434,7 +434,7 @@ public final class CommandLineParser {
         }
         if (c.size() >= maxPositionalArguments) {  //we're checking if there is space to add another argument
             throw new UserException.CommandLineException("No more than " + maxPositionalArguments +
-                    " positional arguments may be specified on the command line, but " +c.size() +" were seen.", getCommandLineAsInput());
+                    " positional arguments may be specified on the command line.", getCommandLineAsInput());
         }
         c.add(value);
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -174,7 +174,6 @@ public final class CommandLineParser {
         return null;
     }
 
-
     private static List<Field> getAllFields(Class<?> clazz) {
         final List<Field> ret = new ArrayList<>();
         do {
@@ -850,5 +849,4 @@ public final class CommandLineParser {
 
         return argumentValues;
     }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -201,7 +201,7 @@ public final class CommandLineParser {
         // filter on common and partition on optional
         final Map<Boolean, List<ArgumentDefinition>> argMap = argumentDefinitions.stream()
                 .filter(argumentDefinition -> printCommon || !argumentDefinition.isCommon())
-                .collect(Collectors.partitioningBy(a -> a.isOptional()));
+                .collect(Collectors.partitioningBy(ArgumentDefinition::isOptional));
 
         final List<ArgumentDefinition> reqArgs = argMap.get(false); // required args
         if (reqArgs != null && !reqArgs.isEmpty()) {
@@ -382,6 +382,7 @@ public final class CommandLineParser {
                 .collect(Collectors.toList());
 
         final List<String> messages = new ArrayList<>();
+
         for( ArgumentDefinition arg: sortedArgs) {
             if(!alreadyOutput.contains(arg)) {
                 messages.add(arg.composeMissingArgumentMessage(argumentMap));
@@ -450,6 +451,7 @@ public final class CommandLineParser {
 
     private void printArgumentUsage(final PrintStream stream, final ArgumentDefinition argumentDefinition) {
         stream.print(argumentDefinition.getArgumentParamUsage(argumentMap));
+        stream.println();
     }
 
     /**
@@ -745,7 +747,7 @@ public final class CommandLineParser {
 
         //first, append args that were explicitly set
         commandLineString.append(argumentDefinitions.stream()
-                .filter(argumentDefinition -> argumentDefinition.hasBeenSet())
+                .filter(ArgumentDefinition::hasBeenSet)
                 .map(ArgumentDefinition::toCommandLineString)
                 .collect(Collectors.joining(" "," ","  ")));
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -254,7 +254,11 @@ public final class CommandLineParser {
             assertArgumentsAreValid();
 
             return true;
-        }catch (UserException.CommandLineException e){
+        } catch (UserException.MissingArgument e){
+            throw e;
+        } catch (UserException.BadArgumentValue e) {
+            throw new UserException.BadArgumentValue()
+        } catch (UserException.CommandLineException e){
                 throw new UserException.CommandLineException(e.getMessage(), getCommandLineAsInput(), e);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParser.java
@@ -150,7 +150,7 @@ public final class CommandLineParser {
         this.programProperties = this.callerArguments.getClass().getAnnotation(CommandLineProgramProperties.class);
     }
 
-    private List<ArgumentDefinition> createArgumentDefinitions(final Object callerArguments) {
+    private void createArgumentDefinitions(final Object callerArguments) {
         for (final Field field : getAllFields(callerArguments.getClass())) {
             if (field.getAnnotation(Argument.class) != null && field.getAnnotation(ArgumentCollection.class) != null){
                 throw new GATKException.CommandLineParserInternalException("An Argument cannot be an argument collection: "
@@ -171,7 +171,6 @@ public final class CommandLineParser {
                 }
             }
         }
-        return null;
     }
 
     private static List<Field> getAllFields(Class<?> clazz) {
@@ -310,10 +309,11 @@ public final class CommandLineParser {
     private static OptionParser setupOptionParser(Collection<ArgumentDefinition> argumentDefinitions, boolean hasPositionalArguments) {
         final OptionParser parser = new OptionParser();
 
+        final StrictBooleanConverter converter = new StrictBooleanConverter();
         for (ArgumentDefinition arg : argumentDefinitions){
             final OptionSpecBuilder bld = parser.acceptsAll(arg.getNames(), arg.getDoc());
             if (arg.isFlag()) {
-                bld.withOptionalArg().withValuesConvertedBy(new StrictBooleanConverter());
+                bld.withOptionalArg().withValuesConvertedBy(converter);
             } else {
                 bld.withRequiredArg();
             }
@@ -560,10 +560,10 @@ public final class CommandLineParser {
 
             final ArgumentDefinition argumentDefinition = new ArgumentDefinition(field, argumentAnnotation, parent);
 
-            for (final String argument : argumentAnnotation.mutex()) {
-                final ArgumentDefinition mutextArgumentDef = argumentMap.get(argument);
-                if (mutextArgumentDef != null) {
-                    mutextArgumentDef.getMutuallyExclusive().add(field.getName());
+            for (final String argumentName : argumentAnnotation.mutex()) {
+                final ArgumentDefinition mutuallyExclusiveArgument = argumentMap.get(argumentName);
+                if (mutuallyExclusiveArgument != null) {
+                    mutuallyExclusiveArgument.getMutuallyExclusive().add(field.getName());
                 }
             }
             if (inArgumentMap(argumentDefinition)) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ClassFinder;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -20,7 +20,7 @@ import java.util.stream.StreamSupport;
  */
 public abstract class ReadWalker extends GATKTool {
 
-    @Argument(fullName = "disable_all_read_filters", shortName = "f", doc = "Disable all read filters", common = false, optional = true)
+    @Argument(fullName = "disable_all_read_filters", shortName = "f", doc = "Disable all read filters", optional = true)
     public boolean disable_all_read_filters = false;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -28,7 +28,7 @@ public abstract class VariantWalker extends GATKTool {
 
     // NOTE: using File rather than FeatureInput<VariantContext> here so that we can keep this driving source
     //       of variants separate from any other potential sources of Features
-    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "A VCF file containing variants", common = false, optional = false)
+    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "A VCF file containing variants", optional = false)
     public File drivingVariantFile;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -30,7 +30,7 @@ public class UserException extends RuntimeException {
     }
 
     protected static String formatMessage(String msg) {
-        return "A UserException has occurred:\n\nThis is an error which is likely to be correctable by the user." + msg
+        return "A UserException has occurred:\n\nThis is an error which is likely to be correctable by the user.\n\n" + msg
                 +"\n\n\nRerun with --help to see more information on available options";
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -94,10 +94,12 @@ public class UserException extends RuntimeException {
             this(message, "");
         }
 
-        public CommandLineException()
-
         public CommandLineException(String message, String commandLine) {
             super(String.format("Invalid command line: %s\n\n%s", commandLine, message));
+        }
+
+        public CommandLineException(String message, String commandLine, Exception exception) {
+            super(String.format("Invalid command line: %s\n\n%s\n\n", commandLine, message), exception);
         }
 
 
@@ -122,6 +124,11 @@ public class UserException extends RuntimeException {
         public BadArgumentValue(String arg, String value, String message){
             super(String.format("Argument %s has a bad value: %s. %s", arg, value,message));
         }
+
+        public BadArgumentValue(String arg, String value, String message, String commandLine){
+            super(String.format("Argument %s has a bad value: %s. %s", arg, value,message), c);
+        }
+
     }
 
     public static class CannotHandleGzippedRef extends UserException {

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -87,19 +87,30 @@ public class UserException extends RuntimeException {
         public MissingReference(String message) { super(message); }
     }
 
+
     public static class CommandLineException extends UserException {
         private static final long serialVersionUID = 0L;
 
+        public boolean includesCommandline() {
+            return includesCommandLine;
+        }
+
+        private final boolean includesCommandLine;
+
         public CommandLineException(String message){
-            this(message, "");
+            super(message);
+            this.includesCommandLine = false;
         }
 
         public CommandLineException(String message, String commandLine) {
             super(String.format("Invalid command line: %s\n\n%s", commandLine, message));
+            this.includesCommandLine = true;
+
         }
 
         public CommandLineException(String message, String commandLine, Exception exception) {
-            super(String.format("Invalid command line: %s\n\n%s\n\n", commandLine, message), exception);
+            super(String.format("Invalid command line: %s\n\n%s", commandLine, message), exception);
+            this.includesCommandLine = true;
         }
 
 
@@ -122,11 +133,11 @@ public class UserException extends RuntimeException {
         }
 
         public BadArgumentValue(String arg, String value, String message){
-            super(String.format("Argument %s has a bad value: %s. %s", arg, value,message));
+            super(String.format("Argument %s has a bad value: %s. %s", arg, value, message));
         }
 
-        public BadArgumentValue(String arg, String value, String message, String commandLine){
-            super(String.format("Argument %s has a bad value: %s. %s", arg, value,message), c);
+        public BadArgumentValue(BadArgumentValue e, String commandLine){
+            super(e.getMessage(), commandLine, e);
         }
 
     }

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -22,11 +22,16 @@ public class UserException extends RuntimeException {
     private static final long serialVersionUID = 0L;
 
     public UserException(final String msg) {
-        super("A USER ERROR has occurred:\n\n" + msg +"\n\nRerun with --help to see more information on available options");
+        super(formatMessage(msg));
     }
 
     public UserException(final String message, final Throwable throwable) {
-        super("A USER ERROR has occurred\n\n: " + message, throwable);
+        super(formatMessage(message), throwable);
+    }
+
+    protected static String formatMessage(String msg) {
+        return "A UserException has occurred:\n\nThis is an error which is likely to be correctable by the user." + msg
+                +"\n\n\nRerun with --help to see more information on available options";
     }
 
     protected static String getMessage(final Throwable t) {
@@ -89,9 +94,13 @@ public class UserException extends RuntimeException {
             this(message, "");
         }
 
+        public CommandLineException()
+
         public CommandLineException(String message, String commandLine) {
-            super(String.format("Invalid command line: %s\n%s", commandLine, message));
+            super(String.format("Invalid command line: %s\n\n%s", commandLine, message));
         }
+
+
     }
 
     public static class ConflictingMutuallyExclusiveArguments extends CommandLineException {

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -22,11 +22,11 @@ public class UserException extends RuntimeException {
     private static final long serialVersionUID = 0L;
 
     public UserException(final String msg) {
-        super("A USER ERROR has occurred: " + msg);
+        super("A USER ERROR has occurred:\n\n" + msg +"\n\nRerun with --help to see more information on available options");
     }
 
     public UserException(final String message, final Throwable throwable) {
-        super("A USER ERROR has occurred: " + message, throwable);
+        super("A USER ERROR has occurred\n\n: " + message, throwable);
     }
 
     protected static String getMessage(final Throwable t) {
@@ -85,9 +85,22 @@ public class UserException extends RuntimeException {
     public static class CommandLineException extends UserException {
         private static final long serialVersionUID = 0L;
 
-        public CommandLineException(String message) {
-            super(String.format("Invalid command line: %s", message));
+        public CommandLineException(String message){
+            this(message, "");
         }
+
+        public CommandLineException(String message, String commandLine) {
+            super(String.format("Invalid command line: %s\n%s", commandLine, message));
+        }
+    }
+
+    public static class ConflictingMutuallyExclusiveArguments extends CommandLineException {
+        private static final long serialVersionUID = 0L;
+
+        public ConflictingMutuallyExclusiveArguments(String message, String commandLine){
+            super(message, commandLine);
+        }
+
     }
 
     public static class BadArgumentValue extends CommandLineException {
@@ -282,8 +295,8 @@ public class UserException extends RuntimeException {
     public static class MissingArgument extends CommandLineException {
         private static final long serialVersionUID = 0L;
 
-        public MissingArgument(String arg, String message) {
-            super(String.format("Argument %s was missing: %s", arg, message));
+        public MissingArgument(String message, String commandLine){
+            super(message, commandLine);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
@@ -54,8 +54,7 @@ public final class SplitNCigarReads extends CommandLineProgram {
     @Argument(fullName = OUTPUT_LONG_NAME, shortName = OUTPUT_SHORT_NAME, doc="Write output to this BAM filename instead of STDOUT")
     protected File OUTPUT;
 
-    @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file.",
-            common = true, optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file.", optional = true)
     public File REFERENCE_SEQUENCE = Defaults.REFERENCE_FASTA;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
@@ -30,7 +30,7 @@ public final class ExampleIntervalWalker extends IntervalWalker {
     @ArgumentCollection
     private OptionalVariantInputArgumentCollection optionalVariants = new OptionalVariantInputArgumentCollection();
 
-    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", optional = true)
     private File outputFile = null;
 
     private PrintStream outputStream = null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
@@ -25,7 +25,7 @@ import java.io.PrintStream;
 )
 public final class ExampleReadWalkerWithReference extends ReadWalker {
 
-    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", optional = true)
     private File OUTPUT_FILE = null;
 
     private PrintStream outputStream = null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
@@ -31,7 +31,7 @@ public final class ExampleReadWalkerWithVariants extends ReadWalker {
     @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "One or more VCF files", optional = true)
     private List<FeatureInput<VariantContext>> variants;
 
-    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", optional = true)
     private File outputFile;
 
     @Argument(fullName = "groupVariantsBySource", shortName = "groupVariantsBySource", doc = "If true, group overlapping variants by their source when outputting them", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
@@ -24,7 +24,7 @@ import java.io.PrintStream;
 )
 public final class ExampleVariantWalker extends VariantWalker {
 
-    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", optional = true)
     private File outputFile = null;
 
     @Argument(fullName="auxiliaryVariants", shortName="av", doc="Auxiliary set of variants", optional=true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
@@ -12,7 +12,7 @@ import htsjdk.variant.vcf.VCFFileReader;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -381,7 +381,7 @@ public class SelectVariants extends VariantWalker {
 
     @Argument(fullName=StandardArgumentDefinitions.LENIENT_LONG_NAME,
                             shortName = StandardArgumentDefinitions.LENIENT_SHORT_NAME,
-                            doc = "Lenient processing of VCF files", common = true, optional = true)
+                            doc = "Lenient processing of VCF files", optional = true)
     private boolean lenientVCFProcessing;
 
     @HiddenOption

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -65,7 +65,7 @@ public final class CommandLineParserTest {
         public Boolean TRUTHINESS;
     }
 
-    class MutexArguments {
+    private static class MutexArguments {
         @Argument(mutex={"M", "N", "Y", "Z"})
         public String A;
         @Argument(mutex={"M", "N", "Y", "Z"})
@@ -200,7 +200,7 @@ public final class CommandLineParserTest {
         final FrobnicateArguments fo = new FrobnicateArguments();
         final CommandLineParser clp = new CommandLineParser(fo);
         Assert.assertTrue(clp.parseArguments(System.err, args));
-        Assert.assertEquals(clp.getCommandLine(),
+        Assert.assertEquals(clp.getFullySpecifiedCommandLine(),
                 "org.broadinstitute.hellbender.cmdline.CommandLineParserTest$FrobnicateArguments  " +
                         "positional1 positional2 --FROBNICATION_THRESHOLD 17 --FROBNICATION_FLAVOR BAR " +
                         "--SHMIGGLE_TYPE shmiggle1 --SHMIGGLE_TYPE shmiggle2 --TRUTHINESS true  --help false " +
@@ -228,7 +228,7 @@ public final class CommandLineParserTest {
         final CommandLineParser clp = new CommandLineParser(sv);
         Assert.assertTrue(clp.parseArguments(System.err, args));
 
-        final String commandLine = clp.getCommandLine();
+        final String commandLine = clp.getFullySpecifiedCommandLine();
 
         Assert.assertTrue(commandLine.contains(unclassified));
         Assert.assertFalse(commandLine.contains(supersecret));
@@ -674,6 +674,41 @@ public final class CommandLineParserTest {
 
         Assert.assertFalse(clp.parseArguments(System.err, new String[]{"--help", "true"}));
         Assert.assertFalse(clp.parseArguments(System.err, new String[]{"--version", "true"}));
+    }
+
+    private static class MutexCollections{
+        @Argument(optional = false, mutex={"alternateValues"})
+        List<Integer> values;
+
+        @Argument(optional = false, mutex={"values"})
+        List<Integer> alternateValues;
+    }
+
+    @DataProvider(name="validMutexCollections")
+    public Object[][] makeValidMutexCollections(){
+        return new Object[][]{
+                {new String[]{"--values", "1", "--values","2"}, Arrays.asList(1,2), Collections.emptyList()},
+                {new String[]{"--values", "1"}, Arrays.asList(1), Collections.emptyList()},
+                {new String[]{"--alternateValues", "3"}, Collections.emptyList(), Arrays.asList(3)},
+                {new String[]{"--alternateValues", "3", "--alternateValues", "4"}, Collections.emptyList(), Arrays.asList(3,4)},
+        };
+    }
+
+    @Test(dataProvider = "validMutexCollections")
+    public void testMutexCollections(String[] args, List<Integer> values, List<Integer> alternateValues){
+        final MutexCollections o = new MutexCollections();
+        final CommandLineParser clp = new CommandLineParser(o);
+        clp.parseArguments(System.err, args);
+        Assert.assertEquals(o.values, values);
+        Assert.assertEquals(o.alternateValues, alternateValues);
+    }
+
+    @Test(expectedExceptions = UserException.ConflictingMutuallyExclusiveArguments.class)
+    public void testInvalidMutexCollection(){
+        String[] args = new String[]{"--values", "1", "--alternateValues", "3"};
+        final MutexCollections o = new MutexCollections();
+        final CommandLineParser clp = new CommandLineParser(o);
+        clp.parseArguments(System.err, args);
     }
 
     /***************************************************************************************

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.GenomeLoc;

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollectionTest.java
@@ -1,11 +1,9 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
 
 public final class ReadInputArgumentCollectionTest {
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
@@ -1,7 +1,13 @@
-package org.broadinstitute.hellbender.cmdline;
+package org.broadinstitute.hellbender.cmdline.parser;
 
 import htsjdk.samtools.util.CollectionUtil;
 import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.PositionalArguments;
+import org.broadinstitute.hellbender.cmdline.SpecialArgumentsCollection;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -13,7 +19,13 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public final class CommandLineParserTest {
     enum FrobnicationFlavor {
@@ -201,7 +213,7 @@ public final class CommandLineParserTest {
         final CommandLineParser clp = new CommandLineParser(fo);
         Assert.assertTrue(clp.parseArguments(System.err, args));
         Assert.assertEquals(clp.getFullySpecifiedCommandLine(),
-                "org.broadinstitute.hellbender.cmdline.CommandLineParserTest$FrobnicateArguments  " +
+                "org.broadinstitute.hellbender.cmdline.parser.CommandLineParserTest$FrobnicateArguments  " +
                         "positional1 positional2 --FROBNICATION_THRESHOLD 17 --FROBNICATION_FLAVOR BAR " +
                         "--SHMIGGLE_TYPE shmiggle1 --SHMIGGLE_TYPE shmiggle2 --TRUTHINESS true  --help false " +
                         "--version false");
@@ -942,6 +954,7 @@ public final class CommandLineParserTest {
                             "One or more gathered argument values not correct");
 
     }
+
 
     /**
      * Nonsensical parameterized class, just to ensure that CommandLineParser.gatherArgumentValuesOfType()

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
@@ -27,7 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public final class CommandLineParserTest {
+public final class CommandLineParserTest extends BaseTest {
     enum FrobnicationFlavor {
         FOO, BAR, BAZ
     }
@@ -137,7 +137,7 @@ public final class CommandLineParserTest {
      * Validate the text emitted by a call to usage by ensuring that required arguments are
      * emitted before optional ones.
      */
-    private void validateRequiredOptionalUsage(final CommandLineParser clp, final boolean withDefault) {
+    private static void validateRequiredOptionalUsage(final CommandLineParser clp, final boolean withDefault) {
         final String out = BaseTest.captureStderr(() -> clp.usage(System.err, withDefault)); // with common args
         // Required arguments should appear before optional ones
         final int reqIndex = out.indexOf("Required Arguments:");
@@ -401,7 +401,7 @@ public final class CommandLineParserTest {
             writer.println("-T 18");
             writer.println("--TRUTHINESS");
             writer.println("--SHMIGGLE_TYPE shmiggle0");
-            writer.println("--" + SpecialArgumentsCollection.ARGUMENTS_FILE_FULLNAME + " " + argumentsFile.getPath());
+            writer.println("--" + SpecialArgumentsCollection.ARGUMENTS_FILE_FULLNAME + ' ' + argumentsFile.getPath());
             //writer.println("--STRANGE_ARGUMENT shmiggle0");
         }
         final String[] args = {
@@ -508,38 +508,32 @@ public final class CommandLineParserTest {
         new CommandLineParser(o);
     }
 
-    class CollectionWithDefaultValuesArguments {
+    private static class CollectionWithDefaultValuesArguments {
         @Argument
         public List<String> LIST = CollectionUtil.makeList("foo", "bar");
     }
 
     @Test
     public void testClearDefaultValuesFromListArgument() {
-        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        final String[] args = {"--LIST","null"};
-        Assert.assertTrue(clp.parseArguments(System.err, args));
-        Assert.assertEquals(o.LIST.size(), 0);
+        assertListIsPopulatedCorrectly(new String[]{"--LIST","null"}, Collections.emptyList());
     }
 
     @Test
     public void testClearDefaultValuesFromListArgumentAndAddNew() {
-        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        final String[] args = {"--LIST","null", "--LIST","baz", "--LIST","frob"};
-        Assert.assertTrue(clp.parseArguments(System.err, args));
-        Assert.assertEquals(o.LIST, CollectionUtil.makeList("baz", "frob"));
+        assertListIsPopulatedCorrectly(new String[]{"--LIST","null", "--LIST","baz", "--LIST","frob"}, CollectionUtil.makeList("baz", "frob"));
     }
 
     @Test
     public void testDefaultValuesListArgument() {
-        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        final String[] args = {"--LIST","baz", "--LIST","frob"};
-        Assert.assertTrue(clp.parseArguments(System.err, args));
-        Assert.assertEquals(o.LIST, CollectionUtil.makeList("foo", "bar", "baz", "frob"));
+        assertListIsPopulatedCorrectly(new String[]{"--LIST","baz", "--LIST","frob"}, CollectionUtil.makeList("foo", "bar", "baz", "frob"));
     }
 
+    public static void assertListIsPopulatedCorrectly(String[] args, List<String> expected) {
+        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
+        final CommandLineParser clp = new CommandLineParser(o);
+        Assert.assertTrue(clp.parseArguments(System.err, args));
+        Assert.assertEquals(o.LIST, expected);
+    }
 
     @Test
        public void testFlagNoArgument(){
@@ -579,7 +573,7 @@ public final class CommandLineParserTest {
         final ArgsCollectionHaver o = new ArgsCollectionHaver();
         final CommandLineParser clp = new CommandLineParser(o);
 
-        String[] args = {"--arg1", "42", "--somenumber", "12"};
+        final String[] args = {"--arg1", "42", "--somenumber", "12"};
         Assert.assertTrue(clp.parseArguments(System.err, args));
         Assert.assertEquals(o.someNumber, 12);
         Assert.assertEquals(o.default_args.Arg1, 42);
@@ -622,7 +616,7 @@ public final class CommandLineParserTest {
 
     @Test(expectedExceptions = GATKException.CommandLineParserInternalException.class)
     public void testBadFieldCausesException(){
-        WithBadField o = new WithBadField();
+        final WithBadField o = new WithBadField();
         final CommandLineParser clp = new CommandLineParser(o);
     }
 
@@ -642,7 +636,7 @@ public final class CommandLineParserTest {
 
     @Test
     public void testFlagWithPositionalFollowing(){
-        PrivateArgument o = new PrivateArgument();
+        final PrivateArgument o = new PrivateArgument();
         final CommandLineParser clp = new CommandLineParser(o);
         Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--flag1","1","2" }));
         Assert.assertTrue(o.booleanFlags.flag1);
@@ -651,7 +645,7 @@ public final class CommandLineParserTest {
 
     @Test
     public void testPrivateArgument(){
-        PrivateArgument o = new PrivateArgument();
+        final PrivateArgument o = new PrivateArgument();
         final CommandLineParser clp = new CommandLineParser(o);
         Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--privateArgument",
                 "--privateCollection", "1", "--privateCollection", "2", "--flag1"}));
@@ -668,7 +662,7 @@ public final class CommandLineParserTest {
         final BooleanFlags o = new BooleanFlags();
         final CommandLineParser clp = new CommandLineParser(o);
 
-        String[] helpArgs = new String[]{"--"+SpecialArgumentsCollection.HELP_FULLNAME};
+        final String[] helpArgs = new String[]{"--"+SpecialArgumentsCollection.HELP_FULLNAME};
 
         String out = BaseTest.captureStderr( () -> {
             Assert.assertFalse(clp.parseArguments(System.err, helpArgs));
@@ -717,7 +711,7 @@ public final class CommandLineParserTest {
 
     @Test(expectedExceptions = UserException.ConflictingMutuallyExclusiveArguments.class)
     public void testInvalidMutexCollection(){
-        String[] args = new String[]{"--values", "1", "--alternateValues", "3"};
+        final String[] args = new String[]{"--values", "1", "--alternateValues", "3"};
         final MutexCollections o = new MutexCollections();
         final CommandLineParser clp = new CommandLineParser(o);
         clp.parseArguments(System.err, args);
@@ -764,7 +758,7 @@ public final class CommandLineParserTest {
         private GatherArgumentValuesTargetSuperType parentUnannotatedTarget;
 
         @ArgumentCollection
-        private GatherArgumentValuesTestSourceParentCollection parentCollection = new GatherArgumentValuesTestSourceParentCollection();
+        private final GatherArgumentValuesTestSourceParentCollection parentCollection = new GatherArgumentValuesTestSourceParentCollection();
     }
 
     private static class GatherArgumentValuesTestSourceChild extends GatherArgumentValuesTestSourceParent {
@@ -795,7 +789,7 @@ public final class CommandLineParserTest {
         private GatherArgumentValuesTargetSuperType childUnannotatedTarget;
 
         @ArgumentCollection
-        private GatherArgumentValuesTestSourceChildCollection childCollection = new GatherArgumentValuesTestSourceChildCollection();
+        private final GatherArgumentValuesTestSourceChildCollection childCollection = new GatherArgumentValuesTestSourceChildCollection();
     }
 
     private static class GatherArgumentValuesTestSourceParentCollection implements ArgumentCollectionDefinition {
@@ -880,8 +874,8 @@ public final class CommandLineParserTest {
                                                               "childCollectionNonTargetArgument", "parentCollectionNonTargetArgument",
                                                               "childNonTargetListArgument");
 
-        List<String> commandLineArguments = new ArrayList<>();
-        List<Pair<String, String>> sortedExpectedGatheredValues = new ArrayList<>();
+        final List<String> commandLineArguments = new ArrayList<>();
+        final List<Pair<String, String>> sortedExpectedGatheredValues = new ArrayList<>();
 
         for ( String targetScalarArgument : targetScalarArguments ) {
             final String argumentValue = targetScalarArgument + "Value";
@@ -924,27 +918,27 @@ public final class CommandLineParserTest {
 
     @Test(dataProvider = "gatherArgumentValuesOfTypeDataProvider")
     public void testGatherArgumentValuesOfType( final List<String> commandLineArguments, final List<Pair<String, String>> sortedExpectedGatheredValues ) {
-        GatherArgumentValuesTestSourceChild argumentSource = new GatherArgumentValuesTestSourceChild();
+        final GatherArgumentValuesTestSourceChild argumentSource = new GatherArgumentValuesTestSourceChild();
 
         // Parse the command line, and inject values into our test instance
-        CommandLineParser clp = new CommandLineParser(argumentSource);
+        final CommandLineParser clp = new CommandLineParser(argumentSource);
         clp.parseArguments(System.err, commandLineArguments.toArray(new String[commandLineArguments.size()]));
 
         // Gather all argument values of type GatherArgumentValuesTargetSuperType (or Collection<GatherArgumentValuesTargetSuperType>),
         // including subtypes.
-        List<Pair<Field, GatherArgumentValuesTargetSuperType>> gatheredArguments =
+        final List<Pair<Field, GatherArgumentValuesTargetSuperType>> gatheredArguments =
                 CommandLineParser.gatherArgumentValuesOfType(GatherArgumentValuesTargetSuperType.class, argumentSource);
 
         // Make sure we gathered the expected number of argument values
         Assert.assertEquals(gatheredArguments.size(), sortedExpectedGatheredValues.size(), "Gathered the wrong number of arguments");
 
         // Make sure actual gathered argument values match expected values
-        List<Pair<String, String>> sortedActualGatheredArgumentValues = new ArrayList<>();
+        final List<Pair<String, String>> sortedActualGatheredArgumentValues = new ArrayList<>();
         for ( Pair<Field, GatherArgumentValuesTargetSuperType> gatheredArgument : gatheredArguments ) {
             Assert.assertNotNull(gatheredArgument.getKey().getAnnotation(Argument.class), "Gathered argument is not annotated with an @Argument annotation");
 
-            String argumentName = gatheredArgument.getKey().getAnnotation(Argument.class).fullName();
-            GatherArgumentValuesTargetSuperType argumentValue = gatheredArgument.getValue();
+            final String argumentName = gatheredArgument.getKey().getAnnotation(Argument.class).fullName();
+            final GatherArgumentValuesTargetSuperType argumentValue = gatheredArgument.getValue();
 
             sortedActualGatheredArgumentValues.add(Pair.of(argumentName, argumentValue != null ? argumentValue.getValue() : null));
         }
@@ -987,16 +981,16 @@ public final class CommandLineParserTest {
     @Test
     @SuppressWarnings("rawtypes")
     public void testGatherArgumentValuesOfTypeWithParameterizedType() {
-        GatherArgumentValuesParameterizedTypeSource argumentSource = new GatherArgumentValuesParameterizedTypeSource();
+        final GatherArgumentValuesParameterizedTypeSource argumentSource = new GatherArgumentValuesParameterizedTypeSource();
 
         // Parse the command line, and inject values into our test instance
-        CommandLineParser clp = new CommandLineParser(argumentSource);
+        final CommandLineParser clp = new CommandLineParser(argumentSource);
         clp.parseArguments(System.err, new String[]{"--parameterizedTypeArgument", "parameterizedTypeArgumentValue",
                                                     "--parameterizedTypeListArgument", "parameterizedTypeListArgumentValue"});
 
         // Gather argument values of the raw type GatherArgumentValuesParameterizedTargetType, and make
         // sure that we match fully-parameterized declarations
-        List<Pair<Field, GatherArgumentValuesParameterizedTargetType>> gatheredArguments =
+        final List<Pair<Field, GatherArgumentValuesParameterizedTargetType>> gatheredArguments =
                 CommandLineParser.gatherArgumentValuesOfType(GatherArgumentValuesParameterizedTargetType.class, argumentSource);
 
         Assert.assertEquals(gatheredArguments.size(), 2, "Wrong number of arguments gathered");

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
@@ -107,7 +107,7 @@ public final class CommandLineParserTest extends BaseTest {
     public void testRequiredOnlyUsage() {
         final RequiredOnlyArguments nr = new RequiredOnlyArguments();
         final CommandLineParser clp = new CommandLineParser(nr);
-        final String out = BaseTest.captureStderr(() -> clp.usage(System.err, false)); // without common args
+        final String out = BaseTest.captureStderr(() -> clp.usage(System.err)); // without common args
         final int reqIndex = out.indexOf("Required Arguments:");
         Assert.assertTrue(reqIndex > 0);
         Assert.assertTrue(out.indexOf("Optional Arguments:", reqIndex) < 0);
@@ -127,7 +127,7 @@ public final class CommandLineParserTest extends BaseTest {
     public void testOptionalOnlyUsage() {
         final OptionalOnlyArguments oo = new OptionalOnlyArguments();
         final CommandLineParser clp = new CommandLineParser(oo);
-        final String out = BaseTest.captureStderr(() -> clp.usage(System.err, false)); // without common args
+        final String out = BaseTest.captureStderr(() -> clp.usage(System.err)); // without common args
         final int reqIndex = out.indexOf("Required Arguments:");
         Assert.assertTrue(reqIndex < 0);
         Assert.assertTrue(out.indexOf("Optional Arguments:", reqIndex) > 0);
@@ -138,7 +138,7 @@ public final class CommandLineParserTest extends BaseTest {
      * emitted before optional ones.
      */
     private static void validateRequiredOptionalUsage(final CommandLineParser clp, final boolean withDefault) {
-        final String out = BaseTest.captureStderr(() -> clp.usage(System.err, withDefault)); // with common args
+        final String out = BaseTest.captureStderr(() -> clp.usage(System.err)); // with common args
         // Required arguments should appear before optional ones
         final int reqIndex = out.indexOf("Required Arguments:");
         Assert.assertTrue(reqIndex > 0);

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/parser/CommandLineParserTest.java
@@ -184,9 +184,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final FrobnicateArguments fo = parseArgumentsIntoObject(new FrobnicateArguments(), args);
         Assert.assertEquals(fo.positionalArguments.size(), 2);
         final File[] expectedPositionalArguments = { new File("positional1"), new File("positional2")};
         Assert.assertEquals(fo.positionalArguments.toArray(), expectedPositionalArguments);
@@ -259,9 +257,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final FrobnicateArguments fo = parseArgumentsIntoObject(new FrobnicateArguments(), args);
         Assert.assertEquals(fo.FROBNICATION_THRESHOLD.intValue(), 20);
     }
 
@@ -274,9 +270,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     class CollectionRequired{
@@ -287,9 +281,7 @@ public final class CommandLineParserTest extends BaseTest {
     @Test(expectedExceptions = UserException.MissingArgument.class)
     public void testMissingRequiredCollectionArgument(){
         final String[] args = {};
-        final CollectionRequired cr = new CollectionRequired();
-        final CommandLineParser clp = new CommandLineParser(cr);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new CollectionRequired(), args);
     }
 
     @Test( expectedExceptions = UserException.BadArgumentValue.class)
@@ -303,9 +295,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test(expectedExceptions = UserException.BadArgumentValue.class)
@@ -318,9 +308,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test(expectedExceptions = UserException.MissingArgument.class)
@@ -331,9 +319,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test(expectedExceptions = UserException.CommandLineException.class)
@@ -347,9 +333,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional2",
                 "positional3",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test(expectedExceptions = UserException.MissingArgument.class)
@@ -360,9 +344,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "--SHMIGGLE_TYPE","shmiggle1",
                 "--SHMIGGLE_TYPE","shmiggle2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test( expectedExceptions = UserException.CommandLineException.class)
@@ -375,9 +357,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "--SHMIGGLE_TYPE","shmiggle2",
                 "positional"
         };
-        final ArgumentsWithoutPositional fo = new ArgumentsWithoutPositional();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new ArgumentsWithoutPositional(), args);
     }
 
     @Test(expectedExceptions = UserException.CommandLineException.class)
@@ -389,9 +369,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
 
     @Test
@@ -415,9 +393,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "positional1",
                 "positional2",
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final FrobnicateArguments fo = parseArgumentsIntoObject(new FrobnicateArguments(), args);
         Assert.assertEquals(fo.positionalArguments.size(), 2);
         final File[] expectedPositionalArguments = { new File("positional1"), new File("positional2")};
         Assert.assertEquals(fo.positionalArguments.toArray(), expectedPositionalArguments);
@@ -444,9 +420,7 @@ public final class CommandLineParserTest extends BaseTest {
                 "--T","17",
                 "--"+SpecialArgumentsCollection.ARGUMENTS_FILE_FULLNAME ,argumentsFile.getPath()
         };
-        final FrobnicateArguments fo = new FrobnicateArguments();
-        final CommandLineParser clp = new CommandLineParser(fo);
-        clp.parseArguments(System.err, args);
+        parseArgumentsIntoObject(new FrobnicateArguments(), args);
     }
     
     @DataProvider(name="failingMutexScenarios")
@@ -461,16 +435,12 @@ public final class CommandLineParserTest extends BaseTest {
 
     @Test
     public void passingMutexCheck(){
-        final MutexArguments o = new MutexArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"-A", "1", "-B", "2"}));
+        parseArgumentsIntoObject(new MutexArguments(), new String[]{"-A", "1", "-B", "2"});
     }
 
     @Test(dataProvider="failingMutexScenarios", expectedExceptions = UserException.CommandLineException.class)
-    public void testFailingMutex(final String testName, final String[] args, final boolean expected) {
-        final MutexArguments o = new MutexArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        clp.parseArguments(System.err, args);
+    public void testFailingMutex(final String testName, final String[] args, final boolean ignored) {
+        parseArgumentsIntoObject(new MutexArguments(), args);
     }
 
     class UninitializedCollectionArguments {
@@ -487,10 +457,8 @@ public final class CommandLineParserTest extends BaseTest {
 
     @Test
     public void testUninitializedCollections() {
-        final UninitializedCollectionArguments o = new UninitializedCollectionArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
         final String[] args = {"--LIST","L1", "--LIST","L2", "--ARRAY_LIST","S1", "--HASH_SET","HS1", "P1", "P2"};
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final UninitializedCollectionArguments o = parseArgumentsIntoObject(new UninitializedCollectionArguments(), args);
         Assert.assertEquals(o.LIST.size(), 2);
         Assert.assertEquals(o.ARRAY_LIST.size(), 1);
         Assert.assertEquals(o.HASH_SET.size(), 1);
@@ -529,25 +497,25 @@ public final class CommandLineParserTest extends BaseTest {
     }
 
     public static void assertListIsPopulatedCorrectly(String[] args, List<String> expected) {
-        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final CollectionWithDefaultValuesArguments o = parseArgumentsIntoObject(new CollectionWithDefaultValuesArguments(), args);
         Assert.assertEquals(o.LIST, expected);
+    }
+
+    public static <T> T parseArgumentsIntoObject(T objectWithUninitializedArgs, String[] args) {
+        final CommandLineParser clp = new CommandLineParser(objectWithUninitializedArgs);
+        Assert.assertTrue(clp.parseArguments(System.err, args));
+        return objectWithUninitializedArgs;
     }
 
     @Test
        public void testFlagNoArgument(){
-        final BooleanFlags o = new BooleanFlags();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--flag1"}));
+        final BooleanFlags o = parseArgumentsIntoObject(new BooleanFlags(), new String[] { "--flag1" });
         Assert.assertTrue(o.flag1);
     }
 
     @Test
     public void testFlagsWithArguments(){
-        final BooleanFlags o = new BooleanFlags();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--flag1", "false", "--flag2", "false"}));
+        final BooleanFlags o = parseArgumentsIntoObject(new BooleanFlags(), new String[] {"--flag1", "false", "--flag2", "false"});
         Assert.assertFalse(o.flag1);
         Assert.assertFalse(o.flag2);
     }
@@ -570,11 +538,7 @@ public final class CommandLineParserTest extends BaseTest {
 
     @Test
     public void testArgumentCollection(){
-        final ArgsCollectionHaver o = new ArgsCollectionHaver();
-        final CommandLineParser clp = new CommandLineParser(o);
-
-        final String[] args = {"--arg1", "42", "--somenumber", "12"};
-        Assert.assertTrue(clp.parseArguments(System.err, args));
+        final ArgsCollectionHaver o = parseArgumentsIntoObject(new ArgsCollectionHaver(), new String[]{"--arg1", "42", "--somenumber", "12"});
         Assert.assertEquals(o.someNumber, 12);
         Assert.assertEquals(o.default_args.Arg1, 42);
 
@@ -599,10 +563,9 @@ public final class CommandLineParserTest extends BaseTest {
 
     @Test
     public void testCombinationOfFlags(){
-        final BooleanFlags o = new BooleanFlags();
-        final CommandLineParser clp = new CommandLineParser(o);
+        final String[] args = {"--flag1", "false", "--flag2"};
+        final BooleanFlags o = parseArgumentsIntoObject( new BooleanFlags(), args);
 
-        clp.parseArguments(System.err, new String[]{"--flag1", "false", "--flag2"});
         Assert.assertFalse(o.flag1);
         Assert.assertTrue(o.flag2);
         Assert.assertFalse(o.flag3);
@@ -617,7 +580,7 @@ public final class CommandLineParserTest extends BaseTest {
     @Test(expectedExceptions = GATKException.CommandLineParserInternalException.class)
     public void testBadFieldCausesException(){
         final WithBadField o = new WithBadField();
-        final CommandLineParser clp = new CommandLineParser(o);
+        new CommandLineParser(o);
     }
 
     class PrivateArgument{
@@ -636,19 +599,17 @@ public final class CommandLineParserTest extends BaseTest {
 
     @Test
     public void testFlagWithPositionalFollowing(){
-        final PrivateArgument o = new PrivateArgument();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--flag1","1","2" }));
+        final String[] args = {"--flag1", "1", "2"};
+        final PrivateArgument o = parseArgumentsIntoObject(new PrivateArgument(), args);
         Assert.assertTrue(o.booleanFlags.flag1);
         Assert.assertEquals(o.positionals, Arrays.asList(1, 2));
     }
 
     @Test
     public void testPrivateArgument(){
-        final PrivateArgument o = new PrivateArgument();
-        final CommandLineParser clp = new CommandLineParser(o);
-        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--privateArgument",
-                "--privateCollection", "1", "--privateCollection", "2", "--flag1"}));
+        final String[] args = {"--privateArgument",
+                "--privateCollection", "1", "--privateCollection", "2", "--flag1"};
+        final PrivateArgument o = parseArgumentsIntoObject(new PrivateArgument(), args);
         Assert.assertTrue(o.privateArgument);
         Assert.assertEquals(o.privateCollection, Arrays.asList(1,2));
         Assert.assertTrue(o.booleanFlags.flag1);
@@ -981,12 +942,10 @@ public final class CommandLineParserTest extends BaseTest {
     @Test
     @SuppressWarnings("rawtypes")
     public void testGatherArgumentValuesOfTypeWithParameterizedType() {
-        final GatherArgumentValuesParameterizedTypeSource argumentSource = new GatherArgumentValuesParameterizedTypeSource();
-
         // Parse the command line, and inject values into our test instance
-        final CommandLineParser clp = new CommandLineParser(argumentSource);
-        clp.parseArguments(System.err, new String[]{"--parameterizedTypeArgument", "parameterizedTypeArgumentValue",
-                                                    "--parameterizedTypeListArgument", "parameterizedTypeListArgumentValue"});
+        final String[] args = {"--parameterizedTypeArgument", "parameterizedTypeArgumentValue",
+                "--parameterizedTypeListArgument", "parameterizedTypeListArgumentValue"};
+        GatherArgumentValuesParameterizedTypeSource argumentSource = parseArgumentsIntoObject(new GatherArgumentValuesParameterizedTypeSource(), args);
 
         // Gather argument values of the raw type GatherArgumentValuesParameterizedTargetType, and make
         // sure that we match fully-parameterized declarations

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
@@ -8,7 +8,7 @@ import htsjdk.tribble.Feature;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.parser.CommandLineParser;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.utils.test.BaseTest;


### PR DESCRIPTION
- error messages will now include all the missing arguments when applicable

- error messages should be more readable
old style:
```
$ hellbender PrintReads
***********************************************************************

A USER ERROR has occurred: Invalid command line: Argument output was missing: Argument 'output' is required.

***********************************************************************
```
new style:
```
$ hellbender PrintReads
***********************************************************************

A USER ERROR has occurred:

Invalid command line:
required argument --input was not specified
required argument --output was not specified

Rerun with --help to see more information on available options

***********************************************************************
```

- fixed a bug in CommandLineParser
  - collection arguments that had a mutual exclusion field would be reported as missing even if one of the mutex arguments was present
 - adding tests for this case

- some refactoring on CommandLineParser

fixes #418

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/broadinstitute/gatk/1144)
<!-- Reviewable:end -->
