### PR TITLE
add --help as a valid 'command'

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -134,7 +134,7 @@ public class Main {
         if (args.length < 1) {
             printUsage(classes, commandLineName);
         } else {
-            if (args[0].equals("-h")) {
+            if (args[0].equals("-h") || args[0].equals("--help")) {
                 printUsage(classes, commandLineName);
             } else {
                 if (simpleNameToClass.containsKey(args[0])) {


### PR DESCRIPTION
fixes https://github.com/broadinstitute/gatk/issues/1301
it turns out `-h` was fine but `--help` was not so I just made it accept `--help`