### PR TITLE
adding gatk-launch script to make it easier to run spark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,10 +84,6 @@ compileTestJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror']
 }
 
-installDist.dependsOn downloadGsaLibFile
-build.dependsOn installDist
-check.dependsOn installDist
-
 dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 
@@ -191,10 +187,6 @@ jar {
 task testAll(type: Test){
     useTestNG{}
 
-    // ensure dataflowRunner is passed to the test VM if specified on the command line
-    systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
-    // increase max buffer size for Spark serialization
-    systemProperty "spark.kryoserializer.buffer.max", "256m"
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     // set heap size for the test JVM(s)
@@ -397,6 +389,14 @@ uploadArchives {
                 ' for more information.' )
             throw new Exception("Missing sonatype username or password, please see the README for properties that must be specified for uploading an archive.")}
         )
-
     }
+
+task installSpark{ dependsOn sparkJar }
+task installAll{  dependsOn installSpark, installDist }
+
+
+installDist.dependsOn downloadGsaLibFile
+build.dependsOn installDist
+check.dependsOn installDist
+
 }

--- a/gatk-launch
+++ b/gatk-launch
@@ -1,0 +1,284 @@
+#!/usr/bin/env python
+import sys
+from subprocess import call
+import os
+import hashlib
+import signal
+
+script = os.path.dirname(os.path.realpath(__file__))
+
+BUILD_LOCATION = script +"/build/install/gatk/bin/"
+GATK_RUN_SCRIPT = BUILD_LOCATION + "gatk"
+BIN_PATH = script + "/build/libs"
+
+DEFAULT_SPARK_ARGS = ["--conf", "spark.kryoserializer.buffer.max=512m",
+"--conf", "spark.driver.maxResultSize=0",
+"--conf", "spark.driver.userClassPathFirst=true",
+"--conf", "spark.executor.userClassPathFirst=true",
+"--conf", "spark.io.compression.codec=lzf",
+"--conf", "spark.yarn.executor.memoryOverhead=600"]
+
+class GATKLaunchException(Exception):
+    pass
+
+
+def signal_handler(signal, frame):
+    sys.exit(1)
+
+
+def main(args):
+    #suppress stack trace when killed by keyboard interrupt
+    signal.signal(signal.SIGINT, signal_handler)
+
+    try:
+        if len(args) is 0:
+            print("")
+            print("Usage:")
+            print(" General format")
+            print("    gatk-launch Tool toolArgs -- sparkArgs")
+            print("")
+            print("    gatk-launch <GATKTool> <GATK arg 1>...<arg n>")
+            print("")
+            print("    gatk-launch <GATKTool> <GATK arg 1>...<arg n>  [ -- --sparkRunner <DIRECT | SUBMIT | GCS>  <Spark arg 1>...<Spark arg n> ]")
+            print("")
+            print("gatk-launch forwards commands to GATK and adds some sugar for submitting spark jobs")
+            print("")
+            print("   --sparkRunner <target>    controls how spark tools are run")
+            print("     valid targets are:")
+            print("     DIRECT:    run using the in memory spark runner")
+            print("     SUBMIT:  run gatk using spark-submit on an existing cluster ")
+            print("               --sparkMaster must be specified")
+            print("               arguments to spark-submit may optionally be specified after -- ")
+            print("     GCS:      run gatk using gcloud dataproc")
+            print("               commands after the -- will be passed to dataproc")
+            print("               --cluster <your-cluster> must be specified after the --")
+            print("               spark properties and some common spark-submit parameters will be translated to dataproc equivalents")
+            print("")
+            print("    --dryRun    may be specified to output the generated command line without running it")
+            sys.exit(0)
+
+        dryRun = "--dryRun" in args
+        if dryRun:
+            dryRun = True
+            args.remove("--dryRun")
+
+        sparkRunner = getValueForArgument(args, "--sparkRunner")
+        if sparkRunner is not None:
+            i = args.index("--sparkRunner")
+            del args[i] #remove spark target
+            del args[i] #and its parameter
+
+        (gatkArgs, sparkArgs) = getSplitArgs(args)
+
+        sparkMaster = getValueForArgument(sparkArgs, "--sparkMaster")
+        if sparkMaster is not None:
+            i = sparkArgs.index("--sparkMaster")
+            del sparkArgs[i] #remove spark target
+            del sparkArgs[i] #and its parameter
+            gatkArgs += ["--sparkMaster", sparkMaster]
+
+        runGATK(sparkRunner, dryRun, gatkArgs, sparkArgs)
+    except GATKLaunchException as e:
+        sys.stderr.write(str(e)+"\n")
+
+
+def getSparkSubmit():
+    sparkhome = os.environ.get("SPARK_HOME")
+    if sparkhome is not None:
+        return sparkhome +"/bin/spark-submit"
+    else:
+        return "spark-submit"
+
+
+def getSparkJar():
+    sparkproperty = os.environ.get('GATK_SPARK_JAR')
+    if not sparkproperty is None:
+        if not os.path.exists(sparkproperty):
+            raise GATKLaunchException("GATK_SPARK_JAR was set to: " + sparkproperty + " but it doesn't exist, please fix your environment")
+        else:
+            return sparkproperty
+
+    if not os.path.exists(BIN_PATH):
+        raise GATKLaunchException("No spark jar was found, please build one by running\n\n    " + script + "/gradlew sparkJar")
+    files = os.listdir(BIN_PATH)
+    sparkjars = [f for f in files if "spark.jar" in f]
+    if len(sparkjars) is 0:
+        raise GATKLaunchException("No spark jar was found, please build one by running\n\n    " + script + "/gradlew sparkJar\n"
+                             "or\n"
+                             "    export GATK_SPARK_JAR=<path_to_spark_jar>")
+    elif len(sparkjars) > 1:
+        raise GATKLaunchException("Multiple spark jars were found please fix the problem by either:\n\n"
+                             "    export GATK_SPARK_JAR=<path_to_spark_jar>\n\nor\n\n"
+                             "   " + script + "/gradlew clean sparkJar")
+    else:
+        return BIN_PATH+ "/" + sparkjars[0]
+
+
+def md5(file):
+    hash = hashlib.md5()
+    with open(file, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash.update(chunk)
+    return hash.hexdigest()
+
+
+def cacheJarOnGCS(jar, dryRun):
+    staging = os.environ.get("GATK_GCS_STAGING")
+    if dryRun is True:
+        return jar
+    elif staging is None:
+        sys.stderr.write( "\njar caching is disabled because GATK_GCS_STAGING is not set\n\n"
+                              "please set GATK_GCS_STAGING to a bucket you have write access too in order to enable jar caching\n"
+                              "add the following line to you .bashrc or equivalent startup script\n\n"
+                              "    export GATK_GCS_STAGING=gs://<my_bucket>/\n")
+        return jar
+    else:
+        jarname = os.path.basename(jar)
+        (name, ext) = os.path.splitext(jarname)
+        jarmd5 = md5(jar)
+        gcsjar = staging + name + "_"+ jarmd5 + ext
+
+        try:
+            if call(["gsutil", "-q", "stat", gcsjar]) is 0:
+                    sys.stderr.write("\nfound cached jar: " + gcsjar + "\n")
+                    return gcsjar
+            else:
+                if call(["gsutil", "cp", jar, gcsjar]) is 0:
+                    sys.stderr.write("\nuploaded " + jar + " -> " + gcsjar + "\n")
+                    return gcsjar
+                else:
+                    sys.stderr.write("\nfailed to upload " + jar + " -> " + gcsjar + "\nThere may be something wrong with your bucket permissions or gsutil installation\n")
+                    return jar
+
+        except OSError:
+            sys.stderr.write("\nTried to execute gsutil to upload the jar but it wasn't available\n "
+                             "See https://cloud.google.com/sdk/#Quick_Start for instructions on installing gsutil\n\n")
+            return jar
+
+
+def runGATK(sparkRunner, dryrun, gatkArgs, sparkArgs):
+    if sparkRunner is None or sparkRunner == "DIRECT":
+        cmd = [getGatkWrapperScript()] + gatkArgs
+        runCommand(cmd, dryrun)
+    elif sparkRunner == "SUBMIT":
+        cmd = [ getSparkSubmit(),
+          "--master", getSparkMasterSpecified(gatkArgs)] \
+              + DEFAULT_SPARK_ARGS \
+              + sparkArgs \
+              + [getSparkJar()] \
+              + gatkArgs
+        try:
+            runCommand(cmd, dryrun)
+        except OSError:
+            raise GATKLaunchException("Tried to run spark-submit but failed.\nMake sure spark-submit is available in your path")
+    elif sparkRunner == "GCS":
+        jarPath = cacheJarOnGCS(getSparkJar(), dryrun)
+        dataprocargs = convertSparkSubmitToDataprocArgs(sparkArgs)
+
+        sys.stderr.write("\nReplacing spark-submit style args with dataproc style args\n\n" + " ".join(sparkArgs) +" -> " + " ".join(dataprocargs) +"\n" )
+
+        cmd = [ "gcloud", "beta", "dataproc", "jobs", "submit", "spark"] \
+              + dataprocargs \
+              + ["--jar", jarPath] \
+              + gatkArgs + ["--sparkMaster", "yarn-client"]
+        try:
+            runCommand(cmd, dryrun)
+        except OSError:
+            raise GATKLaunchException("Tried to run gcloud but failed.\nMake sure gcloud is available in your path and you are properly authenticated")
+    else:
+        raise GATKLaunchException("Value: " + sparkRunner + " is not a valid value for --sparkRunner.  Choose one of DIRECT, SUBMIT, GCS")
+
+
+def getGatkWrapperScript():
+    if not os.path.exists(GATK_RUN_SCRIPT):
+        raise GATKLaunchException("Missing GATK wrapper script: " + GATK_RUN_SCRIPT + "\nTo generate the wrapper run:\n\n    " + script + "/gradlew installDist")
+    return GATK_RUN_SCRIPT
+
+
+def runCommand(cmd, dryrun):
+    if dryrun:
+        print( "\nDry run:\n")
+        print(("    " + " ".join(cmd)+"\n"))
+    else:
+        sys.stderr.write( "\nRunning:\n")
+        sys.stderr.write("    " + " ".join(cmd)+"\n")
+        call(cmd)
+
+def getSplitArgs(args):
+    inFirstGroup = True
+    firstArgs = []
+    secondArgs = []
+
+    for arg in args:
+        if arg == "--":
+            if not inFirstGroup:
+                raise GATKLaunchException("Argument '--' must only be specified once")
+            inFirstGroup = False
+        else:
+            if inFirstGroup:
+                firstArgs.append(arg)
+            else:
+                secondArgs.append(arg)
+    return (firstArgs, secondArgs)
+
+
+def isDryRun(args):
+    return "--dryRun" in args
+
+
+def getValueForArgument(args, argument):
+    if argument in args:
+        i = args.index(argument)
+        if len(args) <= i+1:
+            raise GATKLaunchException("Argument: " + argument + " requires a parameter")
+        return args[i+1]
+    return None
+
+
+def getSparkMasterSpecified(args):
+    value = getValueForArgument(args, "--sparkMaster")
+    if value is None:
+        raise GATKLaunchException("The argument --sparkMaster <master url> must be specified")
+    else:
+        return value
+
+
+# translate select spark-submit parameters to their gcloud equivalent
+def convertSparkSubmitToDataprocArgs(args):
+    replacements = {"--driver-memory": "spark.driver.memory",
+                    "--driver-cores": "spark.driver.cores",
+                    "--executor-memory": "spark.executor.memory",
+                    "--executor-cores": "spark.executor.cores",
+                    "--num-executors": "spark.executor.instances" }
+
+    dataprocargs = []
+    properties = []
+    try:
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg == "--conf":
+                i += 1
+                properties.append(args[i])
+            elif not replacements.get(arg) is None:
+                i += 1
+                propertyname = replacements.get(arg)
+                properties.append(propertyname + "=" + args[i])
+            else:
+                dataprocargs.append(arg)
+            i +=1
+    except IndexError:
+        raise GATKLaunchException("Found an argument: " + arg + "with no matching value.")
+
+    if not len(properties) is 0:
+        dataprocargs.append("--properties")
+        dataprocargs.append(",".join(properties))
+
+    return dataprocargs
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name =	"gatk"

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -18,7 +18,6 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
             shortName = "apiKey", fullName = "apiKey", optional=true)
     protected String apiKey = null;
 
-
     @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
     protected String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -19,14 +19,16 @@ public final class SparkContextFactory {
     private static final boolean SPARK_DEBUG_ENABLED = Boolean.getBoolean("gatk.spark.debug");
 
     public static final Map<String, String> TEST_ATTRIBUTES = ImmutableMap.<String, String>builder()
+            .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
+            .put("spark.kryoserializer.buffer.max", "256m")
+            .build();
+
+    public static final Map<String, String> MANDATORY_ATTRIBUTES = ImmutableMap.<String,String>builder()
             .put("spark.serializer", KryoSerializer.class.getCanonicalName())
             .put("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
-            .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
             .build();
 
     public static final Map<String, String> CMDLINE_ATTRIBUTES = ImmutableMap.<String, String>builder()
-            .put("spark.serializer", KryoSerializer.class.getCanonicalName())
-            .put("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
             .put("spark.kryoserializer.buffer.max", "512m")
             .put("spark.driver.maxResultSize", "0")
             .put("spark.driver.userClassPathFirst", "true")
@@ -103,7 +105,9 @@ public final class SparkContextFactory {
     @VisibleForTesting
     static SparkConf setupSparkConf(final String appName, final String master, final Map<String, String> sparkAttributes) {
         final SparkConf sparkConf = new SparkConf().setAppName(appName).setMaster(master);
-        sparkAttributes.forEach(sparkConf::set);
+
+        MANDATORY_ATTRIBUTES.forEach(sparkConf::set);
+        sparkAttributes.forEach(sparkConf::setIfMissing);
         return sparkConf;
     }
     

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.engine.spark.datasources;
 
 import com.google.api.services.storage.Storage;
 import com.google.cloud.genomics.dataflow.readers.bam.BAMIO;
-
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
@@ -22,7 +21,6 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.broadinstitute.hellbender.engine.AuthHolder;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -155,7 +153,7 @@ public class ReadsSparkSource implements Serializable {
                     return reader.getFileHeader();
                 }
             } catch (Exception e) {
-                throw new UserException("Failed to read bams header from " + filePath + ".", e);
+                throw new UserException("Failed to read bam header from " + filePath + "\n Caused by:" + e.getMessage(), e);
             }
         }
 
@@ -178,7 +176,7 @@ public class ReadsSparkSource implements Serializable {
             }
             return SAMHeaderReader.readSAMHeaderFrom(path, ctx.hadoopConfiguration());
         } catch (IOException e) {
-            throw new UserException("Failed to read bams header from " + filePath + ".", e);
+            throw new UserException("Failed to read bam header from " + filePath + "\n Caused by:" + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
this is a script which can be used after running gradle installDist to run spark jobs
it can be used identically to ths build/install/bin/gatk script, but has extra features for dealing with spark

running a spark tool and supplying the option --sparkTarget with LOCAL, CLUSTER, or GCS has special behavior
LOCAL will run the tool in the in memory spark runner
CLUSTER along with an appropriate --sparkMaster will run on an accessible spark cluster using spark-submit
arguments to spark-submit may be specified before the arguments to GATK by separating them with a --
GCS will submit jobs to google dataproc using gcloud
common arguments for spark submit will be adapted to match the gcloud formating
this will fail if gcloud isn't installed

if GATK_GCS_STAGING is specified, the jar will be uploaded and cached in the specified bucket for rapid re-use

input files will not be autouploaded to the cloud

--dry-run may be specified before the --, this will only print the commands that will be run instead of actually running them

Adding DataProcArgumentReplace simple tool to convert spark-submit args into gcloud args.
This conversion is not guarenteed to translate all spark command line options to matching gcloud ones.
If you find options that are not translated or are miss-translated please file an issue.