### PR TITLE
use async IO by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ If you are looking for the codebase of the current production version of GATK, p
   on a cluster or the cloud by building a Spark jar with `gradle installSpark` and passing the resulting jar in `build/libs/`
   directly to either `spark-submit` or `gcloud`.
 
+* Note: by default, GATK uses asynchronous IO and will use a separate thread for writting read and variant files. On systems with only 1 CPU this may reduce performance. To turn that option off, run GATK like this:
+
+```
+      JAVA_OPTS="-Dsamjdk.use_async_io=false" ./gatk-launch <rest of command>
+```
+
 ##Testing GATK4
 
 * To run all tests, run **`gradle test`**.

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ import de.undercouch.gradle.tasks.download.Download
 import org.gradle.internal.os.OperatingSystem
 
 mainClassName = "org.broadinstitute.hellbender.Main"
+applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io=true"]
 
 task downloadGsaLibFile(type: Download) {
     src 'http://cran.r-project.org/src/contrib/gsalib_2.1.tar.gz'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.cmdline;
 
+import htsjdk.samtools.Defaults;
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
@@ -140,6 +141,7 @@ public abstract class CommandLineProgram {
                         " " + System.getProperty("os.arch") + "; " + System.getProperty("java.vm.name") +
                         " " + System.getProperty("java.runtime.version") +
                         "; Version: " + commandLineParser.getVersion() +
+                        " " + (Defaults.USE_ASYNC_IO ? "asyncIO": "syncIO") +
                         " " + (DeflaterFactory.usingIntelDeflater()? "IntelDeflater": "JdkDeflater"));
             }
             catch (final Exception e) { /* Unpossible! */ }


### PR DESCRIPTION
Switch to using async IO by default. It's an out-of-the-box win for almost everybody because almost everyone has more than 1 CPU. Difference is write speed is at least 20%.  

Also added a line to the output that indicates what IO we're using (a'la deflater)

On single processors it is slower than syncIO, so you can turn it off by running like this:
```
JAVA_OPTS="-Dsamjdk.use_async_io=false" ./gatk-launch PrintReads .....
```

@lbergelson can you review and test?