### PR TITLE
add bwa to reads pipeline

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaHelperShortRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaHelperShortRead.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.hellbender.tools.spark.bwa;
+
+import com.github.lindenb.jbwa.jni.ShortRead;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+/**
+ * The purpose of this data structure is to enable keeping track of which ShortReads correspond to which GATKReads.
+ * The JNI layer ignores the read field.
+ */
+public final class BwaHelperShortRead extends ShortRead{
+    private final GATKRead read; //may be null
+
+    public BwaHelperShortRead(String name, byte[] bases, byte[] baseQualities, GATKRead read) {
+        super(name, bases, baseQualities);
+        this.read = read;
+    }
+
+    public GATKRead getRead(){ return read; }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
@@ -52,9 +52,9 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
     protected void runTool(final JavaSparkContext ctx) {
         final JavaRDD<GATKRead> initialReads = getReads();
         final String referenceFileName = referenceArguments.getReferenceFileName();
-        final BwaSparkEngine engine = new BwaSparkEngine(bwaArgs.numThreads, bwaArgs.fixedChunkSize, referenceFileName);
-        final SAMFileHeader readsHeader = engine.makeHeaderForOutput(getHeaderForReads(), getReferenceSequenceDictionary());
-        final JavaRDD<GATKRead> alignedReads = engine.alignWithBWA(ctx, initialReads, readsHeader);
+        final BwaSparkEngine bwaEngine = new BwaSparkEngine(bwaArgs.numThreads, bwaArgs.fixedChunkSize, referenceFileName);
+        final SAMFileHeader readsHeader = bwaEngine.makeHeaderForOutput(getHeaderForReads(), getReferenceSequenceDictionary());
+        final JavaRDD<GATKRead> alignedReads = bwaEngine.alignWithBWA(ctx, initialReads, readsHeader);
 
         final JavaRDD<GATKRead> markedReadsWithOD = MarkDuplicatesSpark.mark(alignedReads, getHeaderForReads(), duplicatesScoringStrategy, new OpticalDuplicateFinder(), getRecommendedNumReducers());
         final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.cleanupTemporaryAttributes(markedReadsWithOD);

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalUtils.java
@@ -488,6 +488,8 @@ public final class RecalUtils {
     public static void parsePlatformForRead(final GATKRead read, final SAMFileHeader header, final RecalibrationArgumentCollection RAC) {
         final SAMReadGroupRecord readGroup = ReadUtils.getSAMReadGroupRecord(read, header);
 
+        Utils.nonNull(readGroup, "Missing readGroup for read: " + read);
+
         if (RAC.FORCE_PLATFORM != null && (readGroup.getPlatform() == null || !readGroup.getPlatform().equals(RAC.FORCE_PLATFORM))) {
             readGroup.setPlatform(RAC.FORCE_PLATFORM);
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
@@ -105,10 +105,10 @@ public final class ArgumentsBuilder {
     /**
      * add an argument with a given value to this builder
      */
-    public ArgumentsBuilder addArgument(final String argumentName, final String argumentValue) {
-        Utils.nonNull(argumentValue);
-        Utils.nonNull(argumentName);
-        add("--" + argumentName);
+    public ArgumentsBuilder addArgument(final String argumentFullName, final String argumentValue) {
+        Utils.nonNull(argumentValue, "value");
+        Utils.nonNull(argumentFullName, "name");
+        add("--" + argumentFullName);
         add(argumentValue);
         return this;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtils.java
@@ -252,10 +252,12 @@ public final class SamAssertionUtils {
         msg = compareValues(actualRead.getMappingQuality(), expectedRead.getMappingQuality(), readNames + " getMappingQuality");
         if (msg != null){ return msg; }
 
-        msg = compareValues(actualRead.getMateReferenceIndex(), expectedRead.getMateReferenceIndex(), readNames + "getMateReferenceIndex");
-        if (msg != null){ return msg; }
+        msg = compareValues(actualRead.getMateReferenceIndex(), expectedRead.getMateReferenceIndex(), readNames + " getMateReferenceIndex");
+        if (msg != null){
+            return msg;
+        }
 
-        msg = compareValues(actualRead.getMateAlignmentStart(), expectedRead.getMateAlignmentStart(), readNames + "getMateAlignmentStart");
+        msg = compareValues(actualRead.getMateAlignmentStart(), expectedRead.getMateAlignmentStart(), readNames + " getMateAlignmentStart");
         if (msg != null){ return msg; }
 
         msg = compareValues(actualRead.getReferenceIndex(), expectedRead.getReferenceIndex(), readNames + " getReferenceIndex");

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
@@ -8,6 +8,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -17,23 +18,27 @@ public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends Comm
     }
 
     @Test
-    public void test() throws Exception {
-        //This file was created by 1) running bwaspark on the input and 2) running picard MarkDuplicates on the result
-        final File expectedSam = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bwa.md.bam");
+    public void test() throws IOException {
+        //The expected results file was created by
+        // 1) running BwaSpark on the input,
+        // 2) running picard SortSam to sort by coordinate
+        // 3) running picard MarkDuplicates on the result
+        // 4) running picard SortSam to sort by queryname
 
-        final File ref = new File(b37_reference_20_21);
-        final File input = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam");
         final File output = createTempFile("bwa", ".bam");
         if (!output.delete()) {
             Assert.fail();
         }
 
         final ArgumentsBuilder args = new ArgumentsBuilder();
+        final File ref = new File(b37_reference_20_21);
         args.addReference(ref);
+        final File input = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam");
         args.addInput(input);
         args.addOutput(output);
         this.runCommandLine(args.getArgsArray());
 
+        final File expectedSam = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bwa.md.bam");
         SamAssertionUtils.assertSamsEqual(output, expectedSam);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
@@ -26,7 +26,7 @@ public final class BwaSparkIntegrationTest extends CommandLineProgramTest {
             Assert.fail();
         }
 
-        ArgumentsBuilder args = new ArgumentsBuilder();
+        final ArgumentsBuilder args = new ArgumentsBuilder();
         args.addFileArgument("reference", ref);
         args.addFileArgument("input", input);
         args.add("disableSequenceDictionaryValidation=true"); // disable since input does not have a sequence dictionary

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -3,8 +3,10 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSource;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -114,5 +116,30 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
         else {
             SamAssertionUtils.assertEqualBamFiles(outFile, new File(params.expectedFileName), true, ValidationStringency.SILENT);
         }
+    }
+
+    @Test
+    public void testWithBwa() throws IOException {
+        //The expected results file was created by
+        // 1) running BwaSpark on the input,
+        // 2) running ReadsPipelineSpark on the result (without bwa parameter)
+
+        final File output = createTempFile("bwa", ".bam");
+        if (!output.delete()) {
+            Assert.fail();
+        }
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        final File input = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam");
+        args.addArgument("knownSites", getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF);
+        args.addReference(new File(b37_2bit_reference_20_21));
+        args.addBooleanArgument("run_bwa", true);
+        args.addArgument("bwa_reference", b37_reference_20_21);
+        args.addInput(input);
+        args.addOutput(output);
+        this.runCommandLine(args.getArgsArray());
+
+        final File expectedSam = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.ReadsPipelineWithBWA.bam");
+        SamAssertionUtils.assertSamsEqual(output, expectedSam);
     }
 }

--- a/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.ReadsPipelineWithBWA.bam
+++ b/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.ReadsPipelineWithBWA.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:743499e6b923926d02e97f6c412303a55443e801a0dce14e03ba07a23206f075
+size 296780

--- a/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bwa.md.bam
+++ b/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bwa.md.bam
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c251a9bd78f9e7a67e87294777e523f9445e0d371995ae14496bdebf098a5dc
-size 218387
+oid sha256:c5a3c8cf2205a34c400cd8607af1ce4a2c657b789992a9ff6698192868c74e78
+size 279632


### PR DESCRIPTION
fixes https://github.com/broadinstitute/gatk/issues/1904

2 hacks needed to be done for now:
1) bwa loses tags so we keep track of which original read corresponds to which aligned read by creating a subclass of `ShortRead` (the class that jBWA uses for JNI) and putting the original read in a pointer in there.
2) bwa requires a fasta reference while reads pipeline wants a 2bit reference (in the BROADCAST mode, which is the default). The workaround for now is to pass two reference files one of each kind
