### PR TITLE
replacing coveralls with codecov

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ env:
   - HELLBENDER_TEST_STAGING=gs://hellbender/test/staging/
   - HELLBENDER_TEST_PROJECT=broad-dsde-dev
   - HELLBENDER_JSON_SERVICE_ACCOUNT_KEY=servicekey.json
-  #coveralls repo token
-  - secure: RA4LKD82cW+0xPayPVAWSpYqJu5uoPcz7oXXYtYNVuilFmS8PGYx0g/BXs4QMvQsGMt6aMLN8m7lMAPN5XTH/8JSeM3VmQ3mdpgNdP+p3CVlwrapZ2lTq27Wb/E8J1CGEHOg76z716t//FUElyC/gdhS+tfBmXk3YanM5fMXEHs=
   #google API key
   - secure: "eHyDxfcfv6pSIkoqQ9PimiYu9I6vmXJOpY/OkXLkc7ZAUfNTfRVytUGG9Xf/bKKF+Wscm5pIfZJ/TMDG6E3Uyngs9nVK/29QWevcEaLDJy8OdI9OgPZb13hlbM2jbVv5AVBGYcbcNBrTvrTs0MOMOFPEJqZ99xWIj5bzZ/AsIfU="
   #for uploading artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
     travis_wait 30 ./gradlew jacocoTestReport;
   fi
 after_success:
-- if [[ $CLOUD == false ]]; then ./gradlew coveralls; fi
+- bash <(curl -s https://codecov.io/bash)
 - if [[ $TRAVIS_BRANCH == master && $CLOUD == false ]]; then ./gradlew uploadArchives; fi
 after_failure:
 - dmesg | tail -100

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/broadinstitute/gatk.svg?branch=master)](https://travis-ci.org/broadinstitute/gatk)
-[![Coverage Status](https://coveralls.io/repos/broadinstitute/gatk/badge.svg?branch=master)](https://coveralls.io/r/broadinstitute/gatk?branch=master)
+[![codecov](https://codecov.io/gh/broadinstitute/gatk/branch/master/graph/badge.svg)](https://codecov.io/gh/broadinstitute/gatk)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.broadinstitute/gatk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.broadinstitute/gatk)
 [![License (3-Clause BSD)](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,27 @@
 codecov:
   branch: master
-  bot: null
 
 coverage:
   precision: 3
   round: nearest
   range: "0...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: null
+        branches: null
+
+    patch:
+      default:
+        target: auto
+        branches: null
+
+    changes:
+      default:
+        branches: null
+
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  branch: master
+  bot: null
+
+coverage:
+  precision: 3
+  round: nearest
+  range: "0...100"
+
+comment:
+  layout: "header, diff, changes, sunburst, uncovered, tree"
+  branches: null
+  behavior: default


### PR DESCRIPTION
wanted to see how codecov.io works.  don't merge this.  It looks like they fixed all the problems we have with coveralls though and actually generate a useful report.  They have a browser extension that lets you view which lines are covered by tests in github.  It seems like it would actually be pretty useful in code reviews. 