### PR TITLE
Command line validation stringency argument for GATKTool.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -14,6 +14,7 @@ public final class StandardArgumentDefinitions {
     public static final String USE_ORIGINAL_QUALITIES_LONG_NAME = "useOriginalQualities";
     public static final String LENIENT_LONG_NAME = "lenient";
     public static final String VERBOSITY_NAME = "verbosity";
+    public static final String READ_VALIDATION_STRINGENCY_LONG_NAME = "readValidationStringency";
 
     public static final String INPUT_SHORT_NAME = "I";
     public static final String OUTPUT_SHORT_NAME = "O";
@@ -21,6 +22,7 @@ public final class StandardArgumentDefinitions {
     public static final String VARIANT_SHORT_NAME = "V";
     public static final String FEATURE_SHORT_NAME = "F";
     public static final String LENIENT_SHORT_NAME = "LE";
+    public static final String READ_VALIDATION_STRINGENCY_SHORT_NAME = "VS";
     public static final String SAMPLE_ALIAS_SHORT_NAME = "ALIAS";
     public static final String LIBRARY_NAME_SHORT_NAME = "LIB";
     public static final String EXPECTED_INSERT_SIZE_SHORT_NAME = "INSERT";

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
+import htsjdk.samtools.ValidationStringency;
+import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.io.File;
 import java.util.List;
@@ -12,6 +15,16 @@ import java.util.List;
  */
 public abstract class ReadInputArgumentCollection implements ArgumentCollectionDefinition {
     private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = StandardArgumentDefinitions.READ_VALIDATION_STRINGENCY_LONG_NAME,
+            shortName = StandardArgumentDefinitions.READ_VALIDATION_STRINGENCY_SHORT_NAME,
+            doc = "Validation stringency for all SAM/BAM/CRAM/SRA files read by this program.  The default stringency value SILENT " +
+                    "can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) " +
+                    "do not otherwise need to be decoded.",
+            common=true,
+            optional=true)
+    public ValidationStringency readValidationStringency = ValidationStringency.SILENT;
+
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line
      */
@@ -21,4 +34,10 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
      * Get the list of BAM/SAM/CRAM filenames specified at the command line
      */
     public abstract List<String> getReadFilesNames();
+
+    /**
+     * Get the read validation stringency specified at the command line, or the default value if none was specified
+     * at the command line.
+     */
+    public ValidationStringency getReadValidationStringency() { return readValidationStringency; };
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -66,7 +66,7 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
     private boolean indicesAvailable;
 
     /**
-     * Initialize this data source with a single SAM/BAM file
+     * Initialize this data source with a single SAM/BAM file without a reference and validation stringency SILENT.
      *
      * @param samFile SAM/BAM file, not null.
      */
@@ -75,7 +75,7 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
     }
 
     /**
-     * Initialize this data source with multiple SAM/BAM files
+     * Initialize this data source with multiple SAM/BAM files without a reference and validation stringency SILENT.
      *
      * @param samFiles SAM/BAM files, not null.
      */
@@ -87,7 +87,8 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
      * Initialize this data source with a single SAM/BAM file and a custom SamReaderFactory
      *
      * @param samFile SAM/BAM file, not null.
-     * @param customSamReaderFactory SamReaderFactory to use, if null a default factory with validation stringency SILENT is used.
+     * @param customSamReaderFactory SamReaderFactory to use, if null a default factory with no reference and validation
+     *                               stringency SILENT is used.
      */
     public ReadsDataSource( final File samFile, SamReaderFactory customSamReaderFactory) {
         this(samFile != null ? Arrays.asList(samFile) : null, customSamReaderFactory);
@@ -97,7 +98,8 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
      * Initialize this data source with multiple SAM/BAM files and a custom SamReaderFactory
      *
      * @param samFiles SAM/BAM files, not null.
-     * @param customSamReaderFactory SamReaderFactory to use, if null a default factory with validation stringency SILENT is used.
+     * @param customSamReaderFactory SamReaderFactory to use, if null a default factory with no reference and validation
+     *                               stringency SILENT is used.
      */
     public ReadsDataSource( final List<File> samFiles, SamReaderFactory customSamReaderFactory) {
         if ( samFiles == null || samFiles.size() == 0 ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -88,6 +88,7 @@ public abstract class BaseTest {
      */
 
     public static final String NA12878_chr17_1k_BAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.bam";
+    public static final String NA12878_chr17_1k_CRAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.cram";
     public static final String v37_chr17_1Mb_Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
 
     public static final String hg19_chr1_1M_Reference = publicTestDir + "Homo_sapiens_assembly19_chr1_1M.fasta";

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
@@ -112,7 +112,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
         final String argPre = "-R " + hg18Reference + " --knownSites " + dbSNPb37_chr17 + " -I " + HiSeqBam_chr17 + " -O " + tablePre + " ";
         new BaseRecalibrator().instanceMain(Utils.escapeExpressions(argPre));
 
-        final String argApply = "-I " + HiSeqBam_chr17 + " --bqsr_recal_file " + tablePre+ " -O " + actualHiSeqBam_recalibrated_chr17.getAbsolutePath();
+        final String argApply = "-I " + HiSeqBam_chr17 + " --bqsr_recal_file " + tablePre + " -O " + actualHiSeqBam_recalibrated_chr17.getAbsolutePath();
         new ApplyBQSR().instanceMain(Utils.escapeExpressions(argApply));
 
         final File actualTablePost = createTempFile("gatk4.post.cols", ".table");


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/611. Uses  "validationStringency" as the argument; PicardCommandLineProgram currently uses "VALIDATION_STRINGENCY"; should we align all of these to use the same name?

I've done the same work for ReadSparkSource and GATKSparkTool but it requires a Hadoop-BAM upgrade so its in a separate PR.