### PR TITLE
asynch IO back on

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ If you are looking for the codebase of the current production version of GATK, p
    JAVA_OPTS="-Dsamjdk.compression_level=5" ./gatk-launch <rest of command>
 ```
 
+* By default, GATK (non-spark) uses asynchronous IO for writing BAM files (using 1 compression thread per file), to improve speed. To change the default, run GATK like this:
+
+```
+   JAVA_OPTS="-Dsamjdk.use_async_io_samtools=false" ./gatk-launch <rest of command>
+```
+
 ##Testing GATK4
 
 * To run all tests, run **`gradle test`**.

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ import org.gradle.internal.os.OperatingSystem
 mainClassName = "org.broadinstitute.hellbender.Main"
 
 //Note: the test suite must use the same defaults. If you change system properties in this list you must also update the one in the test task
-applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io=false", "-Dsamjdk.intel_deflater_so_path=build/libIntelDeflater.so", "-Dsamjdk.compression_level=1"]
+applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_samtools=true", "-Dsamjdk.use_async_io_tribble=false", "-Dsamjdk.intel_deflater_so_path=build/libIntelDeflater.so", "-Dsamjdk.compression_level=1"]
 
 //Delete the windows script - we never test on Windows so let's not pretend it works
 startScripts {
@@ -223,7 +223,8 @@ test {
         }
     }
 
-    systemProperty "samjdk.use_async_io", "false"
+    systemProperty "samjdk.use_async_io_samtools", "true"
+    systemProperty "samjdk.use_async_io_tribble", "false"
     systemProperty "samjdk.intel_deflater_so_path", "build/libIntelDeflater.so"
     systemProperty "samjdk.compression_level", "1"
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -140,10 +140,13 @@ public abstract class CommandLineProgram {
                         " on " + System.getProperty("os.name") + " " + System.getProperty("os.version") +
                         " " + System.getProperty("os.arch") + "; " + System.getProperty("java.vm.name") +
                         " " + System.getProperty("java.runtime.version") +
-                        "; Version: " + commandLineParser.getVersion() +
-                        " " + (Defaults.USE_ASYNC_IO ? "asyncIO": "syncIO") +
-                        " " + "DefaultBAMCompressionLevel: " + Defaults.COMPRESSION_LEVEL +
-                        " " + (DeflaterFactory.usingIntelDeflater()? "IntelDeflater": "JdkDeflater"));
+                        "; Version: " + commandLineParser.getVersion());
+
+                Defaults.allDefaults().entrySet().stream().forEach(e->
+                        logger.info(Defaults.class.getSimpleName() + "." + e.getKey() + " : " + e.getValue())
+                );
+
+                logger.info("Deflater " + (DeflaterFactory.usingIntelDeflater()? "IntelDeflater": "JdkDeflater"));
             }
             catch (final Exception e) { /* Unpossible! */ }
         }


### PR DESCRIPTION
fixes #1653

ok, results are in, with asyncIO GATK4 out of the box beats GATK3 4.53x on PrintReads and 1.48x on BaseRecalibrator!

PrintReads
syncTribble, asyncSamtools, IntelDeflater: 1x baseline (this is the out-of-the box GATK4 config)
syncTribble,  syncSamtools, IntelDeflater:  1.32x baseline
syncTribble, asyncSamtools, JDKDeflater: 1.68x baseline 
syncTribble,  syncSamtools, JDKDeflater:  2.32x baseline

For comparison, GATK3 out of the box is 4.53x baseline on PrintReads


BaseRecalibrator
syncTribble, asyncSamtools, IntelDeflater: 1x baseline (this is the out-of-the box GATK4 config)
syncTribble,  syncSamtools, IntelDeflater:  1x baseline
asyncTribble, asyncSamtools, IntelDeflater:  2.14x baseline
syncTribble, asyncSamtools, JDKDeflater: 1.04x baseline
syncTribble,  syncSamtools, JDKDeflater:  1.03x baseline
asyncTribble, asyncSamtools, JDKDeflater: 2.12x baseline

For comparison, GATK3 out of the box is 1.48x baseline on BaseRecalibrator
