### PR TITLE
remove unused code from CountSet

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/CountSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/CountSet.java
@@ -1,18 +1,12 @@
 package org.broadinstitute.hellbender.utils.collections;
 
-import org.broadinstitute.hellbender.utils.Utils;
-
-import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
 
 /**
- * Efficient implementation for a small set of integer primitive values.
+ * Implementation of a small set of integer primitive values.
  * <p>
- * It includes a increment operation incAll which is convenient when analyzing the read-threading graphs. Nevertheless
- * it can be also be used in general purpose.
- * </p>
- * <p>
- * It does not provide a O(1) look-up of its elements though. These are kept in a sorted array so look up is implemented
+ * It does not provide a O(1) look-up of its elements. Elements are kept in a sorted array so look up is implemented
  * using a binary search O(log n). Therefore it might not be optimal for problems that require large integer sets.
  * </p>
  * <p>
@@ -20,7 +14,7 @@ import java.util.*;
  * </p>
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class CountSet implements Set<Integer> {
+public final class CountSet {
 
     /**
      * The size of the set.
@@ -39,48 +33,10 @@ public final class CountSet implements Set<Integer> {
      */
     public CountSet(final int initialCapacity) {
         if (initialCapacity < 0) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("initialCapacity must be non-negative but was " + initialCapacity);
         }
         elements = new int[initialCapacity];
         size = 0;
