### PR TITLE
stop CommandLineParser from recognizing abbreviations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     compile 'org.apache.commons:commons-vfs2:2.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.reflections:reflections:0.9.10'
-    compile 'net.sf.jopt-simple:jopt-simple:4.9'
+    compile 'net.sf.jopt-simple:jopt-simple:5.0-beta-1'
     compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:0.4.150727'
     compile 'it.unimi.dsi:fastutil:7.0.6'
     compile 'com.google.apis:google-api-services-genomics:v1beta2-rev56-1.20.0'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -15,8 +15,19 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -213,7 +224,7 @@ public final class CommandLineParser {
     public boolean parseArguments(final PrintStream messageStream, final String[] args) {
         this.argv = args;
 
-        OptionParser parser = new OptionParser();
+        OptionParser parser = new OptionParser(false);
 
         for (ArgumentDefinition arg : argumentDefinitions){
             OptionSpecBuilder bld = parser.acceptsAll(arg.getNames(), arg.doc);

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -101,6 +101,23 @@ public final class CommandLineParserTest {
         Assert.assertTrue(out.indexOf("Optional Arguments:", reqIndex) < 0);
     }
 
+    class AbbreviatableArgument{
+        public static final String ARGUMENT_NAME = "longNameArgument";
+        @Argument(fullName= ARGUMENT_NAME)
+        public boolean longNameArgument;
+    }
+
+    @Test(expectedExceptions = UserException.CommandLineException.class)
+    public void testAbbreviationsAreRejected() {
+        final AbbreviatableArgument abrv = new AbbreviatableArgument();
+        final CommandLineParser clp = new CommandLineParser(abrv);
+        //argument name is valid when it isn't abbreviated
+        Assert.assertTrue(clp.parseArguments(System.err, new String[]{"--" + AbbreviatableArgument.ARGUMENT_NAME}));
+
+        //should throw when the abbreviated name is used
+        clp.parseArguments(System.err, new String[]{"--" + AbbreviatableArgument.ARGUMENT_NAME.substring(0,5)});
+    }
+
     @CommandLineProgramProperties(
             summary = "[oscillation_frequency]\n\nRecalibrates overthruster oscillation. \n",
             oneLineSummary = "Recalibrates the overthruster.",

--- a/src/test/java/org/broadinstitute/hellbender/tools/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/SplitNCigarReadsIntegrationTest.java
@@ -17,7 +17,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-T SplitNCigarReads -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -o %s ",
+                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.bam"));    //results created using gatk3.46
         spec.executeTest("test splits with overhangs", this);
     }
@@ -25,7 +25,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangsNotClipping() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-T SplitNCigarReads --doNotFixOverhangs -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -o %s ",
+                "--doNotFixOverhangs -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.doNotFixOverhangs.bam"));   //results created using gatk3.46
         spec.executeTest("test splits with overhangs not clipping", this);
     }
@@ -33,7 +33,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs0Mismatches() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-T SplitNCigarReads --maxMismatchesInOverhang 0 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -o %s ",
+                "--maxMismatchesInOverhang 0 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxMismatchesInOverhang0.bam"));   //results created using gatk3.46
         spec.executeTest("test splits with overhangs 0 mismatches", this);
     }
@@ -41,7 +41,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs5BasesInOverhang()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-T SplitNCigarReads --maxBasesInOverhang 5 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -o %s ",
+                "--maxBasesInOverhang 5 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxBasesInOverhang5.bam"));    //results created using gatk3.46
         spec.executeTest("test splits with overhangs 5 bases in overhang", this);
     }
