### PR TITLE
Fix CompareBaseQualitiesSpark reference handling.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSpark.java
@@ -42,7 +42,7 @@ final public class CompareBaseQualitiesSpark extends GATKSparkTool  {
     protected void runTool(final JavaSparkContext ctx) {
         JavaRDD<GATKRead> firstReads = getReads();
         ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
-        JavaRDD<GATKRead> secondReads = readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize);
+        JavaRDD<GATKRead> secondReads = readsSource2.getParallelReads(input2, referenceArguments.getReferenceFileName(), getIntervals(), bamPartitionSplitSize);
 
         long firstBamSize = firstReads.count();
         long secondBamSize = secondReads.count();

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/validation/CompareBaseQualitiesSparkIntegrationTest.java
@@ -35,15 +35,21 @@ public final class CompareBaseQualitiesSparkIntegrationTest extends CommandLineP
         final File outFile = BaseTest.createTempFile(getTestDataDir() + "temp.diff", "txt");
         final File firstBam = new File(resourceDir, "single.read.bam");
         final File secondBam = new File(resourceDir, "another.single.read.bam");
+        final File firstCram = new File(resourceDir, "single.read.cram");
+        final File secondCram = new File(resourceDir, "another.single.read.cram");
+        final File referenceFile = new File(b37_reference_20_21);
         return new Object[][]{
-                {firstBam, firstBam, outFile, "single.read.qual.diff.txt"},
-                {firstBam, secondBam, outFile, "two.reads.qual.diff.txt"},
+                {firstBam, firstBam, null, outFile, "single.read.qual.diff.txt"},
+                {firstBam, secondBam, null, outFile, "two.reads.qual.diff.txt"},
+                {firstCram, secondCram, referenceFile, outFile, "two.reads.qual.diff.txt"},
+                {firstBam, secondCram, referenceFile, outFile, "two.reads.qual.diff.txt"},
+                {firstCram, secondBam, referenceFile, outFile, "two.reads.qual.diff.txt"},
         };
 
     }
 
     @Test(dataProvider = "CompareBasesProvider")
-    public void singleReadDiffTest(File firstBam, File secondBam, File outFile, String diffFile) throws Exception {
+    public void singleReadDiffTest(File firstBam, File secondBam, File referenceFile, File outFile, String diffFile) throws Exception {
         final String resourceDir = getTestDataDir() + "/validation/";
 
         ArgumentsBuilder args = new ArgumentsBuilder();
@@ -53,6 +59,10 @@ public final class CompareBaseQualitiesSparkIntegrationTest extends CommandLineP
         args.add(secondBam.getCanonicalPath());
         args.add("--" + "O");
         args.add(outFile.getCanonicalPath());
+        if (null != referenceFile) {
+            args.add("-R");
+            args.add(referenceFile.getAbsolutePath());
+        }
 
         this.runCommandLine(args.getArgsArray());
 


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/1321. Also added some CRAM tests. I started to fix https://github.com/broadinstitute/gatk/issues/1593 as part of this but there are several code paths that need to change so I'll do a separate PR.