### PR TITLE
DataSource for reads check for misencoded qualities and -fixMisencodedQuals option (including Spark)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -52,6 +52,10 @@ public abstract class GATKTool extends CommandLineProgram {
     @Argument(fullName="addOutputSAMProgramRecord", shortName="addOutputSAMProgramRecord", doc = "If true, adds a PG tag to created SAM/BAM/CRAM files.", optional=true)
     public boolean addOutputSAMProgramRecord = true;
 
+    @Argument(fullName = "fix_misencoded_quality_scores", shortName="fixMisencodedQuals", doc="Fix mis-encoded base quality scores", optional = true)
+    public boolean fixMissencodedQualityScores = false;
+
+
     /*
      * TODO: Feature arguments for the current tool are currently discovered through reflection via FeatureManager.
      * TODO: Perhaps we should eventually do the same auto-discovery for all input arguments (reads, reference, etc.)
@@ -118,6 +122,7 @@ public abstract class GATKTool extends CommandLineProgram {
                 throw new UserException.MissingReference("A reference file is required when using CRAM files.");
             }
             reads = new ReadsDataSource(readArguments.getReadFiles(), factory);
+            reads.setFixMisencodedQuals(fixMissencodedQualityScores);
         }
         else {
             reads = null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -82,6 +82,9 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             shortName = "numReducers", fullName = "numReducers", optional = true)
     protected int numReducers = 0;
 
+    @Argument(fullName = "fix_misencoded_quality_scores", shortName="fixMisencodedQuals", doc="Fix mis-encoded base quality scores", optional = true)
+    public boolean fixMissencodedQualityScores = false;
+
     private ReadsSparkSource readsSource;
     private SAMFileHeader readsHeader;
     private String readInput;

--- a/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformer.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.transformers;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Checks for and errors out (or fixes if requested) when it detects reads with base qualities that are not encoded with
@@ -13,8 +16,39 @@ public final class MisencodedBaseQualityReadTransformer implements ReadTransform
 
     private static final int ILLUMINA_ENCODING_FIX_VALUE = 31;  // Illumina_64 - PHRED_33
 
+    private final boolean fixQuals;
+
+    protected static final int samplingFrequency = 1000; // sample 1 read for every 1000 encountered
+    // atomic integer in case of concurrent usage of this transformer
+    protected static AtomicInteger currentReadCounter = new AtomicInteger(0);
+
+    /**
+     * Constructor for allow only checking of misencoded qualities
+     *
+     * @param fixQuals if {@code false} it will just check the qualities; otherwise, it will fix them
+     */
+    public MisencodedBaseQualityReadTransformer(final boolean fixQuals) {
+        this.fixQuals = fixQuals;
+    }
+
+    /**
+     * Constructor for fixing misencoded qualities
+     */
+    public MisencodedBaseQualityReadTransformer() {
+        this(true);
+    }
+
     @Override
     public GATKRead apply(final GATKRead read) {
+        if(fixQuals) {
+            fixMisencodedQuals(read);
+        } else {
+            checkForMisencodedQuals(read);
+        }
+        return read;
+    }
+
+    private void fixMisencodedQuals(final GATKRead read) {
         final byte[] quals = read.getBaseQualities();
         for ( int i = 0; i < quals.length; i++ ) {
             quals[i] -= ILLUMINA_ENCODING_FIX_VALUE;
@@ -22,6 +56,18 @@ public final class MisencodedBaseQualityReadTransformer implements ReadTransform
                 throw new UserException.BadInput("while fixing mis-encoded base qualities we encountered a read that was correctly encoded; we cannot handle such a mixture of reads so unfortunately the BAM must be fixed with some other tool");
         }
         read.setBaseQualities(quals);
-        return read;
     }
+
+    private void checkForMisencodedQuals(final GATKRead read) {
+        // sample reads randomly for checking
+        if ( currentReadCounter.incrementAndGet() >= samplingFrequency ) {
+            currentReadCounter.set(0);
+            final byte[] quals = read.getBaseQualities();
+            for ( final byte qual : quals ) {
+                if ( qual > QualityUtils.MAX_REASONABLE_Q_SCORE )
+                    throw new UserException.MisencodedQualityScoresRead(read, "we encountered an extremely high quality score of " + (int) qual);
+            }
+        }
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/MisencodedBaseQualityReadTransformerUnitTest.java
@@ -55,4 +55,32 @@ public final class MisencodedBaseQualityReadTransformerUnitTest extends BaseTest
         final GATKRead read = createRead(fixedQuals);
         tr.apply(read);
     }
+
+    @Test
+    public void testCheckGoodQualities() {
+        final byte[] fixedQuals = { 28, 29, 31, 32, 33, 30, 31, 27, 26, 60 };
+        final ReadTransformer tr = new MisencodedBaseQualityReadTransformer(false);
+        GATKRead read = createRead(fixedQuals);
+        GATKRead newRead = tr.apply(read);
+        Assert.assertEquals(read, newRead);
+    }
+
+    @Test(expectedExceptions = UserException.MisencodedQualityScoresRead.class)
+    public void testCheckBadQualitiesBlowUp() {
+        final byte[] badQuals = { 59, 60, 62, 63, 64, 61, 62, 58, 57, 56 };
+        final MisencodedBaseQualityReadTransformer tr = new MisencodedBaseQualityReadTransformer(false);
+        // set to the sampling frequency and now it should blow up
+        tr.currentReadCounter.set(tr.samplingFrequency);
+        GATKRead read = createRead(badQuals);
+        tr.apply(read);
+    }
+
+    @Test
+    public void testCheckBadQualitiesWhenNoSampling() {
+        final byte[] badQuals = { 59, 60, 62, 63, 64, 61, 62, 58, 57, 56 };
+        final MisencodedBaseQualityReadTransformer tr = new MisencodedBaseQualityReadTransformer(false);
+        GATKRead read = createRead(badQuals);
+        Assert.assertEquals(read, tr.apply(read));
+    }
+
 }


### PR DESCRIPTION
In the previous framework reads were checked (each 1000 reads) with the `MisencodedBaseQualityReadTransformer` for high qualities and an option was provided for fixing them.

In this PR I implemented the following:

* `MisencodedBaseQualityReadTransformer` with constructor to don't fix qualities and only check for misencoded ones.
* `ReadsDataSource.iterator()` use this transformer for checking by default, with a setter for fix them on request.
* `ReadsSparkSource.getParallelReads()` and `getADAMReads()` use this transformer for checking by default, with a setter for fix them on request.
* `@Argument` in `GATKTool` and `GATKSparkTool` for fix misencoded qualities and set it in the data sources
