### PR TITLE
Remove an excessively long-running test case in ReadsSparkSink

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -43,8 +42,6 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
                 // is not consistent with the definition of coordinate sorting as defined in
                 // htsjdk.samtools.SAMRecordCoordinateComparator
                 {testDataDir + "tools/BQSR/CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam", "ReadsSparkSinkUnitTest3", ".bam"},
-
-                {NA12878_20_21_WGS_bam , "ReadsSparkSinkUnitTest4", ".bam"}
         };
     }
 


### PR DESCRIPTION
This test case is overkill, since the test just before it in the
DataProvider is sufficient to detect bugs in ReadsSparkSink such
as the one we encountered last week. We also think it is responsible
for the recent intermittent timeouts in travis.

Resolves #1342