### PR TITLE
fix lib intel deflater extraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ script:
     echo "Can't run cloud tests without keys so don't run tests";
   else
     bash scripts/install_git_lfs.sh;
+    ./gradlew installDist;
+   ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O /dev/null ;
     travis_wait 30 ./gradlew jacocoTestReport;
   fi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,16 @@ install:
     echo "Can't run cloud tests without keys so don't bother building";
   else
     ./gradlew assemble;
+    ./gradlew installDist;
   fi
 script:
+#basic sanity test to check that gatk-launch actually runs something
+- ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam
+#run tests
 - if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
     echo "Can't run cloud tests without keys so don't run tests";
   else
     bash scripts/install_git_lfs.sh;
-    ./gradlew installDist;
-   ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O /dev/null ;
     travis_wait 30 ./gradlew jacocoTestReport;
   fi
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ buildscript {
         mavenCentral()
         jcenter() // for shadow plugin
      }
-
-
 }
 
 plugins {
@@ -166,7 +164,8 @@ task extractIntelDeflater(type: Copy) {
     from {
         zipTree( htsjdkJar ).matching{ include 'lib/jni/libIntelDeflater.so'}.singleFile
     }
-    into 'build/libIntelDeflater.so'
+    into 'build'
+    rename "lib/jni/libIntelDeflater.so", "libIntelDeflater.so"
 }
 
 
@@ -243,10 +242,6 @@ test {
     if (CI == "true" && CLOUD == "false" ) {
         int count = 0
         // listen to events in the test execution lifecycle
-        testLogging {
-            events "skipped", "failed"
-            exceptionFormat = "full"
-        }
 
         beforeTest { descriptor ->
             count++
@@ -266,6 +261,19 @@ test {
             logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message )
         }
     }
+
+    testLogging {
+        testLogging {
+            events "skipped", "failed"
+            exceptionFormat = "full"
+        }
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+            }
+        }
+    }
+
 }
 
 task wrapper(type: Wrapper) {
@@ -400,6 +408,7 @@ uploadArchives {
 task installSpark{ dependsOn sparkJar }
 task installAll{  dependsOn installSpark, installDist }
 
+test.dependsOn extractIntelDeflater
 installDist.dependsOn downloadGsaLibFile, extractIntelDeflater
 build.dependsOn installDist
 check.dependsOn installDist

--- a/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import org.apache.commons.lang3.SystemUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -9,7 +10,7 @@ import org.testng.annotations.Test;
 /**
  * Test that it's possible to load libIntelDeflater
  */
-public class IntelDeflaterTest {
+public class IntelDeflaterIntegrationTest extends BaseTest {
 
     @Test
     public void testIntelDeflaterIsAvailable(){

--- a/src/test/java/org/broadinstitute/hellbender/IntelDeflaterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelDeflaterTest.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.hellbender;
+
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.apache.commons.lang3.SystemUtils;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/**
+ * Test that it's possible to load libIntelDeflater
+ */
+public class IntelDeflaterTest {
+
+    @Test
+    public void testIntelDeflaterIsAvailable(){
+        if ( !SystemUtils.IS_OS_LINUX ) {
+            throw new SkipException("IntelDeflater not available on this platform");
+        }
+
+        Assert.assertTrue(DeflaterFactory.usingIntelDeflater(), "libIntelDeflater.so was not loaded. " +
+                "This could be due to a configuration error, or your system might not support it.");
+    }
+
+}


### PR DESCRIPTION
the first commit adds a test, which should fail
the second should fix the test.  It's currently failing though, so I'm not sure what's happening yet.  It works on gsa5.