### PR TITLE
Pileup-related changes (LIBS/LocusWalker/ReadPileup)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -545,7 +545,7 @@ public final class AssemblyRegion implements Locatable {
             windowReads.add(read);
         }
 
-        final LocusIteratorByState locusIterator = new LocusIteratorByState(windowReads.iterator(), DownsamplingMethod.NONE, false, false, ReadUtils.getSamplesFromHeader(readsHeader), readsHeader);
+        final LocusIteratorByState locusIterator = new LocusIteratorByState(windowReads.iterator(), DownsamplingMethod.NONE, false, ReadUtils.getSamplesFromHeader(readsHeader), readsHeader, false);
         final ActivityProfile activityProfile = new BandPassActivityProfile(null, maxProbPropagationDistance, activeProbThreshold, BandPassActivityProfile.MAX_FILTER_SIZE, BandPassActivityProfile.DEFAULT_SIGMA, readsHeader);
 
         // First, use our activity profile to determine the bounds of each assembly region:

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/Pileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/Pileup.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -113,14 +114,13 @@ public final class Pileup extends LocusWalker {
     }
 
     @Override
-    public CountingReadFilter makeReadFilter(){
-        return new CountingReadFilter(new WellformedReadFilter(getHeaderForReads()))
-            .and(new CountingReadFilter(ReadFilterLibrary.MAPPED))
-            .and(new CountingReadFilter(ReadFilterLibrary.NOT_DUPLICATE))
-            .and(new CountingReadFilter(ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK))
-            .and(new CountingReadFilter(ReadFilterLibrary.PRIMARY_ALIGNMENT));
+    public List<ReadFilter> getDefaultReadFilters() {
+        final List<ReadFilter> defaultFilters = super.getDefaultReadFilters();
+        defaultFilters.add(ReadFilterLibrary.NOT_DUPLICATE);
+        defaultFilters.add(ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK);
+        defaultFilters.add(ReadFilterLibrary.PRIMARY_ALIGNMENT);
+        return defaultFilters;
     }
-
 
     @Override
     public void onTraversalStart() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateBaseTest.java
@@ -64,11 +64,12 @@ public abstract class LocusIteratorByStateBaseTest extends BaseTest {
         return new LocusIteratorByState(
                 new FakeCloseableIterator<>(reads.iterator()),
                 downsamplingMethod,
-                true,
-                includeNs,
                 keepUniqueReadList,
                 sampleListForSAMWithoutReadGroups(),
-                header);
+                header,
+                true,
+                includeNs
+        );
     }
 
     private boolean isIndel(final CigarElement ce) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
@@ -506,9 +506,14 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
 
         final List<GATKRead> reads = bamBuilder.makeReads();
         final LocusIteratorByState li;
-        li = new LocusIteratorByState(new FakeCloseableIterator<>(reads.iterator()),
-                downsampler, true, keepReads,
-                bamBuilder.getSamples(), bamBuilder.getHeader());
+        li = new LocusIteratorByState(
+                new FakeCloseableIterator<>(reads.iterator()),
+                downsampler,
+                keepReads,
+                bamBuilder.getSamples(),
+                bamBuilder.getHeader(),
+                true
+        );
 
         final Set<GATKRead> seenSoFar = new LinkedHashSet<>();
         final Set<GATKRead> keptReads = new LinkedHashSet<>();
@@ -664,9 +669,14 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         final WeakReadTrackingIterator iterator = new WeakReadTrackingIterator(nReadsPerLocus, readLength, payloadInBytes, header);
 
         final LocusIteratorByState li;
-        li = new LocusIteratorByState(iterator,
-                downsampler, true, false,
-                samples, header);
+        li = new LocusIteratorByState(
+                iterator,
+                downsampler,
+                false,
+                samples,
+                header,
+                true
+        );
 
         while ( li.hasNext() ) {
             final AlignmentContext next = li.next();
@@ -760,9 +770,11 @@ public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBase
         li = new LocusIteratorByState(
                 new FakeCloseableIterator<>(Collections.singletonList(read).iterator()),
                 DownsamplingMethod.NONE,
-                true,
                 false,
-                sampleListForSAMWithoutReadGroups(), header);
+                sampleListForSAMWithoutReadGroups(),
+                header,
+                true
+        );
 
         int expectedPos = read.getStart() + nClipsOnLeft;
         int nPileups = 0;

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
@@ -7,10 +7,12 @@ import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -23,7 +25,7 @@ import static org.broadinstitute.hellbender.utils.read.ReadConstants.NO_MAPPING_
 /**
  * Test routines for read-backed pileup.
  */
