### PR TITLE
Fix reference serialization

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceWindowFunctions.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceWindowFunctions.java
@@ -12,9 +12,20 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 public class ReferenceWindowFunctions {
 
     /**
-     * A function for requesting only reference bases that directly overlap each read
+     * A function for requesting only reference bases that directly overlap each read. To maintain the ability to serialize the reference,
+     * this needs to be a class rather than a simple lambda function because of errors in serializing lambda functions
+     * in Kryo, at least in version 2.21 which we currently using. Partial support for lambda serialization was added in Kryo 3.0.
+     * See https://github.com/broadinstitute/gatk/pull/1489, https://github.com/EsotericSoftware/kryo/issues/215,
+     * https://issues.apache.org/jira/browse/SPARK-7708
      */
-    public static final SerializableFunction<GATKRead, SimpleInterval> IDENTITY_FUNCTION = read -> new SimpleInterval(read);
+    public static final SerializableFunction<GATKRead, SimpleInterval> IDENTITY_FUNCTION = new SerializableFunction<GATKRead, SimpleInterval>() {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public SimpleInterval apply(final GATKRead input) {
+            return new SimpleInterval(input);
+        }
+    };
 
     /**
      * A function for requesting a fixed number of extra bases of reference context on either side

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.hellbender.engine;
+
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import org.apache.spark.SparkConf;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
+import org.broadinstitute.hellbender.engine.spark.SparkTestUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ReferenceMultiSourceUnitTest extends BaseTest {
+
+    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+
+    @Test
+    public void testSerializeRoundTrip2Bit() {
+        PipelineOptions options =null;
+        ReferenceMultiSource referenceMultiSource = new ReferenceMultiSource(options, twoBitRefURL, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+
+        final ReferenceMultiSource roundTrippedReference = SparkTestUtils.roundTripInKryo(referenceMultiSource, ReferenceMultiSource.class, new SparkConf());
+
+        Assert.assertEquals(roundTrippedReference.getReferenceSequenceDictionary(null), referenceMultiSource.getReferenceSequenceDictionary(null),
+                "\nActual ref: " + roundTrippedReference.getReferenceSequenceDictionary(null) + "\nExpected ref: " + referenceMultiSource.getReferenceSequenceDictionary(null));
+        Assert.assertNotNull(roundTrippedReference.getReferenceWindowFunction());
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordSerializerUnitTest.java
@@ -4,14 +4,10 @@ import com.esotericsoftware.kryo.Kryo;
 import htsjdk.samtools.SAMRecord;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoRegistrator;
-import org.apache.spark.serializer.KryoSerializer;
-import org.apache.spark.serializer.SerializerInstance;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import scala.reflect.ClassTag;
-import scala.reflect.ClassTag$;
 
 public class SAMRecordSerializerUnitTest {
     public static class TestGATKRegistrator implements KryoRegistrator {
@@ -26,31 +22,27 @@ public class SAMRecordSerializerUnitTest {
     public void testSerializerRoundTripHeaderlessSAMRecord() {
         SparkConf conf = new SparkConf().set("spark.kryo.registrator",
                 "org.broadinstitute.hellbender.engine.spark.SAMRecordSerializerUnitTest$TestGATKRegistrator");
-        KryoSerializer kryoSerializer = new KryoSerializer(conf);
-        SerializerInstance sparkSerializer = kryoSerializer.newInstance();
 
         // check round trip with no header
         final SAMRecord read = ((SAMRecordToGATKReadAdapter)ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50)).getEncapsulatedSamRecord();
-        check(sparkSerializer, read);
+
+        final SAMRecord roundTrippedRead = SparkTestUtils.roundTripInKryo(read, SAMRecord.class, conf);
+        Assert.assertEquals(roundTrippedRead, read, "\nActual read: " + roundTrippedRead.getSAMString() + "\nExpected read: " + read.getSAMString());
     }
 
     @Test
     public void testChangingContigsOnHeaderlessSAMRecord(){
         final SparkConf conf = new SparkConf().set("spark.kryo.registrator",
                 "org.broadinstitute.hellbender.engine.spark.SAMRecordSerializerUnitTest$TestGATKRegistrator");
-        final KryoSerializer kryoSerializer = new KryoSerializer(conf);
-        final SerializerInstance sparkSerializer = kryoSerializer.newInstance();
         final SAMRecord read = ((SAMRecordToGATKReadAdapter)ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50)).getEncapsulatedSamRecord();
-        check(sparkSerializer, read);
+
+        final SAMRecord roundTrippedRead = SparkTestUtils.roundTripInKryo(read, SAMRecord.class, conf);
+        Assert.assertEquals(roundTrippedRead, read, "\nActual read: " + roundTrippedRead.getSAMString() + "\nExpected read: " + read.getSAMString());
 
         read.setReferenceName("2");
         read.setAlignmentStart(1);
-        check(sparkSerializer, read);
-    }
 
-    private void check(SerializerInstance ser, SAMRecord read) {
-        final ClassTag<SAMRecord> tag = ClassTag$.MODULE$.apply(SAMRecord.class);
-        final SAMRecord actual = ser.deserialize(ser.serialize(read, tag), tag);
-        Assert.assertEquals(actual, read, "\nActual read: " + actual.getSAMString() + "\nExpected read: " + read.getSAMString());
+        final SAMRecord roundTrippedRead2 = SparkTestUtils.roundTripInKryo(read, SAMRecord.class, conf);
+        Assert.assertEquals(roundTrippedRead2, read, "\nActual read: " + roundTrippedRead2.getSAMString() + "\nExpected read: " + read.getSAMString());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -1,18 +1,13 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 import com.esotericsoftware.kryo.Kryo;
-import htsjdk.samtools.SAMRecord;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoRegistrator;
-import org.apache.spark.serializer.KryoSerializer;
-import org.apache.spark.serializer.SerializerInstance;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import scala.reflect.ClassTag;
-import scala.reflect.ClassTag$;
 
 public class SAMRecordToGATKReadAdapterSerializerUnitTest {
 
@@ -28,29 +23,23 @@ public class SAMRecordToGATKReadAdapterSerializerUnitTest {
     public void testSerializerRoundTripHeaderlessRead() {
         SparkConf conf = new SparkConf().set("spark.kryo.registrator",
                 "org.broadinstitute.hellbender.engine.spark.SAMRecordToGATKReadAdapterSerializerUnitTest$TestGATKRegistrator");
-        KryoSerializer kryoSerializer = new KryoSerializer(conf);
-        SerializerInstance sparkSerializer = kryoSerializer.newInstance();
 
         // check round trip with no header
         GATKRead read = ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50);
-        check(sparkSerializer, read);
+        final GATKRead roundTrippedRead = SparkTestUtils.roundTripInKryo(read, GATKRead.class, conf);
+        Assert.assertEquals(roundTrippedRead, read);
     }
 
     @Test
     public void testChangingContigsOnHeaderlessGATKRead(){
         final SparkConf conf = new SparkConf().set("spark.kryo.registrator",
                 "org.broadinstitute.hellbender.engine.spark.SAMRecordToGATKReadAdapterSerializerUnitTest$TestGATKRegistrator");
-        final KryoSerializer kryoSerializer = new KryoSerializer(conf);
-        final SerializerInstance sparkSerializer = kryoSerializer.newInstance();
         final GATKRead read = ArtificialReadUtils.createHeaderlessSamBackedRead("read1", "1", 100, 50);
-        check(sparkSerializer, read);
+        final GATKRead roundTrippedRead = SparkTestUtils.roundTripInKryo(read, GATKRead.class, conf);
+        Assert.assertEquals(roundTrippedRead, read);
 
         read.setPosition("2", 1);
-        check(sparkSerializer, read);
-    }
-
-    private void check(SerializerInstance ser, GATKRead read) {
-        final ClassTag<GATKRead> tag = ClassTag$.MODULE$.apply(SAMRecordToGATKReadAdapter.class);
-        Assert.assertEquals(ser.deserialize(ser.serialize(read, tag), tag), read);
+        final GATKRead roundTrippedRead2 = SparkTestUtils.roundTripInKryo(read, GATKRead.class, conf);
+        Assert.assertEquals(roundTrippedRead2, read);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkTestUtils.java
@@ -1,0 +1,26 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.serializer.SerializerInstance;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+public class SparkTestUtils {
+
+    /**
+     * Takes an input object and returns the value of the object after it has been serialized and then deserialized in Kryo.
+     * Requires the class of the input object as a parameter because it's not gererally possible to get the class of a
+     * generified method parameter with reflection.
+     * @param input The object to be serialized and deserialized.
+     * @param inputClazz The class of the input object.
+     * @param conf SparkConf with any necessary Kryo registrators defined
+     * @return
+     */
+    public static <T> T roundTripInKryo(T input, Class<?> inputClazz, final SparkConf conf) {
+        KryoSerializer kryoSerializer = new KryoSerializer(conf);
+        SerializerInstance sparkSerializer = kryoSerializer.newInstance();
+        final ClassTag<T> tag = ClassTag$.MODULE$.apply(inputClazz);
+        return sparkSerializer.deserialize(sparkSerializer.serialize(input, tag), tag);
+    }
+}


### PR DESCRIPTION
This PR fixes an exception that was thrown when trying to serialize a ReferenceMultisource object.

I was attempting to broadcast a 2bit reference in a Spark tool and found that I received a serialization error of the form:
...
Caused by: com.esotericsoftware.kryo.KryoException: Unable to find class: ReferenceWindowFunctions$$Lambda$1/1599771323

Along with some related error reports (https://github.com/npgall/mobility-rpc/issues/12), this allowed me to track this down to the use of a Lambda function in the ReferenceWindowFunctions class. Replacing it with an explicitly defined function class solves the problem.

Added a unit test which used to fail but now passes.