### PR TITLE
fix typo in AFCalculator error message

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculator.java
@@ -31,7 +31,7 @@ public abstract class AFCalculator {
     public AFCalculationResult getLog10PNonRef(final VariantContext vc, final int defaultPloidy, final int maximumAlternativeAlleles, final double[] log10AlleleFrequencyPriors) {
         Utils.nonNull(vc, "VariantContext cannot be null");
         Utils.nonNull(log10AlleleFrequencyPriors, "priors vector cannot be null");
-        Utils.validateArg( vc.getNAlleles() > 1, "VariantContext has only a single reference allele, but getLog10PNonRef requires at least one at all " + vc);
+        Utils.validateArg( vc.getNAlleles() > 1, "VariantContext has only a single reference allele, but getLog10PNonRef requires at least one alt allele " + vc);
 
         // reset the result, so we can store our new result there
         final StateTracker stateTracker = getStateTracker(true, maximumAlternativeAlleles);


### PR DESCRIPTION
AFCalculator.getLog10PNonRef() was throwing a confusing error due to a typo.