### PR TITLE
use standard arg names in SelectVariants (and use constants everywhere)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
@@ -21,7 +21,7 @@ import java.io.File;
 )
 public final class FixMisencodedBaseQualityReads extends ReadWalker {
 
-    @Argument(fullName = "output", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
     public File OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -19,7 +19,7 @@ import java.io.File;
 )
 public final class PrintReads extends ReadWalker {
 
-    @Argument(fullName = "output", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
     public File OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualities.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualities.java
@@ -7,6 +7,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function2;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.TestSparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
@@ -15,7 +16,10 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import scala.Tuple2;
 
-import java.io.*;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.List;
 
 @CommandLineProgramProperties(summary = "Compares two the quality scores of BAMs", oneLineSummary = "Diff qs of the BAMs",
@@ -36,7 +40,7 @@ final public class CompareBaseQualities extends GATKSparkTool  {
     @Argument(doc="print summary", shortName = "ps", fullName = "printSummary", optional = true)
     protected boolean printSummary = true;
 
-    @Argument(doc="summary output file", shortName = "O", fullName = "output", optional = true)
+    @Argument(doc="summary output file", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = true)
     protected String outputFilename = null;
 
     @Argument(doc="throw error on diff", shortName = "cd", fullName = "throwOnDiff", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
@@ -25,7 +25,7 @@ import java.io.File;
 
 public class RevertBaseQualityScores extends ReadWalker {
 
-    @Argument(fullName = "output", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
     public File OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
@@ -22,7 +22,7 @@ import java.io.File;
 )
 public class UnmarkDuplicates extends ReadWalker {
 
-    @Argument(fullName = "output", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
     public File OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -116,8 +116,10 @@ public class SelectVariants extends VariantWalker {
                     doc="Output variants also called in this comparison track", optional=true)
     private FeatureInput<VariantContext> concordanceTrack;
 
-    @Argument(doc="File to which variants should be written")
-    private File outFile = null;
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+              shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+              doc="File to which variants should be written")
+    public File outFile = null;
 
     /**
      * This argument can be specified multiple times in order to provide multiple sample names.

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -15,7 +15,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
 
     private static String baseTestString(String args, String testFile) {
         return " --variant " + testFile
-                    + " -o %s "
+                    + " -O %s "
                     + args;
     }
 
@@ -28,7 +28,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                         + " --variant " + testFile
                         + " -sn NA11918 "
                         + " -sr " // suppress reference file path in output for test differencing
-                        + " -o %s ",
+                        + " -O %s ",
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleSelection.vcf")
         );
 
@@ -44,7 +44,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                         + " --variant " + testFile
                         + " -select 'DP < 7' "
                         + " -sr " // suppress reference file path in output for test differencing
-                        + " -o %s ",
+                        + " -O %s ",
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleExpressionSelection.vcf")
         );
 


### PR DESCRIPTION
fixes #https://github.com/broadinstitute/gatk/issues/1311