### PR TITLE
Add dependency on jbwa snapshot, script to release future jbwa snapshots, and method to load the library at runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,8 @@ dependencies {
         exclude module: 'kryo' // use Spark's version
     }
 
+    compile 'com.github.lindenb:jbwa:bd72b489f9697a857671533c86ad5906967f8672-20160521.042635-1'
+
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'

--- a/scripts/publish_jbwa.gradle
+++ b/scripts/publish_jbwa.gradle
@@ -1,0 +1,76 @@
+// Gradle script to upload a custom jbwa jar to the Broad artifactory
+// (a temporary expedient until jbwa is available on maven central)
+// 
+// Usage:
+// gradle -b publish_jbwa.gradle uploadArchives -Dversion=version -DartifactoryUser=user -DartifactoryPassword=password
+// 
+// Your jbwa jar must be in the working directory, and be named "jbwa-version-SNAPSHOT.jar"
+// 
+// Non-snapshot releases are not allowed (script forcibly appends "-SNAPSHOT" to the version you give it)
+//
+// The jbwa jar should contain builds of the native libraries for Mac (in lib/libbwajni_mac.jnilib) and
+// Linux (in lib/libbwajni.so). For now, you'll have to add these to the jbwa jar manually after building
+// via a command like "jar uf jbwa-version-SNAPSHOT.jar lib/libbwajni_mac.jnilib lib/libbwajni.so", and
+// then confirm that they're in the lib directory inside the jar via "jar tvf jbwa-version-SNAPSHOT.jar".
+// You should build the Mac version of the library on a Mac, and the Linux version on a Linux machine like gsa6.
+
+plugins {
+    id 'maven'
+}
+
+version = System.getProperty("version") + "-SNAPSHOT"
+group = "com.github.lindenb"
+final artifactoryUser = System.getProperty("artifactoryUser")
+final artifactoryPassword = System.getProperty("artifactoryPassword")
+final jbwaJar = file("jbwa-${version}.jar")
+
+artifacts {
+    archives jbwaJar
+}
+
+uploadArchives {
+    doFirst {
+        println "Attempting to upload $jbwaJar"
+    }
+    repositories {
+        mavenDeployer {
+            repository(url: "https://artifactory.broadinstitute.org/artifactory/libs-release-local/") {
+                authentication(userName: artifactoryUser, password: artifactoryPassword)
+            }
+
+            snapshotRepository(url: "https://artifactory.broadinstitute.org/artifactory/libs-snapshot-local/") {
+                authentication(userName: artifactoryUser, password: artifactoryPassword)
+            }
+
+            pom.project {
+                name 'jbwa'
+                packaging 'jar'
+                description 'Java Bindings (JNI) for bwa'
+                url 'https://github.com/lindenb/jbwa'
+
+                scm {
+                    url 'scm:git@github.com:lindenb/jbwa.git'
+                    connection 'scm:git@github.com:lindenb/jbwa.git'
+                    developerConnection 'scm:git@github.com:lindenb/jbwa.git'
+                }
+
+                developers {
+                    developer {
+                        id = "jbwadev"
+                        name = "Pierre Lindenbaum"
+                        email = "plindenbaum@yahoo.fr"
+                    }
+                }
+
+                licenses {
+                    license {
+                        name 'Apache License Version 2.0'
+                        url 'https://github.com/lindenb/jbwa/blob/master/LICENSE.txt'
+                        distribution 'repo'
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
@@ -1,6 +1,11 @@
 package org.broadinstitute.hellbender.utils;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.io.Resource;
+
+import java.io.File;
 
 /**
  * Utilities to provide architecture-dependent native functions
@@ -12,7 +17,55 @@ public final class NativeUtils {
     /**
      * boolean : returns whether the current platform is PowerPC, LE only
      */
-    public static boolean isPPCArchitecture() {
-	return SystemUtils.OS_ARCH.equals("ppc64le");
+    public static boolean runningOnPPCArchitecture() {
+        return runningOnArchitecture("ppc64le");
+    }
+
+    /**
+     * @param architecture Architecture to look for
+     * @return true if we're running on the specified architecture, otherwise false
+     */
+    public static boolean runningOnArchitecture( final String architecture ) {
+        Utils.nonNull(architecture);
+        final String archtectureString = SystemUtils.OS_ARCH;
+
+        return archtectureString != null && archtectureString.equals(architecture);
+    }
+
+    /**
+     * @return true if we're running on a Mac operating system, otherwise false
+     */
+    public static boolean runningOnMac() {
+        return SystemUtils.IS_OS_MAC;
+    }
+
+    /**
+     * @return true if we're running on a Linux operating system, otherwise false
+     */
+    public static boolean runningOnLinux() {
+        return SystemUtils.IS_OS_LINUX;
+    }
+
+    /**
+     * Loads a native library stored on our classpath by extracting it to a temporary location and invoking
+     * {@link System#load} on it
+     *
+     * @param libraryPathInJar absolute path to the library file on the classpath
+     * @return true if the library was extracted and loaded successfully, otherwise false
+     */
+    public static boolean loadLibraryFromClasspath( final String libraryPathInJar ) {
+        Utils.nonNull(libraryPathInJar);
+        Utils.validateArg(libraryPathInJar.startsWith("/"), "library path in jar must be absolute");
+
+        try {
+            final File extractedLibrary = IOUtils.writeTempResource(new Resource(libraryPathInJar, NativeUtils.class));
+            extractedLibrary.deleteOnExit();
+            System.load(extractedLibrary.getAbsolutePath());
+        }
+        catch ( UnsatisfiedLinkError | UserException e ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelDeflaterIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.utils.NativeUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -15,11 +14,11 @@ public class IntelDeflaterIntegrationTest extends BaseTest {
 
     @Test
     public void testIntelDeflaterIsAvailable(){
-        if ( !SystemUtils.IS_OS_LINUX ) {
+        if ( ! NativeUtils.runningOnLinux() ) {
             throw new SkipException("IntelDeflater not available on this platform");
         }
 
-        if ( NativeUtils.isPPCArchitecture() ) {
+        if ( NativeUtils.runningOnPPCArchitecture() ) {
             throw new SkipException("IntelDeflater not available for this architecture");
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/JBWAIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/JBWAIntegrationTest.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.hellbender;
+
+import com.github.lindenb.jbwa.jni.AlnRgn;
+import com.github.lindenb.jbwa.jni.BwaIndex;
+import com.github.lindenb.jbwa.jni.BwaMem;
+import com.github.lindenb.jbwa.jni.ShortRead;
+import org.broadinstitute.hellbender.utils.NativeUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+public class JBWAIntegrationTest extends BaseTest {
+
+    private void skipJBWATestOnUnsupportedPlatforms() {
+        if ( ! NativeUtils.runningOnLinux() && ! NativeUtils.runningOnMac() ) {
+            throw new SkipException("jbwa not available on this platform");
+        }
+        if ( NativeUtils.runningOnPPCArchitecture() ) {
+            throw new SkipException("jbwa not available for this architecture");
+        }
+    }
+
+    @Test
+    public void testJBWAIsLoadable(){
+        skipJBWATestOnUnsupportedPlatforms();
+
+        final String libraryPath = NativeUtils.runningOnLinux() ? "/lib/libbwajni.so" : "/lib/libbwajni_mac.jnilib";
+        Assert.assertTrue(NativeUtils.loadLibraryFromClasspath(libraryPath), "jbwa library was not loaded. " +
+                "This could be due to a configuration error, or your system might not support it.");
+    }
+
+
+    @Test
+    public void testJBWAAlignSingleRead() throws Exception {
+        skipJBWATestOnUnsupportedPlatforms();
+
+        final String libraryPath = NativeUtils.runningOnLinux() ? "/lib/libbwajni.so" : "/lib/libbwajni_mac.jnilib";
+        Assert.assertTrue(NativeUtils.loadLibraryFromClasspath(libraryPath), "jbwa library was not loaded. " +
+                "This could be due to a configuration error, or your system might not support it.");
+
+        BwaIndex index= new BwaIndex(new File(b37_reference_20_21));
+        final BwaMem bwaMem = new BwaMem(index);
+        //real read taken from src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam
+        final String name="20FUKAAXX100202:3:46:9213:168594";
+        final byte[] seqs= "GTTTTGTTTACTACAGCTTTGTAGTAAATTTTGAACTCTAAAGTGTTAGTTCTCTAACTTTGTTTGTTTTTCAAGAGTGTTTTGACTCTTCTTACTGCATC".getBytes(); ;
+        final byte[] quals= "DGFDGFDHFFFFGFEFHEGFFFGGHEHFHGHHGEGGGGGFGFHGHGHEHGGGFGAEFGDACAHHDHGCGFGGGFGDHGHFFHDDCGGDGEE".getBytes();
+        final ShortRead read = new ShortRead(name, seqs, quals);
+        final AlnRgn[] align = bwaMem.align(read);
+        Assert.assertEquals(align.length, 1);
+        Assert.assertEquals(align[0].getChrom(), "20");
+        Assert.assertEquals(align[0].getCigar(), "101M");
+        Assert.assertEquals(align[0].getMQual(), 60);
+        Assert.assertEquals(align[0].getPos(), 9999997-1); // note difference from the bam file (9999997 in bam, 9999996 here)
+        Assert.assertEquals(align[0].getNm(), 0);
+        bwaMem.dispose();
+    }
+}


### PR DESCRIPTION
-Published a jbwa snapshot to the Broad artifactory, which we now depend on
 via gradle. This snapshot contains builds of the native jbwa code for both
 Mac and Linux.

-Added utility methods to NativeUtils to load this library at runtime,
 and a test proving that it can be loaded successfully. Also switched
 to the new NativeUtils methods for loading the PairHMM, and confirmed
 that it loads successfully with the HaplotypeCaller in protected

-Included a gradle script to publish a new jbwa snapshot, should it
 become necessary, along with instructions on how to do so.

Resolves #1838