### PR TITLE
Re-enable htsjdk-dependent CRAM tests.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFiles.java
@@ -76,7 +76,7 @@ public final class GatherBamFiles extends PicardCommandLineProgram {
             header = SamReaderFactory.makeDefault().referenceSequence(referenceFasta).getFileHeader(inputs.get(0));
         }
 
-        try (final SAMFileWriter out = createSAMWriter(output, referenceFasta, header, true)) {
+        try (final SAMFileWriter out = createSAMWriter(output, referenceFasta, header, false)) {
             for (final File f : inputs) {
                 log.info("Gathering " + f.getAbsolutePath());
                 final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceFasta).open(f);

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFilesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFilesIntegrationTest.java
@@ -145,17 +145,13 @@ public final class GatherBamFilesIntegrationTest extends CommandLineProgramTest 
         );
 
         return new Object[][]{
-                // these require the fix to https://github.com/samtools/htsjdk/issues/365
-                // that is in PR https://github.com/samtools/htsjdk/pull/368
                 {splitCramsUnmappedLast, origCram, true, true},
                 {splitCramsUnmappedFirst, origCram, true, true},
                 {splitCramsUnmappedMissing, origCram, false, false}
         };
     }
 
-    // These tests require the fix to https://github.com/samtools/htsjdk/issues/365
-    // in PR https://github.com/samtools/htsjdk/pull/368
-    @Test(dataProvider="cramgathering", enabled=false)
+    @Test(dataProvider="cramgathering")
     public void testTheCRAMGathering(final List<File> crams, final File original, final boolean expectEqual, final boolean expectEqualLenient) throws IOException {
         testTheGathering(crams, original, new File(TEST_DATA_DIR, "basic.fasta"), CramIO.CRAM_FILE_EXTENSION, expectEqual, expectEqualLenient);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SortSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SortSamIntegrationTest.java
@@ -17,10 +17,10 @@ public class SortSamIntegrationTest extends CommandLineProgramTest {
                 {"count_reads.bam", "count_reads_sorted.bam", null, ".bam", "coordinate"},
                 {"count_reads.bam", "count_reads_sorted.bam", "count_reads.fasta", ".cram", "coordinate"},
                 {"count_reads.bam", "count_reads.bam", null, ".bam", "queryname"},
-                // next two require fix to https://github.com/samtools/htsjdk/issues/365
-                //{"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".cram", "coordinate"},
-                //{"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".bam", "coordinate"},
-                {"count_reads.cram", "count_reads.cram", "count_reads.fasta", ".cram", "queryname"},
+                {"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".cram", "coordinate"},
+                {"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".bam", "coordinate"}
+                // requires fix in https://github.com/samtools/htsjdk/issues/404
+                //{"count_reads.cram", "count_reads.cram", "count_reads.fasta", ".cram", "queryname"}
         };
     }
 
@@ -34,7 +34,7 @@ public class SortSamIntegrationTest extends CommandLineProgramTest {
     {
         final File inputBam = new File(getTestDataDir(), inputFileName);
         final File expectedBam = new File(getTestDataDir(), expectedOutputFileName);
-        final File outputBam = createTempFile("sort_sam", "outputExtension");
+        final File outputBam = createTempFile("sort_sam", outputExtension);
         File referenceFile = null == referenceFileName ? null : new File(getTestDataDir(), referenceFileName);
         ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input"); args.add(inputBam.getCanonicalPath());

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFileIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFileIntegrationTest.java
@@ -31,7 +31,7 @@ public final class ValidateSamFileIntegrationTest extends CommandLineProgramTest
           {"valid.cram", "VERBOSE", "valid.fasta", true}, // the NM tags in the CRAM file do match the reference (ty samtools)
           {"invalid_coord_sort_order.sam", "SUMMARY", null, false},
           {"invalid_coord_sort_order.sam", "SUMMARY", "invalid_coord_sort_order.fasta", false},
-          //{"invalid_coord_sort_order.cram", "SUMMARY", "invalid_coord_sort_order.fasta", false},  // requires htsjdk fix to SamFileValidator
+          {"invalid_coord_sort_order.cram", "SUMMARY", "invalid_coord_sort_order.fasta", false},
         };
     }
 


### PR DESCRIPTION
This contains a change to toggle the presorted flag used by GatherBAMFiles, and enables some CRAM tests that were previously broken due to htsjdk bugs. Fixes https://github.com/broadinstitute/gatk/issues/1138 and all but one from https://github.com/broadinstitute/gatk/issues/1141.