### PR TITLE
squid:S2184 - Math operands should be cast before assignment

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -313,7 +313,7 @@ public final class EstimateLibraryComplexity extends AbstractOpticalDuplicateFin
 
             int groupsProcessed = 0;
             long lastLogTime = System.currentTimeMillis();
-            final int meanGroupSize = Math.max(1, (recordsRead / 2) / (int) pow(4, MIN_IDENTICAL_BASES * 2));
+            final int meanGroupSize = Math.max(1, (recordsRead / 2) / (int) pow(4.0, (double) MIN_IDENTICAL_BASES * 2));
 
             while (iterator.hasNext()) {
                 // Get the next group and split it apart by library

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/TargetCollectionUnitTest.java
@@ -265,7 +265,7 @@ public final class TargetCollectionUnitTest extends BaseTest {
             List<SimpleInterval> intervals = new ArrayList<>(numberOfTargets);
             final String contig = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceName();
             final int contigLength = TargetsToolsTestUtils.REFERENCE_DICTIONARY.getSequence(0).getSequenceLength();
-            final float avgSlotSize = contigLength / numberOfTargets;
+            final float avgSlotSize = (float) contigLength / numberOfTargets;
 
             int nextBasePos = 0;
             for (int i = 0; i < numberOfTargets; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - Math operands should be cast before assignment

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2184

Please let me know if you have any questions.

M-Ezzat