### PR TITLE
Metrics code serialization fix for sample collectors.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/metrics/MultiLevelMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/MultiLevelMetrics.java
@@ -2,8 +2,13 @@ package org.broadinstitute.hellbender.metrics;
 
 import htsjdk.samtools.metrics.MetricBase;
 
-public abstract class MultiLevelMetrics extends MetricBase {
-     /** The sample to which these metrics apply.  If null, it means they apply
+import java.io.Serializable;
+
+public abstract class MultiLevelMetrics extends MetricBase implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The sample to which these metrics apply.  If null, it means they apply
      * to all reads in the file. */
     public String SAMPLE;
 

--- a/src/main/java/org/broadinstitute/hellbender/metrics/PerUnitInsertSizeMetricsCollector.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/PerUnitInsertSizeMetricsCollector.java
@@ -151,11 +151,12 @@ public final class PerUnitInsertSizeMetricsCollector
     }
 
     /**
-     * Combine this InsertSizeMetricsCollector with sourceCollector and return a combined InsertSizeMetricsCollector.
-     * @param sourceCollector InsertSizeMetricsCollector to combine in
-     * @return InsertSizeMetricsCollector representing the combination of the source collector with this collector
+     * Combine this PerUnitInsertSizeMetricsCollector with sourceCollector and return a combined
+     * PerUnitInsertSizeMetricsCollector.
+     * @param sourceCollector PerUnitInsertSizeMetricsCollector to combine in
+     * @return PerUnitInsertSizeMetricsCollector representing the combination of the source collector with this collector
      */
