### PR TITLE
helper scripts to build jar with .dylib and .so

### DIFF
--- a/scripts/build_pair_hmm_so_in_clean_repo.sh
+++ b/scripts/build_pair_hmm_so_in_clean_repo.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#Helper script to be called from upload_artifact_with_both_lib_and_dylib.sh
+#
+#checkout and clone a new copy of gatk in a tmpdir
+#build the .so file and return its location
+#this can only be run on broad machines
+#
+# usage build_pair_hmm_so_in_clean_repo.sh <commit hash>
+
+set -e
+set -v
+
+COMMIT=$1
+
+VECTOR_LIB="libVectorLoglessPairHMM.so"
+LIB_PATH="build/libs/vectorLoglessPairHMM/shared"
+
+export TMPDIR="/broad/hptmp"
+
+GATK_TMP_DIR=`mktemp --tmpdir -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+function finish {
+  rm -rf "$GATK_TMP_DIR/gatk"
+}
+trap finish EXIT
+
+cd "$GATK_TMP_DIR"
+GIT_LFS_SKIP_SMUDGE=1 git clone git@github.com:broadinstitute/gatk.git 1>2
+cd "gatk"
+GIT_LFS_SKIP_SMUDGE=1 git checkout -f "$COMMIT" 1>2
+
+./gradlew copySharedLib 1>2
+cp "$LIB_PATH/$VECTOR_LIB" "$GATK_TMP_DIR/$VECTOR_LIB"
+
+echo "$GATK_TMP_DIR/$VECTOR_LIB"
+exit 0

--- a/scripts/upload_artifact_with_both_lib_and_dylib.sh
+++ b/scripts/upload_artifact_with_both_lib_and_dylib.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#Upload a snapshot build of the current HEAD with both .dylib and .so
+#This can only be run from within Broad
+#this is a temporary workaround for #1645 until we have a solution for cross compiling a dylib and an so on the same machine
+
+set -v
+set -e
+
+SERVER=gsa6.broadinstitute.org
+
+LIB_PATH="build/classes/main/lib/"
+
+./gradlew clean copySharedLib
+vectorLib=$( ssh $SERVER 'bash -s' < scripts/build_pair_hmm_so_in_clean_repo.sh $( git rev-parse HEAD) )
+scp ${SERVER}:${vectorLib} $LIB_PATH
+
+./gradlew uploadArchives
+
+exit 0


### PR DESCRIPTION
adding a pair of scripts to help build both the dylib and so into a single jar, and then upload that jar to sonatype

these can only be run at broad

they should be temporary and removed / exported to a new repot when we resolve the native code question