### PR TITLE
use snappy and 512k blocks

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -28,7 +28,8 @@ EXTRA_JAVA_OPTIONS="-Dsamjdk.intel_deflater_so_path=libIntelDeflater.so -Dsamjdk
 DEFAULT_SPARK_ARGS = ["--conf", "spark.kryoserializer.buffer.max=512m",
 "--conf", "spark.driver.maxResultSize=0",
 "--conf", "spark.driver.userClassPathFirst=true",
-"--conf", "spark.io.compression.codec=lzf",
+"--conf", "spark.io.compression.codec=snappy",
+"--conf", "spark.io.compression.snappy.blockSize=524288", #Snappy with a bigger block size works best (512k)
 "--conf", "spark.yarn.executor.memoryOverhead=600",
 "--conf", "spark.yarn.dist.files=" + script + "/build/libIntelDeflater.so",
 "--conf", "spark.driver.extraJavaOptions=" + EXTRA_JAVA_OPTIONS,

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -42,7 +42,8 @@ public final class SparkContextFactory {
             .put("spark.kryoserializer.buffer.max", "512m")
             .put("spark.driver.maxResultSize", "0")
             .put("spark.driver.userClassPathFirst", "true")
-            .put("spark.io.compression.codec", "lzf")
+            .put("spark.io.compression.codec", "snappy")
+            .put("spark.io.compression.snappy.blockSize", "524288") //Snappy with a bigger block size works best (512k)
             .put("spark.yarn.executor.memoryOverhead", "600")
             .build();
 


### PR DESCRIPTION
improvement proposed by folks at Intel - in my tests it improves performance of MarkDuplicatesSpark by >10% 

@gspowley can you review and/or ask Eric+Lucy ?