### PR TITLE
making BQSR table input parameter names constants

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -39,4 +39,7 @@ public final class StandardArgumentDefinitions {
     public static final String USE_ORIGINAL_QUALITIES_SHORT_NAME = "OQ";
 
     public static final String SPARK_PROPERTY_NAME = "conf";
+
+    public static final String BQSR_TABLE_SHORT_NAME = "bqsr";
+    public static final String BQSR_TABLE_LONG_NAME = "bqsr_recal_file";
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools;
 import org.broadinstitute.hellbender.cmdline.Advanced;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ public class ApplyBQSRUniqueArgumentCollection implements ArgumentCollectionDefi
      * The two types of binning should not be used together.
      */
     @Advanced
-    @Argument(fullName="static_quantized_quals", shortName = "SQQ", doc = "Use static quantized quality scores to a given number of levels (with -BQSR)", optional=true, mutex = "quantize_quals")
+    @Argument(fullName="static_quantized_quals", shortName = "SQQ", doc = "Use static quantized quality scores to a given number of levels (with -"+ StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME+ ")", optional=true, mutex = "quantize_quals")
     public List<Integer> staticQuantizationQuals = new ArrayList<>();
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
@@ -34,7 +34,7 @@ public final class ApplyBQSRSpark extends GATKSparkTool {
      * The covariates tables are produced by the BaseRecalibrator tool.
      * Please be aware that you should only run recalibration with the covariates file created on the same input bam(s).
      */
-    @Argument(fullName="bqsr_recal_file", shortName="bqsr", doc="Input covariates table file for base quality score recalibration")
+    @Argument(fullName= StandardArgumentDefinitions.BQSR_TABLE_LONG_NAME, shortName= StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME, doc="Input covariates table file for base quality score recalibration")
     private String bqsrRecalFile;
 
     @ArgumentCollection

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.recalibration.RecalUtils;
@@ -43,7 +44,7 @@ import java.util.Optional;
  *         <td>Second pass recalibration tables
  *             results from the application of {@link org.broadinstitute.hellbender.transformers.BQSRReadTransformer}
  *             on the alignment recalibrated using the first pass tables</td></tr>
- *       <tr><td>Input</td><td>-BQSR</td><td>BQSR</td><td style="color: #000000">Black</td>
+ *       <tr><td>Input</td><td>-bqsr</td><td>BQSR</td><td style="color: #000000">Black</td>
  *           <td>Any recalibration table without a specific role</td></tr>
  *     </tbody>
  * </table>
@@ -82,7 +83,7 @@ import java.util.Optional;
  * java -jar GenomeAnalysisTK.jar \
  *      -T AnalyzeCovariates \
  *      -R myrefernce.fasta \
- *      -BQSR myrecal.table \
+ *      -bqsr myrecal.table \
  *      -plots BQSR.pdf
  * </pre>
  *
@@ -108,7 +109,7 @@ import java.util.Optional;
  *      -T AnalyzeCovariates \
  *      -R myrefernce.fasta \
  *      -ignoreLMT \
- *      -BQSR recal1.table \   # you can discard any two
+ *      -bqsr recal1.table \   # you can discard any two
  *      -before recal2.table \
  *      -after recal3.table \
  *      -plots myrecals.pdf
@@ -130,7 +131,7 @@ import java.util.Optional;
  * # Generate the second pass recalibration table file.
  * java -jar GenomeAnalysisTK.jar \
  *      -T BaseRecalibrator \
- *      -BQSR firstpass.table \
+ *      -bqsr firstpass.table \
  *      -R myreference.fasta \
  *      -I myinput.bam \
  *      -knownSites bundle/my-trusted-snps.vcf \
@@ -200,7 +201,7 @@ public final class AnalyzeCovariates extends CommandLineProgram {
      * (see Best Practices workflow documentation). The covariates tables are produced by the BaseRecalibrator tool.
      * Please be aware that you should only run recalibration with the covariates file created on the same input bam(s).
      */
-    @Argument(fullName="bqsr_recal_table", shortName="bqsr", optional=true, doc="Input covariates table file for on-the-fly base quality score recalibration")
+    @Argument(fullName= StandardArgumentDefinitions.BQSR_TABLE_LONG_NAME, shortName=StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME, optional=true, doc="Input covariates table file for on-the-fly base quality score recalibration")
     public File BQSR_RECAL_FILE = null;
 
     /**
@@ -218,7 +219,8 @@ public final class AnalyzeCovariates extends CommandLineProgram {
         checkInputReportFile("after",afterFile);
         if (BQSR_RECAL_FILE == null && beforeFile == null && afterFile == null) {
             throw new UserException("you must provide at least one recalibration report file "
-                    + "(arguments -BQSR, -" + BEFORE_ARG_SHORT_NAME + " or -" + AFTER_ARG_SHORT_NAME);
+                    + "(arguments -" + StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME +
+                    ", -" + BEFORE_ARG_SHORT_NAME + " or -" + AFTER_ARG_SHORT_NAME);
         }
 
         checkOutputFile(PDF_ARG_SHORT_NAME,pdfFile);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
@@ -36,7 +36,7 @@ public final class ApplyBQSR extends ReadWalker{
      * The covariates tables are produced by the BaseRecalibrator tool.
      * Please be aware that you should only run recalibration with the covariates file created on the same input bam(s).
      */
-    @Argument(fullName="bqsr_recal_file", shortName="bqsr", doc="Input covariates table file for base quality score recalibration")
+    @Argument(fullName=StandardArgumentDefinitions.BQSR_TABLE_LONG_NAME, shortName=StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME, doc="Input covariates table file for base quality score recalibration")
     public File BQSR_RECAL_FILE;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.recalibration;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.baq.BAQ;
 import org.broadinstitute.hellbender.utils.commandline.HiddenOption;
@@ -73,7 +74,7 @@ public final class RecalibrationArgumentCollection implements ArgumentCollection
     public byte LOW_QUAL_TAIL = 2;
 
     /**
-     * BQSR generates a quantization table for quick quantization later by subsequent tools. BQSR does not quantize the base qualities, this is done by the engine with the -qq or -BQSR options.
+     * BQSR generates a quantization table for quick quantization later by subsequent tools. BQSR does not quantize the base qualities, this is done by the engine with the -qq or -bqsr options.
      * This parameter tells BQSR the number of levels of quantization to use to build the quantization table.
      */
     @Argument(fullName = "quantizing_levels", shortName = "ql", optional = true, doc = "number of distinct quality scores in the quantized output")
@@ -95,7 +96,7 @@ public final class RecalibrationArgumentCollection implements ArgumentCollection
      * but when you select a subset of these reads based on their ability to align to the reference and their dinucleotide effect,
      * your Q2 bin can be elevated to Q8 or Q10, leading to issues downstream.
      */
-    @Argument(fullName = "preserve_qscores_less_than", shortName = "preserveQ", doc = "Don't recalibrate bases with quality scores less than this threshold (with -BQSR)", optional = true)
+    @Argument(fullName = "preserve_qscores_less_than", shortName = "preserveQ", doc = "Don't recalibrate bases with quality scores less than this threshold (with -" + StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME + ")", optional = true)
     public int PRESERVE_QSCORES_LESS_THAN = QualityUtils.MIN_USABLE_Q_SCORE;
 
 


### PR DESCRIPTION
making constants BQSR_TABLE_LONG_NAME and BQSR_TABLE_SHORT_NAME in StandardArgumentDefinitions
fixing outdated references to -BQSR -> -bqsr in documentation and error messages
fixes #1631