-public final class ReadPileupUnitTest {
+public final class ReadPileupUnitTest extends BaseTest {
     private static SAMFileHeader header;
     private Locatable loc;
 
@@ -488,6 +490,146 @@ public final class ReadPileupUnitTest {
         Assert.assertEquals(pu.getSamples(header), Arrays.asList(new String[]{null}), "getSamples");
         Assert.assertTrue(pu.getPileupForLane("fred").isEmpty());
         Assert.assertTrue(pu.makeFilteredPileup(p -> p.getMappingQual() >= 10).isEmpty());
+    }
+
+    @DataProvider(name = "FixPairOverlappingQualitiesTest")
+    public Object[][] overlappingElementsToFix() throws Exception {
+        final byte highQual = 60;
+        final byte lowQual = 10;
+        final byte qualitySum = 70;
+        final byte reducedQuality = 48; // 80% of 60
+        final byte zeroQuality = 0;
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead("6M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("6M");
+        // set the paired and mate state
+        read1.setIsPaired(true);
+        read1.setMatePosition(read2);
+        // set bases and qualities
+        read1.setBases(new byte[] {'A', 'A', 'A', 'A', 'T', 'T'});
+        read1.setBaseQualities(new byte[] {highQual, highQual, highQual, lowQual,
+                highQual, SAMUtils.MAX_PHRED_SCORE});
+        // set the paired and mate state
+        read2.setIsPaired(true);
+        read2.setMatePosition(read1);
+        // set bases and qualities
+        read2.setBases(new byte[] {'A', 'T', 'T', 'T', 'T', 'T'});
+        read2.setBaseQualities(new byte[] {lowQual, highQual, lowQual, highQual,
+                highQual, SAMUtils.MAX_PHRED_SCORE});
+        return new Object[][] {
+                // Same base, first element with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 0),
+                        PileupElement.createPileupForReadAndOffset(read2, 0),
+                        qualitySum, zeroQuality},
+                // Different base, both with same quality
+                {PileupElement.createPileupForReadAndOffset(read1, 1),
+                        PileupElement.createPileupForReadAndOffset(read2, 1),
+                        reducedQuality, zeroQuality},
+                // Different base, first with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 2),
+                        PileupElement.createPileupForReadAndOffset(read2, 2),
+                        reducedQuality, zeroQuality},
+                // Different base, second with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 3),
+                        PileupElement.createPileupForReadAndOffset(read2, 3),
+                        zeroQuality, reducedQuality},
+                // Same base, high quality for both (simple cap)
+                {PileupElement.createPileupForReadAndOffset(read1, 4),
+                        PileupElement.createPileupForReadAndOffset(read2, 4),
+                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
+                // Same base, maximum qualities for both (simple cap)
+                {PileupElement.createPileupForReadAndOffset(read1, 5),
+                        PileupElement.createPileupForReadAndOffset(read2, 5),
+                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
+        };
+    }
+
+    @Test(dataProvider = "FixPairOverlappingQualitiesTest")
+    public void testFixPairOverlappingQualities(final PileupElement first,
+                                                final PileupElement second, final byte expectedQualFirst,
+                                                final byte expectedQualSecond) throws Exception {
+        ReadPileup.fixPairOverlappingQualities(first, second);
+        Assert.assertEquals(first.getQual(), expectedQualFirst);
+        Assert.assertEquals(second.getQual(), expectedQualSecond);
+    }
+
+
+    @Test(dataProvider = "FixPairOverlappingQualitiesTest")
+    public void testFixPairOverlappingQualitiesFromReadPileup(final PileupElement first,
+            final PileupElement second, final byte expectedQualFirst,
+            final byte expectedQualSecond) throws Exception {
+        final List<PileupElement> elements = Arrays.asList(first, second);
+        final ReadPileup pileup = new ReadPileup(loc, elements);
+        pileup.fixOverlaps();
+        Assert.assertEquals(elements.get(0).getQual(), expectedQualFirst);
+        Assert.assertEquals(elements.get(1).getQual(), expectedQualSecond);
+    }
+
+    @Test
+    public void testFixPairOverlappingQualitiesCap() {
+        final PileupElement element1 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element1.getRead().setName("read1");
+        element1.getRead().setBases(new byte[] {'A'});
+        final PileupElement element2 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element2.getRead().setName("read2");
+        element2.getRead().setBases(new byte[] {'A'});
+        final PileupElement element3 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element3.getRead().setName("read3");
+        element2.getRead().setBases(new byte[] {'A'});
+        element3.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
+        // Check all possible combinations that goes beyond the maximum value
+        for (byte i = 0; i < Byte.MAX_VALUE; i++) {
+            final byte[] iArray = new byte[] {i};
+            final byte j = (byte) (Byte.MAX_VALUE - i);
+            element1.getRead().setBaseQualities(iArray);
+            element2.getRead().setBaseQualities(new byte[] {j});
+            logger.debug("Test: fixing ({}) and ({})", element1, element2);
+            ReadPileup.fixPairOverlappingQualities(element1, element2);
+            Assert.assertEquals(element1.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+            Assert.assertEquals(element2.getQual(), 0);
+            element1.getRead().setBaseQualities(iArray);
+            logger.debug("Test: fixing ({}) and ({})", element3, element1);
+            ReadPileup.fixPairOverlappingQualities(element3, element1);
+            Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+            Assert.assertEquals(element1.getQual(), 0);
+        }
+        // Finally, check what happens if both are the maximum value
+        element1.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
+        logger.debug("Test: fixing ({}) and ({})", element3, element1);
+        ReadPileup.fixPairOverlappingQualities(element3, element1);
+        Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+        Assert.assertEquals(element1.getQual(), 0);
+    }
+
+    @Test
+    public void testFixOverlappingQualitiesDeletedElements() throws Exception {
+        // Create two reads with deletion
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("1M1D1M");
+        read.setBases(new byte[] {'A', 'A'});
+        read.setBaseQualities(new byte[] {60, 60});
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("1M1D1M");
+        read.setBases(new byte[] {'A', 'A'});
+        read2.setBaseQualities(new byte[] {40, 40});
+        // Creates PileupElement with a copy of the reads to keep the original read unmodified, because the read from
+        // the PileupElement is a reference to the Object passed to the constructor. This is required
+        // because fixing the overlapping qualities change the read stored into PileupElement and we have to check that
+        // it does not change anything from the read.
+        final GATKRead copy = read.deepCopy();
+        final GATKRead copy2 = read2.deepCopy();
+        final PileupElement deleted = new PileupElement(copy, 1, copy.getCigarElement(1), 1, 0);
+        final PileupElement normal = new PileupElement(copy2, 0, copy.getCigarElement(0), 0, 0);
+        ReadPileup.fixPairOverlappingQualities(deleted, normal);
+        // Copy reads are a reference to the read into the PileupElement, and thus should not be modified.
+        // Thus, we use them to test if it is not modified. This could be checked uncommenting the next two lines:
+        // Assert.assertSame(deleted.getRead(), copy);
+        // Assert.assertSame(normal.getRead(), copy2);
+        Assert.assertEquals(copy, read);
+        Assert.assertEquals(copy2, read2);
+        ReadPileup.fixPairOverlappingQualities(normal, deleted);
+        Assert.assertEquals(copy, read);
+        Assert.assertEquals(copy2, read2);
     }
 
 }


### PR DESCRIPTION
This PR tries to solve several issues:
* Refactoring constructors for LIBS (#1879)
* Adding maximum depth per sample argument to `LocusWalker` to avoid memory overload
* Fixing `Pileup`/`CheckPileup` tools for command line read filters
* Method for fix overlaps in `ReadPileup` in the same way as samtools (#2034)