### PR TITLE
Throw a UserException when an HDFS URI has an unknown host,

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -203,7 +203,7 @@ public final class ReadsSparkSource implements Serializable {
             }
             setHadoopBAMConfigurationProperties(filePath, referencePath);
             return SAMHeaderReader.readSAMHeaderFrom(path, ctx.hadoopConfiguration());
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new UserException("Failed to read bam header from " + filePath + "\n Caused by:" + e.getMessage(), e);
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -74,6 +74,13 @@ public class ReadsSparkSourceUnitTest extends BaseTest {
         Assert.assertEquals(serialReads.size(), parallelReads.size());
     }
 
+    @Test(expectedExceptions = UserException.class, expectedExceptionsMessageRegExp = ".*Failed to read bam header from hdfs://bogus/path.bam.*")
+    public void readsSparkSourceUnknownHostTest() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx, ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY);
+        readSource.getParallelReads("hdfs://bogus/path.bam", null);
+    }
+
     @Test(dataProvider = "loadReads", groups = "spark")
     public void readsSparkSourceTest(String bam, String referencePath) {
         doLoadReadsTest(bam, referencePath);


### PR DESCRIPTION
such as hdfs://local/print_reads.sorted.bam (double slash) instead of
hdfs:///local/print_reads.sorted.bam (triple slash).

Fixes #1257