### PR TITLE
LIBS without keeping only one sample reads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -240,13 +240,16 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
             readStates.collectPendingReads();
 
             final Locatable location = getLocation();
-            final Map<String, ReadPileup> fullPileupPerSample = new HashMap<>();
+//            final Map<String, ReadPileup> fullPileupPerSample = new HashMap<>();
+
+            // single list with pileup elements for all the samples
+            final List<PileupElement> pile = new ArrayList<>(readStates.size());
 
             for (final Map.Entry<String, PerSampleReadStateManager> sampleStatePair : readStates ) {
                 final String sample = sampleStatePair.getKey();
                 final PerSampleReadStateManager readState = sampleStatePair.getValue();
                 final Iterator<AlignmentStateMachine> iterator = readState.iterator();
-                final List<PileupElement> pile = new ArrayList<>(readState.size());
+//                final List<PileupElement> pile = new ArrayList<>(readState.size());
 
                 while (iterator.hasNext()) {
                     // state object with the read/offset information
@@ -267,17 +270,19 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
                     }
                 }
 
-                if (! pile.isEmpty() ){ // if this pileup added at least one base, add it to the full pileup
-                    fullPileupPerSample.put(sample, new ReadPileup(location, pile));
-                }
+//                if (! pile.isEmpty() ){ // if this pileup added at least one base, add it to the full pileup
+//                    fullPileupPerSample.put(sample, new ReadPileup(location, pile));
+//                }
             }
 
             readStates.updateReadStates(); // critical - must be called after we get the current state offsets and location
-            if (!fullPileupPerSample.isEmpty()){ // if we got reads with non-D/N over the current position, we are done
+            if (! pile.isEmpty()) {
+//            if (!fullPileupPerSample.isEmpty()){ // if we got reads with non-D/N over the current position, we are done
 //                if (fullPileupPerSample.keySet().size() > 1){
 //                    throw new UnsupportedOperationException("Multiple samples are currently not supported in GATK4. Samples here:" + fullPileupPerSample.keySet());
 //                }
-                final ReadPileup singlePileup = fullPileupPerSample.values().iterator().next();
+//                final ReadPileup singlePileup = fullPileupPerSample.values().iterator().next();
+                final ReadPileup singlePileup = new ReadPileup(location, pile);
                 nextAlignmentContext = new AlignmentContext(location, singlePileup);
             }
         }


### PR DESCRIPTION
As noted in #1752, only the first sample with coverage is returned in the `AlignmentContext`.

This is a simple patch to make the `LoscusIteratorByState` returns an `AlignmentContext` with all the information in the provided iterator.