### PR TITLE
Hadoop-BAM and htsjdk upgrades, Spark tool changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ compileTestJava {
 
 dependencies {
     compile 'com.google.guava:guava:18.0'
-    compile 'com.github.samtools:htsjdk:2.0.1'
+    compile 'com.github.samtools:htsjdk:2.1.0'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
@@ -105,7 +105,7 @@ dependencies {
     compile 'org.testng:testng:6.9.6' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
     compile 'org.apache.hadoop:hadoop-minicluster:2.7.1' //the version of minicluster should match the version of hadoop
 
-    compile('org.seqdoop:hadoop-bam:7.3.0') {
+    compile('org.seqdoop:hadoop-bam:7.4.0') {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
 import java.io.File;
 import java.util.List;
@@ -23,7 +24,7 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
                     "do not otherwise need to be decoded.",
             common=true,
             optional=true)
-    public ValidationStringency readValidationStringency = ValidationStringency.SILENT;
+    public ValidationStringency readValidationStringency = ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;
 
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -103,9 +103,8 @@ public abstract class GATKTool extends CommandLineProgram {
      * May be overridden by traversals that require custom initialization of the reads data source.
      */
     void initializeReads() {
-        SamReaderFactory factory = null;
         if (! readArguments.getReadFiles().isEmpty()) {
-            factory = SamReaderFactory.makeDefault().validationStringency(readArguments.getReadValidationStringency());
+            SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(readArguments.getReadValidationStringency());
             if (hasReference()) { // pass in reference if available, because CRAM files need it
                 factory = factory.referenceSequence(referenceArguments.getReferenceFile());
             }

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.iterators.SAMRecordToReadIterator;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
 import java.io.File;
 import java.io.IOException;
@@ -112,7 +113,7 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
 
         final SamReaderFactory samReaderFactory =
                 customSamReaderFactory == null ?
-                    SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT) :
+                    SamReaderFactory.makeDefault().validationStringency(ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY) :
                     customSamReaderFactory;
 
         for ( final File samFile : samFiles ) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -10,6 +10,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.parquet.avro.AvroParquetInputFormat;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -24,12 +26,14 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.BDGAlignmentRecordToGATKReadAdapter;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadConstants;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.seqdoop.hadoop_bam.AnySAMInputFormat;
 import org.seqdoop.hadoop_bam.CRAMInputFormat;
 import org.seqdoop.hadoop_bam.SAMRecordWritable;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
@@ -42,8 +46,16 @@ public final class ReadsSparkSource implements Serializable {
     private static final String HADOOP_PART_PREFIX = "part-";
 
     private transient final JavaSparkContext ctx;
-    public ReadsSparkSource(JavaSparkContext ctx) {
+    private ValidationStringency validationStringency = ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;
+
+    private static final Logger logger = LogManager.getLogger(ReadsSparkSource.class);
+
+    public ReadsSparkSource(final JavaSparkContext ctx) { this.ctx = ctx; }
+
+    public ReadsSparkSource(final JavaSparkContext ctx, final ValidationStringency validationStringency)
+    {
         this.ctx = ctx;
+        this.validationStringency = validationStringency;
     }
 
 
@@ -69,40 +81,25 @@ public final class ReadsSparkSource implements Serializable {
      *                  use the default split size (determined by the Hadoop input format, typically the size of one HDFS block).
      * @return RDD of (SAMRecord-backed) GATKReads from the file.
      */
-    public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, final List<SimpleInterval> intervals, long splitSize) {
-        final Configuration conf = new Configuration();
+    public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, final List<SimpleInterval> intervals, final long splitSize) {
+        // use the Hadoop configuration attached to the Spark context to maintain cumulative settings
+        final Configuration conf = ctx.hadoopConfiguration();
         if (splitSize > 0) {
             conf.set("mapreduce.input.fileinputformat.split.maxsize", Long.toString(splitSize));
         }
 
         final JavaPairRDD<LongWritable, SAMRecordWritable> rdd2;
 
-        //Note: in Hadoop-bam AnySAMInputFormat does not support CRAM https://github.com/HadoopGenomics/Hadoop-BAM/issues/35
-        //The workaround is to use CRAMInputFormat
-        if (IOUtils.isCramFileName(readFileName)) {
-            if (referencePath == null){
-                throw new UserException.MissingReference("A reference file is required when using CRAM files.");
-            }
-            //Note: cram input requires a reference and reference is passed by this property.
-            conf.set(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY, referencePath);
+        setHadoopBAMConfigurationProperties(readFileName, referencePath);
 
-            rdd2 = ctx.newAPIHadoopFile(
-                    readFileName, CRAMInputFormat.class, LongWritable.class, SAMRecordWritable.class,
-                    conf);
-        } else {
-            rdd2 = ctx.newAPIHadoopFile(
+        rdd2 = ctx.newAPIHadoopFile(
                     readFileName, AnySAMInputFormat.class, LongWritable.class, SAMRecordWritable.class,
                     conf);
-        }
 
         return rdd2.map(v1 -> {
             SAMRecord sam = v1._2().get();
             if (samRecordOverlaps(sam, intervals)) {
-                try {
-                    return (GATKRead)SAMRecordToGATKReadAdapter.headerlessReadAdapter(sam);
-                } catch (SAMException e) {
-                    // TODO: add stringency
-                }            
+                return (GATKRead)SAMRecordToGATKReadAdapter.headerlessReadAdapter(sam);
             }
             return null;
 
@@ -130,7 +127,7 @@ public final class ReadsSparkSource implements Serializable {
      * @return RDD of (SAMRecord-backed) GATKReads from the file.
      */
     public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, int splitSize) {
-        final SAMFileHeader readsHeader = getHeader(ctx, readFileName, null);
+        final SAMFileHeader readsHeader = getHeader(readFileName, referencePath, null);
         List<SimpleInterval> intervals = IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
         return getParallelReads(readFileName, referencePath, intervals, splitSize);
     }
@@ -161,15 +158,16 @@ public final class ReadsSparkSource implements Serializable {
     /**
      * Loads the header using Hadoop-BAM.
      * @param filePath path to the bam.
+     * @param referencePath Reference path or null if not available. Reference is required for CRAM files.
      * @param auth authentication information if using GCS.
      * @return the header for the bam.
      */
-    public static SAMFileHeader getHeader(final JavaSparkContext ctx, final String filePath, final AuthHolder auth) {
+    public SAMFileHeader getHeader(final String filePath, final String referencePath, final AuthHolder auth) {
         // GCS case
         if (BucketUtils.isCloudStorageUrl(filePath)) {
             try {
                 Storage.Objects storageClient = auth.makeStorageClient();
-                try (final SamReader reader = BAMIO.openBAM(storageClient, filePath, ValidationStringency.DEFAULT_STRINGENCY)) {
+                try (final SamReader reader = BAMIO.openBAM(storageClient, filePath, validationStringency)) {
                     return reader.getFileHeader();
                 }
             } catch (Exception e) {
@@ -194,9 +192,48 @@ public final class ReadsSparkSource implements Serializable {
                 }
                 path = bamFiles[0].getPath(); // Hadoop-BAM writes the same header to each shard, so use the first one
             }
+            setHadoopBAMConfigurationProperties(path.getName(), referencePath);
             return SAMHeaderReader.readSAMHeaderFrom(path, ctx.hadoopConfiguration());
         } catch (IOException e) {
             throw new UserException("Failed to read bam header from " + filePath + "\n Caused by:" + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Propagate any values that need to be passed to Hadoop-BAM through configuration properties:
+     *
+     *   - the validation stringency property is always set using the current value of the
+     *     validationStringency field
+     *   - if the input file is a CRAM file, the reference value will also be set, and must be a URI
+     *     which includes a scheme. if no scheme is provided a "file://" scheme will be used. for
+     *     non-CRAM input the reference may be null.
+     *   - if the input file is not CRAM, the reference property is *unset* to prevent Hadoop-BAM
+     *     from passing a stale value through to htsjdk when multiple read calls are made serially
+     *     with different inputs but the same Spark context
+     */
+    private void setHadoopBAMConfigurationProperties(final String inputName, final String referenceName) {
+        // use the Hadoop configuration attached to the Spark context to maintain cumulative settings
+        final Configuration conf = ctx.hadoopConfiguration();
+        conf.set(SAMHeaderReader.VALIDATION_STRINGENCY_PROPERTY, validationStringency.name());
+
+        if (!IOUtils.isCramFileName(inputName)) { // only set the reference for CRAM input
+            conf.unset(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY);
+        }
+        else {
+            if (null == referenceName) {
+                throw new UserException.MissingReference("A reference is required for CRAM input");
+            }
+            else {
+                if (ReferenceTwoBitSource.isTwoBit(referenceName)) { // htsjdk can't handle 2bit reference files
+                    throw new UserException("A 2bit file cannot be used as a CRAM file reference");
+                }
+                else { // Hadoop-BAM requires the reference to be a URI, including scheme
+                    String referenceURI = null ==  new Path(referenceName).toUri().getScheme() ?
+                            "file://" + new File(referenceName).getAbsolutePath() :
+                            referenceName;
+                    conf.set(CRAMInputFormat.REFERENCE_SOURCE_PATH_PROPERTY, referenceURI);
+                }
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ValidateSamFile.java
@@ -114,7 +114,7 @@ public final class ValidateSamFile extends PicardCommandLineProgram {
             validator.setBisulfiteSequenced(IS_BISULFITE_SEQUENCED);
         }
         if (VALIDATE_INDEX) {
-            validator.setValidateIndex(VALIDATE_INDEX);
+            validator.setIndexValidationStringency(BamIndexValidator.IndexValidationStringency.EXHAUSTIVE);
         }
         if (IOUtil.isRegularPath(INPUT)) {
             // Do not check termination if reading from a stream

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
@@ -88,7 +88,7 @@ public class BaseRecalibratorSparkSharded extends SparkCommandLineProgram {
 
         final ReferenceMultiSource rds = new ReferenceMultiSource(auth, referenceURL, BaseRecalibrationEngine.BQSR_REFERENCE_WINDOW_FUNCTION);
 
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam, auth);
+        SAMFileHeader readsHeader = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency()).getHeader(bam, referenceURL, auth);
         final SAMSequenceDictionary readsDictionary = readsHeader.getSequenceDictionary();
         final SAMSequenceDictionary refDictionary = rds.getReferenceSequenceDictionary(readsDictionary);
         final CountingReadFilter readFilterToApply = BaseRecalibrator.getStandardBQSRReadFilter(readsHeader);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
@@ -41,7 +41,7 @@ final public class CompareBaseQualitiesSpark extends GATKSparkTool  {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         JavaRDD<GATKRead> firstReads = getReads();
-        ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx);
+        ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
         JavaRDD<GATKRead> secondReads = readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize);
 
         long firstBamSize = firstReads.count();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
@@ -54,7 +54,7 @@ public final class CompareDuplicatesSpark extends GATKSparkTool {
 
         JavaRDD<GATKRead> firstReads = filteredReads(getReads(), readArguments.getReadFilesNames().get(0));
 
-        ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx);
+        ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
         JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize), input2);
 
         // Start by verifying that we have same number of reads and duplicates in each BAM.

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadConstants.java
@@ -1,9 +1,16 @@
 package org.broadinstitute.hellbender.utils.read;
 
+import htsjdk.samtools.ValidationStringency;
+
 /**
  * Constants for use with the GATKRead interface
  */
 public final class ReadConstants {
+
+    /**
+     * Value used as the default validation stringency for all read input
+     */
+    public static ValidationStringency DEFAULT_READ_VALIDATION_STRINGENCY = ValidationStringency.SILENT;
 
     /**
      * Value used to represent the absence of a defined start/end position in a read

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -116,7 +116,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
 
         ReadsSparkSource readSource = new ReadsSparkSource(ctx);
         JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, null);
-        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam, null);
+        SAMFileHeader header = readSource.getHeader(inputBam, null, null);
 
         ReadsSparkSink.writeReads(ctx, outputPath, rddParallelReads, header, ReadsWriteFormat.SINGLE);
 
@@ -147,7 +147,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         ReadsSparkSource readSource = new ReadsSparkSource(ctx);
         JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, null);
         rddParallelReads = rddParallelReads.repartition(2); // ensure that the output is in two shards
-        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam, null);
+        SAMFileHeader header = readSource.getHeader(inputBam, null, null);
 
         ReadsSparkSink.writeReads(ctx, outputFile.getAbsolutePath(), rddParallelReads, header, ReadsWriteFormat.SHARDED);
         int shards = outputFile.listFiles((dir, name) -> !name.startsWith(".") && !name.startsWith("_")).length;
@@ -173,7 +173,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
 
         ReadsSparkSource readSource = new ReadsSparkSource(ctx);
         JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, null);
-        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam, null);
+        SAMFileHeader header = readSource.getHeader(inputBam, null, null);
 
         ReadsSparkSink.writeReads(ctx, outputDirectory.getAbsolutePath(), rddParallelReads, header, ReadsWriteFormat.ADAM);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SortSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SortSamIntegrationTest.java
@@ -18,9 +18,8 @@ public class SortSamIntegrationTest extends CommandLineProgramTest {
                 {"count_reads.bam", "count_reads_sorted.bam", "count_reads.fasta", ".cram", "coordinate"},
                 {"count_reads.bam", "count_reads.bam", null, ".bam", "queryname"},
                 {"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".cram", "coordinate"},
-                {"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".bam", "coordinate"}
-                // requires fix in https://github.com/samtools/htsjdk/issues/404
-                //{"count_reads.cram", "count_reads.cram", "count_reads.fasta", ".cram", "queryname"}
+                {"count_reads.cram", "count_reads_sorted.cram", "count_reads.fasta", ".bam", "coordinate"},
+                {"count_reads.cram", "count_reads.cram", "count_reads.fasta", ".cram", "queryname"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUnitTest.java
@@ -36,7 +36,7 @@ public class MarkDuplicatesSparkUnitTest extends BaseTest {
         JavaRDD<GATKRead> reads = readSource.getParallelReads(input, null);
         Assert.assertEquals(reads.count(), totalExpected);
 
-        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, input, null);
+        SAMFileHeader header = readSource.getHeader(input, null, null);
         OpticalDuplicatesArgumentCollection opticalDuplicatesArgumentCollection = new OpticalDuplicatesArgumentCollection();
         final OpticalDuplicateFinder finder = opticalDuplicatesArgumentCollection.READ_NAME_REGEX != null ?
                 new OpticalDuplicateFinder(opticalDuplicatesArgumentCollection.READ_NAME_REGEX, opticalDuplicatesArgumentCollection.OPTICAL_DUPLICATE_PIXEL_DISTANCE, null) : null;


### PR DESCRIPTION
Requires upgrades to Hadoop-BAM (not yet released) and htsjdk.

Fixes https://github.com/broadinstitute/gatk/issues/1346, https://github.com/broadinstitute/gatk/issues/1261, https://github.com/broadinstitute/gatk/issues/1175, https://github.com/broadinstitute/gatk/issues/1326, https://github.com/broadinstitute/gatk/issues/1259, and much of the underlying code for https://github.com/broadinstitute/gatk/issues/1270, which will be enabled in a separate PR.
