### PR TITLE
Update build.gradle to make sure that tests are always rerunable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,13 @@ script:
     echo "Can't run cloud tests without keys so don't run tests";
   else
     bash scripts/install_git_lfs.sh;
-    travis_wait 30 ./gradlew test;
+    travis_wait 30 ./gradlew jacocoTestReport;
   fi
 after_success:
 - if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
     echo "Can't run cloud tests without keys so don't try to record coverage tests";
   else
-   ./gradlew jacocoTestReport coveralls;
+   ./gradlew coveralls;
   fi
 after_failure:
 - dmesg | tail -100

--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ jar {
 
 
 test {
+    outputs.upToDateWhen { false }  //tests will never be "up to date" so you can always rerun them
     String CI = "$System.env.CI"
     String CLOUD = "$System.env.CLOUD"
     String SPARK = "$System.env.SPARK"


### PR DESCRIPTION
Before this change you can run tests only once before gradle decides that the task is "UP-TO-DATE". I want to be able to rerun tests multiple times (bonus: guess what I'm testing) and so this caching got in the way. With this change, tasks are always rerunnable.

Test it by running this twice:
```
./gradlew test --tests *VariantFiltrationIntegrationTest*
```

@lbergelson can you review?