### PR TITLE
Rename BaseRecalibratorSparkOptimized to BaseRecalibratorSparkSharded

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
         oneLineSummary = "Generates recalibration table",
         programGroup = SparkProgramGroup.class
 )
-public class BaseRecalibratorSparkOptimized extends SparkCommandLineProgram {
+public class BaseRecalibratorSparkSharded extends SparkCommandLineProgram {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkShardedIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkShardedIntegrationTest.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
-public class BaseRecalibratorSparkOptimizedIntegrationTest extends CommandLineProgramTest {
+public class BaseRecalibratorSparkShardedIntegrationTest extends CommandLineProgramTest {
 
     private final static String THIS_TEST_FOLDER = "org/broadinstitute/hellbender/tools/BQSR/";
 


### PR DESCRIPTION
To help avoid user confusion.

Resolves #1172