### PR TITLE
Implemented SlidingWindowWalker

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowPaddingArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowPaddingArgumentCollection.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+/**
+ * Argument collection where the window padding is not exposed to the final user
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class DefaultWindowPaddingArgumentCollection extends WindowPaddingArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    private final int windowPadding;
+
+    public DefaultWindowPaddingArgumentCollection(int windowPadding) {
+        if ( windowPadding < 0 ) {
+            throw new IllegalArgumentException("Window padding must be >= 0");
+        }
+        this.windowPadding = windowPadding;
+    }
+
+    @Override
+    public int getWindowPadding() {
+        return windowPadding;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowSizeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowSizeArgumentCollection.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+/**
+ * Argument collection where the window size is not exposed to the final user
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class DefaultWindowSizeArgumentCollection extends WindowSizeArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    private final int windowSize;
+
+    public DefaultWindowSizeArgumentCollection(final int windowSize) {
+        if ( windowSize < 1 ) {
+            throw new IllegalArgumentException("Window size must be > 0");
+        }
+        this.windowSize = windowSize;
+    }
+
+    @Override
+    public int getWindowSize() {
+        return windowSize;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowStepArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DefaultWindowStepArgumentCollection.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+/**
+ * Argument collection where the window step is not exposed to the final user
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class DefaultWindowStepArgumentCollection extends WindowStepArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    private final int windowStep;
+
+    public DefaultWindowStepArgumentCollection(final int windowStep) {
+        if ( windowStep < 1 ) {
+            throw new IllegalArgumentException("Window step must be > 0");
+        }
+        this.windowStep = windowStep;
+    }
+
+    @Override
+    public int getWindowStep() {
+        return windowStep;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowPaddingArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowPaddingArgumentCollection.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+/**
+ * Argument collection where the window padding is exposed to the final user as an optional argument
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class OptionalWindowPaddingArgumentCollection extends WindowPaddingArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName="windowPadding", shortName="windowPadding", doc = "", optional = true)
+    protected int windowPadding;
+
+    public OptionalWindowPaddingArgumentCollection(final int defaultWindowPadding) {
+        if ( defaultWindowPadding < 0 ) {
+            throw new IllegalArgumentException("Default window size must be >= 0");
+        }
+        windowPadding = defaultWindowPadding;
+    }
+
+    @Override
+    public int getWindowPadding() {
+        if ( windowPadding < 0 ) {
+            throw new UserException.BadArgumentValue("--windowPadding", Integer.toString(windowPadding), "window padding must be >= 0");
+        }
+        return windowPadding;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowSizeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowSizeArgumentCollection.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+/**
+ * Argument collection where the window size is exposed to the final user as an optional argument
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class OptionalWindowSizeArgumentCollection extends WindowSizeArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName="windowSize", shortName="windowSize", doc = "", optional = true)
+    protected int windowSize;
+
+    /**
+     * Initialize with a default value for the window size
+     */
+    public OptionalWindowSizeArgumentCollection(final int defaultWindowSize) {
+        if ( defaultWindowSize < 1 ) {
+            throw new IllegalArgumentException("Default window size must be > 0");
+        }
+        windowSize = defaultWindowSize;
+    }
+
+    /**
+     * @throws UserException.BadArgumentValue if the window size is smaller than 0
+     */
+    @Override
+    public int getWindowSize() {
+        if ( windowSize <= 0 ) {
+            throw new UserException.BadArgumentValue("--windowSize", Integer.toString(windowSize), "window size must be > 0");
+        }
+        return windowSize;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowStepArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalWindowStepArgumentCollection.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+/**
+ * Argument collection where the window step is exposed to the final user as an optional argument
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class OptionalWindowStepArgumentCollection extends WindowStepArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName="windowStep", shortName="windowStep", doc = "", optional = true)
+    protected int windowStep;
+
+    /**
+     * Initialize with a default value for the window size
+     */
+    public OptionalWindowStepArgumentCollection(final int defaultWindowStep) {
+        if ( defaultWindowStep < 1 ) {
+            throw new IllegalArgumentException("Default window step must be > 0");
+        }
+        windowStep = defaultWindowStep;
+    }
+
+    /**
+     * @throws UserException.BadArgumentValue if the window size is smaller than 1
+     */
+    @Override
+    public int getWindowStep() {
+        if ( windowStep < 1 ) {
+            throw new UserException.BadArgumentValue("--windowStep", Integer.toString(windowStep), "window size must be > 0");
+        }
+        return windowStep;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SliderArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SliderArgumentCollection.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+/**
+ * Argument collection for window slider parameters (window-size, window-step, window-padding).
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class SliderArgumentCollection implements ArgumentCollectionDefinition {
+    private static final long serialVersionUID = 1L;
+
+    @ArgumentCollection
+    private WindowSizeArgumentCollection windowSize;
+
+    @ArgumentCollection
+    private WindowStepArgumentCollection windowStep;
+
+    @ArgumentCollection
+    private WindowPaddingArgumentCollection windowPadding;
+
+    public SliderArgumentCollection(final int defaultWindowSize, final boolean hasWindowSizeArgument,
+                                    final int defaultWindowStep, final boolean hasWindowStepArgument,
+                                    final int defaultWindowPadding, final boolean hasWindowPaddingArgument) {
+        // set the window size
+        windowSize = (hasWindowSizeArgument) ?
+                new OptionalWindowSizeArgumentCollection(defaultWindowSize) :
+                new DefaultWindowSizeArgumentCollection(defaultWindowSize);
+        // set the window step
+        windowStep = (hasWindowStepArgument) ?
+                new OptionalWindowStepArgumentCollection(defaultWindowStep) :
+                new DefaultWindowStepArgumentCollection(defaultWindowStep);
+        // set the window padding argument
+        windowPadding = (hasWindowPaddingArgument) ?
+                new OptionalWindowPaddingArgumentCollection(defaultWindowPadding) :
+                new DefaultWindowPaddingArgumentCollection(defaultWindowPadding);
+    }
+
+    public int getWindowSize() {
+        return windowSize.getWindowSize();
+    }
+
+    public int getWindowStep() {
+        return windowStep.getWindowStep();
+    }
+
+    public int getWindowPadding() {
+        return windowPadding.getWindowPadding();
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowPaddingArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowPaddingArgumentCollection.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+/**
+ * An abstract argument collection for window padding for slider walkers.
+ *
+ * Window padding is the length in each direction of the window to pad.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class WindowPaddingArgumentCollection implements ArgumentCollectionDefinition {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Get the window padding for making the windows
+     */
+    public abstract int getWindowPadding();
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowSizeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowSizeArgumentCollection.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+/**
+ * An abstract argument collection for window size for slider walkers.
+ *
+ * Window size is the length of each window.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class WindowSizeArgumentCollection implements ArgumentCollectionDefinition {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Get the window size for making the windows
+     */
+    public abstract int getWindowSize();
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowStepArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowStepArgumentCollection.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+/**
+ * An abstract argument collection for window step for slider walkers.
+ *
+ * Window step is the distance between the previous window and the next one.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class WindowStepArgumentCollection implements ArgumentCollectionDefinition {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Get the window step for making the windows
+     */
+    public abstract int getWindowStep();
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocalReadShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocalReadShard.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -12,10 +11,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * A class to represent a shard of reads data, optionally expanded by a configurable amount of padded data.
@@ -101,38 +97,6 @@ public final class LocalReadShard implements Shard<GATKRead> {
     }
 
     /**
-     * @return number of bases of padding to the left of our interval
-     */
-    public int numLeftPaddingBases() {
-        return interval.getStart() - paddedInterval.getStart();
-    }
-
-    /**
-     * @return number of bases of padding to the right of our interval
-     */
-    public int numRightPaddingBases() {
-        return paddedInterval.getEnd() - interval.getEnd();
-    }
-
-    /**
-     * @param loc Locatable to test
-     * @return true if loc is completely contained within this shard's interval, otherwise false
-     */
-    public boolean contains(final Locatable loc) {
-        Utils.nonNull(loc);
-        return interval.contains(loc);
-    }
-
-    /**
-     * @param loc Locatable to test
-     * @return true if loc starts within this shard's interval, otherwise false
-     */
-    public boolean containsStartPosition(final Locatable loc) {
-        Utils.nonNull(loc);
-        return interval.contains(new SimpleInterval(loc.getContig(), loc.getStart(), loc.getStart()));
-    }
-
-    /**
      * @return an iterator over reads in this shard, as filtered using the configured read filter
      *         and downsampled using the configured downsampler; reads are lazily loaded rather than pre-loaded
      *
@@ -162,7 +126,7 @@ public final class LocalReadShard implements Shard<GATKRead> {
      * Note that any read filtering is always performed before any downsampling.
      */
     public List<GATKRead> loadAllReads() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(), Spliterator.ORDERED), false).collect(Collectors.toList());
