### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the var…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
@@ -339,7 +339,7 @@ public final class FastqToSam extends PicardCommandLineProgram {
         if(readName.equals("")) throw new UserException(error(freader,"Pair read name "+pairNum+" cannot be empty: "+readName));
 
         final int idx = readName.lastIndexOf("/");
-        final String result[] = new String[2];
+        final String[] result = new String[2];
 
         if (idx == -1) {
             result[0] = readName;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSam.java
@@ -264,7 +264,7 @@ public final class RevertSam extends PicardCommandLineProgram {
                     // The only valid quality score encoding scheme is standard; if it's not standard, change it.
                     final FastqQualityFormat recordFormat = readGroupToFormat.get(rec.getReadGroup());
                     if (!recordFormat.equals(FastqQualityFormat.Standard)) {
-                        final byte quals[] = rec.getBaseQualities();
+                        final byte[] quals = rec.getBaseQualities();
                         for (int i = 0; i < quals.length; i++) {
                             quals[i] -= SolexaQualityConverter.ILLUMINA_TO_PHRED_SUBTRAHEND;
                         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/InsertSizeMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/InsertSizeMetricsCollectorSpark.java
@@ -216,7 +216,7 @@ public final class InsertSizeMetricsCollectorSpark implements Serializable {
 
     // small utility function to collect bin width on the untrimmed Histogram, but actual work delegated to computeRanges
     private static void collectSymmetricBinWidth(InsertSizeMetrics metrics, final Histogram<Integer> hist){
-        final long bin_widths[] = computeRanges(hist, (int) hist.getMedian(), metrics.READ_PAIRS); // metrics.REAR_PAIRS is assumed to be set properly already
+        final long[] bin_widths = computeRanges(hist, (int) hist.getMedian(), metrics.READ_PAIRS); // metrics.REAR_PAIRS is assumed to be set properly already
         metrics.WIDTH_OF_10_PERCENT = (int) bin_widths[0];
         metrics.WIDTH_OF_20_PERCENT = (int) bin_widths[1];
         metrics.WIDTH_OF_30_PERCENT = (int) bin_widths[2];
@@ -239,7 +239,7 @@ public final class InsertSizeMetricsCollectorSpark implements Serializable {
         int left = start;  // left and right boundaries of histogram bins
         int right = left;  //      start from median, and gradually open up
 
-        final long bin_widths[] = new long[10];   // for storing distance between left and right boundaries of histogram bins
+        final long[] bin_widths = new long[10];   // for storing distance between left and right boundaries of histogram bins
         // dimension is 10 because metrics requires 10 histogram bin width values.
         int i = 0;
         int j = 0;                          // represent lowest and highest indices of bin_widths that needs to be updated

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmer.java
@@ -19,7 +19,7 @@ public final class SVKmer implements Comparable<SVKmer>, Serializable {
     // Lookup table for reverse-complementing each possible byte value.
     // Each pair of bits represents a base, so you have to reverse bits pairwise and then invert all bits.
     // This is most quickly and easily done with a lookup table.
-    private static final long BYTEWISE_REVERSE_COMPLEMENT[];
+    private static final long[] BYTEWISE_REVERSE_COMPLEMENT;
     static {
         BYTEWISE_REVERSE_COMPLEMENT = new long[256];
         for ( int idx = 0; idx != 256; ++idx ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/GeneralPloidyExactAFCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/GeneralPloidyExactAFCalculator.java
@@ -338,7 +338,7 @@ public final class GeneralPloidyExactAFCalculator extends ExactAFCalculator {
         double log10LofK = set.getLog10Likelihoods()[0];
 
         // update the MLE if necessary
-        final int altCounts[] = Arrays.copyOfRange(set.getACcounts().getCounts(), 1, set.getACcounts().getCounts().length);
+        final int[] altCounts = Arrays.copyOfRange(set.getACcounts().getCounts(), 1, set.getACcounts().getCounts().length);
         // TODO -- GUILLERMO THIS CODE MAY PRODUCE POSITIVE LIKELIHOODS OR -INFINITY
         stateTracker.updateMLEifNeeded(Math.max(log10LofK, -Double.MAX_VALUE), altCounts);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodec.java
@@ -74,7 +74,7 @@ public final class TableCodec extends AsciiFeatureCodec<TableFeature> {
                 if (header.size() > 0) {
                     throw new UserException.MalformedFile("Input table file seems to have two header lines.  The second is = " + line);
                 }
-                final String spl[] = line.split(DELIMITER_REGEX);
+                final String[] spl = line.split(DELIMITER_REGEX);
                 Collections.addAll(header, spl);
                 return header;
             } else if (line.startsWith(COMMENT_DELIMITER)) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/BaseRecalibrationEngine.java
@@ -313,10 +313,10 @@ public final class BaseRecalibrationEngine implements Serializable {
         if (recalArgs.defaultBaseQualities < 0) {
             return read;
         }
-        byte reads[] = read.getBases();
-        byte quals[] = read.getBaseQualities();
+        byte[] reads = read.getBases();
+        byte[] quals = read.getBaseQualities();
         if (quals == null || quals.length < reads.length) {
-            byte new_quals[] = new byte[reads.length];
+            byte[] new_quals = new byte[reads.length];
             Arrays.fill(new_quals, recalArgs.defaultBaseQualities);
             read.setBaseQualities(new_quals);
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/text/parsers/BasicInputParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/text/parsers/BasicInputParser.java
@@ -133,8 +133,8 @@ public class BasicInputParser extends AbstractInputParser {
         return currentLineNumber;
     }
 
-    private static InputStream[] filesToInputStreams(final File files[]) {
-        final InputStream result[] = new InputStream[files.length];
+    private static InputStream[] filesToInputStreams(final File[] files) {
+        final InputStream[] result = new InputStream[files.length];
         for (int i = 0; i < files.length; i++) {
             result[i] = IOUtil.openFileForReading(files[i]);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat