### PR TITLE
fixing nprs in spark tools where no output file was specified

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
@@ -34,8 +34,10 @@ public final class CountBasesSpark extends GATKSparkTool {
         final long count = reads.map(r -> (long)r.getLength()).reduce(Long::sum);
         System.out.println(count);
 
-        try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
-            ps.print(count);
+        if( out != null) {
+            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
+                ps.print(count);
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -34,8 +34,10 @@ public final class CountReadsSpark extends GATKSparkTool {
         final long count = reads.count();
         System.out.println(count);
 
-        try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
-            ps.print(count);
+        if(out != null) {
+            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions()))) {
+                ps.print(count);
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
@@ -22,7 +22,7 @@ public final class CountVariantsSpark extends GATKSparkTool {
 
     @Argument(doc = "uri for the input file: a local file path",
             shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME,
-            optional = true)
+            optional = false)
     public String input;
 
 
@@ -39,8 +39,10 @@ public final class CountVariantsSpark extends GATKSparkTool {
         final long count = variants.count();
         System.out.println(count);
 
-        try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
-            ps.print(count);
+        if( out != null) {
+            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions()))) {
+                ps.print(count);
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
@@ -35,8 +35,10 @@ public final class FlagStatSpark extends GATKSparkTool {
         final FlagStatus result = reads.aggregate(new FlagStatus(), FlagStatus::add, FlagStatus::merge);
         System.out.println(result);
 
-        try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
-            ps.print(result);
+        if(out != null ) {
+            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
+                ps.print(result);
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.utils.test;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.Utils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -48,9 +51,45 @@ public final class ArgumentsBuilder {
     }
 
     /**
+     * add an input file argument {@link StandardArgumentDefinitions#INPUT_LONG_NAME}
+     */
+    public void addInput(File input) {
+        addFileArgument(StandardArgumentDefinitions.INPUT_LONG_NAME, input);
+    }
+
+    /**
+     * add an output file argument using {@link StandardArgumentDefinitions#OUTPUT_LONG_NAME}
+     */
+    public void addOutput(File output) {
+        addFileArgument(StandardArgumentDefinitions.OUTPUT_LONG_NAME, output);
+    }
+
+    /**
+     * add a reference file argument using {@link StandardArgumentDefinitions#REFERENCE_LONG_NAME}
+     */
+    public void addReference(File reference){
+        addFileArgument(StandardArgumentDefinitions.REFERENCE_LONG_NAME, reference);
+    }
+
+    /**
+     * add a vcf file argument using {@link StandardArgumentDefinitions#VARIANT_LONG_NAME}
+     */
+    public void addVCF(File fileIn) {
+        addFileArgument(StandardArgumentDefinitions.VARIANT_LONG_NAME, fileIn);
+    }
+
+    /**
+     * add an argument with a file as its parameter
+     */
+    public void addFileArgument(String argumentName, File file){
+        Utils.nonNull(file);
+        Utils.nonNull(argumentName);
+        add("--" + argumentName);
+        add(file.getAbsolutePath());
+    }
+
+    /**
      * Add any object's string representation to the arguments list
-     * @param arg
-     * @return
      */
     public ArgumentsBuilder add(Object arg) {
         this.args.add(arg.toString());
@@ -73,6 +112,7 @@ public final class ArgumentsBuilder {
         return this.args.toArray(new String[this.args.size()]);
     }
 
+
     /**
      * get the arguments as a single String
      * @return
@@ -80,6 +120,4 @@ public final class ArgumentsBuilder {
     public String getString() {
         return String.join(" ", args);
     }
-
-
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSparkIntegrationTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -32,18 +31,22 @@ public final class CountBasesSparkIntegrationTest extends CommandLineProgramTest
         final File unsortedBam = new File(getTestDataDir(), fileName);
         final File outputTxt = createTempFile("count_bases", ".txt");
         ArgumentsBuilder args = new ArgumentsBuilder();
-        args.add("--" + StandardArgumentDefinitions.INPUT_LONG_NAME);
-        args.add(unsortedBam.getCanonicalPath());
-        args.add("--" + StandardArgumentDefinitions.OUTPUT_LONG_NAME);
-        args.add(outputTxt.getCanonicalPath());
+        args.addInput(unsortedBam);
+        args.addOutput(outputTxt);
         if (null != referenceFileName) {
-            final File REF = new File(getTestDataDir(), referenceFileName);
-            args.add("-R");
-            args.add(REF.getAbsolutePath());
+            final File ref = new File(getTestDataDir(), referenceFileName);
+            args.addReference(ref);
         }
         this.runCommandLine(args.getArgsArray());
 
         final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
         Assert.assertEquals((int) Integer.valueOf(readIn), expectedCount);
+    }
+
+    @Test
+    public void testNoNPRWhenOutputIsUnspecified(){
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(new File(getTestDataDir(), "count_bases.bam"));
+        this.runCommandLine(args.getArgsArray());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
@@ -37,19 +36,15 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
         final File outputTxt = createTempFile("count_reads", ".txt");
 
         final ArgumentsBuilder args = new ArgumentsBuilder();
-        args.add("--input");
-        args.add(ORIG_BAM.getAbsolutePath());
-        args.add("--" + StandardArgumentDefinitions.OUTPUT_LONG_NAME);
-        args.add(outputTxt.getCanonicalPath());
+        args.addInput(ORIG_BAM);
+        args.addOutput(outputTxt);
         if (null != referenceName) {
             final File REF = new File(getTestDataDir(), referenceName);
-            args.add("-R");
-            args.add(REF.getAbsolutePath());
+            args.addReference(REF);
         }
         this.runCommandLine(args.getArgsArray());
         final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
         Assert.assertEquals((long)Long.valueOf(readIn), expectedCount);
-
     }
 
     @Test
@@ -57,8 +52,8 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
         final File unsortedBam = new File(getTestDataDir(), "count_reads.bam");
         final File outputTxt = createTempFile("count_reads", ".txt");
         ArgumentsBuilder args = new ArgumentsBuilder();
-        args.add("--"+ StandardArgumentDefinitions.INPUT_LONG_NAME); args.add(unsortedBam.getCanonicalPath());
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(outputTxt.getCanonicalPath());
+        args.addInput(unsortedBam);
+        args.addOutput(outputTxt);
         this.runCommandLine(args.getArgsArray());
 
         final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
@@ -89,15 +84,21 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
         final File ORIG_BAM = new File(getTestDataDir(), "count_reads_sorted.bam");
         final File outputFile = createTempFile("count_reads_spark","count");
         ArgumentsBuilder args = new ArgumentsBuilder();
-        args.add("--"+ StandardArgumentDefinitions.INPUT_LONG_NAME); args.add(ORIG_BAM.getAbsolutePath());
+        args.addInput(ORIG_BAM);
         args.add(interval_args);
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(outputFile);
+        args.addOutput(outputFile);
 
         this.runCommandLine(args.getArgsArray());
 
         try(XReadLines output = new XReadLines(outputFile)){
             Assert.assertEquals((long)Long.valueOf(output.next()), expectedCount);
         }
+    }
 
+    @Test
+    public void testNoNPRWhenOutputIsUnspecified(){
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(new File(getTestDataDir(), "count_reads.bam"));
+        this.runCommandLine(args.getArgsArray());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
@@ -12,6 +12,8 @@ import java.io.File;
 
 public final class CountVariantsSparkIntegrationTest extends CommandLineProgramTest {
 
+    public static final File COUNT_VARIANTS_VCF = new File(getTestDataDir(), "count_variants.vcf");
+
     @Override
     public String getTestedClassName() {
         return CountVariantsSpark.class.getSimpleName();
@@ -21,8 +23,8 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
     public void test(final File fileIn, final long expected) throws Exception {
         final File outputTxt = createTempFile("count_variants", ".txt");
         ArgumentsBuilder args = new ArgumentsBuilder();
-        args.add("--"+ StandardArgumentDefinitions.VARIANT_LONG_NAME); args.add(fileIn);
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(outputTxt.getCanonicalPath());
+        args.addVCF(fileIn);
+        args.addOutput(outputTxt);
         this.runCommandLine(args.getArgsArray());
 
         final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
@@ -32,9 +34,16 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
     @DataProvider(name="filenames")
     public Object[][] filenames() {
         return new Object[][]{
-                {new File(getTestDataDir(), "count_variants.vcf"), 26L},
+                {COUNT_VARIANTS_VCF, 26L},
 //                {new File(getTestDataDir(), "count_variants.blockgz.gz"), 26L}, //disabled because of https://github.com/HadoopGenomics/Hadoop-BAM/issues/68
                 {new File(dbsnp_138_b37_1_65M_vcf), 1375319L},
         };
+    }
+
+    @Test
+    public void testNoNPRWhenOutputIsUnspecified(){
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addVCF(COUNT_VARIANTS_VCF);
+        this.runCommandLine(args.getArgsArray());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSparkIntegrationTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import com.google.common.collect.Lists;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.testng.Assert;
@@ -20,12 +19,11 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void flagStatSparkLocalNoInterval() throws IOException {
-        ArgumentsBuilder args = new ArgumentsBuilder();
-
-        args.add("--"+StandardArgumentDefinitions.INPUT_LONG_NAME); args.add( new File(getToolTestDataDir(),"flag_stat.bam").toString());
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME);
         File outputFile = createTempFile("flagStatTest", ".txt");
-        args.add(outputFile.getPath());
+
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(new File(getToolTestDataDir(), "flag_stat.bam"));
+        args.addOutput(outputFile);
 
         this.runCommandLine(args.getArgsArray());
 
@@ -37,7 +35,7 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
     public void flagStatSparkLocalWithBigInterval() throws IOException {
         ArgumentsBuilder args = new ArgumentsBuilder();
 
-        args.add("--"+StandardArgumentDefinitions.INPUT_LONG_NAME); args.add( new File(getToolTestDataDir(),"flag_stat.bam").toString());
+        args.addInput( new File(getToolTestDataDir(), "flag_stat.bam"));
         args.add("-L"); args.add("chr1");
         args.add("-L"); args.add("chr2");
         args.add("-L"); args.add("chr3");
@@ -46,9 +44,8 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
         args.add("-L"); args.add("chr6");
         args.add("-L"); args.add("chr7");
         args.add("-L"); args.add("chr8");
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME);
         File outputFile = createTempFile("flagStatTest", ".txt");
-        args.add(outputFile.getPath());
+        args.addOutput(outputFile);
 
         this.runCommandLine(args.getArgsArray());
 
@@ -61,16 +58,22 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
     public void flagStatSparkLocalWithSmallInterval() throws IOException {
         ArgumentsBuilder args = new ArgumentsBuilder();
 
-        args.add("--"+StandardArgumentDefinitions.INPUT_LONG_NAME); args.add( new File(getToolTestDataDir(),"flag_stat.bam").toString());
+        args.addInput(  new File(getToolTestDataDir(), "flag_stat.bam"));
         args.add("-L chr7:1-100 -XL chr7:2-100");
-        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME);
         File outputFile = createTempFile("flagStatTest.chr1_1", ".txt");
-        args.add(outputFile.getPath());
+        args.addOutput(outputFile);
 
         this.runCommandLine(args.getArgsArray());
 
         Assert.assertTrue(outputFile.exists());
         //the expected output was created using stand-alone hellbender
         IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() +"/"+ "expectedStats.chr1_1.txt"), false, null);
+    }
+
+    @Test
+    public void testNoNPRWhenOutputIsUnspecified(){
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(new File(getToolTestDataDir(), "flag_stat.bam"));
+        this.runCommandLine(args.getArgsArray());
     }
 }


### PR DESCRIPTION
adding tests for NPR when there's no output specified
this effects CountBasesSpark, CountReadsSpark, FlagStatSpark, and CountVariantsSpark
fixes #1523

fixing an error in CountVariantsSpark where the vcf input was optional

adding some convinience functions to ArgumentsBuilder