### PR TITLE
checking test spec for correctness

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
@@ -1,11 +1,9 @@
 package org.broadinstitute.hellbender.utils.test;
 
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.ValidationStringency;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.tools.picard.sam.SortSam;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
@@ -94,17 +92,20 @@ public final class IntegrationTestSpec {
             tmpFiles.add(fl);
         }
 
-        final String args = String.format(getArgs(), tmpFiles.toArray());
+        final String preFormattedArgs = getArgs();
+        final String formattedArgs = String.format(preFormattedArgs, tmpFiles.toArray());
         System.out.println(StringUtils.repeat('-', 80));
 
         if (expectsException()) {
             // this branch handles the case were we are testing that a walker will fail as expected
-            executeTest(name, test, null, null, tmpFiles, args, getExpectedException());
+            executeTest(name, test, null, null, tmpFiles, formattedArgs, getExpectedException());
         } else {
-            List<String> expectedFileNames = new ArrayList<>();
-            expectedFileNames.addAll(expectedFileNames());
+            final List<String> expectedFileNames = new ArrayList<>(expectedFileNames());
+            if (!expectedFileNames.isEmpty() && preFormattedArgs.equals(formattedArgs)){
+                throw new GATKException("Incorrect test specification - you're expecting " + expectedFileNames.size() + " file(s) the specified arguments do not contain the same number of \"%s\" placeholders");
+            }
 
-            executeTest(name, test, null, expectedFileNames, tmpFiles, args, null);
+            executeTest(name, test, null, expectedFileNames, tmpFiles, formattedArgs, null);
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -4,12 +4,14 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -219,5 +221,17 @@ public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest
 
         runCommandLine(args.getArgsArray());
         SamAssertionUtils.assertSamsEqual(outBam, new File(getTestDataDir(), "expected.print_reads_one_malformed_read.bam"));
+    }
+
+    @Test
+    public void testReadFiltering_asIntegrationTestSpec() throws IOException {
+        final File samWithOneMalformedRead = new File(getTestDataDir(), "print_reads_one_malformed_read.sam");
+
+        final IntegrationTestSpec spec = new IntegrationTestSpec(
+                " --" + StandardArgumentDefinitions.INPUT_LONG_NAME + " " + samWithOneMalformedRead.getCanonicalPath() +
+                " --" + StandardArgumentDefinitions.OUTPUT_LONG_NAME + " " + "%s",
+                Arrays.asList(new File(getTestDataDir(), "expected.print_reads_one_malformed_read.bam").getCanonicalPath())
+        );
+        spec.executeTest("testReadFiltering_asIntegrationTestSpec", this);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpecUnitTest.java
@@ -1,15 +1,19 @@
 package org.broadinstitute.hellbender.utils.test;
 
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.PrintReadsIntegrationTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Testing the test infrastructure
  */
-public final class TestSpecUnitTest extends BaseTest {
+public final class IntegrationTestSpecUnitTest extends BaseTest {
 
     @Test(expectedExceptions = AssertionError.class)
     public void compareTextFiles() throws IOException {
@@ -46,6 +50,21 @@ public final class TestSpecUnitTest extends BaseTest {
     public void compareFilesWithAndWithoutComments_ignoreComments(final String f1, final String f2) throws IOException {
         final String dir = publicTestDir + "org/broadinstitute/hellbender/utils/testing/";
         IntegrationTestSpec.assertEqualTextFiles(new File(dir + f1), new File(dir + f2), "#");
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testSpec_misspecified() throws IOException {
+        final File getTestDataDir = new File("src/test/resources/org/broadinstitute/hellbender/tools/");
+        final File samWithOneMalformedRead = new File(getTestDataDir, "print_reads_one_malformed_read.sam");
+        final File outBam = createTempFile("print_reads_testReadFiltering", ".bam");
+
+        //This test spec is incorrect because has 1 expected file and no placeholders for output files
+        final IntegrationTestSpec spec = new IntegrationTestSpec(
+                " --" + StandardArgumentDefinitions.INPUT_LONG_NAME + " " + samWithOneMalformedRead.getCanonicalPath() +
+                " --" + StandardArgumentDefinitions.OUTPUT_LONG_NAME + " " + outBam.getCanonicalPath(),
+                Arrays.asList(new File(getTestDataDir, "expected.print_reads_one_malformed_read.bam").getCanonicalPath())
+        );
+        spec.executeTest("testReadFiltering_asIntegrationTestSpec", new PrintReadsIntegrationTest());
     }
 
 }


### PR DESCRIPTION
fixes #1164

the problem was that the test spec was incorrect - no placeholders.
 I fixed the spec and added a check for specs in general and added a test to show that the check does work.

for @droazen 