### PR TITLE
Remove and replace custom tool filter args with standard read filters.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/TwoPassReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/TwoPassReadWalker.java
@@ -67,11 +67,6 @@ public abstract class TwoPassReadWalker extends ReadWalker {
                 });
     }
 
-    @Override
-    public List<ReadFilter> getDefaultReadFilters() {
-        return Collections.singletonList(new ReadFilterLibrary.AllowAllReadsReadFilter());
-    }
-
     /**
      * a common abstraction for first and second pass apply functions
      */

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/OverclippedReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/OverclippedReadFilter.java
@@ -32,7 +32,7 @@ public final class OverclippedReadFilter extends ReadFilter{
             doc = "Allow a read to be filtered out based on having only 1 soft-clipped block. By default, both ends must " +
                     "have a soft-clipped block, setting this flag requires only 1 soft-clipped block.",
             optional = true)
-    public Boolean doNotRequireSoftclipsOnBothEnds;
+    public boolean doNotRequireSoftclipsOnBothEnds;
 
     // Command line parser requires a no-arg constructor
     public OverclippedReadFilter() {}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
@@ -14,7 +14,12 @@ import java.util.function.Predicate;
  * based on the implementing class's implementation of test().
  *
  * To be accessible from the command line, subclasses must have a zero-arg constructor and contain
- * an ArgumentCollection.
+ * (optional) ArgumentCollection or Argument annotated fields for filter-specific arguments. Arguments
+ * that are optional=true should have an initial value since the command line parser will not require
+ * the user to provide one; arguments that are optional=false should not have an initial value (and
+ * used boxed types with null default/initial values) since otherwise they will be seen by the command
+ * line parser as having been provided, and the user will not be notified that the value must be provided
+ * on the command line).
  */
 public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
@@ -20,17 +20,27 @@ public final class ReadFilterLibrary {
         @Override public boolean test(final GATKRead read){return true;}}
 
     //Note: do not call getCigar to avoid creation of new Cigar objects
-    public static class CigarIsSupportedReadFilter extends ReadFilter {
+    public static class CigarContainsNoNOperator extends ReadFilter {
         private static final long serialVersionUID = 1L;
         @Override public boolean test(final GATKRead read){
             return ! CigarUtils.containsNOperator(read.getCigarElements());}}
+
+    public static class FirstOfPairReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test (final GATKRead read) {
+            return read.isFirstOfPair();}}
 
     public static class GoodCigarReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
         @Override public boolean test (final GATKRead read) {
             return CigarUtils.isGood(read.getCigar());}}
 
-    public static class HasMatchingBasesAndQualsReadFilter extends ReadFilter {
+    public static class NonZeroFragmentLengthReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read){
+            return read.getFragmentLength() != 0;}}
+
+    public static class MatchingBasesAndQualsReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
         @Override public boolean test(final GATKRead read){
             return read.getLength() == read.getBaseQualityCount();}}
