### PR TITLE
remove BAQ - provide an option to skip BAQ

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/baq/BAQ.java
@@ -396,7 +396,7 @@ public final class BAQ implements Serializable {
         // Offset to base alignment quality (BAQ), of the same length as the read sequence.
         // At the i-th read base, BAQi = Qi - (BQi - 64) where Qi is the i-th base quality.
         // so BQi = Qi - BAQi + 64
-        byte[] bqTag = new byte[baq.length];
+        final byte[] bqTag = new byte[baq.length];
         final byte[] baseQualities = read.getBaseQualities();
         for ( int i = 0; i < bqTag.length; i++) {
             final int bq = (int) baseQualities[i] + 64;
@@ -416,7 +416,6 @@ public final class BAQ implements Serializable {
     public static void addBAQTag(GATKRead read, byte[] baq) {
         read.setAttribute(BAQ_TAG, encodeBQTag(read, baq));
     }
-
 
     /**
       * Returns true if the read has a BAQ tag, or false otherwise

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.recalibration;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+import org.broadinstitute.hellbender.cmdline.Hidden;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.baq.BAQ;
@@ -99,6 +100,9 @@ public final class RecalibrationArgumentCollection implements ArgumentCollection
     @Argument(fullName = "preserve_qscores_less_than", shortName = "preserveQ", doc = "Don't recalibrate bases with quality scores less than this threshold (with -" + StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME + ")", optional = true)
     public int PRESERVE_QSCORES_LESS_THAN = QualityUtils.MIN_USABLE_Q_SCORE;
 
+    @Hidden
+    @Argument(fullName = "skipBAQ", shortName = "skipBAQ", doc = "don't do BAQ correction")
+    public boolean skipBAQ = false;
 
     // --------------------------------------------------------------------------------------------------------------
     //


### PR DESCRIPTION
this PR adds a hidden option to skip BAQ. This is used in the ongoing investigation of BAQ removal in https://github.com/broadinstitute/gatk/issues/1557

@droazen have a look. I could add a test but the recal table would need to be taken on faith.