-    public PerUnitInsertSizeMetricsCollector combine(PerUnitInsertSizeMetricsCollector sourceCollector) {
+    public PerUnitInsertSizeMetricsCollector combine(final PerUnitInsertSizeMetricsCollector sourceCollector) {
         Utils.nonNull(sourceCollector);
         final String validationMessage = "Internal error combining collectors";
         validateEquals(this.sample, sourceCollector.sample, validationMessage);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/AlignmentSummaryMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/AlignmentSummaryMetrics.java
@@ -2,12 +2,17 @@ package org.broadinstitute.hellbender.tools.picard.analysis;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * High level metrics about the alignment of reads within a SAM file, produced by
  * the CollectAlignmentSummaryMetrics program and usually stored in a file with
  * the extension ".alignment_summary_metrics".
  */
-public final class AlignmentSummaryMetrics extends MultiLevelMetrics {
+public final class AlignmentSummaryMetrics extends MultiLevelMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     public enum Category { UNPAIRED, FIRST_OF_PAIR, SECOND_OF_PAIR, PAIR }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/HsMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/HsMetrics.java
@@ -2,12 +2,17 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * The set of metrics captured that are specific to a hybrid selection analysis.
  *
  * @author Tim Fennell
  */
-public final class HsMetrics extends MultiLevelMetrics {
+public final class HsMetrics extends MultiLevelMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     /** The name of the bait set used in the hybrid selection. */
     public String BAIT_SET;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RnaSeqMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RnaSeqMetrics.java
@@ -2,11 +2,16 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * Metrics about the alignment of RNA-seq reads within a SAM file to genes, produced by the CollectRnaSeqMetrics
  * program and usually stored in a file with the extension ".rna_metrics".
  */
-public final class RnaSeqMetrics extends MultiLevelMetrics {
+public final class RnaSeqMetrics extends MultiLevelMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     /** The total number of PF bases including non-aligned reads. */
     public long PF_BASES;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RrbsCpgDetailMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RrbsCpgDetailMetrics.java
@@ -2,11 +2,16 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * Holds information about CpG sites encountered for RRBS processing QC
  * @author jgentry
  */
-public final class RrbsCpgDetailMetrics extends MultiLevelMetrics {
+public final class RrbsCpgDetailMetrics extends MultiLevelMetrics implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
 	/** Sequence the CpG is seen in */
 	public String SEQUENCE_NAME;
 	/** Position within the sequence of the CpG site */

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RrbsSummaryMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/RrbsSummaryMetrics.java
@@ -2,12 +2,17 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * Holds summary statistics from RRBS processing QC
  *
  * @author jgentry
  */
-public final class RrbsSummaryMetrics extends MultiLevelMetrics {
+public final class RrbsSummaryMetrics extends MultiLevelMetrics implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
 	/** Number of mapped reads processed */
 	public Integer READS_ALIGNED;
 	/** Number of times a non-CpG cytosine was encountered */

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetMetrics.java
@@ -2,11 +2,16 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /**
  * For a sequencing run targeting specific regions of the genome this metric class holds metrics describing
  * how well those regions were targeted.
  */
-public final class TargetMetrics extends MultiLevelMetrics {
+public final class TargetMetrics extends MultiLevelMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     /**  The name of the PROBE_SET (BAIT SET, AMPLICON SET, ...) used in this metrics collection run */
     public String PROBE_SET;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetedPcrMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetedPcrMetrics.java
@@ -2,8 +2,12 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
 
+import java.io.Serializable;
+
 /** Metrics class for targeted pcr runs such as TSCA runs */
-public final class TargetedPcrMetrics extends MultiLevelMetrics {
+public final class TargetedPcrMetrics extends MultiLevelMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /**  The name of the amplicon set used in this metrics collection run */
     public String CUSTOM_AMPLICON_SET;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSpark.java
@@ -27,22 +27,21 @@ public final class CollectInsertSizeMetricsSpark
     private static final long serialVersionUID = 1L;
 
     @ArgumentCollection
-    InsertSizeMetricsArgumentCollection insertSizeArgs = new InsertSizeMetricsArgumentCollection();
+    private InsertSizeMetricsArgumentCollection insertSizeArgs = new InsertSizeMetricsArgumentCollection();
 
-    InsertSizeMetricsCollectorSpark insertSizeCollector = null;
+    private InsertSizeMetricsCollectorSpark insertSizeCollector = new InsertSizeMetricsCollectorSpark();
 
     public InsertSizeMetricsArgumentCollection getInputArguments() {
         return insertSizeArgs;
     }
 
-    public SortOrder getExpectedSortOrder() { return SortOrder.unsorted; }
+    protected SortOrder getExpectedSortOrder() { return insertSizeCollector.getExpectedSortOrder(); }
 
-    public void initialize(
+    protected void initialize(
             final InsertSizeMetricsArgumentCollection inputArgs,
             final SAMFileHeader samHeader,
             final List<Header> defaultHeaders)
     {
-        insertSizeCollector = new InsertSizeMetricsCollectorSpark();
         insertSizeCollector.initialize(inputArgs, samHeader, defaultHeaders);
     }
 
@@ -50,12 +49,12 @@ public final class CollectInsertSizeMetricsSpark
      * Return the read filter required for this collector
      */
     @Override
-    public ReadFilter getReadFilter(final SAMFileHeader samHeader) {
+    protected ReadFilter getReadFilter(final SAMFileHeader samHeader) {
         return insertSizeCollector.getReadFilter(samHeader);
     }
 
     @Override
-    public void collectMetrics(
+    protected void collectMetrics(
             final JavaRDD<GATKRead> filteredReads,
             final SAMFileHeader samHeader)
     {
@@ -63,7 +62,7 @@ public final class CollectInsertSizeMetricsSpark
     }
 
     @Override
-    public void finish(final String inputName, final AuthHolder authHolder) {
+    protected void finish(final String inputName, final AuthHolder authHolder) {
         insertSizeCollector.saveMetrics(inputName, authHolder);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSpark.java
@@ -34,20 +34,20 @@ public final class CollectQualityYieldMetricsSpark extends MetricsCollectorSpark
     private QualityYieldMetricsCollectorSpark qualityYieldCollector = new QualityYieldMetricsCollectorSpark();
 
     @Override
-    public SortOrder getExpectedSortOrder() { return qualityYieldCollector.getExpectedSortOrder(); }
+    protected SortOrder getExpectedSortOrder() { return qualityYieldCollector.getExpectedSortOrder(); }
 
     @Override
-    public QualityYieldMetricsArgumentCollection getInputArguments() {
+    protected QualityYieldMetricsArgumentCollection getInputArguments() {
         return qualityYieldArgs;
     }
 
     @Override
-    public ReadFilter getReadFilter(SAMFileHeader samHeader) {
+    protected ReadFilter getReadFilter(SAMFileHeader samHeader) {
         return ReadFilterLibrary.ALLOW_ALL_READS;
     }
 
     @Override
-    public void initialize(
+    protected void initialize(
             final QualityYieldMetricsArgumentCollection inputArgs,
             final SAMFileHeader samHeader,
             final List<Header> defaultHeaders) {
@@ -55,7 +55,7 @@ public final class CollectQualityYieldMetricsSpark extends MetricsCollectorSpark
     }
 
     @Override
-    public void collectMetrics(
+    protected void collectMetrics(
             final JavaRDD<GATKRead> filteredReads,
             final SAMFileHeader samHeader)
     {
@@ -63,7 +63,7 @@ public final class CollectQualityYieldMetricsSpark extends MetricsCollectorSpark
     }
 
     @Override
-    public void finish(final String inputName, final AuthHolder authHolder) {
+    protected void finish(final String inputName, final AuthHolder authHolder) {
         qualityYieldCollector.saveMetrics(inputName, authHolder);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSpark.java
@@ -29,8 +29,8 @@ public class InsertSizeMetricsCollectorSpark
     private InsertSizeMetricsArgumentCollection inputArgs = null;
     private InsertSizeMetricsCollector collector = null;
 
-    InsertSizeMetricsCollector resultMetrics = null;
-    MetricsFile<InsertSizeMetrics, Integer> metricsFile = null;
+    private InsertSizeMetricsCollector resultMetrics = null;
+    private MetricsFile<InsertSizeMetrics, Integer> metricsFile = null;
 
     /**
      * Initialize the collector with input arguments;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSparkTool.java
@@ -33,19 +33,19 @@ public abstract class MetricsCollectorSparkTool<T extends MetricsArgumentCollect
 
     /**
      * The following {@link MetricsCollectorSpark} methods must be implemented by subclasses
-     * and should be forwarded to embedded collector.
+     * and should be forwarded to the embedded collector.
      */
-    abstract public ReadFilter getReadFilter(SAMFileHeader samHeader);
-    abstract SortOrder getExpectedSortOrder();
-    abstract void initialize(T inputArgs, SAMFileHeader samHeader, List<Header> defaultHeaders);
-    abstract void collectMetrics(JavaRDD<GATKRead> filteredReads, SAMFileHeader samHeader);
-    abstract void finish(String inputBaseName, AuthHolder authHolder);
+    abstract protected ReadFilter getReadFilter(SAMFileHeader samHeader);
+    abstract protected SortOrder getExpectedSortOrder();
+    abstract protected void initialize(T inputArgs, SAMFileHeader samHeader, List<Header> defaultHeaders);
+    abstract protected void collectMetrics(JavaRDD<GATKRead> filteredReads, SAMFileHeader samHeader);
+    abstract protected void finish(String inputBaseName, AuthHolder authHolder);
 
     /**
      * To be implemented by subclasses; return the fully initialized and populated
      * argument collection that will be passed to the collector
      */
-    abstract T getInputArguments();
+    abstract protected T getInputArguments();
 
     @Override
     public final boolean requiresReads(){ return true; }

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MultiLevelCollectorTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MultiLevelCollectorTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.*;
 
 import static htsjdk.samtools.util.CollectionUtil.makeSet;
@@ -43,7 +44,9 @@ public final class MultiLevelCollectorTest {
     /** We will just Tally up the number of times records were added to this metric and change FINISHED
      * to true when FINISHED is called
      */
-    class TotalNumberMetric extends MultiLevelMetrics {
+    class TotalNumberMetric extends MultiLevelMetrics implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         /** The number of these encountered **/
         public Integer TALLY = 0;
         public boolean FINISHED = false;

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MultiLevelReducibleCollectorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MultiLevelReducibleCollectorUnitTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.*;
 
 import static htsjdk.samtools.util.CollectionUtil.makeSet;
@@ -43,7 +44,9 @@ public final class MultiLevelReducibleCollectorUnitTest {
     /** We will just Tally up the number of times records were added to this metric and change FINISHED
      * to true when FINISHED is called
      */
-    static final class TotalNumberMetric extends MultiLevelMetrics {
+    static final class TotalNumberMetric extends MultiLevelMetrics implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         /** The number of these encountered **/
         public Integer TALLY = 0;
         public boolean FINISHED = false;


### PR DESCRIPTION
This mostly consists of added "implements Serializable" to MultilLevelMetrics and it's subclasses, which wasn't needed for the existing metrics collectors but affected the Example collectors I'm adding. Also contains some miscellaneous reductions of method/field scope that were unnecessarily broad.