### PR TITLE
Porting same fix from GATK3 for issue 1357

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -98,11 +98,31 @@ public final class GenotypeCalculationArgumentCollection {
      * scales exponentially based on the number of alternate alleles.  Unless there is a good reason to change the default value, we highly recommend
      * that you not play around with this parameter.
      *
-     * As of GATK 2.2 the genotyper can handle a very large number of events, so the default maximum has been increased to 6.
+     * See also {@link #MAX_GENOTYPE_COUNT}.
      */
     @Advanced
     @Argument(fullName = "max_alternate_alleles", shortName = "maxAltAlleles", doc = "Maximum number of alternate alleles to genotype", optional = true)
     public int MAX_ALTERNATE_ALLELES = 6;
+
+    /**
+     * If there are more than this number of genotypes at a locus presented to the genotyper, then only this many genotypes will be used.
+     * The possible genotypes are simply different ways of partitioning alleles given a specific ploidy asumption.
+     * Therefore, we remove genotypes from consideration by removing alternate alleles that are the least well supported.
+     * The estimate of allele support is based on the ranking of the candidate haplotypes coming out of the graph building step.
+     * Note that the reference allele is always kept.
+     *
+     * Note that genotyping sites with large genotype counts is both CPU and memory intensive.
+     * Unless there is a good reason to change the default value, we highly recommend that you not play around with this parameter.
+     *
+     * The maximum number of alternative alleles used in the genotyping step will be the lesser of the two:
+     * 1. the largest number of alt alleles, given ploidy, that yields a genotype count no higher than {@link #MAX_GENOTYPE_COUNT}
+     * 2. the value of {@link #MAX_ALTERNATE_ALLELES}
+     *
+     * See also {@link #MAX_ALTERNATE_ALLELES}.
+     */
+    @Advanced
+    @Argument(fullName = "max_genotype_count", shortName = "maxGT", doc = "Maximum number of genotypes to consider at any site", optional = true)
+    public int MAX_GENOTYPE_COUNT = 1024;
 
     /**
      * By default, the prior specified with the argument --heterozygosity/-hets is used for variant discovery at a particular locus, using an infinite sites model,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculator.java
@@ -150,16 +150,12 @@ public final class GenotypeLikelihoodCalculator {
         this.alleleCount = alleleCount;
         this.ploidy = ploidy;
         genotypeCount = this.alleleFirstGenotypeOffsetByPloidy[ploidy][alleleCount];
-        if (genotypeCount == GenotypeLikelihoodCalculators.GENOTYPE_COUNT_OVERFLOW) {
-            throw new IllegalArgumentException(
-                    String.format("the combination of ploidy (%s) and number of alleles (%s) results in a very large number of genotypes (> %s). You need to limit ploidy or the number of alternative alleles to analyze this locus",
-                            ploidy, alleleCount, Integer.MAX_VALUE));
-        }
+
         alleleHeap = new PriorityQueue<>(ploidy, Comparator.<Integer>naturalOrder().reversed());
         readLikelihoodsByGenotypeIndex = new double[genotypeCount][];
         // The number of possible components is limited by distinct allele count and ploidy.
         maximumDistinctAllelesInGenotype = Math.min(ploidy, alleleCount);
-        genotypeAllelesAndCounts = new int[maximumDistinctAllelesInGenotype << 1];
+        genotypeAllelesAndCounts = new int[maximumDistinctAllelesInGenotype * 2];
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.MathUtils;
+
 import java.util.Arrays;
 
 /**
@@ -245,19 +248,20 @@ public final class GenotypeLikelihoodCalculators {
      * @param alleleCount the required allele-count.
      * @param ploidy the required ploidy-count.
      *
-     * @throws IllegalArgumentException if either {@code ploidy} or {@code alleleCount} is {@code null}, or
-     *      the resulting number of genotypes is too large.
+     * @throws IllegalArgumentException if either {@code ploidy} or {@code alleleCount} is negative, or the resulting number of genotypes is too large.
      *
      * @return never {@code null}.
      */
     public GenotypeLikelihoodCalculator getInstance(final int ploidy, final int alleleCount) {
         checkPloidyAndMaximumAllele(ploidy, alleleCount);
-        if (alleleCount > maximumAllele || ploidy > maximumPloidy) {
-            ensureCapacity(alleleCount, ploidy);
+
+        if (calculateGenotypeCountUsingTables(ploidy, alleleCount) == GENOTYPE_COUNT_OVERFLOW) {
+            final double largeGenotypeCount = Math.pow(10, MathUtils.log10BinomialCoefficient(ploidy + alleleCount - 1, alleleCount - 1));
+            throw new IllegalArgumentException(String.format("the number of genotypes is too large for ploidy %d and allele %d: approx. %.0f", ploidy, alleleCount, largeGenotypeCount));
         }
 
         // At this point the tables must have at least the requested capacity, likely to be much more.
-        return new GenotypeLikelihoodCalculator(ploidy,alleleCount,alleleFirstGenotypeOffsetByPloidy,genotypeTableByPloidy);
+        return new GenotypeLikelihoodCalculator(ploidy, alleleCount, alleleFirstGenotypeOffsetByPloidy, genotypeTableByPloidy);
     }
 
     /**
@@ -331,11 +335,55 @@ public final class GenotypeLikelihoodCalculators {
      * @param ploidy the requested ploidy.
      * @param alleleCount the requested number of alleles.
      *
-     * @throws IllegalArgumentException if {@code ploidy} or {@code alleleCount} is negative.
+     * @throws IllegalArgumentException if {@code ploidy} or {@code alleleCount} is negative or
+     *                                      the number of genotypes is too large (more than {@link Integer#MAX_VALUE}).
      *
-     * @return 0 or greater.
+     * @return the number of genotypes given ploidy and allele count (0 or greater).
      */
     public int genotypeCount(final int ploidy, final int alleleCount) {
+
+        final int result = calculateGenotypeCountUsingTables(ploidy, alleleCount);
+        if (result == GENOTYPE_COUNT_OVERFLOW) {
+            final double largeGenotypeCount = Math.pow(10, MathUtils.log10BinomialCoefficient(ploidy + alleleCount - 1, alleleCount - 1));
+            throw new IllegalArgumentException(String.format("the number of genotypes is too large for ploidy %d and allele %d: approx. %.0f", ploidy, alleleCount, largeGenotypeCount));
+        }
+        return result;
+    }
+
+    /**
+     * Compute the maximally acceptable allele count (ref allele included) given the maximally acceptable genotype count.
+     * @param ploidy            sample ploidy
+     * @param maxGenotypeCount  maximum number of genotype count used to calculate upper bound on number of alleles given ploidy
+     * @throws IllegalArgumentException if {@code ploidy} or {@code alleleCount} is negative.
+     * @return                  the maximally acceptable allele count given ploidy and maximum number of genotypes acceptable
+     */
+    public static int computeMaxAcceptableAlleleCount(final int ploidy, final int maxGenotypeCount){
+
+        checkPloidyAndMaximumAllele(ploidy, ploidy); // a hack to check ploidy makes sense (could duplicate code but choice must be made)
+
+        final double log10MaxGenotypeCount = Math.log10(maxGenotypeCount);
+
+        // Math explanation: genotype count is determined by ${P+A-1 \choose A-1}$, this leads to constraint
+        // $\log(\frac{(P+A-1)!}{(A-1)!}) \le \log(P!G)$,
+        // where $P$ is ploidy, $A$ is allele count, and $G$ is maxGenotypeCount
+        // The upper and lower bounds of the left hand side of the constraint are $P \log(A-1+P)$ and $P \log(A)$
+        // which require $A$ to be searched in interval $[10^{\log(P!G)/P} - (P-1), 10^{\log(P!G)/P}]$
+        // Denote $[10^{\log(P!G)/P}$ as $x$ in the code.
+
+        final double x = Math.pow(10, (MathUtils.log10Factorial(ploidy) + log10MaxGenotypeCount)/ploidy );
+        final int lower = (int)Math.floor(x) - ploidy - 1;
+        final int upper = (int)Math.ceil(x);
+        for(int a=upper; a>=lower; --a){// check one by one
+
+            final double log10GTCnt = MathUtils.log10BinomialCoefficient(ploidy+a-1, a-1);
+            if(log10MaxGenotypeCount >= log10GTCnt) {
+                return a;
+            }
+        }
+        throw new GATKException("Code should never reach here.");
+    }
+
+    private int calculateGenotypeCountUsingTables(int ploidy, int alleleCount) {
         checkPloidyAndMaximumAllele(ploidy, alleleCount);
         if (ploidy > maximumPloidy || alleleCount > maximumAllele) {
             ensureCapacity(alleleCount, ploidy);

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
@@ -107,6 +107,7 @@ public final class Haplotype extends Allele {
         final Haplotype ret = new Haplotype(newBases, isReference());
         ret.setCigar(newCigar);
         ret.setGenomeLocation(loc);
+        ret.setScore(score);
         ret.setAlignmentStartHapwrtRef(newStart + getAlignmentStartHapwrtRef());
         return ret;
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorsUnitTest.java
@@ -75,9 +75,9 @@ public final class GenotypeLikelihoodCalculatorsUnitTest extends BaseTest {
         }
     }
 
-    @Test
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGenotypeCountOverflow() throws Exception {
-        Assert.assertEquals(new GenotypeLikelihoodCalculators().genotypeCount(10_000, 10_000), GenotypeLikelihoodCalculators.GENOTYPE_COUNT_OVERFLOW);
+        final int genotypeCount = new GenotypeLikelihoodCalculators().genotypeCount(10_000, 10_000);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -90,4 +90,13 @@ public final class GenotypeLikelihoodCalculatorsUnitTest extends BaseTest {
         new GenotypeLikelihoodCalculators().genotypeCount(1, -1);
     }
 
+    @Test
+    public void testComputeMaxAcceptableAlleleCount(){
+        Assert.assertEquals(1024, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(1, 1024));
+        Assert.assertEquals(44, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(2, 1024));
+        Assert.assertEquals(17, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(3, 1024));
+        Assert.assertEquals(5, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(10, 1024));
+        Assert.assertEquals(3, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(20, 1024));
+        Assert.assertEquals(2, GenotypeLikelihoodCalculators.computeMaxAcceptableAlleleCount(100, 1024));
+    }
 }


### PR DESCRIPTION
Most changes are trivial, except `computeMaxAcceptableAlleleCount `, which is exactly the same code as in the GATK3 fix.

The part that's missing is changes made to `HaplotypeCallerGenotyingEngine`, which is in GATK-protected, which in turn depends on these classes in GATK. So these changes have to go in first.