### PR TITLE
Filter out SRA readers in SplitReads tests in prep for htsjdk upgrade.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
@@ -139,7 +139,8 @@ public final class SplitReadsIntegrationTest extends CommandLineProgramTest {
                 .filter(f -> f.getType().isAssignableFrom(SamReader.Type.class))
                 .map(f -> orNull(() -> f.get(null)))
                 .filter(v -> v instanceof SamReader.Type)
-                .map(v -> (SamReader.Type) v);
+                .map(v -> (SamReader.Type) v)
+                .filter(v -> !v.fileExtension().equals("sra")); // exclude SRA file types until we have tests
     }
 
     private static <V> V orNull(final Callable<V> callable) {


### PR DESCRIPTION
The SplitReads integration tests will fail once we upgrade htsjdk without this.