### PR TITLE
Porting of vector PairHMM to POWER8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -422,8 +422,15 @@ model {
                     println("WARNING: Building the native AVX PairHMM library is not supported on this OS.")
                 } else {
                     cppCompiler.args "-I", "${System.properties['java.home']}/../include"
-                    cppCompiler.args "-mavx"
                     cppCompiler.args "-Wall"
+		    if(System.getProperty("os.arch") == "ppc64le") {
+                      cppCompiler.args "-mcpu=power8"
+                      cppCompiler.args "-mtune=power8"
+                      cppCompiler.args "-fopenmp"
+                      linker.args "-lgomp"
+		    } else {
+                      cppCompiler.args "-mavx"
+		    }
 
                     // build with gcov options on Travis
                     if (System.env.CI.toString().toBoolean()) {
@@ -466,8 +473,15 @@ model {
         if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
             clang(Clang)
         } else {
-            gcc(Gcc)
+            gcc(Gcc) {
+	      target("linux_ppc64le")	// tentative fix until gradle supports linux ppc64le
+	    }
         }
+    }
+    platforms {
+        linux_ppc64le { 		// tentative fix until gradle supports linux ppc64le
+	    architecture "ppc64le"
+	}
     }
 }
 

--- a/src/main/cpp/VectorLoglessPairHMM/LoadTimeInitializer.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/LoadTimeInitializer.cc
@@ -20,10 +20,12 @@ LoadTimeInitializer g_load_time_initializer;
 LoadTimeInitializer::LoadTimeInitializer()		//will be called when library is loaded
 {
   ConvertChar::init();
+#if defined(__x86_64__)
   //Very important to get good performance on Intel processors
   //Function: enabling FTZ converts denormals to 0 in hardware
   //Denormals cause microcode to insert uops into the core causing big slowdown
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+#endif
 
   //Profiling: times for compute and transfer (either bytes copied or pointers copied)
   m_compute_time = 0;

--- a/src/main/cpp/VectorLoglessPairHMM/README.md
+++ b/src/main/cpp/VectorLoglessPairHMM/README.md
@@ -1,5 +1,4 @@
-This code implements PairHMM using AVX instructions.
+This code implements PairHMM using vector instructions.
 
 Todo:
- * Consider renaming VectorLoglessPairHMM to AVXLoglessPairHMM
- * Add code to report if PairHMM AVX *can run* (AVX is supported and the native library can be loaded)
+ * Add code to report if vector PairHMM *can run* (the vector instruction set is supported and the native library can be loaded)

--- a/src/main/cpp/VectorLoglessPairHMM/avx_function_instantiations.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/avx_function_instantiations.cc
@@ -1,4 +1,6 @@
+#if defined(__x86_64__)
 #define SIMD_ENGINE avx
+#define SIMD_ENGINE_AVX
 
 #include "template.h"
 
@@ -12,3 +14,4 @@
 
 template double compute_full_prob_avxd<double>(testcase* tc, double* nextlog);
 template float compute_full_prob_avxs<float>(testcase* tc, float* nextlog);
+#endif

--- a/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
+++ b/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
@@ -2,6 +2,9 @@
 #define COMMON_DATA_STRUCTURE_H
 
 #include "headers.h"
+#if defined(__POWER8_VECTOR__)
+#include "power8.h"
+#endif
 
 #define CAT(X,Y) X##Y
 #define CONCAT(X,Y) CAT(X,Y)
@@ -29,16 +32,17 @@ template<class NUMBER>
 struct ContextBase
 {
   public:
-    NUMBER ph2pr[128];
-    NUMBER INITIAL_CONSTANT;
-    NUMBER LOG10_INITIAL_CONSTANT;
-    NUMBER RESULT_THRESHOLD; 
+    static NUMBER ph2pr[128];
+    static NUMBER INITIAL_CONSTANT;
+    static NUMBER LOG10_INITIAL_CONSTANT;
+    static NUMBER RESULT_THRESHOLD; 
 
     static bool staticMembersInitializedFlag;
+    static bool staticMembersInitializedFlag1;
     static NUMBER jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
     static NUMBER matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1];
 
-    static void initializeStaticMembers()
+    static void initializeStaticMembers0()
     {
       if(!staticMembersInitializedFlag)
       {
@@ -116,7 +120,18 @@ struct Context : public ContextBase<NUMBER>
 template<>
 struct Context<double> : public ContextBase<double>
 {
-  Context():ContextBase<double>()
+  Context():ContextBase<double>() {}
+
+  static void initializeStaticMembers()
+  {
+      initializeStaticMembers0();
+      if(!staticMembersInitializedFlag1) {
+	initializePh2pr();
+	staticMembersInitializedFlag1 = true;
+      }
+  }
+
+  static void initializePh2pr()
   {
     for (int x = 0; x < 128; x++)
       ph2pr[x] = pow(10.0, -((double)x) / 10.0);
@@ -136,7 +151,18 @@ struct Context<double> : public ContextBase<double>
 template<>
 struct Context<float> : public ContextBase<float>
 {
-  Context() : ContextBase<float>()
+  Context() : ContextBase<float>() {}
+
+  static void initializeStaticMembers()
+  {
+      initializeStaticMembers0();
+      if(!staticMembersInitializedFlag1) {
+	initializePh2pr();
+	staticMembersInitializedFlag1 = true;
+      }
+  }
+
+  static void initializePh2pr()
   {
     for (int x = 0; x < 128; x++)
     {

--- a/src/main/cpp/VectorLoglessPairHMM/define-sse-double.h
+++ b/src/main/cpp/VectorLoglessPairHMM/define-sse-double.h
@@ -1,0 +1,148 @@
+#ifdef PRECISION
+#undef PRECISION
+#undef MAIN_TYPE
+#undef MAIN_TYPE_SIZE
+#undef UNION_TYPE
+#undef IF_128
+#undef IF_MAIN_TYPE
+#undef SHIFT_CONST1
+#undef SHIFT_CONST2
+#undef SHIFT_CONST3
+#undef _128_TYPE
+#undef SIMD_TYPE
+#undef AVX_LENGTH
+#undef HAP_TYPE
+#undef MASK_TYPE
+#undef MASK_ALL_ONES
+
+#undef VEC_EXTRACT_UNIT
+#undef VEC_INSERT_UNIT
+#undef SET_VEC_ZERO
+#undef VEC_OR
+#undef VEC_ADD
+#undef VEC_SUB
+#undef VEC_MUL
+#undef VEC_DIV
+#undef VEC_BLEND
+#undef VEC_BLENDV
+#undef VEC_CAST_256_128
+#undef VEC_EXTRACT_128
+#undef VEC_EXTRACT_UNIT
+#undef VEC_SET1_VAL128
+#undef VEC_MOVE
+#undef VEC_CAST_128_256
+#undef VEC_INSERT_VAL
+#undef VEC_CVT_128_256
+#undef VEC_SET1_VAL
+#undef VEC_POPCVT_CHAR
+#undef VEC_LDPOPCVT_CHAR
+#undef VEC_CMP_EQ
+#undef VEC_SET_LSE
+#undef SHIFT_HAP
+#undef MASK_VEC
+#undef VEC_SSE_TO_AVX
+#undef VEC_SHIFT_LEFT_1BIT
+#undef MASK_ALL_ONES
+#undef COMPARE_VECS
+#undef _256_INT_TYPE
+#undef BITMASK_VEC
+#endif
+
+#define SSE
+#define PRECISION d
+
+#define MAIN_TYPE double
+#define MAIN_TYPE_SIZE 64
+#define UNION_TYPE mix_D128
+#define IF_128 IF_128d
+#define IF_MAIN_TYPE IF_64
+#define SHIFT_CONST1 1
+#define SHIFT_CONST2 8
+#define SHIFT_CONST3 0
+#define _128_TYPE __m128d
+#define SIMD_TYPE __m128d
+#define _256_INT_TYPE __m128i
+#define AVX_LENGTH 2
+#define HAP_TYPE __m128i
+#define MASK_TYPE uint64_t
+#define MASK_ALL_ONES 0xFFFFFFFFFFFFFFFFL
+#define MASK_VEC MaskVec_D
+
+#define VEC_EXTRACT_UNIT(__v1, __im)            \
+    _mm_extract_epi64(__v1, __im)
+
+#define VEC_INSERT_UNIT(__v1,__ins,__im)        \
+    _mm_insert_epi64(__v1,__ins,__im)
+
+#define VEC_OR(__v1, __v2)                      \
+    _mm_or_pd(__v1, __v2)
+
+#define VEC_ADD(__v1, __v2)                     \
+    _mm_add_pd(__v1, __v2)
+
+#define VEC_SUB(__v1, __v2)                     \
+    _mm_sub_pd(__v1, __v2)
+
+#define VEC_MUL(__v1, __v2)                     \
+    _mm_mul_pd(__v1, __v2)
+
+#define VEC_DIV(__v1, __v2)                     \
+    _mm_div_pd(__v1, __v2)
+
+#define VEC_CMP_EQ(__v1, __v2)                  \
+    _mm_cmpeq_pd(__v1, __v2)
+
+#define VEC_BLEND(__v1, __v2, __mask)           \
+    _mm_blend_pd(__v1, __v2, __mask)
+
+#define VEC_BLENDV(__v1, __v2, __maskV)         \
+    _mm_blendv_pd(__v1, __v2, __maskV)
+
+#define SHIFT_HAP(__v1, __val)                  \
+    __v1 = _mm_insert_epi32(_mm_slli_si128(__v1, 4), __val.i, 0)
+
+#define VEC_CVT_128_256(__v1)                   \
+    _mm_cvtepi32_pd(__v1)
+
+#define VEC_SET1_VAL(__val)                     \
+    _mm_set1_pd(__val)
+
+#define VEC_POPCVT_CHAR(__ch)                   \
+    _mm_cvtepi32_pd(_mm_set1_epi32(__ch))
+
+#define VEC_SET_LSE(__val)                      \
+    _mm_set_pd(zero, __val);
+
+#define VEC_LDPOPCVT_CHAR(__addr)               \
+    _mm_cvtepi32_pd(_mm_loadu_si128((__m128i const *)__addr))
+
+#define VEC_SSE_TO_AVX(__vsLow, __vsHigh, __vdst)       \
+    __vdst = _mm_castsi128_pd(_mm_set_epi64(__vsHigh, __vsLow))
+
+#define VEC_SHIFT_LEFT_1BIT(__vs)               \
+    __vs = _mm_slli_epi64(__vs, 1)
+
+
+class BitMaskVec_sse_double {
+
+    MASK_VEC combined_ ;
+    public:
+    inline MASK_TYPE& getLowEntry(int index) {
+        return combined_.masks[index] ;
+    }
+    inline MASK_TYPE& getHighEntry(int index) {
+        return combined_.masks[AVX_LENGTH/2+index] ;
+    }
+
+    inline const SIMD_TYPE& getCombinedMask() {
+        return combined_.vecf ;
+    }
+
+    inline void shift_left_1bit() {
+        VEC_SHIFT_LEFT_1BIT(combined_.vec) ;
+    }
+
+} ;
+
+#define BITMASK_VEC BitMaskVec_sse_double
+

--- a/src/main/cpp/VectorLoglessPairHMM/define-sse-float.h
+++ b/src/main/cpp/VectorLoglessPairHMM/define-sse-float.h
@@ -1,0 +1,148 @@
+#ifdef PRECISION
+#undef PRECISION
+#undef MAIN_TYPE
+#undef MAIN_TYPE_SIZE
+#undef UNION_TYPE
+#undef IF_128
+#undef IF_MAIN_TYPE
+#undef SHIFT_CONST1
+#undef SHIFT_CONST2
+#undef SHIFT_CONST3
+#undef _128_TYPE
+#undef SIMD_TYPE
+#undef AVX_LENGTH
+#undef HAP_TYPE
+#undef MASK_TYPE
+#undef MASK_ALL_ONES
+
+#undef VEC_EXTRACT_UNIT
+#undef VEC_INSERT_UNIT
+#undef SET_VEC_ZERO
+#undef VEC_OR
+#undef VEC_ADD
+#undef VEC_SUB
+#undef VEC_MUL
+#undef VEC_DIV
+#undef VEC_BLEND
+#undef VEC_BLENDV
+#undef VEC_CAST_256_128
+#undef VEC_EXTRACT_128
+#undef VEC_EXTRACT_UNIT
+#undef VEC_SET1_VAL128
+#undef VEC_MOVE
+#undef VEC_CAST_128_256
+#undef VEC_INSERT_VAL
+#undef VEC_CVT_128_256
+#undef VEC_SET1_VAL
+#undef VEC_POPCVT_CHAR
+#undef VEC_LDPOPCVT_CHAR
+#undef VEC_CMP_EQ
+#undef VEC_SET_LSE
+#undef SHIFT_HAP
+#undef MASK_VEC
+#undef VEC_SSE_TO_AVX
+#undef VEC_SHIFT_LEFT_1BIT
+#undef MASK_ALL_ONES
+#undef COMPARE_VECS
+#undef _256_INT_TYPE
+#undef BITMASK_VEC
+#endif
+
+#define SSE
+#define PRECISION s
+
+#define MAIN_TYPE float
+#define MAIN_TYPE_SIZE 32
+#define UNION_TYPE mix_F128
+#define IF_128 IF_128f
+#define IF_MAIN_TYPE IF_32
+#define SHIFT_CONST1 3
+#define SHIFT_CONST2 4
+#define SHIFT_CONST3 0
+#define _128_TYPE __m128
+#define SIMD_TYPE __m128
+#define _256_INT_TYPE __m128i
+#define AVX_LENGTH 4
+//#define MAVX_COUNT  (MROWS+3)/AVX_LENGTH
+#define HAP_TYPE UNION_TYPE
+#define MASK_TYPE uint32_t
+#define MASK_ALL_ONES 0xFFFFFFFF
+#define MASK_VEC MaskVec_F
+
+#define VEC_EXTRACT_UNIT(__v1, __im)            \
+    _mm_extract_epi32(__v1, __im)
+
+#define VEC_INSERT_UNIT(__v1,__ins,__im)        \
+    _mm_insert_epi32(__v1,__ins,__im)
+
+#define VEC_OR(__v1, __v2)                      \
+    _mm_or_ps(__v1, __v2)
+
+#define VEC_ADD(__v1, __v2)                     \
+    _mm_add_ps(__v1, __v2)
+
+#define VEC_SUB(__v1, __v2)                     \
+    _mm_sub_ps(__v1, __v2)
+
+#define VEC_MUL(__v1, __v2)                     \
+    _mm_mul_ps(__v1, __v2)
+
+#define VEC_DIV(__v1, __v2)                     \
+    _mm_div_ps(__v1, __v2)
+
+#define VEC_CMP_EQ(__v1, __v2)                  \
+    _mm_cmpeq_ps(__v1, __v2)
+
+#define VEC_BLEND(__v1, __v2, __mask)           \
+    _mm_blend_ps(__v1, __v2, __mask)
+
+#define VEC_BLENDV(__v1, __v2, __maskV)         \
+    _mm_blendv_ps(__v1, __v2, __maskV)
+
+#define SHIFT_HAP(__v1, __val)                  \
+    _vector_shift_lastsses(__v1, __val.f)
+
+#define VEC_CVT_128_256(__v1)                   \
+    _mm_cvtepi32_ps(__v1.i)
+
+#define VEC_SET1_VAL(__val)                     \
+    _mm_set1_ps(__val)
+
+#define VEC_POPCVT_CHAR(__ch)                   \
+    _mm_cvtepi32_ps(_mm_set1_epi32(__ch))
+
+#define VEC_SET_LSE(__val)                      \
+    _mm_set_ps(zero, zero, zero, __val);
+
+#define VEC_LDPOPCVT_CHAR(__addr)               \
+    _mm_cvtepi32_ps(_mm_loadu_si128((__m128i const *)__addr))
+
+#define VEC_SSE_TO_AVX(__vsLow, __vsHigh, __vdst)       \
+    __vdst = _mm_cvtpi32x2_ps(__vsLow, __vsHigh)
+
+#define VEC_SHIFT_LEFT_1BIT(__vs)               \
+    __vs = _mm_slli_epi32(__vs, 1)
+
+class BitMaskVec_sse_float {
+
+    MASK_VEC combined_ ;
+
+    public:
+    inline MASK_TYPE& getLowEntry(int index) {
+        return combined_.masks[index] ;
+    }
+    inline MASK_TYPE& getHighEntry(int index) {
+        return combined_.masks[AVX_LENGTH/2+index] ;
+    }
+
+    inline const SIMD_TYPE& getCombinedMask() {
+        return combined_.vecf ;
+    }
+
+    inline void shift_left_1bit() {
+        VEC_SHIFT_LEFT_1BIT(combined_.vec) ;
+    }
+
+} ;
+
+#define BITMASK_VEC BitMaskVec_sse_float

--- a/src/main/cpp/VectorLoglessPairHMM/headers.h
+++ b/src/main/cpp/VectorLoglessPairHMM/headers.h
@@ -11,8 +11,12 @@
 
 #include <sys/time.h>
 
+#if defined(__x86_64__)
 #include <immintrin.h>
 #include <emmintrin.h>
+#elif defined(__POWER8_VECTOR__)
+#include <omp.h>
+#endif
 
 #include <string>
 #include <iostream>

--- a/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
@@ -183,7 +183,12 @@ inline JNIEXPORT void JNICALL Java_org_broadinstitute_hellbender_utils_pairhmm_V
 inline void compute_testcases(vector<testcase>& tc_array, unsigned numTestCases, double* likelihoodDoubleArray,
     unsigned maxNumThreadsToUse)
 {
+#if defined(__POWER8_VECTOR__)
+  extern unsigned long g_max_num_threads; 
+  #pragma omp parallel for schedule (dynamic,10) num_threads(g_max_num_threads)
+#else
   #pragma omp parallel for schedule (dynamic,10000) num_threads(maxNumThreadsToUse)
+#endif
   for(unsigned tc_idx=0;tc_idx<numTestCases;++tc_idx)
   {
     float result_avxf = use_double ? 0 : g_compute_full_prob_float(&(tc_array[tc_idx]), 0);

--- a/src/main/cpp/VectorLoglessPairHMM/power8.h
+++ b/src/main/cpp/VectorLoglessPairHMM/power8.h
@@ -1,0 +1,98 @@
+#include <altivec.h>
+
+typedef vector unsigned int __m128i;
+typedef vector float __m128;
+typedef vector double __m128d;
+#define _mm_add_ps(a,b) vec_add(a,b)
+#define _mm_add_pd(a,b) vec_add(a,b)
+#define _mm_sub_ps(a,b) vec_sub(a,b)
+#define _mm_sub_pd(a,b) vec_sub(a,b)
+#define _mm_div_ps(a,b) vec_div(a,b)
+#define _mm_div_pd(a,b) vec_div(a,b)
+#define _mm_mul_ps(a,b) vec_mul(a,b)
+#define _mm_mul_pd(a,b) vec_mul(a,b)
+// r := (b==0)? a32_0 : ((b==1) ? a32_1 : ((b==2) ? a32_2 : a32_3))
+#define _mm_extract_epi32(a,b) vec_extract(a,b<=3?b:3)
+// r := (b==0)? a64_0 : a64_1
+#define _mm_extract_epi64(a,b) vec_extract((vector unsigned long long)a,b<=1?b:1)
+// r0 := (c==0) ? b : a32_0
+// r1 := (c==1) ? b : a32_1
+// r2 := (c==2) ? b : a32_2
+// r3 := (c==3) ? b : a32_3
+#define _mm_insert_epi32(a,b,c) (c<=3 ? vec_insert(b,a,c) : a)
+// r0 := (c==0) ? b : a64_0
+// r1 := (c==1) ? b : a64_1
+#define _mm_insert_epi64(a,b,c) (c<=1 ? (__m128i)vec_insert(b,(vector unsigned long long)a,c) : a)
+// r0 := a32_0 << b
+// r1 := a32_1 << b
+// r2 := a32_2 << b
+// r3 := a32_3 << b
+#define _mm_slli_epi32(a,b) vec_sl(a,((__m128i){b,b,b,b}))
+// r0 := a64_0 << b
+// r1 := a64_1 << b
+#define _mm_slli_epi64(a,b) (__m128i)vec_sl((vector unsigned long long)a,((vector unsigned long long){b,b}))
+// r0 := r1 := r2 := r3 := a32
+#define _mm_set1_ps(a) ((__m128){a,a,a,a})// vec_splat((vector float){a}, 0) // http://lists.freebsd.org/pipermail/freebsd-ppc/2014-July/007110.html 
+// r0 := r1 := a64
+#define _mm_set1_pd(a) ((__m128d){a,a})// vec_splat((vector double){a}, 0)
+// r0 := a32
+// r1 := a32
+// r2 := a32
+// r3 := a32
+#define _mm_set1_epi32(a) ((__m128i){a,a,a,a})//vec_splat((__m128i){a}, 0)
+// r0 := d32
+// r1 := c32
+// r2 := b32
+// r3 := a32
+#define _mm_set_ps(a,b,c,d) ((__m128){d,c,b,a})
+// r0 := b64
+// r1 := a64
+#define _mm_set_pd(a,b) ((__m128d){b,a})
+// r0 := (float)a32_0
+// r1 := (float)a32_1
+// r2 := (float)a32_2
+// r3 := (float)a32_3
+#define _mm_cvtepi32_ps(a) vec_ctf(a,0) // http://www.filibeto.org/unix/macos/lib/dev/documentation/Performance/Conceptual/Accelerate_sse_migration/Accelerate_sse_migration.pdf
+// r0 := (double)a64_0
+// r1 := (double)a64_1
+#if defined(vec_ctd)
+#define _mm_cvtepi32_pd(a) vec_ctd(a,0) /* will be supported by a future version of gcc */
+#else
+#if __GNUC__ > 4
+#define _mm_cvtepi32_pd(a) ((__m128d){(double)vec_extract(a,0),(double)vec_extract(a,1)})
+#else
+// Some g++ cannot compile this because of "sorry, unimplemented: unexpected AST of kind compound_literal_expr"
+#if !defined(_MM_CVTEPI32_PD)
+#define _MM_CVTEPI32_PD
+extern "C" __inline __m128d _mm_cvtepi32_pd(vector unsigned int a) {
+  double const a0 = (double)vec_extract((vector unsigned long long)a,0);
+  double const a1 = (double)vec_extract((vector unsigned long long)a,1);
+  return (__m128d){a0,a1};
+}
+#endif
+#endif
+#endif
+// __m128i r := __m128i a << (int b * 8)
+#define _mm_slli_si128(a,b) \
+  (b==4?vec_perm(a,(__m128i){0,0,0,0},(vector unsigned char){ 16,16,16,16, 0,1,2,3, 4,5,6,7, 8,9,10,11 }): \
+   (b==8?vec_perm(a,(__m128i){0,0,0,0},(vector unsigned char){ 16,16,16,16, 16,16,16,16, 0,1,2,3, 4,5,6,7}): \
+	(__m128i){(exit(-1),0U)}))
+// r0 := (c32_0 & 0x80000000) ? b32_0 : a32_0
+// r1 := (c32_1 & 0x80000000) ? b32_1 : a32_1
+// r2 := (c32_2 & 0x80000000) ? b32_2 : a32_2
+// r3 := (c32_3 & 0x80000000) ? b32_3 : a32_3
+//#define _mm_blendv_ps(a,b,c) vec_sel(a,b,(vector unsigned int){((unsigned int)c[0]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[1]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[2]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[3]&0x80000000)?0xFFFFFFFF:0})
+#define _mm_blendv_ps(a,b,c) vec_sel(a,b,vec_sra((vector signed int)c, (vector unsigned int){31,31,31,31}))
+// r0 := (c64_0 & 0x80000000) ? b64_0 : a64_0
+// r1 := (c64_1 & 0x80000000) ? b64_1 : a64_1
+//#define _mm_blendv_pd(a,b,c) vec_sel(a,b,(vector unsigned long long){(c[0]&0x8000000000000000UL)?0xFFFFFFFFFFFFFFFFUL:0,(c[1]&0x8000000000000000UL)?0xFFFFFFFFFFFFFFFFUL:0})
+#define _mm_blendv_pd(a,b,c) vec_sel(a,b,vec_sra((vector signed long long)c, (vector unsigned long long){63,63}))
+//#if !defined(_MM_BLENDV_PD)
+//#define _MM_BLENDV_PD
+//extern "C" __inline vector double _mm_blendv_pd(vector double a, vector double b, vector double c) {
+//  vector signed long long c1 = (vector signed long long)c;
+//  vector unsigned long long c2 = (vector unsigned long long){63,63};
+//  vector signed long long d = vec_sra(c1, c2);
+//  return vec_sel(a, b, d);
+//}
+//#endif

--- a/src/main/cpp/VectorLoglessPairHMM/shift_template.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/shift_template.cc
@@ -1,5 +1,7 @@
 #ifdef PRECISION
 
+#ifdef SIMD_ENGINE_AVX
+
 inline void CONCAT(CONCAT(_vector_shift,SIMD_ENGINE), PRECISION) (UNION_TYPE &x, MAIN_TYPE shiftIn, MAIN_TYPE &shiftOut)
 {
     IF_128 xlow , xhigh;
@@ -54,5 +56,33 @@ inline void CONCAT(CONCAT(_vector_shift_last,SIMD_ENGINE), PRECISION) (UNION_TYP
     /* insert xhigh to x,1 */
     x.d = VEC_INSERT_VAL(x.d, xhigh.f, 1);
 }
+
+#endif
+
+#ifdef SIMD_ENGINE_SSE
+
+inline void CONCAT(CONCAT(_vector_shift,SIMD_ENGINE), PRECISION) (UNION_TYPE &x, MAIN_TYPE shiftIn, MAIN_TYPE &shiftOut)
+{
+    IF_MAIN_TYPE tempIn, tempOut;
+    tempIn.f = shiftIn;
+    /* extratc H */
+    tempOut.i = VEC_EXTRACT_UNIT(x.i, SHIFT_CONST1);
+    shiftOut = tempOut.f;
+    /* shift     */
+    x.i = _mm_slli_si128(x.i, SHIFT_CONST2);
+    /* insert  L */
+    x.i = VEC_INSERT_UNIT(x.i , tempIn.i, SHIFT_CONST3);
+}
+
+inline void CONCAT(CONCAT(_vector_shift_last,SIMD_ENGINE), PRECISION) (UNION_TYPE &x, MAIN_TYPE shiftIn)
+{
+    IF_MAIN_TYPE temp; temp.f = shiftIn;
+    /* shift     */
+    x.i = _mm_slli_si128(x.i, SHIFT_CONST2);
+    /* insert  L */
+    x.i = VEC_INSERT_UNIT(x.i , temp.i, SHIFT_CONST3);
+}
+
+#endif
 
 #endif

--- a/src/main/cpp/VectorLoglessPairHMM/sse_function_instantiations.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/sse_function_instantiations.cc
@@ -1,0 +1,17 @@
+#if defined(__POWER8_VECTOR__)
+#define SIMD_ENGINE sse
+#define SIMD_ENGINE_SSE
+
+#include "template.h"
+
+#include "define-sse-float.h"
+#include "shift_template.cc"
+#include "pairhmm-template-kernel.cc"
+
+#include "define-sse-double.h"
+#include "shift_template.cc"
+#include "pairhmm-template-kernel.cc"
+
+template double compute_full_prob_ssed<double>(testcase* tc, double* nextlog);
+template float compute_full_prob_sses<float>(testcase* tc, float* nextlog);
+#endif

--- a/src/main/cpp/VectorLoglessPairHMM/template.h
+++ b/src/main/cpp/VectorLoglessPairHMM/template.h
@@ -1,21 +1,29 @@
 #ifndef TEMPLATES_H_
 #define TEMPLATES_H_
 
+#if defined(__POWER8_VECTOR__)
+#include <altivec.h>
+#include "power8.h"
+#endif
 #include "headers.h"
 
 
 #define ALIGNED __attribute__((aligned(32)))
 
+#ifdef SIMD_ENGINE_AVX
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m256 ALIGNED d;
         ALIGNED __m128i ALIGNED s[2];
         ALIGNED float  ALIGNED f[8];
         ALIGNED __m256i ALIGNED i;
 } ALIGNED mix_F ALIGNED;
+#endif
 
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m128 ALIGNED d;
+#if defined(__x86_64__) // 64-bit width vector
         ALIGNED __m64 ALIGNED s[2];
+#endif
         ALIGNED float  ALIGNED f[4];
         ALIGNED __m128i ALIGNED i;
 } ALIGNED mix_F128 ALIGNED;
@@ -27,8 +35,10 @@ typedef union ALIGNED {
 } MaskVec_F ;
 
 typedef union ALIGNED {
+#if defined(__x86_64__) // 64-bit width vector
   __m64 vec ;
   __m64 vecf ;
+#endif
   uint32_t masks[2] ;
 } MaskVec_F128 ;
 
@@ -44,16 +54,20 @@ typedef union ALIGNED
         ALIGNED float  ALIGNED f;
 } ALIGNED IF_32 ALIGNED;
 
+#ifdef SIMD_ENGINE_AVX
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m256d ALIGNED d;
         ALIGNED __m128i ALIGNED s[2];
         ALIGNED double  ALIGNED f[4];
         ALIGNED __m256i ALIGNED i;
 } ALIGNED mix_D ALIGNED;
+#endif
 
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m128d ALIGNED d;
+#if defined(__x86_64__) // 64-bit width vector
         ALIGNED __m64 ALIGNED s[2];
+#endif
         ALIGNED double  ALIGNED f[2];
         ALIGNED __m128i ALIGNED i;
 } ALIGNED mix_D128 ALIGNED;
@@ -65,8 +79,10 @@ typedef union ALIGNED {
 } MaskVec_D ;
 
 typedef union ALIGNED {
+#if defined(__x86_64__) // 64-bit width vector
   __m64 vec ;
   __m64 vecf ;
+#endif
   uint64_t masks[1] ;
 } MaskVec_D128 ;
 

--- a/src/main/cpp/VectorLoglessPairHMM/utils.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/utils.cc
@@ -8,6 +8,9 @@ uint8_t ConvertChar::conversionTable[255];
 //Global function pointers in utils.h
 float (*g_compute_full_prob_float)(testcase *tc, float* before_last_log) = 0;
 double (*g_compute_full_prob_double)(testcase *tc, double* before_last_log) = 0;
+#if defined(__POWER8_VECTOR__)
+unsigned long g_max_num_threads = omp_get_num_procs() *3/8; // 3 threads per core
+#endif
 //Static members in ContextBase
 template<>
 bool ContextBase<double>::staticMembersInitializedFlag = false;
@@ -21,10 +24,33 @@ template<>
 float ContextBase<float>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE] = { };
 template<>
 float ContextBase<float>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1] = { };
+template<> bool ContextBase<double>::staticMembersInitializedFlag1 = false;
+template<> bool ContextBase<float>::staticMembersInitializedFlag1 = false;
+template<> double ContextBase<double>::ph2pr[128] = {0.0};
+template<> float ContextBase<float>::ph2pr[128] = {0.0F};
+template<> double ContextBase<double>::INITIAL_CONSTANT = 0.0;
+template<> float ContextBase<float>::INITIAL_CONSTANT = 0.0F;
+template<> double ContextBase<double>::LOG10_INITIAL_CONSTANT = 0.0;
+template<> float ContextBase<float>::LOG10_INITIAL_CONSTANT = 0.0F;
+template<> double ContextBase<double>::RESULT_THRESHOLD = 0.0;
+template<> float ContextBase<float>::RESULT_THRESHOLD = 0.0F;
 
 
 void initialize_function_pointers()
 {
+#if defined(__x86_64__)
   g_compute_full_prob_float = compute_full_prob_avxs<float>;
   g_compute_full_prob_double = compute_full_prob_avxd<double>;
+#elif defined(__POWER8_VECTOR__)
+  g_compute_full_prob_float = compute_full_prob_sses<float>;
+  g_compute_full_prob_double = compute_full_prob_ssed<double>;
+  char *s = getenv("PHMM_N_THREADS");
+  if (s) {
+    char *endp;
+    long l = strtol(s, &endp, 10);
+    if (endp && *endp == 0) g_max_num_threads = l;
+  }
+#else
+#error "unsupported platform"
+#endif
 }

--- a/src/main/cpp/VectorLoglessPairHMM/utils.h
+++ b/src/main/cpp/VectorLoglessPairHMM/utils.h
@@ -22,10 +22,17 @@ extern float (*g_compute_full_prob_float)(testcase *tc, float *before_last_log);
 extern double (*g_compute_full_prob_double)(testcase *tc, double* before_last_log);
 template<class NUMBER>
 NUMBER compute_full_prob(testcase *tc, NUMBER *before_last_log=0);
+#if defined(__x86_64__)
 template<class NUMBER>
 NUMBER compute_full_prob_avxd(testcase *tc, NUMBER *before_last_log=0);
 template<class NUMBER>
 NUMBER compute_full_prob_avxs(testcase *tc, NUMBER *before_last_log=0);
+#elif defined(__POWER8_VECTOR__)
+template<class NUMBER>
+NUMBER compute_full_prob_ssed(testcase *tc, NUMBER *before_last_log=0);
+template<class NUMBER>
+NUMBER compute_full_prob_sses(testcase *tc, NUMBER *before_last_log=0);
+#endif
 
 void initialize_function_pointers();
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
@@ -27,21 +27,21 @@ public final class VectorPairHMMUnitTest extends BaseTest {
 
    @BeforeClass
     public void initialize() {
-        if (!VectorLoglessPairHMM.isAVXSupported()) {
-          throw new SkipException("AVX is not supported on this system.");
+        if (!VectorLoglessPairHMM.isVectorInstructionSetSupported()) {
+          throw new SkipException("Vector instruction set is not supported on this system.");
         } else {
             try {
                new VectorLoglessPairHMM();
             } catch (final Exception e){
-                throw new SkipException("AVX library not available");
+                throw new SkipException("Vector instruction set library not available");
             }
         }
     }
 
     private List<N2MemoryPairHMM> getHMMs() {
-        final N2MemoryPairHMM avxPairHMM = new VectorLoglessPairHMM();
-        avxPairHMM.doNotUseTristateCorrection();
-        return Collections.singletonList(avxPairHMM);
+        final N2MemoryPairHMM vectorPairHMM = new VectorLoglessPairHMM();
+        vectorPairHMM.doNotUseTristateCorrection();
+        return Collections.singletonList(vectorPairHMM);
     }
 
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
* Modified the files so that we can build libVectorLoglessPairHMM.so on Ubuntu/ppc64le platform
* Restored and modified the files for 128-bit vector that are on GATK3
* Added a new file to replace AVX with POWER8 vector instructions
* [Question] Is any unit test included in the repository to test the library?
* Confirmed that the library was built on Ubuntu 15.10/ppc64le
```
./gradlew installAll
:downloadGsaLibFile UP-TO-DATE
:extractIntelDeflater
:compileJava
:processResources
:classes
:compileVectorLoglessPairHMMSharedLibraryVectorLoglessPairHMMCpp
:linkVectorLoglessPairHMMSharedLibrary
:copySharedLib
:jar
:startScripts
:installDist
:sparkJar
:installSpark
:installAll

BUILD SUCCESSFUL
```