### PR TITLE
update to 4.1 - apache collections 4.0 had a serialization exploit 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-core:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.apache.commons:commons-math3:3.5'
-    compile 'org.apache.commons:commons-collections4:4.0'
+    compile 'org.apache.commons:commons-collections4:4.1'
     compile 'org.apache.commons:commons-vfs2:2.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.reflections:reflections:0.9.10'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/COLLECTIONS-580

credit goes to @gmlewis  who alerted us on https://github.com/broadgsa/gatk/pull/17. Thanks Glenn

@lbergelson any objections?