### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -201,13 +201,13 @@ public final class CommandLineParser {
                 .collect(Collectors.partitioningBy(a -> a.optional));
 
         final List<ArgumentDefinition> reqArgs = argMap.get(false); // required args
-        if (reqArgs != null && reqArgs.size() != 0) {
+        if (reqArgs != null && !reqArgs.isEmpty()) {
             stream.println("\n\nRequired Arguments:\n");
             reqArgs.stream().forEach(argumentDefinition -> printArgumentUsage(stream, argumentDefinition));
         }
 
         final List<ArgumentDefinition> optArgs = argMap.get(true); // optional args
-        if (optArgs != null && optArgs.size() != 0) {
+        if (optArgs != null && !optArgs.isEmpty()) {
             stream.println("\nOptional Arguments:\n");
             optArgs.stream().forEach(argumentDefinition -> printArgumentUsage(stream, argumentDefinition));
         }
@@ -428,7 +428,7 @@ public final class CommandLineParser {
             try (BufferedReader reader = new BufferedReader(new FileReader(argumentsFile))){
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    if (!line.startsWith(COMMENT) && line.trim().length() != 0) {
+                    if (!line.startsWith(COMMENT) && !line.trim().isEmpty()) {
                         args.addAll(Arrays.asList(StringUtils.split(line)));
                     }
                 }
@@ -450,7 +450,7 @@ public final class CommandLineParser {
         String argumentLabel = name;
         if (type != null) argumentLabel = "--"+ argumentLabel;
 
-        if (shortName.length() > 0) {
+        if (!shortName.isEmpty()) {
             argumentLabel+=",-" + shortName;
         }
         argumentLabel += ":" + type;
@@ -475,7 +475,7 @@ public final class CommandLineParser {
 
     private String makeArgumentDescription(final ArgumentDefinition argumentDefinition) {
         final StringBuilder sb = new StringBuilder();
-        if (argumentDefinition.doc.length() > 0) {
+        if (!argumentDefinition.doc.isEmpty()) {
             sb.append(argumentDefinition.doc);
             sb.append("  ");
         }
@@ -505,7 +505,7 @@ public final class CommandLineParser {
                 }
 
                 sb.append(" ").append(mutextArgumentDefinition.fieldName);
-                if (mutextArgumentDefinition.shortName.length() > 0) {
+                if (!mutextArgumentDefinition.shortName.isEmpty()) {
                     sb.append(" (").append(mutextArgumentDefinition.shortName).append(")");
                 }
             }

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -109,7 +109,7 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
      *                               stringency SILENT is used.
      */
     public ReadsDataSource( final List<File> samFiles, SamReaderFactory customSamReaderFactory ) {
-        if ( samFiles == null || samFiles.size() == 0 ) {
+        if ( samFiles == null || samFiles.isEmpty()) {
             throw new IllegalArgumentException("ReadsDataSource cannot be created from empty file list");
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
@@ -301,7 +301,7 @@ public class ReferenceAPISource implements ReferenceSource, Serializable {
                     }
                 }
                 String numsOnly = b.toString();
-                if (numsOnly.length() == 0) return 0;
+                if (numsOnly.isEmpty()) return 0;
                 return Integer.parseInt(numsOnly);
             }
         });

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/HashedListTargetCollection.java
@@ -318,7 +318,7 @@ public class HashedListTargetCollection<T extends Locatable> implements TargetCo
      * @return any integer between <code>-{@link #targetCount()}-1</code> and <code>{@link #targetCount()} - 1</code>.
      */
     private int uncachedBinarySearch(final Locatable location) {
-        if (sortedIntervals.size() == 0) {
+        if (sortedIntervals.isEmpty()) {
             return -1;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
@@ -241,12 +241,12 @@ public final class CollectSequencingArtifactMetrics extends SinglePassSamProgram
             baitBiasSummaryMetricsFile.addAllMetrics(counter.getBaitBiasSummaryMetrics());
 
             for (final PreAdapterDetailMetrics preAdapterDetailMetrics : counter.getPreAdapterDetailMetrics()) {
-                if (CONTEXTS_TO_PRINT.size() == 0 || CONTEXTS_TO_PRINT.contains(preAdapterDetailMetrics.CONTEXT)) {
+                if (CONTEXTS_TO_PRINT.isEmpty() || CONTEXTS_TO_PRINT.contains(preAdapterDetailMetrics.CONTEXT)) {
                     preAdapterDetailMetricsFile.addMetric(preAdapterDetailMetrics);
                 }
             }
             for (final BaitBiasDetailMetrics baitBiasDetailMetrics : counter.getBaitBiasDetailMetrics()) {
-                if (CONTEXTS_TO_PRINT.size() == 0 || CONTEXTS_TO_PRINT.contains(baitBiasDetailMetrics.CONTEXT)) {
+                if (CONTEXTS_TO_PRINT.isEmpty() || CONTEXTS_TO_PRINT.contains(baitBiasDetailMetrics.CONTEXT)) {
                     baitBiasDetailMetricsFile.addMetric(baitBiasDetailMetrics);
                 }
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
@@ -133,7 +133,7 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
     }
 
     private boolean isSequenceFiltered(final String sequenceName) {
-        return (SEQUENCE_NAMES != null) && (SEQUENCE_NAMES.size() > 0) && (!SEQUENCE_NAMES.contains(sequenceName));
+        return (SEQUENCE_NAMES != null) && (!SEQUENCE_NAMES.isEmpty()) && (!SEQUENCE_NAMES.contains(sequenceName));
     }
 
     private void assertIoFiles(final File summaryFile, final File detailsFile, final File plotsFile) {
@@ -163,6 +163,6 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
             errorMsgs.add("MINIMUM_READ_LENGTH must be > 0");
         }
 
-        return errorMsgs.size() == 0 ? null : errorMsgs.toArray(new String[errorMsgs.size()]);
+        return errorMsgs.isEmpty() ? null : errorMsgs.toArray(new String[errorMsgs.size()]);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
@@ -280,7 +280,7 @@ public final class IntervalListTools extends PicardCommandLineProgram {
         if (BREAK_BANDS_AT_MULTIPLES_OF < 0) {
             errorMsgs.add("BREAK_BANDS_AT_MULTIPLES_OF must be greater than or equal to 0.");
         }
-        return errorMsgs.size() == 0 ? null : errorMsgs.toArray(new String[errorMsgs.size()]);
+        return errorMsgs.isEmpty() ? null : errorMsgs.toArray(new String[errorMsgs.size()]);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignment.java
@@ -225,14 +225,14 @@ public final class MergeBamAlignment extends PicardCommandLineProgram {
                     "be included."};
         }
 
-        final boolean r1sExist = READ1_ALIGNED_BAM != null && READ1_ALIGNED_BAM.size() > 0;
-        final boolean r2sExist = READ2_ALIGNED_BAM != null && READ2_ALIGNED_BAM.size() > 0;
+        final boolean r1sExist = READ1_ALIGNED_BAM != null && !READ1_ALIGNED_BAM.isEmpty();
+        final boolean r2sExist = READ2_ALIGNED_BAM != null && !READ2_ALIGNED_BAM.isEmpty();
         if ((r1sExist && !r2sExist) || (r2sExist && !r1sExist)) {
             return new String[]{"READ1_ALIGNED_BAM and READ2_ALIGNED_BAM " +
                     "must both be supplied or neither should be included.  For " +
                     "single-end read use ALIGNED_BAM."};
         }
-        if (ALIGNED_BAM == null || ALIGNED_BAM.size() == 0 && !(r1sExist && r2sExist)) {
+        if (ALIGNED_BAM == null || ALIGNED_BAM.isEmpty() && !(r1sExist && r2sExist)) {
             return new String[]{"Either ALIGNED_BAM or the combination of " +
                     "READ1_ALIGNED_BAM and READ2_ALIGNED_BAM must be supplied."};
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
@@ -167,7 +167,7 @@ public final class SamToFastq extends PicardCommandLineProgram {
             writerMapping.closeAll();
         }
 
-        if (firstSeenMates.size() > 0) {
+        if (!firstSeenMates.isEmpty()) {
             SAMUtils.processValidationError(new SAMValidationError(SAMValidationError.Type.MATE_NOT_FOUND,
                     "Found " + firstSeenMates.size() + " unpaired mates", null), VALIDATION_STRINGENCY);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -362,7 +362,7 @@ public final class EstimateLibraryComplexity extends AbstractOpticalDuplicateFin
                                 }
                             }
 
-                            if (dupes.size() > 0) {
+                            if (!dupes.isEmpty()) {
                                 dupes.add(lhs);
                                 final int duplicateCount = dupes.size();
                                 duplicationHisto.increment(duplicateCount);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
@@ -106,7 +106,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
         IOUtil.assertFileIsWritable(detailedMetricsFile);
         IOUtil.assertFileIsWritable(contingencyMetricsFile);
 
-        final boolean usingIntervals = this.INTERVALS != null && this.INTERVALS.size() > 0;
+        final boolean usingIntervals = this.INTERVALS != null && !this.INTERVALS.isEmpty();
         IntervalList intervals = null;
         SAMSequenceDictionary intervalsSamSequenceDictionary = null;
         if (usingIntervals) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
@@ -113,7 +113,7 @@ public final class CollectMultipleMetricsSpark extends GATKSparkTool {
     protected void runTool( final JavaSparkContext ctx ) {
         final JavaRDD<GATKRead> unFilteredReads = getUnfilteredReads();
 
-        if (collectors.size() == 0) { // run all collectors
+        if (collectors.isEmpty()) { // run all collectors
             collectors.addAll(Arrays.asList(Collectors.values()));
         }
         if (collectors.size() > 1) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
@@ -390,7 +390,7 @@ public final class AnalyzeCovariates extends CommandLineProgram {
         for (int i = 1; i < reportEntries.length; i++) {
             final Map<String,? extends CharSequence> diffs = exampleEntry.getValue().getRAC().compareReportArguments(
                     reportEntries[i].getValue().getRAC(),exampleEntry.getKey(),reportEntries[i].getKey());
-            if (diffs.size() != 0) {
+            if (!diffs.isEmpty()) {
                 throw new UserException.IncompatibleRecalibrationTableParameters("There are differences in relevant arguments of"
                         + " two or more input recalibration reports. Please make sure"
                         + " they have been created using the same recalibration parameters."

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -578,7 +578,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
         }
 
         // add the MLE AC and AF annotations
-        if ( alleleCountsofMLE.size() > 0 ) {
+        if (!alleleCountsofMLE.isEmpty()) {
             attributes.put(GATKVCFConstants.MLE_ALLELE_COUNT_KEY, alleleCountsofMLE);
             final List<Double> MLEfrequencies = calculateMLEAlleleFrequencies(alleleCountsofMLE, genotypes);
             attributes.put(GATKVCFConstants.MLE_ALLELE_FREQUENCY_KEY, MLEfrequencies);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/FamilyLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/FamilyLikelihoods.java
@@ -216,7 +216,7 @@ public final class FamilyLikelihoods {
             updateFamilyGenotypes(vc, mother, father, child, trioGenotypes);
 
             //replace uses sample names to match genotypes, so order doesn't matter
-            if (trioGenotypes.size() > 0) {
+            if (!trioGenotypes.isEmpty()) {
                 genotypesContext.replace(trioGenotypes.get(0));
                 genotypesContext.replace(trioGenotypes.get(1));
                 genotypesContext.replace(trioGenotypes.get(2));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -629,7 +629,7 @@ public final class SelectVariants extends VariantWalker {
     protected VariantFilter makeVariantFilter() {
         VariantFilter compositeFilter = VariantFilterLibrary.ALLOW_ALL_VARIANTS;
 
-        if (selectedTypes.size() != 0) {
+        if (!selectedTypes.isEmpty()) {
             compositeFilter = compositeFilter.and(new VariantTypesVariantFilter(selectedTypes));
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ValidateVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ValidateVariants.java
@@ -212,7 +212,7 @@ public final class ValidateVariants extends VariantWalker {
      * @return the final set of type to validate. May be empty.
      */
     private Collection<ValidationType> calculateValidationTypesToApply(final List<ValidationType> excludeTypes) {
-        if (excludeTypes.size() == 0) {
+        if (excludeTypes.isEmpty()) {
             return Collections.singleton(ValidationType.ALL);
         }
         final Set<ValidationType> excludeTypeSet = new LinkedHashSet<>(excludeTypes);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/Tranche.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/Tranche.java
@@ -203,7 +203,7 @@ final class Tranche {
             Tranche t = findTranche(data, metric, trancheThreshold, model);
 
             if ( t == null ) {
-                if ( tranches.size() == 0 ) {
+                if (tranches.isEmpty()) {
                     throw new UserException(String.format("Couldn't find any tranche containing variants with a %s > %.2f. Are you sure the truth files contain unfiltered variants which overlap the input data?", metric.getName(), metric.getThreshold(trancheThreshold)));
                 }
                 break;

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSet.java
@@ -276,7 +276,7 @@ public final class GenomeLocSortedSet extends AbstractSet<GenomeLoc> {
 
         // if we have no other intervals yet or if the new loc is past the last one in the list (which is usually the
         // case because locs are generally added in order) then be extra efficient and just add the loc to the end
-        if ( mArray.size() == 0 || loc.isPast(mArray.get(mArray.size() - 1)) ) {
+        if (mArray.isEmpty() || loc.isPast(mArray.get(mArray.size() - 1)) ) {
             return mArray.add(loc);
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -311,7 +311,7 @@ public final class IntervalUtils {
             } else {
                 try (XReadLines reader = new XReadLines(new File(fileName))) {
                     for (final String line : reader) {
-                        if (line.trim().length() > 0) {
+                        if (!line.trim().isEmpty()) {
                             ret.add(glParser.parseGenomeLoc(line));
                         }
                     }
@@ -338,8 +338,8 @@ public final class IntervalUtils {
      */
     public static List<GenomeLoc> mergeListsBySetOperator(final List<GenomeLoc> setOne, final List<GenomeLoc> setTwo, final IntervalSetRule rule) {
         // shortcut, if either set is zero, return the other set
-        if (setOne == null || setOne.size() == 0 || setTwo == null || setTwo.size() == 0) {
-            return Collections.unmodifiableList((setOne == null || setOne.size() == 0) ? setTwo : setOne);
+        if (setOne == null || setOne.isEmpty() || setTwo == null || setTwo.isEmpty()) {
+            return Collections.unmodifiableList((setOne == null || setOne.isEmpty()) ? setTwo : setOne);
         }
 
         // our master list, since we can't guarantee removal time in a generic list
@@ -377,7 +377,7 @@ public final class IntervalUtils {
         }
 
         //if we have an empty list, throw an exception.  If they specified intersection and there are no items, this is bad.
-        if (retList.size() == 0) {
+        if (retList.isEmpty()) {
             throw new UserException.EmptyIntersection("There was an empty intersection");
         }
 
@@ -883,7 +883,7 @@ public final class IntervalUtils {
      */
     public static List<GenomeLoc> getIntervalsWithFlanks(final GenomeLocParser parser, final List<GenomeLoc> locs, final int basePairs) {
 
-        if (locs.size() == 0) {
+        if (locs.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/MRUCachingSAMSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MRUCachingSAMSequenceDictionary.java
@@ -32,7 +32,7 @@ final class MRUCachingSAMSequenceDictionary {
      */
     public MRUCachingSAMSequenceDictionary(final SAMSequenceDictionary dict) {
         if ( dict == null ) throw new IllegalArgumentException("Dictionary cannot be null");
-        if ( dict.size() == 0 ) throw new IllegalArgumentException("Dictionary cannot have size zero");
+        if (dict.isEmpty()) throw new IllegalArgumentException("Dictionary cannot have size zero");
 
         this.dict = dict;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
@@ -93,7 +93,7 @@ public final class RScriptExecutor {
 
             StringBuilder expression = new StringBuilder("tempLibDir = '").append(tempLibInstallationDir).append("';");
 
-            if (this.libraries.size() > 0) {
+            if (!this.libraries.isEmpty()) {
                 List<String> tempLibraryPaths = new ArrayList<>();
                 for (RScriptLibrary library: this.libraries) {
                     File tempLibrary = library.writeLibrary(tempLibSourceDir);

--- a/src/main/java/org/broadinstitute/hellbender/utils/SequenceDictionaryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SequenceDictionaryUtils.java
@@ -233,7 +233,7 @@ public final class SequenceDictionaryUtils {
 
         final Set<String> commonContigs = getCommonContigsByName(dict1, dict2);
 
-        if ( commonContigs.size() == 0 ) {
+        if (commonContigs.isEmpty()) {
             return SequenceDictionaryCompatibility.NO_COMMON_CONTIGS;
         }
         else if ( ! commonContigsHaveSameLengths(commonContigs, dict1, dict2) ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -416,13 +416,13 @@ public final class Utils {
         final String[] split = args.split(delimiter);
         for (int i = 0; i < split.length - 1; i += 2) {
             final String arg = split[i].trim();
-            if (arg.length() > 0) { // if the unescaped arg has a size
+            if (!arg.isEmpty()) { // if the unescaped arg has a size
                 command = ArrayUtils.addAll(command, arg.split(" +"));
             }
             command = ArrayUtils.addAll(command, split[i + 1]);
         }
         final String arg = split[split.length - 1].trim();
-        if (split.length % 2 == 1 && arg.length() > 0) { // if the last unescaped arg has a size
+        if (split.length % 2 == 1 && !arg.isEmpty()) { // if the last unescaped arg has a size
             command = ArrayUtils.addAll(command, arg.split(" +"));
         }
         return command;

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodec.java
@@ -71,7 +71,7 @@ public final class TableCodec extends AsciiFeatureCodec<TableFeature> {
             isFirst &= line.startsWith(COMMENT_DELIMITER);
             if (line.startsWith(HEADER_DELIMITER)) {
                 reader.next(); // "Commit" the peek
-                if (header.size() > 0) {
+                if (!header.isEmpty()) {
                     throw new UserException.MalformedFile("Input table file seems to have two header lines.  The second is = " + line);
                 }
                 final String[] spl = line.split(DELIMITER_REGEX);

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/FractionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/FractionalDownsampler.java
@@ -49,7 +49,7 @@ public final class FractionalDownsampler extends ReadsDownsampler {
 
     @Override
     public boolean hasFinalizedItems() {
-        return selectedReads.size() > 0;
+        return !selectedReads.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/LevelingDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/LevelingDownsampler.java
@@ -78,7 +78,7 @@ public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler
 
     @Override
     public boolean hasFinalizedItems() {
-        return groupsAreFinalized && groups.size() > 0;
+        return groupsAreFinalized && !groups.isEmpty();
     }
 
     @Override
@@ -95,7 +95,7 @@ public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler
 
     @Override
     public boolean hasPendingItems() {
-        return ! groupsAreFinalized && groups.size() > 0;
+        return ! groupsAreFinalized && !groups.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -104,7 +104,7 @@ public final class ReadUtils {
             return null;
         }
         final String oqString = read.getAttributeAsString(ORIGINAL_BASE_QUALITIES_TAG);
-        return oqString.length() > 0 ? SAMUtils.fastqToPhred(oqString) : null;
+        return !oqString.isEmpty() ? SAMUtils.fastqToPhred(oqString) : null;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
@@ -81,9 +81,9 @@ public final class SamAlignmentMerger extends AbstractAlignmentMerger {
                 alignedReadsOnly, programRecord, attributesToRetain, attributesToRemove, read1BasesTrimmed,
                 read2BasesTrimmed, expectedOrientations, sortOrder, primaryAlignmentSelectionStrategy, addMateCigar);
 
-        if ((alignedSamFile == null || alignedSamFile.size() == 0) &&
-                (read1AlignedSamFile == null || read1AlignedSamFile.size() == 0 ||
-                        read2AlignedSamFile == null || read2AlignedSamFile.size() == 0)) {
+        if ((alignedSamFile == null || alignedSamFile.isEmpty()) &&
+                (read1AlignedSamFile == null || read1AlignedSamFile.isEmpty() ||
+                        read2AlignedSamFile == null || read2AlignedSamFile.isEmpty())) {
             throw new IllegalArgumentException("Either alignedSamFile or BOTH of read1AlignedSamFile and " +
                     "read2AlignedSamFile must be specified.");
         }
@@ -136,7 +136,7 @@ public final class SamAlignmentMerger extends AbstractAlignmentMerger {
         final SAMFileHeader header;
 
         // When the alignment records, including both ends of a pair, are in SAM files
-        if (alignedSamFile != null && alignedSamFile.size() > 0) {
+        if (alignedSamFile != null && !alignedSamFile.isEmpty()) {
             final List<SAMFileHeader> headers = new ArrayList<>(alignedSamFile.size());
             final List<SamReader> readers = new ArrayList<>(alignedSamFile.size());
             for (final File f : this.alignedSamFile) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportColumn.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportColumn.java
@@ -104,7 +104,7 @@ public final class GATKReportColumn {
     public void updateFormatting(final Object value) {
         if (value != null) {
             final String formatted = formatValue(value);
-            if ( formatted.length() > 0 ) {
+            if (!formatted.isEmpty()) {
                 updateMaxWidth(formatted);
                 updateFormat(formatted);
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
@@ -108,7 +108,7 @@ public final class MendelianViolation {
             Sample sample;
             while (sampleIterator.hasNext()) {
                 sample = sampleIterator.next();
-                if (sampleDB.getParents(sample).size() > 0) {
+                if (!sampleDB.getParents(sample).isEmpty()) {
                     updateViolations(sample.getFamilyID(), sample.getMaternalID(), sample.getPaternalID(), sample.getID(), vc);
                 }
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/text/XReadLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/text/XReadLines.java
@@ -100,7 +100,7 @@ public final class XReadLines implements Iterator<String>, Iterable<String>, Aut
         while ((nextLine = this.in.readLine()) != null) {
             if (this.trimWhitespace) {
                 nextLine = nextLine.trim();
-                if (nextLine.length() == 0)
+                if (nextLine.isEmpty())
                     continue;
             }
             if (this.commentPrefix != null)

--- a/src/main/java/org/broadinstitute/hellbender/utils/text/parsers/BasicInputParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/text/parsers/BasicInputParser.java
@@ -81,7 +81,7 @@ public class BasicInputParser extends AbstractInputParser {
             nextLine = line;
             return line.getBytes();
         }
-        if (inputs.size() > 0) {
+        if (!inputs.isEmpty()) {
             advanceFile();
             return readNextLine();
         }
@@ -89,7 +89,7 @@ public class BasicInputParser extends AbstractInputParser {
     }
 
     protected void advanceFile() {
-        currentFileName = fileNames.size() > 0 ? fileNames.remove(0) : null;
+        currentFileName = !fileNames.isEmpty() ? fileNames.remove(0) : null;
         nextLineNumber = 0;
         nextLine = null;
         reader = new BufferedLineReader(inputs.remove(0));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat