### PR TITLE
Rename VERBOSITY argument slightly to avoid collision with -V for variant input

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender;
 
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.logging.BunnyLog;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
@@ -40,7 +42,7 @@ public abstract class CommandLineProgramTest extends BaseTest {
     }
 
     /**
-     * Look for VERBOSITY argument; if not found, supply a default value that minimizes the amount of logging output.
+     * Look for --verbosity argument; if not found, supply a default value that minimizes the amount of logging output.
      */
     private List<String> injectDefaultVerbosity(final List<String> args) {
 
@@ -48,11 +50,13 @@ public abstract class CommandLineProgramTest extends BaseTest {
         BunnyLog.setEnabled(false);
 
         for (String arg : args) {
-            if (arg.equalsIgnoreCase("--VERBOSITY")) return args;
+            if (arg.equalsIgnoreCase("--" + StandardArgumentDefinitions.VERBOSITY_NAME) || arg.equalsIgnoreCase("-" + StandardArgumentDefinitions.VERBOSITY_NAME)) {
+                return args;
+            }
         }
         List<String> argsWithVerbosity = new ArrayList<>(args);
-        argsWithVerbosity.add("--VERBOSITY");
-        argsWithVerbosity.add("ERROR");
+        argsWithVerbosity.add("--" + StandardArgumentDefinitions.VERBOSITY_NAME);
+        argsWithVerbosity.add(Log.LogLevel.ERROR.name());
         return argsWithVerbosity;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -47,7 +47,7 @@ public abstract class CommandLineProgram {
             "It is unlikely these will ever need to be accessed by the command line program")
     public SpecialArgumentsCollection specialArgumentsCollection = new SpecialArgumentsCollection();
 
-    @Argument(doc = "Control verbosity of logging.", common=true)
+    @Argument(fullName = StandardArgumentDefinitions.VERBOSITY_NAME, shortName = StandardArgumentDefinitions.VERBOSITY_NAME, doc = "Control verbosity of logging.", common = true, optional = true)
     public Log.LogLevel VERBOSITY = Log.LogLevel.INFO;
 
     @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -13,6 +13,7 @@ public final class StandardArgumentDefinitions {
     public static final String FEATURE_LONG_NAME = "feature";
     public static final String USE_ORIGINAL_QUALITIES_LONG_NAME = "useOriginalQualities";
     public static final String LENIENT_LONG_NAME = "lenient";
+    public static final String VERBOSITY_NAME = "verbosity";
 
     public static final String INPUT_SHORT_NAME = "I";
     public static final String OUTPUT_SHORT_NAME = "O";

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -386,7 +386,7 @@ public final class UtilsUnitTest extends BaseTest {
      * Test setting the global logging level for Picard and Log4j and java.util.logging.
      *
      * Note that there are three very similar, but not identical, logging level enums from different namespaces
-     * being used here. The one used by Picard (and Hellbender VERBOSITY) of type "Log.LogLevel", the parallel
+     * being used here. The one used by Picard (and Hellbender --verbosity) of type "Log.LogLevel", the parallel
      * one used by log4j of type "Level", and the one used by java.utils.logging.
      */
     @Test


### PR DESCRIPTION
This is a temporary and imperfect fix -- the ultimate fix is
https://github.com/broadinstitute/gatk/issues/1347

Resolves #1306