### PR TITLE
Move SparkTestUtils to utils/test so that gatk-protected can use it

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/SparkTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/SparkTestUtils.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.engine.spark;
+package org.broadinstitute.hellbender.utils.test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
@@ -4,7 +4,7 @@ import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import org.apache.spark.SparkConf;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
-import org.broadinstitute.hellbender.engine.spark.SparkTestUtils;
+import org.broadinstitute.hellbender.utils.test.SparkTestUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordSerializerUnitTest.java
@@ -6,6 +6,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.utils.test.SparkTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -6,6 +6,7 @@ import org.apache.spark.serializer.KryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.utils.test.SparkTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
SparkTestUtils contains a useful method that tests whether a class is
serializable/deserializable in Kryo. This method is needed by the
gatk-protected test suite, but is not currently packaged in the gatk-public
jar. Moving to utils/test so that it will be packaged.