### PR TITLE
BQSR optimization - reduce object churn by not creating as many Cigar objects and less bases/quals

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.tribble.Feature;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.util.ArrayList;
@@ -242,11 +241,11 @@ public final class FeatureContext {
      *         this FeatureContext's query interval. Empty List if there is no backing data source and/or interval.
      */
     public <T extends Feature> List<T> getValues(final Collection<FeatureInput<T>> featureDescriptors) {
-        if (featureManager == null || interval == null) {
+        if (featureManager == null || interval == null || featureDescriptors.isEmpty()) {
             return Collections.emptyList();
         }
 
-        List<T> features = new ArrayList<>();
+        final List<T> features = new ArrayList<>();
         for (FeatureInput<T> featureSource : featureDescriptors) {
             features.addAll(getValues(featureSource));
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
@@ -565,12 +565,12 @@ public final class BAQ implements Serializable {
      * @param read
      * @return
      */
-    private final Pair<Integer,Integer> calculateQueryRange(GATKRead read) {
+    private final Pair<Integer,Integer> calculateQueryRange(final GATKRead read) {
         int queryStart = -1, queryStop = -1;
         int readI = 0;
 
         // iterate over the cigar elements to determine the start and stop of the read bases for the BAQ calculation
-        for ( CigarElement elt : read.getCigar().getCigarElements() ) {
+        for ( CigarElement elt : read.getCigarElements() ) {
             switch (elt.getOperator()) {
                 case N:  return null; // cannot handle these
                 case H : case P : case D: break; // ignore pads, hard clips, and deletions
@@ -613,7 +613,7 @@ public final class BAQ implements Serializable {
 
         // cap quals
         int readI = 0, refI = 0;
-        for ( CigarElement elt : read.getCigar().getCigarElements() ) {
+        for ( CigarElement elt : read.getCigarElements() ) {
             int l = elt.getLength();
             switch (elt.getOperator()) {
                 case N: // cannot handle these

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
@@ -137,7 +137,7 @@ public final class ClippingOp {
 
         final Cigar unclippedCigar = new Cigar();
         int matchesCount = 0;
-        for (final CigarElement element : read.getCigar().getCigarElements()) {
+        for (final CigarElement element : read.getCigarElements()) {
             if (element.getOperator() == CigarOperator.SOFT_CLIP || element.getOperator() == CigarOperator.MATCH_OR_MISMATCH) {
                 matchesCount += element.getLength();
             } else if (matchesCount > 0) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
@@ -243,16 +243,15 @@ public class ReadClipper {
             return read;
         }
 
-        final byte [] quals = read.getBaseQualities();
         final int readLength = read.getLength();
         int leftClipIndex = 0;
         int rightClipIndex = readLength - 1;
 
         // check how far we can clip both sides
-        while (rightClipIndex >= 0 && quals[rightClipIndex] <= lowQual) {
+        while (rightClipIndex >= 0 && read.getBaseQuality(rightClipIndex) <= lowQual) {
             rightClipIndex--;
         }
-        while (leftClipIndex < readLength && quals[leftClipIndex] <= lowQual) {
+        while (leftClipIndex < readLength && read.getBaseQuality(leftClipIndex) <= lowQual) {
             leftClipIndex++;
         }
 
@@ -297,7 +296,7 @@ public class ReadClipper {
         int cutRight = -1;           // first position to hard clip (inclusive)
         boolean rightTail = false;   // trigger to stop clipping the left tail and start cutting the right tail
 
-        for (final CigarElement cigarElement : read.getCigar().getCigarElements()) {
+        for (final CigarElement cigarElement : read.getCigarElements()) {
             if (cigarElement.getOperator() == CigarOperator.SOFT_CLIP) {
                 if (rightTail) {
                     cutRight = readIndex;
@@ -404,7 +403,7 @@ public class ReadClipper {
             return read;
         }
 
-        for(final CigarElement cigarElement : read.getCigar().getCigarElements()) {
+        for(final CigarElement cigarElement : read.getCigarElements()) {
             if (cigarElement.getOperator() != CigarOperator.HARD_CLIP && cigarElement.getOperator() != CigarOperator.SOFT_CLIP &&
                     cigarElement.getOperator() != CigarOperator.INSERTION) {
                 break;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -5,7 +5,6 @@ import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
-import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 
 import java.util.*;
@@ -323,7 +322,7 @@ public final class AlignmentUtils {
 
         int numHQSoftClips = 0;
         int alignPos = 0;
-        for ( final CigarElement ce : read.getCigar().getCigarElements() ) {
+        for ( final CigarElement ce : read.getCigarElements() ) {
             final int elementLength = ce.getLength();
 
             switch( ce.getOperator() ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
@@ -88,7 +88,7 @@ public final class CigarUtils {
         if (read == null){
             throw new IllegalArgumentException("null read");
         }
-        final List<CigarElement> elems = read.getCigar().getCigarElements();
+        final List<CigarElement> elems = read.getCigarElements();
         if (cigarStartIndex < 0 || cigarEndIndex > elems.size() || cigarStartIndex > cigarEndIndex){
             throw new IllegalArgumentException("invalid index:" + 0 + " -" + elems.size());
         }
@@ -185,7 +185,14 @@ public final class CigarUtils {
      * Returns whether the cigar has any N operators.
      */
     public static boolean containsNOperator(final Cigar cigar) {
-        return Utils.nonNull(cigar).getCigarElements().stream().anyMatch(el -> el.getOperator() == CigarOperator.N);
+        return containsNOperator(Utils.nonNull(cigar).getCigarElements());
+    }
+
+    /**
+     * Returns whether the list has any N operators.
+     */
+    public static boolean containsNOperator(final List<CigarElement> cigarElements) {
+        return Utils.nonNull(cigarElements).stream().anyMatch(el -> el.getOperator() == CigarOperator.N);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -289,7 +289,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
         final List<Integer> convertedBaseQualities = new ArrayList<>(baseQualities.length);
         for ( byte b : baseQualities ) {
             if ( b < 0 ) {
-                throw new GATKException("Base quality score " + b + " is invalid");
+                throw new IllegalArgumentException("Base quality score " + b + " is invalid");
             }
 
             convertedBaseQualities.add((int)b);

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/QualityScoreCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/QualityScoreCovariate.java
@@ -18,18 +18,18 @@ public final class QualityScoreCovariate implements Covariate {
 
     @Override
     public void recordValues(final GATKRead read, final SAMFileHeader header, final ReadCovariates values, final boolean recordIndelValues) {
-        final byte[] baseQualities = read.getBaseQualities();
+        final int baseQualityCount = read.getBaseQualityCount();
         final byte[] baseInsertionQualities = recordIndelValues ? ReadUtils.getBaseInsertionQualities(read) : null;
         final byte[] baseDeletionQualities = recordIndelValues ? ReadUtils.getBaseDeletionQualities(read) : null;
 
         //note: duplicate the loop to avoid checking recordIndelValues on every iteration
         if (recordIndelValues) {
-            for (int i = 0; i < baseQualities.length; i++) {
-                values.addCovariate(baseQualities[i], baseInsertionQualities[i], baseDeletionQualities[i], i);
+            for (int i = 0; i < baseQualityCount; i++) {
+                values.addCovariate(read.getBaseQuality(i), baseInsertionQualities[i], baseDeletionQualities[i], i);
             }
         } else {
-            for (int i = 0; i < baseQualities.length; i++) {
-                values.addCovariate(baseQualities[i], 0, 0, i);
+            for (int i = 0; i < baseQualityCount; i++) {
+                values.addCovariate(read.getBaseQuality(i), 0, 0, i);
             }
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
@@ -532,7 +532,7 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
         Assert.assertEquals(read.getBaseQualities(), newQuals, "Wrong base qualities for read after setBaseQualities()");
     }
 
-    @Test(expectedExceptions = GATKException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetInvalidBaseQualitiesOnGoogleRead() {
         final GATKRead read = basicReadBackedByGoogle();
         read.setBaseQualities(new byte[]{-1});


### PR DESCRIPTION
2 commits - one for Cigars and one for bases/quals
@lbergelson please have a look