### PR TITLE
skip hashtable lookup in Kryo

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -25,7 +25,10 @@ public class GATKRegistrator implements KryoRegistrator {
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public void registerClasses(Kryo kryo) {
-
+	//NOTE: this speeds up serialization because it avoids a hashtable lookup
+	//but it may be dangerous in that it may result in an infinite loop for cyclic object graphs
+	kryo.setReferences(false);
+	
         // JsonSerializer is needed for the Google Genomics classes like Read and Reference.
         kryo.register(Read.class, new JsonSerializer<Read>());
         // htsjdk.variant.variantcontext.CommonInfo has a Map<String, Object> that defaults to


### PR DESCRIPTION
hashtable lookups are expensive in Kryo and they add up to 15% or more of runtime (top hotspot on Xprof). https://twitter.com/aphyr/status/478638361150636032

This PR turns off reference tracking in Kryo which speeds things up ~7.2mins vs 7.4mins on MarkDuplicatesSpark but it's a bit risky because I think it may result in an infinite loop for cyclic object graphs. We do not have any cyclic object graphs now and so it's fine.

The PR is to open a convo about this.
@tomwhite @droazen @laserson wdyt?