-    }
-
-    /**
-     * Set the set contents to a single integer value.
-     * @param value the integer value to set the set to.
-     */
-    public void setTo(final int value) {
-        ensureCapacity(1);
-        size = 1;
-        elements[0] = value;
-    }
-
-    /**
-     * Set the content of this set to a collection of integers.
-     * @param values the new values to be included in the set.
-     * @throws NullPointerException if <code>value</code> is <code>null</code>.
-     */
-    public void setTo(final int ... values) {
-        ensureCapacity(values.length);
-        size = values.length;
-        System.arraycopy(values, 0, elements, 0, size);
-        Arrays.sort(elements, 0, size);
-    }
-
-    /**
-     * Increase (or decrease) all elements in the set by a number.
-     * @param delta the number of add (or substract if negative) to all elements.
-     *
-     * @return <code>true</code> if the set changed as a result of this invocation, <code>false</code> otherwise.
-     */
-    public boolean incAll(final int delta) {
-        if (size == 0 || delta == 0) {
-            return false;
-        }
-        for (int i = 0; i < size; i++) {
-            elements[i] += delta;
-        }
-        return true;
     }
 
     /**
@@ -110,34 +66,6 @@ public final class CountSet implements Set<Integer> {
     }
 
     /**
-     * Adds a range of integer values to the collection.
-     *
-     * This method avoid the need to explicity indicate all values in that range. Notice that the range is fully inclusive.
-     * You can indicate a decrease range (fromValue > toValue).
-     *
-     * @param fromValue the first value to add in the set (inclusive).
-     * @param toValue the last value to add to the set (inclusive).
-     * @return <code>true</code> if the set changed as a result of this invocation, <code>false</code> otherwise.
-     */
-    public boolean addRange(final int fromValue, final int toValue) {
-        final int lowEnd;
-        final int highEnd;
-
-        if (fromValue <= toValue) {
-            lowEnd = fromValue; highEnd = toValue;
-        } else {
-            highEnd = fromValue; lowEnd = toValue;
-        }
-
-        //TODO to be optimized to add missing sub-ranges in one go:
-        boolean result = false;
-        for (int i = lowEnd; i <= highEnd; i++) {
-            result = add(i) || result;
-        }
-        return result;
-    }
-
-    /**
      * Add an integer value to the set.
      * @param value to add to the set.
      * @return <code>true</code> if the set changed as a result of this invocation, <code>false</code> otherwise.
@@ -154,74 +82,6 @@ public final class CountSet implements Set<Integer> {
     }
 
     /**
-     * Add a arbitrary number of integers to the set.
-     *
-     * @param values integer to add to the set.
-     * @return <code>true</code> if the set changed as a result of this invocation, <code>false</code> otherwise.
-     */
-    public boolean addAll(final int ... values) {
-        ensureCapacity(size + values.length);
-        boolean result = false;
-        for (final int v : values) {
-            result = add(v) || result;
-        }
-        return result;
-    }
-
-    @Override
-    public boolean addAll(final Collection<? extends Integer> numbers) {
-        ensureCapacity(size + numbers.size());
-        boolean result = false;
-        for (final Number n : numbers) {
-            result = add(n.intValue()) || result;
-        }
-        return result;
-    }
-
-    /**
-     * Add all values within a range in an integer array.
-     *
-     * @param source array where the values to add are found.
-     * @param fromIndex first position from <code>source</code> to add (inclusive).
-     * @param toIndex index after the last position in <code>source</code> to add (thus exclusive).
-     * @throws NullPointerException if <code>source</code> is <code>null</code>.
-     * @throws NegativeArraySizeException if <code>fromIndex</code> or <code>toIndex</code> are negative.
-     * @throws ArrayIndexOutOfBoundsException if <code>fromIndex</code> or <code>toIndex</code> are beyond bounds
-     *    allowed <code>[0 .. source.length]</code>.
-     * @return <code>true</code> if the set changed as a result of this invocation, <code>false</code> otherwise.
-     */
-    public boolean addAll(final int[] source, final int fromIndex, final int toIndex) {
-        ensureCapacity(size + source.length);
-        boolean result = false;
-        for (int i = fromIndex; i < toIndex; i++) {
-            result = add(source[i]) || result;
-        }
-        return result;
-    }
-
-
-    /**
-     * Add all elements present in a int-set.
-     *
-     * @param other the other inset.
-     *
-     * @throws NullPointerException if <code>other</code> is <code>null</code>.
-     * @return <code>true</code> if this set changed due to this operation, <code>false</code> otherwise.
-     */
-    public boolean addAll(final CountSet other) {
-        return addAll(other.elements,0,other.size);
-    }
-
-    /**
-     * Checks whether a integer value is included in the set.
-     * @param value the value to check.
-     * @return <code>true</code> if <code>value</code> is inside the set, <code>false</code> otherwise.
-     */
-    public boolean contains(final int value) {
-        return Arrays.binarySearch(elements, 0, size, value) >= 0;
-    }
-
-    /**
      * Make sure that this int-set has capacity to handle a number of elements.
      * <p/>
      * If the set has already that or greater capacity nothing would be changed.
@@ -234,189 +94,12 @@ public final class CountSet implements Set<Integer> {
         elements = Arrays.copyOf(elements, newLength);
     }
 
-    @Override
     public int size() {
         return size;
     }
 
-    @Override
     public boolean isEmpty() {
         return size() == 0;
-    }
-
-    @Override
-    public boolean contains(final Object o) {
-        if (o instanceof Integer) {
-            final int i = (Integer)o;
-            return contains(i);
-        } else {
-            return false;  //To change body of implemented methods use File | Settings | File Templates.
-        }
-    }
-
-
-    @Override
-    public Iterator<Integer> iterator() {
-        return new MyIterator();
-    }
-
-    @Override
-    public Object[] toArray() {
-        final Integer[] result = new Integer[size];
-        for (int i = 0; i < size; i++)
-            result[i] = elements[i];
-        return result;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T[] toArray(final T[] a) {
-        Utils.nonNull(a);
-
-        @SuppressWarnings("unchecked")
-        final Class<T> componentClass = (Class) a.getClass().getComponentType();
-        if (!componentClass.isAssignableFrom(Integer.class))
-            throw new ArrayStoreException();
-
-        @SuppressWarnings("unchecked")
-        final T[] dest = (a.length < size) ? (T[]) Array.newInstance(componentClass, size) : a;
-
-        for (int i = 0; i < size; i++) {
-            dest[i] = (T) (Integer) elements[i];
-        }
-        return dest;
-    }
-
-    /**
-     * Copies the content of the set into an integer array. The result can be freely modified by the invoker.
-     * @return never <code>null</code> but a zero-length array if the set is empty.
-     */
-    public int[] toIntArray() {
-        return Arrays.copyOfRange(elements, 0, size);
-    }
-
-    /**
-     * Copy the content of the set into an array.
-     * @param dest the destination array.
-     * @param offset where to store the first element of the set.
-     * @throws NullPointerException if <code>dest</code> is <code>null</code>.
-     * @throws ArrayIndexOutOfBoundsException if <code>offset</code> is out of range of there is not enough
-     * space after <code>offset</code> in the destination array to hold all values in the set.
-     */
-    public void copyTo(final int[] dest, final int offset) {
-        Utils.nonNull(dest);
-        if (dest.length < (size + offset)) {
-            throw new ArrayIndexOutOfBoundsException("destination is to short");
-        }
-        System.arraycopy(elements, 0, dest, offset, size);
-    }
-
-    /**
-     * Copy the content of the set into an array.
-     * @param dest the destination array.
-     * @throws NullPointerException if <code>dest</code> is <code>null</code>.
-     * @throws ArrayIndexOutOfBoundsException if there is not enough
-     * space after <code>offset</code> in the destination array to hold all values in the set.
-     */
-    public void copyTo(final int[] dest) {
-        copyTo(dest,0);
-    }
-
-    @Override
-    public boolean add(final Integer integer) {
-        return add((int) integer);
-    }
-
-    @Override
-    public boolean remove(final Object o) {
-        return o instanceof Integer && remove((int)o);
-    }
-
-    /**
-     * Removes a single integer value for the set.
-     * @param i the value to remove.
-     * @return <code>true</code> if the set has changed as a result of this invocation, <code>false</code> otherwise.
-     */
-    public boolean remove(final int i) {
-        final int pos = Arrays.binarySearch(elements, 0, size, i);
-        if (pos < 0)
-            return false;
-        else {
-            removeIndex(pos);
-            return true;
-        }
-    }
-
-    @Override
-    public boolean containsAll(final Collection<?> c) {
-        for (final Object o : c) {
-            if (!contains(o)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-
-    @Override
-    public boolean retainAll(final Collection<?> c) {
-        if (size == 0) {
-            return false;
-        }
-        final CountSet retainIndices = new CountSet(c.size() + 2);
-        retainIndices.add(-1);
-        retainIndices.add(size);
-        for (final Object o : c) {
-            if (!(o instanceof Integer)) {
-                continue;
-            }
-            final int pos = Arrays.binarySearch(elements, 0, size, (int) o);
-            if (pos < 0) {
-                continue;
-            }
-            retainIndices.add(pos);
-        }
-        if (retainIndices.size == 2) {
-            size = 0;
-            return true;
-        } else if (retainIndices.size == size + 2) {
-            return false;
-        } else {
-            for (int idx = retainIndices.size - 1; idx > 0; idx--) {
-                final int toIdx = retainIndices.elements[idx];
-                final int fromIdx = retainIndices.elements[idx - 1] + 1;
-                removeIndices(toIdx,fromIdx);
-            }
-            return true;
-        }
-    }
-
-    /**
-     * Removes the values found in a range of indexes in {@link #elements}.
-     * @param fromIdx first index to remove (inclusive).
-     * @param toIdx right after last index to remove (exclusive).
-     */
-    private void removeIndices(final int fromIdx, final int toIdx) {
-       System.arraycopy(elements, toIdx, elements, fromIdx, size - toIdx);
-       size -= toIdx - fromIdx;
-    }
-
-    @Override
-    public boolean removeAll(final Collection<?> c) {
-        boolean result = false;
-        for (final Object o : c) {
-            result = remove(o) || result;
-        }
-        return result;
-    }
-
-    private void removeIndex(final int idx) {
-        System.arraycopy(elements, idx + 1, elements, idx, size - idx - 1);
-    }
-
-    @Override
-    public void clear() {
-        size = 0;
     }
 
     @Override
@@ -429,37 +112,4 @@ public final class CountSet implements Set<Integer> {
         sb.replace(sb.length()-1,sb.length(),"}");
         return sb.toString();
     }
-
-    /**
-     * Custom iterator class for {@link CountSet IntSets}
-     */
-    private class MyIterator implements Iterator<Integer> {
-        /** What position I am in. */
-        private final int next = 0;
-
-        @Override
-        public boolean hasNext() {
-            return next < size;
-        }
-
-        @Override
-        public Integer next() {
-            if (next >= size)
-                throw new NoSuchElementException();
-            return elements[next];
-        }
-
-        @Override
-        public void remove() {
-            if (next == 0) {
-                throw new IllegalStateException();
-            }
-            if (next >= size) {
-                throw new NoSuchElementException();
-            }
-            removeIndex(next - 1);
-        }
-    }
-
-
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/collections/CountSetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/collections/CountSetUnitTest.java
@@ -2,97 +2,64 @@ package org.broadinstitute.hellbender.utils.collections;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Random;
 
 /**
  * Unit tests for {@link CountSet}
  */
 public final class CountSetUnitTest extends BaseTest {
 
-    @Test(dataProvider="capacities")
-    public void testSize(final int capacity) {
-        final CountSet empty = new CountSet(capacity);
-        Assert.assertEquals(empty.size(), 0);
-        CountSet nonEmpty = new CountSet(capacity);
-        for (int i = 0; i < capacity * 3; i++) {
-            nonEmpty.add(i);
-            Assert.assertEquals(nonEmpty.size(), i + 1);
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testMinNoElement() throws Exception {
+        new CountSet(1).min();
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testMaxNoElement() throws Exception {
+        new CountSet(1).max();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidCtorArg() throws Exception {
+        new CountSet(-1);
+    }
+
+    @Test
+    public void testSize() {
+        final int capacityLow = 0;
+        final int capacityHigh = 10;
+        for (int capacity = capacityLow; capacity < capacityHigh; capacity++) {
+            final CountSet empty = new CountSet(capacity);
+            Assert.assertEquals(empty.size(), 0);
+            Assert.assertTrue(empty.isEmpty());
+            CountSet nonEmpty = new CountSet(capacity);
+            for (int i = 0; i < capacity * 3; i++) {
+                nonEmpty.add(i);
+                Assert.assertEquals(nonEmpty.size(), i + 1);
+                Assert.assertFalse(nonEmpty.isEmpty());
+            }
         }
     }
 
     @Test
-    public void testSingleValueAdd() {
-        final int CAPACITY = 10;
-        final CountSet subject = new CountSet(CAPACITY);
-        final Set<Integer> reasuranceSet = new LinkedHashSet<>(CAPACITY);
-        final int REPEATS = 1000;
-        final Random rnd = new Random(13);
-        for (int i = 0; i < REPEATS; i++) {
-            int newInt = rnd.nextInt(500);
-            boolean expectedResult = reasuranceSet.add(newInt);
-            boolean result = subject.add(newInt);
-            Assert.assertEquals(result, expectedResult);
-            Assert.assertEquals(subject.size(), reasuranceSet.size());
+    public void testToString() {
+        final int capacityLow = 0;
+        final int capacityHigh = 10;
+        for (int capacity = capacityLow; capacity < capacityHigh; capacity++) {
+            CountSet set = new CountSet(capacity);
+            Assert.assertNotNull(set.toString());
+            for (int i = 0; i < capacity * 3; i++) {
+                set.add(i);
+                Assert.assertEquals(set.size(), i + 1);
+            }
+            Assert.assertNotNull(set.toString());
         }
-        for (final int j : reasuranceSet)
-            Assert.assertTrue(subject.contains(j));
-        for (int j = 0; j < 501; j++)
-            Assert.assertEquals(subject.contains(j), reasuranceSet.contains(j));
     }
 
-    @Test
-    public void testToIntArray() {
-        final CountSet subject = new CountSet(10);
-        subject.addAll(1,4,7);
-        final int[] intArray = subject.toIntArray();
-        Assert.assertEquals(intArray.length, 3);
-        Assert.assertEquals(intArray[0], 1);
-        Assert.assertEquals(intArray[1], 4);
-        Assert.assertEquals(intArray[2], 7);
-    }
-
-    @Test
-    public void testCopyTo() {
-        final CountSet subject = new CountSet(10);
-        subject.addAll(1,4,7);
-        final int[] intArray = new int[3];
-        subject.copyTo(intArray);
-        Assert.assertEquals(intArray[0], 1);
-        Assert.assertEquals(intArray[1], 4);
-        Assert.assertEquals(intArray[2], 7);
-    }
-
-    @Test
-    public void testSetToSingleValue() {
-        final CountSet subject = new CountSet(10);
-        subject.setTo(-31);
-        Assert.assertEquals(subject.size(), 1);
-        Assert.assertEquals(subject.min(), -31);
-        Assert.assertEquals(subject.max(), -31);
-        Assert.assertTrue(subject.contains(-31));
-        Assert.assertFalse(subject.contains(-21));
-    }
-
-    @Test
-    void testSetToArrayOfValues() {
-        final int CAPACITY = 10;
-        final CountSet subject = new CountSet(CAPACITY);
-        final int REPEATS = 1000;
-        final Random rnd = new Random(13);
-        final int[] values = new int[REPEATS];
-        for (int i = 0; i < REPEATS; i++) {
-            int newInt = rnd.nextInt(Integer.MAX_VALUE) * (rnd.nextBoolean() ? -1 : 1);
-            values[i] = newInt;
-        }
-        subject.setTo(values);
-        Arrays.sort(values);
-        Assert.assertEquals(subject.size(), REPEATS);
-        Assert.assertEquals(subject.min(), values[0]);
-        Assert.assertEquals(subject.max(), values[REPEATS - 1]);
-    }
 
     @Test
     public void testMinMax() {
@@ -105,98 +72,11 @@ public final class CountSetUnitTest extends BaseTest {
             int newInt = rnd.nextInt(Integer.MAX_VALUE) * (rnd.nextBoolean() ? -1 : 1);
             values[i] = newInt;
         }
-        subject.addAll(values);
+        for (int i = 0; i < values.length; i++) {
+            subject.add(values[i]);
+        }
         Arrays.sort(values);
         Assert.assertEquals(subject.min(), values[0]);
         Assert.assertEquals(subject.max(), values[REPEATS - 1]);
-    }
-
-    @Test
-    public void testIncrease() {
-        final int CAPACITY = 10;
-        final CountSet subject = new CountSet(CAPACITY);
-        final Set<Integer> reasuranceSet = new LinkedHashSet<>(CAPACITY);
-        final int REPEATS = 1000;
-        final Random rnd = new Random(13);
-        final int[] values = new int[REPEATS];
-        final Integer[] valueWrappers = new Integer[REPEATS];
-        for (int i = 0; i < REPEATS; i++) {
-            int newInt = rnd.nextInt(500);
-            values[i] = newInt;
-            valueWrappers[i] = newInt;
-        }
-
-        subject.incAll(3);
-
-        for (final int j : reasuranceSet)
-            Assert.assertTrue(subject.contains(j + 3));
-        for (int j = 0; j < 501; j++)
-            Assert.assertEquals(subject.contains(j + 3), reasuranceSet.contains(j));
-
-    }
-
-    @Test
-    public void testArrayValueAdd() {
-        final int CAPACITY = 10;
-        final CountSet subject = new CountSet(CAPACITY);
-        final Set<Integer> reasuranceSet = new LinkedHashSet<>(CAPACITY);
-        final int REPEATS = 1000;
-        final Random rnd = new Random(13);
-        final int[] values = new int[REPEATS];
-        final Integer[] valueWrappers = new Integer[REPEATS];
-        for (int i = 0; i < REPEATS; i++) {
-            int newInt = rnd.nextInt(500);
-            values[i] = newInt;
-            valueWrappers[i] = newInt;
-        }
-
-        boolean expectedResult = reasuranceSet.addAll(Arrays.asList(valueWrappers));
-        boolean result = subject.addAll(values);
-        Assert.assertEquals(result, expectedResult);
-        Assert.assertEquals(subject.size(), reasuranceSet.size());
-
-        for (final int j : reasuranceSet)
-            Assert.assertTrue(subject.contains(j));
-        for (int j = 0; j < 501; j++)
-            Assert.assertEquals(subject.contains(j), reasuranceSet.contains(j));
-
-    }
-
-    @Test
-    public void testAddRange() {
-        final CountSet subject = new CountSet(10);
-        subject.addRange(10,21);
-        Assert.assertEquals(subject.size(), 12);
-        for (int i = 10; i < 22; i++)
-            Assert.assertTrue(subject.contains(i));
-        for (int i = -1; i < 10; i++)
-            Assert.assertFalse(subject.contains(i));
-        for (int i = 22; i < 31; i++)
-            Assert.assertFalse(subject.contains(i));
-    }
-
-    @DataProvider(name="capacities")
-    public Iterator<Object[]> capacities() {
-        final int MIN = 0;
-        final int MAX = 255;
-        return new Iterator<Object[]>() {
-                private int current = MIN;
-
-
-            @Override
-            public boolean hasNext() {
-                return current < MAX;
-            }
-
-            @Override
-            public Object[] next() {
-                return new Object[] { Integer.valueOf(current++) };
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
     }
 }


### PR DESCRIPTION
CountSet is only used in protected and only the following methods are used:
```
add(int);
isEmpty()
max();
size();
min();
```

so i deleted all the other unused code. 

Whether this whole code could be just deleted and any sorted int set implementation used instead (eg TreeSet<Integer> or any subclass of `IntSortedSet` from fast `it.unimi.dsi.fastutil.ints`) is another question.

@droazen whyt?