### PR TITLE
Cleanup - squid:S2974 - Classes without public constructors should be…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
@@ -146,7 +146,7 @@ public class CountingReadFilter implements ReadFilter {
     /**
      * Private class for Counting AND filters
      */
-    private class CountingAndReadFilter extends CountingBinopReadFilter {
+    private final class CountingAndReadFilter extends CountingBinopReadFilter {
 
         private static final long serialVersionUID = 1L;
 
@@ -167,7 +167,7 @@ public class CountingReadFilter implements ReadFilter {
     /**
      * Private class for Counting OR filters
      */
-    private class CountingOrReadFilter extends CountingBinopReadFilter {
+    private final class CountingOrReadFilter extends CountingBinopReadFilter {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
@@ -58,7 +58,7 @@ public final class MeanQualityByCycle extends SinglePassSamProgram {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private static class HistogramGenerator {
+    private static final class HistogramGenerator {
         final boolean useOriginalQualities;
         int maxLengthSoFar = 0;
         double[] firstReadTotalsByCycle  = new double[maxLengthSoFar];

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
@@ -389,7 +389,7 @@ public final class SamToFastq extends PicardCommandLineProgram {
      * Allows for lazy construction of the second-of-pair writer, since when we are in the "output per read group mode", we only wish to
      * generate a second-of-pair fastq if we encounter a second-of-pair read.
      */
-    static class FastqWriters {
+    static final class FastqWriters {
         private final FastqWriter firstOfPair, unpaired;
         private final Lazy<FastqWriter> secondOfPair;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -307,7 +307,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
      * Holds information about the alternative allele subsetting based on supporting evidence, genotyping and
      * output modes.
      */
-    private static class OutputAlleleSubset {
+    private static final class OutputAlleleSubset {
         private  final Allele[] alleles;
         private  final boolean siteIsMonomorphic;
         private  final int[] mleCounts;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -1157,7 +1157,7 @@ public final class AlignmentUtils {
      * so not present in 3).  We advance the cigar in 1 by 1 (as we've consumed one base in 1 for the I)
      * but we haven't yet found the base corresponding to the M of op23.  So we don't advance23.
      */
-    private static class CigarPairTransform {
+    private static final class CigarPairTransform {
         private final EnumSet<CigarOperator> op12, op23;
         private final CigarOperator op13;
         private final int advance12, advance23;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
@@ -199,7 +199,7 @@ public final class SamAlignmentMerger extends AbstractAlignmentMerger {
         };
     }
 
-    private class SuffixTrimingSamRecordIterator implements CloseableIterator<SAMRecord> {
+    private final class SuffixTrimingSamRecordIterator implements CloseableIterator<SAMRecord> {
         private final CloseableIterator<SAMRecord> underlyingIterator;
         private final String suffixToTrim;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkConverter.java
@@ -18,7 +18,7 @@ import java.util.LinkedList;
 /**
  * Class with helper methods to convert objects (mostly matrices) to/from Spark (particularly, in MLLib)
  */
-public class SparkConverter {
+public final class SparkConverter {
     private static final Logger logger = LogManager.getLogger(SparkConverter.class);
 
     private SparkConverter() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat