### PR TITLE
Use non-lenient comparison for CRAM.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtils.java
@@ -36,22 +36,6 @@ public final class SamAssertionUtils {
     }
 
     /**
-     *  causes an exception if the given sam files aren't equal using lenient comparison
-     *  @param actualSam the actual file
-     *  @param expectedSam the expected file
-     *  @param validationStringency how stringently do we validate the files
-     *  @param reference is allowed to be null
-     *
-     * The lenient comparison only checks headers and alignment info {@see SamComparison}. Compares headers, and if headers are compatible enough, compares SAMRecords,
-     * looking only at basic alignment info.
-     * NOTE: Lenient comparisons are a temporary workaround and will be removed in the future
-     */
-    public static void assertSamsEqualLenient(final File actualSam, final File expectedSam, final ValidationStringency validationStringency, final File reference) throws IOException {
-        final String equalLenient = samsEqualLenient(actualSam, expectedSam, validationStringency, reference);
-        Assert.assertNull(equalLenient, "SAM file " + actualSam.getPath() + " differs from expected output:" + expectedSam.getPath() + " " + equalLenient);
-    }
-
-    /**
      * causes an exception if the given sam files aren't equal
      *  @param actualSam the actual file
      *  @param expectedSam the expected file
@@ -78,20 +62,6 @@ public final class SamAssertionUtils {
      */
     public static void assertSamsEqual(final File actualSam, final File expectedSam) throws IOException {
         assertSamsEqual(actualSam, expectedSam, ValidationStringency.DEFAULT_STRINGENCY, null);
-    }
-
-    /**
-     * causes an exception if the given sam files aren't equal using lenient comparison
-     *  @param actualSam the actual file
-     *  @param expectedSam the expected file
-     *  @param reference is allowed to be null
-     *
-     * The lenient comparison only checks headers and alignment info {@see SamComparison}. Compares headers, and if headers are compatible enough, compares SAMRecords,
-     * looking only at basic alignment info.
-     *  NOTE: Lenient comparisons are a temporary workaround and will be removed in the future
-     */
-    public static void assertSamsEqualLenient(final File actualSam, final File expectedSam, final File reference) throws IOException {
-        assertSamsEqualLenient(actualSam, expectedSam, ValidationStringency.DEFAULT_STRINGENCY, reference);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -27,33 +27,25 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
         String samFile = fileIn;
         final File outFile = BaseTest.createTempFile(samFile + ".", extOut);
         final File ORIG_BAM = new File(TEST_DATA_DIR, samFile);
+        final File refFile;
 
         final ArrayList<String> args = new ArrayList<>();
         args.add("--input"); args.add(ORIG_BAM.getAbsolutePath());
         args.add("--output"); args.add(outFile.getAbsolutePath());
         if (reference != null) {
-            final File refFile = new File(TEST_DATA_DIR, reference);
+            refFile = new File(TEST_DATA_DIR, reference);
             args.add("-R"); args.add(refFile.getAbsolutePath());
-        };
+        }
+        else {
+            refFile = null;
+        }
         if (testMD5) {
             args.add("--createOutputBamMD5");
             args.add("true");
         }
         runCommandLine(args);
 
-        if (fileIn.endsWith(CramIO.CRAM_FILE_EXTENSION) || extOut.equals(CramIO.CRAM_FILE_EXTENSION)) {
-            final File refFile = new File(TEST_DATA_DIR, reference);
-            if (!fileIn.endsWith(CramIO.CRAM_FILE_EXTENSION)) {
-                // TODO: We still need lenient comparison due to https://github.com/samtools/htsjdk/issues/455
-                // (bam->cram conversion strips out NM/MD tags)
-                SamAssertionUtils.assertSamsEqualLenient(outFile, ORIG_BAM, refFile);
-            }
-            else {
-                SamAssertionUtils.assertSamsEqual(outFile, ORIG_BAM, refFile);
-            }
-        } else {
-            SamAssertionUtils.assertSamsEqual(outFile, ORIG_BAM);
-        }
+        SamAssertionUtils.assertSamsEqual(outFile, ORIG_BAM, refFile);
 
         if (testMD5) {
             checkMD5asExpected(outFile);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -62,13 +62,7 @@ public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest
         }
         runCommandLine(args);
 
-        // TODO: We still need lenient comparison due to https://github.com/samtools/htsjdk/issues/455
-        // (bam->cram conversion strips out NM/MD tags)
-        if (refFile != null && extOut.equals(CramIO.CRAM_FILE_EXTENSION) && !fileIn.endsWith(CramIO.CRAM_FILE_EXTENSION)) {
-            SamAssertionUtils.assertSamsEqualLenient(outFile, originalFile, refFile);
-        } else {
-            SamAssertionUtils.assertSamsEqual(outFile, originalFile, refFile);
-        }
+        SamAssertionUtils.assertSamsEqual(outFile, originalFile, refFile);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/1087 now that https://github.com/samtools/htsjdk/pull/487/files is in.