### PR TITLE
Use IntelDeflater (libIntelDeflater.so) by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,20 @@ import org.gradle.internal.os.OperatingSystem
 
 mainClassName = "org.broadinstitute.hellbender.Main"
 
+applicationDefaultJvmArgs = ["-Dsamjdk.intel_deflater_so_path=build/libs/libIntelDeflater.so"]
+
 task downloadGsaLibFile(type: Download) {
     src 'http://cran.r-project.org/src/contrib/gsalib_2.1.tar.gz'
     dest "src/main/resources/org/broadinstitute/hellbender/utils/R/gsalib.tar.gz"
     overwrite false
 }
 
+task getIntelDeflater(type:Exec) {
+  workingDir '.'
+  
+  String version="2.1.1"
+  commandLine "/bin/bash", "-c", "wget --no-verbose https://github.com/samtools/htsjdk/archive/" + version + ".zip; unzip -q "+ version +".zip ; mkdir -p build/libs/; cp -v htsjdk-"+ version+"/lib/jni/libIntelDeflater.so build/libs/; rm -f "+ version +".zip; rm -fr htsjdk-"+version+"; "
+}
 
 repositories {
     mavenCentral()
@@ -451,11 +459,11 @@ uploadArchives {
         )
     }
 
+
 task installSpark{ dependsOn sparkJar }
 task installAll{  dependsOn installSpark, installDist }
 
-
-installDist.dependsOn downloadGsaLibFile
+installDist.dependsOn downloadGsaLibFile, getIntelDeflater
 build.dependsOn installDist
 check.dependsOn installDist
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'signing'
     id "jacoco"
     id "cpp"
-    id "de.undercouch.download" version "1.2" //used for downloading GSA lib
+    id "de.undercouch.download" version "2.1.0" //used for downloading GSA lib and IntelDeflater
     id "com.github.johnrengelman.shadow" version "1.2.3"
     id "com.github.kt3k.coveralls" version "2.6.3"
     id "com.github.ben-manes.versions" version "0.12.0" //used for identifying dependencies that need updating
@@ -27,7 +27,7 @@ import org.gradle.internal.os.OperatingSystem
 
 mainClassName = "org.broadinstitute.hellbender.Main"
 
-applicationDefaultJvmArgs = ["-Dsamjdk.intel_deflater_so_path=build/libs/libIntelDeflater.so"]
+applicationDefaultJvmArgs = ["-Dsamjdk.intel_deflater_so_path=build/libIntelDeflater.so"]
 
 task downloadGsaLibFile(type: Download) {
     src 'http://cran.r-project.org/src/contrib/gsalib_2.1.tar.gz'
@@ -35,11 +35,10 @@ task downloadGsaLibFile(type: Download) {
     overwrite false
 }
 
-task getIntelDeflater(type:Exec) {
-  workingDir '.'
-  
-  String version="2.1.1"
-  commandLine "/bin/bash", "-c", "wget --no-verbose https://github.com/samtools/htsjdk/archive/" + version + ".zip; unzip -q "+ version +".zip ; mkdir -p build/libs/; cp -v htsjdk-"+ version+"/lib/jni/libIntelDeflater.so build/libs/; rm -f "+ version +".zip; rm -fr htsjdk-"+version+"; "
+task downloadIntelDeflater(type: Download) {
+    //IntelDeflater is not packages with the rest of HTSJDK so we download it by hand
+    src 'https://github.com/samtools/htsjdk/raw/2.1.1/lib/jni/libIntelDeflater.so'
+    dest 'build/'
 }
 
 repositories {
@@ -463,7 +462,7 @@ uploadArchives {
 task installSpark{ dependsOn sparkJar }
 task installAll{  dependsOn installSpark, installDist }
 
-installDist.dependsOn downloadGsaLibFile, getIntelDeflater
+installDist.dependsOn downloadGsaLibFile, downloadIntelDeflater
 build.dependsOn installDist
 check.dependsOn installDist
 


### PR DESCRIPTION
fixes #1585 - getting IntelDeflater from htsjdk zipfile (it's not part of the jar!) and then putting the path to it as a default JVM argument.

@lbergelson can you review? this is a bit of a hack, improvements welcome
Do check that, out of the box (on linux) you get the IntelDeflater. I run this:
```
./gradlew clean installDist
./gatk-launch CountReads -I src/test/resources/large/NA12878.RNAseq.bam
```

and check output for `IntelDeflater`