@@ -42,17 +52,17 @@ public final class ReadFilterLibrary {
 
     public static class MappedReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
-        @Override public boolean test(final GATKRead read){
+        @Override public boolean test(final GATKRead read) {
             return !read.isUnmapped();}}
 
     public static class MappingQualityAvailableReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
-        @Override public boolean test(final GATKRead read){
+        @Override public boolean test(final GATKRead read) {
             return read.getMappingQuality() != QualityUtils.MAPPING_QUALITY_UNAVAILABLE;}}
 
     public static class MappingQualityNotZeroReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
-        @Override public boolean test(final GATKRead read){
+        @Override public boolean test(final GATKRead read) {
             return read.getMappingQuality() != 0;}}
 
     /**
@@ -89,14 +99,37 @@ public final class ReadFilterLibrary {
         @Override public boolean test(final GATKRead read){
             return ! read.isDuplicate();}}
 
+    public static class NotSecondaryAlignmentReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read) {
+            return !read.isSecondaryAlignment();}}
+
+    public static class NotSupplementaryAlignmentReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read) {
+            return !read.isSupplementaryAlignment();}}
+
+    public static class PairedReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read) {
+            return read.isPaired();}}
+
     public static class PassesVendorQualityCheckReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
         @Override public boolean test(final GATKRead read){
             return ! read.failsVendorQualityCheck();}}
 
+    public static class ProperlyPairedReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read) {
+            return read.isProperlyPaired();}}
+
+    //TODO: should this reject supplementary alignments ? If not it should be
+    //removed since its redundant with NotSecondaryAlignmentReadFilter
+    //https://github.com/broadinstitute/gatk/issues/2165
     public static class PrimaryAlignmentReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
-        @Override public boolean test(final GATKRead read){
+        @Override public boolean test(final GATKRead read) {
             return ! read.isSecondaryAlignment();}}
 
     //Note: do not call getCigar to avoid creation of new Cigar objects
@@ -105,6 +138,11 @@ public final class ReadFilterLibrary {
         @Override public boolean test (final GATKRead read) {
             return read.isUnmapped() ||
                     read.getLength() == Cigar.getReadLength(read.getCigarElements());}}
+
+    public static class SecondOfPairReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test (final GATKRead read) {
+            return read.isSecondOfPair();}}
 
     public static class SeqIsStoredReadFilter extends ReadFilter {
         private static final long serialVersionUID = 1L;
@@ -126,20 +164,27 @@ public final class ReadFilterLibrary {
      * Static, stateless read filter instances
      */
     public static final AllowAllReadsReadFilter ALLOW_ALL_READS = new AllowAllReadsReadFilter();
-    public static final CigarIsSupportedReadFilter CIGAR_IS_SUPPORTED = new CigarIsSupportedReadFilter();
+    public static final CigarContainsNoNOperator CIGAR_CONTAINS_NO_N_OPERATOR = new CigarContainsNoNOperator();
+    public static final FirstOfPairReadFilter FIRST_OF_PAIR = new FirstOfPairReadFilter();
     public static final GoodCigarReadFilter GOOD_CIGAR = new GoodCigarReadFilter();
     public static final HasReadGroupReadFilter HAS_READ_GROUP = new HasReadGroupReadFilter();
-    public static final HasMatchingBasesAndQualsReadFilter HAS_MATCHING_BASES_AND_QUALS = new HasMatchingBasesAndQualsReadFilter();
     public static final MappedReadFilter MAPPED = new MappedReadFilter();
     public static final MappingQualityAvailableReadFilter MAPPING_QUALITY_AVAILABLE = new MappingQualityAvailableReadFilter();
     public static final MappingQualityNotZeroReadFilter MAPPING_QUALITY_NOT_ZERO   = new MappingQualityNotZeroReadFilter();
+    public static final MatchingBasesAndQualsReadFilter HAS_MATCHING_BASES_AND_QUALS = new MatchingBasesAndQualsReadFilter();
     public static final MateOnSameContigOrNoMappedMateReadFilter MATE_ON_SAME_CONTIG_OR_NO_MAPPED_MATE = new MateOnSameContigOrNoMappedMateReadFilter();
     public static final MateDifferentStrandReadFilter MATE_DIFFERENT_STRAND = new MateDifferentStrandReadFilter();
-    public static final NotDuplicateReadFilter NOT_DUPLICATE = new NotDuplicateReadFilter();
     public static final NonZeroReferenceLengthAlignmentReadFilter NON_ZERO_REFERENCE_LENGTH_ALIGNMENT = new NonZeroReferenceLengthAlignmentReadFilter();
+    public static final NonZeroFragmentLengthReadFilter NONZERO_FRAGMENT_LENGTH_READ_FILTER = new NonZeroFragmentLengthReadFilter();
+    public static final NotDuplicateReadFilter NOT_DUPLICATE = new NotDuplicateReadFilter();
+    public static final NotSecondaryAlignmentReadFilter NOT_SECONDARY_ALIGNMENT = new NotSecondaryAlignmentReadFilter();
+    public static final NotSupplementaryAlignmentReadFilter NOT_SUPPLEMENTARY_ALIGNMENT = new NotSupplementaryAlignmentReadFilter();
+    public static final PairedReadFilter PAIRED = new PairedReadFilter();
+    public static final ProperlyPairedReadFilter PROPERLY_PAIRED = new ProperlyPairedReadFilter();
     public static final PassesVendorQualityCheckReadFilter PASSES_VENDOR_QUALITY_CHECK = new PassesVendorQualityCheckReadFilter();
     public static final PrimaryAlignmentReadFilter PRIMARY_ALIGNMENT = new PrimaryAlignmentReadFilter();
     public static final ReadLengthEqualsCigarLengthReadFilter READLENGTH_EQUALS_CIGARLENGTH = new ReadLengthEqualsCigarLengthReadFilter();
+    public static final SecondOfPairReadFilter SECOND_OF_PAIR = new SecondOfPairReadFilter();
     public static final SeqIsStoredReadFilter SEQ_IS_STORED = new SeqIsStoredReadFilter();
     public static final ValidAlignmentStartReadFilter VALID_ALIGNMENT_START = new ValidAlignmentStartReadFilter();
     public static final ValidAlignmentEndReadFilter VALID_ALIGNMENT_END = new ValidAlignmentEndReadFilter();

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
@@ -24,7 +24,7 @@ public final class ReadLengthReadFilter extends ReadFilter implements Serializab
             shortName = minLengthArg,
             doc="Keep only reads with length at least equal to the specified value",
             optional=true)
