### PR TITLE
GATKTool pre/post ReadTransformers methods + ReadWalker/LocusWalker integration 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -8,11 +8,13 @@ import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
-import org.broadinstitute.hellbender.utils.iterators.ReadFilteringIterator;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -22,6 +24,12 @@ import java.util.stream.StreamSupport;
  * A LocusWalker is a tool that processes reads that overlap a single position in a reference at a time from
  * one or multiple sources of reads, with optional contextual information from a reference and/or sets of
  * variants/Features.
+ *
+ * Reads will be:
+ * - Transformed with {@link #makePreReadFilterTransformer()} before filtering.
+ * - Filtered with {@link #makeReadFilter()} before post-transformers.
+ * - Transformed with {@link #makePostReadFilterTransformer()} before processing.
+ * - Include them into the {@link AlignmentContext} before passing to {@link #apply(AlignmentContext, ReferenceContext, FeatureContext)}.
  *
  * LocusWalker authors must implement the apply() method to process each position, and may optionally implement
  * onTraversalStart(), onTraversalSuccess() and/or closeTool().
@@ -77,7 +85,7 @@ public abstract class LocusWalker extends GATKTool {
     /**
      * Returns the default list of CommandLineReadFilters that are used for this tool. The filters returned
      * by this method are subject to selective enabling/disabling by the user via the command line. The
-     * default implementation uses the {@link WellformedReadFilter} and {@link ReadFilterLibrary.MappedReadFilter}filter
+     * default implementation uses the {@link WellformedReadFilter} and {@link ReadFilterLibrary.MappedReadFilter} filter
      * with all default options. Subclasses can override to provide alternative filters.
      *
      * Note: this method is called before command line parsing begins, and thus before a SAMFileHeader is
@@ -103,6 +111,32 @@ public abstract class LocusWalker extends GATKTool {
     }
 
     /**
+     * Returns the pre-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
+     * The default implementation uses the {@link ReadTransformer#identity()}.
+     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
+     * the transformer object to avoid object allocation.
+     *
+     * Subclasses can extend to provide own transformers (ie override and call super).
+     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
+     */
+    public ReadTransformer makePreReadFilterTransformer() {
+        return ReadTransformer.identity();
+    }
+
+    /**
+     * Returns the post-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
+     * The default implementation uses the {@link ReadTransformer#identity()}.
+     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
+     * the transformer object to avoid object allocation.
+     *
+     * Subclasses can extend to provide own transformers (ie override and call super).
+     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
+     */
+    public ReadTransformer makePostReadFilterTransformer(){
+        return ReadTransformer.identity();
+    }
+
+    /**
      * Marked final so that tool authors don't override it. Tool authors should override onTraversalStart() instead.
      */
     @Override
@@ -117,8 +151,8 @@ public abstract class LocusWalker extends GATKTool {
      * Implementation of locus-based traversal.
      * Subclasses can override to provide their own behavior but default implementation should be suitable for most uses.
      *
-     * The default implementation iterates over all positions in the reference covered by reads for all samples in the read groups, using
-     * the downsampling method provided by {@link #getDownsamplingInfo()}
+     * The default implementation iterates over all positions in the reference covered by reads (filtered and transformed)
+     * for all samples in the read groups, using the downsampling method provided by {@link #getDownsamplingInfo()}
      * and including deletions only if {@link #includeDeletions()} returns {@code true}.
      */
     @Override
@@ -129,10 +163,19 @@ public abstract class LocusWalker extends GATKTool {
                                           .map(SAMReadGroupRecord::getSample)
                                           .collect(Collectors.toSet());
         final CountingReadFilter countedFilter = makeReadFilter();
+        // get the transformers
+        final ReadTransformer preTransformer = makePreReadFilterTransformer();
+        final ReadTransformer postTransformer = makePostReadFilterTransformer();
+        // get the filter and transformed iterator
+        final Iterator<GATKRead> readIterator = Utils.stream(reads)
+                .map(preTransformer)
+                .filter(countedFilter)
+                .map(postTransformer)
+                .iterator();
         // get the LIBS
-        final LocusIteratorByState libs = new LocusIteratorByState(new ReadFilteringIterator(reads.iterator(), countedFilter), getDownsamplingInfo(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs());
+        final LocusIteratorByState libs = new LocusIteratorByState(readIterator, getDownsamplingInfo(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs());
         // prepare the iterator
-        Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
+        final Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
         // iterate over each alignment, and apply the function
         StreamSupport.stream(iterator, false)
             .forEach(alignmentContext -> {

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -85,12 +85,7 @@ public abstract class ReadWalker extends GATKTool {
         // Process each read in the input stream.
         // Supply reference bases spanning each read, if a reference is available.
         final CountingReadFilter countedFilter = makeReadFilter();
-        final ReadTransformer preTransformer = makePreReadFilterTransformer();
-        final ReadTransformer postTransformer = makePostReadFilterTransformer();
-        Utils.stream(reads)
-                .map(preTransformer)
-                .filter(countedFilter)
-                .map(postTransformer)
+        getTransformedReadStream(countedFilter)
                 .forEach(read -> {
                     final SimpleInterval readInterval = getReadInterval(read);
                     apply(read,

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -123,33 +123,6 @@ public abstract class ReadWalker extends GATKTool {
     }
 
     /**
-     * Returns the pre-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
-     * The default implementation uses the {@link ReadTransformer#identity()}.
-     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
-     * the transformer object to avoid object allocation.
-     *
-     * Subclasses can extend to provide own transformers (ie override and call super).
-     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
-     */
-    public ReadTransformer makePreReadFilterTransformer() {
-        return ReadTransformer.identity();
-    }
-
-    /**
-     * Returns the post-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
-     * The default implementation uses the {@link ReadTransformer#identity()}.
-     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
-     * the transformer object to avoid object allocation.
-     *
-     * Subclasses can extend to provide own transformers (ie override and call super).
-     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
-     */
-    public ReadTransformer makePostReadFilterTransformer(){
-        return ReadTransformer.identity();
-    }
-
-
-    /**
      * Process an individual read (with optional contextual information). Must be implemented by tool authors.
      * In general, tool authors should simply stream their output from apply(), and maintain as little internal state
      * as possible.

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -4,6 +4,7 @@ import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -17,6 +18,12 @@ import java.util.List;
  * optional contextual information from a reference and/or sets of variants/Features.
  *
  * If multiple sources of reads are specified, they are merged together into a single sorted stream of reads.
+ *
+ * Reads will be:
+ * - Transformed with {@link #makePreReadFilterTransformer()} before filtering.
+ * - Filtered with {@link #makeReadFilter()} before post-transformers.
+ * - Transformed with {@link #makePostReadFilterTransformer()} before processing.
+ * - Passed to {@link #apply(GATKRead, ReferenceContext, FeatureContext)} for processing.
  *
  * ReadWalker authors must implement the apply() method to process each read, and may optionally implement
  * onTraversalStart() and/or onTraversalSuccess(). See the PrintReadsWithReference walker for an example.
@@ -68,8 +75,9 @@ public abstract class ReadWalker extends GATKTool {
      * Implementation of read-based traversal.
      * Subclasses can override to provide own behavior but default implementation should be suitable for most uses.
      *
-     * The default implementation creates filters using {@link #makeReadFilter}
-     * and then iterates over all reads, applies the filter and hands the resulting reads to the {@link #apply}
+     * The default implementation creates filters using {@link #makeReadFilter} and transformers using
+     * {@link #makePreReadFilterTransformer()} {@link #makePostReadFilterTransformer()} and then iterates over all reads, applies
+     * the pre-filter transformer, the filter, then the post-filter transformer and hands the resulting reads to the {@link #apply}
      * function of the walker (along with additional contextual information, if present, such as reference bases).
      */
     @Override
@@ -77,9 +85,12 @@ public abstract class ReadWalker extends GATKTool {
         // Process each read in the input stream.
         // Supply reference bases spanning each read, if a reference is available.
         final CountingReadFilter countedFilter = makeReadFilter();
-
+        final ReadTransformer preTransformer = makePreReadFilterTransformer();
+        final ReadTransformer postTransformer = makePostReadFilterTransformer();
         Utils.stream(reads)
+                .map(preTransformer)
                 .filter(countedFilter)
+                .map(postTransformer)
                 .forEach(read -> {
                     final SimpleInterval readInterval = getReadInterval(read);
                     apply(read,
@@ -115,6 +126,33 @@ public abstract class ReadWalker extends GATKTool {
     public List<ReadFilter> getDefaultReadFilters() {
         return Collections.singletonList(new WellformedReadFilter());
     }
+
+    /**
+     * Returns the pre-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
+     * The default implementation uses the {@link ReadTransformer#identity()}.
+     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
+     * the transformer object to avoid object allocation.
+     *
+     * Subclasses can extend to provide own transformers (ie override and call super).
+     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
+     */
+    public ReadTransformer makePreReadFilterTransformer() {
+        return ReadTransformer.identity();
+    }
+
+    /**
+     * Returns the post-filter read transformer (simple or composite) that will be applied to the reads before calling {@link #apply}.
+     * The default implementation uses the {@link ReadTransformer#identity()}.
+     * Default implementation of {@link #traverse()} calls this method once before iterating over the reads and reuses
+     * the transformer object to avoid object allocation.
+     *
+     * Subclasses can extend to provide own transformers (ie override and call super).
+     * Multiple transformers can be composed by using {@link ReadTransformer} composition methods.
+     */
+    public ReadTransformer makePostReadFilterTransformer(){
+        return ReadTransformer.identity();
+    }
+
 
     /**
      * Process an individual read (with optional contextual information). Must be implemented by tool authors.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
@@ -49,18 +49,23 @@ public final class ApplyBQSR extends ReadWalker{
     
     private SAMFileGATKReadWriter outputWriter;
 
-    private ReadTransformer transform;
+    /**
+     * Returns the BQSR post-transformer.
+     */
+    @Override
+    public ReadTransformer makePostReadFilterTransformer(){
+        return new BQSRReadTransformer(getHeaderForReads(), BQSR_RECAL_FILE, bqsrArgs);
+    }
 
     @Override
     public void onTraversalStart() {
         outputWriter = createSAMWriter(OUTPUT, true);
-        transform = new BQSRReadTransformer(getHeaderForReads(), BQSR_RECAL_FILE, bqsrArgs);
         Utils.warnOnNonIlluminaReadGroups(getHeaderForReads(), logger);
     }
 
     @Override
     public void apply( GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext ) {
-        outputWriter.addRead(transform.apply(read));
+        outputWriter.addRead(read);
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
@@ -1,0 +1,81 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class LocusWalkerUnitTest extends CommandLineProgramTest {
+
+    @CommandLineProgramProperties(
+            summary = "Dummy that reads file and counts how many pileup elements are transformed",
+            oneLineSummary = "none",
+            programGroup = TestProgramGroup.class
+    )
+    private static class TestTransformedLocusWalker extends LocusWalker {
+        public int preTransformed = 0;
+        public int postTransformed = 0;
+        public int totalPileup = 0;
+        @Override
+        public ReadTransformer makePreReadFilterTransformer() {
+
+            // transforming name of unmapped mates
+            return new ReadTransformer() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public GATKRead apply(GATKRead gatkRead) {
+                    if (gatkRead.isReverseStrand()) {
+                        preTransformed++;
+                    }
+                    return gatkRead;
+                }
+            };
+        }
+        @Override
+        public ReadTransformer makePostReadFilterTransformer() {
+
+            // transforming name of unmapped mates
+            return new ReadTransformer() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public GATKRead apply(GATKRead gatkRead) {
+                    if (gatkRead.mateIsUnmapped()) {
+                        postTransformed++;
+                    }
+                    return gatkRead;
+                }
+            };
+        }
+        public void apply(AlignmentContext alignmentContext, ReferenceContext referenceContext, FeatureContext featureContext) {
+            totalPileup++;
+        }
+    }
+
+    @Test
+    public void testTransformReads() throws IOException {
+
+        final TestTransformedLocusWalker tool = new TestTransformedLocusWalker();
+
+        final String[] args = {
+                "-I", getTestDataDir()+ "/print_reads.sorted.bam",
+                "-R", getTestDataDir()+ "/print_reads.fasta",
+                "-L", "chr7:21-21"
+        };
+
+        tool.instanceMain(args);
+
+        Assert.assertEquals(tool.preTransformed, 4);
+        Assert.assertEquals(tool.postTransformed, 1);
+        Assert.assertEquals(tool.totalPileup, 1);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.engine;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
@@ -24,6 +26,7 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
         public int preTransformed = 0;
         public int postTransformed = 0;
         public int totalPileup = 0;
+
         @Override
         public ReadTransformer makePreReadFilterTransformer() {
 
@@ -32,6 +35,10 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
                 private static final long serialVersionUID = 1L;
                 @Override
                 public GATKRead apply(GATKRead gatkRead) {
+                    // test that the attribute is not set
+                    Assert.assertFalse(gatkRead.hasAttribute("tr"));
+                    gatkRead.setAttribute("tr", "PRE");
+
                     if (gatkRead.isReverseStrand()) {
                         preTransformed++;
                     }
@@ -39,6 +46,23 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
                 }
             };
         }
+
+        @Override
+        public CountingReadFilter makeReadFilter() {
+            return new CountingReadFilter(new ReadFilter() {
+                @Override
+                public boolean test(GATKRead read) {
+                    // test that the attribute is pre-transformed
+                    Assert.assertEquals(read.getAttributeAsString("tr"), "PRE");
+                    // test that the attribute is not set
+                    Assert.assertFalse(read.hasAttribute("ft"));
+                    // and set as filtered
+                    read.setAttribute("ft", "yes");
+                    return true;
+                }
+            });
+        }
+
         @Override
         public ReadTransformer makePostReadFilterTransformer() {
 
@@ -47,6 +71,9 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
                 private static final long serialVersionUID = 1L;
                 @Override
                 public GATKRead apply(GATKRead gatkRead) {
+                    Assert.assertEquals(gatkRead.getAttributeAsString("tr"), "PRE");
+                    gatkRead.setAttribute("tr", "POST");
+
                     if (gatkRead.mateIsUnmapped()) {
                         postTransformed++;
                     }
@@ -54,7 +81,9 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
                 }
             };
         }
+
         public void apply(AlignmentContext alignmentContext, ReferenceContext referenceContext, FeatureContext featureContext) {
+            alignmentContext.getBasePileup().getReads().forEach(read -> Assert.assertEquals(read.getAttributeAsString("tr"), "POST"));
             totalPileup++;
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
@@ -1,10 +1,9 @@
 package org.broadinstitute.hellbender.engine;
 
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
-import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
@@ -29,8 +29,6 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
 
         @Override
         public ReadTransformer makePreReadFilterTransformer() {
-
-            // transforming name of unmapped mates
             return new ReadTransformer() {
                 private static final long serialVersionUID = 1L;
                 @Override
@@ -50,6 +48,7 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
         @Override
         public CountingReadFilter makeReadFilter() {
             return new CountingReadFilter(new ReadFilter() {
+                private static final long serialVersionUID = 1L;
                 @Override
                 public boolean test(GATKRead read) {
                     // test that the attribute is pre-transformed
@@ -65,8 +64,6 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
 
         @Override
         public ReadTransformer makePostReadFilterTransformer() {
-
-            // transforming name of unmapped mates
             return new ReadTransformer() {
                 private static final long serialVersionUID = 1L;
                 @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -9,8 +9,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-
-import static org.testng.Assert.*;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class ReadWalkerUnitTest extends CommandLineProgramTest {
+
+    @CommandLineProgramProperties(
+            summary = "Dummy that reads file and count how many reads are transformed",
+            oneLineSummary = "empty class",
+            programGroup = TestProgramGroup.class
+    )
+    private static class TestTransformedReadWalker extends ReadWalker {
+        public int preTransformed = 0;
+        public int postTransformed = 0;
+        public int totalReads = 0;
+        @Override
+        public ReadTransformer makePreReadFilterTransformer() {
+
+            // transforming name of unmapped mates
+            return new ReadTransformer() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public GATKRead apply(GATKRead gatkRead) {
+                    if (gatkRead.isReverseStrand()) {
+                        preTransformed++;
+                    }
+                    return gatkRead;
+                }
+            };
+        }
+        @Override
+        public ReadTransformer makePostReadFilterTransformer() {
+
+            // transforming name of unmapped mates
+            return new ReadTransformer() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                public GATKRead apply(GATKRead gatkRead) {
+                    if (gatkRead.mateIsUnmapped()) {
+                        postTransformed++;
+                    }
+                    return gatkRead;
+                }
+            };
+        }
+        @Override
+        public void apply(GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext) {
+            totalReads++;
+        }
+    }
+
+    @Test
+    public void testTransformReads() throws IOException {
+
+        final TestTransformedReadWalker tool = new TestTransformedReadWalker();
+
+        final String[] args = {
+                "-I", getTestDataDir()+ "/print_reads.sorted.bam",
+                "-R", getTestDataDir()+ "/print_reads.fasta",
+                "-L", "chr7:21-21"
+        };
+
+        tool.instanceMain(args);
+
+        Assert.assertEquals(tool.preTransformed, 4);
+        Assert.assertEquals(tool.postTransformed, 1);
+        Assert.assertEquals(tool.totalReads, 5);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerUnitTest.java
@@ -29,8 +29,6 @@ public class ReadWalkerUnitTest extends CommandLineProgramTest {
 
         @Override
         public ReadTransformer makePreReadFilterTransformer() {
-
-            // transforming name of unmapped mates
             return new ReadTransformer() {
                 private static final long serialVersionUID = 1L;
                 @Override
@@ -51,6 +49,7 @@ public class ReadWalkerUnitTest extends CommandLineProgramTest {
         @Override
         public CountingReadFilter makeReadFilter() {
             return new CountingReadFilter(new ReadFilter() {
+                private static final long serialVersionUID = 1L;
                 @Override
                 public boolean test(GATKRead read) {
                     // test that the attribute is pre-transformed
@@ -66,8 +65,6 @@ public class ReadWalkerUnitTest extends CommandLineProgramTest {
 
         @Override
         public ReadTransformer makePostReadFilterTransformer() {
-
-            // transforming name of unmapped mates
             return new ReadTransformer() {
                 private static final long serialVersionUID = 1L;
                 @Override


### PR DESCRIPTION
In the same way as `makeReadFilter()`, I implemented a function to include read transformers in `ReadWalker` and `LocusWalker` to use already transformed reads in `apply` (as requested in #1886).

This function could be added to the `GATKSparkTool` too, and include it in `getReads()`.
