### PR TITLE
user-specified spark core num; disable intelDeflator testing on PPC

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
@@ -1,0 +1,18 @@
+package org.broadinstitute.hellbender.utils;
+
+import org.apache.commons.lang3.SystemUtils;
+
+/**
+ * Utilities to provide architecture-dependent native functions
+ */
+public final class NativeUtils {
+
+    private NativeUtils(){}
+
+    /**
+     * boolean : returns whether the current platform is PowerPC, LE only
+     */
+    public static boolean isPPCArchitecture() {
+	return SystemUtils.OS_ARCH.equals("ppc64le");
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import org.apache.commons.lang3.SystemUtils;
+import org.broadinstitute.hellbender.utils.NativeUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -16,6 +17,10 @@ public class IntelDeflaterIntegrationTest extends BaseTest {
     public void testIntelDeflaterIsAvailable(){
         if ( !SystemUtils.IS_OS_LINUX ) {
             throw new SkipException("IntelDeflater not available on this platform");
+        }
+
+        if ( NativeUtils.isPPCArchitecture() ) {
+            throw new SkipException("IntelDeflater not available for this architecture");
         }
 
         Assert.assertTrue(DeflaterFactory.usingIntelDeflater(), "libIntelDeflater.so was not loaded. " +


### PR DESCRIPTION
1. User can define the number of Spark cores in gradle test by environmental variable GATK_TEST_SPARK_CORES. If the variable is not defined, or the value is bogus, will fall back to default of "local[\*]"
2. Skip intelDeflator test on PPC platforms.