### PR TITLE
Enable query-by-interval of VCFs (including blockgzipped VCFs) on Spark.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSource.java
@@ -7,10 +7,12 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.variant.GATKVariant;
 import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
 import org.seqdoop.hadoop_bam.VCFInputFormat;
 import org.seqdoop.hadoop_bam.VariantContextWritable;
+import org.seqdoop.hadoop_bam.util.BGZFCodec;
 
 import java.util.List;
 
@@ -28,21 +30,25 @@ public final class VariantsSparkSource {
     /**
      * Loads variants in parallel using Hadoop-BAM for vcfs and bcfs.
      * @param vcf file to load variants from.
+     * @param intervals intervals of variants to include, or null if all should be included.
      * @return JavaRDD<GATKVariant> of variants from the variants file specified in vcf.
      */
-    public JavaRDD<GATKVariant> getParallelVariants(final String vcf) {
-        return getParallelVariantContexts(vcf).filter(vc -> vc.getCommonInfo() != null).map(vc -> VariantContextVariantAdapter.sparkVariantAdapter(vc));
+    public JavaRDD<GATKVariant> getParallelVariants(final String vcf, final List<SimpleInterval> intervals) {
+        return getParallelVariantContexts(vcf, intervals)
+                .filter(vc -> vc.getCommonInfo() != null)
+                .map(vc -> VariantContextVariantAdapter.sparkVariantAdapter(vc));
     }
 
     /**
      * Loads variants from multiple inputs in parallel using Hadoop-BAM for vcfs and bcfs.
      * @param vcfs List of input files to load variants from.
+     * @param intervals intervals of variants to include, or null if all should be included.
      * @return JavaRDD<VariantContext> rdd containing the union of all variants from the variant
      * files specified in vcfs.
      */
-    public JavaRDD<GATKVariant> getParallelVariants(final List<String> vcfs) {
+    public JavaRDD<GATKVariant> getParallelVariants(final List<String> vcfs, final List<SimpleInterval> intervals) {
         return vcfs.parallelStream()
-                .map(vcf -> getParallelVariants(vcf))
+                .map(vcf -> getParallelVariants(vcf, intervals))
                 .reduce(ctx.emptyRDD(), (result, rdd) -> result.union(rdd)
         );
     }
@@ -50,12 +56,18 @@ public final class VariantsSparkSource {
     /**
      * Loads variants in parallel using Hadoop-BAM for vcfs and bcfs.
      * @param vcf file to load variants from.
+     * @param intervals intervals of variants to include, or null if all should be included.
      * @return JavaRDD<VariantContext> of variants from all files.
      */
-    public JavaRDD<VariantContext> getParallelVariantContexts(final String vcf) {
+    public JavaRDD<VariantContext> getParallelVariantContexts(final String vcf, final List<SimpleInterval> intervals) {
+        Configuration conf = new Configuration();
+        conf.set("io.compression.codecs", BGZFCodec.class.getCanonicalName());
+        if (intervals != null && !intervals.isEmpty()) {
+            VCFInputFormat.setIntervals(conf, intervals);
+        }
         final JavaPairRDD<LongWritable, VariantContextWritable> rdd2 = ctx.newAPIHadoopFile(
                 vcf, VCFInputFormat.class, LongWritable.class, VariantContextWritable.class,
-                new Configuration());
+                conf);
         return rdd2.map(v1 -> v1._2().get());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -79,7 +79,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
 
         JavaRDD<GATKRead> initialReads = getReads();
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(knownVariants);
+        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(knownVariants, getIntervals());
 
         // TODO: Look into broadcasting the reference to all of the workers. This would make AddContextDataToReadSpark
         // TODO: and ApplyBQSRStub simpler (#855).

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -88,7 +88,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         final JavaRDD<GATKRead> filteredReadsForBQSR = initialReads.filter(read -> bqsrReadFilter.test(read));
 
         final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants);
+        final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
 
         final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(filteredReadsForBQSR, getReference(), bqsrKnownVariants, joinStrategy);
         //note: we use the reference dictionary from the reads themselves.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
@@ -34,7 +34,7 @@ public final class CountVariantsSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         final VariantsSparkSource vss = new VariantsSparkSource(ctx);
-        final JavaRDD<VariantContext> variants = vss.getParallelVariantContexts(input);
+        final JavaRDD<VariantContext> variants = vss.getParallelVariantContexts(input, getIntervals());
 
         final long count = variants.count();
         System.out.println(count);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -103,7 +103,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         final JavaRDD<GATKRead> markedFilteredReadsForBQSR = markedReads.filter(read -> bqsrReadFilter.test(read));
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants);
+        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
 
         JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(markedFilteredReadsForBQSR, getReference(), bqsrKnownVariants, joinStrategy);
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getReferenceSequenceDictionary(), bqsrArgs);

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
@@ -41,7 +41,7 @@ public final class VariantsSparkSourceUnitTest extends BaseTest {
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
         JavaRDD<GATKVariant> rddParallelVariants =
-                variantsSparkSource.getParallelVariants(vcf);
+                variantsSparkSource.getParallelVariants(vcf, null);
 
         List<GATKVariant> serialVariants = getSerialVariants(vcf);
         List<GATKVariant> parallelVariants = rddParallelVariants.collect();
@@ -54,7 +54,7 @@ public final class VariantsSparkSourceUnitTest extends BaseTest {
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
         JavaRDD<VariantContext> rddParallelVariantContexts =
-                variantsSparkSource.getParallelVariantContexts(vcf);
+                variantsSparkSource.getParallelVariantContexts(vcf, null);
 
         VariantContextTestUtils.assertEqualVariants(getSerialVariantContexts(vcf), rddParallelVariantContexts.collect());
     }
@@ -72,7 +72,7 @@ public final class VariantsSparkSourceUnitTest extends BaseTest {
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
 
         JavaRDD<GATKVariant> rddParallelVariants =
-                variantsSparkSource.getParallelVariants(vcfList);
+                variantsSparkSource.getParallelVariants(vcfList, null);
 
         // retrieve the same set of variants, but through VariantsSource, and wrapped by
         // the same wrapper class used by VariantsSparkSource to facilitate comparison

--- a/src/test/resources/large/dbsnp_138.b37.20.21.vcf.blockgz.gz
+++ b/src/test/resources/large/dbsnp_138.b37.20.21.vcf.blockgz.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e999f3eabe5c09106966b5e3282e7b3a825cc3f61cd193825c17300b7f01412
+size 223192

--- a/src/test/resources/large/dbsnp_138.b37.20.21.vcf.blockgz.gz.tbi
+++ b/src/test/resources/large/dbsnp_138.b37.20.21.vcf.blockgz.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba203541c434d7d5b456dbb48db440f0443127d5f5868a6210ffbbbec2b99368
+size 476


### PR DESCRIPTION
Fixes #1651.

Thanks to @droazen for suggesting the use of `-R` as a source for the sequence dictionary.