### PR TITLE
Add PairedEnds to GATKRegistrator for Kryo

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -2,11 +2,13 @@ package org.broadinstitute.hellbender.engine.spark;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.google.api.services.genomics.model.Read;
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import htsjdk.samtools.SAMRecord;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.utils.read.markduplicates.PairedEnds;
 
 import java.util.Collections;
 
@@ -41,6 +43,9 @@ public class GATKRegistrator implements KryoRegistrator {
 
         kryo.register(SAMRecord.class, new SAMRecordSerializer());
 
+	//register to avoid writing the full name of this class over and over
+	kryo.register(PairedEnds.class, new FieldSerializer<>(kryo, PairedEnds.class));
+	
         // register the ADAM data types using Avro serialization, including:
         //     AlignmentRecord
         //     Genotype


### PR DESCRIPTION
registering PairedEnds for Kryo. The reason is that Kryo serializes each object graph separately (for us, ther's a object graph for reach read pair, so there're billions of them). Now, for unregistered classes, the first encounter of such a class means that Kryo must serialize the class's full name (it uses an ID for subsequent uses of this class in the same object graph). For us, that means that the string "org.broadinstitute.hellbender.utils.read.markduplicates.PairedEnds" gets serialized billions of times. If this class is registered, then it's always referred to by ID not by name. This PR does not change the serializer used, just forces Kryo to always refer to this type by ID.

It saves ~2% of shuffle volume (99.7 GB vs 97.9 GB) and saves some time: 7.2 mins vs 7.4 mins on MarkDuplicatesSpark