### PR TITLE
Patch gatk-launch to allow it to run with standalone packaged GATK jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are looking for the codebase of the current production version of GATK, p
 * Git 2.5 or greater
 * Optional, but recommended:
     * Gradle 2.12 or greater, needed for building the GATK. We recommend using the `./gradlew` script which will
-      download and use an appropriate gradle version automatically), see examples below.
+      download and use an appropriate gradle version automatically (see examples below).
     * Python 2.6 or greater (needed for running the `gatk-launch` frontend script)
     * R 3.1.3 (needed for producing plots in certain tools, and for running the test suite)
     * [git-lfs](https://git-lfs.github.com/) 1.1.0 or greater (needed to download large files for the complete test suite).
@@ -43,22 +43,30 @@ If you are looking for the codebase of the current production version of GATK, p
 
 ##Building GATK4
 
-* **Recommended method:** To build everything you need to run all GATK tools, run **`./gradlew installAll`**.
-    * This does both the standard build and the Spark build described below.
+* To do a fast build that lets you run GATK tools locally (but not on a cluster) from inside a git clone, run
+        
+        ./gradlew installDist
+        
+* To do a slower build that lets you run GATK tools both locally and on a cluster from inside a git clone, run
 
-* To _only_ do a standard build to save time, run **`./gradlew installDist`**.
-    * The resulting executable will be `build/install/gatk/bin/gatk`,
-      and will be suitable for running non-Spark tools and for running Spark tools locally (not on a cluster).
-    * This executable is **not** a fully-packaged executable that can be copied across machines, it's just
-      for running in-place. To create a packaged version of this build, run `./gradlew shadowJar`. The
-      packaged jar will be in `build/libs/` with a name like `gatk-all-*-SNAPSHOT-shadowJar.jar`.
+        ./gradlew installAll
+     
+* To build a fully-packaged GATK jar that can be distributed and includes all dependencies needed for running tools locally, run
 
-* To _only_ build a special jar suitable for running spark tools on a cluster, run **`./gradlew installSpark`**.
-    * The resulting jar will be in `build/libs/` and will have a name like `gatk-all-*-SNAPSHOT-spark.jar`
-    * This jar will not include Spark and Hadoop libraries, in order to allow
-      the versions of Spark and Hadoop installed on your cluster to be used.
+        ./gradlew localJar
+        
+    * The resulting jar will be in `build/libs` with a name like `gatk-package-VERSION-local.jar`
+    
+* To build a fully-packaged GATK jar that can be distributed and includes all dependencies needed for running spark tools on a cluster, run
 
-* To remove previous builds, run **`./gradlew clean`**
+        ./gradlew sparkJar
+        
+    * The resulting jar will be in `build/libs` with a name like `gatk-package-VERSION-spark.jar`
+    * This jar will not include Spark and Hadoop libraries, in order to allow the versions of Spark and Hadoop installed on your cluster to be used.
+
+* To remove previous builds, run 
+
+        ./gradlew clean
 
 * For faster gradle operations, add `org.gradle.daemon=true` to your `~/.gradle/gradle.properties` file.
   This will keep a gradle daemon running in the background and avoid the ~6s gradle start up time on every command.
@@ -70,6 +78,10 @@ If you are looking for the codebase of the current production version of GATK, p
 * The standard way to run GATK4 tools is via the **`gatk-launch`** wrapper script located in the root directory of a clone of this repository.
     * Requires Python 2.6 or greater.
     * You need to have built the GATK as described in the "Building GATK4" section above before running this script.
+    * There are three ways `gatk-launch` can be run:
+        * from the root of your git clone after building
+        * or, put the `gatk-launch` script within the same directory as fully-packaged GATK jars produced by `./gradlew localJar` and `./gradlew sparkJar`
+        * or, the environment variables `GATK_LOCAL_JAR` and `GATK_SPARK_JAR` can be defined, and contain the paths to the fully-packaged GATK jars produced by `./gradlew localJar` and `./gradlew sparkJar` 
     * Can run non-Spark tools as well as Spark tools, and can run Spark tools locally, on a Spark cluster, or on Google Cloud Dataproc.
 
 * For help on using `gatk-launch` itself, run **`./gatk-launch --help`**
@@ -79,11 +91,6 @@ If you are looking for the codebase of the current production version of GATK, p
       `Spark` categories. All other tools are non-Spark-based.
 
 * To print help for a particular tool, run **`./gatk-launch ToolName --help`**.
-
-* If you don't want to run the GATK via the `gatk-launch` script, it's possible to run non-Spark and local Spark
-  tools directly using the `build/install/gatk/bin/gatk` executable after a `./gradlew installDist`, and to run Spark tools
-  on a cluster or the cloud by building a Spark jar with `./gradlew installSpark` and passing the resulting jar in `build/libs/`
-  directly to either `spark-submit` or `gcloud`.
 
 * To run a non-Spark tool, or to run a Spark tool locally, the syntax is:
 **`./gatk-launch ToolName toolArguments`**.
@@ -331,9 +338,9 @@ source("scripts/install_R_packages.R")
     
 ##Setting up profiling using JProfiler (not using IntelliJ)
     
-   * Build GATK using `./gradlew installAll`
+   * Build a full GATK4 jar using `./gradlew localJar`
 
-   * In the "Session Settings" windown, select the `all` GATK4 jar, eg `~/gatk/build/libs/gatk-all-4.alpha-196-gb542813-SNAPSHOT-spark.jar` for "Main class or executable JAR" and enter the right "Arguments"
+   * In the "Session Settings" window, select the GATK4 jar, eg. `~/gatk/build/libs/gatk-package-4.alpha-196-gb542813-SNAPSHOT-local.jar` for "Main class or executable JAR" and enter the right "Arguments"
 
 ##Updating the Intellij project when dependencies change
 If there are dependency changes in `build.gradle` it is necessary to refresh the gradle project. This is easily done with the following steps.

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ task wrapper(type: Wrapper) {
 
 tasks.withType(ShadowJar) {
     from(project.sourceSets.main.output)
-    baseName = project.name + '-all'
+    baseName = project.name + '-package'
     mergeServiceFiles()
     relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
     zip64 true
@@ -338,9 +338,11 @@ configurations {
 
 shadowJar {
     configurations = [project.configurations.runtime]
-    classifier = 'shadowJar'
+    classifier = 'local'
     mergeServiceFiles('reference.conf')
 }
+
+task localJar{ dependsOn shadowJar }
 
 task sparkJar(type: ShadowJar) {
     group = "Shadow"

--- a/gatk-launch
+++ b/gatk-launch
@@ -1,9 +1,27 @@
 #!/usr/bin/env python
+#
+# Launcher script for GATK tools. Delegates to java -jar, spark-submit, or gcloud as appropriate,
+# and sets many important Spark and htsjdk properties before launch.
+#
+# If running a non-Spark tool, or a Spark tool in local mode, will search for GATK executables
+# as follows:
+#     -If the GATK_LOCAL_JAR environment variable is set, uses that jar
+#     -Otherwise if the GATK_RUN_SCRIPT created by "gradle installDist" exists, uses that
+#     -Otherwise uses the newest local jar in the same directory as the script or the BIN_PATH
+#      (in that order of precedence)
+#
+# If running a Spark tool, searches for GATK executables as follows:
+#     -If the GATK_SPARK_JAR environment variable is set, uses that jar
+#     -Otherwise uses the newest Spark jar in the same directory as the script or the BIN_PATH
+#      (in that order of precedence)
+#
+
 import sys
 from subprocess import check_call, CalledProcessError, call
 import os
 import hashlib
 import signal
+import re
 
 script = os.path.dirname(os.path.realpath(__file__))
 
@@ -21,6 +39,8 @@ projectName = properties["rootProject.name"]
 
 BUILD_LOCATION = script +"/build/install/" + projectName + "/bin/"
 GATK_RUN_SCRIPT = BUILD_LOCATION + projectName
+GATK_LOCAL_JAR_ENV_VARIABLE = "GATK_LOCAL_JAR"
+GATK_SPARK_JAR_ENV_VARIABLE = "GATK_SPARK_JAR"
 BIN_PATH = script + "/build/libs"
 
 EXTRA_JAVA_OPTIONS="-Dsamjdk.compression_level=1 -DGATK_STACKTRACE_ON_USER_EXCEPTION=true "
@@ -105,8 +125,6 @@ def main(args):
     except CalledProcessError as e:
         sys.exit(e.returncode)
 
-
-
 def getSparkSubmit():
     sparkhome = os.environ.get("SPARK_HOME")
     if sparkhome is not None:
@@ -114,27 +132,82 @@ def getSparkSubmit():
     else:
         return "spark-submit"
 
+def getLocalGatkRunCommand():
+    localJarFromEnv = getJarFromEnv(GATK_LOCAL_JAR_ENV_VARIABLE)
+    if localJarFromEnv is not None:
+        return ["java", "-jar", localJarFromEnv]
 
-def getSparkJar():
-    sparkproperty = os.environ.get('GATK_SPARK_JAR')
-    if not sparkproperty is None:
-        if not os.path.exists(sparkproperty):
-            raise GATKLaunchException("GATK_SPARK_JAR was set to: " + sparkproperty + " but it doesn't exist, please fix your environment")
+    wrapperScript = getGatkWrapperScript(throwIfNotFound=False)
+    if wrapperScript is not None:
+        return [wrapperScript]
+
+    return ["java", "-jar", getLocalJar()]  # will throw if local jar not found
+
+def getGatkWrapperScript(throwIfNotFound=True):
+    if not os.path.exists(GATK_RUN_SCRIPT):
+        if throwIfNotFound:
+            raise GATKLaunchException("Missing GATK wrapper script: " + GATK_RUN_SCRIPT + "\nTo generate the wrapper run:\n\n    " + script + "/gradlew installDist")
         else:
-            return sparkproperty
+            return None
 
-    if not os.path.exists(BIN_PATH):
-        raise GATKLaunchException("No spark jar was found, please build one by running\n\n    " + script + "/gradlew sparkJar")
-    files = os.listdir(BIN_PATH)
-    sparkjars = [f for f in files if "spark.jar" in f]
-    if len(sparkjars) is 0:
-        raise GATKLaunchException("No spark jar was found, please build one by running\n\n    " + script + "/gradlew sparkJar\n"
-                             "or\n"
-                             "    export GATK_SPARK_JAR=<path_to_spark_jar>")
-    else:
-        newest = max(sparkjars, key=lambda x: os.stat(BIN_PATH + "/" + x).st_mtime)
-        return BIN_PATH+ "/" + newest
+    sys.stderr.write("Using GATK wrapper script " + GATK_RUN_SCRIPT)
+    return GATK_RUN_SCRIPT
 
+def getLocalJar(throwIfNotFound=True):
+    localJar = findJar("local.jar", envVariableOverride=GATK_LOCAL_JAR_ENV_VARIABLE)
+    if localJar is None and throwIfNotFound:
+        raise GATKLaunchException("No local jar was found, please build one by running\n\n    " +
+                                  script + "/gradlew localJar\n"
+                                           "or\n"
+                                           "    export " + GATK_LOCAL_JAR_ENV_VARIABLE + "=<path_to_local_jar>")
+    return localJar
+
+def getSparkJar(throwIfNotFound=True):
+    sparkJar = findJar("spark.jar", envVariableOverride=GATK_SPARK_JAR_ENV_VARIABLE)
+    if sparkJar is None and throwIfNotFound:
+        raise GATKLaunchException("No spark jar was found, please build one by running\n\n    " +
+                                  script + "/gradlew sparkJar\n"
+                                  "or\n"
+                                  "    export " + GATK_SPARK_JAR_ENV_VARIABLE + "=<path_to_spark_jar>")
+    return sparkJar
+
+def findJar(jarSuffix, jarPrefix=projectName, envVariableOverride=None, jarSearchDirs=(script, BIN_PATH)):
+    if envVariableOverride is not None:
+        jarPathFromEnv = getJarFromEnv(envVariableOverride)
+        if jarPathFromEnv is not None:
+            return jarPathFromEnv
+
+    for jarDir in jarSearchDirs:
+        jar = getNewestJarInDir(jarDir, jarSuffix, jarPrefix)
+        if jar is not None:
+            sys.stderr.write("Using GATK jar " + jar)
+            return jar
+
+    return None
+
+def getJarFromEnv(envVariableName):
+    jarPathFromEnv = os.environ.get(envVariableName)
+    if jarPathFromEnv is not None:
+        if not os.path.exists(jarPathFromEnv):
+            raise GATKLaunchException(envVariableName + " was set to: " + jarPathFromEnv + " but this file doesn't exist. Please fix your environment")
+        else:
+            sys.stderr.write("Using GATK jar " + jarPathFromEnv + " defined in environment variable " + envVariableName)
+            return jarPathFromEnv
+
+    return None
+
+def getNewestJarInDir(dir, jarSuffix, jarPrefix):
+    if not os.path.exists(dir):
+        return None
+
+    dirContents = os.listdir(dir)
+    jarPattern = re.compile("^" + jarPrefix + ".*" + jarSuffix + "$")
+    jars = [f for f in dirContents if jarPattern.match(f)]
+    if len(jars) != 0:
+        newestJar = max(jars, key=lambda x: os.stat(dir + "/" + x).st_mtime)
+        return dir + "/" + newestJar
+
+    return None
 
 def md5(file):
     hash = hashlib.md5()
@@ -180,7 +253,7 @@ def cacheJarOnGCS(jar, dryRun):
 
 def runGATK(sparkRunner, dryrun, gatkArgs, sparkArgs):
     if sparkRunner is None or sparkRunner == "LOCAL":
-        cmd = [getGatkWrapperScript()] + gatkArgs + sparkArgs
+        cmd = getLocalGatkRunCommand() + gatkArgs + sparkArgs
         runCommand(cmd, dryrun)
     elif sparkRunner == "SPARK":
         cmd = [ getSparkSubmit(),
@@ -209,13 +282,6 @@ def runGATK(sparkRunner, dryrun, gatkArgs, sparkArgs):
             raise GATKLaunchException("Tried to run gcloud but failed.\nMake sure gcloud is available in your path and you are properly authenticated")
     else:
         raise GATKLaunchException("Value: " + sparkRunner + " is not a valid value for --sparkRunner.  Choose one of LOCAL, SPARK, GCS")
-
-
-def getGatkWrapperScript():
-    if not os.path.exists(GATK_RUN_SCRIPT):
-        raise GATKLaunchException("Missing GATK wrapper script: " + GATK_RUN_SCRIPT + "\nTo generate the wrapper run:\n\n    " + script + "/gradlew installDist")
-    return GATK_RUN_SCRIPT
-
 
 def runCommand(cmd, dryrun):
     if dryrun:


### PR DESCRIPTION
-Will now look for both shadow and spark jars in the same directory
 as the gatk-launch script, and use them if found. Also checks
 BIN_PATH for jars.

-Environment variable overrides GATK_SHADOW_JAR and GATK_SPARK_JAR
 take precedence over everything

-Wrapper script is used if found and GATK_SHADOW_JAR is not set.

Resolves #1693