### PR TITLE
symbolic names for sources of reads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -2,9 +2,8 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.TaggedInputFileArgument;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -14,20 +13,12 @@ import java.util.List;
 public final class OptionalReadInputArgumentCollection extends ReadInputArgumentCollection {
     private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = true)
-    private List<String> readFilesNames;
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
+              shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME,
+              doc = "BAM/SAM/CRAM file containing reads",
+              optional = true)
+    private List<TaggedInputFileArgument> readInputs;
 
     @Override
-    public List<File> getReadFiles() {
-        ArrayList<File> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(new File(fn));
-        }
-        return ret;
-    }
-
-    @Override
-    public List<String> getReadFilesNames() {
-        return new ArrayList<String>(readFilesNames);
-    }
+    public List<TaggedInputFileArgument> getReadInputs() { return readInputs; }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -4,10 +4,14 @@ import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.TaggedInputFileArgument;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
 import java.io.File;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 
 /**
@@ -29,16 +33,36 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line
      */
-    public abstract List<File> getReadFiles();
+    public List<File> getReadFiles() {
+        return getReadInputs().stream().map(TaggedInputFileArgument::getFile).collect(Collectors.toList());
+    }
 
     /**
      * Get the list of BAM/SAM/CRAM filenames specified at the command line
      */
-    public abstract List<String> getReadFilesNames();
+    public List<String> getReadFileNames() {
+        return getReadInputs().stream().map(TaggedInputFileArgument::getFilePath).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a map of symbolicName -> ReadInput.
+     * The map is sorted by symbolic name
+     */
+    public SortedMap<String, TaggedInputFileArgument> getInputsBySymbolicName(){
+        final List<TaggedInputFileArgument> readInputs = getReadInputs();
+        final SortedMap<String, TaggedInputFileArgument> result = new TreeMap<>();//sort by name
+        readInputs.forEach(ri -> result.put(ri.getName(), ri));
+        return result;
+    }
+
+    /**
+     * Returns all ReadInputs in this argument collection.
+     */
+    public abstract List<TaggedInputFileArgument> getReadInputs();
 
     /**
      * Get the read validation stringency specified at the command line, or the default value if none was specified
      * at the command line.
      */
-    public ValidationStringency getReadValidationStringency() { return readValidationStringency; };
+    public ValidationStringency getReadValidationStringency() { return readValidationStringency; }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
@@ -2,9 +2,8 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.TaggedInputFileArgument;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -13,20 +12,13 @@ import java.util.List;
  */
 public final class RequiredReadInputArgumentCollection extends ReadInputArgumentCollection {
     private static final long serialVersionUID = 1L;
-    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = false)
-    public List<String> readFilesNames;
+
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
+              shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME,
+              doc = "BAM/SAM/CRAM file containing reads",
+              optional = false)
+    private List<TaggedInputFileArgument> readInputs;
 
     @Override
-    public List<File> getReadFiles() {
-        ArrayList<File> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(new File(fn));
-        }
-        return ret;
-    }
-
-    @Override
-    public List<String> getReadFilesNames() {
-        return new ArrayList<>(readFilesNames);
-    }
+    public List<TaggedInputFileArgument> getReadInputs() { return readInputs; }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -1,14 +1,11 @@
 package org.broadinstitute.hellbender.engine;
 
-import com.google.common.annotations.VisibleForTesting;
 import htsjdk.tribble.Feature;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Class to represent a Feature-containing input file. Tools should declare @Argument-annotated fields of
