### PR TITLE
less memory allocation in GATKRead operations

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElement.java
@@ -368,12 +368,11 @@ public final class PileupElement {
     CigarOperator getAdjacentOperator(final Direction direction) {
         final int increment = direction.getIncrement();
 
-        final List<CigarElement> cigarElements = read.getCigarElements();
         final int i = currentCigarOffset + increment;
-        if (i < 0 || i >= cigarElements.size()) {
+        if (i < 0 || i >= read.numCigarElements()) {
             return null;
         }
-        return cigarElements.get(i).getOperator();
+        return read.getCigarElement(i).getOperator();
     }
     /**
      * Get the cigar element of the previous genomic aligned position
@@ -411,7 +410,7 @@ public final class PileupElement {
         final int nCigarElements = read.numCigarElements();
 
         for ( int i = currentCigarOffset + increment; i >= 0 && i < nCigarElements; i += increment) {
-            final CigarElement elt = read.getCigar().getCigarElement(i);
+            final CigarElement elt = read.getCigarElement(i);
             if ( ON_GENOME_OPERATORS.contains(elt.getOperator()) ) {
                 return elt;
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
@@ -185,7 +185,15 @@ public final class CigarUtils {
      * Returns whether the cigar has any N operators.
      */
     public static boolean containsNOperator(final Cigar cigar) {
-        return containsNOperator(Utils.nonNull(cigar).getCigarElements());
+        Utils.nonNull(cigar);
+        //Note: reach the elements directly rather that calling getCigarElements because
+        // we want to avoid allocating a new unmodifiable list view (comes up in profiling of HaplotypeCaller)
+        for (int i = 0, n = cigar.numCigarElements(); i < n; i++) {
+            if (cigar.getCigarElement(i).getOperator() == CigarOperator.N){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -269,6 +269,17 @@ public interface GATKRead extends Locatable {
     }
 
     /**
+     * Return the cigar element at a given index.
+     *
+     * Note: the default implementation return <code>getCigarElements().get(i)</code>.
+     * Subclasses may override, for example to reduce the memory allocation or improve speed.
+     * @throws IndexOutOfBoundsException if the index is out of range  (<code>index < 0 || index >= numCigarElements()</code>)
+     */
+    default CigarElement getCigarElement(final int i){
+       return getCigarElements().get(i);
+    }
+
+    /**
      * The number of cigar elements in this read. The default implementation returns <code>getCigar().numCigarElements()</code>.
      * Subclasses may override to provide more efficient implementations.
      */

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -447,7 +447,7 @@ public final class ReadUtils {
      * @return the length of the first insertion, or 0 if there is none (see warning).
      */
     public static int getFirstInsertionOffset(final GATKRead read) {
-        final CigarElement e = read.getCigarElements().get(0);
+        final CigarElement e = read.getCigarElement(0);
         if ( e.getOperator() == CigarOperator.I ) {
             return e.getLength();
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Implementation of the {@link GATKRead} interface for the {@link SAMRecord} class.
@@ -268,6 +269,19 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     public List<CigarElement> getCigarElements(){
         //Cigar.getCigarElements returns an unmodifiable list so we don't wrap it again
         return samRecord.getCigar() == null ? Collections.emptyList() : samRecord.getCigar().getCigarElements();
+    }
+
+    /**
+     * This implementation avoids the creation of the unmodifiable view of the underlying list of CigarElements
+     * and simply retrieves the element that is requested.
+     */
+    @Override
+    public CigarElement getCigarElement(final int index) {
+        //we can't blow up with NPE, we promised in the contract
+        if (samRecord.getCigar() == null){
+            throw new IndexOutOfBoundsException("Index: "+index);
+        }
+        return samRecord.getCigar().getCigarElement(index);
     }
 
     /**
@@ -579,13 +593,13 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
         SAMRecordToGATKReadAdapter that = (SAMRecordToGATKReadAdapter) o;
 
-        return !(samRecord != null ? !samRecord.equals(that.samRecord) : that.samRecord != null);
+        return Objects.equals(samRecord, that.samRecord);
 
     }
 
     @Override
     public int hashCode() {
-        return samRecord != null ? samRecord.hashCode() : 0;
+        return Objects.hashCode(samRecord);
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
@@ -497,6 +497,9 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
         read.setBases(newBases);
         Assert.assertEquals(read.getBases(), newBases, "Wrong bases for read after setBases()");
         Assert.assertEquals(read.getBasesString(), "GCGG", "Wrong base string for read after setBases()");
+        for (int i = 0; i < newBases.length; i++) {
+            Assert.assertEquals(read.getBase(i), newBases[i], "Wrong base string for read after setBases()");
+        }
     }
 
     @DataProvider(name = "GetAndSetBaseQualitiesData")
@@ -526,10 +529,15 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
     @Test(dataProvider = "GetAndSetBaseQualitiesData")
     public void testGetAndSetBaseQualities( final GATKRead read, final byte[] expectedQuals ) {
         Assert.assertEquals(read.getBaseQualities(), expectedQuals, "Wrong base qualities for read");
+        Assert.assertEquals(read.getBaseQualityCount(), expectedQuals.length, "Wrong number of base qualities for read");
 
         final byte[] newQuals = {1, 2, 3, 4};
         read.setBaseQualities(newQuals);
         Assert.assertEquals(read.getBaseQualities(), newQuals, "Wrong base qualities for read after setBaseQualities()");
+        Assert.assertEquals(read.getBaseQualityCount(), newQuals.length, "Wrong number of base qualities for read after setBaseQualities()");
+        for (int i = 0; i < newQuals.length; i++) {
+            Assert.assertEquals(read.getBaseQuality(i), newQuals[i], "Wrong base quality for read after setBaseQualities()");
+        }
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -566,10 +574,13 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
     @Test(dataProvider = "GetAndSetCigarData")
     public void testGetAndSetCigar( final GATKRead read, final Cigar expectedCigar ) {
         Assert.assertEquals(read.getCigar(), expectedCigar, "Wrong cigar for read");
+        Assert.assertEquals(read.numCigarElements(), expectedCigar.numCigarElements(), "Wrong numCigarElements for read");
 
         final Cigar newCigar = TextCigarCodec.decode("4M");
         read.setCigar(newCigar);
         Assert.assertEquals(read.getCigar(), newCigar, "Wrong cigar for read after setCigar()");
+        Assert.assertEquals(read.numCigarElements(), newCigar.numCigarElements(), "Wrong numCigarElements for read");
+        Assert.assertEquals(read.getCigarElement(0), newCigar.getCigarElement(0), "Wrong numCigarElement for read");
 
         read.setCigar("2M2I");
         Assert.assertEquals(read.getCigar(), TextCigarCodec.decode("2M2I"), "Wrong cigar for read after setCigar()");


### PR DESCRIPTION
reduced memory consumption: identified by profiling HC. 
+ added a bunch of tests while I was there.

note: the equals/hashcode changes are just for clean code - no perf improvements

@lbergelson can you have a look?