### PR TITLE
BQSR: improve runtime and memory allocation by lifting a few operations out of loops

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
@@ -397,8 +397,9 @@ public final class BAQ implements Serializable {
         // At the i-th read base, BAQi = Qi - (BQi - 64) where Qi is the i-th base quality.
         // so BQi = Qi - BAQi + 64
         byte[] bqTag = new byte[baq.length];
+        final byte[] baseQualities = read.getBaseQualities();
         for ( int i = 0; i < bqTag.length; i++) {
-            final int bq = (int)read.getBaseQualities()[i] + 64;
+            final int bq = (int) baseQualities[i] + 64;
             final int baq_i = (int)baq[i];
             final int tag = bq - baq_i;
             // problem with the calculation of the correction factor; this is our problem
@@ -406,7 +407,7 @@ public final class BAQ implements Serializable {
                 throw new GATKException("BAQ tag calculation error.  BAQ value above base quality at " + read);
             // the original quality is too high, almost certainly due to using the wrong encoding in the BAM file
             if ( tag > Byte.MAX_VALUE )
-                throw new UserException.MisencodedQualityScoresRead(read, "we encountered an extremely high quality score (" + (int)read.getBaseQualities()[i] + ") with BAQ correction factor of " + baq_i);
+                throw new UserException.MisencodedQualityScoresRead(read, "we encountered an extremely high quality score (" + (int) baseQualities[i] + ") with BAQ correction factor of " + baq_i);
             bqTag[i] = (byte)tag;
         }
         return new String(bqTag);


### PR DESCRIPTION
getBaseQualities is expensive because it allocates a new byte array every time
getSoftStart etc are also costly because they create many objects
getCigar creates a new Cigar object every time

all of those clearly show on the profiler when running BaseRecalibrator

this PR lifts these operations out of the loops they're in. 
@lbergelson please review -