### PR TITLE
use getCigarLength() rather than getCigar().numCigarElements() 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -66,7 +66,7 @@ public final class LeftAlignIndels extends ReadWalker {
     @Override
     public void apply( GATKRead read, ReferenceContext ref, FeatureContext featureContext ) {
         // we can not deal with screwy records
-        if ( read.isUnmapped() || read.getCigar().numCigarElements() == 0 ) {
+        if ( read.isUnmapped() || read.numCigarElements() == 0 ) {
             outputWriter.addRead(read);
             return;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
@@ -136,7 +136,7 @@ public final class SplitNCigarReads extends CommandLineProgram {
      * @param read     the read to split
      */
     public static GATKRead splitNCigarRead(final GATKRead read, OverhangFixingManager manager) {
-        final int numCigarElements = read.getCigar().numCigarElements();
+        final int numCigarElements = read.numCigarElements();
 
         int firstCigarIndex = 0;
         for ( int i = 0; i < numCigarElements; i++ ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
@@ -352,7 +352,7 @@ public class ReadClipper {
      */
     public static GATKRead hardClipToRegionIncludingClippedBases( final GATKRead read, final int refStart, final int refStop ) {
         final int start = read.getUnclippedStart();
-        final int stop = start + CigarUtils.countRefBasesBasedOnCigar(read, 0, read.getCigar().numCigarElements()) - 1;
+        final int stop = start + CigarUtils.countRefBasesBasedOnCigar(read, 0, read.numCigarElements()) - 1;
         return hardClipToRegion(read, refStart, refStop, start, stop);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
@@ -388,7 +388,7 @@ public final class PileupElement {
      */
     private CigarElement getNeighboringOnGenomeCigarElement(final Direction direction) {
         final int increment = direction == Direction.NEXT ? 1 : -1;
-        final int nCigarElements = read.getCigar().numCigarElements();
+        final int nCigarElements = read.numCigarElements();
 
         for ( int i = currentCigarOffset + increment; i >= 0 && i < nCigarElements; i += increment) {
             final CigarElement elt = read.getCigar().getCigarElement(i);

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -269,11 +269,11 @@ public interface GATKRead extends Locatable {
     }
 
     /**
-     * The number of cigar elements in this read. The default implementation returns <code>getCigarElements().size()</code>.
+     * The number of cigar elements in this read. The default implementation returns <code>getCigar().numCigarElements()</code>.
      * Subclasses may override to provide more efficient implementations.
      */
     default int numCigarElements(){
-        return getCigarElements().size();
+        return getCigar().numCigarElements();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -276,7 +276,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
      */
     @Override
     public int numCigarElements(){
-        return samRecord.getCigar() == null ? 0 : samRecord.getCigar().numCigarElements();
+        return samRecord.getCigar() == null ? 0 : samRecord.getCigarLength();
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignmentIntegrationTest.java
@@ -340,9 +340,9 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
 
             if (!sam.getReadUnmappedFlag()) {
                 final CigarElement firstMergedCigarElement = sam.getCigar().getCigarElement(0);
-                final CigarElement lastMergedCigarElement = sam.getCigar().getCigarElement(sam.getCigar().numCigarElements() - 1);
+                final CigarElement lastMergedCigarElement = sam.getCigar().getCigarElement(sam.getCigarLength() - 1);
                 final CigarElement firstAlignedCigarElement = alignment.getCigar().getCigarElement(0);
-                final CigarElement lastAlignedCigarElement = alignment.getCigar().getCigarElement(alignment.getCigar().numCigarElements() - 1);
+                final CigarElement lastAlignedCigarElement = alignment.getCigar().getCigarElement(alignment.getCigarLength() - 1);
 
                 if (beginning > 0) {
                     Assert.assertEquals(firstMergedCigarElement.getOperator(), CigarOperator.S, "First element is not a soft clip");

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/AlignmentStateMachineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/AlignmentStateMachineUnitTest.java
@@ -70,7 +70,7 @@ public final class AlignmentStateMachineUnitTest extends LocusIteratorByStateBas
 
         Assert.assertEquals(bpVisited, expectedBpToVisit, "Didn't visit the expected number of bp");
         Assert.assertEquals(state.getReadOffset(), read.getLength());
-        Assert.assertEquals(state.getCurrentCigarElementOffset(), read.getCigar().numCigarElements());
+        Assert.assertEquals(state.getCurrentCigarElementOffset(), read.numCigarElements());
         Assert.assertEquals(state.getCurrentCigarElement(), null);
         Assert.assertNotNull(state.toString());
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LIBS_position.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LIBS_position.java
@@ -27,7 +27,7 @@ public final class LIBS_position {
 
     public LIBS_position(final GATKRead read) {
         this.read = read;
-        numOperators = read.getCigar().numCigarElements();
+        numOperators = read.numCigarElements();
     }
 
     public int getCurrentReadOffset() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementUnitTest.java
@@ -73,7 +73,7 @@ public final class PileupElementUnitTest extends LocusIteratorByStateBaseTest {
             Assert.assertTrue(basesOfImmediatelyFollowingInsertion == null || basesOfImmediatelyFollowingInsertion.length() == lengthOfImmediatelyFollowingIndel);
 
             // Don't test -- pe.getBaseIndex();
-            if ( pe.atEndOfCurrentCigar() && state.getCurrentCigarElementOffset() < read.getCigar().numCigarElements() - 1 ) {
+            if ( pe.atEndOfCurrentCigar() && state.getCurrentCigarElementOffset() < read.numCigarElements() - 1 ) {
                 final CigarElement nextElement = read.getCigar().getCigarElement(state.getCurrentCigarElementOffset() + 1);
                 if ( nextElement.getOperator() == CigarOperator.I ) {
                     Assert.assertTrue(pe.getBetweenNextPosition().size() >= 1);


### PR DESCRIPTION
addresses #1797 
some small speedup and less object allocation when using BAMs

@lbergelson please review