### PR TITLE
LIBS/LocusWalker refactoring and overlapping read-pairs handling

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -544,7 +544,7 @@ public final class AssemblyRegion implements Locatable {
             windowReads.add(read);
         }
 
-        final LocusIteratorByState locusIterator = new LocusIteratorByState(windowReads.iterator(), DownsamplingMethod.NONE, false, false, ReadUtils.getSamplesFromHeader(readsHeader), readsHeader);
+        final LocusIteratorByState locusIterator = new LocusIteratorByState(windowReads.iterator(), DownsamplingMethod.NONE, false, ReadUtils.getSamplesFromHeader(readsHeader), readsHeader, false);
         final ActivityProfile activityProfile = new BandPassActivityProfile(null, maxProbPropagationDistance, activeProbThreshold, BandPassActivityProfile.MAX_FILTER_SIZE, BandPassActivityProfile.DEFAULT_SIGMA, readsHeader);
 
         // First, use our activity profile to determine the bounds of each assembly region:

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator
 import org.broadinstitute.hellbender.utils.iterators.ReadFilteringIterator;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.downsampling.DownsamplingMethod;
+import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 
 import java.util.*;
@@ -30,6 +31,9 @@ public abstract class LocusWalker extends GATKTool {
 
     @Argument(fullName = "disable_all_read_filters", shortName = "f", doc = "Disable all read filters", common = false, optional = true)
     public boolean disableAllReadFilters = false;
+
+    @Argument(fullName = "ignore_overlaps", shortName = "x", doc = "Disable read-pair overlap detection", common = false, optional = true)
+    public boolean ignoreOverlpas = false;
 
     /**
      * Should the LIBS keep unique reads? Tools that do should override to return {@code true}.
@@ -122,7 +126,7 @@ public abstract class LocusWalker extends GATKTool {
                 new CountingReadFilter("Allow all", ReadFilterLibrary.ALLOW_ALL_READS ) :
                 makeReadFilter();
         // get the LIBS
-        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), includeDeletions(), includeNs(), keepUniqueReadListInLibs(), samples, header);
+        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), includeDeletions(), includeNs(), keepUniqueReadListInLibs(), samples, header, ignoreOverlpas);
         // prepare the iterator
         Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
         // iterate over each alignment, and apply the function

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
 import org.broadinstitute.hellbender.utils.iterators.ReadFilteringIterator;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.downsampling.DownsamplingMethod;
+import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 
 import java.util.*;
@@ -33,6 +33,9 @@ public abstract class LocusWalker extends GATKTool {
 
     @Argument(fullName = "ignore_overlaps", shortName = "x", doc = "Disable read-pair overlap detection", common = false, optional = true)
     public boolean ignoreOverlpas = false;
+
+    @Argument(fullName = "maxDepthPerSample", shortName = "maxDepthPerSample", doc = "Maximum number of reads to retain per sample. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
+    protected int maxDepthPerSample = defaultMaxDepthPerSample();
 
     /**
      * Should the LIBS keep unique reads? Tools that do should override to return {@code true}.
@@ -85,15 +88,9 @@ public abstract class LocusWalker extends GATKTool {
     }
 
     /**
-     * Get the information about how to downsample the reads. By default {@link DownsamplingMethod#NONE} is returned.
-     * Subclasses should override it to provide their own downsampling methods.
-     *
-     * @return the downsampling method for the reads
+     * @return Default value for the {@link #maxDepthPerSample} parameter, if none is provided on the command line
      */
-    public DownsamplingMethod getDownsamplingMethod() {
-        // TODO: change when downsampling command line options are implemented
-        return DownsamplingMethod.NONE;
-    }
+    protected abstract int defaultMaxDepthPerSample();
 
     /**
      * Marked final so that tool authors don't override it. Tool authors should override onTraversalStart() instead.
@@ -107,12 +104,20 @@ public abstract class LocusWalker extends GATKTool {
     }
 
     /**
+     * Returns the downsampling info using {@link #maxDepthPerSample} as target coverage
+     */
+    protected final LIBSDownsamplingInfo getDownsamplingInfo() {
+        return new LIBSDownsamplingInfo(maxDepthPerSample != 0, maxDepthPerSample);
+    }
+
+    /**
      * Implementation of locus-based traversal.
      * Subclasses can override to provide their own behavior but default implementation should be suitable for most uses.
      *
-     * The default implementation iterates over all positions in the reference covered by reads for all samples in the read groups, using
-     * the downsampling method provided by {@link #getDownsamplingMethod()}
-     * and including deletions only if {@link #includeDeletions()} returns {@code true}.
+     * The default implementation iterates over all positions in the reference covered by reads for all samples in the
+     * read groups, downsampling per sample using {@link #getDownsamplingInfo()},
+     * including deletions and Ns depending on {@link #includeDeletions()} and {@link #includeNs()}
+     * and keeping unique reads depending on {@link #keepUniqueReadListInLibs()}
      */
     @Override
     public void traverse() {
@@ -125,7 +130,7 @@ public abstract class LocusWalker extends GATKTool {
                 new CountingReadFilter("Allow all", ReadFilterLibrary.ALLOW_ALL_READS ) :
                 makeReadFilter();
         // get the LIBS
-        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs(), ignoreOverlpas);
+        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingInfo(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs(), ignoreOverlpas);
         // prepare the iterator
         Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
         // iterate over each alignment, and apply the function

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -10,7 +10,6 @@ import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator
 import org.broadinstitute.hellbender.utils.iterators.ReadFilteringIterator;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.downsampling.DownsamplingMethod;
-import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 
 import java.util.*;
@@ -126,7 +125,7 @@ public abstract class LocusWalker extends GATKTool {
                 new CountingReadFilter("Allow all", ReadFilterLibrary.ALLOW_ALL_READS ) :
                 makeReadFilter();
         // get the LIBS
-        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), includeDeletions(), includeNs(), keepUniqueReadListInLibs(), samples, header, ignoreOverlpas);
+        LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingMethod(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs(), ignoreOverlpas);
         // prepare the iterator
         Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
         // iterate over each alignment, and apply the function

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalker.java
@@ -47,6 +47,11 @@ public class ExampleLocusWalker extends LocusWalker {
     }
 
     @Override
+    protected int defaultMaxDepthPerSample() {
+        return 0;
+    }
+
+    @Override
     public void apply(AlignmentContext alignmentContext, ReferenceContext referenceContext, FeatureContext featureContext) {
         // Get pileup and counts
         ReadPileup pileup = alignmentContext.getBasePileup();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/CheckPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/CheckPileup.java
@@ -90,6 +90,12 @@ public final class CheckPileup extends LocusWalker {
         }
     }
 
+    // No downsampling by default
+    @Override
+    protected int defaultMaxDepthPerSample() {
+        return 0;
+    }
+
     public void apply(final AlignmentContext context, final ReferenceContext ref, final FeatureContext featureContext) {
         final ReadPileup pileup = context.getBasePileup();
         final SAMPileupFeature truePileup = getTruePileup(featureContext);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/Pileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/Pileup.java
@@ -121,6 +121,12 @@ public final class Pileup extends LocusWalker {
             .and(new CountingReadFilter("Primary alignment", ReadFilterLibrary.PRIMARY_ALIGNMENT));
     }
 
+    // No downsampling by default
+    @Override
+    protected int defaultMaxDepthPerSample() {
+        return 0;
+    }
+
 
     @Override
     public void onTraversalStart() {

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -445,7 +445,15 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
     }
 
     /**
-     * Fix the quality of two elements that comes from an overlaping pair
+     * Fix the quality of two elements that comes from an overlaping pair in the same way as samtools does
+     * {@see tweak_overlap_quality function in <a href="https://github.com/samtools/htslib/blob/master/sam.c">samtools</a>}.
+     *
+     * Setting the quality of one of the bases to 0 effectively remove the redundant base for calling. In addition, if the
+     * bases overlaps we have increased confidence if they agree (or reduced if they don't). Thus, the algorithm proceed as following:
+     *
+     * 1. If the bases are the same, the quality of the first element is the sum of both qualities and the quality of the second is reduced to 0.
+     * 2. If the bases are different, the base with the highest quality is reduced with a factor of 0.8, and the quality of the lowest is reduced to 0.
+     *
      */
     @VisibleForTesting
     static void fixPairOverlappingQualities(final PileupElement firstElement, final PileupElement secondElement) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
@@ -64,11 +64,12 @@ public abstract class LocusIteratorByStateBaseTest extends BaseTest {
         return new LocusIteratorByState(
                 new FakeCloseableIterator<>(reads.iterator()),
                 downsamplingMethod,
-                true,
-                includeNs,
                 keepUniqueReadList,
                 sampleListForSAMWithoutReadGroups(),
-                header);
+                header,
+                true,
+                includeNs
+        );
     }
 
     private boolean isIndel(final CigarElement ce) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
@@ -776,4 +776,33 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         final int nExpectedPileups = nReadContainingPileups;
         Assert.assertEquals(nPileups, nExpectedPileups, "Wrong number of pileups seen");
     }
