### PR TITLE
updating google-api-services-genomics off of the beta api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:5.0-beta-1'
     compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:0.4.150727'
     compile 'it.unimi.dsi:fastutil:7.0.6'
-    compile 'com.google.apis:google-api-services-genomics:v1beta2-rev56-1.20.0'
+    compile 'com.google.apis:google-api-services-genomics:v1-rev90-1.22.0'
     compile 'com.google.cloud.genomics:google-genomics-utils:v1beta2-0.30'
 
    compile 'org.ojalgo:ojalgo:39.0'

--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
@@ -197,7 +197,7 @@ public class ReferenceAPISource implements ReferenceSource, Serializable {
               if (received.length < interval.size()) {
                   final List<byte[]> blobs = new ArrayList<>();
                   blobs.add(received);
-                  while (result.getNextPageToken() != null) {
+                  while (! result.getNextPageToken().isEmpty()) {
                       listRequest.setPageToken(result.getNextPageToken());
                       result = listRequest.execute();
                       blobs.add(result.getSequence().getBytes());

--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceAPISource.java
@@ -197,7 +197,7 @@ public class ReferenceAPISource implements ReferenceSource, Serializable {
               if (received.length < interval.size()) {
                   final List<byte[]> blobs = new ArrayList<>();
                   blobs.add(received);
-                  while (! result.getNextPageToken().isEmpty()) {
+                  while (result.getNextPageToken() != null  && !result.getNextPageToken().isEmpty()) {
                       listRequest.setPageToken(result.getNextPageToken());
                       result = listRequest.execute();
                       blobs.add(result.getSequence().getBytes());

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -500,6 +500,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
         return genomicsRead.getInfo() != null && genomicsRead.getInfo().containsKey(attributeName);
     }
 
+    @SuppressWarnings("unchecked")
     private String getRawAttributeValue( final String attributeName, final String targetType ) {
         ReadUtils.assertAttributeNameIsLegal(attributeName);
 
@@ -507,7 +508,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return null;
         }
 
-        final List<String> rawValue = genomicsRead.getInfo().get(attributeName);
+        final List<Object> rawValue = genomicsRead.getInfo().get(attributeName);
         if ( rawValue == null || rawValue.isEmpty() || rawValue.get(0) == null ) {
             return null;
         }
@@ -517,7 +518,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             throw new GATKException.ReadAttributeTypeMismatch(attributeName, targetType);
         }
 
-        return rawValue.get(0);
+        return (String)rawValue.get(0);
     }
 
     @Override
@@ -561,7 +562,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<String> encodedValue = Arrays.asList(attributeValue.toString());
+        final List<Object> encodedValue = Arrays.asList(attributeValue.toString());
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 
@@ -574,7 +575,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<String> encodedValue = Arrays.asList(attributeValue);
+        final List<Object> encodedValue = Arrays.asList(attributeValue);
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 
@@ -587,7 +588,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<String> encodedValue = Arrays.asList(new String(attributeValue));
+        final List<Object> encodedValue = Arrays.asList(new String(attributeValue));
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 
@@ -729,8 +730,8 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             genomicsRead.setAlignedQuality(new ArrayList<>(alignedQuality));
         }
         if (null!=genomicsRead.getInfo()) {
-            Map<String, List<String>> infoCopy = new LinkedHashMap<>();
-            for (Map.Entry<String, List<String>> entry : genomicsRead.getInfo().entrySet()) {
+            Map<String, List<Object>> infoCopy = new LinkedHashMap<>();
+            for (Map.Entry<String, List<Object>> entry : genomicsRead.getInfo().entrySet()) {
                 infoCopy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
             }
             genomicsRead.setInfo(infoCopy);

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -518,6 +518,10 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             throw new GATKException.ReadAttributeTypeMismatch(attributeName, targetType);
         }
 
+        /*
+         * This cast is necessary since the API requires storing a map of String -> Object, but requires that those objects be Strings
+         * See: https://developers.google.com/resources/api-libraries/documentation/genomics/v1/java/latest/com/google/api/services/genomics/model/Read.html#setInfo(java.util.Map)
+         */
         return (String)rawValue.get(0);
     }
 
@@ -562,7 +566,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<Object> encodedValue = Arrays.asList(attributeValue.toString());
+        final List<Object> encodedValue = Collections.singletonList(attributeValue.toString());
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 
@@ -575,7 +579,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<Object> encodedValue = Arrays.asList(attributeValue);
+        final List<Object> encodedValue = Collections.singletonList(attributeValue);
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 
@@ -588,7 +592,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
             return;
         }
 
-        final List<Object> encodedValue = Arrays.asList(new String(attributeValue));
+        final List<Object> encodedValue = Collections.singletonList(new String(attributeValue));
         genomicsRead.getInfo().put(attributeName, encodedValue);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
@@ -145,7 +145,7 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
         read.setNumberReads(2);
         read.setReadNumber(0);
         read.setProperPlacement(false);
-        Map<String, List<String>> infoMap = new LinkedHashMap<String, List<String>>();
+        Map<String, List<Object>> infoMap = new LinkedHashMap<>();
         infoMap.put(SAMTag.PG.name(), Collections.singletonList(BASIC_PROGRAM));
         read.setInfo(infoMap);
 


### PR DESCRIPTION
We got an email complaining that we were the only users in the world still using the beta API.

This updates to the most recent version, they changed the api from `List<String> -> List<Object>`, but the documentation still says it has to be a `String`, so I've just added some explicit casts.  

Fix for #2009 