### PR TITLE
Use default input split size while still allowing for high parallelis…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
@@ -8,19 +8,11 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
-
-import java.io.IOException;
 
 @CommandLineProgramProperties(summary = "Print reads from the input BAM", oneLineSummary = "PrintReads on Spark", programGroup = SparkProgramGroup.class)
 public final class PrintReadsSpark extends GATKSparkTool {
-
-    public static final String SHARDED_OUTPUT_LONG_ARG = "shardedOutput";
-    public static final String SHARDED_OUTPUT_SHORT_ARG = "shardedOutput";
 
     private static final long serialVersionUID = 1L;
 
@@ -32,9 +24,6 @@ public final class PrintReadsSpark extends GATKSparkTool {
             optional = false)
     public String output;
 
-    @Argument(doc = "If specified, shard the output bam", shortName = SHARDED_OUTPUT_SHORT_ARG, fullName = SHARDED_OUTPUT_LONG_ARG, optional = true)
-    public boolean shardedOutput = false;
-
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         if (getHeaderForReads().getSortOrder() != SAMFileHeader.SortOrder.coordinate){
@@ -43,11 +32,6 @@ public final class PrintReadsSpark extends GATKSparkTool {
         }
 
         final JavaRDD<GATKRead> reads = getReads();
-
-        try {
-            ReadsSparkSink.writeReads(ctx, output, reads, getHeaderForReads(), shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
-        } catch (final IOException e) {
-            throw new GATKException("unable to write bam: " + e);
-        }
+        writeReads(ctx, output, reads);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -49,10 +49,10 @@ public class MarkDuplicatesSparkUtils {
      *       highest scoring as duplicates.
      *   (b) Determine which duplicates are optical duplicates and increase the overall count.
      */
-    static JavaRDD<GATKRead> transformReads(final SAMFileHeader header, final MarkDuplicatesScoringStrategy scoringStrategy, final OpticalDuplicateFinder finder, final JavaRDD<GATKRead> reads, final int parallelism) {
+    static JavaRDD<GATKRead> transformReads(final SAMFileHeader header, final MarkDuplicatesScoringStrategy scoringStrategy, final OpticalDuplicateFinder finder, final JavaRDD<GATKRead> reads, final int numReducers) {
 
         JavaPairRDD<String, Iterable<GATKRead>> keyedReads =
-                reads.mapToPair(read -> new Tuple2<>(ReadsKey.keyForRead(header, read), read)).groupByKey(parallelism);
+                reads.mapToPair(read -> new Tuple2<>(ReadsKey.keyForRead(header, read), read)).groupByKey(numReducers);
 
         JavaPairRDD<String, Iterable<PairedEnds>> keyedPairs = keyedReads.flatMapToPair(keyedRead -> {
             List<Tuple2<String, PairedEnds>> out = Lists.newArrayList();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
@@ -42,7 +42,7 @@ final public class CompareBaseQualitiesSpark extends GATKSparkTool  {
     protected void runTool(final JavaSparkContext ctx) {
         JavaRDD<GATKRead> firstReads = getReads();
         ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx);
-        JavaRDD<GATKRead> secondReads = readsSource2.getParallelReads(input2, null, getIntervals());
+        JavaRDD<GATKRead> secondReads = readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize);
 
         long firstBamSize = firstReads.count();
         long secondBamSize = secondReads.count();
@@ -64,7 +64,7 @@ final public class CompareBaseQualitiesSpark extends GATKSparkTool  {
             return new Tuple2<>(getReadKey(read), new Quals(read.getBaseQualities()));
         });
 
-        JavaPairRDD<String, Tuple2<Iterable<Quals>, Iterable<Quals>>> cogroup = firstQuals.cogroup(secondQuals);
+        JavaPairRDD<String, Tuple2<Iterable<Quals>, Iterable<Quals>>> cogroup = firstQuals.cogroup(secondQuals, getRecommendedNumReducers());
         CompareMatrix finalMatrix = cogroup.map(v1 -> {
             List<Quals> lFirstQuals = Lists.newArrayList(v1._2()._1());
             List<Quals> lSecondQuals = Lists.newArrayList(v1._2()._2());

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
@@ -55,7 +55,7 @@ public final class CompareDuplicatesSpark extends GATKSparkTool {
         JavaRDD<GATKRead> firstReads = filteredReads(getReads(), readArguments.getReadFilesNames().get(0));
 
         ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx);
-        JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, getIntervals()), input2);
+        JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize), input2);
 
         // Start by verifying that we have same number of reads and duplicates in each BAM.
         long firstBamSize = firstReads.count();
@@ -80,7 +80,7 @@ public final class CompareDuplicatesSpark extends GATKSparkTool {
         // Group the reads of each BAM by MarkDuplicates key, then pair up the the reads for each BAM.
         JavaPairRDD<String, GATKRead> firstKeyed = firstReads.mapToPair(read -> new Tuple2<>(ReadsKey.keyForFragment(bHeader.getValue(), read), read));
         JavaPairRDD<String, GATKRead> secondKeyed = secondReads.mapToPair(read -> new Tuple2<>(ReadsKey.keyForFragment(bHeader.getValue(), read), read));
-        JavaPairRDD<String, Tuple2<Iterable<GATKRead>, Iterable<GATKRead>>> cogroup = firstKeyed.cogroup(secondKeyed);
+        JavaPairRDD<String, Tuple2<Iterable<GATKRead>, Iterable<GATKRead>>> cogroup = firstKeyed.cogroup(secondKeyed, getRecommendedNumReducers());
 
 
         // Produces an RDD of MatchTypes, e.g., EQUAL, DIFFERENT_REPRESENTATIVE_READ, etc. per MarkDuplicates key,

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/testers/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/testers/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -593,7 +593,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
 
     @Test(dataProvider = "testMDdata")
     public void testMDOrder(final File input, final File expectedOutput) throws Exception {
-        // This method is overridden in MarkDuplicatesSparkIntegrationTest to provide a --parallelism argument
+        // This method is overridden in MarkDuplicatesSparkIntegrationTest to provide a --numReducers argument
         testMDOrderImpl(input, expectedOutput, "");
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -97,7 +97,7 @@ public class ReadsSparkSourceUnitTest extends BaseTest {
 
         ReadsSparkSource readSource = new ReadsSparkSource(ctx);
         JavaRDD<GATKRead> allInOnePartition = readSource.getParallelReads(bam, null);
-        JavaRDD<GATKRead> smallPartitions = readSource.getParallelReads(bam, null, ReadsSparkSource.DEFAULT_SPLIT_SIZE / 100);
+        JavaRDD<GATKRead> smallPartitions = readSource.getParallelReads(bam, null,  100 * 1024); // 100 kB
         Assert.assertEquals(allInOnePartition.partitions().size(), 1);
         Assert.assertEquals(smallPartitions.partitions().size(), 2);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortReadFileSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortReadFileSparkIntegrationTest.java
@@ -46,7 +46,7 @@ public final class SortReadFileSparkIntegrationTest extends CommandLineProgramTe
             args.add("--R");
             args.add(referenceFile.getAbsolutePath());
         }
-        args.add("--parallelism"); args.add("1");
+        args.add("--numReducers"); args.add("1");
 
         //https://github.com/broadinstitute/gatk/issues/1260
 //        args.add("--SORT_ORDER");
@@ -65,7 +65,7 @@ public final class SortReadFileSparkIntegrationTest extends CommandLineProgramTe
         ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--"+ StandardArgumentDefinitions.INPUT_LONG_NAME); args.add(unsortedBam.getCanonicalPath());
         args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(outputBam.getCanonicalPath());
-        args.add("--parallelism"); args.add("1");
+        args.add("--numReducers"); args.add("1");
 
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -96,4 +96,25 @@ public final class BucketUtilsTest extends BaseTest {
         }
     }
 
+    @Test
+    public void testDirSize() throws IOException {
+        File dir = createTempDir("dir");
+        File file1 = new File(dir, "file1.txt");
+        File file2 = new File(dir, "file2.txt");
+        File subdir = new File(dir, "sub");
+        subdir.mkdir();
+        File file3 = new File(subdir, "file3.txt");
+
+        for (File file : new File[] { file1, file2, file3 }) {
+            try (FileWriter fw = new FileWriter(file)){
+                fw.write("Hello!");
+            }
+        }
+
+        long fileSize = BucketUtils.fileSize(file1.getAbsolutePath(), null);
+        Assert.assertTrue(fileSize > 0);
+        long dirSize = BucketUtils.dirSize(dir.getAbsolutePath(), null);
+        Assert.assertEquals(dirSize, fileSize * 2);
+    }
+
 }


### PR DESCRIPTION
…m for shuffle jobs.

This is a first attempt at #1403 to get feedback on the approach.

For aggregating tools that don’t have a shuffle (like CountReadsSpark), the existing 10MB per split is an issue since it dramatically slows down processing. Increasing the split size can be done via -bps, but that is not at all obvious and shouldn’t be necessary. The change I’ve made here uses the default split size for Hadoop (which is 128MB on HDFS).

For tools that do have a shuffle, I’ve added a -P argument for all of them, which sets the level of parallelism to use for the shuffle. If not set it defaults to one partition per 10MB of input, which is the existing default. Note that for tools that write an output BAM, the level of parallelism set by -P is used for writing a single BAM (the default, since shardedOutput is false), since the reads are first sorted and written to multiple BAM files before finally being merged.

Question: there’s a lot of duplicated code here. Would it be a good idea to have a ParallelismArgumentCollection and a ShardedOutputParallel collection? Note that some tools need a -P but not -shardedOutput (e.g. CompareDuplicatesSpark).