### PR TITLE
Find promiscuous kmers only among those being used to pull reads for assembly.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSparkUnitTest.java
@@ -40,7 +40,7 @@ public final class FindBreakpointEvidenceSparkUnitTest extends BaseTest {
     private final ReadMetadata readMetadataExpected = new ReadMetadata(header, reads);
     private final Broadcast<ReadMetadata> broadcastMetadata = ctx.broadcast(readMetadataExpected);
     private final FindBreakpointEvidenceSpark.Locations locations =
-        new FindBreakpointEvidenceSpark.Locations(null, null, null, null, null, null, null, null);
+        new FindBreakpointEvidenceSpark.Locations(null, null, null, null, null, null, null);
     private final Set<String> expectedQNames = loadExpectedQNames(qNamesFile);
     private final Set<String> expectedAssemblyQNames = loadExpectedQNames(asmQNamesFile);
     private final List<SVInterval> expectedIntervalList = Arrays.asList(testIntervals);
@@ -64,12 +64,9 @@ public final class FindBreakpointEvidenceSparkUnitTest extends BaseTest {
 
     @Test(groups = "spark")
     public void getKmerIntervalsTest() {
-        final List<SVKmer> highCountKmers = FindBreakpointEvidenceSpark.getHighCountKmers(params, reads, locations, null);
-        Assert.assertEquals(2, highCountKmers.size());
         final Set<SVKmer> killSet = new HashSet<>();
         killSet.add(SVKmerizer.toKmer("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG"));
         killSet.add(SVKmerizer.toKmer("TACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC"));
-        killSet.addAll(highCountKmers);
         Assert.assertEquals(2, killSet.size());
 
         final HopscotchUniqueMultiMap<String, Integer, FindBreakpointEvidenceSpark.QNameAndInterval> qNameMultiMap =


### PR DESCRIPTION
Rather than finding all over-represented kmers among the reads.  Halves run time, but increases the size of a few assemblies.