-    public Integer minReadLength = 1;
+    public int minReadLength = 1;
 
     @Override
     public boolean test( final GATKRead read ) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadStrandFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadStrandFilter.java
@@ -12,7 +12,7 @@ public final class ReadStrandFilter extends ReadFilter {
     @Argument(fullName = "keepReverse",
             shortName = "keepReverse",
             doc="Keep only reads on the reverse strand",
-            optional=true)
+            optional=false)
 	public Boolean keepOnlyReverse;
 
     public ReadStrandFilter() {}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
@@ -37,7 +37,7 @@ public final class WellformedReadFilter extends ReadFilter {
                 .and(ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS)
                 .and(ReadFilterLibrary.READLENGTH_EQUALS_CIGARLENGTH)
                 .and(ReadFilterLibrary.SEQ_IS_STORED)
-                .and(ReadFilterLibrary.CIGAR_IS_SUPPORTED);
+                .and(ReadFilterLibrary.CIGAR_CONTAINS_NO_N_OPERATOR);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetricsArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetricsArgumentCollection.java
@@ -45,59 +45,7 @@ public class InsertSizeMetricsArgumentCollection extends MetricsArgumentCollecti
     @Argument(doc = "Should an output plot be created")
     public boolean producePlot = false;
 
-    // read filtering criteria
-    @Argument(doc = "If set to true, filter pairs of reads that are not properly--as judged by aligner--oriented.",
-            shortName = "PP",
-            fullName = "filterNonProperlyPairedReads",
-            optional = true)
-    public boolean filterNonProperlyPairedReads = false;
-
-    @Argument(doc = "If set to true, include duplicated reads as well.",
-            shortName = "Dup",
-            fullName = "useDuplicateReads",
-            optional = true)
-    public boolean useDuplicateReads = false;
-
-    @Argument(doc = "If set to true, include secondary alignments.",
-            shortName = "S",
-            fullName = "useSecondaryAlignments",
-            optional = true)
-    public boolean useSecondaryAlignments = false;
-
-    @Argument(doc = "If set to true, include supplementary alignments.",
-            shortName = "SS",
-            fullName = "useSupplementaryAlignments",
-            optional = true)
-    public boolean useSupplementaryAlignments = false;
-
-    @Argument(doc = "If set non-zero value, only include reads passing certain mapping quality threshold. " +
-            "If set to zero, reads with zero mapping quality will be included in calculating metrics.",
-            shortName = "MAPQ",
-            fullName = "MAPQThreshold",
-            optional = true)
-    public int MQPassingThreshold = 0;
-
     @ArgumentCollection
     public MetricAccumulationLevelArgumentCollection metricAccumulationLevel = new MetricAccumulationLevelArgumentCollection();
 
-    /**
-     * Which end of a read pair to use for collecting insert size metrics.
-     */
-    public enum EndToUse {
-        FIRST(1), SECOND(2);
-        private final int value;
-        EndToUse(int value){
-            this.value = value;
-        }
-        public int getValue(){
-            return value;
-        }
-    }
-
-    @Argument(doc = "Which end of pairs to use for collecting information. " +
-            "Possible values:{FIRST, SECOND}.",
-            shortName = "E",
-            fullName = "whichEndOfPairToUse",
-            optional = true)
-    public EndToUse useEnd = EndToUse.FIRST;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -81,8 +81,8 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
             throw new UserException.Require2BitReferenceForBroadcast();
         }
         //Should this get the getUnfilteredReads? getReads will merge default and command line filters.
