### PR TITLE
LocusWalker with the possibility of include reads with Ns

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -56,6 +56,15 @@ public abstract class LocusWalker extends GATKTool {
     }
 
     /**
+     * Does this tool require Ns in the AlignmentContext? Tools that do should override to return {@code true}.
+     *
+     * @return {@code true} if this tool requires Ns, {@code false} otherwise
+     */
+    public boolean includeNs() {
+        return false;
+    }
+
+    /**
      * Returns the read filter (simple or composite) that will be applied to the reads in each window.
      *
      * The default implementation uses the {@link WellformedReadFilter} filter with all default options,
@@ -113,7 +122,7 @@ public abstract class LocusWalker extends GATKTool {
                 new CountingReadFilter("Allow all", ReadFilterLibrary.ALLOW_ALL_READS ) :
                 makeReadFilter();
         // get the LIBS
-        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), includeDeletions(), keepUniqueReadListInLibs(), samples, header);
+        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), includeDeletions(), includeNs(), keepUniqueReadListInLibs(), samples, header);
         // prepare the iterator
         Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
         // iterate over each alignment, and apply the function

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -104,6 +104,7 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
      *                This is generally just the set of read group sample fields in the SAMFileHeader.  This
      *                list of samples may contain a null element, and all reads without read groups will
      *                be mapped to this null sample
+     * @param header header from the reads
      */
     public LocusIteratorByState(final Iterator<GATKRead> samIterator,
                                 final DownsamplingMethod downsamplingMethod,
@@ -124,6 +125,37 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
      *
      * @param samIterator the iterator of reads to process into pileups.  Reads must be ordered
      *                    according to standard coordinate-sorted BAM conventions
+     * @param downsamplingMethod information about how to downsample the reads
+     * @param includeReadsWithDeletionAtLoci Include reads with deletion at loci
+     * @param includeReadsWithNsAtLoci Include reads with Ns at loci (usually it is not needed)
+     * @param keepUniqueReadListInLIBS Keep unique read list in LIBS
+     * @param samples a complete list of samples present in the read groups for the reads coming from samIterator.
+     *                This is generally just the set of read group sample fields in the SAMFileHeader.  This
+     *                list of samples may contain a null element, and all reads without read groups will
+     *                be mapped to this null sample
+     * @param header header from the reads
+     */
+    public LocusIteratorByState(final Iterator<GATKRead> samIterator,
+        final DownsamplingMethod downsamplingMethod,
+        final boolean includeReadsWithDeletionAtLoci,
+        final boolean includeReadsWithNsAtLoci,
+        final boolean keepUniqueReadListInLIBS,
+        final Collection<String> samples,
+        final SAMFileHeader header) {
+        this(samIterator,
+            LIBSDownsamplingInfo.toDownsamplingInfo(downsamplingMethod),
+            includeReadsWithDeletionAtLoci,
+            includeReadsWithNsAtLoci,
+            samples,
+            keepUniqueReadListInLIBS,
+            header);
+    }
+
+    /**
+     * Create a new LocusIteratorByState
+     *
+     * @param samIterator the iterator of reads to process into pileups.  Reads must be ordered
+     *                    according to standard coordinate-sorted BAM conventions
      * @param downsamplingInfo meta-information about how to downsampling the reads
      * @param includeReadsWithDeletionAtLoci Include reads with deletion at loci
      * @param samples a complete list of samples present in the read groups for the reads coming from samIterator.
@@ -132,6 +164,7 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
      *                be mapped to this null sample
      * @param keepUniqueReadListInLIBS if true, we will keep the unique reads from off the samIterator and make them
      *                                available via the transferReadsFromAllPreviousPileups interface
+     * @param header header from the reads
      */
     public LocusIteratorByState(final Iterator<GATKRead> samIterator,
                                 final LIBSDownsamplingInfo downsamplingInfo,
@@ -162,6 +195,7 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
      *                be mapped to this null sample
      * @param keepUniqueReadListInLIBS if true, we will keep the unique reads from off the samIterator and make them
      *                                available via the transferReadsFromAllPreviousPileups interface
+     * @param header header from the reads
      */
     public LocusIteratorByState(final Iterator<GATKRead> samIterator,
         final LIBSDownsamplingInfo downsamplingInfo,

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
@@ -44,8 +44,20 @@ public abstract class LocusIteratorByStateBaseTest extends BaseTest {
         return makeLIBS(reads, null, false, header);
     }
 
+    protected LocusIteratorByState makeLIBSwithNs(final List<GATKRead> reads, final SAMFileHeader header) {
+        return makeLIBS(reads, null, true, false, header);
+    }
+
+    protected LocusIteratorByState makeLIBS(final List<GATKRead> reads,
+        final DownsamplingMethod downsamplingMethod,
+        final boolean keepUniqueReadList,
+        final SAMFileHeader header) {
+        return makeLIBS(reads, downsamplingMethod, false, keepUniqueReadList, header);
+    }
+
     protected LocusIteratorByState makeLIBS(final List<GATKRead> reads,
                                             final DownsamplingMethod downsamplingMethod,
+                                            final boolean includeNs,
                                             final boolean keepUniqueReadList,
                                             final SAMFileHeader header) {
         reads.sort(new ReadCoordinateComparator(header));
@@ -53,6 +65,7 @@ public abstract class LocusIteratorByStateBaseTest extends BaseTest {
                 new FakeCloseableIterator<>(reads.iterator()),
                 downsamplingMethod,
                 true,
+                includeNs,
                 keepUniqueReadList,
                 sampleListForSAMWithoutReadGroups(),
                 header);

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
@@ -308,6 +308,30 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         }
     }
 
+    /**
+     * Test to make sure that if there are reads with Ns are keeped
+     */
+    @Test
+    public void testKeepingNs() {
+        final int firstLocus = 44367788, secondLocus = firstLocus + 1;
+
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(header,"read1",0,secondLocus,1);
+        read.setBases(Utils.dupBytes((byte) 'N', 1));
+        read.setBaseQualities(Utils.dupBytes((byte) '@', 1));
+        read.setCigar("1I");
+
+        // create the iterator by state with the fake reads and fake records
+        LocusIteratorByState libs = makeLIBSwithNs(Collections.singletonList(read), header);
+
+        while(libs.hasNext()) {
+            final AlignmentContext alignmentContext = libs.next();
+            final ReadPileup rp = alignmentContext.getBasePileup();
+            Assert.assertEquals(rp.size(), 1);
+            final PileupElement pe = rp.iterator().next();
+            Assert.assertEquals(pe.getBase(), (byte) 'N');
+        }
+
+    }
 
     /////////////////////////////////////////////
     // get event length and bases calculations //


### PR DESCRIPTION
In #1774 I added to LIBS the possibility to keep reads with Ns. This is a simple commit to allow `LocusWalker` implementations to use this behaviour (switch off by default).