### PR TITLE
check containsVertex faster and added tests to 100%

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
@@ -122,9 +122,7 @@ public final class Path<T extends BaseVertex, E extends BaseEdge> {
      */
     public boolean containsVertex(final T v) {
         Utils.nonNull(v, "Vertex cannot be null");
-
-        // TODO -- warning this is expensive.  Need to do vertex caching
-        return getVertices().contains(v);
+        return v.equals(getFirstVertex()) || edgesInOrder.stream().map(graph::getEdgeTarget).anyMatch(v::equals);
     }
 
     @Override
@@ -142,30 +140,21 @@ public final class Path<T extends BaseVertex, E extends BaseEdge> {
     }
 
     /**
-     * Get the edges of this path in order
+     * Get the edges of this path in order.
+     * Returns an unmodifiable view of the underlying list
      * @return a non-null list of edges
      */
-    public Collection<E> getEdges() { return edgesInOrder; }
+    public List<E> getEdges() { return Collections.unmodifiableList(edgesInOrder); }
 
     /**
      * Get the list of vertices in this path in order defined by the edges of the path
      * @return a non-null, non-empty list of vertices
      */
     public List<T> getVertices() {
-        if ( getEdges().isEmpty() ) {
-            return Collections.singletonList(lastVertex);
-        } else {
-            final LinkedList<T> vertices = new LinkedList<>();
-            boolean first = true;
-            for ( final E e : getEdges() ) {
-                if ( first ) {
-                    vertices.add(graph.getEdgeSource(e));
-                    first = false;
-                }
-                vertices.add(graph.getEdgeTarget(e));
-            }
-            return vertices;
-        }
+        final List<T> result = new ArrayList<>(edgesInOrder.size()+1);
+        result.add(getFirstVertex());
+        result.addAll(edgesInOrder.stream().map(graph::getEdgeTarget).collect(Collectors.toList()));
+        return result;
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/PathUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/PathUnitTest.java
@@ -1,10 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import htsjdk.samtools.Cigar;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseEdge;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.Path;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqVertex;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -23,6 +19,61 @@ public final class PathUnitTest extends BaseTest {
         Assert.assertNull(cigar, "Should have failed gracefully");
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPath() throws Exception {
+        final SeqGraph g = new SeqGraph(3);
+        final SeqVertex v1 = new SeqVertex("a");
+        new Path<>(v1, g);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPath2() throws Exception {
+
+        final SeqGraph g = new SeqGraph(3);
+        final SeqVertex v2 = new SeqVertex("b");
+        g.addVertex(v2);
+        final Path<SeqVertex,BaseEdge> path = new Path<>(v2, g);
+
+        final SeqGraph g2 = new SeqGraph(3);
+        final SeqVertex v3_2 = new SeqVertex("c2");
+        final SeqVertex v4_2 = new SeqVertex("d2");
+        g2.addVertex(v3_2);   //source
+        g2.addVertex(v4_2);
+        final BaseEdge e34_2 = g2.addEdge(v3_2, v4_2);
+
+        new Path<>(path, e34_2);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPath3() throws Exception {
+
+        final SeqGraph g = new SeqGraph(3);
+        final SeqVertex v2 = new SeqVertex("b");
+        g.addVertex(v2);
+        final Path<SeqVertex,BaseEdge> path = new Path<>(v2, g);
+
+        final SeqGraph g2 = new SeqGraph(3);
+        final SeqVertex v3_2 = new SeqVertex("c2");
+        final SeqVertex v4_2 = new SeqVertex("d2");
+        g2.addVertex(v3_2);   //source
+        g2.addVertex(v4_2);
+        final BaseEdge e34_2 = g2.addEdge(v3_2, v4_2);
+
+        new Path<>(e34_2, path);
+    }
+
+    @Test
+    public void testPathWithNoEdgesContains1Node() throws Exception {
+        final SeqGraph g = new SeqGraph(3);
+        final SeqVertex v1 = new SeqVertex("a");
+        final SeqVertex v2 = new SeqVertex("b");
+        g.addVertex(v1);   //source
+        g.addVertex(v2);
+        final Path<SeqVertex,BaseEdge> path = new Path<>(v2, g);
+        Assert.assertFalse(path.containsVertex(v1));
+        Assert.assertTrue(path.containsVertex(v2));
+    }
+
     @Test
     public void testMakePath() {
         final SeqGraph g = new SeqGraph(3);
@@ -35,16 +86,41 @@ public final class PathUnitTest extends BaseTest {
         g.addVertex(v3);
         g.addVertex(v4);  //sink
         final BaseEdge e1 = g.addEdge(v1, v2);
+
+        e1.incMultiplicity(1);
+
         final BaseEdge e2 = g.addEdge(v2, v3);
         g.addEdge(v3, v4);
         final Path<SeqVertex,BaseEdge> path = new Path<>(v2, g);
         final Path<SeqVertex,BaseEdge> path1 = new Path<>(path, e2);
         final Path<SeqVertex,BaseEdge> path2 = new Path<>(e1, path1);
+
+        //path = v2
+        //path1 = v2 -> v3
+        //path2 = v1 -> v2 -> v3
         Assert.assertEquals(path.length(), 0);
         Assert.assertEquals(path1.length(), 1);
         Assert.assertEquals(path2.length(), 2);
 
+        Assert.assertEquals(path.getScore(), 0);
+        Assert.assertEquals(path1.getScore(), 1);
+        Assert.assertEquals(path2.getScore(), 3); //score is not the same as length - uses multiplicity
+
         Assert.assertTrue(path2.containsVertex(v1));
+        Assert.assertTrue(path2.containsVertex(v2));
+        Assert.assertTrue(path2.containsVertex(v3));
+        Assert.assertFalse(path2.containsVertex(v4));
+
+        Assert.assertFalse(path1.containsVertex(v1));
+        Assert.assertTrue(path1.containsVertex(v2));
+        Assert.assertTrue(path1.containsVertex(v3));
+        Assert.assertFalse(path1.containsVertex(v4));
+
+        Assert.assertFalse(path.containsVertex(v1));
+        Assert.assertTrue(path.containsVertex(v2));
+        Assert.assertFalse(path.containsVertex(v3));
+        Assert.assertFalse(path.containsVertex(v4));
+
         Assert.assertFalse(path2.pathsAreTheSame(path1));
         Assert.assertTrue(path1.pathsAreTheSame(path1));
         path2.toString();//just test not blowing up - we dont' make any claims about the toString code


### PR DESCRIPTION
This came up during profiling - containsVertex was creating full lists for vertices all the time only to check membership. Using a scan now (no caching but that's possible too if needed later)

Tests for Path at 100% now.

@lbergelson can you review?