### PR TITLE
adding --conf option to SparkCommandLineProgram

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -164,7 +164,7 @@ def cacheJarOnGCS(jar, dryRun):
 
 def runGATK(sparkRunner, dryrun, gatkArgs, sparkArgs):
     if sparkRunner is None or sparkRunner == "LOCAL":
-        cmd = [getGatkWrapperScript()] + gatkArgs
+        cmd = [getGatkWrapperScript()] + gatkArgs + sparkArgs
         runCommand(cmd, dryrun)
     elif sparkRunner == "SPARK":
         cmd = [ getSparkSubmit(),

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -34,4 +34,6 @@ public final class StandardArgumentDefinitions {
     public static final String MINIMUM_LOD_SHORT_NAME = "LOD";
     public static final String SORT_ORDER_SHORT_NAME = "SO";
     public static final String USE_ORIGINAL_QUALITIES_SHORT_NAME = "OQ";
+
+    public static final String SPARK_PROPERTY_NAME = "conf";
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Command line arguments needed for configuring a spark context
+ */
+public final class SparkCommandLineArgumentCollection implements ArgumentCollectionDefinition {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
+    private String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
+
+    @Argument(
+            doc = "spark properties to set on the spark context in the format <property>=<value>",
+            shortName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
+            fullName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
+            optional = true
+    )
+    final List<String> sparkProperties = new ArrayList<>();
+
+    public Map<String,String> getSparkProperties(){
+        final Map<String, String> propertyMap = new LinkedHashMap<>();
+        for( String property: sparkProperties) {
+            final String[] splits = property.split("=");
+            if (splits.length != 2 || splits[0].isEmpty() || splits[1].isEmpty()) {
+                throw new UserException.BadArgumentValue(StandardArgumentDefinitions.SPARK_PROPERTY_NAME, property, "Expected a value of the form spark.property.name=value");
+            } else {
+                propertyMap.put(splits[0], splits[1]);
+            }
+        }
+        return propertyMap;
+    }
+
+    public String getSparkMaster() {
+        return sparkMaster;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -4,6 +4,7 @@ import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.engine.AuthHolder;
 
@@ -18,9 +19,6 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
             shortName = "apiKey", fullName = "apiKey", optional=true)
     protected String apiKey = null;
 
-    @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
-    protected String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
-
     @Argument(
             doc = "Name of the program running",
             shortName = "N",
@@ -29,9 +27,13 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
     )
     public String programName;
 
+    @ArgumentCollection
+    public SparkCommandLineArgumentCollection sparkArgs = new SparkCommandLineArgumentCollection();
+
+
     @Override
     protected Object doWork() {
-        final JavaSparkContext ctx = SparkContextFactory.getSparkContext(getProgramName(), sparkMaster);
+        final JavaSparkContext ctx = SparkContextFactory.getSparkContext(getProgramName(), sparkArgs.getSparkProperties(), sparkArgs.getSparkMaster());
         try{
             runPipeline(ctx);
             return null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -6,6 +6,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.serializer.KryoSerializer;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -18,17 +19,20 @@ public final class SparkContextFactory {
     public static final String DEFAULT_SPARK_MASTER = "local[*]";
     private static final boolean SPARK_DEBUG_ENABLED = Boolean.getBoolean("gatk.spark.debug");
 
-    public static final Map<String, String> TEST_ATTRIBUTES = ImmutableMap.<String, String>builder()
-            .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
-            .put("spark.kryoserializer.buffer.max", "256m")
-            .build();
-
-    public static final Map<String, String> MANDATORY_ATTRIBUTES = ImmutableMap.<String,String>builder()
+    /**
+     * GATK will not run without these properties
+     * They will always be set unless explicitly overridden with {@link org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions#SPARK_PROPERTY_NAME}
+     */
+    public static final Map<String, String> MANDATORY_PROPERTIES = ImmutableMap.<String,String>builder()
             .put("spark.serializer", KryoSerializer.class.getCanonicalName())
             .put("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
             .build();
 
-    public static final Map<String, String> CMDLINE_ATTRIBUTES = ImmutableMap.<String, String>builder()
+    /**
+     * Default properties, GATK may not run if these are set to bad values.
+     * These will be set if there were not already set in the environment.
+     */
+    public static final Map<String, String> DEFAULT_PROPERTIES = ImmutableMap.<String, String>builder()
             .put("spark.kryoserializer.buffer.max", "512m")
             .put("spark.driver.maxResultSize", "0")
             .put("spark.driver.userClassPathFirst", "true")
@@ -37,11 +41,15 @@ public final class SparkContextFactory {
             .put("spark.yarn.executor.memoryOverhead", "600")
             .build();
 
+    public static final Map<String, String> DEFAULT_TEST_PROPERTIES = ImmutableMap.<String, String>builder()
+            .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
+            .put("spark.kryoserializer.buffer.max", "256m")
+            .build();
+
     private static boolean testContextEnabled;
     private static JavaSparkContext testContext;
 
-    private SparkContextFactory() {
-    }
+    private SparkContextFactory() {}
 
     /**
      * Register a shared global {@link JavaSparkContext} for this JVM; this should only be used for testing.
@@ -54,11 +62,12 @@ public final class SparkContextFactory {
      * Get a {@link JavaSparkContext}. If the test context has been set then it will be returned.
      *
      * @param appName the name of the application to run
+     * @param overridingProperties properties to set on the spark context, overriding any existing value for the same property
      * @param master the Spark master URL
      */
-    public static synchronized JavaSparkContext getSparkContext(final String appName, final String master) {
+    public static synchronized JavaSparkContext getSparkContext(final String appName, final Map<String, String> overridingProperties, final String master) {
         if (testContextEnabled) {
-            final JavaSparkContext context = getTestSparkContext();
+            final JavaSparkContext context = getTestSparkContext(overridingProperties);
             if (!master.equals(context.master())) {
                 throw new IllegalArgumentException(String.format("Cannot reuse spark context " +
                                 "with different spark master URL. Existing: %s, requested: %s.",
@@ -66,16 +75,27 @@ public final class SparkContextFactory {
             }
             return context;
         }
-        return createSparkContext(appName, master);
+        return createSparkContext(appName, overridingProperties, master);
+    }
+
+
+
+
+    /**
+     * Get the test {@link JavaSparkContext} if it has been registered, otherwise returns null.
+     */
+    public static synchronized JavaSparkContext getTestSparkContext() {
+        return getTestSparkContext(Collections.emptyMap());
     }
 
     /**
      * Get the test {@link JavaSparkContext} if it has been registered, otherwise returns null.
      *
+     * @param overridingProperties properties to set on the spark context, possibly overriding values already set
      */
-    public static synchronized JavaSparkContext getTestSparkContext() {
+    public static synchronized JavaSparkContext getTestSparkContext(Map<String, String> overridingProperties) {
         if (testContextEnabled && testContext == null) {
-            testContext = createTestSparkContext();
+            testContext = createTestSparkContext(overridingProperties);
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public void run() {
@@ -85,6 +105,8 @@ public final class SparkContextFactory {
         }
         return testContext;
     }
+
+
 
     /**
      * Stop a {@link JavaSparkContext}, unless it is the test context.
@@ -101,23 +123,31 @@ public final class SparkContextFactory {
 
     /**
      * setup a spark context with the given name, master, and settings
+     *
+     * @param appName human readable name
+     * @param master spark master to use
+     * @param suggestedProperties properties to set if no values are set for them already
+     * @param overridingProperties properties to force to the given value ignoring values already set
      */
     @VisibleForTesting
-    static SparkConf setupSparkConf(final String appName, final String master, final Map<String, String> sparkAttributes) {
+    static SparkConf setupSparkConf(final String appName, final String master, final Map<String, String> suggestedProperties, final Map<String,String> overridingProperties) {
         final SparkConf sparkConf = new SparkConf().setAppName(appName).setMaster(master);
 
-        MANDATORY_ATTRIBUTES.forEach(sparkConf::set);
-        sparkAttributes.forEach(sparkConf::setIfMissing);
+        suggestedProperties.forEach(sparkConf::setIfMissing);
+        MANDATORY_PROPERTIES.forEach(sparkConf::set);
+        overridingProperties.forEach(sparkConf::set);
+
         return sparkConf;
     }
     
-    private static JavaSparkContext createSparkContext(final String appName, final String master) {
-        final SparkConf sparkConf = setupSparkConf(appName, master, CMDLINE_ATTRIBUTES);
+    private static JavaSparkContext createSparkContext(final String appName, Map<String,String> overridingProperties, final String master) {
+        final SparkConf sparkConf = setupSparkConf(appName, master, DEFAULT_PROPERTIES, overridingProperties);
+
         return new JavaSparkContext(sparkConf);
     }
 
-    private static JavaSparkContext createTestSparkContext() {
-        final SparkConf sparkConf = setupSparkConf("TestContext", DEFAULT_SPARK_MASTER, TEST_ATTRIBUTES);
+    private static JavaSparkContext createTestSparkContext(Map<String, String> overridingProperties) {
+        final SparkConf sparkConf = setupSparkConf("TestContext", DEFAULT_SPARK_MASTER, DEFAULT_TEST_PROPERTIES, overridingProperties);
         return new JavaSparkContext(sparkConf);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollectionTest.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class SparkCommandLineArgumentCollectionTest {
+
+    private static final String prop1 = "spark.config";
+    private static final String value1 = "something";
+    private static final String prop2 = "spark.someother.value";
+    private static final String value2 = "somethingelse";
+
+
+    @Test
+    public void testGetSparkProperties(){
+        final SparkCommandLineArgumentCollection sparkArgumentCollection = new SparkCommandLineArgumentCollection();
+
+        sparkArgumentCollection.sparkProperties.addAll(Arrays.asList(prop1+ '=' +value1, prop2 + '=' + value2));
+        final Map<String, String> sparkProperties = sparkArgumentCollection.getSparkProperties();
+        Assert.assertEquals(sparkProperties.size(),2);
+        Assert.assertEquals(sparkProperties.get(prop1), value1);
+        Assert.assertEquals(sparkProperties.get(prop2), value2);
+    }
+
+    @DataProvider(name="badSplits")
+    public Object[][] badSplits(){
+        return new Object[][] {
+                {"spark"},
+                {"="},
+                {"spark="},
+                {"=spark"},
+                {"spark=spark=spark"}
+        };
+    }
+
+    @Test(dataProvider = "badSplits", expectedExceptions = UserException.BadArgumentValue.class)
+    public void testBadProperties(String property){
+        final SparkCommandLineArgumentCollection sparkArgumentCollection = new SparkCommandLineArgumentCollection();
+        sparkArgumentCollection.sparkProperties.add(property);
+        sparkArgumentCollection.getSparkProperties();
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactoryUnitTest.java
@@ -1,24 +1,46 @@
 package org.broadinstitute.hellbender.engine.spark;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.spark.SparkConf;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-
 public class SparkContextFactoryUnitTest extends BaseTest {
+
+    private static final String prop1 = "spark.value1";
+    private static final String value1 = "10";
+    private static final String value1_override = "4";
+
+    private static final String prop2 = "spark.value2";
+    private static final String value2 = "something";
+
+    private static final String prop3 = "spark.value3";
+    private static final String value3 = "something";
+
+    private static final ImmutableMap<String, String> OVERRIDE = new ImmutableMap.Builder<String,String>()
+            .put(prop1, value1_override)
+            .put(prop2, value2)
+            .build();
+
+    private static final ImmutableMap<String, String> SUGGESTED = new ImmutableMap.Builder<String,String>()
+            .put(prop1, value1)
+            .put(prop3, value3)
+            .build();
 
     @Test
     public void testSetupSparkConf(){
         final String appName = "appName";
         final String master = "master";
-        final SparkConf sparkConf = SparkContextFactory.setupSparkConf(appName, master, SparkContextFactory.TEST_ATTRIBUTES);
+        final SparkConf sparkConf = SparkContextFactory.setupSparkConf(appName, master, SUGGESTED, OVERRIDE);
         Assert.assertEquals(sparkConf.get("spark.master"), master);
         Assert.assertEquals(sparkConf.get("spark.app.name"), appName);
-        for(Map.Entry<String,String> entry: SparkContextFactory.TEST_ATTRIBUTES.entrySet()){
-            Assert.assertEquals(sparkConf.get(entry.getKey()), entry.getValue());
-        }
+
+        Assert.assertEquals(sparkConf.get(prop1), value1_override);
+        Assert.assertEquals(sparkConf.get(prop2), value2);
+        Assert.assertEquals(sparkConf.get(prop3), value3);
     }
+
+
 
 }


### PR DESCRIPTION
using --conf passes args into the spark configuration

these args will take precendence over spark args specified in any other way

moved --sparkMaster and --conf to their own SparkCommandLineArgumentCollection

passing spark options through to gatk with DIRECT, this will only work with --sparkMaster and --conf.

fixes #1339 