### PR TITLE
Cleanup - pmd:UseIndexOfChar - Use Index Of Char

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/BuildBamIndex.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/BuildBamIndex.java
@@ -64,7 +64,7 @@ public final class BuildBamIndex extends PicardCommandLineProgram {
             final String baseFileName;
             if (inputUrl != null) {
                 final String path = inputUrl.getPath();
-                final int lastSlash = path.lastIndexOf("/");
+                final int lastSlash = path.lastIndexOf('/');
                 baseFileName = path.substring(lastSlash + 1, path.length());
             } else {
                 baseFileName = inputFile.getAbsolutePath();
@@ -72,7 +72,7 @@ public final class BuildBamIndex extends PicardCommandLineProgram {
 
             if (baseFileName.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION)) {
 
-                final int index = baseFileName.lastIndexOf(".");
+                final int index = baseFileName.lastIndexOf('.');
                 OUTPUT = new File(baseFileName.substring(0, index) + BAMIndex.BAMIndexSuffix);
 
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
@@ -338,7 +338,7 @@ public final class FastqToSam extends PicardCommandLineProgram {
     private String [] getReadNameTokens(final String readName, final int pairNum, final FastqReader freader) {
         if(readName.equals("")) throw new UserException(error(freader,"Pair read name "+pairNum+" cannot be empty: "+readName));
 
-        final int idx = readName.lastIndexOf("/");
+        final int idx = readName.lastIndexOf('/');
         final String[] result = new String[2];
 
         if (idx == -1) {
@@ -366,7 +366,7 @@ public final class FastqToSam extends PicardCommandLineProgram {
 
     // Read names cannot contain blanks
     private String getReadName(final String fastqHeader, final boolean paired) {
-        final int idx = fastqHeader.indexOf(" ");
+        final int idx = fastqHeader.indexOf(' ');
         String readName = (idx == -1) ? fastqHeader : fastqHeader.substring(0,idx);
 
         // NOTE: the while loop isn't necessarily the most efficient way to handle this but we don't


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:UseIndexOfChar - Use Index Of Char

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseIndexOfChar

Please let me know if you have any questions.

M-Ezzat