### PR TITLE
propagating exit codes from GATK through gatk-launch

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from subprocess import call
+from subprocess import check_call, CalledProcessError, call
 import os
 import hashlib
 import signal
@@ -85,6 +85,10 @@ def main(args):
         runGATK(sparkRunner, dryRun, gatkArgs, sparkArgs)
     except GATKLaunchException as e:
         sys.stderr.write(str(e)+"\n")
+        sys.exit(3)
+    except CalledProcessError as e:
+        sys.exit(e.returncode)
+
 
 
 def getSparkSubmit():
@@ -204,7 +208,7 @@ def runCommand(cmd, dryrun):
     else:
         sys.stderr.write( "\nRunning:\n")
         sys.stderr.write("    " + " ".join(cmd)+"\n")
-        call(cmd)
+        check_call(cmd)
 
 def getSplitArgs(args):
     inFirstGroup = True


### PR DESCRIPTION
gatk-launch wasn't exiting with the same exit code that GATK did
this causes problems for testing infrastructure that expects non-zero exit codes from failures

fixes #1599