### PR TITLE
Change google-http-client version from SNAPSHOT now that 1.21.0 is out.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.google.http-client:google-http-client:1.21.0-SNAPSHOT'
+        force 'com.google.http-client:google-http-client:1.21.0'
         // the snapshot folder contains a dev version of guava, we don't want to use that.
         force 'com.google.guava:guava:18.0'
     }


### PR DESCRIPTION
The build is failing since 1.21.0-SNAPSHOT is no longer available in any Maven repositories. It looks like 1.21.0 was released last week: https://repo1.maven.org/maven2/com/google/http-client/google-http-client/, and changing the build to use that version seems to fix the problem.

Related to #650.