### PR TITLE
removing beta from our gcloud dataproc script

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -183,7 +183,7 @@ def runGATK(sparkRunner, dryrun, gatkArgs, sparkArgs):
 
         sys.stderr.write("\nReplacing spark-submit style args with dataproc style args\n\n" + " ".join(sparkArgs) +" -> " + " ".join(dataprocargs) +"\n" )
 
-        cmd = [ "gcloud", "beta", "dataproc", "jobs", "submit", "spark"] \
+        cmd = [ "gcloud", "dataproc", "jobs", "submit", "spark"] \
               + dataprocargs \
               + ["--jar", jarPath] \
               + gatkArgs + ["--sparkMaster", "yarn-client"]


### PR DESCRIPTION
dataproc is no longer beta, so this is not needed anymore