### PR TITLE
Upgrade to htsjdk2.0.0 and update HadoopReferenceSequenceFileFactory for nio path changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 
     compile 'com.google.guava:guava:18.0'
-    compile 'com.github.samtools:htsjdk:1.141-6dceff7-SNAPSHOT'
+    compile 'com.github.samtools:htsjdk:2.0.0'
     compile ('com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15') {
         // an upstream dependency includes guava-jdk5, but we want the newer version instead.
         exclude module: 'guava-jdk5'

--- a/src/main/java/htsjdk/samtools/reference/HadoopReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/HadoopReferenceSequenceFileFactory.java
@@ -110,7 +110,7 @@ public class HadoopReferenceSequenceFileFactory {
                     channelBuffer = ByteBuffer.wrap(channelBytes, 0, bytesRead);
                     // End Hellbender changes
                 } catch (IOException ex) {
-                    throw new SAMException("Unable to load " + contig + "(" + start + ", " + stop + ") from " + file);
+                    throw new SAMException("Unable to load " + contig + "(" + start + ", " + stop + ") from " + getPath());
                 }
 
                 // Reset the buffer for outbound transfers.


### PR DESCRIPTION
This change is dependent on [this recent change](https://github.com/samtools/htsjdk/commit/4f550e1f1afabf21467957fa672ca2a4ad457897#diff-b678735810949d4263df7bd0fffdecb8L42) in htsjdk (and the build will fail without it). Once htsjdk2.0 is available we'll upgrade it  in this branch/pr so the two changes can go in together.