-        // but the code below uses other filters for other parts of the pipline that do not honor
-        // the commandline.
+        //but the code below uses other filters for other parts of the pipeline that do not honor
+        //the commandline.
         final JavaRDD<GATKRead> initialReads = getReads();
 
         // The initial reads have already had the WellformedReadFilter applied to them, which

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
@@ -82,8 +82,6 @@ public final class CollectMultipleMetricsSpark extends GATKSparkTool {
                 final InsertSizeMetricsArgumentCollection isArgs = new InsertSizeMetricsArgumentCollection();
                 isArgs.output = localBaseName + ".txt";
                 isArgs.histogramPlotFile = localBaseName + ".pdf";
-
-                isArgs.useEnd = InsertSizeMetricsArgumentCollection.EndToUse.SECOND;
                 isArgs.metricAccumulationLevel.accumulationLevels = metricAccumulationLevel;
 
                 final InsertSizeMetricsCollectorSpark collector = new InsertSizeMetricsCollectorSpark();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.TwoPassReadWalker;
-import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.transformers.NDNCigarReadTransformer;
@@ -101,10 +101,10 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
     SAMFileHeader header;
 
     @Override
-    public CountingReadFilter makeReadFilter() {
-        return new CountingReadFilter(ReadFilterLibrary.ALLOW_ALL_READS);
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.ALLOW_ALL_READS);
     }
