### PR TITLE
close all resources regardless of success

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -512,10 +512,29 @@ public abstract class GATKTool extends CommandLineProgram {
 
     @Override
     protected final Object doWork() {
-        onTraversalStart();
-        progressMeter.start();
-        traverse();
-        progressMeter.stop();
-        return onTraversalSuccess();
+        try {
+            onTraversalStart();
+            progressMeter.start();
+            traverse();
+            progressMeter.stop();
+            return onTraversalSuccess();
+        } finally {
+            closeTool();
+        }
+    }
+
+    /**
+     * This method is called by the GATK framework at the end of the {@link #doWork} template method.
+     * It is called regardless of whether the {@link #traverse} has succeeded or not.
+     * It is called <em>after</em> the {@link #onTraversalSuccess} has completed (successfully or not)
+     * but before the {@link #doWork} method returns.
+     *
+     * In other words, on successful runs both {@link #onTraversalSuccess} and {@link #closeTool} will be called (in this order) while
+     * on failed runs (when {@link #traverse} causes an exception), only {@link #closeTool} will be called.
+     *
+     * The default implementation does nothing.
+     * Subclasses should override this method to close any resources that must be closed regardless of the success of traversal.
+     */
+    public void closeTool(){
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
@@ -305,13 +305,20 @@ public final class ClipReads extends ReadWalker {
     public ClippingData onTraversalSuccess(){
         if ( outputStats != null ){
             outputStats.printf(accumulator.toString());
+        }
+        return accumulator;
+    }
+
+    @Override
+    public void closeTool() {
+        if ( outputStats != null ){
             outputStats.close();
         }
         if ( outputBam != null ) {
             outputBam.close();
         }
-        return accumulator;
     }
+
     /**
      * Helper function that adds a seq with name and bases (as bytes) to the list of sequences to be clipped
      *

--- a/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
@@ -40,10 +40,9 @@ public final class FixMisencodedBaseQualityReads extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -84,10 +84,9 @@ public final class LeftAlignIndels extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -35,10 +35,9 @@ public final class PrintReads extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -87,11 +87,10 @@ public final class SplitReads extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outs != null ) {
             outs.values().forEach(writer -> writer.close());
         }
-        return null;
     }
 
     // Create an output stream on demand for holding any reads that do not have a value for one or more of the

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
@@ -82,12 +82,10 @@ public final class ExampleIntervalWalker extends IntervalWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputStream != null ) {
             outputStream.close();
         }
-
-        return null;
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
@@ -54,10 +54,9 @@ public final class ExampleReadWalkerWithReference extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
-        if ( outputStream != null )
+    public void closeTool() {
+        if ( outputStream != null ) {
             outputStream.close();
-
-        return null;
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
@@ -83,10 +83,9 @@ public final class ExampleReadWalkerWithVariants extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
-        if ( outputStream != null )
+    public void closeTool() {
+        if ( outputStream != null ) {
             outputStream.close();
-
-        return null;
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
@@ -79,11 +79,9 @@ public final class ExampleVariantWalker extends VariantWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputStream != null ) {
             outputStream.close();
         }
-
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -342,8 +342,23 @@ public final class CalculateTargetCoverage extends ReadWalker {
         logger.log(Level.INFO, "Writing counts done.");
 
         writeColumnSummaryOutput();
-        closeOutputs();
         return "SUCCESS";
+    }
+
+    @Override
+    public void closeTool() {
+        if (columnSummaryOutputWriter != null) {
+            columnSummaryOutputWriter.close();
+        }
+        if (outputWriter != null){
+            outputWriter.close();
+        }
+        if (rowSummaryOutputWriter != null) {
+            rowSummaryOutputWriter.close();
+        }
+        if (columnSummaryOutputWriter != null) {
+            columnSummaryOutputWriter.close();
+        }
     }
 
     /**
@@ -378,20 +393,6 @@ public final class CalculateTargetCoverage extends ReadWalker {
                             columnNames.get(i),
                             String.valueOf(sum),
                             String.format(AVERAGE_DOUBLE_FORMAT, sum / (double) totalSize)));
-        }
-        columnSummaryOutputWriter.close();
-    }
-
-    /**
-     * Close all output writers.
-     */
-    private void closeOutputs() {
-        outputWriter.close();
-        if (rowSummaryOutputWriter != null) {
-            rowSummaryOutputWriter.close();
-        }
-        if (columnSummaryOutputWriter != null) {
-            columnSummaryOutputWriter.close();
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
@@ -53,10 +53,9 @@ public class RevertBaseQualityScores extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
@@ -44,10 +44,9 @@ public class UnmarkDuplicates extends ReadWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
@@ -62,11 +62,9 @@ public final class ApplyBQSR extends ReadWalker{
     }
 
     @Override
-    public Object onTraversalSuccess() {
+    public void closeTool() {
         if ( outputWriter != null ) {
             outputWriter.close();
         }
-        return null;
     }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -396,9 +396,10 @@ public final class VariantFiltration extends VariantWalker {
     }
 
     @Override
-    public Object onTraversalSuccess() {
-        writer.close();
-        return null;
+    public void closeTool() {
+        if (writer != null){
+            writer.close();
+        }
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -588,9 +588,10 @@ public final class SelectVariants extends VariantWalker {
      * Close out the new variants file.
      */
     @Override
-    public Object onTraversalSuccess() {
-        vcfWriter.close();
-        return null;
+    public void closeTool() {
+        if (vcfWriter != null) {
+            vcfWriter.close();
+        }
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/broadinstitute/gatk/issues/1741 by closing the writer regardless of success. Added an `onTraversalDone` template method to `GATKTool` to take care of this. Otherwise we'll always leak resources on exceptions.

@droazen please review