### PR TITLE
squid:S2063 - Comparators should be Serializable

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.ClassUtils;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -162,7 +163,9 @@ public class Main {
         return clazz.getAnnotation(CommandLineProgramProperties.class);
     }
 
-    private static class SimpleNameComparator implements Comparator<Class<?>> {
+    private static class SimpleNameComparator implements Comparator<Class<?>>, Serializable {
+        private static final long serialVersionUID = 1096632824580028876L;
+
         @Override
         public int compare(final Class<?> aClass, final Class<?> bClass) {
             return aClass.getSimpleName().compareTo(bClass.getSimpleName());

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -209,7 +210,9 @@ public final class EstimateLibraryComplexity extends AbstractOpticalDuplicateFin
     /**
      * Comparator that orders read pairs on the first N bases of both reads.
      */
-    class PairedReadComparator implements Comparator<PairedReadSequence> {
+    class PairedReadComparator implements Comparator<PairedReadSequence>, Serializable {
+        private static final long serialVersionUID = 7452449563074722818L;
+
         final int BASES = EstimateLibraryComplexity.this.MIN_IDENTICAL_BASES;
 
         public int compare(final PairedReadSequence lhs, final PairedReadSequence rhs) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
 import org.broadinstitute.hellbender.utils.read.*;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -310,8 +311,9 @@ public class OverhangFixingManager {
     }
 
     // class to represent the comparator for the split reads
-    private final class SplitReadComparator implements Comparator<SplitRead> {
+    private final class SplitReadComparator implements Comparator<SplitRead>, Serializable {
 
+        private static final long serialVersionUID = 7956407034441782842L;
         private final ReadCoordinateComparator readComparator;
 
         public SplitReadComparator() {
@@ -349,7 +351,8 @@ public class OverhangFixingManager {
     }
 
     // class to represent the comparator for the split reads
-    private final class SpliceComparator implements Comparator<Splice> {
+    private final class SpliceComparator implements Comparator<Splice>, Serializable {
+        private static final long serialVersionUID = -7783679773557594065L;
 
         public int compare(final Splice position1, final Splice position2) {
             return position1.loc.compareTo(position2.loc);

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/EventMap.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/EventMap.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -367,7 +368,9 @@ public final class EventMap extends TreeMap<Integer, VariantContext> {
         return startPosKeySet;
     }
 
-    private static class VariantContextComparator implements Comparator<VariantContext> {
+    private static class VariantContextComparator implements Comparator<VariantContext>, Serializable {
+        private static final long serialVersionUID = -2549166273822365485L;
+
         @Override
         public int compare(VariantContext vc1, VariantContext vc2) {
             return vc1.getStart() - vc2.getStart();

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/BestEndMapqPrimaryAlignmentStrategy.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/BestEndMapqPrimaryAlignmentStrategy.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.utils.read.mergealignment;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMUtils;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -65,7 +66,9 @@ public final class BestEndMapqPrimaryAlignmentStrategy implements PrimaryAlignme
     }
 
     // Sorts in descending order, but 255 is considered > 0 but < 1, and unmapped is worst of all
-    private static class MapqComparator implements Comparator<SAMRecord> {
+    private static class MapqComparator implements Comparator<SAMRecord>, Serializable {
+        private static final long serialVersionUID = 6763153425070516820L;
+
         public int compare(final SAMRecord rec1, final SAMRecord rec2) {
             if (rec1.getReadUnmappedFlag()) {
                 if (rec2.getReadUnmappedFlag()) return 0;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/HitsForInsert.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/HitsForInsert.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.utils.read.mergealignment;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMTag;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -222,7 +223,9 @@ public final class HitsForInsert {
     }
 
     // null HI tag sorts after any non-null.
-    private static class HitIndexComparator implements Comparator<SAMRecord> {
+    private static class HitIndexComparator implements Comparator<SAMRecord>, Serializable {
+        private static final long serialVersionUID = 6543097107370587679L;
+
         public int compare(final SAMRecord rec1, final SAMRecord rec2) {
             final Integer hi1 = rec1.getIntegerAttribute(SAMTag.HI.name());
             final Integer hi2 = rec2.getIntegerAttribute(SAMTag.HI.name());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063 - Comparators should be "Serializable"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063

Please let me know if you have any questions.

M-Ezzat