### PR TITLE
update GATKSparkTool.getRecommendedNumReducers for GCS

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -252,7 +252,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         if (numReducers != 0) {
             return numReducers;
         }
-        return 1 + (int) (BucketUtils.dirSize(getReadSourceName(), null) / getTargetPartitionSize());
+        return 1 + (int) (BucketUtils.dirSize(getReadSourceName(), getAuthenticatedGCSOptions()) / getTargetPartitionSize());
     }
 
     /**


### PR DESCRIPTION
running SparkTools on GCS was failing beceause BucketUtils.dirSize didn't support GCS paths
updating it to support GCS paths and updating GATKSparkTool to pass in the necessary Auth