### PR TITLE
Renames Exon to Target

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollection.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * Exon collection supported by a list of intervals sorted by location and with quick
+ * Target collection supported by a list of intervals sorted by location and with quick
  * look-up by name using a hash.
  * <p>
  *     Intervals are sorted using {@link IntervalUtils#LEXICOGRAPHICAL_ORDER_COMPARATOR}.
@@ -111,13 +111,13 @@ public class HashedListTargetCollection<T extends Locatable> implements TargetCo
     }
 
     @Override
-    public String name(final T exon) {
-        Utils.nonNull(exon,"null target not allowed");
-        final String contig = exon.getContig();
+    public String name(final T target) {
+        Utils.nonNull(target,"null target not allowed");
+        final String contig = target.getContig();
         if (contig == null) {
             return null;
         } else {
-            return String.format("%s:%d-%d", contig, exon.getStart(), exon.getEnd());
+            return String.format("%s:%d-%d", contig, target.getStart(), target.getEnd());
         }
     }
 
@@ -145,11 +145,11 @@ public class HashedListTargetCollection<T extends Locatable> implements TargetCo
 
     @Override
     public int index(final String name) {
-        final T exon = intervalsByName.get(name);
-        if (exon == null) {
+        final T target = intervalsByName.get(name);
+        if (target == null) {
             return -1;
         } else {
-            final int searchIndex = uncachedBinarySearch(location(exon));
+            final int searchIndex = uncachedBinarySearch(location(target));
             if (searchIndex < 0) { // checking just in case.
                 throw new IllegalStateException("could not found named interval amongst sorted intervals, impossible");
             }
@@ -171,8 +171,8 @@ public class HashedListTargetCollection<T extends Locatable> implements TargetCo
     }
 
     @Override
-    public SimpleInterval location(final T exon) {
-        return new SimpleInterval(Utils.nonNull(exon, "the target cannot be null"));
+    public SimpleInterval location(final T target) {
+        return new SimpleInterval(Utils.nonNull(target, "the target cannot be null"));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetCollection.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 /**
- * target collection.
+ * Target collection.
  * <p>
  *      This interface includes operations to query targets based on genomic coordinates and their names (if provided).
  * </p>
@@ -26,7 +26,7 @@ import java.util.stream.IntStream;
 public interface TargetCollection<E> {
 
     /**
-     * Returns the number of targets in this Exome.
+     * Returns the number of targets in this collection.
      *
      * @return 0 or greater.
      */
@@ -182,11 +182,11 @@ public interface TargetCollection<E> {
     }
 
     /**
-     * Returns the size of the exome in base-pairs (computed as the sum of all its targets sizes).
+     * Returns the total size of this collection in base-pairs (computed as the sum of all its targets sizes).
      *
      * @return 0 or greater.
      */
-    default long exomeSize() {
+    default long totalSize() {
         return IntStream.range(0, targetCount())
                 .map(i -> location(i).size()).sum();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUtils.java
@@ -12,16 +12,16 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * Utility class used to create {@link TargetCollections} from common target data sources.
+ * Utility class used to create {@link TargetCollection} from common target data sources.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class TargetCollections {
+public final class TargetCollectionUtils {
 
     /**
      * Disabled instantiation of this helper class.
      */
-    private TargetCollections() {
+    private TargetCollectionUtils() {
 
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/TargetsToolsTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/TargetsToolsTestUtils.java
@@ -9,13 +9,13 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import java.io.File;
 
 /**
- * Some common elements for exome analysis tool unit and integration tests.
+ * Some common elements for target collection analysis tool unit and integration tests.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class ExomeToolsTestUtils {
+public final class TargetsToolsTestUtils {
 
-    private ExomeToolsTestUtils(){} //don't instantiate this
+    private TargetsToolsTestUtils(){} //don't instantiate this
 
     /**
      * Returns a {@link File} pointing to the directory that contains the test data.
@@ -26,7 +26,7 @@ public final class ExomeToolsTestUtils {
     }
 
     /**
-     * {@link File} pointing to the test toy reference used in exome analysis tool tests.
+     * {@link File} pointing to the test toy reference used in targets analysis tool tests.
      */
     public static final File REFERENCE_FILE = new File(getTestDataDir(),"test_reference.fasta");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverageIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverageIntegrationTest.java
@@ -4,7 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.ExomeToolsTestUtils;
+import org.broadinstitute.hellbender.utils.test.TargetsToolsTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -15,14 +15,14 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Integration tests for {@link ExomeReadCounts}.
+ * Integration tests for {@link CalculateTargetCoverage}.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest {
+public final class CalculateTargetCoverageIntegrationTest extends CommandLineProgramTest {
 
     private static File testFile(final String fileName) {
-        return new File(ExomeToolsTestUtils.getTestDataDir(),fileName);
+        return new File(TargetsToolsTestUtils.getTestDataDir(),fileName);
     }
 
     //////////////////////
@@ -132,7 +132,7 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
 
     @Override
     public String getTestedClassName() {
-        return ExomeReadCounts.class.getSimpleName();
+        return CalculateTargetCoverage.class.getSimpleName();
     }
 
     /**
@@ -152,8 +152,8 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
                         COHORT_COUNT_EXPECTED_OUTPUT,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
                         new String[0]
                 },
                 {       ALL_BAMS,
@@ -161,26 +161,26 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
                         SAMPLE_COUNT_EXPECTED_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_ROW_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.SAMPLE.name()}
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.SAMPLE.name()}
                 },
                 {       ALL_BAMS,
                         INTERVALS_LIST,
                         READ_GROUP_COUNT_EXPECTED_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_ROW_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.READ_GROUP.name()}
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.READ_GROUP.name()}
                 },
                 {       ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_PCOV_OUTPUT,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.PCOV,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
+                        CalculateTargetCoverage.Transform.PCOV,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
                         new String[0]
                 },
                 {       ALL_BAMS,
@@ -188,27 +188,27 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
                         SAMPLE_COUNT_EXPECTED_PCOV_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_ROW_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.PCOV,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.SAMPLE.name()}
+                        CalculateTargetCoverage.Transform.PCOV,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.SAMPLE.name()}
                 },
                 {       ALL_BAMS,
                         INTERVALS_LIST,
                         READ_GROUP_COUNT_EXPECTED_PCOV_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_ROW_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.PCOV,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.READ_GROUP.name()}
+                        CalculateTargetCoverage.Transform.PCOV,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.READ_GROUP.name()}
                 },
                 {       ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()},
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()},
                 },
 
                 {       ALL_BAMS,
@@ -216,83 +216,83 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
                         SAMPLE_COUNT_EXPECTED_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_ROW_OUTPUT,
                         SAMPLE_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.SAMPLE.name(),
-                                "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()}
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.SAMPLE.name(),
+                                "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()}
                 },
                 {       ALL_BAMS,
                         INTERVALS_LIST,
                         READ_GROUP_COUNT_EXPECTED_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_ROW_OUTPUT,
                         READ_GROUP_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.COORDS,
-                        new String[] { "-" + ExomeReadCounts.GROUP_BY_SHORT_NAME,ExomeReadCounts.GroupBy.READ_GROUP.name(),
-                                "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()}
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.COORDS,
+                        new String[] { "-" + CalculateTargetCoverage.GROUP_BY_SHORT_NAME, CalculateTargetCoverage.GroupBy.READ_GROUP.name(),
+                                "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME,INTERVALS_BED.getAbsolutePath()}
                 },{     ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_NAMES,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_NAMES,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.FULL,
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.FULL,
                         new String[0]
                 },{     ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_NAMES_ONLY,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_NAMES_ONLY,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.NAME,
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.NAME,
                         new String[0]
                 },{     ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_NAMES,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_NAMES,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.FULL,
-                        new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.FULL,
+                        new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
                 },{     ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_NAMES_ONLY,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_NAMES_ONLY,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.NAME,
-                        new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.NAME,
+                        new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
                 },{     ALL_BAMS,
                         INTERVALS_LIST,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_MISSING_NAMES,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_MISSING_NAMES,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.FULL,
-                        new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED_MISSING_NAMES.getAbsolutePath() }
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.FULL,
+                        new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED_MISSING_NAMES.getAbsolutePath() }
                 },{     DUPREADS_BAM,
                         INTERVALS_LIST_DUPS,
                         COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_NAMES_DUPS,
                         COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_NAMES_DUPS,
                         COHORT_COUNT_EXPECTED_COLUMN_OUTPUT_DUPS,
-                        ExomeReadCounts.Transform.RAW,
-                        ExomeReadCounts.ExonOutInfo.FULL,
-                        new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED_DUPS.getAbsolutePath(),
-                                "-" + ExomeReadCounts.KEEP_DUPLICATE_READS_SHORT_NAME},
+                        CalculateTargetCoverage.Transform.RAW,
+                        CalculateTargetCoverage.TargetOutInfo.FULL,
+                        new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED_DUPS.getAbsolutePath(),
+                                "-" + CalculateTargetCoverage.KEEP_DUPLICATE_READS_SHORT_NAME},
                 }
         };
     }
 
     @Test(expectedExceptions = UserException.class)
-    public void testMissingExonNameRun() {
+    public void testMissingTargetNameRun() {
         testCorrectRun(ALL_BAMS,
                 INTERVALS_LIST,
                 COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                ExomeReadCounts.Transform.RAW,
-                ExomeReadCounts.ExonOutInfo.NAME,
-                new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED_MISSING_NAMES.getAbsolutePath() }
+                CalculateTargetCoverage.Transform.RAW,
+                CalculateTargetCoverage.TargetOutInfo.NAME,
+                new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED_MISSING_NAMES.getAbsolutePath() }
         );
     }
 
@@ -303,56 +303,56 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
                 COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                ExomeReadCounts.Transform.RAW,
-                ExomeReadCounts.ExonOutInfo.NAME,
+                CalculateTargetCoverage.Transform.RAW,
+                CalculateTargetCoverage.TargetOutInfo.NAME,
                 new String[0]
         );
     }
 
     @Test
-    public void testExonFileOnly() {
+    public void testTargetFileOnly() {
         testCorrectRun(ALL_BAMS,
                 null,
                 COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_NAMES,
                 COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_NAMES,
                 COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                ExomeReadCounts.Transform.RAW,
-                ExomeReadCounts.ExonOutInfo.FULL,
-                new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
+                CalculateTargetCoverage.Transform.RAW,
+                CalculateTargetCoverage.TargetOutInfo.FULL,
+                new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_BED.getAbsolutePath() }
         );
     }
 
     @Test(expectedExceptions = UserException.BadInput.class)
-    public void testNonBEDExonFile() {
+    public void testNonBEDTargetFile() {
         testCorrectRun(ALL_BAMS,
                 null,
                 COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_NAMES,
                 COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_NAMES,
                 COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                ExomeReadCounts.Transform.RAW,
-                ExomeReadCounts.ExonOutInfo.FULL,
-                new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, NON_BED_FEATURE_FILE.getAbsolutePath() }
+                CalculateTargetCoverage.Transform.RAW,
+                CalculateTargetCoverage.TargetOutInfo.FULL,
+                new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, NON_BED_FEATURE_FILE.getAbsolutePath() }
         );
     }
 
     @Test(expectedExceptions = UserException.class)
-    public void testBadExonFile() {
+    public void testBadTargetFile() {
         testCorrectRun(ALL_BAMS,
                 INTERVALS_LIST,
                 COHORT_COUNT_EXPECTED_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_ROW_OUTPUT_WITH_BED_MISSING_NAMES,
                 COHORT_COUNT_EXPECTED_COLUMN_OUTPUT,
-                ExomeReadCounts.Transform.RAW,
-                ExomeReadCounts.ExonOutInfo.NAME,
-                new String[] { "-" + ExomeReadCounts.EXOME_FILE_SHORT_NAME, INTERVALS_LIST.getAbsolutePath() }
+                CalculateTargetCoverage.Transform.RAW,
+                CalculateTargetCoverage.TargetOutInfo.NAME,
+                new String[] { "-" + CalculateTargetCoverage.TARGET_FILE_SHORT_NAME, INTERVALS_LIST.getAbsolutePath() }
         );
     }
 
 
     @Test(dataProvider = "correctRunData")
     public void testCorrectRun(final File[] bamFiles, final File intervalFile, final File expectedOutputFile, final File expectedRowOutputFile,
-                               final File expectedColumnOutputFile, final ExomeReadCounts.Transform transform,
-                               final ExomeReadCounts.ExonOutInfo exonOutInfo,
+                               final File expectedColumnOutputFile, final CalculateTargetCoverage.Transform transform,
+                               final CalculateTargetCoverage.TargetOutInfo targetOutInfo,
                                final String[] additionalArguments) {
         final File outputFile = createTempFile("cohort-output");
         final File rowOutputFile = createTempFile("cohort-row-output");
@@ -360,10 +360,10 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
 
         final List<String> arguments = new ArrayList<>(Arrays.asList(
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputFile.getAbsolutePath(),
-                "-" + ExomeReadCounts.ROW_SUMMARY_OUTPUT_SHORT_NAME, rowOutputFile.getAbsolutePath(),
-                "-" + ExomeReadCounts.COLUMN_SUMMARY_OUTPUT_SHORT_NAME, columnOutputFile.getAbsolutePath(),
-                "-" + ExomeReadCounts.TRANSFORM_SHORT_NAME, transform.name(),
-                "-" + ExomeReadCounts.EXON_OUT_INFO_SHORT_NAME, exonOutInfo.name()
+                "-" + CalculateTargetCoverage.ROW_SUMMARY_OUTPUT_SHORT_NAME, rowOutputFile.getAbsolutePath(),
+                "-" + CalculateTargetCoverage.COLUMN_SUMMARY_OUTPUT_SHORT_NAME, columnOutputFile.getAbsolutePath(),
+                "-" + CalculateTargetCoverage.TRANSFORM_SHORT_NAME, transform.name(),
+                "-" + CalculateTargetCoverage.TARGET_OUT_INFO_SHORT_NAME, targetOutInfo.name()
         ));
         if (intervalFile != null) {
             arguments.add("-L");
@@ -385,17 +385,17 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
 
         switch (transform) {
             case RAW:
-                checkTableRawConsistency(exonOutInfo, outputFile, rowOutputFile, columnOutputFile);
+                checkTableRawConsistency(targetOutInfo, outputFile, rowOutputFile, columnOutputFile);
                 break;
             case PCOV:
-                checkTablePcovConsistency(exonOutInfo, outputFile, rowOutputFile, columnOutputFile);
+                checkTablePcovConsistency(targetOutInfo, outputFile, rowOutputFile, columnOutputFile);
                 break;
             default:
                 Assert.fail("bug in testing code: unexpected transform " + transform.name());
         }
     }
 
-    private void checkTableRawConsistency(final ExomeReadCounts.ExonOutInfo exonOutInfo, final File outputFile, final File rowOutputFile, final File columnOutputFile) {
+    private void checkTableRawConsistency(final CalculateTargetCoverage.TargetOutInfo targetOutInfo, final File outputFile, final File rowOutputFile, final File columnOutputFile) {
         final Table matrix;
         final Table row;
         final Table column;
@@ -417,47 +417,47 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
             for (int r = 0; r < matrix.rowCount; r++) {
                 // Check coordinates agree:
                 Assert.assertEquals(matrix.getString(r, 0), row.getString(r, 0));
-                if (exonOutInfo != ExomeReadCounts.ExonOutInfo.NAME) {
+                if (targetOutInfo != CalculateTargetCoverage.TargetOutInfo.NAME) {
                     Assert.assertEquals(matrix.getLong(r, 1), row.getLong(r, 1));
                     Assert.assertEquals(matrix.getLong(r, 2), row.getLong(r, 2));
                 }
                 // Check row sum agree:
                 long rowCount = 0;
-                for (int c = exonOutInfo.columnCount(); c < matrix.columnCount; c++)
+                for (int c = targetOutInfo.columnCount(); c < matrix.columnCount; c++)
                     rowCount += matrix.getLong(r, c);
-                Assert.assertEquals(rowCount, row.getLong(r, exonOutInfo.columnCount()));
+                Assert.assertEquals(rowCount, row.getLong(r, targetOutInfo.columnCount()));
                 // Check consistent average per bp and column epsilon of 0.005 assume two decimal precision (~ %.2f).
-                if (exonOutInfo != ExomeReadCounts.ExonOutInfo.NAME) {
+                if (targetOutInfo != CalculateTargetCoverage.TargetOutInfo.NAME) {
                     final long size = matrix.getLong(r, 2) - matrix.getLong(r, 1) + 1;
-                    Assert.assertEquals(rowCount / ((double) size * (matrix.columnCount - exonOutInfo.columnCount())), row.getDouble(r, exonOutInfo.columnCount() + 1), 0.01);
+                    Assert.assertEquals(rowCount / ((double) size * (matrix.columnCount - targetOutInfo.columnCount())), row.getDouble(r, targetOutInfo.columnCount() + 1), 0.01);
                 }
             }
         }
 
         if (column != null) {
-            Assert.assertEquals(matrix.columnCount - exonOutInfo.columnCount(), column.rowCount,
+            Assert.assertEquals(matrix.columnCount - targetOutInfo.columnCount(), column.rowCount,
                     "main output count column count must match column output rows");
 
-            for (int c = exonOutInfo.columnCount(); c < matrix.columnCount; c++) {
-                Assert.assertEquals(matrix.columnNames[c], column.getString(c - exonOutInfo.columnCount(), 0));
+            for (int c = targetOutInfo.columnCount(); c < matrix.columnCount; c++) {
+                Assert.assertEquals(matrix.columnNames[c], column.getString(c - targetOutInfo.columnCount(), 0));
                 long totalSum = 0;
                 for (int r = 0; r < matrix.rowCount; r++) {
                     totalSum += matrix.getLong(r, c);
                 }
-                Assert.assertEquals(column.getLong(c - exonOutInfo.columnCount(), 1), totalSum);
-                if (exonOutInfo != ExomeReadCounts.ExonOutInfo.NAME) {
+                Assert.assertEquals(column.getLong(c - targetOutInfo.columnCount(), 1), totalSum);
+                if (targetOutInfo != CalculateTargetCoverage.TargetOutInfo.NAME) {
                     long totalBp = 0;
                     for (int r = 0; r < matrix.rowCount; r++) {
                         totalBp += matrix.getLong(r, 2) - matrix.getLong(r, 1) + 1;
                     }
-                    Assert.assertEquals(column.getDouble(c - exonOutInfo.columnCount(), 2), totalSum / (double) totalBp, 0.005);
+                    Assert.assertEquals(column.getDouble(c - targetOutInfo.columnCount(), 2), totalSum / (double) totalBp, 0.005);
                 }
             }
         }
 
     }
 
-    private void checkTablePcovConsistency(final ExomeReadCounts.ExonOutInfo exonOutInfo, final File outputFile, final File rowOutputFile, final File columnOutputFile) {
+    private void checkTablePcovConsistency(final CalculateTargetCoverage.TargetOutInfo targetOutInfo, final File outputFile, final File rowOutputFile, final File columnOutputFile) {
         final Table matrix;
         final Table row;
         final Table column;
@@ -478,8 +478,8 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
             return;
         }
 
-        for (int i = exonOutInfo.columnCount(); i < matrix.columnCount; i++) {
-            if (column.getLong(i-exonOutInfo.columnCount(),1) > 0) {
+        for (int i = targetOutInfo.columnCount(); i < matrix.columnCount; i++) {
+            if (column.getLong(i- targetOutInfo.columnCount(),1) > 0) {
                 double sumPcov = 0;
                 for (int j = 0; j < matrix.rowCount; j++) {
                     sumPcov += matrix.getDouble(j,i);
@@ -492,16 +492,16 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
             }
         }
 
-        Assert.assertEquals(matrix.columnCount - exonOutInfo.columnCount(), column.rowCount,
+        Assert.assertEquals(matrix.columnCount - targetOutInfo.columnCount(), column.rowCount,
                 "main output count column count must match column output rows");
 
-        for (int c = exonOutInfo.columnCount(); c < matrix.columnCount; c++) {
-            Assert.assertEquals(matrix.columnNames[c], column.getString(c - exonOutInfo.columnCount(), 0));
+        for (int c = targetOutInfo.columnCount(); c < matrix.columnCount; c++) {
+            Assert.assertEquals(matrix.columnNames[c], column.getString(c - targetOutInfo.columnCount(), 0));
             long totalBp = 0;
             for (int r = 0; r < matrix.rowCount; r++) {
                 totalBp += matrix.getLong(r, 2) - matrix.getLong(r, 1) + 1;
             }
-            Assert.assertEquals(column.getDouble(c - exonOutInfo.columnCount(), 2), column.getLong(c - exonOutInfo.columnCount(), 1) / (double) totalBp, 0.005);
+            Assert.assertEquals(column.getDouble(c - targetOutInfo.columnCount(), 2), column.getLong(c - targetOutInfo.columnCount(), 1) / (double) totalBp, 0.005);
         }
 
         if (row != null) {
@@ -511,20 +511,20 @@ public final class ExomeReadCountIntegrationTest extends CommandLineProgramTest 
             for (int r = 0; r < matrix.rowCount; r++) {
                 // Check coordinates agree:
                 Assert.assertEquals(matrix.getString(r, 0), row.getString(r, 0));
-                if (exonOutInfo != ExomeReadCounts.ExonOutInfo.NAME) {
+                if (targetOutInfo != CalculateTargetCoverage.TargetOutInfo.NAME) {
                     Assert.assertEquals(matrix.getLong(r, 1), row.getLong(r, 1));
                     Assert.assertEquals(matrix.getLong(r, 2), row.getLong(r, 2));
                 }
                 // Check row sum agree:
                 long rowCount = 0;
-                for (int c = exonOutInfo.columnCount(); c < matrix.columnCount; c++) {
-                    rowCount += Math.round(matrix.getDouble(r, c) * column.getLong(c - exonOutInfo.columnCount(), 1));
+                for (int c = targetOutInfo.columnCount(); c < matrix.columnCount; c++) {
+                    rowCount += Math.round(matrix.getDouble(r, c) * column.getLong(c - targetOutInfo.columnCount(), 1));
                 }
-                Assert.assertEquals(rowCount, row.getLong(r, exonOutInfo.columnCount()));
+                Assert.assertEquals(rowCount, row.getLong(r, targetOutInfo.columnCount()));
                 // Check consistent average per bp and column epsilon of 0.005 assume two decimal precision (~ %.2f).
-                if (exonOutInfo != ExomeReadCounts.ExonOutInfo.NAME) {
+                if (targetOutInfo != CalculateTargetCoverage.TargetOutInfo.NAME) {
                     final long size = matrix.getLong(r, 2) - matrix.getLong(r, 1) + 1;
-                    Assert.assertEquals(rowCount / ((double) size * (matrix.columnCount - exonOutInfo.columnCount())), row.getDouble(r, exonOutInfo.columnCount() + 1), 0.01);
+                    Assert.assertEquals(rowCount / ((double) size * (matrix.columnCount - targetOutInfo.columnCount())), row.getDouble(r, targetOutInfo.columnCount() + 1), 0.01);
                 }
             }
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollectionUnitTest.java
@@ -5,7 +5,7 @@ import org.broadinstitute.hellbender.utils.IndexRange;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.ExomeToolsTestUtils;
+import org.broadinstitute.hellbender.utils.test.TargetsToolsTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -24,32 +24,32 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
     /**
      * Average target size for randomly generated test data.
      */
-    private static final int averageExonSize = 100;
+    private static final int averageTargetSize = 100;
 
     /**
      * Std. dev. for target size for randomly generated test data.
      */
-    private static final float sdExonSize = 20;
+    private static final float sdTargetSize = 20;
 
     /**
      * Average inter-target gap in bp for randomly generated test data.
      */
-    private static final int averageExonIntergapSize = 100;
+    private static final int averageTargetIntergapSize = 100;
 
     /**
      * Std. dev. for inter-target gap in bp for randomly generated test data.
      */
-    private static final float sdExonIntergapSize = 20;
+    private static final float sdTargetIntergapSize = 20;
 
     /**
      * Minimum inter-target gap size for randomly generated test data.
      */
-    private static final int minimumExonIntergapSize = 20;
+    private static final int minimumTargetIntergapSize = 20;
 
     /**
      * Minimum target size for randomly generated test data.
      */
-    private static final int minimumExonSize = 1;
+    private static final int minimumTargetSize = 1;
 
     /**
      * Reference to the test intervals.
@@ -57,7 +57,7 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
      *     Initialized before all tests in {@link #setUp}.
      * </p>
      */
-    private List<SimpleInterval> nonOverlappingExomeIntervals;
+    private List<SimpleInterval> nonOverlappingTargetIntervals;
 
     /**
      * A HashedListTargetCollection of the test intervals.
@@ -65,56 +65,56 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
      *     Initialized before all tests in {@link #setUp}.
      * </p>
      */
-    private HashedListTargetCollection<SimpleInterval> exonDB;
+    private HashedListTargetCollection<SimpleInterval> targetDB;
 
     @BeforeClass
     public void setUp() {
-        nonOverlappingExomeIntervals = new ArrayList<>(100);
+        nonOverlappingTargetIntervals = new ArrayList<>(100);
         final Random rdn = new Random(13);// some "random" but fixed seed to make sure errors are deterministic.
-        for (int i = 0; i < ExomeToolsTestUtils.REFERENCE_DICTIONARY.size(); i++) {
+        for (int i = 0; i < TargetsToolsTestUtils.REFERENCE_DICTIONARY.size(); i++) {
             int current = 0;
-            final SAMSequenceRecord sequence = ExomeToolsTestUtils.REFERENCE_DICTIONARY.getSequence(i);
+            final SAMSequenceRecord sequence = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(i);
             while (current < sequence.getSequenceLength()) {
-                int start = current + Math.max(minimumExonIntergapSize,
-                        (int) Math.round(rdn.nextGaussian() * sdExonIntergapSize + averageExonIntergapSize));
+                int start = current + Math.max(minimumTargetIntergapSize,
+                        (int) Math.round(rdn.nextGaussian() * sdTargetIntergapSize + averageTargetIntergapSize));
                 if (start >= sequence.getSequenceLength()) {
                     break;
                 }
-                int size = Math.max(minimumExonSize,
-                        (int) Math.round(rdn.nextGaussian() * sdExonSize + averageExonSize));
+                int size = Math.max(minimumTargetSize,
+                        (int) Math.round(rdn.nextGaussian() * sdTargetSize + averageTargetSize));
                 int stop = start + size - 1;
                 if (stop >= sequence.getSequenceLength()) {
                     break;
                 }
-                nonOverlappingExomeIntervals.add(
-                        ExomeToolsTestUtils.createInterval(
+                nonOverlappingTargetIntervals.add(
+                        TargetsToolsTestUtils.createInterval(
                                 sequence.getSequenceName(), start, stop));
                 current = stop + 1;
             }
         }
-        Collections.sort(nonOverlappingExomeIntervals, IntervalUtils.LEXICOGRAPHICAL_ORDER_COMPARATOR);
-        exonDB = new HashedListTargetCollection<>(nonOverlappingExomeIntervals);
+        Collections.sort(nonOverlappingTargetIntervals, IntervalUtils.LEXICOGRAPHICAL_ORDER_COMPARATOR);
+        targetDB = new HashedListTargetCollection<>(nonOverlappingTargetIntervals);
     }
 
     @Test
     public void testCorrectInitialization() {
-        new HashedListTargetCollection<>(nonOverlappingExomeIntervals);
+        new HashedListTargetCollection<>(nonOverlappingTargetIntervals);
     }
 
     @Test
     public void testCorrectInitializationSortingContigsByName() {
-        final List<SimpleInterval> sortedLexicographically = nonOverlappingExomeIntervals.stream()
+        final List<SimpleInterval> sortedLexicographically = nonOverlappingTargetIntervals.stream()
                 .sorted(IntervalUtils.LEXICOGRAPHICAL_ORDER_COMPARATOR).collect(Collectors.toList());
-        final HashedListTargetCollection<SimpleInterval> exonCollection = new HashedListTargetCollection<>(nonOverlappingExomeIntervals);
-        Assert.assertEquals(exonCollection.targetCount(),nonOverlappingExomeIntervals.size());
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            Assert.assertEquals(exonCollection.target(i),sortedLexicographically.get(i));
+        final HashedListTargetCollection<SimpleInterval> targetCollection = new HashedListTargetCollection<>(nonOverlappingTargetIntervals);
+        Assert.assertEquals(targetCollection.targetCount(), nonOverlappingTargetIntervals.size());
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            Assert.assertEquals(targetCollection.target(i),sortedLexicographically.get(i));
         }
     }
 
     @Test
     public void testCorrectInitializationUnsorted() {
-        final List<SimpleInterval> unsortedIntervals = new ArrayList<>(nonOverlappingExomeIntervals);
+        final List<SimpleInterval> unsortedIntervals = new ArrayList<>(nonOverlappingTargetIntervals);
         final Random rdn = new Random(13313);
         // shuffle forward:
         for (int i = 0; i < unsortedIntervals.size() - 1; i++) {
@@ -142,10 +142,10 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
             }
         }
         Assert.assertTrue(foundOutOfOrder,"the order randomization step is not working");
-        final HashedListTargetCollection<SimpleInterval> exonCollection = new HashedListTargetCollection<>(unsortedIntervals);
-        Assert.assertEquals(exonCollection.targetCount(),nonOverlappingExomeIntervals.size());
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            Assert.assertEquals(exonCollection.target(i),nonOverlappingExomeIntervals.get(i));
+        final HashedListTargetCollection<SimpleInterval> targetCollection = new HashedListTargetCollection<>(unsortedIntervals);
+        Assert.assertEquals(targetCollection.targetCount(), nonOverlappingTargetIntervals.size());
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            Assert.assertEquals(targetCollection.target(i), nonOverlappingTargetIntervals.get(i));
         }
     }
 
@@ -166,128 +166,128 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testIncorrectInitialization2() {
-        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingExomeIntervals);
-        intervals.add(nonOverlappingExomeIntervals.size() >> 1,null);
+        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingTargetIntervals);
+        intervals.add(nonOverlappingTargetIntervals.size() >> 1,null);
         new HashedListTargetCollection<>(intervals);
     }
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testIncorrectInitialization5() {
-        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingExomeIntervals);
+        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingTargetIntervals);
         intervals.add(1,intervals.get(0));
         new HashedListTargetCollection<>(intervals);
     }
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testIncorrectInitialization6() {
-        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingExomeIntervals);
+        final List<SimpleInterval> intervals = new ArrayList<>(nonOverlappingTargetIntervals);
         final SimpleInterval interval = intervals.get(0);
         intervals.add(1, new SimpleInterval(interval));
         new HashedListTargetCollection<>(intervals);
     }
 
     @Test(dependsOnMethods={"testCorrectInitialization"})
-    public void testExonCount() {
-        Assert.assertEquals(exonDB.targetCount(),nonOverlappingExomeIntervals.size());
+    public void testTargetCount() {
+        Assert.assertEquals(targetDB.targetCount(), nonOverlappingTargetIntervals.size());
     }
 
     @Test(dependsOnMethods={"testCorrectInitialization"})
-    public void testExomeSize() {
+    public void testTotalSize() {
         int size = 0;
-        for (final SimpleInterval loc : nonOverlappingExomeIntervals) {
+        for (final SimpleInterval loc : nonOverlappingTargetIntervals) {
             size += loc.size();
         }
-        Assert.assertEquals(exonDB.exomeSize(),size);
+        Assert.assertEquals(targetDB.totalSize(),size);
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"})
-    public void testExons() {
-        final List<SimpleInterval> exons = exonDB.targets();
-        Assert.assertNotNull(exons);
-        Assert.assertEquals(exons.size(),nonOverlappingExomeIntervals.size());
-        for (int i = 0; i < exons.size(); i++) {
-            Assert.assertEquals(exons.get(i), nonOverlappingExomeIntervals.get(i));
+    public void testTargets() {
+        final List<SimpleInterval> targets = targetDB.targets();
+        Assert.assertNotNull(targets);
+        Assert.assertEquals(targets.size(), nonOverlappingTargetIntervals.size());
+        for (int i = 0; i < targets.size(); i++) {
+            Assert.assertEquals(targets.get(i), nonOverlappingTargetIntervals.get(i));
         }
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"})
-    public void testExonsFullRange() {
-        final List<SimpleInterval> exons = exonDB.targets(0, exonDB.targetCount());
-        Assert.assertNotNull(exons);
-        Assert.assertEquals(exons.size(),nonOverlappingExomeIntervals.size());
-        for (int i = 0; i < exons.size(); i++) {
-            Assert.assertEquals(exons.get(i), nonOverlappingExomeIntervals.get(i));
+    public void testTargetsFullRange() {
+        final List<SimpleInterval> targets = targetDB.targets(0, targetDB.targetCount());
+        Assert.assertNotNull(targets);
+        Assert.assertEquals(targets.size(), nonOverlappingTargetIntervals.size());
+        for (int i = 0; i < targets.size(); i++) {
+            Assert.assertEquals(targets.get(i), nonOverlappingTargetIntervals.get(i));
         }
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization","testCorrectRangeObjectInitialization"})
-    public void testExonFullRangeObject() {
-        final IndexRange range = new IndexRange(0,exonDB.targetCount());
-        final List<SimpleInterval> exons = exonDB.targets(range);
-        Assert.assertNotNull(exons);
-        Assert.assertEquals(exons.size(),nonOverlappingExomeIntervals.size());
-        for (int i = 0; i < exons.size(); i++) {
-            Assert.assertEquals(exons.get(i), nonOverlappingExomeIntervals.get(i));
+    public void testTargetFullRangeObject() {
+        final IndexRange range = new IndexRange(0, targetDB.targetCount());
+        final List<SimpleInterval> targets = targetDB.targets(range);
+        Assert.assertNotNull(targets);
+        Assert.assertEquals(targets.size(), nonOverlappingTargetIntervals.size());
+        for (int i = 0; i < targets.size(); i++) {
+            Assert.assertEquals(targets.get(i), nonOverlappingTargetIntervals.get(i));
         }
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"})
     public void testEmptyRange() {
-        final List<SimpleInterval> exons = exonDB.targets(0, 0);
-        Assert.assertNotNull(exons);
-        Assert.assertEquals(exons.size(),0);
+        final List<SimpleInterval> targets = targetDB.targets(0, 0);
+        Assert.assertNotNull(targets);
+        Assert.assertEquals(targets.size(),0);
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization","testCorrectRangeObjectInitialization"})
     public void testEmptyRangeObject() {
         final IndexRange range = new IndexRange(0,0);
-        final List<SimpleInterval> exons = exonDB.targets(range);
-        Assert.assertNotNull(exons);
-        Assert.assertEquals(exons.size(),0);
+        final List<SimpleInterval> targets = targetDB.targets(range);
+        Assert.assertNotNull(targets);
+        Assert.assertEquals(targets.size(),0);
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"},
-          dataProvider = "arbitraryExonRageData")
-    public void testArbitraryExonRange(final int from, final int to) {
-        final List<SimpleInterval> exons = exonDB.targets(from, to);
-        Assert.assertNotNull(exons);
+          dataProvider = "arbitraryTargetRageData")
+    public void testArbitraryTargetRange(final int from, final int to) {
+        final List<SimpleInterval> targets = targetDB.targets(from, to);
+        Assert.assertNotNull(targets);
         final int expectedSize = to - from;
-        Assert.assertEquals(exons.size(), expectedSize);
+        Assert.assertEquals(targets.size(), expectedSize);
         for (int i = from; i < to; i++) {
-            Assert.assertEquals(exons.get(i - from), nonOverlappingExomeIntervals.get(i));
+            Assert.assertEquals(targets.get(i - from), nonOverlappingTargetIntervals.get(i));
         }
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization","testCorrectRangeObjectInitialization"},
-            dataProvider = "arbitraryExonRageData")
-    public void testArbitraryExonRangeObject(final int from, final int to) {
+            dataProvider = "arbitraryTargetRageData")
+    public void testArbitraryTargetRangeObject(final int from, final int to) {
         final IndexRange range = new IndexRange(from,to);
-        final List<SimpleInterval> exons = exonDB.targets(range);
-        Assert.assertNotNull(exons);
+        final List<SimpleInterval> targets = targetDB.targets(range);
+        Assert.assertNotNull(targets);
         final int expectedSize = to - from;
-        Assert.assertEquals(exons.size(), expectedSize);
+        Assert.assertEquals(targets.size(), expectedSize);
         for (int i = from; i < to; i++) {
-            Assert.assertEquals(exons.get(i - from), nonOverlappingExomeIntervals.get(i));
+            Assert.assertEquals(targets.get(i - from), nonOverlappingTargetIntervals.get(i));
         }
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization")
     public void testLocation() {
-        for (final SimpleInterval loc : nonOverlappingExomeIntervals) {
-            Assert.assertEquals(exonDB.location(loc), loc);
+        for (final SimpleInterval loc : nonOverlappingTargetIntervals) {
+            Assert.assertEquals(targetDB.location(loc), loc);
         }
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization",
         expectedExceptions = IllegalArgumentException.class )
     public void testWrongLocation() {
-        exonDB.location(null);
+        targetDB.location(null);
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization")
     public void testLocationFromIndex() {
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            Assert.assertEquals(exonDB.location(i), nonOverlappingExomeIntervals.get(i));
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            Assert.assertEquals(targetDB.location(i), nonOverlappingTargetIntervals.get(i));
         }
     }
 
@@ -295,7 +295,7 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
           expectedExceptions = {IndexOutOfBoundsException.class, IllegalArgumentException.class},
           dataProvider = "invalidRangeData")
     public void testInvalidRange(final int from, final int to) {
-        exonDB.targets(from, to);
+        targetDB.targets(from, to);
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization","testCorrectRangeObjectInitialization"},
@@ -303,14 +303,14 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
             dataProvider = "invalidRangeData")
     public void testInvalidRangeUsingObject(final int from, final int to) {
         final IndexRange range = new IndexRange(from,to);
-        exonDB.targets(range);
+        targetDB.targets(range);
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization",
-          dataProvider = "exonLookUpData")
-    public void testExonByLocation(final SimpleInterval location, final SimpleInterval expected,
-                                   @SuppressWarnings("unused") final int index) {
-        final SimpleInterval actual = exonDB.target(location);
+          dataProvider = "targetLookUpData")
+    public void testTargetByLocation(final SimpleInterval location, final SimpleInterval expected,
+                                     @SuppressWarnings("unused") final int index) {
+        final SimpleInterval actual = targetDB.target(location);
         if (expected == null) {
             Assert.assertNull(actual);
         } else {
@@ -320,87 +320,87 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization",
-              dataProvider = "exonLookUpData")
-    public void testExonIndexByLocation(final SimpleInterval location, @SuppressWarnings("unused")  final SimpleInterval expected,
-                                   final int index) {
-        final int actual = exonDB.index(location);
+              dataProvider = "targetLookUpData")
+    public void testTargetIndexByLocation(final SimpleInterval location, @SuppressWarnings("unused") final SimpleInterval expected,
+                                          final int index) {
+        final int actual = targetDB.index(location);
         Assert.assertEquals(actual, index);
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization",
-              dataProvider = "wrongExonLookUpData",
+              dataProvider = "wrongTargetLookUpData",
             expectedExceptions = {TargetCollection.AmbiguousTargetException.class, IllegalArgumentException.class})
-    public void testWrongExonIndexByLocation(final SimpleInterval location) {
-        exonDB.index(location);
+    public void testWrongTargetIndexByLocation(final SimpleInterval location) {
+        targetDB.index(location);
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization",
-            dataProvider = "wrongExonLookUpData",
+            dataProvider = "wrongTargetLookUpData",
             expectedExceptions = {TargetCollection.AmbiguousTargetException.class, IllegalArgumentException.class})
-    public void testWrongExonByLocation(final SimpleInterval location) {
-        exonDB.target(location);
+    public void testWrongTargetByLocation(final SimpleInterval location) {
+        targetDB.target(location);
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization")
-    public void testExonByName() {
-        for (final SimpleInterval loc : nonOverlappingExomeIntervals) {
-            Assert.assertEquals(exonDB.target(loc.toString()), loc);
+    public void testTargetByName() {
+        for (final SimpleInterval loc : nonOverlappingTargetIntervals) {
+            Assert.assertEquals(targetDB.target(loc.toString()), loc);
         }
-        Assert.assertNull(exonDB.target("no-id"));
+        Assert.assertNull(targetDB.target("no-id"));
     }
 
     @Test(dependsOnMethods = "testCorrectInitialization")
-    public void testExonIndexByName() {
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            Assert.assertEquals(exonDB.index(nonOverlappingExomeIntervals.get(i)),i);
+    public void testTargetIndexByName() {
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            Assert.assertEquals(targetDB.index(nonOverlappingTargetIntervals.get(i)),i);
         }
-        Assert.assertEquals(exonDB.index("no-id"), -1);
+        Assert.assertEquals(targetDB.index("no-id"), -1);
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"},
         dataProvider="indexRangeData")
     public void testIndexRange(final SimpleInterval region, final IndexRange expected) {
-        final IndexRange range = exonDB.indexRange(region);
+        final IndexRange range = targetDB.indexRange(region);
         Assert.assertEquals(range, expected);
-        Assert.assertEquals(exonDB.targetCount(region), range.size());
+        Assert.assertEquals(targetDB.targetCount(region), range.size());
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"},
             dataProvider="indexRangeData")
-    public void testForEachExon(final SimpleInterval region, final IndexRange expected) {
-        final List<SimpleInterval> exons = exonDB.targets(region);
-        final List<Integer> exonIndices = new ArrayList<>(exons.size());
-        final List<SimpleInterval> exonObjects = new ArrayList<>(exons.size());
-        exonDB.forEachTarget(region, (index, exon) -> {
-            exonIndices.add(index);
-            exonObjects.add(exon);
+    public void testForEachTarget(final SimpleInterval region, final IndexRange expected) {
+        final List<SimpleInterval> targets = targetDB.targets(region);
+        final List<Integer> targetIndices = new ArrayList<>(targets.size());
+        final List<SimpleInterval> targetObjects = new ArrayList<>(targets.size());
+        targetDB.forEachTarget(region, (index, target) -> {
+            targetIndices.add(index);
+            targetObjects.add(target);
         });
-        Assert.assertEquals(exonIndices.size(),exons.size());
-        for (int i = 0; i < exons.size(); i++) {
-            Assert.assertEquals(exonIndices.get(i).intValue(),expected.from + i);
-            Assert.assertEquals(exonObjects.get(i),exons.get(i));
+        Assert.assertEquals(targetIndices.size(),targets.size());
+        for (int i = 0; i < targets.size(); i++) {
+            Assert.assertEquals(targetIndices.get(i).intValue(),expected.from + i);
+            Assert.assertEquals(targetObjects.get(i),targets.get(i));
         }
     }
 
     @Test(dependsOnMethods = {"testCorrectInitialization"},
        dataProvider = "indexRangeData")
-    public void testExons(final SimpleInterval region, final IndexRange expected) {
-        final List<SimpleInterval> exons = exonDB.targets(region);
-        final List<SimpleInterval> expectedExons =  nonOverlappingExomeIntervals.subList(expected.from,expected.to);
-        Assert.assertEquals(exons,expectedExons);
+    public void testTargets(final SimpleInterval region, final IndexRange expected) {
+        final List<SimpleInterval> targets = targetDB.targets(region);
+        final List<SimpleInterval> expectedTargets =  nonOverlappingTargetIntervals.subList(expected.from,expected.to);
+        Assert.assertEquals(targets,expectedTargets);
     }
 
-    @Test(dependsOnMethods={"testCorrectInitialization","testExonCount"})
-    public void testExonName() {
-        for (int i = 0; i < exonDB.targetCount(); i++) {
-            final SimpleInterval loc = exonDB.target(i);
-            final String name = exonDB.name(loc);
-            final SimpleInterval observed = exonDB.target(name);
+    @Test(dependsOnMethods={"testCorrectInitialization", "testTargetCount"})
+    public void testTargetName() {
+        for (int i = 0; i < targetDB.targetCount(); i++) {
+            final SimpleInterval loc = targetDB.target(i);
+            final String name = targetDB.name(loc);
+            final SimpleInterval observed = targetDB.target(name);
             Assert.assertEquals(observed,loc);
-            Assert.assertEquals(exonDB.index(name),i);
+            Assert.assertEquals(targetDB.index(name),i);
         }
-        Assert.assertNull(exonDB.target("no-interval"));
-        Assert.assertEquals(exonDB.index("no-interval"),-1);
+        Assert.assertNull(targetDB.target("no-interval"));
+        Assert.assertEquals(targetDB.index("no-interval"),-1);
     }
 
     @DataProvider(name="indexRangeData")
@@ -408,21 +408,21 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
         final List<Object[]> result = new ArrayList<>();
 
         final Random rdn = new Random(131313);
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            result.add(new Object[]{nonOverlappingExomeIntervals.get(i), new IndexRange(i, i + 1)});
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            result.add(new Object[]{nonOverlappingTargetIntervals.get(i), new IndexRange(i, i + 1)});
             result.add(new Object[]{
-                    ExomeToolsTestUtils.createInterval(nonOverlappingExomeIntervals.get(i).getContig(),
-                            nonOverlappingExomeIntervals.get(i).getStart() - 1), new IndexRange(i,i)});
+                    TargetsToolsTestUtils.createInterval(nonOverlappingTargetIntervals.get(i).getContig(),
+                            nonOverlappingTargetIntervals.get(i).getStart() - 1), new IndexRange(i,i)});
             int j;
-            for (j = i + 1; j < nonOverlappingExomeIntervals.size() && rdn.nextBoolean(); j++) {
-                if (!nonOverlappingExomeIntervals.get(j).getContig().equals(nonOverlappingExomeIntervals.get(i).getContig())) {
+            for (j = i + 1; j < nonOverlappingTargetIntervals.size() && rdn.nextBoolean(); j++) {
+                if (!nonOverlappingTargetIntervals.get(j).getContig().equals(nonOverlappingTargetIntervals.get(i).getContig())) {
                     break;
                 }
             }
             result.add(new Object[]{
-                    ExomeToolsTestUtils.createInterval(nonOverlappingExomeIntervals.get(i).getContig(),
-                            nonOverlappingExomeIntervals.get(i).getStart(),
-                            nonOverlappingExomeIntervals.get(j - 1).getEnd()),
+                    TargetsToolsTestUtils.createInterval(nonOverlappingTargetIntervals.get(i).getContig(),
+                            nonOverlappingTargetIntervals.get(i).getStart(),
+                            nonOverlappingTargetIntervals.get(j - 1).getEnd()),
                     new IndexRange(i, j)
             });
         }
@@ -452,28 +452,28 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
         return new Object[][] {
                 { -1 , 0},
                 { 2, 0},
-                { nonOverlappingExomeIntervals.size() + 1, nonOverlappingExomeIntervals.size() }
+                { nonOverlappingTargetIntervals.size() + 1, nonOverlappingTargetIntervals.size() }
         };
     }
 
-    @DataProvider(name="arbitraryExonRageData")
-    public Object[][] arbitraryExonRageData() {
-        final int exonCount = nonOverlappingExomeIntervals.size();
+    @DataProvider(name="arbitraryTargetRageData")
+    public Object[][] arbitraryTargetRageData() {
+        final int targetCount = nonOverlappingTargetIntervals.size();
         final Random rdn = new Random(1313); // feeling very lucky.
         final Object[][] result = new Object[100][];
         // make sure there is at least a one element target range request.
-        result[0] = new Object[] { exonCount - 4, exonCount - 3 };
+        result[0] = new Object[] { targetCount - 4, targetCount - 3 };
         for (int i = 1; i < result.length; i++) {
-            final int from = rdn.nextInt(exonCount);
-            final int to = rdn.nextInt(exonCount - from) + from;
+            final int from = rdn.nextInt(targetCount);
+            final int to = rdn.nextInt(targetCount - from) + from;
             result[i] = new Object[] { from , to};
         }
         return result;
     }
 
     @Test
-    public void testRandomLookupExonByLocation() {
-        final Object[][] lookups = exonLookUpData();
+    public void testRandomLookupTargetByLocation() {
+        final Object[][] lookups = targetLookUpData();
         final Random rdn = new Random(11132331);
         for (int i = 0; i < 1000; i++) {
             final Object[] params = lookups[rdn.nextInt(lookups.length)];
@@ -481,52 +481,52 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
             final SimpleInterval query = (SimpleInterval) params[0];
             @SuppressWarnings("unchecked")
             final SimpleInterval expected = (SimpleInterval) params[1];
-            final SimpleInterval observed = exonDB.target(query);
+            final SimpleInterval observed = targetDB.target(query);
             Assert.assertEquals(observed,expected);
         }
 
     }
 
-    @DataProvider(name="exonLookUpData")
-    public Object[][] exonLookUpData() {
+    @DataProvider(name="targetLookUpData")
+    public Object[][] targetLookUpData() {
         final List<Object[]> result = new ArrayList<>();
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            result.add(new Object[]{nonOverlappingExomeIntervals.get(i), nonOverlappingExomeIntervals.get(i), i});
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            result.add(new Object[]{nonOverlappingTargetIntervals.get(i), nonOverlappingTargetIntervals.get(i), i});
         }
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            final SimpleInterval interval = nonOverlappingExomeIntervals.get(i);
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            final SimpleInterval interval = nonOverlappingTargetIntervals.get(i);
             result.add(new Object[]{new SimpleInterval(interval.getContig(),interval.getStart(),interval.getStart()), interval, i});
         }
-        for (int i = 0; i < nonOverlappingExomeIntervals.size(); i++) {
-            final SimpleInterval interval = nonOverlappingExomeIntervals.get(i);
+        for (int i = 0; i < nonOverlappingTargetIntervals.size(); i++) {
+            final SimpleInterval interval = nonOverlappingTargetIntervals.get(i);
             result.add(new Object[]{new SimpleInterval(interval.getContig(),interval.getEnd(),interval.getEnd()), interval, i});
         }
-        for (int i = 1; i < nonOverlappingExomeIntervals.size(); i++) {
-            final SimpleInterval previous = nonOverlappingExomeIntervals.get(i-1);
-            final SimpleInterval next = nonOverlappingExomeIntervals.get(i);
+        for (int i = 1; i < nonOverlappingTargetIntervals.size(); i++) {
+            final SimpleInterval previous = nonOverlappingTargetIntervals.get(i-1);
+            final SimpleInterval next = nonOverlappingTargetIntervals.get(i);
             final SimpleInterval query = previous.getContig().equals(next.getContig())
-                    ? ExomeToolsTestUtils.createInterval(previous.getContig(), previous.getEnd() + 1, next.getStart() - 1)
-                    : ExomeToolsTestUtils.createInterval(next.getContig(), 1, next.getStart() - 1);
+                    ? TargetsToolsTestUtils.createInterval(previous.getContig(), previous.getEnd() + 1, next.getStart() - 1)
+                    : TargetsToolsTestUtils.createInterval(next.getContig(), 1, next.getStart() - 1);
             result.add(new Object[]{query, null, -i - 1});
         }
         return result.toArray(new Object[result.size()][]);
     }
 
-    @DataProvider(name="wrongExonLookUpData")
-    public Object[][] wrongExonLookUpData() {
+    @DataProvider(name="wrongTargetLookUpData")
+    public Object[][] wrongTargetLookUpData() {
         return new Object[][] {
                 {null},
-                {ExomeToolsTestUtils.createOverEntireContig(nonOverlappingExomeIntervals.get(0).getContig())},
-                {ExomeToolsTestUtils.createInterval(nonOverlappingExomeIntervals.get(0).getContig(),
-                        nonOverlappingExomeIntervals.get(0).getEnd(),
-                        nonOverlappingExomeIntervals.get(1).getStart())}
+                {TargetsToolsTestUtils.createOverEntireContig(nonOverlappingTargetIntervals.get(0).getContig())},
+                {TargetsToolsTestUtils.createInterval(nonOverlappingTargetIntervals.get(0).getContig(),
+                        nonOverlappingTargetIntervals.get(0).getEnd(),
+                        nonOverlappingTargetIntervals.get(1).getStart())}
         };
     }
 
     @DataProvider(name="trimmedIntervalData")
     public Object[][] trimmedIntervalData() {
 
-        final List<SimpleInterval> intervals = nonOverlappingExomeIntervals;    //alias to reduce clutter
+        final List<SimpleInterval> intervals = nonOverlappingTargetIntervals;    //alias to reduce clutter
 
         final String contig = intervals.get(0).getContig();
         //find the last index of the first contig
@@ -537,7 +537,7 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
         j--;
 
         //shift of untrimmed interval ends
-        final int offset = minimumExonIntergapSize/2;
+        final int offset = minimumTargetIntergapSize /2;
 
          // Each data row is {untrimmed interval, epected trimmed interval
         final int firstTargetStart = intervals.get(0).getStart();
@@ -559,6 +559,6 @@ public final class HashedListTargetCollectionUnitTest extends BaseTest {
 
     @Test(dataProvider = "trimmedIntervalData")
     public void testTrimmedInterval(final SimpleInterval untrimmed, final SimpleInterval trimmed) {
-        Assert.assertEquals(exonDB.trimmedInterval(untrimmed), trimmed);
+        Assert.assertEquals(targetDB.trimmedInterval(untrimmed), trimmed);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUnitTest.java
@@ -5,7 +5,7 @@ import org.broadinstitute.hellbender.utils.IndexRange;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.ExomeToolsTestUtils;
+import org.broadinstitute.hellbender.utils.test.TargetsToolsTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -22,49 +22,49 @@ import java.util.*;
 public final class TargetCollectionUnitTest extends BaseTest {
 
     /**
-     * General exon_db_test_data, will contain ExonDB instances as a single arguments.
+     * General target_db_test_data, will contain TargetDB instances as a single arguments.
      *
      *  <p>
      *  Initialized by {@link #setUp} before any tests.
      * </p>
      */
-    private static Object[][] EXON_DB_TEST_DATA;
+    private static Object[][] TARGET_DB_TEST_DATA;
 
     @BeforeClass
     public void setUp() {
         final Random rdn = new Random(11131719);
-        final List<Object[]> exonDBTestData = new ArrayList<>(30);
-        exonDBTestData.add(new Object[] { new TargetCollectionStub(0,rdn) });
-        exonDBTestData.add(new Object[] { new TargetCollectionStub(1,rdn) });
-        exonDBTestData.add(new Object[] { new TargetCollectionStub(33,rdn) });
-        final int maxExonCount = ExomeToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceLength() / 50;
-        final int minExonCount = 2;
-        while (exonDBTestData.size() < 30) {
-            final int exonCount = rdn.nextInt(maxExonCount - minExonCount + 1) + minExonCount;
-            exonDBTestData.add(new Object[] { new TargetCollectionStub(exonCount,rdn)});
+        final List<Object[]> targetDBTestData = new ArrayList<>(30);
+        targetDBTestData.add(new Object[]{new TargetCollectionStub(0, rdn)});
+        targetDBTestData.add(new Object[] { new TargetCollectionStub(1,rdn) });
+        targetDBTestData.add(new Object[] { new TargetCollectionStub(33,rdn) });
+        final int maxTargetCount = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceLength() / 50;
+        final int minTargetCount = 2;
+        while (targetDBTestData.size() < 30) {
+            final int targetCount = rdn.nextInt(maxTargetCount - minTargetCount + 1) + minTargetCount;
+            targetDBTestData.add(new Object[] { new TargetCollectionStub(targetCount,rdn)});
         }
-        EXON_DB_TEST_DATA = exonDBTestData.toArray(new Object[exonDBTestData.size()][]);
+        TARGET_DB_TEST_DATA = targetDBTestData.toArray(new Object[targetDBTestData.size()][]);
     }
 
-    @Test(dataProvider = "exonDBData")
-    public void testExonByName(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData")
+    public void testTargetByName(final TargetCollection<SimpleInterval> targetCollection) {
         Assert.assertNull(targetCollection.target("silly-name"));
         for (int i = 0; i < targetCollection.targetCount(); i++) {
             Assert.assertEquals(targetCollection.target("" + i), targetCollection.target(i));
         }
     }
 
-    @Test(dataProvider = "exonDBData")
-    public void testExonByLocationExactMatch(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData")
+    public void testTargetByLocationExactMatch(final TargetCollection<SimpleInterval> targetCollection) {
         for (int i = 0; i < targetCollection.targetCount(); i++) {
             final SimpleInterval si = targetCollection.target(i);
             Assert.assertEquals(targetCollection.target(si), si);
         }
     }
 
-    @Test(dataProvider = "exonDBData")
-    public void testExonByLocationNonOverlapping(final TargetCollection<SimpleInterval> targetCollection) {
-        final SimpleInterval otherChromosome =  ExomeToolsTestUtils.createOverEntireContig(2);
+    @Test(dataProvider = "targetDBData")
+    public void testTargetByLocationNonOverlapping(final TargetCollection<SimpleInterval> targetCollection) {
+        final SimpleInterval otherChromosome =  TargetsToolsTestUtils.createOverEntireContig(2);
         Assert.assertNull(targetCollection.target(otherChromosome));
         for (int i = 0; i < targetCollection.targetCount() - 1; i++) {
             final int start = targetCollection.target(i).getEnd() + 1;
@@ -72,17 +72,17 @@ public final class TargetCollectionUnitTest extends BaseTest {
             if (end < start) {   // avoid zero-length intra-target intervals (due to artificial data construction).
                 continue;
             }
-            final SimpleInterval loc = ExomeToolsTestUtils.createInterval(targetCollection.target(i).getContig(), start, end);
+            final SimpleInterval loc = TargetsToolsTestUtils.createInterval(targetCollection.target(i).getContig(), start, end);
             Assert.assertNull(targetCollection.target(loc),"query = " + targetCollection.target(i).getContig() + ":" + start + "-" + end);
         }
     }
 
-    @Test(dataProvider = "twoOrMoreExonDBData")
-    public void testExonByLocationAmbiguousOverlapping(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "twoOrMoreTargetDBData")
+    public void testTargetByLocationAmbiguousOverlapping(final TargetCollection<SimpleInterval> targetCollection) {
         for (int i = 0; i < targetCollection.targetCount() - 1; i++) {
             final int start = targetCollection.target(i).getEnd() - 1;
             final int end = targetCollection.target(i + 1).getStart() + 1;
-            final SimpleInterval loc = ExomeToolsTestUtils.createInterval(targetCollection.target(i).getContig(), start, end);
+            final SimpleInterval loc = TargetsToolsTestUtils.createInterval(targetCollection.target(i).getContig(), start, end);
             try {
                 targetCollection.target(loc);
                 Assert.fail("expected exception. Index == " + i);
@@ -97,18 +97,18 @@ public final class TargetCollectionUnitTest extends BaseTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testForEachNullTask() {
         final TargetCollection<SimpleInterval> targetCollection = new TargetCollectionStub(0,new Random(13));
-        targetCollection.forEachTarget(ExomeToolsTestUtils.createOverEntireContig(0), null);
+        targetCollection.forEachTarget(TargetsToolsTestUtils.createOverEntireContig(0), null);
     }
 
-    @Test(dataProvider = "exonDBData")
+    @Test(dataProvider = "targetDBData")
     public void testForEachSingleCallExactMatch(final TargetCollection<SimpleInterval> targetCollection) {
         for (int i = 0; i < targetCollection.targetCount(); i++) {
             final SimpleInterval simpleInterval = targetCollection.target(i);
-            final SimpleInterval loc = ExomeToolsTestUtils.createInterval(simpleInterval.getContig(), simpleInterval.getStart(), simpleInterval.getEnd());
+            final SimpleInterval loc = TargetsToolsTestUtils.createInterval(simpleInterval.getContig(), simpleInterval.getStart(), simpleInterval.getEnd());
             final int expectedIdx = i;
             final int[] totalCalls = new int[] { 0 };
-            targetCollection.forEachTarget(loc, (idx, exon) -> {
-                Assert.assertEquals(exon, simpleInterval);
+            targetCollection.forEachTarget(loc, (idx, target) -> {
+                Assert.assertEquals(target, simpleInterval);
                 Assert.assertEquals(idx, expectedIdx);
                 totalCalls[0]++;
             });
@@ -116,7 +116,7 @@ public final class TargetCollectionUnitTest extends BaseTest {
         }
     }
 
-    @Test(dataProvider = "exonDBData")
+    @Test(dataProvider = "targetDBData")
     public void testForEachExhaustiveRanges(final TargetCollection<SimpleInterval> targetCollection) {
         final int min = 0;
         final int max = targetCollection.targetCount();
@@ -134,7 +134,7 @@ public final class TargetCollectionUnitTest extends BaseTest {
                 if (start > end) {
                     continue;
                 }
-                final SimpleInterval loc = ExomeToolsTestUtils.createInterval(contig, start, end);
+                final SimpleInterval loc = TargetsToolsTestUtils.createInterval(contig, start, end);
                 final List<SimpleInterval> visited = new ArrayList<>(j - i + 1);
                 final int iFinal = i;
                 targetCollection.forEachTarget(loc, (idx, e) -> {
@@ -147,18 +147,18 @@ public final class TargetCollectionUnitTest extends BaseTest {
         }
     }
 
-    @Test(dataProvider = "exonDBData", expectedExceptions = IllegalArgumentException.class)
-    public void testExonsByBadIndexRange(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData", expectedExceptions = IllegalArgumentException.class)
+    public void testTargetsByBadIndexRange(final TargetCollection<SimpleInterval> targetCollection) {
         targetCollection.targets(new IndexRange(targetCollection.targetCount(), targetCollection.targetCount() + 1));
     }
 
-    @Test(dataProvider = "exonDBData", expectedExceptions = IllegalArgumentException.class)
-    public void testExonsByNullIndexRange(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData", expectedExceptions = IllegalArgumentException.class)
+    public void testTargetsByNullIndexRange(final TargetCollection<SimpleInterval> targetCollection) {
         targetCollection.targets((IndexRange) null);
     }
 
 
-    @Test(dataProvider = "exonDBData")
+    @Test(dataProvider = "targetDBData")
     public void testForEachExhaustiveZeroRanges(final TargetCollection<SimpleInterval> targetCollection) {
         final int min = 0;
         final int max = targetCollection.targetCount();
@@ -172,13 +172,13 @@ public final class TargetCollectionUnitTest extends BaseTest {
             if (start < end)
                 continue;
             targetCollection.forEachTarget(
-                    ExomeToolsTestUtils.createInterval(iInterval.getContig(), start, end),
+                    TargetsToolsTestUtils.createInterval(iInterval.getContig(), start, end),
                     (idx, e) -> Assert.fail("no target should be call"));
         }
     }
 
-    @Test(dataProvider = "exonDBData")
-    public void testExonsByLocationExhaustiveZeroRanges(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData")
+    public void testTargetsByLocationExhaustiveZeroRanges(final TargetCollection<SimpleInterval> targetCollection) {
         final int min = 0;
         final int max = targetCollection.targetCount();
         for (int i = min; i < max - 1; i++) {
@@ -190,18 +190,18 @@ public final class TargetCollectionUnitTest extends BaseTest {
             final int end = jInterval.getStart() - 1;
             if (start < end)
                 continue;
-            final List<SimpleInterval> observed = targetCollection.targets(ExomeToolsTestUtils.createInterval(iInterval.getContig(), start, end));
+            final List<SimpleInterval> observed = targetCollection.targets(TargetsToolsTestUtils.createInterval(iInterval.getContig(), start, end));
             Assert.assertEquals(observed.size(), 0);
         }
     }
 
-    @Test(dataProvider = "exonDBData")
-    public void testExonSize(final TargetCollection<SimpleInterval> targetCollection) {
+    @Test(dataProvider = "targetDBData")
+    public void testTargetSize(final TargetCollection<SimpleInterval> targetCollection) {
         long totalSize = 0;
         for (int i = 0; i < targetCollection.targetCount(); i++) {
             totalSize += targetCollection.target(i).size();
         }
-        Assert.assertEquals(targetCollection.exomeSize(), totalSize);
+        Assert.assertEquals(targetCollection.totalSize(), totalSize);
     }
 
     @Test
@@ -249,7 +249,7 @@ public final class TargetCollectionUnitTest extends BaseTest {
      * Stub class to test default implementations of {@link TargetCollection}.
      *
      * <p>
-     *     This class should not implement any method that has a default implementation in {@code ExonDB} as
+     *     This class should not implement any method that has a default implementation in {@link TargetCollection} as
      *     that would interfere with its testing.
      * </p>
      */
@@ -257,22 +257,22 @@ public final class TargetCollectionUnitTest extends BaseTest {
 
         private final List<SimpleInterval> intervals;
 
-        public TargetCollectionStub(final int numberOfExons, final Random rdn) {
-            if (numberOfExons == 0) {
+        public TargetCollectionStub(final int numberOfTargets, final Random rdn) {
+            if (numberOfTargets == 0) {
                 this.intervals = Collections.emptyList();
                 return;
             }
-            List<SimpleInterval> intervals = new ArrayList<>(numberOfExons);
-            final String contig = ExomeToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceName();
-            final int contigLength = ExomeToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceLength();
-            final float avgSlotSize = contigLength / numberOfExons;
+            List<SimpleInterval> intervals = new ArrayList<>(numberOfTargets);
+            final String contig = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceName();
+            final int contigLength = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceLength();
+            final float avgSlotSize = contigLength / numberOfTargets;
 
             int nextBasePos = 0;
-            for (int i = 0; i < numberOfExons; i++) {
+            for (int i = 0; i < numberOfTargets; i++) {
                 final int slotLength = (int) Math.max(1,Math.min(3 * avgSlotSize,(rdn.nextGaussian() * avgSlotSize * .5) + avgSlotSize));
-                final int exonLength = (int) Math.max(1,slotLength * rdn.nextDouble());
-                final int start = Math.max(nextBasePos,1 + nextBasePos + ((slotLength - exonLength) >> 1));
-                final int stop = start + exonLength;
+                final int targetLength = (int) Math.max(1,slotLength * rdn.nextDouble());
+                final int start = Math.max(nextBasePos,1 + nextBasePos + ((slotLength - targetLength) >> 1));
+                final int stop = start + targetLength;
                 intervals.add(new SimpleInterval(contig,start,stop));
                 nextBasePos += slotLength;
                 nextBasePos = Math.max(nextBasePos,stop + 1);
@@ -291,11 +291,11 @@ public final class TargetCollectionUnitTest extends BaseTest {
         }
 
         @Override
-        public String name(final SimpleInterval exon) {
-            if (exon == null) {
+        public String name(final SimpleInterval target) {
+            if (target == null) {
                 throw new IllegalArgumentException("the input target cannot be null");
             }
-            return exon.toString();
+            return target.toString();
         }
 
         @Override
@@ -328,13 +328,13 @@ public final class TargetCollectionUnitTest extends BaseTest {
         }
 
         @Override
-        public SimpleInterval location(final SimpleInterval exon) {
-            return Utils.nonNull(exon, "the input target cannot be null");
+        public SimpleInterval location(final SimpleInterval target) {
+            return Utils.nonNull(target, "the input target cannot be null");
         }
 
         @Override
         public IndexRange indexRange(final Locatable location) {
-            if (!location.getContig().equals(ExomeToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceName()))
+            if (!location.getContig().equals(TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceName()))
                 return new IndexRange(targetCount(), targetCount());
             else {
                 int from = 0;
@@ -359,7 +359,7 @@ public final class TargetCollectionUnitTest extends BaseTest {
     }
 
     @Test
-    public void testExonDBSubOnlyImplementsNonDefaults() throws NoSuchMethodException {
+    public void testTargetDBSubOnlyImplementsNonDefaults() throws NoSuchMethodException {
         final List<Method> overriddenDefaults = new ArrayList<>(10);
         for (final Method method : TargetCollection.class.getMethods()) {
             if (!method.isDefault())
@@ -374,15 +374,15 @@ public final class TargetCollectionUnitTest extends BaseTest {
                 + Utils.join(", ",Arrays.asList(overriddenDefaults.stream().map(Method::getName).toArray())));
     }
 
-    @DataProvider(name="exonDBData")
-    public Object[][] exonDBData() {
-        return EXON_DB_TEST_DATA;
+    @DataProvider(name="targetDBData")
+    public Object[][] targetDBData() {
+        return TARGET_DB_TEST_DATA;
     }
 
-    @DataProvider(name="twoOrMoreExonDBData")
-    public Object[][] twoOrMoreExonDBData() {
-        final List<Object[]> result = new ArrayList<>(EXON_DB_TEST_DATA.length);
-        for (final Object[] params : EXON_DB_TEST_DATA) {
+    @DataProvider(name="twoOrMoreTargetDBData")
+    public Object[][] twoOrMoreTargetDBData() {
+        final List<Object[]> result = new ArrayList<>(TARGET_DB_TEST_DATA.length);
+        for (final Object[] params : TARGET_DB_TEST_DATA) {
             @SuppressWarnings("unchecked")
             final TargetCollection<SimpleInterval> db = (TargetCollection<SimpleInterval>)params[0];
             if (db.targetCount() <= 1)


### PR DESCRIPTION
Renamed:
* ExomeReadCounts -> CalculateTargetCoverage
* Exome -> Targets or TargetCollection (Only in code related to the old ExomeReadCounts class.)
* Exon  -> Target (Only in code related to the old ExomeReadCounts class.)

Addresses issue #1252