### PR TITLE
updates to ReadSparkSink

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ dependencies {
 
     compile 'org.jgrapht:jgrapht-core:0.9.1'
     compile 'org.testng:testng:6.9.6' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
+    compile 'org.apache.hadoop:hadoop-minicluster:2.7.1' //the version of minicluster should match the version of hadoop
+
     compile('org.seqdoop:hadoop-bam:7.3.0') {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
@@ -124,7 +126,6 @@ dependencies {
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.hadoop:hadoop-minicluster:2.7.1' //the version of minicluster should match the version of hadoop
     testCompile "org.mockito:mockito-core:1.10.19"
 }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -32,6 +32,10 @@ public final class BucketUtils {
     public static final String GCS_PREFIX = "gs://";
     public static final String HDFS_PREFIX = "hdfs://";
 
+    // slashes omitted since hdfs paths seem to only have 1 slash which would be weirder to include than no slashes
+    public static final String FILE_PREFIX = "file:";
+
+
     public static final Logger logger = LogManager.getLogger("org.broadinstitute.hellbender.utils.gcs");
 
     private BucketUtils(){} //private so that no one will instantiate this class
@@ -316,5 +320,9 @@ public final class BucketUtils {
         } catch (IOException e) {
             throw new UserException("Failed to determine total input size of " + path + "\n Caused by:" + e.getMessage(), e);
         }
+    }
+
+    public static boolean isFileUrl(String path) {
+        return path.startsWith(FILE_PREFIX);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/MiniClusterUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/MiniClusterUtils.java
@@ -1,0 +1,87 @@
+package org.broadinstitute.hellbender.utils.test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.testng.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Utilities to help manage a {@link MiniDFSCluster} for use in tests.
+ */
+public final class MiniClusterUtils {
+
+    /**
+     * @return a new empty cluster
+     * @throws IOException
+     */
+    public static MiniDFSCluster getMiniCluster() throws IOException {
+        final File baseDir = BaseTest.createTempDir("minicluster_storage");
+        final Configuration conf = new Configuration();
+        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+        return new MiniDFSCluster.Builder(conf).build();
+    }
+
+    /**
+     * @return a unique path in the filesystem on the given cluster
+     * @throws IOException
+     */
+    public static Path getTempPath(MiniDFSCluster cluster, String prefix, String extension) throws IOException {
+        return new Path(cluster.getFileSystem().getWorkingDirectory(), prefix + "_" + UUID.randomUUID() + extension);
+    }
+
+    /**
+     * @return path to the working directory in the given cluster
+     * @throws IOException
+     */
+    public static Path getWorkingDir(MiniDFSCluster cluster) throws IOException {
+        return cluster.getFileSystem().getWorkingDirectory();
+    }
+
+    /**
+     * shut down the cluster
+     */
+    public static void stopCluster(MiniDFSCluster cluster){
+        if(cluster != null){
+            cluster.shutdown(true);
+        }
+    }
+
+    /**
+     * Create a new isolated {@link MiniDFSCluster}, run a {@link MiniClusterTest} on it and then shut it down.
+     * @param test a function to run on the cluster, this should indicate success or failure by usine {@link Assert}
+     * @throws Exception
+     */
+    public static void runOnIsolatedMiniCluster(MiniClusterTest test) throws Exception {
+        MiniDFSCluster cluster = null;
+        try {
+            cluster = getMiniCluster();
+            test.test(cluster);
+        } finally {
+            stopCluster(cluster);
+        }
+    }
+
+    /**
+     * An interface for writing tests that run on a minicluster.
+     * Implementers should write test to make use of the passed in cluster
+     */
+    @FunctionalInterface
+    public interface MiniClusterTest {
+        /**
+         * A test to be run using an hdfs MiniCluster
+         * It's alright for this to make destructive changes to the cluster since it is given it's own isolated setup.
+         *
+         * Test failure is indicated use standard {@link Assert} methods
+         *
+         * @param cluster an isolated MiniDFSCluster instance
+         * @throws Exception in order to allow any checked exception to be thrown
+         */
+        void test(MiniDFSCluster cluster) throws Exception;
+    }
+
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
@@ -2,10 +2,10 @@ package org.broadinstitute.hellbender.metrics;
 
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -21,15 +21,13 @@ public class MetricsUtilsTest extends BaseTest {
 
     @BeforeClass(alwaysRun = true)
     private void setupMiniCluster() throws IOException {
-        cluster = new MiniDFSCluster.Builder(new Configuration()).build();
-        hdfsWorkingDir = cluster.getFileSystem().getWorkingDirectory().toString();
+        cluster = MiniClusterUtils.getMiniCluster();
+        hdfsWorkingDir = MiniClusterUtils.getWorkingDir(cluster).toString();
     }
 
     @AfterClass(alwaysRun = true)
     private void shutdownMiniCluster() {
-        if (cluster != null) {
-            cluster.shutdown();
-        }
+       MiniClusterUtils.stopCluster(cluster);
     }
 
     @DataProvider(name = "metricsPaths")


### PR DESCRIPTION
- fixup for problem with fully specified `file:///` names that I introduced in #1450 
   - adding test for fully specified `file:///` url
- adding additional tests to `ReadSparkSink` for HDFS
  - tests for writing to HDFS using `MiniDFSCluster`
  - tests for overwriting existing HDFS paths
- fixed instance of Wrong FileSystem exception in `ReadSparkSink`
- refactored `ReadSparkSink` to remove duplication
- adding `MiniClusterUtils`
    - revising existing code using `MiniDFSCluster` to go through `MiniClusterUtils`
    - had to make the minicluster dependency a compile time instead of test dependency so downstream projects can make use of MiniClusterUtils.  