### PR TITLE
Fixes null pointer exception in OverhangFixingManger

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitNCigarReads.java
@@ -117,7 +117,9 @@ public final class SplitNCigarReads extends CommandLineProgram {
 
     private SAMFileGATKReadWriter initialize(final SamReader in) {
         final SAMFileHeader outputHeader = ReadUtils.cloneSAMFileHeader(in.getFileHeader());
-        final SAMFileGATKReadWriter outputWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(OUTPUT, REFERENCE_SEQUENCE, outputHeader, true, false, false));
+        //preSorted is set to false for this writer since ReadCoordinateComparator doesn't match HTSJDK's when an unmapped read has a mapped mate.
+        //Also, we don't want to assume that reads will be written in order by the manager because in deep, deep pileups it won't work
+        final SAMFileGATKReadWriter outputWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(OUTPUT, REFERENCE_SEQUENCE, outputHeader, false, false, false));
 
         try {
             final IndexedFastaSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(REFERENCE_SEQUENCE);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -158,7 +158,7 @@ public class OverhangFixingManager {
 
         // if the new read is on a different contig or we have too many reads, then we need to flush the queue and clear the map
         final boolean tooManyReads = getNReadsInQueue() >= MAX_RECORDS_IN_MEMORY;
-        final boolean encounteredNewContig = getNReadsInQueue() > 0 && !waitingReads.peek().read.getContig().equals(read.getContig());
+        final boolean encounteredNewContig = getNReadsInQueue() > 0 && !waitingReads.peek().read.isUnmapped() && !waitingReads.peek().read.getContig().equals(read.getContig());
 
         if ( tooManyReads || encounteredNewContig ) {
             if ( DEBUG ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/SplitNCigarReadsIntegrationTest.java
@@ -53,4 +53,12 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
                 Arrays.asList(getTestDataDir() +"/" + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
         spec.executeTest("test fix NDN", this);
     }
+
+    @Test //regression test for https://github.com/broadinstitute/gatk/pull/1853
+    public void testSplitsOfUnpairedAndUnmappedReads() throws Exception {
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "K-562.duplicateMarked.chr20.bam -O %s",
+                Arrays.asList(largeFileTestDir + "expected.K-562.splitNCigarReads.chr20.bam")); //results created using gatk3.5
+        spec.executeTest("regression test for unmapped and unpaired reads", this);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
@@ -119,17 +119,34 @@ public final class OverhangFixingManagerUnitTest extends BaseTest {
         Assert.assertEquals(manager.overhangingBasesMismatch(read, readStart, ref, refStart, overhang), expected, new String(read) + " vs. " + new String(ref) + " @" + overhang);
     }
 
-    @Test
-    public void testUnmappedReadsDoNotFail() {
-        // create an unmapped read
+    @DataProvider(name = "unmappedRead")
+    public Object[][] makeUnmappedRead() {
+        final List<Object[]> tests = new ArrayList<>();
         final GATKRead read = ArtificialReadUtils.createRandomRead(100);
         read.setName("foo");
         read.setCigar("*");
         read.setIsUnmapped();
 
-        // try to add it to the manager
+        tests.add(new Object[]{read});
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "unmappedRead")
+     public void testUnmappedReadsDoNotFail(final GATKRead read) {
+        // try to add unmapped read to the manager
         final OverhangFixingManager manager = new OverhangFixingManager(getHG19Header(), null, null, null, 100, 1, 30, false);
         manager.addRead(read); // we just want to make sure that the following call does not fail
-        Assert.assertTrue(true);
+    }
+
+
+   /* This tests that if we peek in the waiting reads (which occurs if there are more than one read added) we don't get
+    an NPE from getContig() of an unmapped read.*/
+    @Test(dataProvider = "unmappedRead")
+    public void testTwoUnmappedReadsDoNotFail(final GATKRead read) {
+        // try to add unmapped read to the manager twice
+        final OverhangFixingManager manager = new OverhangFixingManager(getHG19Header(), null, null, null, 100, 1, 30, false);
+        manager.addRead(read); // we need to check when there is an unmapped read waiting to be added (so we need to add two)
+        manager.addRead(read); // we just want to make sure that the following call does not fail
     }
 }

--- a/src/test/resources/large/.gitattributes
+++ b/src/test/resources/large/.gitattributes
@@ -23,3 +23,6 @@ human_g1k_v37.20.21.fasta.pac filter=lfs diff=lfs merge=lfs -text
 human_g1k_v37.20.21.fasta.ann filter=lfs diff=lfs merge=lfs -text
 human_g1k_v37.20.21.fasta.amb filter=lfs diff=lfs merge=lfs -text
 human_g1k_v37.20.21.fasta.sa filter=lfs diff=lfs merge=lfs -text
+K-562.duplicateMarked.chr20.bam filter=lfs diff=lfs merge=lfs -text
+expected.K-562.splitNCigarReads.chr20.bam filter=lfs diff=lfs merge=lfs -text
+K-562.duplicateMarked.chr20.bai filter=lfs diff=lfs merge=lfs -text

--- a/src/test/resources/large/K-562.duplicateMarked.chr20.bai
+++ b/src/test/resources/large/K-562.duplicateMarked.chr20.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ec8d98fcb8f727ae6aa704e540f33219a00fd3617daa9ed07cc9a0cb793f8ee
+size 53616

--- a/src/test/resources/large/K-562.duplicateMarked.chr20.bam
+++ b/src/test/resources/large/K-562.duplicateMarked.chr20.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50df712d137b91eac019c7db4397c2a7ecda542dc4fe92311221ac10cb596522
+size 1243094

--- a/src/test/resources/large/expected.K-562.splitNCigarReads.chr20.bam
+++ b/src/test/resources/large/expected.K-562.splitNCigarReads.chr20.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9984d665944c0beb77a61020529000ef6571621261b43ff796641e8c8e1ce368
+size 1347324


### PR DESCRIPTION
which is used by SplitNCigarReads.