### PR TITLE
set FTZ always on jniComputeLikelihoods

### DIFF
--- a/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
@@ -225,6 +225,12 @@ JNIEXPORT void JNICALL Java_org_broadinstitute_hellbender_utils_pairhmm_VectorLo
   (JNIEnv* env, jobject thisObject, jint numReads, jint numHaplotypes, 
    jobjectArray readDataArray, jobjectArray haplotypeDataArray, jdoubleArray likelihoodArray, jint maxNumThreadsToUse)
 {
+  //Very important to get good performance on Intel processors
+  //Function: enabling FTZ converts denormals to 0 in hardware
+  //Denormals cause microcode to insert uops into the core causing big slowdown
+  //NOTE: To protect against this flag being reset on us, we're going to set it on every call to jniComputeLikelihoods
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+
 #ifdef DEBUG
   cout << "JNI numReads "<<numReads<<" numHaplotypes "<<numHaplotypes<<"\n";
 #endif


### PR DESCRIPTION
this solves a nasty precision issue in the HaplotypeCaller integration tests where tests would pass or fail depending on the order in which they ran!