### PR TITLE
Command line read filters for walkers and Spark tools.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/ArgumentCollection.java
@@ -13,4 +13,12 @@ import java.lang.annotation.*;
 public @interface ArgumentCollection {
     /** Text that appears for this group of options in text describing usage of the command line program. */
     String doc() default "";
+
+    // The arguments in this collection are dependent on (and only enabled with the presence of)
+    // another argument. This may be used alone or together with dependsOnValue.
+    String dependsOnArgument() default "";
+
+    // The arguments in this collection are dependent on (and only enabled with the presence of)
+    // another argument with this specific value.
+    String dependsOnValue() default "";
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -17,6 +17,7 @@ public final class StandardArgumentDefinitions {
     public static final String VERBOSITY_NAME = "verbosity";
     public static final String READ_VALIDATION_STRINGENCY_LONG_NAME = "readValidationStringency";
     public static final String ASSUME_SORTED_LONG_NAME = "assumeSorted";
+    public static final String READ_FILTER_LONG_NAME = "readFilter";
 
     public static final String INPUT_SHORT_NAME = "I";
     public static final String OUTPUT_SHORT_NAME = "O";
@@ -38,6 +39,7 @@ public final class StandardArgumentDefinitions {
     public static final String MINIMUM_LOD_SHORT_NAME = "LOD";
     public static final String SORT_ORDER_SHORT_NAME = "SO";
     public static final String USE_ORIGINAL_QUALITIES_SHORT_NAME = "OQ";
+    public static final String READ_FILTER_SHORT_NAME = "RF";
 
     public static final String SPARK_PROPERTY_NAME = "conf";
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/CustomReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/CustomReadFilterArgumentCollection.java
@@ -1,0 +1,18 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Argument collection representing custom, dynamically discovered read filters.
+ */
+public class CustomReadFilterArgumentCollection implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName="customFilterName", optional=true)
+    List<String> customReadFilters = new ArrayList<>();
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadFilterArgumentCollection.java
@@ -1,0 +1,251 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.cmdline.*;
+import org.broadinstitute.hellbender.engine.filters.*;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * {@link org.broadinstitute.hellbender.cmdline.ArgumentCollection} for allowing read filters to
+ * be enabled/disabled on the command line.
+ */
+public class ReadFilterArgumentCollection implements ArgumentCollectionDefinition {
+    private static final Logger logger = LogManager.getLogger(ReadFilterArgumentCollection.class);
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Enum of read filters that can be enabled/disabled from the command line
+     */
+    public enum CommandLineReadFilter implements Serializable {
+        /**
+         * No-arg filters: these filters have no arguments and one static instance,
+         * so the supplier function just returns the static instance and ignores
+         * the hdr and args arguments
+         */
+        ALLOW_ALL                   ((hdr, args) -> ReadFilterLibrary.ALLOW_ALL_READS),
+        CIGAR_IS_SUPPORTED          ((hdr, args) -> ReadFilterLibrary.CIGAR_IS_SUPPORTED),
+        GOOD_CIGAR                  ((hdr, args) -> ReadFilterLibrary.GOOD_CIGAR),
+        HAS_READ_GROUP              ((hdr, args) -> ReadFilterLibrary.HAS_READ_GROUP),
+        HAS_MATCHING_BASES_AND_QUALS((hdr, args) -> ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS),
+        MAPPED                      ((hdr, args) -> ReadFilterLibrary.MAPPED),
+        MAPPING_QUALITY_AVAILABLE   ((hdr, args) -> ReadFilterLibrary.MAPPING_QUALITY_AVAILABLE),
+        MAPPING_QUALITY_NOT_ZERO    ((hdr, args) -> ReadFilterLibrary.MAPPING_QUALITY_NOT_ZERO),
+        MATE_ON_SAME_CONTIG_OR_NO_MAPPED_MATE((hdr, args) -> ReadFilterLibrary.MATE_ON_SAME_CONTIG_OR_NO_MAPPED_MATE),
+        MATE_DIFFERENT_STRAND       ((hdr, args) -> ReadFilterLibrary.MATE_DIFFERENT_STRAND),
+        NOT_DUPLICATE               ((hdr, args) -> ReadFilterLibrary.NOT_DUPLICATE),
+        PRIMARY_ALIGNMENT           ((hdr, args) -> ReadFilterLibrary.PRIMARY_ALIGNMENT),
+        PASSES_VENDOR_QUALITY_CHECK ((hdr, args) -> ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK),
+        READLENGTH_EQUALS_CIGARLENGTH ((hdr, args) -> ReadFilterLibrary.READLENGTH_EQUALS_CIGARLENGTH),
+        SEQ_IS_STORED               ((hdr, args) -> ReadFilterLibrary.SEQ_IS_STORED),
+        VALID_ALIGNMENT_START       ((hdr, args) -> ReadFilterLibrary.VALID_ALIGNMENT_START),
+        VALID_ALIGNMENT_END         ((hdr, args) -> ReadFilterLibrary.VALID_ALIGNMENT_END),
+
+        /**
+         * Read filters with user-defined arguments. The supplier function validates the
+         * user provided values and returns the already-populated filter embedded in the
+         * argument collection.
+         *
+         * For read filters with user-defined arguments that also require a SAMFileHeader,
+         * the supplier function creates a new instance of the read filter using the
+         * given header, populating the other args from the instance embedded in
+         * the read filter argument collection; updates the embedded filter with the
+         * new one and returns it.
+         */
+        ALIGNMENT_AGREES_WITH_HEADER((hdr, args) -> new AlignmentAgreesWithHeaderReadFilter(hdr)),
+        FRAGMENT_LENGTH((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("FRAGMENT_LENGTH"), args.fragmentLengthFilter::validate);
+            return args.fragmentLengthFilter;
+        }),
+        LIBRARY((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("LIBRARY"), args.libraryFilter::validate);
+            LibraryReadFilter lrf = new LibraryReadFilter(hdr);
+            lrf.libraryToKeep = args.libraryFilter.libraryToKeep;
+            // update the actual argument collection filter just in case...
+            args.libraryFilter = lrf;
+            return lrf;
+        }),
+        MAPPING_QUALITY((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("MAPPING_QUALITY"), args.mappingQualityFilter::validate);
+            MappingQualityReadFilter mqf = new MappingQualityReadFilter(args.mappingQualityFilter.minMappingQualityScore);
+            // update the actual argument collection filter just in case...
+            args.mappingQualityFilter = mqf;
+            return mqf;
+        }),
+        PLATFORM((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("PLATFORM"), args.platformFilter::validate);
+            PlatformReadFilter pf = new PlatformReadFilter(hdr);
+            pf.PLFilterNames = args.platformFilter.PLFilterNames;
+            // update the actual argument collection filter just in case...
+            args.platformFilter = pf;
+            return pf;
+        }),
+        PLATFORM_UNIT((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("PLATFORM_UNIT"), args.platformUnitFilter::validate);
+            PlatformUnitReadFilter pfuf = new PlatformUnitReadFilter(hdr);
+            pfuf.blackListedLanes = args.platformUnitFilter.blackListedLanes;
+            // update the actual argument collection filter just in case...
+            args.platformUnitFilter = pfuf;
+            return pfuf;
+        }),
+        READ_GROUP((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("READ_GROUP"), args.readGroupFilter::validate);
+            return args.readGroupFilter;
+        }),
+        READ_GROUP_BLACK_LISTED((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("READ_GROUP_BLACK_LISTED"), args.readGroupBlackListFilter::validate);
+            ReadGroupBlackListReadFilter rgblf = new ReadGroupBlackListReadFilter(
+                    args.readGroupBlackListFilter.blackList, hdr);
+            // update the actual argument collection filter just in case...
+            args.readGroupBlackListFilter = rgblf;
+            return rgblf;
+        }),
+        READ_NAME((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("READ_NAME"), args.readNameFilter::validate);
+            return args.readNameFilter;
+        }),
+        READ_LENGTH((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("READ_LENGTH"), args.readLengthFilter::validate);
+            return args.readLengthFilter;
+        }),
+        READ_STRAND((hdr, args) -> { return args.readStrandFilter; }),
+        SAMPLE((hdr, args) -> {
+            validateArgs(CommandLineReadFilter.valueOf("SAMPLE"), args.sampleFilter::validate);
+            SampleReadFilter sf = new SampleReadFilter(hdr);
+            sf.samplesToKeep = args.sampleFilter.samplesToKeep;
+            // update the actual argument collection filter just in case...
+            args.sampleFilter = sf;
+            return sf;
+        }),
+        WELLFORMED((hdr, args) -> new WellformedReadFilter(hdr));
+
+        /**
+         * Each filter in the enum has an accompanying filter supplier function that accepts
+         * a ReadFilterArgumentCollection object, extracts the filter's required arguments
+         * from the argument collection, validates the arguments, and returns the initialized
+         * read filter.
+         */
+        private BiFunction<SAMFileHeader, ReadFilterArgumentCollection, ReadFilter> filterSupplier = null;
+        CommandLineReadFilter(final BiFunction<SAMFileHeader, ReadFilterArgumentCollection,ReadFilter> filterSupplier) {
+            this.filterSupplier = filterSupplier;
+        }
+
+        /**
+         * Execute the filter supplier and return the initialized filter
+         *
+         */
+        public ReadFilter getFilterInstance(
+                final SAMFileHeader samHeader,
+                final ReadFilterArgumentCollection readFilterCollection)
+        {
+            return filterSupplier.apply(samHeader, readFilterCollection);
+        };
+
+        public static boolean validateArgs(
+                final CommandLineReadFilter filter,
+                final Supplier<String> validator)
+        {
+            String errorMessage = validator.get();
+            if (null != errorMessage) {
+                throw new UserException.CommandLineException("The " + filter.name() + " read filter " + errorMessage);
+            }
+            return true;
+        }
+    }
+
+    @Argument(fullName = StandardArgumentDefinitions.READ_FILTER_LONG_NAME,
+            shortName = StandardArgumentDefinitions.READ_FILTER_SHORT_NAME,
+            doc = "Filters to apply to reads before analysis",
+            common = true,
+            optional = true)
+    public List<CommandLineReadFilter> enabledCommandLineFilters = new ArrayList<>();
+
+    @Argument(fullName = "disableReadFilter",
+            shortName = "df",
+            doc = "Filters to be disabled before analysis",
+            common = true,
+            optional = true)
+    public List<CommandLineReadFilter> disabledCommandLineFilters = new ArrayList<>();
+
+    @Argument(fullName = "disableAllReadFilters", shortName = "f", doc = "Disable all read filters", common = false, optional = true)
+    public boolean disableAllReadFilters = false;
+
+    //************************************************************
+    // Argument collections for read filters that accept arguments
+
+    @ArgumentCollection(doc="Read filter for fragment length", dependsOnArgument="RF", dependsOnValue="FRAGMENT_LENGTH")
+    FragmentLengthReadFilter fragmentLengthFilter = new FragmentLengthReadFilter();
+
+    @ArgumentCollection(doc="Read filter for library name", dependsOnArgument="RF", dependsOnValue="LIBRARY")
+    LibraryReadFilter libraryFilter = new LibraryReadFilter(null);
+
+    @ArgumentCollection(doc="Read filter for mapping quality", dependsOnArgument="RF", dependsOnValue="MAPPING_QUALITY")
+    MappingQualityReadFilter mappingQualityFilter = new MappingQualityReadFilter(0);
+
+    @ArgumentCollection(doc="Read filter for platform", dependsOnArgument="RF", dependsOnValue="PLATFORM")
+    PlatformReadFilter platformFilter = new PlatformReadFilter(null);
+
+    @ArgumentCollection(doc="Read filter for filtering lanes", dependsOnArgument="RF", dependsOnValue="PLATFORM_UNIT")
+    PlatformUnitReadFilter platformUnitFilter = new PlatformUnitReadFilter(null);
+
+    @ArgumentCollection(doc="Read filter for read name", dependsOnArgument="RF", dependsOnValue="READ_NAME")
+    ReadNameReadFilter readNameFilter = new ReadNameReadFilter();
+
+    @ArgumentCollection(doc="Read filter for read length", dependsOnArgument="RF", dependsOnValue="READ_LENGTH")
+    ReadLengthReadFilter readLengthFilter = new ReadLengthReadFilter();
+
+    @ArgumentCollection(doc="Read filter for read group", dependsOnArgument="RF", dependsOnValue="READ_GROUP")
+    ReadGroupReadFilter readGroupFilter = new ReadGroupReadFilter();
+
+    @ArgumentCollection(doc="Read filter for read group tag", dependsOnArgument="RF", dependsOnValue="READ_GROUP_BLACK_LISTED")
+    ReadGroupBlackListReadFilter readGroupBlackListFilter = new ReadGroupBlackListReadFilter(new ArrayList<String>(), null);
+
+    @ArgumentCollection(doc="Read filter for strand", dependsOnArgument="RF", dependsOnValue="READ_STRAND")
+    ReadStrandFilter readStrandFilter = new ReadStrandFilter();
+
+    @ArgumentCollection(doc="Read filter for sample name", dependsOnArgument="RF", dependsOnValue="SAMPLE")
+    SampleReadFilter sampleFilter = new SampleReadFilter(null);
+
+    /**
+     * Returns the list of read filters that result from combining the provided default
+     * read filters with command line arguments for enabling/disabling individual
+     * filters.
+     *
+     * @param defaultFilters List of default command line read filters to be merged
+     *                       with command line arguments. May not be null.
+     * @return List of CommandLineReadFilters, resulting from combining the default
+     * filters with all filters enabled/disabled on the command line.
+     */
+    public List<CommandLineReadFilter> getMergedCommandLineFilters(final List<CommandLineReadFilter> defaultFilters) {
+        Utils.nonNull(defaultFilters, "A default read filter must be provided");
+
+        // warn if any filters that were requested to be disabled are not enabled
+        disabledCommandLineFilters.stream()
+                .filter(f -> !defaultFilters.contains(f))
+                .forEach(f -> logger.warn("Disabled filter: " + f.name() + " is already disabled"));
+
+        final List<CommandLineReadFilter> curatedFilters = new ArrayList<>();
+        if (!disableAllReadFilters) {
+            // add in the defaults first (order matters), removing any that were explicitly
+            // disabled on the command line, followed by the ones that were explicitly enabled
+            // on the command line
+            curatedFilters.addAll(defaultFilters.stream().filter(
+                    f -> !disabledCommandLineFilters.contains(f)).collect(Collectors.toList())
+            );
+            // if you disabled AND enabled, enabled wins
+            curatedFilters.addAll(enabledCommandLineFilters);
+        }
+
+        return curatedFilters;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
@@ -26,6 +27,9 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
             optional=true)
     public ValidationStringency readValidationStringency = ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;
 
