### PR TITLE
Ignore spanning deletions in Rank Sum tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
@@ -19,6 +19,7 @@ import java.util.*;
  * Abstract root for all RankSum based annotations
  */
 public abstract class RankSumTest extends InfoFieldAnnotation {
+    protected static double INVALID_ELEMENT_FROM_READ = Double.NEGATIVE_INFINITY;
     private boolean useDithering = true;
 
     public RankSumTest(final boolean useDithering){
@@ -76,7 +77,8 @@ public abstract class RankSumTest extends InfoFieldAnnotation {
             final GATKRead read = el.getKey();
             if ( isUsableRead(read, refLoc) ) {
                 final OptionalDouble value = getElementForRead(read, refLoc, a);
-                if ( !value.isPresent() ) {
+                // Bypass read if the clipping goal is not reached or the refloc is inside a spanning deletion
+                if ( !value.isPresent() || value.getAsDouble() == INVALID_ELEMENT_FROM_READ ) {
                     continue;
                 }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosRankSumTest.java
@@ -46,6 +46,11 @@ public final class ReadPosRankSumTest extends RankSumTest implements StandardAnn
             return OptionalDouble.empty();
         }
 
+        // If the offset inside a deletion, it does not lie on a read.
+        if ( AlignmentUtils.isInsideDeletion(read.getCigar(), offset) ) {
+            return OptionalDouble.of(INVALID_ELEMENT_FROM_READ);
+        }
+
         int readPos = AlignmentUtils.calcAlignmentByteArrayOffset(read.getCigar(), offset, false, 0, 0);
         final int numAlignedBases = AlignmentUtils.getNumAlignedBasesCountingSoftClips( read );
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RankSumTest.java
@@ -109,7 +109,7 @@ public abstract class AS_RankSumTest extends RankSumTest implements ReducibleAnn
             final GATKRead read = el.getKey();
             if ( isUsableRead(read, refLoc) ) {
                 final OptionalDouble value = getElementForRead(read, refLoc, a);
-                if (! value.isPresent() ) {
+                if (! value.isPresent() || value.getAsDouble() == INVALID_ELEMENT_FROM_READ ) {
                     continue;
                 }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
@@ -54,6 +54,11 @@ public class AS_ReadPosRankSumTest extends AS_RankSumTest implements AS_Standard
             return OptionalDouble.empty();
         }
 
+        // If the offset inside a deletion, it does not lie on a read.
+        if ( AlignmentUtils.isInsideDeletion(read.getCigar(), offset) ) {
+            return OptionalDouble.of(INVALID_ELEMENT_FROM_READ);
+        }
+
         int readPos = AlignmentUtils.calcAlignmentByteArrayOffset(read.getCigar(), offset, false, 0, 0);
         final int numAlignedBases = AlignmentUtils.getNumAlignedBasesCountingSoftClips( read );
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/AlignmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/AlignmentUtilsUnitTest.java
@@ -648,6 +648,28 @@ public final class AlignmentUtilsUnitTest {
         Assert.assertEquals(actual, expectedResult, "Wrong alignment offset detected for cigar " + cigar.toString());
     }
 
+    @Test
+    public void testIsInsideDeletion() {
+        final List<CigarElement> cigarElements = Arrays.asList(new CigarElement(5, CigarOperator.S),
+                new CigarElement(5, CigarOperator.M),
+                new CigarElement(5, CigarOperator.EQ),
+                new CigarElement(6, CigarOperator.N),
+                new CigarElement(5, CigarOperator.X),
+                new CigarElement(6, CigarOperator.D),
+                new CigarElement(1, CigarOperator.P),
+                new CigarElement(1, CigarOperator.H));
+        final Cigar cigar = new Cigar(cigarElements);
+        for ( int i=-1; i <= 20; i++ ) {
+            Assert.assertFalse(AlignmentUtils.isInsideDeletion(cigar, i));
+        }
+        for ( int i=21; i <= 26; i++ ){
+            Assert.assertTrue(AlignmentUtils.isInsideDeletion(cigar, i));
+        }
+        for ( int i=27; i <= 28; i++ ) {
+            Assert.assertFalse(AlignmentUtils.isInsideDeletion(cigar, i));
+        }
+    }
+
     ////////////////////////////////////////////////////
     // Test AlignmentUtils.readToAlignmentByteArray() //
     ////////////////////////////////////////////////////


### PR DESCRIPTION
Implements #2059.
Ignore loci inside spanning deletions in Rank Sum tests.