### PR TITLE
addresses issue #1280 from GATK3 (issue was originally found in GATK3)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -64,13 +64,19 @@ public abstract class IntervalArgumentCollection implements ArgumentCollectionDe
     @Argument(fullName = "interval_set_rule", shortName = "isr", doc = "Set merging approach to use for combining interval inputs")
     protected IntervalSetRule intervalSetRule = IntervalSetRule.UNION;
     /**
-     * Use this to add padding to the intervals specified using -L and/or -XL. For example, '-L 1:100' with a
+     * Use this to add padding to the intervals specified using -L. For example, '-L 1:100' with a
      * padding value of 20 would turn into '-L 1:80-120'. This is typically used to add padding around targets when
      * analyzing exomes.
      */
-    @Argument(fullName = "interval_padding", shortName = "ip", doc = "Amount of padding (in bp) to add to each interval")
+    @Argument(fullName = "interval_padding", shortName = "ip", doc = "Amount of padding (in bp) to add to each interval you are including.")
     protected int intervalPadding = 0;
-
+    /**
+     * Use this to add padding to the intervals specified using -XL. For example, '-XL 1:100' with a
+     * padding value of 20 would turn into '-XL 1:80-120'. This is typically used to add padding around targets when
+     * analyzing exomes.
+     */
+    @Argument(fullName = "interval_exclusion_padding", shortName= "ixp", doc = "Amount of padding (in bp) to add to each interval you are excluding.")
+    protected int intervalExclusionPadding = 0;
     /**
      * Full parameters for traversal, including our parsed intervals and a flag indicating whether unmapped records
      * should be returned. Lazily initialized.
@@ -124,7 +130,7 @@ public abstract class IntervalArgumentCollection implements ArgumentCollectionDe
             }
         }
 
-        final GenomeLocSortedSet excludeSortedSet = IntervalUtils.loadIntervals(excludeIntervalStrings, IntervalSetRule.UNION, intervalMerging, intervalPadding, genomeLocParser);
+        final GenomeLocSortedSet excludeSortedSet = IntervalUtils.loadIntervals(excludeIntervalStrings, IntervalSetRule.UNION, intervalMerging, intervalExclusionPadding, genomeLocParser);
         if ( excludeSortedSet.contains(GenomeLoc.UNMAPPED) ) {
             throw new UserException("-XL unmapped is not currently supported");
         }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -124,7 +124,7 @@ public abstract class IntervalArgumentCollection implements ArgumentCollectionDe
             }
         }
 
-        final GenomeLocSortedSet excludeSortedSet = IntervalUtils.loadIntervals(excludeIntervalStrings, IntervalSetRule.UNION, intervalMerging, 0, genomeLocParser);
+        final GenomeLocSortedSet excludeSortedSet = IntervalUtils.loadIntervals(excludeIntervalStrings, IntervalSetRule.UNION, intervalMerging, intervalPadding, genomeLocParser);
         if ( excludeSortedSet.contains(GenomeLoc.UNMAPPED) ) {
             throw new UserException("-XL unmapped is not currently supported");
         }

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -51,7 +51,6 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         clp.parseArguments(System.out, args);
     }
 
-
     @Test(dataProvider = "optionalOrNot",expectedExceptions = GATKException.class)
     public void emptyIntervalsTest(IntervalArgumentCollection iac){
         Assert.assertFalse(iac.intervalsSpecified());
@@ -68,8 +67,8 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
 
     @Test(dataProvider = "optionalOrNot")
     public void testExcludeWithPadding(IntervalArgumentCollection iac){
-        iac.intervalPadding = 10;
-        iac.addToIntervalStrings("1:10-100");
+        iac.intervalExclusionPadding = 10;
+        iac.addToIntervalStrings("1:1-100");
         iac.excludeIntervalStrings.add("1:90-100");
         Assert.assertTrue(iac.intervalsSpecified());
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 79)));
@@ -81,6 +80,13 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.excludeIntervalStrings.add("1:90-200");
         Assert.assertTrue(iac.intervalsSpecified());
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 89)));
+    }
+
+    @Test(dataProvider = "optionalOrNot")
+    public void testIncludeWithPadding(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:20-30");
+        iac.intervalPadding = 10;
+        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 10, 40)));
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -99,12 +105,6 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 200)));
     }
 
-    @Test(dataProvider = "optionalOrNot")
-    public void testPadding(IntervalArgumentCollection iac){
-        iac.addToIntervalStrings("1:20-30");
-        iac.intervalPadding = 10;
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 10, 40)));
-    }
 
     @Test(dataProvider = "optionalOrNot", expectedExceptions = UserException.BadArgumentValue.class)
     public void testAllExcluded(IntervalArgumentCollection iac){

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -67,6 +67,15 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
     }
 
     @Test(dataProvider = "optionalOrNot")
+    public void testExcludeWithPadding(IntervalArgumentCollection iac){
+        iac.intervalPadding = 10;
+        iac.addToIntervalStrings("1:10-100");
+        iac.excludeIntervalStrings.add("1:90-100");
+        Assert.assertTrue(iac.intervalsSpecified());
+        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 79)));
+    }
+
+    @Test(dataProvider = "optionalOrNot")
     public void testIncludeWithExclude(IntervalArgumentCollection iac){
         iac.addToIntervalStrings("1:1-100");
         iac.excludeIntervalStrings.add("1:90-200");


### PR DESCRIPTION
addresses issue https://github.com/broadinstitute/gsa-unstable/issues/1280 from GATK3 (issue was originally found in GATK3 but same issue was present in GATK4) now interval padding works for exclude intervals