### PR TITLE
small cleanup in IntervalsSkipList and friends

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/ContextShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ContextShard.java
@@ -86,7 +86,7 @@ public class ContextShard implements Serializable {
     /**
      * Returns the variants that overlap the query interval, in start-position order.
      */
-    public ArrayList<GATKVariant> variantsOverlapping(SimpleInterval interval) {
+    public List<GATKVariant> variantsOverlapping(SimpleInterval interval) {
         return variants.getOverlapping(interval);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkOptimized.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkOptimized.java
@@ -155,7 +155,7 @@ public final class AddContextDataToReadSparkOptimized implements Serializable {
         ArrayList<ReadContextData> readContext = new ArrayList<>();
         for (GATKRead r : shard.reads) {
             SimpleInterval readInterval = new SimpleInterval(r);
-            ArrayList<GATKVariant> variantsOverlappingThisRead = shard.variantsOverlapping(readInterval);
+            List<GATKVariant> variantsOverlappingThisRead = shard.variantsOverlapping(readInterval);
             // we pass all the bases. That's better because this way it's just a shared
             // pointer instead of being an array copy. Downstream processing is fine with having
             // extra bases (it expects a few, actually).

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipList.java
@@ -4,9 +4,7 @@ import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.List;
+import java.util.*;
 
 /**
  * Holds many intervals in memory, with an efficient operation to get
@@ -17,7 +15,7 @@ import java.util.List;
 public final class IntervalsSkipList<T extends Locatable> implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final Hashtable<String, IntervalsSkipListOneContig<T>> intervals;
+    private final Map<String, IntervalsSkipListOneContig<T>> intervals;
 
     /**
      * Creates an IntervalsSkipList that holds a copy of the given intervals, sorted
@@ -25,20 +23,14 @@ public final class IntervalsSkipList<T extends Locatable> implements Serializabl
      *
      * @param loc Locatables, not necessarily sorted. Will be iterated over exactly once.
      */
-    public IntervalsSkipList(Iterable<T> loc) {
-        Hashtable<String,ArrayList<T>> variantsPerContig = new Hashtable<>();
-        for (T v : loc) {
-            String k = v.getContig();
-            ArrayList<T> l;
-            if (variantsPerContig.containsKey(k)) {
-                l = variantsPerContig.get(k);
-            } else {
-                l = new ArrayList<>();
-                variantsPerContig.put(k,l);
-            }
-            l.add(v);
+    public IntervalsSkipList(final Iterable<T> loc) {
+        final Map<String, List<T>> variantsPerContig = new HashMap<>();
+        for (final T v : loc) {
+            final String k = v.getContig();
+            variantsPerContig.putIfAbsent(k, new ArrayList<>());
+            variantsPerContig.get(k).add(v);
         }
-        intervals = new Hashtable<>();
+        intervals = new HashMap<>();
         for (String k : variantsPerContig.keySet()) {
             intervals.put(k, new IntervalsSkipListOneContig<>(variantsPerContig.get(k)));
         }
@@ -50,10 +42,13 @@ public final class IntervalsSkipList<T extends Locatable> implements Serializabl
      * hold, but of course if it isn't you'll get an empty result.
      * You may modify the returned list.
      */
-    public List<T> getOverlapping(SimpleInterval query) {
-        String k = query.getContig();
-        if (!intervals.containsKey(k)) return new ArrayList<>();
-        return intervals.get(k).getOverlapping(query);
+    public List<T> getOverlapping(final SimpleInterval query) {
+        final String k = query.getContig();
+        final IntervalsSkipListOneContig<T> result = intervals.get(k);
+        if (result == null){
+            return new ArrayList<>();
+        }
+        return result.getOverlapping(query);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipListOneContig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipListOneContig.java
@@ -1,14 +1,17 @@
 package org.broadinstitute.hellbender.utils.collections;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import htsjdk.samtools.util.Locatable;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Holds many intervals in memory, with an efficient operation to get
@@ -32,7 +35,8 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
     // reach: bucket# -> how far that bucket reaches.
     // e.g. bucket 0 contains the first 2**shift locatables. reach[0] is the max over their .getEnd()
     //      reach[x] is the max over the .getEnd for that bucket and all the ones before it.
-    private int[] reach;
+    private final int[] reach;
+    private final int reachLength;
 
     /**
      * Creates an IntervalsSkipList that holds a copy of the given intervals, sorted
@@ -40,8 +44,15 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
      *
      * @param loc Locatables, not necessarily sorted. Will be iterated over exactly once.
      */
-    public IntervalsSkipListOneContig(Iterable<T> loc) {
+    public IntervalsSkipListOneContig(final Iterable<T> loc) {
+        Utils.nonNull(loc);
         vs = Lists.newArrayList(loc);
+
+        final Set<String> contigs = vs.stream().map(l -> l.getContig()).collect(Collectors.toSet());
+        if (contigs.size() > 1){
+            throw new IllegalArgumentException("Only one contig expected but got " + contigs);
+        }
+
         if (vs.isEmpty()) {
             contig="";
         } else {
@@ -51,10 +62,15 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
         // heuristic: if we have too many small buckets then we're better off instead
         // taking fewer but bigger steps, and then iterating through a few values.
         // Thus, put a lower bound on bucket size.
-        if (bSize<32) bSize=32;
+        if (bSize < 32) {
+            bSize = 32;
+        }
         shift = floorLog2(bSize);
-        sortVariants();
-        buildIndexAndCheck();
+
+        vs.sort(Comparator.comparing(Locatable::getContig).thenComparingInt(Locatable::getStart).thenComparing(Locatable::getEnd));
+
+        reach = buildIndexAndCheck();
+        reachLength = reach.length;
     }
 
     /**
@@ -63,19 +79,20 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
      * hold, but of course if it isn't you'll get an empty result.
      * You may modify the returned list.
      */
-    public ArrayList<T> getOverlapping(SimpleInterval query) {
+    public List<T> getOverlapping(final SimpleInterval query) {
+        Utils.nonNull(query);
         if (!contig.equals(query.getContig())) {
             // different contig, so we know no one'll overlap.
-            return new ArrayList<T>();
+            return new ArrayList<>();
         }
-        ArrayList<T> ret = new ArrayList<T>();
+        final List<T> ret = new ArrayList<>();
         // use index to skip early non-overlapping entries.
         int idx = firstPotentiallyReaching(query.getStart());
         if (idx<0) {
             idx=0;
         }
         for (;idx<vs.size();idx++) {
-            T v = vs.get(idx);
+            final T v = vs.get(idx);
             // they are sorted by start location, so if this one starts too late
             // then all of the others will, too.
             if (v.getStart() > query.getEnd()) {
@@ -90,13 +107,14 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
 
     // returns all the intervals that overlap with the query.
     // (use the optimized version instead, unless you're testing it and need something to compare against)
-    protected ArrayList<T> getOverlappingIgnoringIndex(SimpleInterval query) {
+    @VisibleForTesting
+    List<T> getOverlappingIgnoringIndex(final SimpleInterval query) {
         if (!contig.equals(query.getContig())) {
           // different contig, so we know no one'll overlap.
-          return new ArrayList<T>();
+          return new ArrayList<>();
         }
-        ArrayList<T> ret = new ArrayList<T>();
-        for (T v : vs) {
+        final List<T> ret = new ArrayList<>();
+        for (final T v : vs) {
             // they are sorted by start location, so if this one starts too late
             // then all of the others will, too.
             if (v.getStart() > query.getEnd()) {
@@ -111,8 +129,8 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
 
     // returns an index into the vs array s.t. no entry before that index
     // reaches (or extends beyond) the given position.
-    private int firstPotentiallyReaching(int position) {
-        for (int i=0; i<reach.length; i++) {
+    private int firstPotentiallyReaching(final int position) {
+        for (int i=0; i<reachLength; i++) {
             if (reach[i]>=position) {
                 return i<<shift;
             }
@@ -121,33 +139,17 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
         return vs.size()-1;
     }
 
-    private void sortVariants() {
-        vs.sort(new Comparator<Locatable>() {
-            @Override
-            public int compare(Locatable o1, Locatable o2) {
-                if (o1.getContig().equals(o2.getContig())) {
-                    return Integer.compare(o1.getStart(), o2.getStart());
-                } else {
-                    return o1.getContig().compareTo(o2.getContig());
-                }
-            }
-        });
-    }
-
     // build index and check everyone's in the same contig
-    private void buildIndexAndCheck() {
+    private int[] buildIndexAndCheck() {
         int max = 0;
         int key = 0;
         int idx = 0;
-        // reach: bucket# -> how far that bucket reaches
-        reach = new int[(vs.size()>>shift)+1];
+        // result: bucket# -> how far that bucket reaches
+        final int[] result = new int[(vs.size()>>shift)+1];
         for (Locatable v : vs) {
-            if (!contig.equals(v.getContig())) {
-                throw new GATKException("All intervals in IntervalsSkipList should have the same contig, but found both '"+v.getContig()+"' and '"+contig+"'.");
-            }
             int k = idx>>shift;
             if (k>key) {
-                reach[key]=max;
+                result[key]=max;
                 key=k;
             }
             if (v.getEnd()>max) {
@@ -155,10 +157,11 @@ public final class IntervalsSkipListOneContig<T extends Locatable> implements Se
             }
             idx++;
         }
-        reach[key]=max;
+        result[key]=max;
+        return result;
     }
 
-    private static int floorLog2(int n){
+    private static int floorLog2(final int n){
         if (n <= 0) {
             throw new IllegalArgumentException();
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipListUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipListUnitTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class IntervalsSkipListUnitTest extends BaseTest {
+public final class IntervalsSkipListUnitTest extends BaseTest {
 
     @DataProvider(name="intervals")
     public Object[][] intervals(){


### PR DESCRIPTION
there was some not nice code in IntervalsSkipList (using Hashtables (sic! we had Hashtables in 2016), declaring things as ArrayList, verbose comparators etc). This is a small cleanup