-    
+
     @Override
     public void onTraversalStart() {
         header = getHeaderForSAMWriter();

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
@@ -315,6 +315,65 @@ public class ReadFilterPluginUnitTest {
                 WellformedReadFilter.class.getSimpleName()
         };
 
+        int count = verifyAndFilterOrder(rf, expectedOrder);
+        Assert.assertEquals(6, count);
+    }
+
+    @Test
+    public void testPreserveToolDefaultFilterOrder() {
+
+        List<ReadFilter> orderedDefaults = new ArrayList<>();
+        orderedDefaults.add(new WellformedReadFilter());
+        orderedDefaults.add(ReadFilterLibrary.MAPPED);
+        orderedDefaults.add(ReadFilterLibrary.HAS_READ_GROUP);
+        orderedDefaults.add(ReadFilterLibrary.MAPPING_QUALITY_NOT_ZERO);
+        orderedDefaults.add(ReadFilterLibrary.PAIRED);
+        orderedDefaults.add(ReadFilterLibrary.NONZERO_FRAGMENT_LENGTH_READ_FILTER);
+        orderedDefaults.add(ReadFilterLibrary.FIRST_OF_PAIR);
+        orderedDefaults.add(ReadFilterLibrary.PROPERLY_PAIRED);
+        orderedDefaults.add(ReadFilterLibrary.NOT_DUPLICATE);
+        orderedDefaults.add(ReadFilterLibrary.NOT_SECONDARY_ALIGNMENT);
+        orderedDefaults.add(ReadFilterLibrary.NOT_SUPPLEMENTARY_ALIGNMENT);
+
+        CommandLineParser clp = new CommandLineParser(new Object(),
+                Collections.singletonList(new GATKReadFilterPluginDescriptor(orderedDefaults)));
+        clp.parseArguments(System.out, new String[] {
+                //disable one just to mix things up
+                "-disableReadFilter", ReadFilterLibrary.MAPPED.getClass().getSimpleName(),
+                "-readFilter", ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS.getClass().getSimpleName(),
+                "-readFilter", ReadFilterLibrary.GOOD_CIGAR.getClass().getSimpleName()});
+
+        // Now get the final merged read filter and verify the execution order. We need to ensure that
+        // getMergedReadFilter creates a composite filter that honors the filter test execution
+        // order rules (tool defaults first, in order, followed by command line-specified, in order
+        // listed). So reach inside the filter and navigate down the tree. Since these are
+        // "and" filters that are built bottom-up, and we're traversing down, we visit the nodes
+        // in the opposite of the order their tests are executed.
+        ReadFilter rf = instantiateFilter(clp, createHeaderWithReadGroups());
+        String expectedOrder[] = {
+                // this list is in the order we encounter the nodes on the way down, which is the
+                // reverse of the order of test execution
+                ReadFilterLibrary.GOOD_CIGAR.getClass().getSimpleName(),
+                ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS.getClass().getSimpleName(),
+                ReadFilterLibrary.NOT_SUPPLEMENTARY_ALIGNMENT.getClass().getSimpleName(),
+                ReadFilterLibrary.NOT_SECONDARY_ALIGNMENT.getClass().getSimpleName(),
+                ReadFilterLibrary.NOT_DUPLICATE.getClass().getSimpleName(),
+                ReadFilterLibrary.PROPERLY_PAIRED.getClass().getSimpleName(),
+                ReadFilterLibrary.FIRST_OF_PAIR.getClass().getSimpleName(),
+                ReadFilterLibrary.NONZERO_FRAGMENT_LENGTH_READ_FILTER.getClass().getSimpleName(),
+                ReadFilterLibrary.PAIRED.getClass().getSimpleName(),
+                ReadFilterLibrary.MAPPING_QUALITY_NOT_ZERO.getClass().getSimpleName(),
+                ReadFilterLibrary.HAS_READ_GROUP.getClass().getSimpleName(),
+                WellformedReadFilter.class.getSimpleName()
+        };
+
+        int count = verifyAndFilterOrder(rf, expectedOrder);
+        Assert.assertEquals(12, count);
+    }
+
+    private int verifyAndFilterOrder(final ReadFilter rf,  final String[] expectedOrder) {
+        // Since these are "and" filters that are built bottom-up, and we're traversing down, we
+        // visit the nodes in the opposite of the order their tests are executed.
         int count = 0;
         ReadFilter.ReadFilterAnd rfAnd = (ReadFilter.ReadFilterAnd) rf;
         while(rfAnd != null) {
@@ -330,8 +389,7 @@ public class ReadFilterPluginUnitTest {
             }
             count++;
         }
-
-        Assert.assertEquals(6, count);
+        return count;
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.pipelines.metrics;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.metrics.InsertSizeMetricsArgumentCollection;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -11,9 +11,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 public final class CollectInsertSizeMetricsSparkIntegrationTest extends CommandLineProgramTest {
     private static final File TEST_DATA_DIR = new File(getTestDataDir(), "picard/analysis/CollectInsertSizeMetrics");
@@ -75,8 +72,10 @@ public final class CollectInsertSizeMetricsSparkIntegrationTest extends CommandL
         }
 
         // some filter options
-        args.add("-" + "E");
-        args.add(InsertSizeMetricsArgumentCollection.EndToUse.SECOND.name());
+        args.add("-DF");
+        args.add(ReadFilterLibrary.FirstOfPairReadFilter.class.getSimpleName());
+        args.add("-RF");
+        args.add(ReadFilterLibrary.SecondOfPairReadFilter.class.getSimpleName());
 
         if (allLevels) {
             // accumulation level options (all included for better test coverage)


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/2148, https://github.com/broadinstitute/gatk/issues/2142, and a bug where we were honoring command line order of read filters but not tool default order. Also contains a few TODOs with questions about the suitability of names and/or implementations of some existing read filters.