### PR TITLE
fix resource leaks in MarkDuplicates

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractMarkDuplicatesCommandLineProgram.java
@@ -198,6 +198,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
         @Override
         public void close(){
             CloserUtil.close(readers);
+            CloserUtil.close(iterator);
         }
     }
 


### PR DESCRIPTION
This was debugged while testing https://github.com/samtools/htsjdk/pull/576. Readers allocated in `AbstractMarkDuplicatesCommandLineProgram.openInputs` were never closed. In the asyncIO realm (if we switch to async reading) this is a big problem because one worker thread is then created and abandoned (it keeps living after its master is long gone - unless the master is closed which will inform the worker to finish).

The diffs are much more trivial than it looks in github gui - essentially 2 things were put in try-with-resources (two lines like this) and lot of white-space shifting followed.
`final SamHeaderAndIterator headerAndIterator = openInputs();`

