### PR TITLE
Fix CreateSequenceDictionary (issue #2093)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
@@ -1,9 +1,6 @@
 package org.broadinstitute.hellbender.tools.picard.sam;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMFileWriter;
-import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.*;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
@@ -83,7 +80,8 @@ CreateSequenceDictionary extends PicardCommandLineProgram {
         SAMFileWriter samWriter = null;
         //This writes the header with sequenceDictionary
         try {
-            samWriter = createSAMWriter(OUTPUT, REFERENCE_SEQUENCE, samHeader, false);
+            // do not use createSAMWriter because it does not create a plain text file without a .sam extension
+            samWriter = new SAMFileWriterFactory().makeSAMWriter(samHeader, false, OUTPUT);
         }
         finally {
             samWriter.close();

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
@@ -29,8 +29,7 @@ import static org.broadinstitute.hellbender.utils.Utils.calcMD5;
         oneLineSummary = "Creates a dict file from reference sequence in fasta format",
         programGroup = FastaProgramGroup.class
 )
-public final class
-CreateSequenceDictionary extends PicardCommandLineProgram {
+public final class CreateSequenceDictionary extends PicardCommandLineProgram {
 
     // The following attributes define the command-line arguments
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,9 +27,11 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
         outputDict.delete();
         final String[] argv = {
                 "--reference", BASIC_FASTA.getAbsolutePath(),
-                "--output", outputDict.getAbsolutePath()
+                "--output", outputDict.getAbsolutePath(),
+                "--URI", BASIC_FASTA.getName()
         };
         runCommandLine(argv);
+        IntegrationTestSpec.assertEqualTextFiles(outputDict, new File(BASIC_FASTA.getAbsolutePath() + ".dict"));
     }
 
     /**

--- a/src/test/resources/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary/basic.fasta.dict
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary/basic.fasta.dict
@@ -1,0 +1,3 @@
+@HD	VN:1.5	SO:unsorted
+@SQ	SN:chr1	LN:8	M5:cc0af3a4fedb18378b4b57b98068e69f	UR:basic.fasta
+@SQ	SN:chr2	LN:8	M5:58b3bceed569f4f0a3002b2f625bdada	UR:basic.fasta


### PR DESCRIPTION
Fix #2093: `CreateSequenceDictionary` now generates a plain-text dictionary as expected by tools that use it.