### PR TITLE
disabling htsjdk snappy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ import de.undercouch.gradle.tasks.download.Download
 mainClassName = "org.broadinstitute.hellbender.Main"
 
 //Note: the test suite must use the same defaults. If you change system properties in this list you must also update the one in the test task
-applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=1"]
+applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=1", "-Dsnappy.disable=true"]
 
 //Delete the windows script - we never test on Windows so let's not pretend it works
 startScripts {
@@ -240,6 +240,7 @@ test {
     systemProperty "samjdk.use_async_io_write_samtools", "true"
     systemProperty "samjdk.use_async_io_write_tribble", "false"
     systemProperty "samjdk.compression_level", "1"
+    systemProperty "snappy.disable", "true"
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     // set heap size for the test JVM(s)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.hellbender.tools.walkers.rnaseq;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.util.Arrays;
 
 /**
@@ -68,5 +70,15 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
                 "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s -L 20:2444518-2454410",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.subSequenceTest.bam")); //results created using gatk3.5
         spec.executeTest("regression test for unmapped and unpaired reads", this);
+    }
+
+    @Test //regression test for https://github.com/broadinstitute/gatk/issues/2026
+    public void testLargeFileThatForcesSnappyUsage(){
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addReference(new File(b37_reference_20_21))
+                .addInput(new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam"))
+                .addOutput(createTempFile("largeSplitNCigarReadsTest",".bam"));
+        //Just make sure this doesn't fail with NoClassDefFoundError
+        runCommandLine(args);
     }
 }


### PR DESCRIPTION
adding snappy.disable=true to prevent htsjdk from using snappy
this is a temporary solution for #2026 until we can patch htsjdk to fix incompatibilities with more modern snappy

fixes #2026 