### PR TITLE
Cleanup - squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
@@ -538,11 +538,11 @@ public final class ClipReads extends ReadWalker {
             nRangeClippedBases += data.nRangeClippedBases;
             nSeqClippedBases += data.nSeqClippedBases;
 
-            for (String seqClip : data.seqClipCounts.keySet()) {
-                Long count = data.seqClipCounts.get(seqClip);
-                if (seqClipCounts.containsKey(seqClip))
-                    count += seqClipCounts.get(seqClip);
-                seqClipCounts.put(seqClip, count);
+            for (Map.Entry<String, Long> entry : data.seqClipCounts.entrySet()) {
+                Long count = data.seqClipCounts.get(entry.getKey());
+                if (seqClipCounts.containsKey(entry.getKey()))
+                    count += entry.getValue();
+                seqClipCounts.put(entry.getKey(), count);
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSam.java
@@ -211,8 +211,8 @@ public final class RevertSam extends PicardCommandLineProgram {
                 readGroupToFormat.put(rg, QualityEncodingDetector.detect(QualityEncodingDetector.DEFAULT_MAX_RECORDS_TO_ITERATE, new FilteringSamIterator(reader.iterator(), filter), RESTORE_ORIGINAL_QUALITIES));
                 CloserUtil.close(reader);
             }
-            for (final SAMReadGroupRecord r : readGroupToFormat.keySet()) {
-                logger.info("Detected quality format for " + r.getReadGroupId() + ": " + readGroupToFormat.get(r));
+            for (final Map.Entry<SAMReadGroupRecord, FastqQualityFormat> entry : readGroupToFormat.entrySet()) {
+                logger.info("Detected quality format for " + entry.getKey().getReadGroupId() + ": " + entry.getValue());
             }
             if (readGroupToFormat.values().contains(FastqQualityFormat.Solexa)) {
                 logger.error("No quality score encoding conversion implemented for " + FastqQualityFormat.Solexa);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
@@ -248,8 +248,8 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
         genotypeConcordanceContingencyMetricsFile.addMetric(contingencyMetrics);
         genotypeConcordanceContingencyMetricsFile.write(contingencyMetricsFile);
 
-        for (final String condition : unClassifiedStatesMap.keySet()) {
-            logger.info("Uncovered truth/call Variant Context Type Counts: " + condition + " " + unClassifiedStatesMap.get(condition));
+        for (final Map.Entry<String, Integer> entry : unClassifiedStatesMap.entrySet()) {
+            logger.info("Uncovered truth/call Variant Context Type Counts: " + entry.getKey() + " " + entry.getValue());
         }
 
         return null;

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/IntervalsSkipList.java
@@ -31,8 +31,8 @@ public final class IntervalsSkipList<T extends Locatable> implements Serializabl
             variantsPerContig.get(k).add(v);
         }
         intervals = new LinkedHashMap<>();
-        for (String k : variantsPerContig.keySet()) {
-            intervals.put(k, new IntervalsSkipListOneContig<>(variantsPerContig.get(k)));
+        for (Map.Entry<String, List<T>> entry : variantsPerContig.entrySet()) {
+            intervals.put(entry.getKey(), new IntervalsSkipListOneContig<>(entry.getValue()));
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/CapturedStreamOutput.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/CapturedStreamOutput.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.utils.io.HardThresholdingOutputStream;
 
 import java.io.*;
 import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Stream output captured from a stream.
@@ -98,10 +99,10 @@ public final class CapturedStreamOutput extends StreamOutput {
                     outputStream.write(buf, 0, readCount);
                 }
         } finally {
-            for (StreamLocation location : this.outputStreams.keySet()) {
-                OutputStream outputStream = this.outputStreams.get(location);
+            for (Map.Entry<StreamLocation, OutputStream> entry : this.outputStreams.entrySet()) {
+                OutputStream outputStream = this.outputStreams.get(entry.getKey());
                 outputStream.flush();
-                if (location != StreamLocation.Standard)
+                if (entry.getKey() != StreamLocation.Standard)
                     IOUtils.closeQuietly(outputStream);
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat