### PR TITLE
fixing spark-submit not running with local[*]

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -14,7 +14,6 @@ BIN_PATH = script + "/build/libs"
 DEFAULT_SPARK_ARGS = ["--conf", "spark.kryoserializer.buffer.max=512m",
 "--conf", "spark.driver.maxResultSize=0",
 "--conf", "spark.driver.userClassPathFirst=true",
-"--conf", "spark.executor.userClassPathFirst=true",
 "--conf", "spark.io.compression.codec=lzf",
 "--conf", "spark.yarn.executor.memoryOverhead=600"]
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -39,7 +39,6 @@ public final class SparkContextFactory {
             .put("spark.kryoserializer.buffer.max", "512m")
             .put("spark.driver.maxResultSize", "0")
             .put("spark.driver.userClassPathFirst", "true")
-            .put("spark.executor.userClassPathFirst", "true")
             .put("spark.io.compression.codec", "lzf")
             .put("spark.yarn.executor.memoryOverhead", "600")
             .build();


### PR DESCRIPTION
removing spark.executor.userClassPathFirst=true seems to fix the problems encountered when running using spark-submit and sparkMaster local
this fixes #1315 and also fixes #1386

Removing it doesn't seem to cause any problems when running under yarn on the cluster.  I tested with a reasonable size file using the ReadSparkPipeline so that should cover most of our bases.

I'm not certain why we added spark.executor.userClassPathFirst=true in the first place.  I assumed it was necessary, like spark.driver.userClassPathFirst=true is.  
It seems plausible that it was only added for symmetry and it was never actually needed in the first place.