### PR TITLE
Suppress writing CRC files for local filesystem.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -26,6 +26,8 @@ public final class SparkContextFactory {
     public static final Map<String, String> MANDATORY_PROPERTIES = ImmutableMap.<String,String>builder()
             .put("spark.serializer", KryoSerializer.class.getCanonicalName())
             .put("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
+            // remap the Hadoop FS implementation for file:// URIs to RawLocalFileSystem to avoid writing CRC files for local files
+            .put("spark.hadoop.fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
             .build();
 
     /**
@@ -44,6 +46,7 @@ public final class SparkContextFactory {
     public static final Map<String, String> DEFAULT_TEST_PROPERTIES = ImmutableMap.<String, String>builder()
             .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
             .put("spark.kryoserializer.buffer.max", "256m")
+            .put("spark.hadoop.fs.file.impl.disable.cache", "true") // so RawLocalFileSystem is not cached between tests
             .build();
 
     private static boolean testContextEnabled;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -107,6 +107,9 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         ReadsSparkSink.writeReads(ctx, outputFile.getAbsolutePath(), rddParallelReads, header, ReadsWriteFormat.SHARDED);
         int shards = outputFile.listFiles((dir, name) -> !name.startsWith(".") && !name.startsWith("_")).length;
         Assert.assertEquals(shards, 2);
+        // check that no local .crc files are created
+        int crcs = outputFile.listFiles((dir, name) -> name.startsWith(".") && name.endsWith(".crc")).length;
+        Assert.assertEquals(crcs, 0);
 
         JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputFile.getAbsolutePath(), null);
         // reads are not globally sorted, so don't test that


### PR DESCRIPTION
@droazen or @davidadamsphd, I think you mentioned you had a problem with CRC files getting out of sync? There's no real need to generate them for local files (they are built-in for HDFS, and don't cause a problem there). This fix should do it.