### PR TITLE
moved dependency fixes from protected to here

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ dependencies {
 
     compile 'org.jgrapht:jgrapht-core:0.9.1'
     compile 'org.testng:testng:6.9.6' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
-    compile 'org.apache.hadoop:hadoop-minicluster:2.7.1' //the version of minicluster should match the version of hadoop
+    compile 'org.apache.hadoop:hadoop-minicluster:2.7.2' //the version of minicluster should match the version of hadoop
 
     compile('org.seqdoop:hadoop-bam:7.5.0') {
         exclude group: 'org.apache.hadoop'
@@ -155,6 +155,22 @@ dependencies {
     compile('de.javakaffee:kryo-serializers:0.37') {
         exclude module: 'kryo' // use Spark's version
     }
+
+    // Dependency change for including MLLib
+    compile('org.objenesis:objenesis:1.2')
+    testCompile('org.objenesis:objenesis:2.1')
+
+    // Comment the next line to disable native code proxies in Spark MLLib
+    compile('com.github.fommil.netlib:all:1.1.2')
+
+    // Dependency change for including MLLib
+    compile('com.esotericsoftware:kryo:3.0.3'){
+        exclude group: 'com.esotericsoftware', module: 'reflectasm'
+        exclude group: 'org.ow2.asm', module: 'asm'
+    }
+
+    // Dependency change for including MLLib
+    compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
     compile 'com.github.lindenb:jbwa:bd72b489f9697a857671533c86ad5906967f8672-20160521.042635-1'
 
@@ -294,7 +310,12 @@ tasks.withType(ShadowJar) {
 
 
 
+// Dependency change for including MLLib
 configurations {
+    compile.exclude module: 'jul-to-slf4j'
+    compile.exclude module: 'javax.servlet'
+    compile.exclude module: 'servlet-api'
+    compile.exclude group: 'com.esotericsoftware.kryo'
 
     sparkConfiguration {
         extendsFrom runtime
@@ -303,6 +324,13 @@ configurations {
         exclude group: 'org.apache.hadoop'
         exclude module: 'spark-core_2.10'
         exclude group: 'org.slf4j'
+        exclude module: 'jul-to-slf4j'
+        exclude module: 'javax.servlet'
+        exclude module: 'servlet-api'
+        exclude group: 'com.esotericsoftware.kryo'
+        exclude module: 'spark-mllib_2.10'
+        exclude group: 'org.scala-lang'
+        exclude module: 'kryo'
     }
 }
 


### PR DESCRIPTION
these are moved over from protected to public. Without them, even count reads does not work after we added mllib.

