### PR TITLE
faster PileupElement.isBefore and isAfter queries with no linked list allocation.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.pileup;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -61,6 +62,16 @@ public final class ReadPileup implements Iterable<PileupElement>{
      */
     public ReadPileup(final Locatable loc, final List<GATKRead> reads, final List<Integer> offsets) {
         this(loc, readsOffsetsToPileup(reads, offsets));
+    }
+
+    /**
+     * Returns the first element corresponding to the given read or null there is no such element.
+     * @param read or null if elements with no reads are to be retrieved from this pileup.
+     * @return the first element corresponding to the given read or null there is no such element.
+     */
+    @VisibleForTesting
+    PileupElement getElementForRead(final GATKRead read){
+        return getElementStream().filter(el -> Objects.equals(el.getRead(), read)).findAny().orElse(null);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementUnitTest.java
@@ -13,9 +13,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+
+import static htsjdk.samtools.CigarOperator.*;
 
 /**
  * testing of the new (non-legacy) version of LocusIteratorByState
@@ -34,7 +34,7 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
         final AlignmentStateMachine state = new AlignmentStateMachine(read);
         final LIBS_position tester = new LIBS_position(read);
 
-        while ( state.stepForwardOnGenome() != null ) {
+        while (state.stepForwardOnGenome() != null) {
             tester.stepForwardOnGenome();
             final PileupElement pe = state.makePileupElement();
 
@@ -42,12 +42,12 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
             Assert.assertEquals(pe.getMappingQual(), read.getMappingQuality());
             Assert.assertEquals(pe.getOffset(), state.getReadOffset());
 
-            Assert.assertEquals(pe.isDeletion(), state.getCigarOperator() == CigarOperator.D);
+            Assert.assertEquals(pe.isDeletion(), state.getCigarOperator() == D);
             Assert.assertEquals(pe.isAfterInsertion(), tester.isAfterInsertion);
             Assert.assertEquals(pe.isBeforeInsertion(), tester.isBeforeInsertion);
             Assert.assertEquals(pe.isNextToSoftClip(), tester.isNextToSoftClip);
 
-            if ( ! hasNeighboringPaddedOps(params.getElements(), pe.getCurrentCigarOffset()) ) {
+            if (!hasNeighboringPaddedOps(params.getElements(), pe.getCurrentCigarOffset())) {
                 Assert.assertEquals(pe.isAfterDeletionEnd(), tester.isAfterDeletionEnd);
                 Assert.assertEquals(pe.isBeforeDeletionStart(), tester.isBeforeDeletionStart);
             }
@@ -75,24 +75,24 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
             // Don't test -- pe.getBaseIndex();
             if ( pe.atEndOfCurrentCigar() && state.getCurrentCigarElementOffset() < read.numCigarElements() - 1 ) {
                 final CigarElement nextElement = read.getCigar().getCigarElement(state.getCurrentCigarElementOffset() + 1);
-                if ( nextElement.getOperator() == CigarOperator.I ) {
+                if (nextElement.getOperator() == CigarOperator.I) {
                     Assert.assertTrue(pe.getBetweenNextPosition().size() >= 1);
                     Assert.assertEquals(pe.getBetweenNextPosition().get(0), nextElement);
                 }
-                if ( nextElement.getOperator() == CigarOperator.M ) {
+                if (nextElement.getOperator() == M) {
                     Assert.assertTrue(pe.getBetweenNextPosition().isEmpty());
                 }
             } else {
                 Assert.assertTrue(pe.getBetweenNextPosition().isEmpty());
             }
 
-            if ( pe.atStartOfCurrentCigar() && state.getCurrentCigarElementOffset() > 0 ) {
+            if (pe.atStartOfCurrentCigar() && state.getCurrentCigarElementOffset() > 0) {
                 final CigarElement prevElement = read.getCigar().getCigarElement(state.getCurrentCigarElementOffset() - 1);
-                if ( prevElement.getOperator() == CigarOperator.I ) {
+                if (prevElement.getOperator() == CigarOperator.I) {
                     Assert.assertTrue(pe.getBetweenPrevPosition().size() >= 1);
-                    Assert.assertEquals(pe.getBetweenPrevPosition().getLast(), prevElement);
+                    Assert.assertEquals(pe.getBetweenPrevPosition().get(pe.getBetweenPrevPosition().size() - 1), prevElement);
                 }
-                if ( prevElement.getOperator() == CigarOperator.M ) {
+                if (prevElement.getOperator() == M) {
                     Assert.assertTrue(pe.getBetweenPrevPosition().isEmpty());
                 }
             } else {
@@ -112,17 +112,17 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
 
         final List<CigarOperator> operators = Arrays.asList(CigarOperator.I, CigarOperator.P, CigarOperator.S);
 
-        for ( final CigarOperator firstOp : Arrays.asList(CigarOperator.M) ) {
-            for ( final CigarOperator lastOp : Arrays.asList(CigarOperator.M, CigarOperator.D) ) {
-                for ( final int nIntermediate : Arrays.asList(1, 2, 3) ) {
-                    for ( final List<CigarOperator> combination : Utils.makePermutations(operators, nIntermediate, false) ) {
+        for (final CigarOperator firstOp : Arrays.asList(M)) {
+            for (final CigarOperator lastOp : Arrays.asList(M, D)) {
+                for (final int nIntermediate : Arrays.asList(1, 2, 3)) {
+                    for (final List<CigarOperator> combination : Utils.makePermutations(operators, nIntermediate, false)) {
                         final int readLength = 2 + combination.size();
                         final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "read", 0, 1, readLength);
                         read.setBases(Utils.dupBytes((byte) 'A', readLength));
                         read.setBaseQualities(Utils.dupBytes((byte) 30, readLength));
 
                         String cigar = "1" + firstOp;
-                        for ( final CigarOperator op : combination ) {
+                        for (final CigarOperator op : combination) {
                             cigar += "1" + op;
                         }
                         cigar += "1" + lastOp;
@@ -141,6 +141,7 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
     public void testPrevAndNextTest(final GATKRead read, final CigarOperator firstOp, final CigarOperator lastOp, final List<CigarOperator> ops) {
         final AlignmentStateMachine state = new AlignmentStateMachine(read);
 
+        //before the first 'op' from the list
         state.stepForwardOnGenome();
         final PileupElement pe = state.makePileupElement();
         Assert.assertEquals(pe.getBetweenNextPosition().size(), ops.size());
@@ -150,6 +151,7 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
         Assert.assertNotNull(pe.getNextOnGenomeCigarElement());
         Assert.assertEquals(pe.getNextOnGenomeCigarElement().getOperator(), lastOp);
 
+        //after the first 'op' from the list
         state.stepForwardOnGenome();
         final PileupElement pe2 = state.makePileupElement();
         Assert.assertEquals(pe2.getBetweenPrevPosition().size(), ops.size());
@@ -160,17 +162,94 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
         Assert.assertEquals(pe2.getNextOnGenomeCigarElement(), null);
     }
 
+    @Test(dataProvider = "PrevAndNextTest")
+    public void testImmediateBeforeAndAfterTest(final GATKRead read, final CigarOperator firstOp, final CigarOperator lastOp, final List<CigarOperator> ops) {
+        final AlignmentStateMachine state = new AlignmentStateMachine(read);
+
+        //before the first 'op' from the list
+        state.stepForwardOnGenome();
+        final PileupElement pe1 = state.makePileupElement();
+        Assert.assertEquals(pe1.getAdjacentOperator(PileupElement.Direction.PREV), null);
+        Assert.assertEquals(pe1.getAdjacentOperator(PileupElement.Direction.NEXT), ops.get(0));
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertEquals(pe1.isImmediatelyBefore(op), ops.get(0) == op, op.toString());
+            Assert.assertFalse(pe1.isImmediatelyAfter(op), op.toString());
+        }
+
+        //after the first 'op' from the list
+        state.stepForwardOnGenome();
+        final PileupElement pe2 = state.makePileupElement();
+        Assert.assertEquals(pe2.getAdjacentOperator(PileupElement.Direction.PREV), ops.get(ops.size() - 1));
+        Assert.assertEquals(pe2.getAdjacentOperator(PileupElement.Direction.NEXT), null);
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe2.isImmediatelyBefore(op), "immediately before " + op);
+            Assert.assertEquals(pe2.isImmediatelyAfter(op), op == ops.get(ops.size() - 1), "immediately after " + op);
+        }
+    }
+
+    @DataProvider(name = "PrevAndNextTest_simple")
+    public Object[][] makePrevAndNextTest_simple() {
+        final List<Object[]> tests = new LinkedList<>();
+
+        for (final CigarOperator firstOp : Arrays.asList(M)) {
+            for (final CigarOperator lastOp : Arrays.asList(M)) {
+                for (final CigarOperator middleOp : Arrays.asList(CigarOperator.I, CigarOperator.P, CigarOperator.S)) {
+                    final int readLength = 3;
+                    final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "read", 0, 1, readLength);
+                    read.setBases(Utils.dupBytes((byte) 'A', readLength));
+                    read.setBaseQualities(Utils.dupBytes((byte) 30, readLength));
+
+                    String cigar = "1" + firstOp;
+                    cigar += "1" + middleOp;
+                    cigar += "1" + lastOp;
+                    read.setCigar(cigar);
+
+                    tests.add(new Object[]{read, middleOp});
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "PrevAndNextTest_simple")
+    public void testImmediateBeforeAndAfterTest_simple(final GATKRead read, final CigarOperator middleOp) {
+        final AlignmentStateMachine state = new AlignmentStateMachine(read);
+
+        state.stepForwardOnGenome();
+
+        //before the 'middleOp'
+        final PileupElement pe1 = state.makePileupElement();
+        Assert.assertEquals(pe1.getAdjacentOperator(PileupElement.Direction.PREV), null, "PREV");
+        Assert.assertEquals(pe1.getAdjacentOperator(PileupElement.Direction.NEXT), middleOp, "NEXT");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertEquals(pe1.isImmediatelyBefore(op), middleOp == op, op.toString());
+            Assert.assertFalse(pe1.isImmediatelyAfter(op), op.toString());
+        }
+
+        state.stepForwardOnGenome();
+
+        //after the 'middleOp'
+        final PileupElement pe2 = state.makePileupElement();
+        Assert.assertEquals(pe2.getAdjacentOperator(PileupElement.Direction.PREV), middleOp, "PREV");
+        Assert.assertEquals(pe2.getAdjacentOperator(PileupElement.Direction.NEXT), null, "NEXT");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe2.isImmediatelyBefore(op), op.toString());
+            Assert.assertEquals(pe2.isImmediatelyAfter(op), op == middleOp, op.toString());
+        }
+    }
+
     private void assertEqualsOperators(final List<CigarElement> elements, final List<CigarOperator> ops) {
-        for ( int i = 0; i < elements.size(); i++ ) {
+        for (int i = 0; i < elements.size(); i++) {
             Assert.assertEquals(elements.get(i).getOperator(), ops.get(i), "elements doesn't have expected operator at position " + i);
         }
     }
 
     @Test
-    public void testCreatePileupForReadAndOffset1(){
+    public void testCreatePileupForReadAndOffset1() {
         final GATKRead read = ArtificialReadUtils.createArtificialRead("100M");
         final PileupElement pe0 = PileupElement.createPileupForReadAndOffset(read, 0);
-        final LinkedList<CigarElement> betweenNextPosition = pe0.getBetweenNextPosition();
+        final List<CigarElement> betweenNextPosition = pe0.getBetweenNextPosition();
         Assert.assertTrue(betweenNextPosition.isEmpty());
         Assert.assertEquals(pe0.getOffset(), 0);
 
@@ -179,13 +258,172 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
     }
 
     @Test
-    public void testCreatePileupForReadAndOffset2(){
+    public void testCreatePileupForReadAndOffset2() {
         final GATKRead read = ArtificialReadUtils.createArtificialRead("10M10D10M");
         final PileupElement pe10 = PileupElement.createPileupForReadAndOffset(read, 10);
         Assert.assertEquals(pe10.getOffset(), 10);
 
         final PileupElement pe15 = PileupElement.createPileupForReadAndOffset(read, 15);
         Assert.assertEquals(pe15.getOffset(), 15);
+    }
 
+    @Test
+    public void testIsImmediatelyAfter_insideMs() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M10D10M");
+        final PileupElement pe = PileupElement.createPileupForReadAndOffset(read, 5);
+        Assert.assertFalse(pe.atStartOfCurrentCigar(), "atStartOfCurrentCigar");
+        Assert.assertFalse(pe.atEndOfCurrentCigar(), "atEndOfCurrentCigar");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyAfter(op), "isImmediatelyAfter " + op);
+        }
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyBefore(op), "isImmediatelyBefore " + op);
+        }
+    }
+
+    @Test
+    public void testIsImmediatelyAfter_afterLastM() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M10D10M");
+        final PileupElement pe = PileupElement.createPileupForReadAndOffset(read, 9);
+        Assert.assertFalse(pe.atStartOfCurrentCigar(), "atStartOfCurrentCigar");
+        Assert.assertTrue(pe.atEndOfCurrentCigar(), "atEndOfCurrentCigar");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyAfter(op), "isImmediatelyAfter " + op);
+        }
+
+        Assert.assertTrue(pe.isImmediatelyBefore(D));
+        for (final CigarOperator op : CigarOperator.values()) {
+            if (op != D) {
+                Assert.assertFalse(pe.isImmediatelyBefore(op), "isImmediatelyBefore " + op);
+            }
+        }
+    }
+
+    @Test
+    public void testIsImmediatelyAfter_afterFirstD() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M10D10M");
+        final PileupElement pe = PileupElement.createPileupForReadAndOffset(read, 10);
+        Assert.assertFalse(pe.atEndOfCurrentCigar(), "atEndOfCurrentCigar");
+        Assert.assertTrue(pe.atStartOfCurrentCigar(), "atStartOfCurrentCigar");
+        Assert.assertTrue(pe.isImmediatelyAfter(D));
+        for (final CigarOperator op : CigarOperator.values()) {
+            if (op != D) {
+                Assert.assertFalse(pe.isImmediatelyAfter(op), "isImmediatelyAfter " + op);
+            }
+        }
+
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyBefore(op));
+        }
+    }
+
+    @Test
+    public void testIsImmediatelyAfter_insideFinalMs() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M10D10M");
+        final PileupElement pe = PileupElement.createPileupForReadAndOffset(read, 15);
+        Assert.assertFalse(pe.atStartOfCurrentCigar(), "atStartOfCurrentCigar");
+        Assert.assertFalse(pe.atEndOfCurrentCigar(), "atEndOfCurrentCigar");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyAfter(op), "isImmediatelyAfter " + op);
+        }
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertFalse(pe.isImmediatelyBefore(op), "isImmediatelyBefore " + op);
+        }
+    }
+
+    @DataProvider(name = "adjacentElementTestData")
+    private Object[][] adjacentElementTestData() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M" + "10D" + "10N" + "10P" + "10=" + "10X" + "10M" + "10S" + "10H");
+        return new Object[][]{
+                {read, 0, true, false, null, D},
+                {read, 1, false, false, null, D},
+                {read, 2, false, false, null, D},
+                {read, 3, false, false, null, D},
+                {read, 4, false, false, null, D},
+                {read, 5, false, false, null, D},
+                {read, 6, false, false, null, D},
+                {read, 7, false, false, null, D},
+                {read, 8, false, false, null, D},
+                {read, 9, false, true, null, D},
+                {read, 10, true, false, P, X},
+                {read, 11, false, false, P, X},
+                {read, 12, false, false, P, X},
+                {read, 13, false, false, P, X},
+                {read, 14, false, false, P, X},
+                {read, 15, false, false, P, X},
+                {read, 16, false, false, P, X},
+                {read, 17, false, false, P, X},
+                {read, 18, false, false, P, X},
+                {read, 19, false, true, P, X},
+                {read, 20, true, false, EQ, M},
+                {read, 21, false, false, EQ, M},
+                {read, 22, false, false, EQ, M},
+                {read, 23, false, false, EQ, M},
+                {read, 24, false, false, EQ, M},
+                {read, 25, false, false, EQ, M},
+                {read, 26, false, false, EQ, M},
+                {read, 27, false, false, EQ, M},
+                {read, 28, false, false, EQ, M},
+                {read, 29, false, true, EQ, M},
+                {read, 30, true, false, X, S},
+                {read, 31, false, false, X, S},
+                {read, 32, false, false, X, S},
+                {read, 33, false, false, X, S},
+                {read, 34, false, false, X, S},
+                {read, 35, false, false, X, S},
+                {read, 36, false, false, X, S},
+                {read, 37, false, false, X, S},
+                {read, 38, false, false, X, S},
+                {read, 39, false, true, X, S},
+        };
+    }
+
+    @Test(dataProvider = "adjacentElementTestData")
+    public void testAdjacentElements(GATKRead read, int goodOffset, boolean atStartOfCurrentCigar, boolean atEndOfCurrentCigar, CigarOperator prev, CigarOperator next) throws Exception {
+        final PileupElement pe = PileupElement.createPileupForReadAndOffset(read, goodOffset);
+        Assert.assertEquals(pe.atStartOfCurrentCigar(), atStartOfCurrentCigar, "atStartOfCurrentCigar");
+        Assert.assertEquals(pe.atEndOfCurrentCigar(), atEndOfCurrentCigar, "atEndOfCurrentCigar");
+        Assert.assertEquals(pe.getAdjacentOperator(PileupElement.Direction.PREV), prev, "prev");
+        Assert.assertEquals(pe.getAdjacentOperator(PileupElement.Direction.NEXT), next, "next");
+        for (final CigarOperator op : CigarOperator.values()) {
+            Assert.assertEquals(pe.isImmediatelyAfter(op), atStartOfCurrentCigar && op == prev);
+            Assert.assertEquals(pe.isImmediatelyBefore(op), atEndOfCurrentCigar && op == next);
+        }
+    }
+
+    @DataProvider(name = "elementData_badOffset")
+    private Object[][] elementData_badOffsetWithinBounds() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M" + "10D" + "10N" + "10P" + "10=" + "10X" + "10M" + "10S" + "10H");
+        return new Object[][]{
+                {read, 40},
+                {read, 41},
+                {read, 42},
+                {read, 43},
+                {read, 44},
+                {read, 45},
+                {read, 46},
+                {read, 47},
+                {read, 48},
+                {read, 49},
+        };
+    }
+
+    @Test(dataProvider = "elementData_badOffsetWithinBounds", expectedExceptions = IllegalStateException.class)
+    public void testBadOffsetWithinBounds(GATKRead read, int badOffset) throws Exception {
+        PileupElement.createPileupForReadAndOffset(read, badOffset);
+    }
+
+    @DataProvider(name = "elementData_badOffsetOutOfBounds")
+    private Object[][] elementData_badOffsetOutOfBounds() {
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("10M" + "10D" + "10N" + "10P" + "10=" + "10X" + "10M" + "10S" + "10H");
+        return new Object[][]{
+                {read, 50},     //these are not even within the span of the read
+                {read, 1000},
+        };
+    }
+
+    @Test(dataProvider = "elementData_badOffsetOutOfBounds", expectedExceptions = IllegalArgumentException.class)
+    public void testBadOffsetOutOfBounds(GATKRead read, int badOffset) throws Exception {
+        PileupElement.createPileupForReadAndOffset(read, badOffset);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.pileup;
 
 import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.util.Locatable;
@@ -393,6 +394,13 @@ public final class ReadPileupUnitTest {
 
         final int offset = 4;
         final ReadPileup pu = new ReadPileup(loc, reads, offset);
+
+        final PileupElement firstElem = pu.getElementForRead(read1);
+        Assert.assertNull(firstElem.getAdjacentOperator(PileupElement.Direction.NEXT));
+        Assert.assertNull(firstElem.getAdjacentOperator(PileupElement.Direction.PREV));
+        final PileupElement secondElem = pu.getElementForRead(read2);
+        Assert.assertEquals(secondElem.getAdjacentOperator(PileupElement.Direction.NEXT), CigarOperator.I);
+        Assert.assertNull(secondElem.getAdjacentOperator(PileupElement.Direction.PREV));
 
         Assert.assertNotNull(pu.toString()); //checking non-blowup. We're not making any claims about the format of toString
 


### PR DESCRIPTION
those came up clearly on HaplotypeCaller profiles and allocated many megabytes of objects for now reason