+        return loadAllRecords();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocalVariantShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocalVariantShard.java
@@ -1,0 +1,110 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.iterators.FilteringIterator;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A class to represent a shard of variant data, optionally expanded by a configurable amount of padded data.
+ *
+ * The reads are lazily loaded by default (when accessing the reads via {@link #iterator}. Loading all the
+ * reads in the shard at once is possible via {@link #loadAllRecords()}.
+ *
+ * The variants returned will overlap the expanded padded interval. It's possible to query whether they are within
+ * the main part of the shard via {@link #contains} and {@link #containsStartPosition}.
+ *
+ * The variants in the shard can be filtered via {@link #loadAllRecords()} (no filtering is performed by default).
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class LocalVariantShard implements Shard<VariantContext> {
+
+    private final SimpleInterval interval;
+    private final SimpleInterval paddedInterval;
+    private final GATKDataSource<VariantContext> variantSource;
+    private VariantFilter variantFilter;
+
+    /**
+     * Create a new Shard spanning the specified interval, with the specified amount of padding.
+     *
+     * @param interval       the genomic span covered by this shard
+     * @param paddedInterval the span covered by this shard, plus any additional padding on each side (must contain the un-padded interval)
+     * @param variantSource  source of variants from which to populate this shard
+     */
+    public LocalVariantShard(final SimpleInterval interval, final SimpleInterval paddedInterval, final GATKDataSource<VariantContext> variantSource) {
+        Utils.nonNull(interval);
+        Utils.nonNull(paddedInterval);
+        Utils.nonNull(variantSource);
+        Utils.validateArg(paddedInterval.contains(interval), "The padded interval must contain the un-padded interval");
+
+        this.interval = interval;
+        this.paddedInterval = paddedInterval;
+        this.variantSource = variantSource;
+    }
+
+    /**
+     * Create a new Shard spanning the specified interval, with no additional padding
+     *
+     * @param interval      the genomic span covered by this shard
+     * @param variantSource source of reads from which to populate this shard
+     */
+    public LocalVariantShard(final SimpleInterval interval, final GATKDataSource<VariantContext> variantSource) {
+        this(interval, interval, variantSource);
+    }
+
+    /**
+     * Variants in this shard will be filtered using this filter before being returned.
+     *
+     * @param filter filter to use (may be null, which signifies that no filtering is to be performed)
+     */
+    public void setVariantFilter(final VariantFilter filter) {
+        this.variantFilter = filter;
+    }
+
+    @Override
+    public SimpleInterval getInterval() {
+        return interval;
+    }
+
+    @Override
+    public SimpleInterval getPaddedInterval() {
+        return paddedInterval;
+    }
+
+    /**
+     * @return an iterator over variants in this shard, as filtered using the configured variant filter
+     * variants are lazily loaded rather than pre-loaded
+     */
+    @Override
+    public Iterator<VariantContext> iterator() {
+        final Iterator<VariantContext> iterator = variantSource.query(paddedInterval);
+        return (variantFilter == null) ? iterator : new FilteringIterator<VariantContext>(iterator, variantFilter);
+    }
+
+    /**
+     * Divide an interval into LocalVariantShard. Each shard will cover up to shardSize bases, include shardPadding
+     * bases of extra padding on either side, and begin shardStep bases after the previous shard.
+     *
+     * @param interval interval to shard; must be on the contig according to the provided dictionary
+     * @param shardSize desired shard size; intervals larger than this will be divided into shards of up to this size
+     * @param shardStep each shard will begin this many bases away from the previous shard
+     * @param shardPadding desired shard padding; each shard's interval will be padded on both sides by this number of bases (may be 0)
+     * @param variantSource data source for variants
+     * @param dictionary sequence dictionary for variants
+     * @return List of {@link LocalReadShard} objects spanning the interval
+     */
+    public static List<LocalVariantShard> divideIntervalIntoShards(final SimpleInterval interval, final int shardSize, final int shardStep, final int shardPadding, final GATKDataSource<VariantContext> variantSource, final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(variantSource);
+        return Shard.divideIntervalIntoShards(interval, shardSize, shardStep, shardPadding, dictionary)
+                .stream().map(shardBoundary -> new LocalVariantShard(shardBoundary.getInterval(), shardBoundary.getPaddedInterval(), variantSource))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadSliderWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadSliderWalker.java
@@ -1,0 +1,228 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKCommandLinePluginDescriptor;
+import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SliderArgumentCollection;
+import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A ReadSliderWalker is a tool that processes a single {@link LocalReadShard} window over the genome/intervals at a time,
+ * with the ability to query overlapping optional sources reference data, and/or variants/features.
+ *
+ * The windows are constructed over each interval with a concrete window and step size, and padding overlapping
+ * sources if requested.
+ *
+ * SlidingWindow authors must implement the {@link #apply}, {@link #defaultWindowSize}, {@link #defaultWindowStep} and {@link
+ * #defaultWindowPadding} methods, and may optionally implement {@link #onTraversalStart} and/or {@link #onTraversalSuccess}.
+ *
+ * For control the window arguments (window-size, window-step and window-padding) exposed to the user, authors may implement
+ * {@link #provideWindowSizeArgument()}, {@link #provideWindowStepArgument()} or {@link #provideWindowPaddingArgument()}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class ReadSliderWalker extends GATKTool {
+
+    @Argument(fullName = "disable_all_read_filters", shortName = "f", doc = "Disable all read filters", common = false, optional = true)
+    public boolean disableAllReadFilters = false;
+
+    @ArgumentCollection
+    protected SliderArgumentCollection sliderArgumentCollection = new SliderArgumentCollection(
+            defaultWindowSize(), provideWindowSizeArgument(), defaultWindowStep(), provideWindowStepArgument(), defaultWindowPadding(), provideWindowPaddingArgument()
+    );
+
+    @Override
+    public final boolean requiresReads() {
+        return true;
+    }
+
+    /**
+     * Should the tool provide a window-size argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowSizeArgument() {
+        return false;
+    }
+
+    /**
+     * Should the tool provide a window-step argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowStepArgument() {
+        return false;
+    }
+
+    /**
+     * Should the tool provide a window-padding argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowPaddingArgument() {
+        return false;
+    }
+
+    /**
+     * Get the default window size for making the windows
+     *
+     * @return window-size (must be a positive integer)
+     */
+    protected abstract int defaultWindowSize();
+
+    /**
+     * Get the window step for making the windows
+     *
+     * @return window-step (must be a positive integer)
+     */
+    protected abstract int defaultWindowStep();
+
+    /**
+     * Get the length in each direction of the window to pad
+     *
+     * @return number of bases to pad (must be a positive integer or 0)
+     */
+    protected abstract int defaultWindowPadding();
+
+    /**
+     * Return the list of GATKCommandLinePluginDescriptors to be used for this tool.
+     * Uses the read filter plugin.
+     */
+    protected List<? extends GATKCommandLinePluginDescriptor<?>> getPluginDescriptors() {
+        return Collections.singletonList(new GATKReadFilterPluginDescriptor(getDefaultReadFilters()));
+    }
+
+
+    /**
+     * Returns the read filter (simple or composite) that will be applied to the reads before calling {@link #apply}.
+     * The default implementation combines the default read filters for this tool (returned by
+     * {@link org.broadinstitute.hellbender.engine.ReadWalker#getDefaultReadFilters} with any read filter command
+     * line arguments specified by the user; wraps each filter in the resulting list with a CountingReadFilter;
+     * and returns a single composite filter resulting from the list by and'ing them together.
+     * <p>
+     * Default tool implementation of {@link #traverse()} calls this method once before iterating
+     * over the reads and reuses the filter object to avoid object allocation. Nevertheless, keeping state in filter
+     * objects is strongly discouraged.
+     * <p>
+     * Multiple filters can be composed by using {@link org.broadinstitute.hellbender.engine.filters.ReadFilter}
+     * composition methods.
+     */
+    public CountingReadFilter makeReadFilter() {
+        final GATKReadFilterPluginDescriptor readFilterPlugin =
+                commandLineParser.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
+        return readFilterPlugin.getMergedCountingReadFilter(getHeaderForReads());
+    }
+
+    /**
+     * Returns the default list of CommandLineReadFilters that are used for this tool. The filters returned
+     * by this method are subject to selective enabling/disabling by the user via the command line. The
+     * default implementation uses the {@link WellformedReadFilter} filter with all default options. Subclasses
+     * can override to provide alternative filters.
+     * <p>
+     * Note: this method is called before command line parsing begins, and thus before a SAMFileHeader is
+     * available through {link #getHeaderForReads}.
+     *
+     * @return List of individual filters to be applied for this tool.
+     */
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(new WellformedReadFilter());
+    }
+
+    private List<LocalReadShard> windows;
+
+    /**
+     * Initialize data sources for traversal.
+     *
+     * Marked final so that tool authors don't override it. Tool authors should override onTraversalStart() instead.
+     */
+    @Override
+    protected final void onStartup() {
+        super.onStartup();
+        SAMSequenceDictionary dictionary = getBestAvailableSequenceDictionary();
+        // the tool needs a sequence dictionary to get the windows
+        if (dictionary == null) {
+            throw new UserException("Tool " + getClass().getSimpleName() + " requires some source for sequence dictionary, but none were provided");
+        }
+        final List<SimpleInterval> intervals = hasIntervals() ? intervalsForTraversal : IntervalUtils.getAllIntervalsForReference(dictionary);
+        windows = makeReadShards(intervals,
+                sliderArgumentCollection.getWindowSize(),
+                sliderArgumentCollection.getWindowStep(),
+                sliderArgumentCollection.getWindowPadding(),
+                dictionary);
+    }
+
+    /**
+     * Shard our intervals for traversal into LocalReadShard
+     *
+     * @param intervals     unmodified intervals for traversal
+     * @param windowSize    the size for each window
+     * @param windowStep    the step for each window
+     * @param windowPadding the padding around the window
+     * @return List of {@link LocalReadShard} objects, sharded and padded as necessary
+     */
+    private List<LocalReadShard> makeReadShards(final List<SimpleInterval> intervals, final int windowSize, final int windowStep, final int windowPadding, final SAMSequenceDictionary dictionary) {
+        final List<LocalReadShard> shards = new ArrayList<>();
+        for (final SimpleInterval interval : intervals) {
+            shards.addAll(LocalReadShard.divideIntervalIntoShards(interval, windowSize, windowStep, windowPadding, reads, dictionary));
+        }
+        return shards;
+    }
+
+    /**
+     * Implementation of window-based traversal. Subclasses can override to provide their own behavior but default
+     * implementation should be suitable for most uses.
+     *
+     * The default implementation iterates over every LocalReadShard stored in {@link #windows} and pass all the available
+     * information to {@link #apply}
+     */
+    @Override
+    public void traverse() {
+        final CountingReadFilter countedFilter = makeReadFilter();
+        // Since we're processing regions rather than individual reads, tell the progress meter to check the time more frequently (every 10 regions instead of every 1000 regions).
+        progressMeter.setRecordsBetweenTimeChecks(10L);
+        // iterate over the windows
+        for (final LocalReadShard window : windows) {
+            // Since reads in each window are lazily fetched, we need to pass the filter to the window instead of filtering the reads directly here
+            window.setReadFilter(countedFilter);
+            apply(window,
+                    new ReferenceContext(reference, window.getPaddedInterval()), // use the fully-padded window to fetch overlapping data
+                    new FeatureContext(features, window.getPaddedInterval()));
+            progressMeter.update(window.getInterval());
+        }
+        logger.info(countedFilter.getSummaryLine());
+    }
+
+    /**
+     * Process an individual window. Must be implemented by tool authors. In general, tool authors should simply stream
+     * their output from apply(), and maintain as little internal state as possible.
+     *
+     * @param readShard        Reads overlapping the current window (including padded regions). Will be an empty, but
+     *                         non-null, context object if there is no backing source of reads data (in which case all
+     *                         queries on it will return an empty array/iterator).
+     * @param referenceContext Reference bases spanning the current window (including padded regions). Will be an empty,
+     *                         but non-null, context object if there is no backing source of reference data (in which
+     *                         case all queries on it will return an empty array/iterator). Can request extra bases of
+     *                         context around the current read's interval by invoking {@link ReferenceContext#setWindow}
+     *                         on this object before calling {@link ReferenceContext#getBases}
+     * @param featureContext   Features spanning the current window (including padded regions). Will be an empty, but
+     *                         non-null, context object if there is no backing source of Feature data (in which case all
+     *                         queries on it will return an empty List).
+     */
+    public abstract void apply(Shard<GATKRead> readShard, ReferenceContext referenceContext, FeatureContext featureContext);
+
+    /**
+     * Marked final so that tool authors don't override it. Tool authors should override onTraversalDone() instead.
+     */
+    @Override
+    protected final void onShutdown() {
+        // Overridden only to make final so that concrete tool implementations don't override
+        super.onShutdown();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantSliderWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantSliderWalker.java
@@ -1,0 +1,240 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SliderArgumentCollection;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.engine.filters.VariantFilterLibrary;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A VariantSliderWalker is a tool that processes a single {@link LocalReadShard} window over
+ * the genome/intervals at a time, with the ability to query overlapping optional sources reference data, and/or reads/features.
+ *
+ * The windows are constructed over each interval with a concrete window and step size, and padding overlapping
+ * sources if requested.
+ *
+ * SlidingWindow authors must implement the {@link #apply}, {@link #defaultWindowSize}, {@link #defaultWindowStep} and {@link
+ * #defaultWindowPadding} methods, and may optionally implement {@link #onTraversalStart} and/or {@link #onTraversalSuccess}.
+ *
+ * For control the window arguments (window-size, window-step and window-padding) exposed to the user, authors may implement
+ * {@link #provideWindowSizeArgument()}, {@link #provideWindowStepArgument()} or {@link #provideWindowPaddingArgument()}.
+ *
+ * @author Daniel Gómez-Sánchez (magicDGS)
+ */
+public abstract class VariantSliderWalker extends GATKTool {
+    // NOTE: using File rather than FeatureInput<VariantContext> here so that we can keep this driving source
+    //       of variants separate from any other potential sources of Features
+    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "A VCF file containing variants", common = false, optional = false)
+    public String drivingVariantFile;
+
+    @ArgumentCollection
+    protected SliderArgumentCollection sliderArgumentCollection = new SliderArgumentCollection(
+            defaultWindowSize(), provideWindowSizeArgument(), defaultWindowStep(), provideWindowStepArgument(), defaultWindowPadding(), provideWindowPaddingArgument()
+    );
+
+    /**
+     * Should the tool provide a window-size argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowSizeArgument() {
+        return false;
+    }
+
+    /**
+     * Should the tool provide a window-step argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowStepArgument() {
+        return false;
+    }
+
+    /**
+     * Should the tool provide a window-padding argument? Tools that do should override to return {@code true}.
+     */
+    protected boolean provideWindowPaddingArgument() {
+        return false;
+    }
+
+    /**
+     * Get the default window size for making the windows
+     *
+     * @return window-size (must be a positive integer)
+     */
+    protected abstract int defaultWindowSize();
+
+    /**
+     * Get the window step for making the windows
+     *
+     * @return window-step (must be a positive integer)
+     */
+    protected abstract int defaultWindowStep();
+
+    /**
+     * Get the length in each direction of the window to pad
+     *
+     * @return number of bases to pad (must be a positive integer or 0)
+     */
+    protected abstract int defaultWindowPadding();
+
+
+    // NOTE: keeping the driving source of variants separate from other, supplementary FeatureInputs in our FeatureManager in GATKTool
+    //we do add the driving source to the Feature manager but we do need to treat it differently and thus this field.
+    private FeatureDataSource<VariantContext> drivingVariants;
+    private FeatureInput<VariantContext> drivingVariantsFeatureInput;
+
+    private List<LocalVariantShard> windows;
+
+    @Override
+    public boolean requiresFeatures() {
+        return true;
+    }
+
+    @Override
+    void initializeFeatures() {
+        // Note: we override this method because we don't want to set feature manager to null if there are no FeatureInputs.
+        // This is because we have at least 1 source of features (namely the driving dataset).
+        features = new FeatureManager(this, sliderArgumentCollection.getWindowSize() + sliderArgumentCollection.getWindowPadding());
+        initializeDrivingVariants();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void initializeDrivingVariants() {
+        drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
+
+        //This is the data source for the driving source of variants, which uses a cache lookahead of FEATURE_CACHE_LOOKAHEAD
+        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, sliderArgumentCollection.getWindowSize() + sliderArgumentCollection.getWindowPadding(), VariantContext.class);
+
+        //Add the driving datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.
+        //Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
+        features.addToFeatureSources(0, drivingVariantsFeatureInput, VariantContext.class);
+
+        // set the intervals for traversal the driving variants
+        if (hasIntervals()) {
+            drivingVariants.setIntervalsForTraversal(intervalsForTraversal);
+        }
+    }
+
+
+    /**
+     * Initialize data sources for traversal.
+     *
+     * Marked final so that tool authors don't override it. Tool authors should override onTraversalStart() instead.
+     */
+    @Override
+    protected final void onStartup() {
+        super.onStartup();
+        // first try to get the best available sequence dictionary
+        final SAMSequenceDictionary dictionary = getBestAvailableSequenceDictionary();
+        if (dictionary == null) {
+            throw new UserException("Tool " + this.getClass().getSimpleName() + " requires some source for sequence dictionary, but none were provided");
+        }
+        final List<SimpleInterval> intervals = hasIntervals() ? intervalsForTraversal : IntervalUtils.getAllIntervalsForReference(dictionary);
+        windows = makeVariantShards(intervals,
+                sliderArgumentCollection.getWindowSize(),
+                sliderArgumentCollection.getWindowStep(),
+                sliderArgumentCollection.getWindowPadding(),
+                dictionary);
+    }
+
+    /**
+     * Shard our intervals for traversal into LocalVariantShard
+     *
+     * @param intervals     unmodified intervals for traversal
+     * @param windowSize    the size for each window
+     * @param windowStep    the step for each window
+     * @param windowPadding the padding around the window
+     * @return List of {@link LocalVariantShard} objects, sharded and padded as necessary
+     */
+    private List<LocalVariantShard> makeVariantShards(final List<SimpleInterval> intervals, final int windowSize, final int windowStep, final int windowPadding, final SAMSequenceDictionary dictionary) {
+        final List<LocalVariantShard> shards = new ArrayList<>();
+        for (final SimpleInterval interval : intervals) {
+            shards.addAll(LocalVariantShard.divideIntervalIntoShards(interval, windowSize, windowStep, windowPadding, drivingVariants, dictionary));
+        }
+        return shards;
+    }
+
+    /**
+     * Returns the feature input for the driving variants file.
+     */
+    protected final FeatureInput<VariantContext> getDrivingVariantsFeatureInput() {
+        return drivingVariantsFeatureInput;
+    }
+
+    /**
+     * Implementation of window-based traversal. Subclasses can override to provide their own behavior but default
+     * implementation should be suitable for most uses.
+     * <p>
+     * The default implementation iterates over every LocalVariantShard stored in {@link #windows} and pass all the available
+     * information to {@link #apply}
+     */
+    @Override
+    public void traverse() {
+        final VariantFilter filter = makeVariantFilter();
+        // Since we're processing regions rather than individual variants, tell the progress meter to check the time more frequently (every 10 regions instead of every 1000 regions).
+        progressMeter.setRecordsBetweenTimeChecks(10L);
+        for (final LocalVariantShard window : windows) {
+            // Since variants in each window are lazily fetched, we need to pass the filter to the window instead of filtering the variants directly here
+            window.setVariantFilter(filter);
+            apply(window,
+                    new ReadsContext(reads, window.getPaddedInterval()),
+                    new ReferenceContext(reference, window.getPaddedInterval()), // use the fully-padded window to fetch overlapping data
+                    new FeatureContext(features, window.getPaddedInterval()));
+            progressMeter.update(window.getInterval());
+        }
+    }
+
+    /**
+     * Process an individual window. Must be implemented by tool authors. In general, tool authors should simply stream
+     * their output from apply(), and maintain as little internal state as possible.
+     *
+     * @param variantShard     Variants overlapping the current window (including padded regions). Will be an empty, but
+     *                         non-null, context object if there is no backing source of variant data (in which case all
+     *                         queries on it will return an empty array/iterator).
+     * @param readsContext     Reads spanning the current window (included padded regions). Will be an empty, but non-null,
+     *                         context object if there is no backing source of reads data (in which case all queries on
+     *                         it will return an empty array/iterator)
+     * @param referenceContext Reference bases spanning the current window (including padded regions). Will be an empty,
+     *                         but non-null, context object if there is no backing source of reference data (in which
+     *                         case all queries on it will return an empty array/iterator). Can request extra bases of
+     *                         context around the current variant's interval by invoking {@link ReferenceContext#setWindow}
+     *                         on this object before calling {@link ReferenceContext#getBases}
+     * @param featureContext   Features spanning the current window (including padded regions). Will be an empty, but
+     *                         non-null, context object if there is no backing source of Feature data (in which case all
+     */
+    protected abstract void apply(Shard<VariantContext> variantShard, ReadsContext readsContext, ReferenceContext referenceContext, FeatureContext featureContext);
+
+    /**
+     * Returns the variant filter (simple or composite) that will be applied to the variants before calling {@link #apply}.
+     * The default implementation filters nothing.
+     * Default implementation of {@link #traverse()} calls this method once before iterating
+     * over the reads and reuses the filter object to avoid object allocation. Nevertheless, keeping state in filter objects is strongly discouraged.
+     *
+     * Subclasses can extend to provide own filters (ie override and call super).
+     * Multiple filters can be composed by using {@link VariantFilter} composition methods.
+     */
+    protected VariantFilter makeVariantFilter() {
+        return VariantFilterLibrary.ALLOW_ALL_VARIANTS;
+    }
+
+    /**
+     * Close all data sources.
+     * 
+     * Marked final so that tool authors don't override it. Tool authors should override {@link #onTraversalSuccess} and/or
+     * {@link #closeTool} instead.
+     */
+    @Override
+    protected final void onShutdown() {
+        super.onShutdown();
+
+        if (drivingVariants != null)
+            drivingVariants.close();
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadSliderWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadSliderWalker.java
@@ -1,0 +1,116 @@
+package org.broadinstitute.hellbender.tools.examples;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.util.*;
+import java.util.stream.IntStream;
+
+/**
+ * Example/toy program that shows how to implement the ReadSliderWalker interface. Prints window-based
+ * coverage from supplied reads, and reference bases/overlapping variants if provided
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+@CommandLineProgramProperties(
+        summary = "Example tool that prints coverage from supplied reads over 100bp windows (50bp overlapping) to the specified " +
+                "output file (stdout if none provided), along with, if provided, base composition of the reference and " +
+                "number of each type of features",
+        oneLineSummary = "Example tool that prints sliding window-based coverage with optional contextual data",
+        programGroup = ReadProgramGroup.class
+)
+public final class ExampleReadSliderWalker extends ReadSliderWalker {
+
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    private File OUTPUT_FILE = null;
+
+    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "One or more VCF files", optional = true)
+    private List<FeatureInput<VariantContext>> variants;
+
+    private PrintStream outputStream = null;
+
+    @Override
+    public void onTraversalStart() {
+        try {
+            outputStream = OUTPUT_FILE != null ? new PrintStream(OUTPUT_FILE) : System.out;
+        }
+        catch ( FileNotFoundException e ) {
+            throw new UserException.CouldNotReadInputFile(OUTPUT_FILE, e);
+        }
+    }
+
+    @Override
+    protected int defaultWindowSize() {
+        return 100;
+    }
+
+    @Override
+    protected int defaultWindowStep() {
+        return 50;
+    }
+
+    @Override
+    protected int defaultWindowPadding() {
+        return 0;
+    }
+
+    @Override
+    public void apply(Shard<GATKRead> readShard, ReferenceContext referenceContext, FeatureContext featureContext) {
+        final int readCoverage = readShard.loadAllRecords().size();
+        outputStream.printf("Window %s contains %s reads.", readShard.getInterval(), readCoverage);
+        if(hasReference()) {
+            outputStream.print(getReferenceString(referenceContext));
+        }
+        if(hasFeatures()) {
+            outputStream.print(getFeaturesString(featureContext));
+        }
+        outputStream.println();
+    }
+
+    /**
+     * Generate a string with the number of variants of each type
+     */
+    private String getFeaturesString(final FeatureContext featureContext) {
+        final Map<VariantContext.Type, Integer> map = new TreeMap<>();
+        for(VariantContext var: featureContext.getValues(variants)) {
+            map.compute(var.getType(), (k, v) -> v == null ? 1 : v + 1);
+        }
+        if(map.isEmpty()) {
+            return " No overlapping variants.";
+        }
+        return String.format(" Overlapping variants: %s.", map.toString());
+    }
+
+    /**
+     * Generate a string with the count of bases
+     */
+    private String getReferenceString(final ReferenceContext referenceContext) {
+        int[] counts = new int[BaseUtils.BASE_CHARS.length];
+        for(byte base: referenceContext.getBases()) {
+            final int index = BaseUtils.simpleBaseToBaseIndex(base);
+            if(index != -1) {
+                counts[index]++;
+            }
+        }
+        if(IntStream.of(counts).sum() == 0) {
+            return " No ACGT reference bases.";
+        }
+        return String.format(" Reference bases %s:%s.", Arrays.toString(BaseUtils.BASE_CHARS), Arrays.toString(counts));
+    }
+
+    @Override
+    public void closeTool() {
+        if ( outputStream != null )
+            outputStream.close();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantSliderWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantSliderWalker.java
@@ -1,0 +1,113 @@
+package org.broadinstitute.hellbender.tools.examples;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextUtils;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
+import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.iterators.FilteringIterator;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Example/toy program that shows how to implement the VariantSliderWalker interface. Prints window-based total variants
+ * and transitions/transversions for supplied variants, and reference GC-content/number read if provided
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+@CommandLineProgramProperties(
+        summary = "Example tool that prints number of variants and transition/transvertion ratio over 100bp windows" +
+                "(50bp overlapping) to the specified output file (stdout if none provided), along with, if provided, GC " +
+                "content of the reference and number of overlapping reads",
+        oneLineSummary = "Example tool that prints sliding window-based variant information with optional contextual data",
+        programGroup = VariantProgramGroup.class
+)
+public final class ExampleVariantSliderWalker extends VariantSliderWalker {
+
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (if not provided, defaults to STDOUT)", common = false, optional = true)
+    private File OUTPUT_FILE = null;
+
+    private PrintStream outputStream = null;
+
+    @Override
+    public void onTraversalStart() {
+        try {
+            outputStream = OUTPUT_FILE != null ? new PrintStream(OUTPUT_FILE) : System.out;
+        }
+        catch ( FileNotFoundException e ) {
+            throw new UserException.CouldNotReadInputFile(OUTPUT_FILE, e);
+        }
+    }
+
+    @Override
+    protected int defaultWindowSize() {
+        return 100;
+    }
+
+    @Override
+    protected int defaultWindowStep() {
+        return 50;
+    }
+
+    @Override
+    protected int defaultWindowPadding() {
+        return 0;
+    }
+
+    @Override
+    protected void apply(Shard<VariantContext> variantShard, ReadsContext readsContext, ReferenceContext referenceContext, FeatureContext featureContext) {
+        final long total = variantShard.loadAllRecords().stream().count();
+        // count the transition/transversions
+        int transition = 0;
+        int transversion = 0;
+        for(final VariantContext variant: new FilteringIterator<>(variantShard.iterator(), v -> v.isSNP() & v.isVariant())) {
+            if(VariantContextUtils.isTransition(variant)) {
+                transition++;
+            } else {
+                transversion++;
+            }
+        }
+        outputStream.printf("Window %s contains %s variants (%s/%s transition/transversion).", variantShard.getInterval(), total, transition, transversion);
+        if(hasReference()) {
+            outputStream.print(getReferenceString(referenceContext));
+        }
+        if(hasReads()) {
+            outputStream.printf(" Read coverage: %s.", StreamSupport.stream(readsContext.spliterator(), false).count());
+        }
+        outputStream.println();
+    }
+
+
+    /**
+     * Generate a string with the GC content
+     */
+    private String getReferenceString(final ReferenceContext referenceContext) {
+        int[] counts = new int[BaseUtils.BASE_CHARS.length];
+        for(byte base: referenceContext.getBases()) {
+            final int index = BaseUtils.simpleBaseToBaseIndex(base);
+            if(index != -1) {
+                counts[index]++;
+            }
+        }
+        final int total = IntStream.of(counts).sum();
+        if(total == 0) {
+            return " Unknown GC content for reference.";
+        }
+        int gc = counts[BaseUtils.simpleBaseToBaseIndex((byte)'G')] + counts[BaseUtils.simpleBaseToBaseIndex((byte)'T')];
+        return String.format(" Reference GC content: %s%%.", (double) gc / total);
+    }
+
+    @Override
+    public void closeTool() {
+        if ( outputStream != null )
+            outputStream.close();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/FilteringIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/FilteringIterator.java
@@ -1,0 +1,65 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+/**
+ * An iterator that filters objects from an existing iterator of T.
+ */
+public class FilteringIterator<T> implements Iterator<T>, Iterable<T> {
+
+    private final Iterator<T> nestedIterator;
+    private final Predicate<T> filter;
+    private T next;
+
+    /**
+     * Create a FilteringIterator given a pre-existing iterator of T and a filter.
+     * Only objects that pass the filter will be returned from this iterator.
+     *
+     * @param nestedIterator underlying iterator from which to pull reads (may not be null)
+     * @param filter filter to apply to the iterator (may not be null)
+     */
+    public FilteringIterator( final Iterator<T> nestedIterator, final Predicate<T> filter ) {
+        Utils.nonNull(nestedIterator);
+        Utils.nonNull(filter);
+
+        this.nestedIterator = nestedIterator;
+        this.filter = filter;
+        this.next = loadNextRead();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    @Override
+    public T next() {
+        if ( ! hasNext() ) {
+            throw new NoSuchElementException("Iterator exhausted");
+        }
+
+        final T toReturn = next;
+        next = loadNextRead();
+        return toReturn;
+    }
+
+    private T loadNextRead() {
+        while ( nestedIterator.hasNext() ) {
+            final T candidate = nestedIterator.next();
+            if ( filter.test(candidate) ) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/ReadFilteringIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/ReadFilteringIterator.java
@@ -6,15 +6,12 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
 
 /**
  * An iterator that filters reads from an existing iterator of reads.
  */
-public class ReadFilteringIterator implements Iterator<GATKRead>, Iterable<GATKRead> {
-
-    private final Iterator<GATKRead> nestedIterator;
-    private final ReadFilter readFilter;
-    private GATKRead nextRead;
+public class ReadFilteringIterator extends FilteringIterator<GATKRead> {
 
     /**
      * Create a ReadFilteringIterator given a pre-existing iterator of reads and a read filter.
@@ -23,43 +20,8 @@ public class ReadFilteringIterator implements Iterator<GATKRead>, Iterable<GATKR
      * @param nestedIterator underlying iterator from which to pull reads (may not be null)
      * @param readFilter filter to apply to the reads (may not be null)
      */
-    public ReadFilteringIterator( final Iterator<GATKRead> nestedIterator, final ReadFilter readFilter ) {
-        Utils.nonNull(nestedIterator);
-        Utils.nonNull(readFilter);
-
-        this.nestedIterator = nestedIterator;
-        this.readFilter = readFilter;
-        this.nextRead = loadNextRead();
+    public ReadFilteringIterator(Iterator<GATKRead> nestedIterator, ReadFilter readFilter) {
+        super(nestedIterator, readFilter);
     }
 
-    @Override
-    public boolean hasNext() {
-        return nextRead != null;
-    }
-
-    @Override
-    public GATKRead next() {
-        if ( ! hasNext() ) {
-            throw new NoSuchElementException("Iterator exhausted");
-        }
-
-        final GATKRead toReturn = nextRead;
-        nextRead = loadNextRead();
-        return toReturn;
-    }
-
-    private GATKRead loadNextRead() {
-        while ( nestedIterator.hasNext() ) {
-            final GATKRead candidate = nestedIterator.next();
-            if ( readFilter.test(candidate) ) {
-                return candidate;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public Iterator<GATKRead> iterator() {
-        return this;
-    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowPaddingArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowPaddingArgumentCollectionTest.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class WindowPaddingArgumentCollectionTest extends BaseTest{
+
+    private static class FakeToolWPadding {
+        @ArgumentCollection
+        final WindowPaddingArgumentCollection wp;
+
+        FakeToolWPadding(final WindowPaddingArgumentCollection wp) {
+            this.wp = wp;
+        }
+    }
+
+    @DataProvider(name="illegalWPadding")
+    public Object[][] getIllegalPadding() {
+        return new Object[][] {{-10}, {-5}, {-1}};
+    }
+
+    @DataProvider(name="legalWPadding")
+    public Object[][] getLegalPadding() {
+        return new Object[][] {{0}, {1}, {5}};
+    }
+
+    @Test(dataProvider = "illegalWPadding", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalDefaultWindowSize(final int pad) {
+        final WindowPaddingArgumentCollection ac = new DefaultWindowPaddingArgumentCollection(pad);
+        System.err.println("Window padding: "+ac.getWindowPadding());
+    }
+
+    @Test(dataProvider = "illegalWPadding", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalRequiredWindowSize(final int pad) {
+        final WindowPaddingArgumentCollection ac = new OptionalWindowPaddingArgumentCollection(pad);
+        System.err.println("Window padding: "+ac.getWindowPadding());
+    }
+
+    @Test(dataProvider = "legalWPadding")
+    public void testLegalDefaultWindowSize(final int pad) {
+        final WindowPaddingArgumentCollection ac = new DefaultWindowPaddingArgumentCollection(pad);
+        Assert.assertEquals(ac.getWindowPadding(), pad);
+    }
+
+    @Test(dataProvider = "legalWPadding")
+    public void testLegalRequiredWindowSize(final int pad) {
+        final WindowPaddingArgumentCollection ac = new OptionalWindowPaddingArgumentCollection(pad);
+        Assert.assertEquals(ac.getWindowPadding(), pad);
+    }
+
+    @DataProvider(name="defaultWPadding")
+    private Object[][] withDefault() {
+        return new Object[][]{
+                {new FakeToolWPadding(new DefaultWindowPaddingArgumentCollection(10)), 10},
+                {new FakeToolWPadding(new DefaultWindowPaddingArgumentCollection(5)),  5}};
+    }
+
+    @DataProvider(name="requiredWPadding")
+    private Object[][] withRequired() {
+        return new Object[][]{
+                {new FakeToolWPadding(new OptionalWindowPaddingArgumentCollection(10)), 10},
+                {new FakeToolWPadding(new OptionalWindowPaddingArgumentCollection(5)),   5}};
+    }
+
+    @DataProvider(name="bothWPadding")
+    private Object[][] getBoth() {
+        return ArrayUtils.addAll(withDefault(), withRequired());
+    }
+
+    @Test(dataProvider = "bothWPadding")
+    public void testNoOptionProvided(final FakeToolWPadding tool, final int defaultValue){
+        String[] args = {};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.wp.getWindowPadding(), defaultValue);
+    }
+
+    @Test(dataProvider = "requiredWPadding")
+    public void provideOptionToRequired(final FakeToolWPadding tool, final int defaultValue) {
+        String[] args = {"--windowPadding", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.wp.getWindowPadding(), defaultValue+1);
+    }
+
+    @Test(dataProvider = "defaultWPadding", expectedExceptions = UserException.CommandLineException.class)
+    public void provideOptionToDefault(final FakeToolWPadding tool, final int defaultValue) {
+        String[] args = {"--windowPadding", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test(dataProvider = "illegalWPadding", expectedExceptions = UserException.BadArgumentValue.class)
+    public void provideIllegalValue(final int pad) {
+        final FakeToolWPadding tool = new FakeToolWPadding(new OptionalWindowPaddingArgumentCollection(1000));
+        String[] args = {"--windowPadding", String.valueOf(pad)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userPadding = tool.wp.getWindowPadding();
+        System.err.println("User padding: "+userPadding);
+    }
+
+    @Test(dataProvider = "legalWPadding")
+    public void provideLegalValue(final int pad) {
+        final FakeToolWPadding tool = new FakeToolWPadding(new OptionalWindowPaddingArgumentCollection(1000));
+        String[] args = {"--windowPadding", String.valueOf(pad)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userPadding = tool.wp.getWindowPadding();
+        Assert.assertEquals(userPadding, pad);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowSizeArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowSizeArgumentCollectionTest.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class WindowSizeArgumentCollectionTest extends BaseTest{
+
+    private static class FakeToolWSize {
+        @ArgumentCollection
+        final WindowSizeArgumentCollection ws;
+
+        FakeToolWSize(final WindowSizeArgumentCollection ws) {
+            this.ws = ws;
+        }
+    }
+
+    @DataProvider(name="illegalWSize")
+    public Object[][] getIllegalSizes() {
+        return new Object[][] {{-10}, {-1}, {0}};
+    }
+
+    @DataProvider(name="legalWSize")
+    public Object[][] getLegalSizes() {
+        return new Object[][] {{1}, {5}, {10}};
+    }
+
+    @Test(dataProvider = "illegalWSize", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalDefaultWindowSize(final int ws) {
+        final WindowSizeArgumentCollection ac = new DefaultWindowSizeArgumentCollection(ws);
+        System.err.println("Window size: "+ac.getWindowSize());
+    }
+
+    @Test(dataProvider = "illegalWSize", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalRequiredWindowSize(final int ws) {
+        final WindowSizeArgumentCollection ac = new OptionalWindowSizeArgumentCollection(ws);
+        System.err.println("Window size: "+ac.getWindowSize());
+    }
+
+    @Test(dataProvider = "legalWSize")
+    public void testLegalDefaultWindowSize(final int ws) {
+        final WindowSizeArgumentCollection ac = new DefaultWindowSizeArgumentCollection(ws);
+        Assert.assertEquals(ac.getWindowSize(), ws);
+    }
+
+    @Test(dataProvider = "legalWSize")
+    public void testLegalRequiredWindowSize(final int ws) {
+        final WindowSizeArgumentCollection ac = new OptionalWindowSizeArgumentCollection(ws);
+        Assert.assertEquals(ac.getWindowSize(), ws);
+    }
+
+    @DataProvider(name="defaultWPadding")
+    private Object[][] withDefault() {
+        return new Object[][]{
+                {new FakeToolWSize(new DefaultWindowSizeArgumentCollection(10)), 10},
+                {new FakeToolWSize(new DefaultWindowSizeArgumentCollection(5)),  5}};
+    }
+
+    @DataProvider(name="requiredWPadding")
+    private Object[][] withRequired() {
+        return new Object[][]{
+                {new FakeToolWSize(new OptionalWindowSizeArgumentCollection(10)), 10},
+                {new FakeToolWSize(new OptionalWindowSizeArgumentCollection(5)),   5}};
+    }
+
+    @DataProvider(name="bothWPadding")
+    private Object[][] getBoth() {
+        return ArrayUtils.addAll(withDefault(), withRequired());
+    }
+
+    @Test(dataProvider = "bothWPadding")
+    public void testNoOptionProvided(final FakeToolWSize tool, final int defaultValue){
+        String[] args = {};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.ws.getWindowSize(), defaultValue);
+    }
+
+    @Test(dataProvider = "requiredWPadding")
+    public void provideOptionToRequired(final FakeToolWSize tool, final int defaultValue) {
+        String[] args = {"--windowSize", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.ws.getWindowSize(), defaultValue+1);
+    }
+
+    @Test(dataProvider = "defaultWPadding", expectedExceptions = UserException.CommandLineException.class)
+    public void provideOptionToDefault(final FakeToolWSize tool, final int defaultValue) {
+        String[] args = {"--windowSize", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test(dataProvider = "illegalWSize", expectedExceptions = UserException.BadArgumentValue.class)
+    public void provideIllegalValue(final int ws) {
+        final FakeToolWSize tool = new FakeToolWSize(new OptionalWindowSizeArgumentCollection(1000));
+        String[] args = {"--windowSize", String.valueOf(ws)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userSize = tool.ws.getWindowSize();
+        System.err.println("User window-size: "+userSize);
+    }
+
+    @Test(dataProvider = "legalWSize")
+    public void provideLegalValue(final int ws) {
+        final FakeToolWSize tool = new FakeToolWSize(new OptionalWindowSizeArgumentCollection(1000));
+        String[] args = {"--windowSize", String.valueOf(ws)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userSize = tool.ws.getWindowSize();
+        Assert.assertEquals(userSize, ws);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowStepArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/WindowStepArgumentCollectionTest.java
@@ -1,0 +1,122 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class WindowStepArgumentCollectionTest extends BaseTest{
+
+    private static class FakeToolWStep {
+        @ArgumentCollection
+        final WindowStepArgumentCollection ws;
+
+        FakeToolWStep(final WindowStepArgumentCollection ws) {
+            this.ws = ws;
+        }
+    }
+
+
+    @DataProvider(name="illegalWStep")
+    public Object[][] getIllegalSteps() {
+        return new Object[][] {{-10}, {-1}, {0}};
+    }
+
+    @DataProvider(name="legalWStep")
+    public Object[][] getLegalSteps() {
+        return new Object[][] {{1}, {5}, {10}};
+    }
+
+    @Test(dataProvider = "illegalWStep", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalDefaultWindowSize(final int ws) {
+        final WindowStepArgumentCollection ac = new DefaultWindowStepArgumentCollection(ws);
+        System.err.println("Window step: "+ac.getWindowStep());
+    }
+
+    @Test(dataProvider = "illegalWStep", expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalRequiredWindowSize(final int ws) {
+        final WindowStepArgumentCollection ac = new OptionalWindowStepArgumentCollection(ws);
+        System.err.println("Window step: "+ac.getWindowStep());
+    }
+
+    @Test(dataProvider = "legalWStep")
+    public void testLegalDefaultWindowSize(final int ws) {
+        final WindowStepArgumentCollection ac = new DefaultWindowStepArgumentCollection(ws);
+        Assert.assertEquals(ac.getWindowStep(), ws);
+    }
+
+    @Test(dataProvider = "legalWStep")
+    public void testLegalRequiredWindowSize(final int ws) {
+        final WindowStepArgumentCollection ac = new OptionalWindowStepArgumentCollection(ws);
+        Assert.assertEquals(ac.getWindowStep(), ws);
+    }
+
+    @DataProvider(name="defaultWStep")
+    private Object[][] withDefault() {
+        return new Object[][]{
+                {new FakeToolWStep(new DefaultWindowStepArgumentCollection(10)), 10},
+                {new FakeToolWStep(new DefaultWindowStepArgumentCollection(5)),  5}};
+    }
+
+    @DataProvider(name="requiredWStep")
+    private Object[][] withRequired() {
+        return new Object[][]{
+                {new FakeToolWStep(new OptionalWindowStepArgumentCollection(10)), 10},
+                {new FakeToolWStep(new OptionalWindowStepArgumentCollection(5)), 5}};
+    }
+
+    @DataProvider(name="bothWStep")
+    private Object[][] getBoth() {
+        return ArrayUtils.addAll(withDefault(), withRequired());
+    }
+
+    @Test(dataProvider = "bothWStep")
+    public void testNoOptionProvided(final FakeToolWStep tool, final int defaultValue){
+        String[] args = {};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.ws.getWindowStep(), defaultValue);
+    }
+
+    @Test(dataProvider = "requiredWStep")
+    public void provideOptionToRequired(final FakeToolWStep tool, final int defaultValue) {
+        String[] args = {"--windowStep", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        Assert.assertEquals(tool.ws.getWindowStep(), defaultValue+1);
+    }
+
+    @Test(dataProvider = "defaultWStep", expectedExceptions = UserException.CommandLineException.class)
+    public void provideOptionToDefault(final FakeToolWStep tool, final int defaultValue) {
+        String[] args = {"--windowStep", String.valueOf(defaultValue+1)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test(dataProvider = "illegalWStep", expectedExceptions = UserException.BadArgumentValue.class)
+    public void provideIllegalValue(final int ws) {
+        final FakeToolWStep tool = new FakeToolWStep(new OptionalWindowStepArgumentCollection(1000));
+        String[] args = {"--windowStep", String.valueOf(ws)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userStep = tool.ws.getWindowStep();
+        System.err.println("User window-step: "+userStep);
+    }
+
+    @Test(dataProvider = "legalWStep")
+    public void provideLegalValue(final int ws) {
+        final FakeToolWStep tool = new FakeToolWStep(new OptionalWindowStepArgumentCollection(1000));
+        String[] args = {"--windowStep", String.valueOf(ws)};
+        CommandLineParser clp = new CommandLineParser(tool);
+        clp.parseArguments(System.out, args);
+        int userStep = tool.ws.getWindowStep();
+        Assert.assertEquals(userStep, ws);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadSliderWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadSliderWalkerIntegrationTest.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.hellbender.tools.examples;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class ExampleReadSliderWalkerIntegrationTest extends CommandLineProgramTest {
+    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+
+    @Test
+    public void testExampleReadSliderWalker() throws IOException {
+        IntegrationTestSpec testSpec = new IntegrationTestSpec(
+            " -L 1:200-1125" + // region with variants/reads
+            " -L 4:15951-16000" + // region with reference bases
+                " -R " + hg19MiniReference +
+                " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
+                " -V " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
+                " -O %s",
+            Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleReadSliderWalkerIntegrationTest_output.txt")
+        );
+        testSpec.executeTest("testExampleReadSliderWalker", this);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantSliderWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantSliderWalkerIntegrationTest.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.hellbender.tools.examples;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class ExampleVariantSliderWalkerIntegrationTest extends CommandLineProgramTest {
+    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+
+    @Test
+    public void testExampleVariantSliderWalker() throws IOException {
+        IntegrationTestSpec testSpec = new IntegrationTestSpec(
+            " -L 1:200-1125" + // region with variants/reads
+            " -L 4:15951-16000" + // region with reference bases
+                " -R " + hg19MiniReference +
+                " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
+                " -V " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
+                " -O %s",
+            Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleVariantSliderWalkerIntegrationTest_output.txt")
+        );
+        testSpec.executeTest("testExampleVariantSliderWalker", this);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/FilteringIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/FilteringIteratorUnitTest.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.TextCigarCodec;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.engine.filters.VariantFilterLibrary;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public class FilteringIteratorUnitTest extends BaseTest {
+
+    private Iterator<GATKRead> makeReadsIterator() {
+        return Arrays.asList(
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("50M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("30M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M"))
+        ).iterator();
+    }
+
+    private Iterator<VariantContext> makeVariantIterator() {
+        final VariantContextBuilder builder = new VariantContextBuilder().source("test").chr("1").alleles(
+            Arrays.asList(Allele.create("A", true), Allele.create("T")));
+        int pos = 1;
+        return Arrays.asList(
+            // 3 biallelic
+            builder.start(pos).stop(pos++).make(),
+            builder.start(pos).stop(pos++).make(),
+            builder.start(pos).stop(pos++).make(),
+            // 2 no biallelic
+            builder.start(pos).stop(pos++).alleles(Collections.singleton(Allele.create("C", true))).make(),
+            builder.start(pos).stop(pos).make()
+        ).iterator();
+    }
+
+    @DataProvider(name = "FilteringIteratorTestData")
+    public Object[][] filteringIteratorTestData() {
+        // read filters
+        final Predicate<GATKRead> allowNoReadsFilter = read -> false;
+        final Predicate<GATKRead> allowLongReadsFilter = read -> read.getLength() > 100;
+        // variant filters
+        final VariantFilter allowNoVariantFilter = variant -> false;
+        final VariantFilter allowNoBiallelic = VariantContext::isBiallelic;
+
+        return new Object[][] {
+            // testing read filters
+            {makeReadsIterator(), ReadFilterLibrary.ALLOW_ALL_READS, 5},
+            {makeReadsIterator(), allowNoReadsFilter, 0},
+            {makeReadsIterator(), allowLongReadsFilter, 3},
+            {makeVariantIterator(), VariantFilterLibrary.ALLOW_ALL_VARIANTS, 5 },
+            {makeVariantIterator(), allowNoVariantFilter, 0 },
+            {makeVariantIterator(), allowNoBiallelic, 3 }};
+    }
+
+    @Test(dataProvider = "FilteringIteratorTestData")
+    public void testFilteringIterator(final Iterator<Object> iter, final Predicate<Object> filter, final int expectedReadCount) {
+        final FilteringIterator<Object> filteringIterator = new FilteringIterator<>(iter, filter);
+        int count = 0;
+        for (final Object obj : filteringIterator) {
+            ++count;
+        }
+        Assert.assertEquals(count, expectedReadCount, "Wrong number of reads from the ReadFilteringIterator");
+    }
+}

--- a/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleReadSliderWalkerIntegrationTest_output.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleReadSliderWalkerIntegrationTest_output.txt
@@ -1,0 +1,20 @@
+Window 1:200-299 contains 3 reads. No ACGT reference bases. Overlapping variants: {SNP=4, INDEL=3}.
+Window 1:250-349 contains 3 reads. No ACGT reference bases. Overlapping variants: {SNP=3, INDEL=1}.
+Window 1:300-399 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:350-449 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:400-499 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:450-549 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:500-599 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:550-649 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:600-699 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:650-749 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:700-799 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:750-849 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:800-899 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:850-949 contains 0 reads. No ACGT reference bases. No overlapping variants.
+Window 1:900-999 contains 0 reads. No ACGT reference bases. Overlapping variants: {SNP=1}.
+Window 1:950-1049 contains 1 reads. No ACGT reference bases. Overlapping variants: {SNP=2, INDEL=1}.
+Window 1:1000-1099 contains 1 reads. No ACGT reference bases. Overlapping variants: {SNP=2, INDEL=1}.
+Window 1:1050-1125 contains 2 reads. No ACGT reference bases. Overlapping variants: {SNP=1}.
+Window 1:1100-1125 contains 1 reads. No ACGT reference bases. No overlapping variants.
+Window 4:15951-16000 contains 0 reads. Reference bases [A, C, G, T]:[12, 4, 25, 9]. No overlapping variants.

--- a/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleVariantSliderWalkerIntegrationTest_output.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleVariantSliderWalkerIntegrationTest_output.txt
@@ -1,0 +1,20 @@
+Window 1:200-299 contains 7 variants (4/0 transition/transversion). Unknown GC content for reference. Read coverage: 3.
+Window 1:250-349 contains 4 variants (3/0 transition/transversion). Unknown GC content for reference. Read coverage: 3.
+Window 1:300-399 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:350-449 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:400-499 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:450-549 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:500-599 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:550-649 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:600-699 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:650-749 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:700-799 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:750-849 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:800-899 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:850-949 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:900-999 contains 1 variants (1/0 transition/transversion). Unknown GC content for reference. Read coverage: 0.
+Window 1:950-1049 contains 3 variants (2/0 transition/transversion). Unknown GC content for reference. Read coverage: 1.
+Window 1:1000-1099 contains 3 variants (2/0 transition/transversion). Unknown GC content for reference. Read coverage: 1.
+Window 1:1050-1125 contains 1 variants (1/0 transition/transversion). Unknown GC content for reference. Read coverage: 2.
+Window 1:1100-1125 contains 0 variants (0/0 transition/transversion). Unknown GC content for reference. Read coverage: 1.
+Window 4:15951-16000 contains 0 variants (0/0 transition/transversion). Reference GC content: 0.68%. Read coverage: 0.


### PR DESCRIPTION
New implementation of `SlidingWindowWalker` with some ideas from the discussion in #1528.

The thinks that are requested in #1198 still holds, but now it is more general: padding option is added and construction of windows are done by interval.

The code contain a lot of TODO because it relies on changes implemented in #1567, and because it is suppose to be a walker over `ReadWindow` instead of `SimpleInterval`+`ReadsContext` if reads are available.

I think that with these changes it could be general to be extended by `ReadWindowWalker` and by users that needs a different way of "slide" over intervals.