@@ -37,18 +34,9 @@ import java.util.Map;
 public final class FeatureInput<T extends Feature> {
 
     /**
-     * Logical name for this source of Features optionally provided by the user on the command line
-     * using the --argument_name logical_name:feature_file syntax. Defaults to the absolute path of
-     * the underlying file if no logical name is specified
+     * File with a symbolic name and key-value mappings.
      */
-    private final String name;
-
-    private final Map<String, String> kevValueMap;
-
-    /**
-     * File containing Features as specified by the user on the command line
-     */
-    private final File featureFile;
+    private final TaggedInputFileArgument taggedInputFileArgument;
 
     /**
      * Type of Feature in the featureFile. Set manually by the engine after construction.
@@ -56,133 +44,19 @@ public final class FeatureInput<T extends Feature> {
     private Class<? extends Feature> featureType;
 
     /**
-     * Delimiter between the logical name and the file name in the --argument_name logical_name:feature_file syntax
-     */
-    public static final String FEATURE_ARGUMENT_TAG_DELIMITER = ":";
-
-    /**
-     * Delimiter between key-value pairs in the --argument_name logical_name,key1=value1,key2=value2:feature_file syntax.
-     */
-    public static final String FEATURE_ARGUMENT_KEY_VALUE_PAIR_DELIMITER = ",";
-
-    /**
-     * Separator between keys and values in the --argument_name logical_name,key1=value1,key2=value2:feature_file syntax.
-     */
-    public static final String FEATURE_ARGUMENT_KEY_VALUE_SEPARATOR = "=";
-
-    /**
-     * Represents a parsed argument for the FeatureInput.
-     * Always has a file and a name.
-     * May have attributes.
-     */
-    private static final class ParsedArgument{
-        private final Map<String, String> keyValueMap;
-        private final String name;
-        private final File file;
-
-        /**
-         * Parses an argument value String of the forms:
-         * "logical_name(,key=value)*:feature_file" or
-         * "logical_name:feature_file" or
-         * "feature_file"
-         * into logical name and file name and key=value pairs.
-         *
-         * The absolute path of the file is used as the logical name if none is present.
-         *
-         * @param rawArgumentValue argument value from the command line to parse
-         * @return The argument parsed from the provided string.
-         */
-        public static ParsedArgument of(final String rawArgumentValue) {
-            final String[] tokens = rawArgumentValue.split(FEATURE_ARGUMENT_TAG_DELIMITER, -1);
-            final String usage = "Argument must either be a file, or of the form logical_name:file or logical_name(,key=value)*:feature_file";
-
-            // Check for malformed argument values
-            if (tokens.length > 2 || tokens.length == 0) {
-                throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
-            }
-            for (final String token : tokens) {
-                if (token.isEmpty()) {
-                    throw new UserException.BadArgumentValue("", rawArgumentValue, "Empty name/file encountered. " + usage);
-                }
-            }
-
-            if (tokens.length == 1) {
-                // No user-specified logical name for this FeatureInput, so use the absolute path to the File as its name
-                final File featureFile = new File(tokens[0]);
-                return new ParsedArgument(featureFile.getAbsolutePath(), featureFile);
-            }
-
-            // User specified a logical name (and optional list of key-value pairs)
-            // for this FeatureInput using name(,key=value)*:File syntax.
-            // eg foo:file.vcf
-            // eg foo,a=3,b=false,c=fred:file.vcf
-            final String[] subtokens= tokens[0].split(FEATURE_ARGUMENT_KEY_VALUE_PAIR_DELIMITER, -1);
-            if (subtokens[0].isEmpty()){
-                throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
-            }
-            final ParsedArgument pa= new ParsedArgument(subtokens[0], new File(tokens[1]));
-            //note: starting from 1 because 0 is the name
-            for (int i = 1; i < subtokens.length; i++){
-                final String[] kv = subtokens[i].split(FEATURE_ARGUMENT_KEY_VALUE_SEPARATOR, -1);
-                if (kv.length != 2 || kv[0].isEmpty() || kv[1].isEmpty()){
-                    throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
-                }
-                if (pa.containsKey(kv[0])){
-                    throw new UserException.BadArgumentValue("", rawArgumentValue, "Duplicate key " + kv[0] + "\n" + usage);
-                }
-                pa.addKeyValue(kv[0], kv[1]);
-            }
-            return pa;
-        }
-
-        private ParsedArgument(final String name, final File file) {
-            this.name=name;
-            this.file=file;
-            this.keyValueMap = new LinkedHashMap<>(2);
-        }
-
-        public File getFile(){
-            return file;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * Returns an immutable view of the key-value map.
-         */
-        public Map<String, String> keyValueMap() {
-            return Collections.unmodifiableMap(keyValueMap);
-        }
-
-        public void addKeyValue(final String k, final String v) {
-            keyValueMap.put(k, v);
-        }
-
-        private boolean containsKey(final String k) {
-            return keyValueMap.containsKey(k);
-        }
-    }
-
-    /**
      * Construct a FeatureInput from a String argument value either of the form "logical_name:feature_file"
-     * or simply "feature_file".
+     * or simply "feature_file", or "logical_name(,key=value)*:feature_file".
      *
      * Only meant to be called by the argument parsing system, and therefore marked as package-visible --
      * FeatureInputs constructed some other way will not be recognized by the engine.
      *
      * Note: cannot delegate to another constructor because Java only allows a call to "this" on the first line of a constructor.
      *
-     * @param rawArgumentValue String of the form "logical_name:feature_file" or "feature_file"
+     * @param rawArgumentValue String of the form "logical_name:feature_file", "feature_file" or "logical_name(,key=value)*:feature_file".
      */
     FeatureInput(final String rawArgumentValue) {
         Utils.nonNull(rawArgumentValue, "rawArgumentValue");
-        final ParsedArgument parsedArgument = ParsedArgument.of(rawArgumentValue);
-
-        name = parsedArgument.getName();
-        kevValueMap = parsedArgument.keyValueMap();
-        featureFile = parsedArgument.getFile();
+        taggedInputFileArgument = new TaggedInputFileArgument(rawArgumentValue);
         featureType = null;  // Must be set after construction
     }
 
@@ -192,14 +66,11 @@ public final class FeatureInput<T extends Feature> {
      * This constructor is meant to be called by the engine and test classes --
      * FeatureInputs constructed some other way will not be recognized by the engine.
      */
-    @VisibleForTesting
-    public FeatureInput(final String name, final Map<String, String> kevValueMap, final File featureFile) {
+    public FeatureInput(final String name, final Map<String, String> keyValueMap, final File featureFile) {
         Utils.nonNull(name, "name");
-        Utils.nonNull(kevValueMap, "kevValueMap");
+        Utils.nonNull(keyValueMap, "keyValueMap");
         Utils.nonNull(featureFile, "featureFile");
-        this.name = name;
-        this.kevValueMap = Collections.unmodifiableMap(new LinkedHashMap<>(kevValueMap));   //make a unmodifiable copy
-        this.featureFile = featureFile;
+        this.taggedInputFileArgument = new TaggedInputFileArgument(name, keyValueMap, featureFile);
         this.featureType = null;  // Must be set after construction
     }
 
@@ -210,7 +81,7 @@ public final class FeatureInput<T extends Feature> {
      */
     public String getAttribute(final String key) {
         Utils.nonNull(key);
-        return kevValueMap.get(key);
+        return taggedInputFileArgument.getAttribute(key);
     }
 
     /**
@@ -221,7 +92,7 @@ public final class FeatureInput<T extends Feature> {
      * @return logical name of this source of Features
      */
     public String getName() {
-        return name;
+        return taggedInputFileArgument.getName();
     }
 
     /**
@@ -230,7 +101,7 @@ public final class FeatureInput<T extends Feature> {
      * @return file backing this source of Features
      */
     public File getFeatureFile() {
-        return featureFile;
+        return taggedInputFileArgument.getFile();
     }
 
     /**
@@ -254,11 +125,12 @@ public final class FeatureInput<T extends Feature> {
     /**
      * FeatureInputs will be hashed by the engine, so make an effort to produce a reasonable hash code
      *
-     * @return hash code for this FeatureInput (combination of hash codec of the name and file)
+     * @return hash code for this FeatureInput (combination of hash code of the name and file)
      */
     @Override
     public int hashCode() {
-        return 31 * name.hashCode() + featureFile.hashCode();
+        //Note: the featureType does not count for hashCode
+        return Objects.hashCode(taggedInputFileArgument);
     }
 
     /**
@@ -269,12 +141,16 @@ public final class FeatureInput<T extends Feature> {
      */
     @Override
     public boolean equals(final Object other) {
-        if (! (other instanceof FeatureInput)) {
+        if (other == this){
+            return true;
+        }
+        if (!(other instanceof FeatureInput)){
             return false;
         }
 
-        final FeatureInput<?> otherFeature = (FeatureInput<?>)other;
-        return name.equals(otherFeature.name) && featureFile.equals(otherFeature.featureFile);
+        final FeatureInput<?> that = (FeatureInput<?>)other;
+        //Note: the featureType does not count for equality
+        return Objects.equals(this.taggedInputFileArgument, that.taggedInputFileArgument);
     }
 
     /**
@@ -286,8 +162,6 @@ public final class FeatureInput<T extends Feature> {
      */
     @Override
     public String toString() {
-        final String featureFilePath = featureFile.getAbsolutePath();
-        return name.equals(featureFilePath) ? featureFilePath :
-                                              String.format("%s%s%s", name, FEATURE_ARGUMENT_TAG_DELIMITER, featureFilePath);
+        return taggedInputFileArgument.toString();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/TaggedInputFileArgument.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/TaggedInputFileArgument.java
@@ -1,0 +1,198 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a file argument that has a symbolic name and may have attributes key-value mappings.
+ *
+ * TaggedInputFileArgument can be assigned logical names on the command line using the syntax:
+ *
+ *     --argument_name logical_name:file
+ *
+ * These logical names can then be retrieved by the tool at runtime via {@link #getName}
+ *
+ * Furthermore, a list of comma-separated key=value pairs may be provided as follows:
+ *
+ *     --argument_name logical_name,key1=value1,key2=value2:file
+ *
+ * the string value provided for a given key can be retrieved via {@link #getAttribute(String)}. Keys must be unique.
+ */
+public final class TaggedInputFileArgument {
+
+    /**
+     * Delimiter between the logical name and the file name in the --argument_name logical_name:file syntax
+     */
+    public static final String ARGUMENT_TAG_DELIMITER = ":";
+
+    /**
+     * Delimiter between key-value pairs in the --argument_name logical_name,key1=value1,key2=value2:file syntax.
+     */
+    public static final String ARGUMENT_KEY_VALUE_PAIR_DELIMITER = ",";
+
+    /**
+     * Separator between keys and values in the --argument_name logical_name,key1=value1,key2=value2:file syntax.
+     */
+    public static final String ARGUMENT_KEY_VALUE_SEPARATOR = "=";
+
+    private final Map<String, String> keyValueMap;
+    private final String name;
+    private final File file;
+
+    /**
+     * Parses an argument value String of the forms:
+     * "logical_name(,key=value)*:file" or
+     * "logical_name:file" or
+     * "file"
+     * into logical name and file name and key=value pairs.
+     *
+     * The absolute path of the file is used as the logical name if none is present.
+     *
+     * @param rawArgumentValue argument value from the command line to parse
+     */
+    public TaggedInputFileArgument(final String rawArgumentValue) {
+        Utils.nonNull(rawArgumentValue);
+        final String[] tokens = rawArgumentValue.split(ARGUMENT_TAG_DELIMITER, -1);
+        final String usage = "Argument must either be a file, or of the form logical_name:file or logical_name(,key=value)*:file";
+
+        // Check for malformed argument values
+        if (tokens.length > 2 || tokens.length == 0) {
+            throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
+        }
+        for (final String token : tokens) {
+            if (token.isEmpty()) {
+                throw new UserException.BadArgumentValue("", rawArgumentValue, "Empty name/file encountered. " + usage);
+            }
+        }
+
+        if (tokens.length == 1) {
+            // No user-specified logical name for this TaggedArgument, so use the absolute path to the File as its name
+            final File file = new File(tokens[0]);
+            this.name = file.getAbsolutePath();
+            this.file = file;
+            this.keyValueMap = Collections.emptyMap();
+        } else {
+            // User specified a logical name (and optional list of key-value pairs)
+            // for this TaggedArgument using name(,key=value)*:File syntax.
+            // eg foo:file.vcf
+            // eg foo,a=3,b=false,c=fred:file.vcf
+            final String[] subtokens = tokens[0].split(ARGUMENT_KEY_VALUE_PAIR_DELIMITER, -1);
+            if (subtokens[0].isEmpty()) {
+                throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
+            }
+            this.name = subtokens[0];
+            this.file = new File(tokens[1]);
+            final Map<String, String> keyValueMap = new LinkedHashMap<>(2);
+            //note: starting from 1 because 0 is the name
+            for (int i = 1; i < subtokens.length; i++) {
+                final String[] kv = subtokens[i].split(ARGUMENT_KEY_VALUE_SEPARATOR, -1);
+                if (kv.length != 2 || kv[0].isEmpty() || kv[1].isEmpty()) {
+                    throw new UserException.BadArgumentValue("", rawArgumentValue, usage);
+                }
+                if (keyValueMap.containsKey(kv[0])) {
+                    throw new UserException.BadArgumentValue("", rawArgumentValue, "Duplicate key " + kv[0] + "\n" + usage);
+                }
+                keyValueMap.put(kv[0], kv[1]);
+            }
+            this.keyValueMap = Collections.unmodifiableMap(keyValueMap);
+        }
+    }
+
+    /**
+     * Create a new argument from the given arguments.
+     * No argument may be null.
+     */
+    public TaggedInputFileArgument(final String name, final Map<String, String> keyValueMap, final File file) {
+        this.name = Utils.nonNull(name, "name");
+        this.file = Utils.nonNull(file, "file");
+        Utils.nonNull(keyValueMap, "keyValueMap");
+        this.keyValueMap = Collections.unmodifiableMap(new LinkedHashMap<>(keyValueMap));//make an unmodifiable copy
+    }
+
+    /**
+     * Returns the file represented by this argument.
+     */
+    public File getFile(){
+        return file;
+    }
+
+    /**
+     * Gets the path of the file represented by this argument.
+     */
+    public String getFilePath() {
+        return file.getAbsolutePath();
+    }
+
+    /**
+     * Returns the symbolic name of this argument.
+     * If no explicit symbolic name was given when the argument was created,
+     * then this is the name of the file that this argument represents.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the value for the given key associated with this argument or {@code null}
+     * if no value is associated with a given key.
+     * @throws IllegalArgumentException if the key is {@code null}.
+     */
+    public String getAttribute(final String key) {
+        Utils.nonNull(key);
+        return keyValueMap.get(key);
+    }
+
+    /**
+     * Returns the key value pairings in this argument. The returned map may be empty and
+     * it is always unmodifiable.
+     */
+    public Map<String, String> getAttributes() {
+        return keyValueMap;
+    }
+
+    /**
+     * Returns whether this input has a specific symbolic name that is different than the default.
+     */
+    public boolean hasSymbolicName(){
+        return !Objects.equals(name, getFilePath());
+    }
+
+    /**
+     * Returns a String representation of this ReadInput. Will be the absolute path to
+     * the readFile if we have no logical name, or a String of the form
+     * "logical_name:absolute_path_to_readFile" if we do have a logical name.
+     *
+     * @return String representation of this ReadInput
+     */
+    @Override
+    public String toString() {
+        final String readFilePath = file.getAbsolutePath();
+        return !hasSymbolicName() ? readFilePath :
+                String.format("%s%s%s", getName(), TaggedInputFileArgument.ARGUMENT_TAG_DELIMITER, readFilePath);
+    }
+
+    @Override
+    public int hashCode() {
+        //key-value pairs do not count for hashCode
+        return Objects.hash(name, file);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this){
+            return true;
+        }
+        if (!(obj instanceof TaggedInputFileArgument)){
+            return false;
+        }
+        //key-value pairs do not count for equality
+        final TaggedInputFileArgument that = (TaggedInputFileArgument)obj;
+        return Objects.equals(this.name, that.name) &&  Objects.equals(this.file, that.file);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -327,15 +327,15 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * Does nothing if no reads inputs are present.
      */
     private void initializeReads(final JavaSparkContext sparkContext) {
-        if ( readArguments.getReadFilesNames().isEmpty() ) {
+        if ( readArguments.getReadFileNames().isEmpty() ) {
             return;
         }
 
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
+        if ( readArguments.getReadFileNames().size() != 1 ) {
             throw new UserException("Sorry, we only support a single reads input for spark tools for now.");
         }
 
-        readInput = readArguments.getReadFilesNames().get(0);
+        readInput = readArguments.getReadFileNames().get(0);
         readsSource = new ReadsSparkSource(sparkContext, readArguments.getReadValidationStringency());
         readsHeader = readsSource.getHeader(
                 readInput,

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
@@ -5,10 +5,7 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
-import org.broadinstitute.hellbender.engine.FeatureContext;
-import org.broadinstitute.hellbender.engine.FeatureInput;
-import org.broadinstitute.hellbender.engine.ReadWalker;
-import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -16,6 +13,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Example/toy program that prints reads from the provided file or files along with overlapping variants
@@ -43,9 +41,16 @@ public final class ExampleReadWalkerWithVariants extends ReadWalker {
     public void onTraversalStart() {
         try {
             outputStream = outputFile != null ? new PrintStream(outputFile) : System.out;
-        }
-        catch ( FileNotFoundException e ) {
+        } catch ( FileNotFoundException e ) {
             throw new UserException.CouldNotReadInputFile(outputFile, e);
+        }
+        if (readArguments.getReadInputs().stream().anyMatch(TaggedInputFileArgument::hasSymbolicName)) {
+            final Map<String, TaggedInputFileArgument> map = readArguments.getInputsBySymbolicName();
+            outputStream.println("reads inputs:");
+            for (final Map.Entry<String, TaggedInputFileArgument> kv : map.entrySet()){
+                outputStream.println("  " + kv.getKey() + ":" + kv.getValue().getFile().getName());
+            }
+            outputStream.println();
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
@@ -36,8 +36,7 @@ public final class ExampleVariantWalker extends VariantWalker {
     public void onTraversalStart() {
         try {
             outputStream = outputFile != null ? new PrintStream(outputFile) : System.out;
-        }
-        catch ( final FileNotFoundException e ) {
+        } catch ( final FileNotFoundException e ) {
             throw new UserException.CouldNotReadInputFile(outputFile, e);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
@@ -78,10 +78,10 @@ public class BaseRecalibratorSparkSharded extends SparkCommandLineProgram {
 
     @Override
     protected void runPipeline( JavaSparkContext ctx ) {
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
+        if ( readArguments.getReadFileNames().size() != 1 ) {
             throw new UserException("Sorry, we only support a single reads input for now.");
         }
-        final String bam = readArguments.getReadFilesNames().get(0);
+        final String bam = readArguments.getReadFileNames().get(0);
         final String referenceURL = referenceArguments.getReferenceFileName();
 
         auth = getAuthHolder();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
@@ -51,7 +51,7 @@ public final class CompareDuplicatesSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
 
-        JavaRDD<GATKRead> firstReads = filteredReads(getReads(), readArguments.getReadFilesNames().get(0));
+        JavaRDD<GATKRead> firstReads = filteredReads(getReads(), readArguments.getReadFileNames().get(0));
 
         ReadsSparkSource readsSource2 = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
         JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, getIntervals(), bamPartitionSplitSize), input2);

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/TestProgramGroup.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/TestProgramGroup.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.hellbender.cmdline;
+
+/**
+ * only for testing
+ */
+public final class TestProgramGroup implements CommandLineProgramGroup {
+    @Override
+    public String getName() {
+        return "Testing";
+    }
+
+    @Override
+    public String getDescription() {
+        return "group used for testing";
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/TaggedInputFileArgumentUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/TaggedInputFileArgumentUnitTest.java
@@ -1,0 +1,280 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+public class TaggedInputFileArgumentUnitTest extends BaseTest {
+
+    @CommandLineProgramProperties(
+            summary = "test",
+            oneLineSummary = "",
+            programGroup = TestProgramGroup.class
+    )
+    private static final class TestReadWalker extends ReadWalker{
+        TaggedInputFileArgument tumor;
+        TaggedInputFileArgument normal;
+        TaggedInputFileArgument met;
+
+        @Override
+        public void onTraversalStart() {
+            tumor  = readArguments.getInputsBySymbolicName().get("tumor");
+            normal = readArguments.getInputsBySymbolicName().get("normal");
+            met = readArguments.getInputsBySymbolicName().get("met");
+        }
+
+        @Override
+        public void apply(GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext) {
+             //do nothing
+        }
+    }
+
+    @Test
+    public void testSymbolicNames() throws Exception {
+        final TestReadWalker tool = new TestReadWalker();
+        final CommandLineParser clp = new CommandLineParser(tool);
+        final File bamFileT = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File bamFileN = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test2.bam");
+        final String[] args = {
+                "-I", "tumor:" + bamFileT.getCanonicalPath(),
+                "-I", "normal:" + bamFileN.getCanonicalPath(),
+        };
+        clp.parseArguments(System.out, args);
+        tool.onStartup();
+        Assert.assertNull(tool.tumor, "tumor");
+        Assert.assertNull(tool.normal, "normal");
+        Assert.assertNull(tool.met, "met");
+        tool.doWork();
+        Assert.assertNotNull(tool.tumor, "tumor");
+        Assert.assertEquals(tool.tumor.getFile(), bamFileT);
+        Assert.assertNotNull(tool.normal, "normal");
+        Assert.assertEquals(tool.normal.getFile(), bamFileN);
+        Assert.assertNull(tool.met, "met");   //this one was not provided
+        tool.onShutdown();
+    }
+
+    @CommandLineProgramProperties(summary = "",
+            oneLineSummary = "",
+            programGroup = TestProgramGroup.class)
+    private static final class TestGATKSparkTool extends GATKSparkTool{
+        private static final long serialVersionUID = -7467286444549225596L;
+        TaggedInputFileArgument tumor;
+        TaggedInputFileArgument normal;
+
+        @Override
+        protected void runTool( JavaSparkContext ctx ){
+            tumor = readArguments.getInputsBySymbolicName().get("tumor");
+            normal = readArguments.getInputsBySymbolicName().get("normal");
+        }
+    }
+
+    @Test
+    public void testSymbolicNamesInSpark() throws Exception {
+        final TestGATKSparkTool tool = new TestGATKSparkTool();
+        final CommandLineParser clp = new CommandLineParser(tool);
+        final File bamFileT = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final String[] args = {
+                "-I", "tumor:" + bamFileT.getCanonicalPath(),
+        };
+        //Note: only 1 input file is supported for Spark tools
+        clp.parseArguments(System.out, args);
+        Assert.assertNull(tool.tumor, "tumor");
+        Assert.assertNull(tool.normal, "normal");   //this one was not provided
+        tool.runTool();
+        Assert.assertNotNull(tool.tumor, "tumor");
+        Assert.assertEquals(tool.tumor.getFile(), bamFileT);
+        Assert.assertNull(tool.normal, "normal");   //this one was not provided
+    }
+
+    @DataProvider(name = "InvalidFeatureArgumentValuesDataProvider")
+    public Object[][] getInvalidFeatureArgumentValues() {
+        return new Object[][] {
+                { "name:file:file2" },
+                { "name:" },
+                { ":file" },
+                { ",:file" },
+                { "name,key=value=fred:file" },
+                { "name,:file"},
+                { ",key=value:file"},
+                {"name,key:file"},
+                {"name,key=:file"},
+                {"name,=value:file"},
+                {"name,=:file"},
+                { ":" },
+                { ",:" },
+                { "::" },
+                { "" },
+                { "name,key=value1,key=value2:file" },   //duplicate key
+                { "name,key=value,key=value:file" }      //duplicate key
+        };
+    }
+
+    @Test(dataProvider = "InvalidFeatureArgumentValuesDataProvider", expectedExceptions = UserException.BadArgumentValue.class)
+    public void testInvalidFeatureArgumentValue( final String invalidFeatureArgumentValue ) {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument(invalidFeatureArgumentValue);
+    }
+
+    @DataProvider(name = "ValidFileOnlyFeatureArgumentValuesDataProvider")
+    public Object[][] getValidFileOnlyFeatureArgumentValues() {
+        return new Object[][] {
+                {"myFile"},
+                {"myName,key1=value,myFile"},     //allowed - all of this is treated as a file name
+                {"=myFile"},                      //allowed - all of this is treated as a file name
+                {",myFile"},                    //allowed - all of this is treated as a file name
+                {"=,myFile"},                    //allowed - all of this is treated as a file name
+                {"key1=value,myFile"}             //allowed - all of this is treated as a file name
+        };
+    }
+    @Test(dataProvider = "ValidFileOnlyFeatureArgumentValuesDataProvider")
+    public void testNoFeatureNameSpecified(final String validFileOnlyFeatureArgumentValue) {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument(validFileOnlyFeatureArgumentValue);   //"myName,key1=value,myFile"
+
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File(validFileOnlyFeatureArgumentValue), "Wrong File in TaggedInputFileArgument");
+        // Name should default to the absolute path of the File when no name is specified
+        Assert.assertEquals(taggedInputFileArgument.getName(), new File(validFileOnlyFeatureArgumentValue).getAbsolutePath(), "Wrong default name in TaggedInputFileArgument");
+    }
+
+    @DataProvider(name = "ValidPairsForComparisonDataProvider")
+    public Object[][] getValidPairsForComparison() {
+        final String n1 = "myFile";
+        final String n2 = "myName,key1=value,myFile";
+        final String n3 = "myName,key1=value1,key2=value2:myFile";
+        final String n3_noKV = "myName:myFile";
+        final String n3_moreKV = "myName,key1=value1,key2=value2,key3=value3:myFile";
+        return new Object[][] {
+                {n1, n2, false},
+                {n2, n3, false},
+                {n1, n3, false},
+                {n3, n3_noKV, true},
+                {n3, n3_moreKV, true},
+                {n3_noKV, n3_noKV, true},
+        };
+    }
+    @Test(dataProvider = "ValidPairsForComparisonDataProvider")
+    public void testEquality(final String string1, final String string2, final boolean expectedEquals) {
+        final TaggedInputFileArgument tifa1 = new TaggedInputFileArgument(string1);
+        final TaggedInputFileArgument tifa2 = new TaggedInputFileArgument(string2);
+        Assert.assertNotEquals(tifa1, null);
+        Assert.assertNotEquals(null, tifa1);
+        Assert.assertNotEquals(tifa2, null);
+        Assert.assertNotEquals(null, tifa2);
+        Assert.assertEquals(tifa1, tifa1);
+        Assert.assertEquals(tifa2, tifa2);
+        Assert.assertNotEquals(tifa1, "fred");
+        Assert.assertNotEquals(tifa2, "fred");
+        Assert.assertNotEquals("fred", tifa1);
+        Assert.assertNotEquals("fred", tifa2);
+
+        Assert.assertEquals(tifa1.hashCode(), tifa1.hashCode());
+        Assert.assertEquals(tifa2.hashCode(), tifa2.hashCode());
+
+        Assert.assertEquals(tifa1.equals(tifa2), expectedEquals);
+        Assert.assertEquals(tifa2.equals(tifa1), expectedEquals);
+
+        final TaggedInputFileArgument tifa1Copy = new TaggedInputFileArgument(tifa1.getName(), tifa1.getAttributes(), tifa1.getFile());
+        final TaggedInputFileArgument tifa2Copy = new TaggedInputFileArgument(tifa2.getName(), tifa2.getAttributes(), tifa2.getFile());
+        Assert.assertEquals(tifa1, tifa1Copy);
+        Assert.assertEquals(tifa1Copy, tifa1);
+        Assert.assertEquals(tifa2, tifa2Copy);
+        Assert.assertEquals(tifa2Copy, tifa2);
+    }
+
+    @Test
+    public void testFeatureNameSpecified() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("myName:myFile");
+
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("myFile"), "Wrong File in TaggedInputFileArgument");
+        Assert.assertEquals(taggedInputFileArgument.getName(), "myName", "Wrong name in TaggedInputFileArgument");
+    }
+
+    @Test
+    public void testNullOKAsFeatureName() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("null:myFile");
+
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("myFile"), "Wrong File in TaggedInputFileArgument");
+        Assert.assertEquals(taggedInputFileArgument.getName(), "null", "Wrong name in TaggedInputFileArgument");
+    }
+
+    @Test
+    public void testNullOKAsFileName() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("myName:null");
+
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("null"), "Wrong File in TaggedInputFileArgument");
+        Assert.assertEquals(taggedInputFileArgument.getName(), "myName", "Wrong name in TaggedInputFileArgument");
+    }
+
+
+    @Test
+    public void testFeatureKeyValuePairsSpecified() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("myName,key1=value1,key2=value2,null=null:myFile");
+
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key1"), "value1", "wrong attribute value for key1");
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key2"), "value2", "wrong attribute value for key2");
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("null"), "null", "wrong attribute value for key \"null\"");
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key3"), null, "wrong attribute value for key3 (not present)");
+
+        Assert.assertEquals(taggedInputFileArgument.getName(), "myName");
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("myFile"));
+    }
+
+    @Test
+    public void testFeatureKeyValuePairSpecified() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("myName,key1=value1:myFile");
+
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key1"), "value1", "wrong attribute value for key1");
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key2"), null, "wrong attribute value for key2 (not present)");
+
+        Assert.assertEquals(taggedInputFileArgument.getName(), "myName");
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("myFile"));
+    }
+
+    @Test
+    public void testFeatureKeyValuePairsSpecifiedSameValue() {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument("myName,key1=value,key2=value:myFile");
+
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key1"), "value", "wrong attribute value for key1");
+        Assert.assertEquals(taggedInputFileArgument.getAttribute("key2"), "value", "wrong attribute value for key2");
+
+        Assert.assertEquals(taggedInputFileArgument.getName(), "myName");
+        Assert.assertEquals(taggedInputFileArgument.getFile(), new File("myFile"));
+    }
+
+    @DataProvider(name = "KeyValuesDataProviderForTestingNull")
+    public Object[][] getKeyValuesDataProviderForTestingNull() {
+        return new Object[][] {
+                { "myName,key1=value1,key2=value2:myFile" },
+                { "myName,null=value:myFile"},
+                { "myName:myFile" },
+                { "myFile" },
+                { "null" },
+                { "null:myFile" },
+                { "null:null" },
+        };
+    }
+
+    @Test(dataProvider = "KeyValuesDataProviderForTestingNull", expectedExceptions = IllegalArgumentException.class)
+    public void testFeatureValuesForNullKey(final String taggedInputFileArgumentArgument ) {
+        TaggedInputFileArgument taggedInputFileArgument = new TaggedInputFileArgument(taggedInputFileArgumentArgument);
+        taggedInputFileArgument.getAttribute(null);
+    }
+
+    @Test
+    public void testToString() {
+        final TaggedInputFileArgument namelessTaggedInputFileArgument = new TaggedInputFileArgument("file1");
+        final TaggedInputFileArgument namedTaggedInputFileArgument = new TaggedInputFileArgument("name:file1");
+
+        Assert.assertEquals(namelessTaggedInputFileArgument.toString(), new File("file1").getAbsolutePath(), "String representation of nameless TaggedInputFileArgument incorrect");
+        Assert.assertEquals(namedTaggedInputFileArgument.toString(), "name:" + new File("file1").getAbsolutePath(), "String representation of named TaggedInputFileArgument incorrect");
+    }
+}
+

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariantsIntegrationTest.java
@@ -7,23 +7,21 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.Arrays;
 
-public final class ExampleVariantWalkerIntegrationTest extends CommandLineProgramTest {
+public final class ExampleReadWalkerWithVariantsIntegrationTest extends CommandLineProgramTest {
 
     private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
     private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
-    public void testExampleVariantWalker() throws IOException {
+    public void testExampleReadWalkerWithVariants() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
                 " -L 1:100-200" +
                 " -R " + hg19MiniReference +
-                " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
-                " -V " + TEST_DATA_DIRECTORY + "example_variants.vcf" +
-                " -auxiliaryVariants " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
+                " -I tumor:" + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
+                " -V " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
                 " -O %s",
-                Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleVariantWalkerIntegrationTest_output.txt")
+                Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleReadWalkerWithVariantsIntegrationTest_output.txt")
         );
-        testSpec.executeTest("testExampleIntervalWalker", this);
+        testSpec.executeTest("testExampleReadWalkerWithVariants", this);
     }
-
 }

--- a/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleReadWalkerWithVariantsIntegrationTest_output.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/examples/expected_ExampleReadWalkerWithVariantsIntegrationTest_output.txt
@@ -1,0 +1,9 @@
+reads inputs:
+  tumor:reads_data_source_test1.bam
+
+Read at 1:200-275:
+ACCCTAACCCTAACCCTAACCCTAACCATAACCCTAAGACTAACCCTAAACCTAACCCTCATAATCGAAATACAAC
+Overlapping variant at 1:199-200: Ref: GG* Alt(s): [G]
+Overlapping variant at 1:200-200: Ref: G* Alt(s): [A]
+Overlapping variant at 1:203-206: Ref: GGGG* Alt(s): [G]
+


### PR DESCRIPTION
this enables users to give symbolic names to input files (read files). Essentially expands the functionality we had for feature files to read files. This functionality exists in gatk3 and is used for example in ContEst and M2 (in gatk3 you specify -I:tumor file1.bam -I:normal file2.bam, in gatk4 you specify -I tumor:file1.bam -I normal:file2.bam).

@droazen please review