### PR TITLE
fix intel deflater on dataproc

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -23,14 +23,17 @@ BUILD_LOCATION = script +"/build/install/" + projectName + "/bin/"
 GATK_RUN_SCRIPT = BUILD_LOCATION + projectName
 BIN_PATH = script + "/build/libs"
 
+EXTRA_JAVA_OPTIONS="-Dsamjdk.intel_deflater_so_path=libIntelDeflater.so -Dsamjdk.compression_level=1 -DGATK_STACKTRACE_ON_USER_EXCEPTION=true "
+
 DEFAULT_SPARK_ARGS = ["--conf", "spark.kryoserializer.buffer.max=512m",
 "--conf", "spark.driver.maxResultSize=0",
 "--conf", "spark.driver.userClassPathFirst=true",
 "--conf", "spark.io.compression.codec=lzf",
 "--conf", "spark.yarn.executor.memoryOverhead=600",
 "--conf", "spark.yarn.dist.files=" + script + "/build/libIntelDeflater.so",
-"--conf", "spark.executor.extraJavaOptions=-Dsamjdk.intel_deflater_so_path=libIntelDeflater.so -Dsamjdk.compression_level=1"]
-      
+"--conf", "spark.driver.extraJavaOptions=" + EXTRA_JAVA_OPTIONS,
+"--conf", "spark.executor.extraJavaOptions=" + EXTRA_JAVA_OPTIONS]
+
 class GATKLaunchException(Exception):
     pass
 
@@ -272,6 +275,7 @@ def convertSparkSubmitToDataprocArgs(args):
                     "--num-executors": "spark.executor.instances" }
 
     dataprocargs = []
+    filesToAdd = []
     properties = []
     try:
         i = 0
@@ -279,7 +283,12 @@ def convertSparkSubmitToDataprocArgs(args):
             arg = args[i]
             if arg == "--conf":
                 i += 1
-                properties.append(args[i])
+                property = args[i]
+                if "spark.yarn.dist.files" in property:  #intercept yarn files and pass it through --files instead
+                    files = property.split("=")[1]
+                    filesToAdd = filesToAdd + files.split(",")
+                else:
+                    properties.append(args[i])
             elif not replacements.get(arg) is None:
                 i += 1
                 propertyname = replacements.get(arg)
@@ -293,6 +302,10 @@ def convertSparkSubmitToDataprocArgs(args):
     if not len(properties) is 0:
         dataprocargs.append("--properties")
         dataprocargs.append(",".join(properties))
+
+    if not len(filesToAdd) is 0:
+        dataprocargs.append("--files")
+        dataprocargs.append(",".join(filesToAdd))
 
     return dataprocargs
 

--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -90,7 +90,7 @@ public class Main {
             System.err.println();
             System.err.println("***********************************************************************");
 
-            if( "true".equals(System.getenv(STACK_TRACE_ON_USER_EXCEPTION_PROPERTY)) ) {
+            if( "true".equals(System.getenv(STACK_TRACE_ON_USER_EXCEPTION_PROPERTY)) || Boolean.getBoolean(STACK_TRACE_ON_USER_EXCEPTION_PROPERTY) ) {
                 e.printStackTrace();
             }
             System.exit(USER_EXCEPTION_EXIT_VALUE);

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -252,7 +252,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         if (numReducers != 0) {
             return numReducers;
         }
-        return 1 + (int) (BucketUtils.dirSize(getReadSourceName(), null) / getTargetPartitionSize());
+        return 1 + (int) (BucketUtils.dirSize(getReadSourceName(), getAuthenticatedGCSOptions()) / getTargetPartitionSize());
     }
 
     /**


### PR DESCRIPTION
fixes #1784  and #1780  which both caused problems with the intel deflater

note: this incorporates the changes in https://github.com/broadinstitute/gatk/pull/1717 because without them it fails with

```
java.lang.UnsupportedOperationException: Directory size listing not supported on GCS.
	at org.broadinstitute.hellbender.utils.gcs.BucketUtils.dirSize(BucketUtils.java:301)
	at org.broadinstitute.hellbender.engine.spark.GATKSparkTool.getRecommendedNumReducers(GATKSparkTool.java:255)
	at org.broadinstitute.hellbender.engine.spark.GATKSparkTool.writeReads(GATKSparkTool.java:237)
	at org.broadinstitute.hellbender.tools.spark.pipelines.PrintReadsSpark.runTool(PrintReadsSpark.java:35)
	at org.broadinstitute.hellbender.engine.spark.GATKSparkTool.runPipeline(GATKSparkTool.java:313)
	at org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram.doWork(SparkCommandLineProgram.java:38)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.runTool(CommandLineProgram.java:102)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMainPostParseArgs(CommandLineProgram.java:155)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:174)
	at org.broadinstitute.hellbender.Main.instanceMain(Main.java:67)
	at org.broadinstitute.hellbender.Main.main(Main.java:82)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:731)
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:181)
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:206)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:121)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

example commandline:

```
./gatk-launch PrintReadsSpark -I gs://hellbender/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -O output --apiKey $HELLBENDER_TEST_APIKEY -- --sparkRunner GCS --cluster dataproc-cluster-3 --project broad-dsde-dev
```