### PR TITLE
upgrade spark to 1.6.1 and a few more upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,17 +134,17 @@ dependencies {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
     }
-    compile('org.apache.hadoop:hadoop-client:2.7.1') // should be a 'provided' dependency
-    compile('com.github.jsr203hadoop:jsr203hadoop:1.0.1')
+    compile('org.apache.hadoop:hadoop-client:2.7.2') // should be a 'provided' dependency
+    compile('com.github.jsr203hadoop:jsr203hadoop:1.0.2')
 
-    compile('org.apache.spark:spark-core_2.10:1.5.0') {
+    compile('org.apache.spark:spark-core_2.10:1.6.1') {
         // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
         exclude module: 'jul-to-slf4j'
         exclude module: 'javax.servlet'
         exclude module: 'servlet-api'
     }
 
-    compile('de.javakaffee:kryo-serializers:0.26') {
+    compile('de.javakaffee:kryo-serializers:0.37') {
         exclude module: 'kryo' // use Spark's version
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -183,8 +184,8 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         Assert.assertEquals(rddParallelReads.count(), rddParallelReads2.count());
 
         // Test the round trip
-        List<GATKRead> samList = rddParallelReads.collect();
-        List<GATKRead> adamList = rddParallelReads2.collect();
+        List<GATKRead> samList = new ArrayList<>(rddParallelReads.collect());//make a mutable copy for sort
+        List<GATKRead> adamList = new ArrayList<>(rddParallelReads2.collect());//make a mutable copy for sort
         Comparator<GATKRead> comparator = new ReadCoordinateComparator(header);
         samList.sort(comparator);
         adamList.sort(comparator);


### PR DESCRIPTION
@tomwhite can you review? We have CHD 5.7 running now and 1.6 is available on the cloud so no reason to not upgrade AFAIK

For some reason, the lists returned from `.collect` are no longer mutable so i have to make copies in 1 test