### PR TITLE
clone deep to fix continuous snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 sudo: required
 dist: trusty
+git:
+  depth: 9999999
 jdk:
 - oraclejdk8
 env:


### PR DESCRIPTION
this aims to fix https://github.com/broadinstitute/gatk/issues/1993

@lbergelson can you look at it?

the command i see on travis now is 
```
git clone --depth=9999999 --branch=ak_deep_clone https://github.com/broadinstitute/gatk.git
```

(the `depth` option is documented [here](https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth))
