### PR TITLE
Add official nio and test (with Travis test this time hopefully)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - HELLBENDER_TEST_INPUTS=gs://hellbender/test/resources/
   - HELLBENDER_TEST_STAGING=gs://hellbender/test/staging/
   - HELLBENDER_TEST_PROJECT=broad-dsde-dev
+  - HELLBENDER_JSON_SERVICE_ACCOUNT_KEY=servicekey.json
   #coveralls repo token
   - secure: RA4LKD82cW+0xPayPVAWSpYqJu5uoPcz7oXXYtYNVuilFmS8PGYx0g/BXs4QMvQsGMt6aMLN8m7lMAPN5XTH/8JSeM3VmQ3mdpgNdP+p3CVlwrapZ2lTq27Wb/E8J1CGEHOg76z716t//FUElyC/gdhS+tfBmXk3YanM5fMXEHs=
   #google API key

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ configurations.all {
         force 'com.google.guava:guava:18.0'
         // force the htsjdk version so we don't get a different one transitively
         force 'com.github.samtools:htsjdk:' + htsjdkVersion
+        // later versions explode Hadoop
+        force 'com.google.protobuf:protobuf-java:3.0.0-beta-1'
     }
     all*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
     all*.exclude group: 'com.google.guava', module: 'guava-jdk5'
@@ -106,6 +108,10 @@ dependencies {
     compile 'com.opencsv:opencsv:3.4'
     compile 'com.google.guava:guava:18.0'
     compile 'com.github.samtools:htsjdk:'+ htsjdkVersion
+    // Using the shaded version to avoid conflicts between its protobuf dependency
+    // and that of Hadoop/Spark (either the one we reference explicitly, or the one
+    // provided by dataproc).
+    compile 'com.google.cloud:gcloud-java-nio:0.2.5:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -148,6 +148,14 @@ public abstract class BaseTest {
         return getNonNullEnvironmentVariable("HELLBENDER_TEST_INPUTS");
     }
 
+    /**
+     * A local path where the service account credentials are stored
+     * @return GOOGLE_APPLICATION_CREDENTIALS env. var if defined, throws otherwise.
+     */
+    public static String getGoogleServiceAccountKeyPath() {
+      return getNonNullEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+    }
+
     protected static String getNonNullEnvironmentVariable(String envVarName) {
         String value = System.getenv(envVarName);
         if (null == value) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
@@ -1,0 +1,103 @@
+package org.broadinstitute.hellbender.utils.nio;
+
+import com.google.cloud.AuthCredentials;
+import com.google.cloud.RetryParams;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration;
+import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.Arrays;
+
+/**
+ * Test GCS access via the NIO APIs.
+ */
+public final class GcsNioIntegrationTest extends BaseTest {
+
+    final String privateFilePath = "org/broadinstitute/hellbender/utils/nio/private_file.txt";
+    final String privateFilePath2 = "org/broadinstitute/hellbender/utils/nio/private_file_2.txt";
+
+    @Test
+    public void testGcsEnabled() {
+        FileSystem fs = FileSystems.getFileSystem(URI.create("gs://domain-registry-alpha"));
+    }
+
+    @Test
+    public void openPublicFile() throws IOException {
+        try (InputStream inputStream = Files.newInputStream(Paths.get(URI.create(
+                "gs://pgp-harvard-data-public/hu011C57/GS000018120-DID/GS000015172-ASM/manifest.all.sig")))) {
+            int firstByte = inputStream.read();
+        }
+    }
+
+
+    /**
+     * When we give no explicit credentials, then the system will still work if either
+     * - the GOOGLE_APPLICATION_CREDENTIALS environment variable is set
+     * - the user ran "gcloud auth login" first
+     * - the code is running on a Google Cloud Compute machine.
+     * (see http://gcloud-python.readthedocs.org/en/latest/gcloud-auth.html)
+     */
+    @Test(groups = {"cloud"})
+    public void openPrivateFileUsingDefaultCredentials() throws IOException {
+        // this file, potentially unlike the others in the set, is not marked as "Public link".
+        final String privateFile = getGCPTestInputPath() + privateFilePath;
+
+        Path path = Paths.get(URI.create((privateFile)));
+        int firstByte = Files.newInputStream(path).read();
+    }
+
+    /**
+     * Opening the private file even when the user is not logged in on gcloud should work
+     * when we provide explicit credentials.
+     */
+    @Test(groups = {"cloud"})
+    public void openPrivateFileWithExplicitCredentials() throws IOException {
+        // this file, potentially unlike the others in the set, is not marked as "Public link".
+        final String privateFile = getGCPTestInputPath() + privateFilePath;
+        final String BUCKET = BucketUtils.getBucket(privateFile);
+        final String pathWithoutBucket = BucketUtils.getPathWithoutBucket(privateFile);
+
+        FileSystem fs = getAuthenticatedGcs(BUCKET);
+        Path path = fs.getPath(pathWithoutBucket);
+        int firstByte = Files.newInputStream(path).read();
+    }
+
+    /**
+     * Using explicit credentials only works on that access, they are not kept.
+     * This test will fail if default credentials are available.
+     * That means that you must NOT set $GOOGLE_APPLICATION_CREDENTIALS
+     * Yet you must set getGoogleServiceAccountKeyPath() (you may have to switch it to a different
+     * environment variable).
+     */
+    @Test(enabled = false, groups = {"cloud"}, expectedExceptions = {StorageException.class})
+    public void explicitCredentialsAreNotKept() throws IOException {
+        // this file, potentially unlike the others in the set, is not marked as "Public link".
+        final String privateFile = getGCPTestInputPath() + privateFilePath;
+        final String privateFile2 = getGCPTestInputPath() + privateFilePath2;
+        final String BUCKET = BucketUtils.getBucket(privateFile);
+        final String pathWithoutBucket = BucketUtils.getPathWithoutBucket(privateFile);
+
+        FileSystem fs = getAuthenticatedGcs(BUCKET);
+        Path path = fs.getPath(pathWithoutBucket);
+        int firstByte = Files.newInputStream(path).read();
+
+        // now let's open another private file. It shouldn't work.
+        path = Paths.get(URI.create((privateFile2)));
+        firstByte = Files.newInputStream(path).read();
+    }
+
+    private FileSystem getAuthenticatedGcs(String bucket) throws IOException {
+        byte[] creds = Files.readAllBytes(Paths.get(getGoogleServiceAccountKeyPath()));
+        return BucketUtils.getAuthenticatedGcs(getGCPTestProject(), bucket, creds);
+    }
+
+
+}

--- a/src/test/resources/org/broadinstitute/hellbender/utils/nio/private_file.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/utils/nio/private_file.txt
@@ -1,0 +1,1 @@
+This file is meant to be copied to GCS so that NioTests can make sure they can get to it, even if it's not public.

--- a/src/test/resources/org/broadinstitute/hellbender/utils/nio/private_file_2.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/utils/nio/private_file_2.txt
@@ -1,0 +1,1 @@
+This file is meant to be copied to GCS so that NioTests can make sure they can get to it, even if it's not public.


### PR DESCRIPTION
Add a dependency to the official NIO jar and include tests for gcloud-java-nio.

This is based on the earlier NIO example. Now that NIO support is official we can move this test to our main branch.

I'm resubmitting this as a branch from broadinstitute/ directly so (hopefully) the Travis cloud tests will run.

CC: @lbergelson @droazen