### PR TITLE
Add a --shardedOutput argument to MarkDuplicatesSpark, for consistency with BQSRPipelineSpark and ReadsPipelineSpark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -59,7 +59,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
     @Argument(doc = "the known variants", shortName = "knownSites", fullName = "knownSites", optional = false)
     private List<String> knownVariants;
 
-    @Argument(doc = "the join strategy for reference bases", shortName = "joinStrategy", fullName = "joinStrategy", optional = true)
+    @Argument(doc = "the join strategy for reference bases and known variants", shortName = "joinStrategy", fullName = "joinStrategy", optional = true)
     private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
 
     @Argument(doc = "Path to save the final recalibration tables to.",

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -47,6 +47,9 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
     @ArgumentCollection
     protected OpticalDuplicatesArgumentCollection opticalDuplicatesArgumentCollection = new OpticalDuplicatesArgumentCollection();
 
+    @Argument(doc = "If specified, shard the output bam", shortName = "shardedOutput", fullName = "shardedOutput", optional = true)
+    private boolean shardedOutput = false;
+
     @Argument(doc="The output parallelism, sets the number of reducers. Defaults to the number of partitions in the input.",
             shortName = "P", fullName = "parallelism", optional = true)
     protected int parallelism = 0;
@@ -88,7 +91,7 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
         final JavaRDD<GATKRead> finalReads = cleanupTemporaryAttributes(finalReadsForMetrics);
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, finalReads, getHeaderForReads(), parallelism == 1 ? ReadsWriteFormat.SINGLE : ReadsWriteFormat.SHARDED);
+            ReadsSparkSink.writeReads(ctx, output, finalReads, getHeaderForReads(), shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
         } catch (final IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
@@ -44,9 +44,9 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
     @Test(dataProvider = "testMDdata")
     @Override
     public void testMDOrder(final File input, final File expectedOutput) throws Exception {
-        // Override this test case to provide a --parallelism argument, so that we write a single, sorted
+        // Override this test case to provide a --shardedOutput false argument, so that we write a single, sorted
         // bam (since sharded output is not sorted, and this test case is sensitive to order).
-        testMDOrderImpl(input, expectedOutput, "--parallelism 1");
+        testMDOrderImpl(input, expectedOutput, "--shardedOutput false");
     }
 
     @DataProvider(name = "md")


### PR DESCRIPTION
Since writing a single or sharded output bam is orthogonal to the "parallelism" setting, add a
--shardedOutput arg to MarkDuplicatesSpark and use that to decide whether to write a single or
sharded bam instead of using the value of --parallelism.

Resolves #1335