@@ -49,7 +49,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsFixNDN() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-T SplitNCigarReads -R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -o %s -fixNDN",
+                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN",
                 Arrays.asList(getTestDataDir() +"/" + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
         spec.executeTest("test fix NDN", this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/FilterReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/FilterReadsIntegrationTest.java
@@ -112,7 +112,7 @@ public final class FilterReadsIntegrationTest extends CommandLineProgramTest {
         }
 
         if (!writeReadsFile) { // defaults to true
-            args.add("--WRITE_READS_FILE");
+            args.add("--WRITE_READS_FILES");
             args.add("false");
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -318,7 +318,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcf4.1.example.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec (
-                " --variant " + testFile + " -o %s ",
+                " --variant " + testFile + " -O %s ",
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_NoGTs.vcf")
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
@@ -11,28 +11,25 @@ import java.util.Arrays;
 public final class VariantsToTableIntegrationTest extends CommandLineProgramTest {
     private String variantsToTableCmd(String moreArgs) {
         return  " --variant " + getToolTestDataDir() + "soap_gatk_annotated.noChr_lines.vcf" +
-                " -T VariantsToTable" +
                 " -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F FILTER -F TRANSITION -F DP -F SB -F set -F RankSumP -F refseq.functionalClass*" +
                 " -O %s" + moreArgs;
     }
 
     private String variantsToTableMultiAllelicCmd(String moreArgs) {
         return  " --variant " + getToolTestDataDir() + "multiallelic.vcf" +
-                " -T VariantsToTable" +
                 " -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F MULTI-ALLELIC -F AC -F AF" +
                 " -O %s" + moreArgs;
     }
 
     private String variantsToTableCmdNoSamples(String moreArgs) {
         return  " --variant " + getToolTestDataDir() + "vcfexample.noSamples.vcf" +
-                " -T VariantsToTable" +
                 " -O %s" + moreArgs;
     }
 
     @Test
     public void testInputFileFail() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                " --variant does_not_exist.vcf -o %s",
+                " --variant does_not_exist.vcf -O %s",
                 1, UserException.CouldNotReadInputFile.class);
         spec.executeTest("testComplexVariantsToTable-FAIL", this);
     }
@@ -99,9 +96,8 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testGenotypeFields() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "vcfexample2.vcf" +
-                        " -T VariantsToTable" +
                         " -GF RD" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.table"));
         spec.executeTest("testGenotypeFields", this);
     }
@@ -110,11 +106,10 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testMultiallelicGenotypeFields() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "multiallelic_gt.vcf" +
-                        " -T VariantsToTable" +
                         " -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F MULTI-ALLELIC" +
                         " -GF PL -GF AD" +
                         " -SMA" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic_gt.table"));
         spec.executeTest("testMultiallelicGenotypeFields", this);
     }
@@ -123,9 +118,8 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testGenotypeFieldsWithInline() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "vcfexample2.vcf" +
-                        " -T VariantsToTable" +
                         " -GF RD -GF GT -GF GQ" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.GF_GT.GF_GT.table"));
         spec.executeTest("testGenotypeFieldsWithInline", this);
     }
@@ -134,9 +128,8 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testListFields() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "vcfexample.withMLE.vcf" +
-                        " -T VariantsToTable" +
                         " -GF PL" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample.withMLE.GF_PL.table"));
         spec.executeTest("testGenotypeFields", this);
     }
@@ -145,10 +138,9 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testMoltenOutput() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "vcfexample2.vcf" +
-                        " -T VariantsToTable" +
                         " -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F FILTER" +
                         " --moltenize" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.moltenize.table"));
         spec.executeTest("testMoltenOutput", this);
     }
@@ -157,10 +149,9 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testMoltenOutputWithGenotypeFields() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "vcfexample2.vcf" +
-                        " -T VariantsToTable" +
                         " -GF RD" +
                         " --moltenize" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.moltenize.table"));
         spec.executeTest("testMoltenOutputWithGenotypeFields", this);
     }
@@ -169,10 +160,9 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
     public void testMoltenOutputWithMultipleAlleles() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " --variant " + getToolTestDataDir() + "multiallelic.vcf" +
-                        " -T VariantsToTable" +
                         " -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F MULTI-ALLELIC -F AC -F AF" +
                         " --moltenize -SMA" +
-                        " -o %s",
+                        " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic.moltenize.SMA.table"));
         spec.executeTest("testMoltenOutputWithMultipleAlleles", this);
     }


### PR DESCRIPTION
previously CommandLineParser would accept non-ambiguous abbreviations for longopts
this caused issues where -v would have different meanings in different tools

I patched joptSimple to add an option to disallow abbreviations, and updated to 5.0-beta-1 which incorporates the necessary changes.
fixes #1347