### PR TITLE
Allow Spark UI to run during tests by setting the gatk.spark.debug system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,7 @@ task testAll(type: Test){
     systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
     // increase max buffer size for Spark serialization
     systemProperty "spark.kryoserializer.buffer.max", "256m"
+    systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"
@@ -237,6 +238,8 @@ test {
             excludeGroups 'spark'
         }
     }
+
+    systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -16,11 +16,12 @@ import java.util.Map;
 public final class SparkContextFactory {
 
     public static final String DEFAULT_SPARK_MASTER = "local[*]";
+    private static final boolean SPARK_DEBUG_ENABLED = Boolean.getBoolean("gatk.spark.debug");
 
     public static final Map<String, String> TEST_ATTRIBUTES = ImmutableMap.<String, String>builder()
             .put("spark.serializer", KryoSerializer.class.getCanonicalName())
             .put("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
-            .put("spark.ui.enabled", "false")
+            .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
             .build();
 
     public static final Map<String, String> CMDLINE_ATTRIBUTES = ImmutableMap.<String, String>builder()


### PR DESCRIPTION
This it for https://github.com/broadinstitute/gatk/issues/972. By adding `-Dgatk.spark.debug=true` you can run a single Spark test and look at the Spark UI (on http://localhost:4040/) as it runs.