### PR TITLE
add substring search to smith-waterman and new tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -900,4 +900,28 @@ public final class Utils {
     public static boolean xor(final boolean x, final boolean y) {
         return x != y;
     }
+
+    /**
+     * Find the last occurrence of the query sequence in the reference sequence
+     *
+     * Returns the index of the last occurrence or -1 if the query sequence is not found
+     *
+     * @param reference the reference sequence
+     * @param query the query sequence
+     */
+    public static int lastIndexOf(final byte[] reference, final byte[] query) {
+        int queryLength = query.length;
+
+        // start search from the last possible matching position and search to the left
+        for (int r = reference.length - queryLength; r >= 0; r--) {
+            int q = 0;
+            while (q < queryLength && reference[r+q] == query[q]) {
+                q++;
+            }
+            if (q == queryLength) {
+                return r;
+            }
+        }
+        return -1;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SWPairwiseAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SWPairwiseAlignment.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 
 import java.util.ArrayList;
@@ -172,16 +173,33 @@ public final class SWPairwiseAlignment {
         if ( reference == null || reference.length == 0 || alternate == null || alternate.length == 0 )
             throw new IllegalArgumentException("Non-null, non-empty sequences are required for the Smith-Waterman calculation");
 
-        final int n = reference.length+1;
-        final int m = alternate.length+1;
-        final int[][] sw = new int[n][m];
-        if ( keepScoringMatrix ) {
-            SW = sw;
+        // avoid running full Smith-Waterman if there is an exact match of alternate in reference
+        int matchIndex = -1;
+        if (overhangStrategy == OverhangStrategy.SOFTCLIP || overhangStrategy == OverhangStrategy.IGNORE) {
+            // Use a substring search to find an exact match of the alternate in the reference
+            // NOTE: This approach only works for SOFTCLIP and IGNORE overhang strategies
+            matchIndex = Utils.lastIndexOf(reference, alternate);
         }
-        final int[][] btrack=new int[n][m];
 
-        calculateMatrix(reference, alternate, sw, btrack);
-        alignmentResult = calculateCigar(sw, btrack, overhangStrategy); // length of the segment (continuous matches, insertions or deletions)
+        if (matchIndex != -1) {
+            // generate the alignment result when the substring search was successful
+            final List<CigarElement> lce = new ArrayList<>(alternate.length);
+            lce.add(makeElement(State.MATCH, alternate.length));
+            alignmentResult = new SWPairwiseAlignmentResult(AlignmentUtils.consolidateCigar(new Cigar(lce)), matchIndex);
+        }
+        else {
+            // run full Smith-Waterman
+            final int n = reference.length+1;
+            final int m = alternate.length+1;
+            final int[][] sw = new int[n][m];
+            if ( keepScoringMatrix ) {
+                SW = sw;
+            }
+            final int[][] btrack=new int[n][m];
+
+            calculateMatrix(reference, alternate, sw, btrack);
+            alignmentResult = calculateCigar(sw, btrack, overhangStrategy); // length of the segment (continuous matches, insertions or deletions)
+        }
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -532,4 +532,66 @@ public final class UtilsUnitTest extends BaseTest {
         //Note 'from' is inclusive, 'to' is exclusive
         Assert.assertEquals(Utils.equalRange(arr1, from, arr2, 0, to - from), expected);
     }
+
+    @Test
+    public void testLastIndexOfQueryTooLong() {
+        final String reference = "AAAA";
+        final String query     = "AAAAAAA";
+
+        final int result = Utils.lastIndexOf(reference.getBytes(), query.getBytes());
+        final int expected = reference.lastIndexOf(query);
+        Assert.assertEquals(result, expected);
+    }
+
+    @Test
+    public void testLastIndexOfLastBoundaries() {
+        final String reference = "AAAACCCCTTTTGGGG";
+
+        // match right boundary of reference
+        String query = "TGGGG";
+        int result = Utils.lastIndexOf(reference.getBytes(), query.getBytes());
+        int expected = reference.lastIndexOf(query);
+        Assert.assertEquals(result, expected);
+
+        // match left boundary of reference
+        query = "AAAAC";
+        result = Utils.lastIndexOf(reference.getBytes(), query.getBytes());
+        expected = reference.lastIndexOf(query);
+        Assert.assertEquals(result, expected);
+    }
+
+    private void randomByteString(Random rng, byte[] bytes) {
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte)(rng.nextInt(94) + 32);
+        }
+    }
+
+    @Test
+    public void testLastIndexOfRandom() {
+        final int num_tests = 100;
+        final int referenceLength = 1000;
+        final int queryLength = 100;
+        
+        byte [] reference = new byte[referenceLength];
+        byte [] query = new byte[queryLength];
+
+        final Random rng = Utils.getRandomGenerator();
+        
+        for (int i = 0; i < num_tests; i++) {
+            randomByteString(rng, reference);
+            randomByteString(rng, query);
+
+            // add query to reference at a random location for 75% of the tests
+            if (i % 4 > 0) {
+                final int index = rng.nextInt(referenceLength - queryLength);
+                for (int j = 0; j < queryLength; j++) {
+                    reference[index+j] = query[j];
+                }
+            }
+            
+            final int result = Utils.lastIndexOf(reference, query);
+            final int expected = new String(reference).lastIndexOf(new String(query));
+            Assert.assertEquals(result, expected);
+        }
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/smithwaterman/SWPairwiseAlignmentUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/smithwaterman/SWPairwiseAlignmentUnitTest.java
@@ -117,4 +117,119 @@ public final class SWPairwiseAlignmentUnitTest extends BaseTest {
         }
     }
 
+    @Test(enabled = true)
+    public void testSubstringMatchSoftclip() {
+        final String match     = "CCCCC";
+        final String reference = "AAA" + match;
+        final String read      = match;
+        final int expectedStart = 3;
+        final String expectedCigar = "5M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.SOFTCLIP);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchIndel() {
+        final String match     = "CCCCC";
+        final String reference = "AAA" + match;
+        final String read      = match;
+        final int expectedStart = 0;
+        final String expectedCigar = "3D5M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.INDEL);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchLeadingIndel() {
+        final String match     = "CCCCC";
+        final String reference = "AAA" + match;
+        final String read      = match;
+        final int expectedStart = 0;
+        final String expectedCigar = "3D5M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.LEADING_INDEL);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchIgnore() {
+        final String match     = "CCCCC";
+        final String reference = "AAA" + match;
+        final String read      = match;
+        final int expectedStart = 3;
+        final String expectedCigar = "5M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.IGNORE);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchSoftclipLong() {
+        final String reference = "ATAGAAAATAGTTTTTGGAAATATGGGTGAAGAGACATCTCCTCTTATGGAAAAAGGGATTCTAGAATTTAACAATAAATATTCCCAACTTTCCCCAAGGCTTTAAAATCTACCTTGAAGGAGCAGCTGATGTATTTCTAGAACAGACTTAGGTGTCTTGGTGTGGCCTGTAAAGAGATACTGTCTTTCTCTTTTGAGTGTAAGAGAGAAAGGACAGTCTACTCAATAAAGAGTGCTGGGAAAACTGAATATCCACACACAGAATAATAAAACTAGATCCTATCTCTCACCATATACAAAGATCAACTCAAAACAAATTAAAGACCTAAATGTAAGACAAGAAATTATAAAACTACTAGAAAAAAACACAAGGGAAATGCTTCAGGACATTGGC";
+        final String read      = "AAAAAAA";
+        final int expectedStart = 359;
+        final String expectedCigar = "7M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.SOFTCLIP);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchIndelLong() {
+        final String reference = "ATAGAAAATAGTTTTTGGAAATATGGGTGAAGAGACATCTCCTCTTATGGAAAAAGGGATTCTAGAATTTAACAATAAATATTCCCAACTTTCCCCAAGGCTTTAAAATCTACCTTGAAGGAGCAGCTGATGTATTTCTAGAACAGACTTAGGTGTCTTGGTGTGGCCTGTAAAGAGATACTGTCTTTCTCTTTTGAGTGTAAGAGAGAAAGGACAGTCTACTCAATAAAGAGTGCTGGGAAAACTGAATATCCACACACAGAATAATAAAACTAGATCCTATCTCTCACCATATACAAAGATCAACTCAAAACAAATTAAAGACCTAAATGTAAGACAAGAAATTATAAAACTACTAGAAAAAAACACAAGGGAAATGCTTCAGGACATTGGC";
+        final String read      = "AAAAAAA";
+        final int expectedStart = 0;
+        final String expectedCigar = "1M358D6M29D";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.INDEL);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchLeadingIndelLong() {
+        final String reference = "ATAGAAAATAGTTTTTGGAAATATGGGTGAAGAGACATCTCCTCTTATGGAAAAAGGGATTCTAGAATTTAACAATAAATATTCCCAACTTTCCCCAAGGCTTTAAAATCTACCTTGAAGGAGCAGCTGATGTATTTCTAGAACAGACTTAGGTGTCTTGGTGTGGCCTGTAAAGAGATACTGTCTTTCTCTTTTGAGTGTAAGAGAGAAAGGACAGTCTACTCAATAAAGAGTGCTGGGAAAACTGAATATCCACACACAGAATAATAAAACTAGATCCTATCTCTCACCATATACAAAGATCAACTCAAAACAAATTAAAGACCTAAATGTAAGACAAGAAATTATAAAACTACTAGAAAAAAACACAAGGGAAATGCTTCAGGACATTGGC";
+        final String read      = "AAAAAAA";
+        final int expectedStart = 0;
+        final String expectedCigar = "1M1D6M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.LEADING_INDEL);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
+
+    @Test(enabled = true)
+    public void testSubstringMatchLeadingIgnoreLong() {
+        final String reference = "ATAGAAAATAGTTTTTGGAAATATGGGTGAAGAGACATCTCCTCTTATGGAAAAAGGGATTCTAGAATTTAACAATAAATATTCCCAACTTTCCCCAAGGCTTTAAAATCTACCTTGAAGGAGCAGCTGATGTATTTCTAGAACAGACTTAGGTGTCTTGGTGTGGCCTGTAAAGAGATACTGTCTTTCTCTTTTGAGTGTAAGAGAGAAAGGACAGTCTACTCAATAAAGAGTGCTGGGAAAACTGAATATCCACACACAGAATAATAAAACTAGATCCTATCTCTCACCATATACAAAGATCAACTCAAAACAAATTAAAGACCTAAATGTAAGACAAGAAATTATAAAACTACTAGAAAAAAACACAAGGGAAATGCTTCAGGACATTGGC";
+        final String read      = "AAAAAAA";
+        final int expectedStart = 359;
+        final String expectedCigar = "7M";
+        final SWPairwiseAlignment sw = new SWPairwiseAlignment(reference.getBytes(), read.getBytes(),
+                                                               SWPairwiseAlignment.ORIGINAL_DEFAULT,
+                                                               SWPairwiseAlignment.OverhangStrategy.IGNORE);
+        sw.printAlignment(reference.getBytes(), read.getBytes());
+        Assert.assertEquals(sw.getAlignmentStart2wrt1(), expectedStart);
+        Assert.assertEquals(sw.getCigar().toString(), expectedCigar);
+    }
 }


### PR DESCRIPTION
#1629 @akiezun @droazen @lbergelson
Added a substring search to `SWPairwiseAlignment.align `to avoid running the full Smith-Waterman when the query is found in the reference without any indels. The performance benefit of this code will be data dependent. In the current HaplotypeCaller test, >80% of the Smith-Waterman calls are filtered by the substring search.

Added tests to cover all of the overhang strategies.

**Note:** The substring search only works for the `SOFTCLIP `and `IGNORE `overhang strategies. The `INDEL `and `LEADING_INDEL `can result in more complicated CIGAR strings. See the `SWPairwiseAlignmentUnitTest.testSubstringMatchIndelLong` and `SWPairwiseAlignmentUnitTest.testSubstringMatchLeadingIndelLong` tests for examples.