### PR TITLE
speedup to LIBS by not duplicating calls to GATKRead methods

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -330,11 +330,11 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
                         continue;
                     }
 
-                    if (!dontIncludeReadInPileup(read, location.getStart())) {
-                        if ( ! includeReadsWithDeletionAtLoci && op == CigarOperator.D ) {
-                            continue;
-                        }
+                    if ( ! includeReadsWithDeletionAtLoci && op == CigarOperator.D ) {
+                        continue;
+                    }
 
+                    if (!dontIncludeReadInPileup(read, location.getStart())) {
                         pile.add(state.makePileupElement());
                     }
                 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -59,6 +59,32 @@ public interface GATKRead extends Locatable {
     }
 
     /**
+     * Gets the contig name for the contig this is mapped to.  May return null if there is no unique mapping.
+     *
+     * @param isUnmapped
+     * @return name of the contig this is mapped to, potentially null
+     */
+    default String getContig(final boolean isUnmapped){
+        return getContig();
+    }
+
+    /**
+     * @param isUnmapped
+     * @return 1-based start position, undefined if getContig() == null
+     */
+    default int getStart(final boolean isUnmapped){
+        return getStart();
+    }
+
+    /**
+     * @param isUnmapped
+     * @return 1-based closed-ended position, undefined if getContig() == null
+     */
+    default int getEnd(final boolean isUnmapped){
+        return getEnd();
+    }
+
+    /**
      * Set the position of the read (the contig and the start position). Cannot be used to
      * set the read to an unmapped position; use {@link #setIsUnmapped} for that purpose.
      *
@@ -113,6 +139,24 @@ public interface GATKRead extends Locatable {
     int getUnclippedStart();
 
     /**
+     * Returns the alignment start (1-based, inclusive) adjusted for clipped bases.
+     * For example, if the read has an alignment start of 100 but the first 4 bases
+     * were clipped (hard or soft clipped) then this method will return 96.
+     *
+     * For unmapped reads, always returns {@link ReadConstants#UNSET_POSITION}
+     *
+     * This method is a performance shortcut that will not call {@link #isUnmapped()} but rather use the provided value.
+     * The default implementation ignores the parameter and calls the unoptimized version. Subclasses may override.
+     *
+     * @param isUnmapped whether this read is unmapped.
+     * @return The alignment start (1-based, inclusive) adjusted for clipped bases,
+     *         or {@link ReadConstants#UNSET_POSITION} if the read is unmapped.
+     */
+    default int getUnclippedStart(final boolean isUnmapped){
+        return getUnclippedStart();
+    }
+
+    /**
      * Returns the alignment end (1-based, inclusive) adjusted for clipped bases.
      * For example, if the read has an alignment end of 100 but the last 7 bases
      * were clipped (hard or soft clipped) then this method will return 107.
@@ -124,11 +168,19 @@ public interface GATKRead extends Locatable {
      */
     int getUnclippedEnd();
 
+    default int getUnclippedEnd(final boolean isUnmapped){
+        return getUnclippedEnd();
+    }
+
     /**
      * @return The contig that this read's mate is mapped to, or {@code null} if the mate is unmapped
      * @throws IllegalStateException if the read is not paired (has no mate)
      */
     String getMateContig();
+
+    default String getMateContig(final boolean mateIsUnmapped){
+        return getMateContig();
+    }
 
     /**
      * @return The alignment start (1-based, inclusive) of this read's mate, or {@link ReadConstants#UNSET_POSITION}
@@ -136,6 +188,10 @@ public interface GATKRead extends Locatable {
      * @throws IllegalStateException if the read is not paired (has no mate)
      */
     int getMateStart();
+
+    default int getMateStart(final boolean mateIsUnmapped){
+        return getMateStart();
+    }
 
     /**
      * Set the position of the read's mate (the contig and the start position). Cannot be used to

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKRead.java
@@ -454,6 +454,16 @@ public interface GATKRead extends Locatable {
     boolean mateIsUnmapped();
 
     /**
+     * @param isPaired is the read paired
+     * @return True if this read's mate is unmapped (this includes mates that have a position but are explicitly marked as unmapped,
+     *         as well as mates that lack a fully-defined position but are not explicitly marked as unmapped). Otherwise false.
+     * @throws IllegalStateException if the read is not paired (has no mate)
+     */
+    default boolean mateIsUnmapped(boolean isPaired){
+        return mateIsUnmapped();
+    }
+
+    /**
      * Mark the read's mate as unmapped (lacking a defined position on the genome).
      *
      * To mark the read's mate as mapped, use {@link #setMatePosition}
@@ -482,6 +492,16 @@ public interface GATKRead extends Locatable {
      * @throws GATKException.MissingReadField if this information is not available
      */
     boolean mateIsReverseStrand();
+
+    /**
+     * @param isPaired is the read paired
+     * @return True if this read's mate is on the reverse strand as opposed to the forward strand, otherwise false.
+     * @throws IllegalStateException if the read is not paired (has no mate)
+     * @throws GATKException.MissingReadField if this information is not available
+     */
+    default boolean mateIsReverseStrand(final boolean isPaired){
+        return mateIsReverseStrand();
+    }
 
     /**
      * Mark the read's mate as being on the reverse (or forward) strand.

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -1059,16 +1059,7 @@ public final class ReadUtils {
 
         //Note: this method is very heavily hit during LocusWalker iterations
         // so it's important to keep it optimized and exit as soon as possible
-        final boolean isUnmapped = read.isUnmapped();
-        if (isUnmapped){
-            return false;
-        }
-        final boolean isUnpaired = ! read.isPaired();
-        if (isUnpaired){
-            return false;
-        }
-        final boolean mateIsUnmapped = read.mateIsUnmapped();
-        if (mateIsUnmapped){
+        if (! read.isPaired() || read.isUnmapped() || read.mateIsUnmapped(true)){
             return false;
         }
         final int fragmentLength = read.getFragmentLength();
@@ -1077,7 +1068,7 @@ public final class ReadUtils {
             return false;
         }
         final boolean reverseStrand = read.isReverseStrand();
-        if ( reverseStrand == read.mateIsReverseStrand() ) {
+        if ( reverseStrand == read.mateIsReverseStrand(true) ) {
             // sanity check on isProperlyPaired to ensure that read1 and read2 aren't on the same strand
             return false;
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -469,13 +469,14 @@ public final class ReadUtils {
         {
             return false;
 	    }
-        if ( read.isReverseStrand() == read.mateIsReverseStrand() )
+        final boolean reverseStrand = read.isReverseStrand();
+        if ( reverseStrand == read.mateIsReverseStrand() )
         // sanity check on isProperlyPaired to ensure that read1 and read2 aren't on the same strand
         {
             return false;
         }
 
-        if ( read.isReverseStrand() ) {
+        if (reverseStrand) {
             // we're on the negative strand, so our read runs right to left
             return read.getEnd(false) > read.getMateStart(false);
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -401,14 +401,19 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public boolean mateIsUnmapped() {
-        if ( ! isPaired() ) {
+        return mateIsUnmapped(isPaired());
+    }
+
+    @Override
+    public boolean mateIsUnmapped(boolean isPaired){
+        if ( ! isPaired ) {
             throw new IllegalStateException("Cannot get mate information for an unpaired read");
         }
 
         return samRecord.getMateUnmappedFlag() ||
-               samRecord.getMateReferenceName() == null ||
-               samRecord.getMateAlignmentStart() == SAMRecord.NO_ALIGNMENT_START ||
-               samRecord.getMateReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME);
+                samRecord.getMateReferenceName() == null ||
+                samRecord.getMateAlignmentStart() == SAMRecord.NO_ALIGNMENT_START ||
+                samRecord.getMateReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME);
     }
 
     @Override
@@ -431,7 +436,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public boolean mateIsReverseStrand() {
-        if ( ! isPaired() ) {
+        return mateIsReverseStrand(isPaired());
+    }
+
+    @Override
+    public boolean mateIsReverseStrand(final boolean isPaired){
+        if ( ! isPaired ) {
             throw new IllegalStateException("Cannot get mate information for an unpaired read");
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -55,7 +55,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public String getContig() {
-        if ( isUnmapped() ) {
+        return getContig(isUnmapped());
+    }
+
+    @Override
+    public String getContig(final boolean isUnmapped) {
+        if ( isUnmapped ) {
             return null;
         }
 
@@ -65,7 +70,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public int getStart() {
-        if ( isUnmapped() ) {
+        return getStart(isUnmapped());
+    }
+
+    @Override
+    public int getStart(final boolean isUnmapped){
+        if ( isUnmapped ) {
             return ReadConstants.UNSET_POSITION;
         }
 
@@ -75,7 +85,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public int getEnd() {
-        if ( isUnmapped() ) {
+        return getEnd(isUnmapped());
+    }
+
+    @Override
+    public int getEnd(final boolean isUnmapped){
+        if ( isUnmapped ) {
             return ReadConstants.UNSET_POSITION;
         }
 
@@ -115,7 +130,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public int getUnclippedStart() {
-        if ( isUnmapped() ) {
+        return getUnclippedStart(isUnmapped());
+    }
+
+    @Override
+    public int getUnclippedStart(final boolean isUnmapped) {
+        if ( isUnmapped ) {
             return ReadConstants.UNSET_POSITION;
         }
 
@@ -124,7 +144,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public int getUnclippedEnd() {
-        if ( isUnmapped() ) {
+        return getUnclippedEnd (isUnmapped());
+    }
+
+    @Override
+    public int getUnclippedEnd(final boolean isUnmapped) {
+        if ( isUnmapped ) {
             return ReadConstants.UNSET_POSITION;
         }
 
@@ -133,7 +158,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public String getMateContig() {
-        if ( mateIsUnmapped() ) {
+        return getMateContig(mateIsUnmapped());
+    }
+
+    @Override
+    public String getMateContig(final boolean mateIsUnmapped) {
+        if ( mateIsUnmapped ) {
             return null;
         }
 
@@ -142,7 +172,12 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public int getMateStart() {
-        if ( mateIsUnmapped() ) {
+        return getMateStart(mateIsUnmapped());
+    }
+
+    @Override
+    public int getMateStart(final boolean mateIsUnmapped) {
+        if ( mateIsUnmapped ) {
             return ReadConstants.UNSET_POSITION;
         }
 
@@ -354,8 +389,9 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     @Override
     public boolean isUnmapped() {
         return samRecord.getReadUnmappedFlag() ||
-               samRecord.getReferenceName() == null || samRecord.getReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME) ||
-               samRecord.getAlignmentStart() == SAMRecord.NO_ALIGNMENT_START;
+               samRecord.getReferenceName() == null ||
+               samRecord.getAlignmentStart() == SAMRecord.NO_ALIGNMENT_START ||
+               samRecord.getReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME);
     }
 
     @Override
@@ -370,8 +406,9 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
         }
 
         return samRecord.getMateUnmappedFlag() ||
-               samRecord.getMateReferenceName() == null || samRecord.getMateReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME) ||
-               samRecord.getMateAlignmentStart() == SAMRecord.NO_ALIGNMENT_START;
+               samRecord.getMateReferenceName() == null ||
+               samRecord.getMateAlignmentStart() == SAMRecord.NO_ALIGNMENT_START ||
+               samRecord.getMateReferenceName().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME);
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -315,7 +315,7 @@ public final class ReadUtilsUnitTest extends BaseTest {
     }
 
     @Test(dataProvider = "HasWellDefinedFragmentSizeData")
-    private void testHasWellDefinedFragmentSize(final String name, final GATKRead read, final boolean expected) {
+    public void testHasWellDefinedFragmentSize(final String name, final GATKRead read, final boolean expected) {
         Assert.assertEquals(ReadUtils.hasWellDefinedFragmentSize(read), expected);
     }
 


### PR DESCRIPTION
this PR gives 5-7% speedup on LIBS (benchmarked using ExampleLocusWalker)

it's done by not repeating calls to isPaired and isMapped 

Note: there's still good speedup potential in `PileupElement.<init>` because almost all the time spent there is in the parameter checks (which are always passing when the ctor is called from the AlignmentStateMachine.

@droazen please review - if the general idea seems fine by you, I'll complete the documentation for new default methods on GATKRead and cleanup a bit 