### PR TITLE
moving to sudo enabled travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
-language: java
-addons:
-  apt:
-    sources:
-    - r-packages-precise
-    - ubuntu-toolchain-r-test
-    packages:
-    - r-base
-    - gcc-4.8
-    - g++-4.8
+sudo: required
+dist: trusty
 jdk:
 - oraclejdk8
 env:
@@ -52,13 +44,16 @@ before_install:
     $GCLOUD/gcloud config set project broad-dsde-dev;
     $GCLOUD/gcloud auth activate-service-account --key servicekey.json;
   fi
+#install R
+- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+- sudo add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/"
+- sudo apt-get update
+- sudo apt-get install -y --force-yes r-base
 - R --version
-# create links to newer gcc for gradle
-- mkdir $HOME/bin
-- ln -s /usr/bin/gcc-4.8 $HOME/bin/gcc
-- ln -s /usr/bin/g++-4.8 $HOME/bin/g++
-- export PATH=$HOME/bin:$PATH
+#install gcc
+- sudo apt-get install -y --force-yes  gcc
 - gcc --version
+#install git-lfs
 install:
 - if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
     echo "Can't run cloud tests without keys so don't bother building";


### PR DESCRIPTION
travis support recommended that we move to travis with sudo since the capacity problems have been fixed
the travis nodes with sudo are more powerful now and there shouldn't be long startup delays like there used to be
also moving to the newer ubuntu image