### PR TITLE
Fix test in BQSRSparkIntegrationTest.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -147,7 +147,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
 
     @Test(dataProvider = "BQSRTest")
     public void testBQSRSpark(BQSRTest params) throws IOException {
-        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
+        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLineNoApiKey());
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 ab.getString(),
                 Arrays.asList(params.expectedFileName));


### PR DESCRIPTION
One of the non-cloud tests in BQSRSparkIntegrationTest tries to use the API key when its not required; as a result the test fails when the key isn't set even though it should pass. Introduced in the test refactoring that was part of https://github.com/broadinstitute/gatk/pull/1533.