### PR TITLE
PileupElement : save memory and time by accessing bases and quals directly without copying. 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
@@ -14,7 +14,7 @@ import static org.broadinstitute.hellbender.utils.BaseUtils.Base.D;
 /**
  * Represents an individual base in a reads pileup.
  */
-public class PileupElement {
+public final class PileupElement {
 
     private static final EnumSet<CigarOperator> ON_GENOME_OPERATORS =
             EnumSet.of(CigarOperator.M, CigarOperator.EQ, CigarOperator.X, CigarOperator.D);
@@ -51,7 +51,7 @@ public class PileupElement {
         Utils.nonNull(read, "read is null");
         Utils.nonNull(currentElement, "currentElement is null");
         Utils.validIndex(baseOffset, read.getLength());
-        Utils.validIndex(currentCigarOffset, read.getCigar().numCigarElements());
+        Utils.validIndex(currentCigarOffset, read.getCigarElements().size());
         Utils.validIndex(offsetInCurrentCigar, currentElement.getLength());
         this.read = read;
         this.offset = baseOffset;
@@ -152,7 +152,7 @@ public class PileupElement {
      * @return a base encoded as a byte
      */
     public byte getBase() {
-        return isDeletion() ? DELETION_BASE : read.getBases()[offset];
+        return isDeletion() ? DELETION_BASE : read.getBase(offset);
     }
 
     /**
@@ -160,7 +160,7 @@ public class PileupElement {
      * @return a phred-scaled quality score as a byte
      */
     public byte getQual() {
-        return isDeletion() ? DELETION_QUAL : read.getBaseQualities()[offset];
+        return isDeletion() ? DELETION_QUAL : read.getBaseQuality(offset);
     }
 
     /**
@@ -329,9 +329,10 @@ public class PileupElement {
     private LinkedList<CigarElement> getBetween(final Direction direction) {
         final int increment = direction == Direction.NEXT ? 1 : -1;
         LinkedList<CigarElement> elements = null;
-        final int nCigarElements = read.getCigar().numCigarElements();
+        final List<CigarElement> cigarElements = read.getCigarElements();
+        final int nCigarElements = cigarElements.size();
         for ( int i = currentCigarOffset + increment; i >= 0 && i < nCigarElements; i += increment) {
-            final CigarElement elt = read.getCigar().getCigarElement(i);
+            final CigarElement elt = cigarElements.get(i);
             if ( ON_GENOME_OPERATORS.contains(elt.getOperator()) ) {
                 break;
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -233,7 +233,7 @@ public interface GATKRead extends Locatable {
      * @throws IllegalArgumentException if i is negative or of i is not smaller than the number
      * of base qualities (as reported by {@link #getBaseQualityCount()}.
      */
-    default int getBaseQuality(final int i){
+    default byte getBaseQuality(final int i){
         return getBaseQualities()[i];
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -230,7 +230,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     //Overridden default method to avoid a call to getBaseQualities which makes a copy of data
     @Override
-    public int getBaseQuality(final int i){
+    public byte getBaseQuality(final int i){
         final byte[] baseQualities = samRecord.getBaseQualities();
         if (baseQualities == null){
             throw new IllegalArgumentException("Invalid call - there are no baseQualities");


### PR DESCRIPTION
PileupElement: save memory and time by accessing bases and quals directly without copying. Showed up on profile in HC