### PR TITLE
removing mutable static cache from BQSR

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/LRUCache.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/LRUCache.java
@@ -9,14 +9,15 @@ import java.util.Map;
 public final class LRUCache<K,V> extends LinkedHashMap<K,V> {
 
     private static final long serialVersionUID = 1L;
-    private final int capacity; // Maximum number of items in the cache.
+    private final int maxCapacity; // Maximum number of items in the cache.
 
-    public LRUCache(int capacity) {
-        super(capacity+1, 1.0f, true); // Pass 'true' for accessOrder.
-        this.capacity = capacity;
+    public LRUCache(int maxCapacity) {
+        super(maxCapacity+1, 1.0f, true); // Pass 'true' for accessOrder.
+        this.maxCapacity = maxCapacity;
     }
 
+    @Override
     protected boolean removeEldestEntry(final Map.Entry<K,V> entry) {
-        return (size() > this.capacity);
+        return size() > this.maxCapacity;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
@@ -21,6 +21,7 @@ import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.Covariate;
+import org.broadinstitute.hellbender.utils.recalibration.covariates.CovariateKeyCache;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.ReadCovariates;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
 
@@ -31,6 +32,7 @@ public final class BaseRecalibrationEngine implements Serializable {
     private static final long serialVersionUID = 1L;
 
     protected static final Logger logger = LogManager.getLogger(BaseRecalibrationEngine.class);
+    private final CovariateKeyCache keyCache;
 
     /**
      * Reference window function for BQSR. For each read, returns an interval representing the span of
@@ -82,6 +84,7 @@ public final class BaseRecalibrationEngine implements Serializable {
             throw new UserException("Number of read groups must be >= 1, but is " + numReadGroups);
         }
         recalTables = new RecalibrationTables(covariates, numReadGroups);
+        keyCache = new CovariateKeyCache();
     }
 
     public void logCovariatesUsed() {
@@ -115,7 +118,7 @@ public final class BaseRecalibrationEngine implements Serializable {
         final byte[] baqArray = nErrors == 0 ? flatBAQArray(read) : calculateBAQArray(read, refDS);
 
         if( baqArray != null ) { // some reads just can't be BAQ'ed
-            final ReadCovariates covariates = RecalUtils.computeCovariates(read, readsHeader, this.covariates, true);
+            final ReadCovariates covariates = RecalUtils.computeCovariates(read, readsHeader, this.covariates, true, keyCache);
             final boolean[] skip = calculateSkipArray(read, knownSites); // skip known sites of variation as well as low quality and non-regular bases
             final double[] snpErrors = calculateFractionalErrorArray(isSNP, baqArray);
             final double[] insertionErrors = calculateFractionalErrorArray(isInsertion, baqArray);

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.io.Resource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.Covariate;
+import org.broadinstitute.hellbender.utils.recalibration.covariates.CovariateKeyCache;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.ReadCovariates;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
 import org.broadinstitute.hellbender.utils.report.GATKReport;
@@ -527,8 +528,8 @@ public final class RecalUtils {
      * @param recordIndelValues   should we compute covariates for indel BQSR?
      * @return a matrix with all the covariates calculated for every base in the read
      */
-    public static ReadCovariates computeCovariates(final GATKRead read, final SAMFileHeader header, final StandardCovariateList covariates, final boolean recordIndelValues) {
-        final ReadCovariates readCovariates = new ReadCovariates(read.getLength(), covariates.size());
+    public static ReadCovariates computeCovariates(final GATKRead read, final SAMFileHeader header, final StandardCovariateList covariates, final boolean recordIndelValues, final CovariateKeyCache keyCache) {
+        final ReadCovariates readCovariates = new ReadCovariates(read.getLength(), covariates.size(), keyCache);
         computeCovariates(read, header, covariates, readCovariates, recordIndelValues);
         return readCovariates;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/CovariateKeyCache.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/CovariateKeyCache.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.hellbender.utils.recalibration.covariates;
+
+import org.broadinstitute.hellbender.utils.LRUCache;
+import org.broadinstitute.hellbender.utils.Utils;
+
+/*
+ * Use an LRU cache to keep cache of keys (int[][][]) arrays for each read length we've seen.
+ * The cache allows us to avoid the expense of recreating these arrays for every read.  The LRU
+ * keeps the total number of cached arrays to less than LRU_CACHE_SIZE.
+ */
+public final class CovariateKeyCache {
+
+    /**
+     * How big should we let the LRU cache grow
+     */
+    private static final int LRU_CACHE_SIZE = 500;
+
+    private final LRUCache<Integer, int[][][]> keysCache = new LRUCache<>(LRU_CACHE_SIZE);
+
+    /**
+     * Get the cached value for the given readlength or null is no value is cached.
+     */
+    public int[][][] get(final int readLength) {
+        return keysCache.get(readLength);
+    }
+
+    /**
+     * Store the given array in the cache.
+     */
+    public void put(final int readLength, final int[][][] keys) {
+        Utils.nonNull(keys);
+        keysCache.put(readLength, keys);
+    }
+
+    /**
+     * Returns the size of this cache.
+     */
+    public int size() {
+        return keysCache.size();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/ReadRecalibrationInfoUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/ReadRecalibrationInfoUnitTest.java
@@ -4,10 +4,10 @@ import htsjdk.samtools.SAMUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.recalibration.covariates.CovariateKeyCache;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.ReadCovariates;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -17,10 +17,6 @@ import java.util.EnumMap;
 import java.util.List;
 
 public final class ReadRecalibrationInfoUnitTest extends BaseTest {
-    @BeforeMethod
-    public void init() {
-        ReadCovariates.clearKeysCache();
-    }
 
     @DataProvider(name = "InfoProvider")
     public Object[][] createCombineTablesProvider() {
@@ -34,9 +30,10 @@ public final class ReadRecalibrationInfoUnitTest extends BaseTest {
 
         return tests.toArray(new Object[][]{});
     }
+
     @Test(dataProvider = "InfoProvider")
     public void testReadInfo(final int readLength, final boolean includeIndelErrors) {
-        final ReadCovariates covariates = new ReadCovariates(readLength, 2);
+        final ReadCovariates covariates = new ReadCovariates(readLength, 2, new CovariateKeyCache());
 
         final byte[] bases = new byte[readLength];
         final byte[] baseQuals = new byte[readLength];

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationReportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationReportUnitTest.java
@@ -7,13 +7,9 @@ import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.collections.NestedIntegerArray;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.recalibration.covariates.Covariate;
-import org.broadinstitute.hellbender.utils.recalibration.covariates.CycleCovariate;
-import org.broadinstitute.hellbender.utils.recalibration.covariates.ReadCovariates;
-import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
+import org.broadinstitute.hellbender.utils.recalibration.covariates.*;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -23,10 +19,6 @@ import java.util.List;
 import java.util.Random;
 
 public final class RecalibrationReportUnitTest extends BaseTest {
-    @BeforeMethod
-    public void init() {
-        ReadCovariates.clearKeysCache();
-    }
 
     private static RecalDatum createRandomRecalDatum(int maxObservations, int maxErrors) {
         final Random random = new Random();
@@ -75,7 +67,7 @@ public final class RecalibrationReportUnitTest extends BaseTest {
 
         final int expectedKeys = expectedNumberOfKeys(length, RAC.INDELS_CONTEXT_SIZE, RAC.MISMATCHES_CONTEXT_SIZE);
         int nKeys = 0;  // keep track of how many keys were produced
-        final ReadCovariates rc = RecalUtils.computeCovariates(read, header, covariateList, true);
+        final ReadCovariates rc = RecalUtils.computeCovariates(read, header, covariateList, true, new CovariateKeyCache());
 
         final RecalibrationTables recalibrationTables = new RecalibrationTables(covariateList);
         final NestedIntegerArray<RecalDatum> rgTable = recalibrationTables.getReadGroupTable();

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
@@ -10,7 +10,6 @@ import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCo
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -29,11 +28,6 @@ public final class ContextCovariateUnitTest extends BaseTest {
         covariate = new ContextCovariate(RAC);
     }
 
-    @BeforeMethod
-    public void initCache() {
-        ReadCovariates.clearKeysCache();
-    }
-
     @Test
     public void testSimpleContexts() {
         final Random rnd = Utils.getRandomGenerator();
@@ -43,7 +37,7 @@ public final class ContextCovariateUnitTest extends BaseTest {
             final GATKRead read = ArtificialReadUtils.createRandomRead(header, 1000);
             read.setIsReverseStrand(rnd.nextBoolean());
             final GATKRead clippedRead = ReadClipper.clipLowQualEnds(read, RAC.LOW_QUAL_TAIL, ClippingRepresentation.WRITE_NS);
-            final ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1);
+            final ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1, new CovariateKeyCache());
             covariate.recordValues(read, header, readCovariates, true);
 
             verifyCovariateArray(readCovariates.getMismatchesKeySet(), RAC.MISMATCHES_CONTEXT_SIZE, clippedRead, covariate, RAC.LOW_QUAL_TAIL);

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/CycleCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/CycleCovariateUnitTest.java
@@ -10,7 +10,6 @@ import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCo
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -30,11 +29,6 @@ public final class CycleCovariateUnitTest extends BaseTest {
         illuminaReadGroup.setPlatform("illumina");
     }
 
-    @BeforeMethod
-    public void initCache() {
-        ReadCovariates.clearKeysCache();
-    }
-
     @Test
     public void testSimpleCycles() {
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeaderWithReadGroup(illuminaReadGroup);
@@ -44,7 +38,7 @@ public final class CycleCovariateUnitTest extends BaseTest {
         read.setIsPaired(true);
         read.setReadGroup(illuminaReadGroup.getReadGroupId());
 
-        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1);
+        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1, new CovariateKeyCache());
         covariate.recordValues(read, header, readCovariates, true);
         verifyCovariateArray(readCovariates.getMismatchesKeySet(), 1, (short) 1);
 
@@ -78,7 +72,7 @@ public final class CycleCovariateUnitTest extends BaseTest {
         read.setIsPaired(true);
         read.setReadGroup(illuminaReadGroup.getReadGroupId());
 
-        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1);
+        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1, new CovariateKeyCache());
         covariate.recordValues(read, header, readCovariates, true);
     }
 
@@ -91,7 +85,7 @@ public final class CycleCovariateUnitTest extends BaseTest {
         read.setIsPaired(true);
         read.setReadGroup(illuminaReadGroup.getReadGroupId());
 
-        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1);
+        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1, new CovariateKeyCache());
         covariate.recordValues(read, header, readCovariates, true);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadCovariatesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadCovariatesUnitTest.java
@@ -10,18 +10,12 @@ import org.broadinstitute.hellbender.utils.recalibration.RecalUtils;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Random;
 
 public final class ReadCovariatesUnitTest extends BaseTest {
-
-    @BeforeMethod
-    public void init() {
-        ReadCovariates.clearKeysCache();
-    }
 
     @Test
     public void testCovariateGeneration() {
@@ -37,6 +31,7 @@ public final class ReadCovariatesUnitTest extends BaseTest {
 
         final int NUM_READS = 100;
         final Random rnd = Utils.getRandomGenerator();
+        final CovariateKeyCache keyCache= new CovariateKeyCache();
 
         for (int idx = 0; idx < NUM_READS; idx++) {
             for (final String readGroupID : readGroups) {
@@ -52,7 +47,7 @@ public final class ReadCovariatesUnitTest extends BaseTest {
                 final byte[] mQuals = read.getBaseQualities();
                 final byte[] iQuals = ReadUtils.getBaseInsertionQualities(read);
                 final byte[] dQuals = ReadUtils.getBaseDeletionQualities(read);
-                ReadCovariates rc = RecalUtils.computeCovariates(read, header, covariates, true);
+                ReadCovariates rc = RecalUtils.computeCovariates(read, header, covariates, true, keyCache);
 
                 // check that the length is correct
                 Assert.assertEquals(rc.getMismatchesKeySet().length, length);

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadGroupCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadGroupCovariateUnitTest.java
@@ -6,7 +6,6 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -14,11 +13,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public final class ReadGroupCovariateUnitTest {
-
-    @BeforeMethod
-    public void initCache() {
-        ReadCovariates.clearKeysCache();
-    }
 
     @Test
     public void testSingleRecord() {
@@ -80,7 +74,7 @@ public final class ReadGroupCovariateUnitTest {
         GATKRead read = ArtificialReadUtils.createRandomRead(header, 10);
         read.setReadGroup(rg.getReadGroupId());
 
-        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1);
+        ReadCovariates readCovariates = new ReadCovariates(read.getLength(), 1, new CovariateKeyCache());
         covariate.recordValues(read, header, readCovariates, true);
         verifyCovariateArray(readCovariates.getMismatchesKeySet(), expected, covariate);
 


### PR DESCRIPTION
part of https://github.com/broadinstitute/gatk/issues/914

we do need some caching because the new array creation would happen on every read. For non-spark, the caching going to be on the walker level (ie no change because we're 1-threaded), for spark we get 1 cache per partition in baseRecalibration phase but then there is 1 per read in applyBQSRSpark). The latter is going to cause problems - see https://github.com/broadinstitute/gatk/issues/1381