### PR TITLE
findNumberOfRepetitions makes fewer useless arrays

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -474,4 +474,36 @@ public final class UtilsUnitTest extends BaseTest {
                 {"romeo+juliette" , "01111010111001" },
         };
     }
+
+    @DataProvider(name = "testEqualRange")
+    public Object[][] testEqualRange(){
+        final Object[][] result = {
+            {"ATGATGATGATG".getBytes(), 0, 3, "ATG".getBytes(), true},
+            {"ATGATGATGATG".getBytes(), 3, 6, "ATG".getBytes(), true},
+            {"ATGATGATGATG".getBytes(), 9, 12, "ATG".getBytes(), true},
+
+            {"ATGATGATGATG".getBytes(), 0, 1, "G".getBytes(), false},
+            {"ATGATGATCATG".getBytes(), 0, 2, "AT".getBytes(), true},
+            {"ATGATGATCATG".getBytes(), 2, 4, "AT".getBytes(), false},
+
+            {"T".getBytes(), 0, 1, "T".getBytes(), true},
+
+            {"CCCCCCCC".getBytes(), 0, 3, "CCC".getBytes(), true},
+            {"CCCCCCCC".getBytes(), 5, 8, "CCC".getBytes(), true},
+
+            {"GATAT".getBytes(), 3, 5, "AT".getBytes(), true},
+            {"GATAT".getBytes(), 1, 3, "AT".getBytes(), true},
+
+            {"ATGATGATGATG".getBytes(), 11, 12, "G".getBytes(), true},
+            {"ATGATGATGATG".getBytes(), 10, 11, "G".getBytes(), false},
+            {"ATGATGATCATG".getBytes(), 10, 12, "AT".getBytes(), false},
+        };
+        return result;
+    }
+
+    @Test(dataProvider = "testEqualRange")
+    public void testEqualRange(byte[] arr1, int from, int to, byte[] arr2, boolean expected) throws Exception {
+        //Note 'from' is inclusive, 'to' is exclusive
+        Assert.assertEquals(Utils.equalRange(arr1, from, arr2, 0, to - from), expected);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -773,6 +773,43 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
     }
 
     @Test
+    public void testFindNumberOfRepetitions() throws Exception {
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("ATG".getBytes(), "ATGATGATGATG".getBytes(), true),4);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("G".getBytes(), "ATGATGATGATG".getBytes(), true),0);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("T".getBytes(), "T".getBytes(), true),1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "ATGATGATCATG".getBytes(), true),1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("CCC".getBytes(), "CCCCCCCC".getBytes(), true),2);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("CCCCCCCC".getBytes(), "CCC".getBytes(), true),0);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "AT".getBytes(), true), 1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "".getBytes(), true), 0); //empty test string
+
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "GATAT".getBytes(), false), 2);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("ATG".getBytes(), "ATGATGATGATG".getBytes(), false),4);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("G".getBytes(), "ATGATGATGATG".getBytes(), false),1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("T".getBytes(), "T".getBytes(), false),1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "ATGATGATCATG".getBytes(), false),0);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("CCC".getBytes(), "CCCCCCCC".getBytes(), false),2);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("CCCCCCCC".getBytes(), "CCC".getBytes(), false),0);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "AT".getBytes(), false), 1);
+        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "".getBytes(), false), 0); //empty test string
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testFindNumberOfRepetitionsNullArg1() throws Exception {
+        GATKVariantContextUtils.findNumberOfRepetitions(null, "AT".getBytes(), false);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testFindNumberOfRepetitionsNullArg2() throws Exception {
+        GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), null, false);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testFindNumberOfRepetitionsEmptyArg1() throws Exception {
+        GATKVariantContextUtils.findNumberOfRepetitions("".getBytes(), "AT".getBytes(), false);
+    }
+
+    @Test
     public void testRepeatAllele() {
         Allele nullR = Allele.create("A", true);
         Allele nullA = Allele.create("A", false);
@@ -794,12 +831,6 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
 
         Pair<List<Integer>,byte[]> result;
         byte[] refBytes = "TATCATCATCGGA".getBytes();
-
-        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("ATG".getBytes(), "ATGATGATGATG".getBytes(), true),4);
-        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("G".getBytes(), "ATGATGATGATG".getBytes(), true),0);
-        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("T".getBytes(), "T".getBytes(), true),1);
-        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("AT".getBytes(), "ATGATGATCATG".getBytes(), true),1);
-        Assert.assertEquals(GATKVariantContextUtils.findNumberOfRepetitions("CCC".getBytes(), "CCCCCCCC".getBytes(), true),2);
 
         Assert.assertEquals(GATKVariantContextUtils.findRepeatedSubstring("ATG".getBytes()),3);
         Assert.assertEquals(GATKVariantContextUtils.findRepeatedSubstring("AAA".getBytes()),1);


### PR DESCRIPTION
Came in in profiling - findNumberOfRepetitions was creating lots of byte arrays that were discarded right away after comparing of a small range. This PR makes the comparison work on arrays directly.

@lbergelson can you have a look?