### PR TITLE
Provide option for not capturing stdio of programs launched via ProcessBuilder

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/RunBWAMEMViaCommandLine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/RunBWAMEMViaCommandLine.java
@@ -84,8 +84,9 @@ public final class RunBWAMEMViaCommandLine extends CommandLineProgram {
 
         validateUserOptions();
 
+        // stdout capture of bwa mem process must be enabled because bwa mem output is dumped to stdout
         final BWAMEMModule bwamem = new BWAMEMModule();
-        final BWAMEMModule.RuntimeInfo result = bwamem.run(Paths.get(pathToBWA), new File(System.getProperty("user.dir")), makeArgs());
+        final BWAMEMModule.RuntimeInfo result = bwamem.run(Paths.get(pathToBWA), new File(System.getProperty("user.dir")), makeArgs(), true);
 
         return validateResults(result);
     }


### PR DESCRIPTION
This affects `RunBWAMEMViaCommandLine.java` and `RunSGAViaProcessBuilderOnSpark.java`, where stdio are always captured.
Capturing BWA MEM's stdout is a must because the result is piped to stdout.
For SGA, this helps debugging. But this also slows down the performance.

Hence an option would be useful.