### PR TITLE
Enable multi-threaded AVX PairHMM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,6 +460,8 @@ model {
                         cppCompiler.args "-I", "${System.properties['java.home']}/../include/Darwin"
                     } else {
                         cppCompiler.args "-I", "${System.properties['java.home']}/../include/linux"
+                        cppCompiler.args "-fopenmp"
+                        linker.args "-fopenmp"
                         linker.args "-static-libgcc"
                     }
 

--- a/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
+++ b/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
@@ -29,10 +29,10 @@ template<class NUMBER>
 struct ContextBase
 {
   public:
-    NUMBER ph2pr[128];
-    NUMBER INITIAL_CONSTANT;
-    NUMBER LOG10_INITIAL_CONSTANT;
-    NUMBER RESULT_THRESHOLD; 
+    static NUMBER ph2pr[128];
+    static NUMBER INITIAL_CONSTANT;
+    static NUMBER LOG10_INITIAL_CONSTANT;
+    static NUMBER RESULT_THRESHOLD; 
 
     static bool staticMembersInitializedFlag;
     static NUMBER jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
@@ -116,10 +116,14 @@ struct Context : public ContextBase<NUMBER>
 template<>
 struct Context<double> : public ContextBase<double>
 {
-  Context():ContextBase<double>()
-  {
-    for (int x = 0; x < 128; x++)
+  Context():ContextBase<double>() {}
+
+  static void initializeStaticMembers() {
+    ContextBase<double>::initializeStaticMembers();
+
+    for (int x = 0; x < 128; x++) {
       ph2pr[x] = pow(10.0, -((double)x) / 10.0);
+    }
 
     INITIAL_CONSTANT = ldexp(1.0, 1020.0);
     LOG10_INITIAL_CONSTANT = log10(INITIAL_CONSTANT);
@@ -136,10 +140,12 @@ struct Context<double> : public ContextBase<double>
 template<>
 struct Context<float> : public ContextBase<float>
 {
-  Context() : ContextBase<float>()
-  {
-    for (int x = 0; x < 128; x++)
-    {
+  Context() : ContextBase<float>() {}
+
+  static void initializeStaticMembers() {
+    ContextBase<float>::initializeStaticMembers();
+
+    for (int x = 0; x < 128; x++) {
       ph2pr[x] = powf(10.f, -((float)x) / 10.f);
     }
 
@@ -169,6 +175,20 @@ struct Context<float> : public ContextBase<float>
   : ctx.matchToMatchProb[((maxQual * (maxQual + 1)) >> 1) + minQual];           \
 }
 
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::ph2pr[128];
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::INITIAL_CONSTANT;
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::LOG10_INITIAL_CONSTANT;
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::RESULT_THRESHOLD;
+template<typename NUMBER>
+bool ContextBase<NUMBER>::staticMembersInitializedFlag;
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
+template<typename NUMBER>
+NUMBER ContextBase<NUMBER>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1];
 
 
 typedef struct

--- a/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
@@ -1,3 +1,6 @@
+#ifdef linux
+#include <omp.h>
+#endif
 #include "headers.h"
 #include "jni_common.h"
 #include "org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.h"
@@ -183,7 +186,11 @@ inline JNIEXPORT void JNICALL Java_org_broadinstitute_hellbender_utils_pairhmm_V
 inline void compute_testcases(vector<testcase>& tc_array, unsigned numTestCases, double* likelihoodDoubleArray,
     unsigned maxNumThreadsToUse)
 {
-  #pragma omp parallel for schedule (dynamic,10000) num_threads(maxNumThreadsToUse)
+  // TODO: move number of thread calculation to "initialize" after moving to native library interface
+#ifdef linux
+  int threads = min((int)maxNumThreadsToUse, omp_get_max_threads());
+#endif
+  #pragma omp parallel for schedule(dynamic, 1) num_threads(threads)
   for(unsigned tc_idx=0;tc_idx<numTestCases;++tc_idx)
   {
     float result_avxf = use_double ? 0 : g_compute_full_prob_float(&(tc_array[tc_idx]), 0);

--- a/src/main/cpp/VectorLoglessPairHMM/utils.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/utils.cc
@@ -8,19 +8,6 @@ uint8_t ConvertChar::conversionTable[255];
 //Global function pointers in utils.h
 float (*g_compute_full_prob_float)(testcase *tc, float* before_last_log) = 0;
 double (*g_compute_full_prob_double)(testcase *tc, double* before_last_log) = 0;
-//Static members in ContextBase
-template<>
-bool ContextBase<double>::staticMembersInitializedFlag = false;
-template<>
-double ContextBase<double>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE] = { };
-template<>
-double ContextBase<double>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1] = { };
-template<>
-bool ContextBase<float>::staticMembersInitializedFlag = false;
-template<>
-float ContextBase<float>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE] = { };
-template<>
-float ContextBase<float>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1] = { };
 
 
 void initialize_function_pointers()

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -28,6 +28,12 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
     long pairHMMSetupTime = 0;
     static Boolean isVectorLoglessPairHMMLibraryLoaded = false;
 
+    // maxNumberOfThreads used by native pairHMM
+    // native pairHMM may use less than maxNumberOfThreads, depending on the number of threads are available in hardware
+    // TODO: pass maxNumberOfThreads in to VectorLoglessPairHMM
+    // TODO: set maxNumberOfThreads in the native library "initialize" function after moving to the native library
+    private int maxNumberOfThreads = 100;
+
     //Hold the mapping between haplotype and index in the list of Haplotypes passed to initialize
     //Use this mapping in computeLikelihoods to find the likelihood value corresponding to a given Haplotype
     HashMap<Haplotype, Integer> haplotypeToHaplotypeListIdxMap = new HashMap<>();
@@ -190,7 +196,7 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
         //for(reads)
         //   for(haplotypes)
         //       compute_full_prob()
-        jniComputeLikelihoods(readListSize, numHaplotypes, readDataArray, mHaplotypeDataArray, mLogLikelihoodArray, 12);
+        jniComputeLikelihoods(readListSize, numHaplotypes, readDataArray, mHaplotypeDataArray, mLogLikelihoodArray, maxNumberOfThreads);
 
         int readIdx = 0;
         for (int r = 0; r < readListSize; r++) {


### PR DESCRIPTION
Changes to enable multi-threaded native AVX PairHMM using OpenMP. Also includes a performance improvement in the native C++ `Context` class.

`VectorLoglessPairHMM.java` is hardcoded to set the maximum number of PairHMM threads (`maxNumberOfThreads`) to 100. This is the maximum number of threads **allowed** by GATK, not the number of threads **requested**. C code in the native library will query OpenMP for the number of threads available on the platform, and use min(OpenMP threads available, `maxNumberOfThreads`) threads.

**Measured Speedup**
Command
```
./gatk-launch HaplotypeCaller -R src/test/resources/large/human_g1k_v37.20.21.fasta -I src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -O out.g.vcf -ERC GVCF
```
1 thread
INFO  PairHMM - Total compute time in PairHMM computeLogLikelihoods() : 36.882098080000006
2 threads
INFO  PairHMM - Total compute time in PairHMM computeLogLikelihoods() : 18.160468659000003
3 threads
INFO  PairHMM - Total compute time in PairHMM computeLogLikelihoods() : 12.541517043
4 threads
INFO  PairHMM - Total compute time in PairHMM computeLogLikelihoods() : 9.727374342000001

**Potential issues**
* The target platform running GATK must have OpenMP installed
* The code has not been tested on Mac

**Todo**
* New Java code to allow the user to specify `maxNumberOfThreads` variable in `VectorLoglessPairHMM.java`.
* Move `maxNumberOfThreads` to the native `initialize` function, once we migrate to the new native library.