### PR TITLE
CommandLineProgramTestInterface for API users

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.CommandLineProgramTestInterface;
+import org.broadinstitute.hellbender.utils.test.CommandLineProgramTester;
 
 import java.io.File;
 import java.util.List;
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Utility class for GATK CommandLine Program testing.
  */
-public abstract class CommandLineProgramTest extends BaseTest implements CommandLineProgramTestInterface {
+public abstract class CommandLineProgramTest extends BaseTest implements CommandLineProgramTester {
 
     /**
      * Returns the location of the resource directory. The default implementation points to the common directory for tools.

--- a/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
@@ -1,87 +1,29 @@
 package org.broadinstitute.hellbender;
 
-import htsjdk.samtools.util.Log;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.utils.logging.BunnyLog;
-import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.CommandLineProgramTestInterface;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
- * Utility class for CommandLine Program testing.
+ * Utility class for GATK CommandLine Program testing.
  */
-public abstract class CommandLineProgramTest extends BaseTest {
+public abstract class CommandLineProgramTest extends BaseTest implements CommandLineProgramTestInterface {
 
     /**
      * Returns the location of the resource directory. The default implementation points to the common directory for tools.
      */
-    public static File getTestDataDir(){
+    public static File getTestDataDir() {
         return new File("src/test/resources/org/broadinstitute/hellbender/tools/");
     }
 
-    /**
-     * For testing support.  Given a name of a Main CommandLineProgram and it's arguments, builds the arguments appropriate for calling the
-     * program through Main
-     *
-     * @param args List<String> of command line arguments
-     * @return String[] of command line arguments
-     */
-    public String[] makeCommandLineArgs(final List<String> args) {
-        return makeCommandLineArgs(args, getTestedClassName());
-    }
-
-    /**
-     * For testing support.  Given a name of a Main CommandLineProgram and it's arguments, builds the arguments appropriate for calling the
-     * program through Main
-     *
-     * @param args List<String> of command line arguments
-     * @param toolname name of the tool to test
-     * @return String[] of command line arguments
-     */
-    public String[] makeCommandLineArgs(final List<String> args, final String toolname) {
-        List<String> curatedArgs = injectDefaultVerbosity(args);
-        final String[] commandLineArgs = new String[curatedArgs.size() + 1];
-        commandLineArgs[0] = toolname;
-        int i = 1;
-        for (final String arg : curatedArgs) {
-            commandLineArgs[i++] = arg;
-        }
-        return commandLineArgs;
-    }
-
-    /**
-     * Look for --verbosity argument; if not found, supply a default value that minimizes the amount of logging output.
-     */
-    private List<String> injectDefaultVerbosity(final List<String> args) {
-
-        // global toggle for BunnyLog output.
-        BunnyLog.setEnabled(false);
-
-        for (String arg : args) {
-            if (arg.equalsIgnoreCase("--" + StandardArgumentDefinitions.VERBOSITY_NAME) || arg.equalsIgnoreCase("-" + StandardArgumentDefinitions.VERBOSITY_NAME)) {
-                return args;
-            }
-        }
-        List<String> argsWithVerbosity = new ArrayList<>(args);
-        argsWithVerbosity.add("--" + StandardArgumentDefinitions.VERBOSITY_NAME);
-        argsWithVerbosity.add(Log.LogLevel.ERROR.name());
-        return argsWithVerbosity;
+    public String getTestedToolName() {
+        return getTestedClassName();
     }
 
     public Object runCommandLine(final List<String> args) {
         return new Main().instanceMain(makeCommandLineArgs(args));
-    }
-
-    public Object runCommandLine(final String[] args) {
-        return runCommandLine(Arrays.asList(args));
-    }
-
-    public Object runCommandLine(final ArgumentsBuilder args) {
-        return runCommandLine(args.getArgsList());
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/CommandLineProgramTestInterface.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/CommandLineProgramTestInterface.java
@@ -1,0 +1,94 @@
+package org.broadinstitute.hellbender.utils.test;
+
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.hellbender.Main;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.logging.BunnyLog;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility interface for CommandLine Program testing.
+ */
+public interface CommandLineProgramTestInterface {
+
+    /**
+     * Returns the name for the tested tool.
+     */
+    public String getTestedToolName();
+
+    /**
+     * For testing support. Given a name of a Main CommandLineProgram and it's arguments, builds the arguments appropriate for calling the
+     * program through Main.
+     *
+     * Default behaviour uses {@link #makeCommandLineArgs(List, String)} with the tool name provided by {@link #getTestedToolName()}.
+     *
+     * @param args List<String> of command line arguments
+     * @return String[] of command line arguments
+     */
+    default String[] makeCommandLineArgs(final List<String> args) {
+        return makeCommandLineArgs(args, getTestedToolName());
+    }
+
+    /**
+     * For testing support. Given a name of a Main CommandLineProgram and it's arguments, builds the arguments appropriate for calling the
+     * program through Main.
+     *
+     * Default behaviour generates a command line in the form "toolname args", with the verbosity parameter returned by {@link #injectDefaultVerbosity(List)}.
+     *
+     * @param args     List<String> of command line arguments
+     * @param toolname name of the tool to test
+     * @return String[] of command line arguments
+     */
+    default String[] makeCommandLineArgs(final List<String> args, final String toolname) {
+        List<String> curatedArgs = injectDefaultVerbosity(args);
+        final String[] commandLineArgs = new String[curatedArgs.size() + 1];
+        commandLineArgs[0] = toolname;
+        int i = 1;
+        for (final String arg : curatedArgs) {
+            commandLineArgs[i++] = arg;
+        }
+        return commandLineArgs;
+    }
+
+    /**
+     * Inject the verbosity parameter into the list.
+     *
+     * Default behaviour look for --verbosity argument; if not found, supply a default value that minimizes the amount of logging output.
+     */
+    default List<String> injectDefaultVerbosity(final List<String> args) {
+
+        // global toggle for BunnyLog output.
+        BunnyLog.setEnabled(false);
+
+        for (String arg : args) {
+            if (arg.equalsIgnoreCase("--" + StandardArgumentDefinitions.VERBOSITY_NAME) || arg.equalsIgnoreCase("-" + StandardArgumentDefinitions.VERBOSITY_NAME)) {
+                return args;
+            }
+        }
+        List<String> argsWithVerbosity = new ArrayList<>(args);
+        argsWithVerbosity.add("--" + StandardArgumentDefinitions.VERBOSITY_NAME);
+        argsWithVerbosity.add(Log.LogLevel.ERROR.name());
+        return argsWithVerbosity;
+    }
+
+    /**
+     * Runs the command line implemented by this test.
+     *
+     * Default behaviour uses {@link Main} with the command line arguments created by {@link #makeCommandLineArgs(List)}.
+     */
+    default Object runCommandLine(final List<String> args) {
+        return new Main().instanceMain(makeCommandLineArgs(args));
+    }
+
+    default Object runCommandLine(final String[] args) {
+        return runCommandLine(Arrays.asList(args));
+    }
+
+    default Object runCommandLine(final ArgumentsBuilder args) {
+        return runCommandLine(args.getArgsList());
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/CommandLineProgramTester.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/CommandLineProgramTester.java
@@ -10,9 +10,10 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Utility interface for CommandLine Program testing.
+ * Utility interface for CommandLine Program testing. API users that have their own Main implementation
+ * should override {@link #makeCommandLineArgs(List)} to make their tests work with {@link IntegrationTestSpec}.
  */
-public interface CommandLineProgramTestInterface {
+public interface CommandLineProgramTester {
 
     /**
      * Returns the name for the tested tool.

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
@@ -83,7 +83,7 @@ public final class IntegrationTestSpec {
         return expectedFileNames;
     }
 
-    public void executeTest(final String name, CommandLineProgramTestInterface test) throws IOException {
+    public void executeTest(final String name, CommandLineProgramTester test) throws IOException {
         List<File> tmpFiles = new ArrayList<>();
         for (int i = 0; i < nOutputFiles; i++) {
             String ext = DEFAULT_TEMP_EXTENSION;
@@ -118,7 +118,7 @@ public final class IntegrationTestSpec {
      * @param args                  the argument list
      * @param expectedException     the expected exception or null
      */
-    private void executeTest(String testName, CommandLineProgramTestInterface testClass, File outputFileLocation, List<String> expectedFileNames, List<File> tmpFiles, String args, Class<?> expectedException) throws IOException {
+    private void executeTest(String testName, CommandLineProgramTester testClass, File outputFileLocation, List<String> expectedFileNames, List<File> tmpFiles, String args, Class<?> expectedException) throws IOException {
         if (outputFileLocation != null) {
             args += " -O " + outputFileLocation.getAbsolutePath();
         }
@@ -137,7 +137,7 @@ public final class IntegrationTestSpec {
      * @param args              the argument list
      * @param expectedException the expected exception or null
      */
-    private void executeTest(String testName, CommandLineProgramTestInterface testClass, String args, Class<?> expectedException) {
+    private void executeTest(String testName, CommandLineProgramTester testClass, String args, Class<?> expectedException) {
         String[] command = Utils.escapeExpressions(args);
         // run the executable
         boolean gotAnException = false;

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpec.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.utils.test;
 
 import htsjdk.samtools.ValidationStringency;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
@@ -47,7 +46,7 @@ public final class IntegrationTestSpec {
     }
 
     public IntegrationTestSpec(String args, int nOutputFiles, Class<?> expectedException) {
-        if (expectedException == null){
+        if (expectedException == null) {
             throw new IllegalArgumentException("expected exception is null");
         }
         this.args = args;
@@ -68,7 +67,7 @@ public final class IntegrationTestSpec {
         return expectedException;
     }
 
-    public void setCompareBamFilesSorted(final boolean compareBamFilesSorted){
+    public void setCompareBamFilesSorted(final boolean compareBamFilesSorted) {
         this.compareBamFilesSorted = compareBamFilesSorted;
     }
 
@@ -84,7 +83,7 @@ public final class IntegrationTestSpec {
         return expectedFileNames;
     }
 
-    public void executeTest(final String name, CommandLineProgramTest test) throws IOException {
+    public void executeTest(final String name, CommandLineProgramTestInterface test) throws IOException {
         List<File> tmpFiles = new ArrayList<>();
         for (int i = 0; i < nOutputFiles; i++) {
             String ext = DEFAULT_TEMP_EXTENSION;
@@ -101,7 +100,7 @@ public final class IntegrationTestSpec {
             executeTest(name, test, null, null, tmpFiles, formattedArgs, getExpectedException());
         } else {
             final List<String> expectedFileNames = new ArrayList<>(expectedFileNames());
-            if (!expectedFileNames.isEmpty() && preFormattedArgs.equals(formattedArgs)){
+            if (!expectedFileNames.isEmpty() && preFormattedArgs.equals(formattedArgs)) {
                 throw new GATKException("Incorrect test specification - you're expecting " + expectedFileNames.size() + " file(s) the specified arguments do not contain the same number of \"%s\" placeholders");
             }
 
@@ -119,7 +118,7 @@ public final class IntegrationTestSpec {
      * @param args                  the argument list
      * @param expectedException     the expected exception or null
      */
-    private void executeTest(String testName, CommandLineProgramTest testClass, File outputFileLocation, List<String> expectedFileNames, List<File> tmpFiles, String args, Class<?> expectedException) throws IOException {
+    private void executeTest(String testName, CommandLineProgramTestInterface testClass, File outputFileLocation, List<String> expectedFileNames, List<File> tmpFiles, String args, Class<?> expectedException) throws IOException {
         if (outputFileLocation != null) {
             args += " -O " + outputFileLocation.getAbsolutePath();
         }
@@ -138,7 +137,7 @@ public final class IntegrationTestSpec {
      * @param args              the argument list
      * @param expectedException the expected exception or null
      */
-    private void executeTest(String testName, CommandLineProgramTest testClass, String args, Class<?> expectedException) {
+    private void executeTest(String testName, CommandLineProgramTestInterface testClass, String args, Class<?> expectedException) {
         String[] command = Utils.escapeExpressions(args);
         // run the executable
         boolean gotAnException = false;
@@ -209,7 +208,7 @@ public final class IntegrationTestSpec {
         for (int i = 0; i < minLen; i++) {
             Assert.assertEquals(actualLines.get(i).toString(), expectedLines.get(i).toString(), "Line number " + i + " (not counting comments)");
         }
-        Assert.assertEquals (actualLines.size(), expectedLines.size(), "line counts");
+        Assert.assertEquals(actualLines.size(), expectedLines.size(), "line counts");
     }
 
 }


### PR DESCRIPTION
This is a very minimal change of the testing framework to allow users of the framework to use `IntegrationTestSpec` with their own classes.

It solves the problem of a custom  `Main` class to run the command line test in programs using the framework (through overriding default behavior), and the loading of `GenomeLocParser` by the `BaseTest` if the test is simply extending `CommandLineProgramTest`. More details for this issue in #2033.

Now API users could implements and modify default behavior of `CommandLineProgramTestInterface` and use this test classes in `IntegrationTestSpec`.