+
+
+    @DataProvider(name = "FixPairOverlappingQualitiesTest")
+    public Object[][] overlappingElementsToFix() {
+        final byte highQual = 60;
+        final byte lowQual = 10;
+        final byte qualitySum = 70;
+        final byte reducedQuality = 48; // 80% of 60
+        final byte zeroQuality = 0;
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead("4M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("4M");
+        read1.setBases(new byte[]{'A', 'A', 'A', 'A'});
+        read1.setBaseQualities(new byte[]{highQual, highQual, highQual, lowQual});
+        read2.setBases(new byte[]{'A', 'T', 'T', 'T'});
+        read2.setBaseQualities(new byte[]{lowQual, highQual, lowQual, highQual});
+        return new Object[][]{
+                {PileupElement.createPileupForReadAndOffset(read1, 0), PileupElement.createPileupForReadAndOffset(read2, 0), qualitySum,     zeroQuality},
+                {PileupElement.createPileupForReadAndOffset(read1, 1), PileupElement.createPileupForReadAndOffset(read2, 1), reducedQuality, zeroQuality},
+                {PileupElement.createPileupForReadAndOffset(read1, 2), PileupElement.createPileupForReadAndOffset(read2, 2), reducedQuality, zeroQuality},
+                {PileupElement.createPileupForReadAndOffset(read1, 3), PileupElement.createPileupForReadAndOffset(read2, 3), zeroQuality,    reducedQuality}
+        };
+    }
+
+    @Test(enabled = true, dataProvider = "FixPairOverlappingQualitiesTest")
+    public void testFixPairOverlappingQualities(final PileupElement first, final PileupElement second, final byte expectedQualFirst, final byte expectedQualSecond) {
+        LocusIteratorByState.fixPairOverlappingQualities(first, second);
+        Assert.assertEquals(first.getQual(), expectedQualFirst);
+        Assert.assertEquals(second.getQual(), expectedQualSecond);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
@@ -507,8 +507,8 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         final List<GATKRead> reads = bamBuilder.makeReads();
         final LocusIteratorByState li;
         li = new LocusIteratorByState(new FakeCloseableIterator<>(reads.iterator()),
-                downsampler, true, keepReads,
-                bamBuilder.getSamples(), bamBuilder.getHeader());
+                downsampler, keepReads, bamBuilder.getSamples(), bamBuilder.getHeader(), true
+        );
 
         final Set<GATKRead> seenSoFar = new LinkedHashSet<>();
         final Set<GATKRead> keptReads = new LinkedHashSet<>();
@@ -665,8 +665,8 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
 
         final LocusIteratorByState li;
         li = new LocusIteratorByState(iterator,
-                downsampler, true, false,
-                samples, header);
+                downsampler, false, samples, header, true
+        );
 
         while ( li.hasNext() ) {
             final AlignmentContext next = li.next();
@@ -760,9 +760,8 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         li = new LocusIteratorByState(
                 new FakeCloseableIterator<>(Collections.singletonList(read).iterator()),
                 DownsamplingMethod.NONE,
-                true,
-                false,
-                sampleListForSAMWithoutReadGroups(), header);
+                false, sampleListForSAMWithoutReadGroups(), header, true
+        );
 
         int expectedPos = read.getStart() + nClipsOnLeft;
         int nPileups = 0;


### PR DESCRIPTION
As described in #2034, samtools mpileup and the internal pileup generated by `LocusIteratorByState` (LIBS) is not providing the same result because overlapping read-pairs are not taken into account. In this PR I addressed this issue using the same approach as samtools to combine qualities, including new functionality to LIBS and `LocusWalker`:

* Refactoring constructors for LIBS, solving #1879.
* Including an option for ignore overlapping read-pairs in LIBS
* Including command line option in `LocusWalker`to ignore overlapping read-pairs and to downsample with a maximum coverage by sample.