+    @ArgumentCollection
+    public ReadFilterArgumentCollection readFilterArgumentCollection = new ReadFilterArgumentCollection();
+
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line
      */
@@ -41,4 +45,8 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
      * at the command line.
      */
     public ValidationStringency getReadValidationStringency() { return readValidationStringency; };
+
+    public ReadFilterArgumentCollection getReadFilterArgumentCollection() {
+        return readFilterArgumentCollection;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/AlignmentAgreesWithHeaderReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/AlignmentAgreesWithHeaderReadFilter.java
@@ -4,11 +4,13 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
+import java.io.Serializable;
+
 /**
  * Checks to ensure that the alignment of each read makes sense based on the contents of the header.
  */
-public final class AlignmentAgreesWithHeaderReadFilter implements ReadFilter {
-    private static final long serialVersionUID = 1l;
+public final class AlignmentAgreesWithHeaderReadFilter implements ReadFilter, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final SAMFileHeader header;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CommandLineFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CommandLineFilter.java
@@ -1,0 +1,10 @@
+package org.broadinstitute.hellbender.engine.filters;
+
+import java.io.Serializable;
+
+/**
+ * Interface implemented by command-line accessible read filters for argument validation.
+ */
+public interface CommandLineFilter extends Serializable {
+    String validate();
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CustomReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CustomReadFilter.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.hellbender.engine.filters;
+
+import htsjdk.samtools.SAMFileHeader;
+
+/**
+ * Interface to be implemented by custom read filters that can be dynamically
+ * discovered at runtime and instantiated by using the "CUSTOM_READ_FILTER"
+ * CommandLineReadFilter.
+ */
+public abstract class CustomReadFilter implements ReadFilter {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Set the SAMFileHeader being used for this read filter.
+     * @param header
+     */
+    abstract public void setSAMFileHeader(SAMFileHeader header);
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/FragmentLengthReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/FragmentLengthReadFilter.java
@@ -3,13 +3,20 @@ package org.broadinstitute.hellbender.engine.filters;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
+import java.io.Serializable;
+
 /**
  * Keep reads that are within a given max fragment length.
  */
-public final class FragmentLengthReadFilter implements ReadFilter {
-    private static final long serialVersionUID = 1l;
+public final class FragmentLengthReadFilter implements ReadFilter, CommandLineFilter, Serializable {
+    private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = "maxFragmentLength", shortName = "maxFragment", doc="Keep only read pairs with fragment length at most equal to the given value", optional=true)
+    private final static String maxLengthArgName = "maxFragmentLength";
+
+    @Argument(fullName = maxLengthArgName,
+            shortName = "maxFragment",
+            doc="Keep only read pairs with fragment length at most equal to the given value",
+            optional=true)
     public int maxFragmentLength = 1000000;
 
     @Override
@@ -20,4 +27,15 @@ public final class FragmentLengthReadFilter implements ReadFilter {
         //Note fragment length is negative if mate maps to lower position than read so we take absolute value.
         return Math.abs(read.getFragmentLength()) <= maxFragmentLength;
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (maxFragmentLength < 1) {
+            message = "requires a non-zero value for \"" + maxLengthArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
@@ -5,12 +5,17 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
+import java.io.Serializable;
+
 /**
  * Keep only reads from the specified library.
  */
-public final class LibraryReadFilter implements ReadFilter {
+public final class LibraryReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = "library", shortName = "library", doc="The name of the library to keep", optional=false)
+
+    private final static String libraryArgName = "library";
+
+    @Argument(fullName = libraryArgName, shortName = "library", doc="The name of the library to keep", optional=true)
     public String libraryToKeep = null;
 
     private final SAMFileHeader header;
@@ -24,4 +29,14 @@ public final class LibraryReadFilter implements ReadFilter {
         final String library = ReadUtils.getLibrary(read, header);
         return library != null && library.equals(libraryToKeep);
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (libraryToKeep == null || libraryToKeep.length() < 1) {
+            message = "A value for \"" + libraryArgName + "\" must be provided";
+        }
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/MappingQualityReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/MappingQualityReadFilter.java
@@ -1,14 +1,20 @@
 package org.broadinstitute.hellbender.engine.filters;
 
+import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.Serializable;
 
 /**
  * Keep reads with mapping qualities above a specified threshold.
  */
-public final class MappingQualityReadFilter implements ReadFilter {
+public final class MappingQualityReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private int minMappingQualityScore = 10;
+    private final static String mappingQualityArgName = "mappingQuality";
+
+    @Argument(fullName=mappingQualityArgName, shortName="mq", optional=true)
+    public int minMappingQualityScore = 10;
 
     public MappingQualityReadFilter( final int minMappingQualityScore ) {
         this.minMappingQualityScore = minMappingQualityScore;
@@ -18,4 +24,15 @@ public final class MappingQualityReadFilter implements ReadFilter {
     public boolean test( final GATKRead read ) {
         return read.getMappingQuality() >= minMappingQualityScore;
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (minMappingQualityScore <= 0 || minMappingQualityScore > 255) {
+            message = "requires a value in the range [0, 255] for \"" + mappingQualityArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/PlatformReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/PlatformReadFilter.java
@@ -5,6 +5,10 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -12,10 +16,13 @@ import java.util.Set;
  * Matching is done by case-insensitive substring matching
  * (checking if the read's platform tag contains the given string).
  */
-public final class PlatformReadFilter implements ReadFilter {
+public final class PlatformReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = "PLFilterName", shortName = "PLFilterName", doc="Keep reads with RG:PL attribute containing this string", optional=true)
-    public Set<String> PLFilterNames;
+
+    private final static String platformArgName = "PLFilterName";
+
+    @Argument(fullName = platformArgName, shortName = "PLFilterName", doc="Keep reads with RG:PL attribute containing this string", optional=true)
+    public Set<String> PLFilterNames = new LinkedHashSet<>();
 
     private final SAMFileHeader header;
 
@@ -38,4 +45,15 @@ public final class PlatformReadFilter implements ReadFilter {
         }
         return false;
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (PLFilterNames.size() <= 0) {
+            message = "requires one or more values for \"" + platformArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/PlatformUnitReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/PlatformUnitReadFilter.java
@@ -3,9 +3,11 @@ package org.broadinstitute.hellbender.engine.filters;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMTag;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
+import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -13,10 +15,12 @@ import java.util.Set;
  * Keep reads that do not have blacklisted platform unit tags.
  * Matching is done by exact case-sensitive text matching.
  */
-public final class PlatformUnitReadFilter implements ReadFilter {
+public final class PlatformUnitReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = "blackListedLanes", shortName = "blackListedLanes", doc="Keep reads with platform units not on the list", optional=true)
+    private final static String laneNamesArgName = "blackListedLanes";
+
+    @Argument(fullName = laneNamesArgName, shortName = "blackListedLanes", doc="Keep reads with platform units not on the list", optional=true)
     public Set<String> blackListedLanes = new LinkedHashSet<>();
 
     private final SAMFileHeader header;
@@ -42,4 +46,15 @@ public final class PlatformUnitReadFilter implements ReadFilter {
 
         return ReadUtils.getPlatformUnit(read, header);
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (blackListedLanes.size() <= 0) {
+            message = "requires one or more values for \"" + laneNamesArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
@@ -6,14 +6,14 @@ import org.broadinstitute.hellbender.utils.read.CigarUtils;
 
 /**
  * Standard ReadFilters
+ *
+ * TODO: add a note here about how to make these accessible to the command line
  */
 public final class ReadFilterLibrary {
 
-    private ReadFilterLibrary(){ /*no instance*/ }
-
     public static final ReadFilter ALLOW_ALL_READS = read -> true;
 
-    public static final ReadFilter MAPPED =  read -> ! read.isUnmapped();
+    public static final ReadFilter MAPPED = read -> ! read.isUnmapped();
     public static final ReadFilter PRIMARY_ALIGNMENT = read -> ! read.isSecondaryAlignment();
     public static final ReadFilter NOT_DUPLICATE = read -> ! read.isDuplicate();
     public static final ReadFilter PASSES_VENDOR_QUALITY_CHECK = read -> ! read.failsVendorQualityCheck();

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadGroupReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadGroupReadFilter.java
@@ -3,13 +3,17 @@ package org.broadinstitute.hellbender.engine.filters;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
+import java.io.Serializable;
+
 /**
  * Only use reads from the specified read group.
  * Matching is done by case-sensitive exact match.
  */
-public final class ReadGroupReadFilter implements ReadFilter {
+public final class ReadGroupReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = "read_group_to_keep", shortName = "goodRG", doc="The name of the read group to keep", optional=false)
+
+    private final static String groupArgName = "readGroup";
+    @Argument(fullName = groupArgName, shortName = "goodRG", doc="The name of the read group to keep", optional=true)
     public String readGroup = null;
 
     @Override
@@ -17,4 +21,15 @@ public final class ReadGroupReadFilter implements ReadFilter {
         final String rg = read.getReadGroup();
         return readGroup != null && rg.equals(this.readGroup);
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (readGroup == null || readGroup.length() < 1) {
+            message = "requires a value for \"" + groupArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
@@ -3,19 +3,37 @@ package org.broadinstitute.hellbender.engine.filters;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
+import java.io.Serializable;
+
 /**
  * Keep only reads whose length is >= min value and <= max value.
  */
-public final class ReadLengthReadFilter implements ReadFilter {
+public final class ReadLengthReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = "maxReadLength", shortName = "maxRead", doc="Keep only reads with length at most equal to the specified value", optional=false)
-    public int maxReadLength;
 
-    @Argument(fullName = "minReadLength", shortName = "minRead", doc="Keep only reads with length at least equal to the specified value", optional=false)
-    public int minReadLength = 1;
+    private static final String maxLengthArgName = "maxReadLength";
+
+    @Argument(fullName = maxLengthArgName, shortName = "maxRead", doc="Keep only reads with length at most equal to the specified value", optional=false)
+    public int maxReadLength = 0;
+
+    private static final String minLengthArg = "minReadLength";
+    @Argument(fullName = minLengthArg, shortName = "minRead", doc="Keep only reads with length at least equal to the specified value", optional=false)
+    public int minReadLength = 0;
 
     @Override
     public boolean test( final GATKRead read ) {
         return read.getLength() >= minReadLength && read.getLength() <= maxReadLength;
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (maxReadLength <= 0 || minReadLength <= 0) {
+            message = "requires non-zero argument values for \"" +
+                    minLengthArg + "\" and \"" + maxLengthArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadNameReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadNameReadFilter.java
@@ -3,18 +3,32 @@ package org.broadinstitute.hellbender.engine.filters;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
+import java.io.Serializable;
+
 /**
  * Keep only reads with this read name.
  * Matching is done by case-sensitive exact match.
  */
-public final class ReadNameReadFilter implements ReadFilter {
+public final class ReadNameReadFilter implements ReadFilter, CommandLineFilter, Serializable {
     private static final long serialVersionUID = 1L;
 
-     @Argument(fullName = "readName", shortName = "rn", doc="Keep only reads with this read name", optional=false)
+    private final static String readNameArgName = "readName";
+    @Argument(fullName = readNameArgName, shortName = "rn", doc="Keep only reads with this read name", optional=true)
     public String readName;
 
     @Override
     public boolean test( final GATKRead read ) {
         return read.getName() != null && read.getName().equals(readName);
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (readName == null || readName.length() < 1) {
+            message = "requires a value for \"" + readNameArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadStrandFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadStrandFilter.java
@@ -10,7 +10,7 @@ public final class ReadStrandFilter implements ReadFilter {
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = "keepReverse", shortName = "kr", doc="Keep only reads on the reverse strand",optional=true)
-	boolean keepOnlyReverse = false;
+	public boolean keepOnlyReverse = false;
 
     @Override
     public boolean test( final GATKRead read ) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/SampleReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/SampleReadFilter.java
@@ -5,16 +5,20 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Keep only reads for a given sample.
  * Matching is done by case-sensitive exact match.
  */
-public final class SampleReadFilter implements ReadFilter {
+public final class SampleReadFilter implements ReadFilter, CommandLineFilter {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = "sample_to_keep", shortName = "goodSM", doc="The name of the sample(s) to keep, filtering out all others", optional=false)
-    public Set<String> samplesToKeep = null;
+
+    private final static String sampleArgName = "sample";
+
+    @Argument(fullName = sampleArgName, shortName = "goodSM", doc="The name of the sample(s) to keep, filtering out all others", optional=true)
+    public Set<String> samplesToKeep = new HashSet<>();
 
     private final SAMFileHeader header;
 
@@ -27,4 +31,15 @@ public final class SampleReadFilter implements ReadFilter {
         final String sample = ReadUtils.getSampleName(read, header);
         return sample != null && samplesToKeep.contains(sample);
     }
+
+    @Override
+    public String validate() {
+        String message = null;
+        if (samplesToKeep.size() <= 0) {
+            message = "requires one or more values for \"" + sampleArgName + "\"";
+        }
+
+        return message;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
@@ -17,7 +17,7 @@ import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.ContextShard;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.datasources.VariantsSource;
-import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.AddContextDataToReadSparkOptimized;
 import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
@@ -91,7 +91,7 @@ public class BaseRecalibratorSparkSharded extends SparkCommandLineProgram {
         SAMFileHeader readsHeader = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency()).getHeader(bam, referenceURL, auth);
         final SAMSequenceDictionary readsDictionary = readsHeader.getSequenceDictionary();
         final SAMSequenceDictionary refDictionary = rds.getReferenceSequenceDictionary(readsDictionary);
-        final CountingReadFilter readFilterToApply = BaseRecalibrator.getStandardBQSRReadFilter(readsHeader);
+        final ReadFilter readFilterToApply = BaseRecalibrator.getStandardBQSRReadFilter(readsHeader);
 
         SequenceDictionaryUtils.validateDictionaries("reference", refDictionary, "reads", readsDictionary);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -79,12 +80,16 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         if (joinStrategy == JoinStrategy.BROADCAST && ! getReference().isCompatibleWithSparkBroadcast()){
             throw new UserException.Require2BitReferenceForBroadcast();
         }
+        //TOOO: should this get the getUnfilteredReads? getReads will apply default and command line filters
         final JavaRDD<GATKRead> initialReads = getReads();
 
         // The initial reads have already had the WellformedReadFilter applied to them, which
         // is all the filtering that ApplyBQSR wants. BQSR itself wants additional filtering
         // performed, so we do that here.
-        final ReadFilter bqsrReadFilter = BaseRecalibrator.makeBQSRSpecificReadFilters();
+        //NOTE: this doesn't honor enabled/disabled commandline filters
+        final ReadFilter bqsrReadFilter = BaseRecalibrator.makeBQSRSpecificReadFilters().stream()
+                .map(f -> f.getFilterInstance(getHeaderForReads(), null))
+                .reduce(ReadFilterLibrary.ALLOW_ALL_READS, (f1, f2) -> f1.and(f2));
         final JavaRDD<GATKRead> filteredReadsForBQSR = initialReads.filter(read -> bqsrReadFilter.test(read));
 
         final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -91,6 +93,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
             throw new UserException.Require2BitReferenceForBroadcast();
         }
 
+        //TOOO: should this use getUnfilteredReads? getReads will apply default and command line filters
         final JavaRDD<GATKRead> initialReads = getReads();
 
         final JavaRDD<GATKRead> markedReadsWithOD = MarkDuplicatesSpark.mark(initialReads, getHeaderForReads(), duplicatesScoringStrategy, new OpticalDuplicateFinder(), getRecommendedNumReducers());
@@ -99,7 +102,11 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         // The markedReads have already had the WellformedReadFilter applied to them, which
         // is all the filtering that MarkDupes and ApplyBQSR want. BQSR itself wants additional
         // filtering performed, so we do that here.
-        final ReadFilter bqsrReadFilter = BaseRecalibrator.makeBQSRSpecificReadFilters();
+        //NOTE: this doesn't honor enabled/disabled commandline filters
+        final ReadFilter bqsrReadFilter = BaseRecalibrator.makeBQSRSpecificReadFilters().stream()
+                .map(f -> f.getFilterInstance(getHeaderForReads(), null))
+                .reduce(ReadFilterLibrary.ALLOW_ALL_READS, (f1, f2) -> f1.and(f2));
+
         final JavaRDD<GATKRead> markedFilteredReadsForBQSR = markedReads.filter(read -> bqsrReadFilter.test(read));
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -693,6 +693,71 @@ public final class CommandLineParserTest {
         Assert.assertFalse(clp.parseArguments(System.err, new String[]{"--version", "true"}));
     }
 
+    // test ArgumentCollection depends on
+    class ArgTarget {
+        @Argument(fullName="argTarget", optional = true)
+        String argTarget;
+    }
+    class ArgAndValueTarget {
+        @Argument(fullName="argAndValueTarget", optional = true)
+        String argAndValueTarget;
+    }
+
+    class TestArgs {
+        @Argument(fullName="master", optional = true)
+        int rf;
+
+        @ArgumentCollection(dependsOnArgument = "master")
+        ArgTarget t1 = new ArgTarget();
+
+        @ArgumentCollection(dependsOnArgument = "master", dependsOnValue="27")
+        ArgAndValueTarget t2 = new ArgAndValueTarget();
+    }
+
+    @Test
+    public void testDependsOnArgument() {
+        TestArgs tArgs = new TestArgs();
+        String args[] = {
+                "--master", "35",
+                "-argTarget", "foo"
+        };
+        final CommandLineParser clp = new CommandLineParser(tArgs);
+        clp.parseArguments(System.err, args);
+    }
+
+    @Test(expectedExceptions = UserException.CommandLineException.class)
+    public void testFailsDependsOnArgument() {
+        TestArgs tArgs = new TestArgs();
+        String args[] = {
+                //missing --master
+                "--argTarget", "foo"
+        };
+        final CommandLineParser clp = new CommandLineParser(tArgs);
+        clp.parseArguments(System.err, args);
+    }
+
+    @Test
+    public void testDependsOnArgumentAndValue() {
+        TestArgs tArgs = new TestArgs();
+        String args[] = {
+                "--master", "27",
+                "--argAndValueTarget", "foo"
+        };
+        final CommandLineParser clp = new CommandLineParser(tArgs);
+        clp.parseArguments(System.err, args);
+    }
+
+    @Test(expectedExceptions = UserException.CommandLineException.class)
+    public void testFailsDependsOnArgumentValue() {
+        TestArgs tArgs = new TestArgs();
+        String args[] = {
+                "--master", "0",
+                "--argAndValueTarget", "foo" // depends on --master 27
+        };
+        final CommandLineParser clp = new CommandLineParser(tArgs);
+        clp.parseArguments(System.err, args);
+    }
+
     /***************************************************************************************
      * Start of tests and helper classes for CommandLineParser.gatherArgumentValuesOfType()
      ***************************************************************************************/

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadFilterArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadFilterArgumentCollectionTest.java
@@ -1,0 +1,379 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.TextCigarCodec;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+// - walker and spark tool integration tests
+
+public class ReadFilterArgumentCollectionTest {
+
+    class TestArgCollection {
+        @ArgumentCollection
+        public ReadFilterArgumentCollection rfc = new ReadFilterArgumentCollection();
+        public TestArgCollection(){};
+        public TestArgCollection (Consumer<ReadFilterArgumentCollection> t) {
+            t.accept(this.rfc);
+        }
+    };
+
+    @DataProvider(name="filtersWithArguments")
+    public Object[][] badArguments(){
+        return new Object[][]{
+                { ReadFilterArgumentCollection.CommandLineReadFilter.LIBRARY, "--library", "fakeLibrary" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.MAPPING_QUALITY, "--mappingQuality", "25" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.PLATFORM, "--PLFilterName", "fakePlatform" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.PLATFORM_UNIT, "--blackListedLanes", "fakeUnit" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_GROUP, "--readGroup", "fakeGroup" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_GROUP_BLACK_LISTED, "--blackList", "tg:sub"},
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME, "--readName", "fakeRead" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH, "--maxReadLength", "10" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.SAMPLE, "--sample", "fakeSample" }
+        };
+    }
+
+    // verify that all filters that require arguments and have no defaults complain if the
+    // arguments are not set on the command line
+    @Test(dataProvider = "filtersWithArguments", expectedExceptions = UserException.CommandLineException.class)
+    public void testRequiresArguments(
+            ReadFilterArgumentCollection.CommandLineReadFilter filter,
+            String argName,   //unused
+            String argValue)  //unused
+    {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        String[] args = { "--readFilter", filter.name() }; // no args, just enable filters
+
+        clp.parseArguments(System.out, args);
+
+        // we need to render the filter to trigger execution of the validation code
+        testArgs.rfc.getMergedCommandLineFilters(Arrays.asList())
+                .stream()
+                .map(f-> f.getFilterInstance(new SAMFileHeader(), testArgs.rfc))
+                .collect(Collectors.toList());
+    }
+
+    // verify that all filters that require arguments throw if the arguments are passed but the
+    // corresponding filter is not enabled
+    @Test(dataProvider = "filtersWithArguments", expectedExceptions = UserException.CommandLineException.class)
+    public void testArgumentsRequireFilter(
+            ReadFilterArgumentCollection.CommandLineReadFilter filter,
+            String argName,
+            String argValue)
+    {
+        TestArgCollection tArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(tArgs);
+        String[] args = { argName, argValue }; // no read filter set
+
+        // dependsOn errors are caught by the command line parser
+        clp.parseArguments(System.out, args);
+    }
+
+    @DataProvider(name="validationFailures")
+    public Object[][] validationFailures(){
+        return new Object[][]{
+                { ReadFilterArgumentCollection.CommandLineReadFilter.LIBRARY, "--library", "" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.MAPPING_QUALITY, "--mappingQuality", "1000" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_GROUP, "--readGroup", "" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_GROUP_BLACK_LISTED, "--blackList", "zzz:sub"},
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME, "--readName", "" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH, "--maxReadLength", "-1" }
+        };
+    }
+
+    // test that all filters that require validation fail given bad arguments
+    @Test(dataProvider = "validationFailures", expectedExceptions =
+            {UserException.CommandLineException.class, UserException.class})
+    public void testArgumentFailsValidations(
+            ReadFilterArgumentCollection.CommandLineReadFilter filter,
+            String argName,
+            String argValue)
+    {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        String[] args = {
+                "--readFilter", filter.name(),
+                argName, argValue
+        };
+
+        clp.parseArguments(System.out, args);
+        testArgs.rfc.getMergedCommandLineFilters(Arrays.asList())
+                .stream()
+                .map(f-> f.getFilterInstance(new SAMFileHeader(), testArgs.rfc))
+                .collect(Collectors.toList());
+    }
+
+    @DataProvider(name="filtersWithGoodArguments")
+    public Object[][] filtersWithGoodArguments(){
+        return new Object[][]{
+                { ReadFilterArgumentCollection.CommandLineReadFilter.LIBRARY,
+                        (Consumer<SetupTest>) this::setupLibraryTest, "--library", "Foo" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.MAPPING_QUALITY,
+                        (Consumer<SetupTest>) this::setupMappingQualityTest, "--mappingQuality", "255" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_GROUP,
+                        (Consumer<SetupTest>) this::setupReadGroupTest, "--readGroup", "fred" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME,
+                        (Consumer<SetupTest>) this::setupReadNameTest, "--readName", "fred" },
+                { ReadFilterArgumentCollection.CommandLineReadFilter.SAMPLE,
+                        (Consumer<SetupTest>) this::setupSampleTest, "--sample", "fred" }
+        };
+    }
+
+    @Test(dataProvider = "filtersWithGoodArguments")
+    public void testFiltersWithArguments(
+            ReadFilterArgumentCollection.CommandLineReadFilter filter,
+            Consumer<SetupTest> setup,
+            String argName,
+            String argValue)
+    {
+        TestArgCollection tArgs = new TestArgCollection();
+
+        final SAMFileHeader header = createHeaderWithReadGroups();
+        final GATKRead read = simpleGoodRead(header);
+
+        CommandLineParser clp = new CommandLineParser(tArgs);
+        String[] args = {
+                "--readFilter", filter.name(),
+                argName, argValue
+        };
+        clp.parseArguments(System.out, args);
+        ReadFilter rf = instantiateFilter(tArgs.rfc, header);
+
+        // to ensure that the filter is actually working, verify that the test record
+        // we're using fails the filter test *before* we set it up to pass the filter
+        Assert.assertFalse(rf.test(read));
+
+        // setup the header and read for this test
+        setup.accept(new SetupTest(header, read, argValue));
+
+        Assert.assertTrue(rf.test(read));
+    }
+
+    @Test
+    public void testNoReadFiltersSpecified() {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        clp.parseArguments(System.out, new String[]{});
+        List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                testArgs.rfc.getMergedCommandLineFilters(Arrays.asList());
+        Assert.assertEquals(filters.size(), 0);
+    }
+
+    @Test
+    public void testDisableAllReadFilters() {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        clp.parseArguments(System.out, new String[] {
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED.name(), "--disableAllReadFilters"});
+        List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                testArgs.rfc.getMergedCommandLineFilters(Arrays.asList(
+                        ReadFilterArgumentCollection.CommandLineReadFilter.CIGAR_IS_SUPPORTED,
+                        ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR
+                ));
+        Assert.assertEquals(filters.size(), 0);
+    }
+
+    @Test
+    public void testDisableOneReadFilter() {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        clp.parseArguments(System.out, new String[] {
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED.name(),
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS.name(),
+                "-disableReadFilter", ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR.name()});
+
+        List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                testArgs.rfc.getMergedCommandLineFilters(Arrays.asList(
+                        ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR
+                ));
+
+        Assert.assertEquals(filters.size(), 2);
+        Assert.assertTrue(filters.contains(ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED));
+        Assert.assertTrue(filters.contains(ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS));
+    }
+
+    @Test
+    public void testDisableMultipleReadFilters() {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        clp.parseArguments(System.out, new String[] {
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED.name(),
+                "-disableReadFilter", ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR.name()});
+
+        List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                testArgs.rfc.getMergedCommandLineFilters(Arrays.asList(
+                        ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR,
+                        ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS
+                ));
+
+        Assert.assertEquals(filters.size(), 2);
+        Assert.assertTrue(filters.contains(ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED));
+        Assert.assertTrue(filters.contains(ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS));
+    }
+
+    @Test
+    public void testPreserveSpecifiedOrder() {
+        TestArgCollection testArgs = new TestArgCollection();
+        CommandLineParser clp = new CommandLineParser(testArgs);
+        clp.parseArguments(System.out, new String[] {
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED.name(),
+                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS.name()});
+
+        List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                testArgs.rfc.getMergedCommandLineFilters(Arrays.asList(
+                        ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR
+                ));
+
+        // defaults first, then command line, in order
+        Assert.assertEquals(filters.size(), 3);
+        Assert.assertEquals(filters.get(0), ReadFilterArgumentCollection.CommandLineReadFilter.GOOD_CIGAR);
+        Assert.assertEquals(filters.get(1), ReadFilterArgumentCollection.CommandLineReadFilter.MAPPED);
+        Assert.assertEquals(filters.get(2), ReadFilterArgumentCollection.CommandLineReadFilter.HAS_MATCHING_BASES_AND_QUALS);
+    }
+
+    @Test
+    public void testMultipleFilters() {
+        TestArgCollection tArgs = new TestArgCollection();
+
+        final SAMFileHeader header = createHeaderWithReadGroups();
+        final GATKRead read = simpleGoodRead(header);
+
+        CommandLineParser clp = new CommandLineParser(tArgs);
+        String[] args = {
+                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                "--minReadLength", "10",
+                "--maxReadLength", "20",
+                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                "--readName", "fred"
+        };
+        clp.parseArguments(System.out, args);
+        ReadFilter rf = instantiateFilter(tArgs.rfc, header);
+
+        Assert.assertFalse(rf.test(read));
+        read.setName("fred");
+        read.setBases(new byte[15]);
+        Assert.assertTrue(rf.test(read));
+    }
+
+    @Test
+    public void testReadLengthFilter() {
+        TestArgCollection tArgs = new TestArgCollection();
+
+        final SAMFileHeader header = createHeaderWithReadGroups();
+        final GATKRead read = simpleGoodRead(header);
+
+        CommandLineParser clp = new CommandLineParser(tArgs);
+        String[] args = {
+                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                "--minReadLength", "10",
+                "--maxReadLength", "20"
+        };
+        clp.parseArguments(System.out, args);
+        ReadFilter rf = instantiateFilter(tArgs.rfc, header);
+
+        read.setBases(new byte[5]);
+        Assert.assertFalse(rf.test(read));
+        read.setBases(new byte[25]);
+        Assert.assertFalse(rf.test(read));
+        read.setBases(new byte[15]);
+        Assert.assertTrue(rf.test(read));
+    }
+
+    private ReadFilter instantiateFilter(final ReadFilterArgumentCollection rfc, final SAMFileHeader header) {
+        final List<ReadFilterArgumentCollection.CommandLineReadFilter> filters =
+                rfc.getMergedCommandLineFilters(Arrays.asList());
+        return filters.stream()
+                .map(f-> f.getFilterInstance(header, rfc))
+                .reduce(
+                        ReadFilterLibrary.ALLOW_ALL_READS,
+                        (f1, f2) -> f1.and(f2)
+                );
+    }
+
+    private static final int CHR_COUNT = 2;
+    private static final int CHR_START = 1;
+    private static final int CHR_SIZE = 1000;
+    private static final int GROUP_COUNT = 5;
+
+    private SAMFileHeader createHeaderWithReadGroups() {
+        return ArtificialReadUtils.createArtificialSamHeaderWithGroups(CHR_COUNT, CHR_START, CHR_SIZE, GROUP_COUNT);
+    }
+
+    /**
+     * Creates a read record.
+     *
+     * @param header header for the new record
+     * @param cigar the new record CIGAR.
+     * @param group the new record group index that must be in the range \
+     *              [0,{@link #GROUP_COUNT})
+     * @param reference the reference sequence index (0-based)
+     * @param start the start position of the read alignment in the reference
+     *              (1-based)
+     * @return never <code>null</code>
+     */
+    private GATKRead createRead(final SAMFileHeader header, final Cigar cigar, final int group,
+                                final int reference, final int start ) {
+        final GATKRead record = ArtificialReadUtils.createArtificialRead(header, cigar);
+        record.setPosition(header.getSequence(reference).getSequenceName(), start);
+        record.setReadGroup(header.getReadGroups().get(group).getReadGroupId());
+        return record;
+    }
+
+    private GATKRead simpleGoodRead( final SAMFileHeader header ) {
+        final String cigarString = "101M";
+        final Cigar cigar = TextCigarCodec.decode(cigarString);
+        GATKRead read = createRead(header, cigar, 1, 0, 10);
+        read.setMappingQuality(50);
+        return read;
+    }
+
+    // object for holding test setup params to use as a type for test lambdas
+    public class SetupTest {
+        public SAMFileHeader hdr;
+        public GATKRead read;
+        public String argValue;
+
+        public SetupTest(SAMFileHeader hdr, GATKRead read, String argValue) {
+            this.hdr = hdr;
+            this.read = read;
+            this.argValue = argValue;
+        }
+    }
+
+    // setup methods to initialize reads for individual filter tests
+    private void setupLibraryTest(SetupTest setup) {
+        setup.hdr.getReadGroup(setup.read.getReadGroup()).setLibrary(setup.argValue);
+    }
+
+    private void setupMappingQualityTest(SetupTest setup) {
+        setup.read.setMappingQuality(Integer.parseInt(setup.argValue));
+    }
+
+    private void setupReadGroupTest(SetupTest setup) {
+        setup.read.setReadGroup(setup.argValue);
+    }
+
+    private void setupReadNameTest(SetupTest setup) {
+        setup.read.setName(setup.argValue);
+    }
+
+    private void setupSampleTest(SetupTest setup) {
+        setup.hdr.getReadGroup(setup.read.getReadGroup()).setSample(setup.argValue);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/TestCustomReadFilter.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/TestCustomReadFilter.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.hellbender.engine.filters;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+/**
+ * CustomReadFilter-derived class used for testing custom read filters.
+ */
+public class TestCustomReadFilter extends CustomReadFilter {
+    private static final long serialVersionUID = 1L;
+
+    private SAMFileHeader samHeader;
+
+    public void setSAMFileHeader(SAMFileHeader header) { this.samHeader = header; }
+
+    public boolean test(GATKRead read) { return true;}
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -1,18 +1,25 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.ReadFilterArgumentCollection;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -196,4 +203,103 @@ public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest
         );
         spec.executeTest("testReadFiltering_asIntegrationTestSpec", this);
     }
+
+    @DataProvider(name="readFilterTestData")
+    public Object[][] testReadFilterData() {
+        return new Object[][]{
+                {"print_reads.sorted.sam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads.sorted.sam", null, ".sam",
+                        Arrays.asList(
+                                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                                "--readName", "both_reads_align_clip_adapter"),
+                        2},
+                {"print_reads.sorted.sam", null, ".sam",
+                        Arrays.asList(
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "100",
+                                "--maxReadLength", "200"),
+                        8},
+                {"print_reads.sorted.sam", null, ".sam",
+                        Arrays.asList(
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "1",
+                                "--maxReadLength", "10"),
+                        0},
+                {"print_reads.sorted.sam", null, ".sam",
+                        Arrays.asList(
+                                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                                "--readName", "both_reads_align_clip_adapter",
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "100",
+                                "--maxReadLength", "101"),
+                        2},
+                {"print_reads.sorted.bam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads.sorted.bam", null, ".sam",
+                        Arrays.asList(
+                                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                                "--readName", "both_reads_align_clip_adapter"),
+                        2},
+                {"print_reads.sorted.bam", null, ".sam",
+                        Arrays.asList(
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "100",
+                                "--maxReadLength", "101"),
+                        8},
+                {"print_reads.sorted.bam", null, ".sam",
+                        Arrays.asList(
+                                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                                "--readName", "both_reads_align_clip_adapter",
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "100",
+                                "--maxReadLength", "101"),
+                        2},
+                {"print_reads.sorted.cram", "print_reads.fasta", ".sam",
+                        Arrays.asList(
+                                "--readFilter", ReadFilterArgumentCollection.CommandLineReadFilter.READ_NAME.name(),
+                                "--readName", "both_reads_align_clip_adapter",
+                                "--RF", ReadFilterArgumentCollection.CommandLineReadFilter.READ_LENGTH.name(),
+                                "--minReadLength", "100",
+                                "--maxReadLength", "101"),
+                        2},
+        };
+    }
+
+    @Test(dataProvider = "readFilterTestData")
+    public void testReadFilters(
+            final String input,
+            final String reference,
+            final String extOut,
+            final List<String> inputArgs,
+            final int expectedCount) throws IOException
+    {
+        final File outFile = createTempFile("testReadFilter", extOut);
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("-I"); args.add(new File(TEST_DATA_DIR, input).getAbsolutePath());
+        args.add("-O"); args.add(outFile.getAbsolutePath());
+        if ( reference != null ) {
+            args.add("-R"); args.add(new File(TEST_DATA_DIR, reference).getAbsolutePath());
+        }
+        for (final String filter : inputArgs) {
+            args.add(filter);
+        }
+
+        runCommandLine(args);
+
+
+        SamReaderFactory factory = SamReaderFactory.makeDefault();
+        if (reference != null) {
+            factory = factory.referenceSequence(new File(TEST_DATA_DIR, reference));
+        }
+        int count = 0;
+        try (final SamReader reader = factory.open(outFile)) {
+            Iterator<SAMRecord> it = reader.iterator();
+            while (it.hasNext()) {
+                SAMRecord rec = it.next();
+                count++;
+            }
+        }
+        Assert.assertEquals(count, expectedCount);
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/589 (Walkers and Spark tools only, not integrated with Picard tools).