### PR TITLE
fixed comments about low weight pruning

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -376,7 +376,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
         for( final E edge : edgeSet() ) {
             final String edgeString =  String.format("\t%s -> %s ", getEdgeSource(edge).toString(), getEdgeTarget(edge).toString());
             final String edgeLabelString;
-            if (edge.getMultiplicity() > 0 && edge.getMultiplicity() <= pruneFactor){
+            if (edge.getMultiplicity() > 0 && edge.getMultiplicity() < pruneFactor){
                 edgeLabelString = String.format("[style=dotted,color=grey,label=\"%s\"];", edge.getDotLabel());
             } else {
                 edgeLabelString = String.format("[label=\"%s\"];", edge.getDotLabel());
@@ -433,7 +433,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     }
 
     /**
-     * Prune all chains from this graph where any edge in the path has multiplicity < pruneFactor
+     * Prune all chains from this graph where all edges in the path have multiplicity < pruneFactor
      *
      * @see LowWeightChainPruner for more information
      *

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/LowWeightChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/LowWeightChainPruner.java
@@ -5,11 +5,11 @@ import org.broadinstitute.hellbender.utils.Utils;
 import java.util.*;
 
 /**
- * Prune all chains from this graph where all edges in the path have multiplicity <= pruneFactor
+ * Prune all chains from this graph where all edges in the path have multiplicity < pruneFactor
  *
- * Unlike pruneGraph, this function will remove only linear chains in the graph where all edges have weight <= pruneFactor.
+ * Unlike pruneGraph, this function will remove only linear chains in the graph where all edges have weight < pruneFactor.
  *
- * For A -[1]> B -[1]> C -[1]> D would be removed with pruneFactor 1
+ * For A -[1]> B -[1]> C -[1]> D would be removed with pruneFactor 2
  * but A -[1]> B -[2]> C -[1]> D would not be because the linear chain includes an edge with weight >= 2
  *
  */
@@ -35,7 +35,7 @@ public final class LowWeightChainPruner<V extends BaseVertex, E extends BaseEdge
 
             for ( final Path<V,E> linearChain : getLinearChains(graph) ) {
                 if( mustBeKept(linearChain, pruneFactor) ) {
-                    // we must keep edges in any path that contains a reference edge or an edge with weight > pruneFactor
+                    // we must keep edges in any path that contains a reference edge or an edge with weight >= pruneFactor
                     edgesToKeep.addAll(linearChain.getEdges());
                 }
             }
@@ -50,8 +50,8 @@ public final class LowWeightChainPruner<V extends BaseVertex, E extends BaseEdge
     }
 
     /**
-     * Traverse the edges in the path and determine if any are either ref edges or have weight above or equal to
-     * the pruning factor and should therefore not be pruned away.
+     * Traverse the edges in the path and determine if any are either ref edges or have weight >= pruneFactor
+     * and should therefore not be pruned away.
      *
      * @param path the path in question
      * @param pruneFactor the integer pruning factor

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -461,7 +461,7 @@ public final class ReadThreadingAssembler {
     private AssemblyResult getAssemblyResult(final Haplotype refHaplotype, final int kmerSize, final ReadThreadingGraph rtgraph) {
         printDebugGraphTransform(rtgraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.0.raw_readthreading_graph.dot");
 
-        // go through and prune all of the chains where all edges have <= pruneFactor.  This must occur
+        // prune all of the chains where all edges have multiplicity < pruneFactor.  This must occur
         // before recoverDanglingTails in the graph, so that we don't spend a ton of time recovering
         // tails that we'll ultimately just trim away anyway, as the dangling tail edges have weight of 1
         rtgraph.pruneLowWeightChains(pruneFactor);


### PR DESCRIPTION
All comments are now consistent with actual behavior in `LowWeightChainPruner`.  No actual code was changed except for which parts of the graph are given dotted lines in the debugging output.  This change,  from `<=` to `<` is also to make everything consistent with `LowWeightChainPruner`.