### PR TITLE
add READLENGTH_EQUALS_CIGARLENGTH to well formed read filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
@@ -18,7 +18,7 @@ public final class ReadFilterLibrary {
     public static final ReadFilter PASSES_VENDOR_QUALITY_CHECK = read -> ! read.failsVendorQualityCheck();
     public static final ReadFilter MAPPING_QUALITY_AVAILABLE = read -> read.getMappingQuality() != QualityUtils.MAPPING_QUALITY_UNAVAILABLE;
     public static final ReadFilter MAPPING_QUALITY_NOT_ZERO = read -> read.getMappingQuality() != 0;
-    public static final ReadFilter READLENGTH_EQUALS_CIGARLENGTH = read -> read.getLength() == read.getCigar().getReadLength();
+    public static final ReadFilter READLENGTH_EQUALS_CIGARLENGTH = read -> read.isUnmapped() || read.getLength() == read.getCigar().getReadLength();
     public static final ReadFilter GOOD_CIGAR =  read -> CigarUtils.isGood(read.getCigar());
     public static final ReadFilter NON_ZERO_REFERENCE_LENGTH_ALIGNMENT = read -> read.getCigar().getCigarElements().stream().anyMatch(c -> c.getOperator().consumesReferenceBases() && c.getLength() > 0);
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
@@ -21,13 +21,13 @@ public final class WellformedReadFilter implements ReadFilter {
                              .and(alignmentAgreesWithHeader)
                              .and(ReadFilterLibrary.HAS_READ_GROUP)
                              .and(ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS)
+                             .and(ReadFilterLibrary.READLENGTH_EQUALS_CIGARLENGTH)
                              .and(ReadFilterLibrary.SEQ_IS_STORED)
                              .and(ReadFilterLibrary.CIGAR_IS_SUPPORTED);
     }
 
-
     @Override
-    public boolean test( GATKRead read ) {
+    public boolean test(final GATKRead read ) {
         return wellFormedFilter.test(read);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -11,6 +11,8 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicatesArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -41,6 +43,11 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
 
     @ArgumentCollection
     protected OpticalDuplicatesArgumentCollection opticalDuplicatesArgumentCollection = new OpticalDuplicatesArgumentCollection();
+
+    @Override
+    public ReadFilter makeReadFilter() {
+        return ReadFilterLibrary.ALLOW_ALL_READS;
+    }
 
     public static JavaRDD<GATKRead> mark(final JavaRDD<GATKRead> reads, final SAMFileHeader header,
                                          final MarkDuplicatesScoringStrategy scoringStrategy,


### PR DESCRIPTION
READLENGTH_EQUALS_CIGARLENGTH was not used at all - I added it to WellFormedFilter.

In GATK3 that check (checking if read length is the same as cigar length) is done in BadCigarFilter but that's a bogus place for it because BadCigarFilter should only for malformed cigars - the problem here is that cigar disagrees with the rest of the read (but it's otherwise a wellformed cigar)

@lbergelson please review

this should close #348 