### PR TITLE
Revert "Enable multi-threaded AVX PairHMM"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -463,8 +463,6 @@ model {
                         cppCompiler.args "-I", "${System.properties['java.home']}/../include/Darwin"
                     } else {
                         cppCompiler.args "-I", "${System.properties['java.home']}/../include/linux"
-                        cppCompiler.args "-fopenmp"
-                        linker.args "-fopenmp"
                         linker.args "-static-libgcc"
                     }
 

--- a/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
+++ b/src/main/cpp/VectorLoglessPairHMM/common_data_structure.h
@@ -29,10 +29,10 @@ template<class NUMBER>
 struct ContextBase
 {
   public:
-    static NUMBER ph2pr[128];
-    static NUMBER INITIAL_CONSTANT;
-    static NUMBER LOG10_INITIAL_CONSTANT;
-    static NUMBER RESULT_THRESHOLD; 
+    NUMBER ph2pr[128];
+    NUMBER INITIAL_CONSTANT;
+    NUMBER LOG10_INITIAL_CONSTANT;
+    NUMBER RESULT_THRESHOLD; 
 
     static bool staticMembersInitializedFlag;
     static NUMBER jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
@@ -116,14 +116,10 @@ struct Context : public ContextBase<NUMBER>
 template<>
 struct Context<double> : public ContextBase<double>
 {
-  Context():ContextBase<double>() {}
-
-  static void initializeStaticMembers() {
-    ContextBase<double>::initializeStaticMembers();
-
-    for (int x = 0; x < 128; x++) {
+  Context():ContextBase<double>()
+  {
+    for (int x = 0; x < 128; x++)
       ph2pr[x] = pow(10.0, -((double)x) / 10.0);
-    }
 
     INITIAL_CONSTANT = ldexp(1.0, 1020.0);
     LOG10_INITIAL_CONSTANT = log10(INITIAL_CONSTANT);
@@ -140,12 +136,10 @@ struct Context<double> : public ContextBase<double>
 template<>
 struct Context<float> : public ContextBase<float>
 {
-  Context() : ContextBase<float>() {}
-
-  static void initializeStaticMembers() {
-    ContextBase<float>::initializeStaticMembers();
-
-    for (int x = 0; x < 128; x++) {
+  Context() : ContextBase<float>()
+  {
+    for (int x = 0; x < 128; x++)
+    {
       ph2pr[x] = powf(10.f, -((float)x) / 10.f);
     }
 
@@ -175,20 +169,6 @@ struct Context<float> : public ContextBase<float>
   : ctx.matchToMatchProb[((maxQual * (maxQual + 1)) >> 1) + minQual];           \
 }
 
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::ph2pr[128];
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::INITIAL_CONSTANT;
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::LOG10_INITIAL_CONSTANT;
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::RESULT_THRESHOLD;
-template<typename NUMBER>
-bool ContextBase<NUMBER>::staticMembersInitializedFlag;
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
-template<typename NUMBER>
-NUMBER ContextBase<NUMBER>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1];
 
 
 typedef struct

--- a/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.cc
@@ -1,6 +1,3 @@
-#ifdef linux
-#include <omp.h>
-#endif
 #include "headers.h"
 #include "jni_common.h"
 #include "org_broadinstitute_hellbender_utils_pairhmm_VectorLoglessPairHMM.h"
@@ -186,11 +183,7 @@ inline JNIEXPORT void JNICALL Java_org_broadinstitute_hellbender_utils_pairhmm_V
 inline void compute_testcases(vector<testcase>& tc_array, unsigned numTestCases, double* likelihoodDoubleArray,
     unsigned maxNumThreadsToUse)
 {
-  // TODO: move number of thread calculation to "initialize" after moving to native library interface
-#ifdef linux
-  int threads = min((int)maxNumThreadsToUse, omp_get_max_threads());
-#endif
-  #pragma omp parallel for schedule(dynamic, 1) num_threads(threads)
+  #pragma omp parallel for schedule (dynamic,10000) num_threads(maxNumThreadsToUse)
   for(unsigned tc_idx=0;tc_idx<numTestCases;++tc_idx)
   {
     float result_avxf = use_double ? 0 : g_compute_full_prob_float(&(tc_array[tc_idx]), 0);

--- a/src/main/cpp/VectorLoglessPairHMM/utils.cc
+++ b/src/main/cpp/VectorLoglessPairHMM/utils.cc
@@ -8,6 +8,19 @@ uint8_t ConvertChar::conversionTable[255];
 //Global function pointers in utils.h
 float (*g_compute_full_prob_float)(testcase *tc, float* before_last_log) = 0;
 double (*g_compute_full_prob_double)(testcase *tc, double* before_last_log) = 0;
+//Static members in ContextBase
+template<>
+bool ContextBase<double>::staticMembersInitializedFlag = false;
+template<>
+double ContextBase<double>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE] = { };
+template<>
+double ContextBase<double>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1] = { };
+template<>
+bool ContextBase<float>::staticMembersInitializedFlag = false;
+template<>
+float ContextBase<float>::jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE] = { };
+template<>
+float ContextBase<float>::matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1] = { };
 
 
 void initialize_function_pointers()

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -28,12 +28,6 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
     long pairHMMSetupTime = 0;
     static Boolean isVectorLoglessPairHMMLibraryLoaded = false;
 
-    // maxNumberOfThreads used by native pairHMM
-    // native pairHMM may use less than maxNumberOfThreads, depending on the number of threads are available in hardware
-    // TODO: pass maxNumberOfThreads in to VectorLoglessPairHMM
-    // TODO: set maxNumberOfThreads in the native library "initialize" function after moving to the native library
-    private int maxNumberOfThreads = 100;
-
     //Hold the mapping between haplotype and index in the list of Haplotypes passed to initialize
     //Use this mapping in computeLikelihoods to find the likelihood value corresponding to a given Haplotype
     HashMap<Haplotype, Integer> haplotypeToHaplotypeListIdxMap = new HashMap<>();
@@ -196,7 +190,7 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
         //for(reads)
         //   for(haplotypes)
         //       compute_full_prob()
-        jniComputeLikelihoods(readListSize, numHaplotypes, readDataArray, mHaplotypeDataArray, mLogLikelihoodArray, maxNumberOfThreads);
+        jniComputeLikelihoods(readListSize, numHaplotypes, readDataArray, mHaplotypeDataArray, mLogLikelihoodArray, 12);
 
         int readIdx = 0;
         for (int r = 0; r < readListSize; r++) {


### PR DESCRIPTION
Reverts broadinstitute/gatk#1813 for now.

We have to revert this because there's no fallback to lack of OMP or incompatible libraries:  https://github.com/broadinstitute/gatk/issues/1819

What happens then is that we build the so file on a one machine and the protected repo uses a different machine and blows up with ```java.lang.UnsatisfiedLinkError: /tmp/libVectorLoglessPairHMM.4842381956752440752.so: /usr/lib/x86_64-linux-gnu/libgomp.so.1: version `GOMP_4.0' not found (required by /tmp/libVectorLoglessPairHMM.4842381956752440752.so)```


