### PR TITLE
packaging avx code during spark and shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,70 +97,6 @@ compileTestJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror','-Xdiags:verbose']
 }
 
-model {
-  components {
-    VectorLoglessPairHMM(NativeLibrarySpec) {
-      // set location of source files
-      sources.cpp.source {
-        srcDirs "src/main/cpp/VectorLoglessPairHMM"
-        include "*.cc"
-      }
-
-      binaries.withType(SharedLibraryBinarySpec) { binary ->
-        if (System.env.GATK_SKIP_NATIVE_BUILD.toString().toBoolean()) {
-          buildable = false
-          println("INFO: \$GATK_SKIP_NATIVE_BUILD is true, skipping native AVX PairHMM library build.")
-        } else if (!OperatingSystem.current().isLinux() && !OperatingSystem.current().isMacOsX()) {
-          buildable = false
-          println("WARNING: Building the native AVX PairHMM library is not supported on this OS.")
-        } else {
-          cppCompiler.args "-I", "${System.properties['java.home']}/../include"
-          cppCompiler.args "-mavx"
-          cppCompiler.args "-Wall"
-
-          // build with gcov options on Travis
-          if (System.env.CI.toString().toBoolean()) {
-            cppCompiler.args "-g"
-            cppCompiler.args "-O0"
-            cppCompiler.args "--coverage"
-            linker.args "--coverage"
-          } else {
-            cppCompiler.args "-O3"
-          }
-
-          if (OperatingSystem.current().isMacOsX()) {
-            cppCompiler.args "-I", "${System.properties['java.home']}/../include/Darwin"
-          } else {
-            cppCompiler.args "-I", "${System.properties['java.home']}/../include/linux"
-            linker.args "-static-libgcc"
-          }
-
-          task copySharedLib(type: Copy) {
-            from binary.sharedLibraryFile
-            into "$compileJava.destinationDir/lib"
-          }
-          
-          copySharedLib.dependsOn binary.tasks
-          jar.dependsOn copySharedLib
-        }
-      }
-
-      // skip static library build
-      binaries.withType(StaticLibraryBinarySpec) { binary ->
-        buildable = false
-      }
-    }
-  }
-
-  toolChains {
-    if (OperatingSystem.current().isMacOsX()) {
-      clang(Clang)
-    } else {
-      gcc(Gcc)
-    }
-  }
-}
-
 task gcovTestReport(type: Exec){
     dependsOn test
     group = "Reporting"
@@ -459,5 +395,72 @@ task installAll{  dependsOn installSpark, installDist }
 installDist.dependsOn downloadGsaLibFile, downloadIntelDeflater
 build.dependsOn installDist
 check.dependsOn installDist
+
+model {
+    components {
+        VectorLoglessPairHMM(NativeLibrarySpec) {
+            // set location of source files
+            sources.cpp.source {
+                srcDirs "src/main/cpp/VectorLoglessPairHMM"
+                include "*.cc"
+            }
+
+            binaries.withType(SharedLibraryBinarySpec) { binary ->
+                if (System.env.GATK_SKIP_NATIVE_BUILD.toString().toBoolean()) {
+                    buildable = false
+                    println("INFO: \$GATK_SKIP_NATIVE_BUILD is true, skipping native AVX PairHMM library build.")
+                } else if (!OperatingSystem.current().isLinux() && !OperatingSystem.current().isMacOsX()) {
+                    buildable = false
+                    println("WARNING: Building the native AVX PairHMM library is not supported on this OS.")
+                } else {
+                    cppCompiler.args "-I", "${System.properties['java.home']}/../include"
+                    cppCompiler.args "-mavx"
+                    cppCompiler.args "-Wall"
+
+                    // build with gcov options on Travis
+                    if (System.env.CI.toString().toBoolean()) {
+                        cppCompiler.args "-g"
+                        cppCompiler.args "-O0"
+                        cppCompiler.args "--coverage"
+                        linker.args "--coverage"
+                    } else {
+                        cppCompiler.args "-O3"
+                    }
+
+                    if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
+                        cppCompiler.args "-I", "${System.properties['java.home']}/../include/Darwin"
+                    } else {
+                        cppCompiler.args "-I", "${System.properties['java.home']}/../include/linux"
+                        linker.args "-static-libgcc"
+                    }
+
+                    task copySharedLib(type: Copy) {
+                        from binary.sharedLibraryFile
+                        into "$compileJava.destinationDir/lib"
+                        dependsOn binary.tasks
+                    }
+
+                    jar.dependsOn copySharedLib
+                    shadowJar.dependsOn copySharedLib
+                    sparkJar.dependsOn copySharedLib
+                    test.dependsOn copySharedLib
+                }
+            }
+
+            // skip static library build
+            binaries.withType(StaticLibraryBinarySpec) { binary ->
+                buildable = false
+            }
+        }
+    }
+
+    toolChains {
+        if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
+            clang(Clang)
+        } else {
+            gcc(Gcc)
+        }
+    }
+}
 
 }


### PR DESCRIPTION
previously avx code was sometimes included if installDist had been run prior to running sparkJar, now sparkJar will always contain the native code
fixes #1576

also changing download of inteldeflator.so to only happen if it doesn't exist already