### PR TITLE
Fix a bug responsible for creating duplicate inversion calls

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointAllele.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointAllele.java
@@ -1,7 +1,12 @@
 package org.broadinstitute.hellbender.tools.spark.sv;
 
+import com.esotericsoftware.kryo.DefaultSerializer;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -9,17 +14,16 @@ import static org.broadinstitute.hellbender.tools.spark.sv.BreakpointAllele.Inve
 import static org.broadinstitute.hellbender.tools.spark.sv.BreakpointAllele.InversionType.INV_5_TO_3;
 
 /**
- * This class represents the allele of an SV breakpoint (a novel adjacency between two genomic locations
+ * This class represents the allele of an SV breakpoint (a novel adjacency between two genomic locations)
  */
+@DefaultSerializer(BreakpointAllele.Serializer.class)
 class BreakpointAllele {
+
     final SimpleInterval leftAlignedLeftBreakpoint;
     final SimpleInterval leftAlignedRightBreakpoint;
     final String insertedSequence;
     final String homology;
-    final InversionType inversionType;
-
-    // not included in equals and hashCode so as not to break grouping by breakpoint allele if the mappings are different
-    final List<String> insertionMappings;
+    private final InversionType inversionType;
 
     public BreakpointAllele(final SimpleInterval leftAlignedLeftBreakpoint, final SimpleInterval leftAlignedRightBreakpoint, final String insertedSequence, final String homology, final boolean fiveToThree, final boolean threeToFive, final List<String> insertionMappings) {
         this.leftAlignedLeftBreakpoint = leftAlignedLeftBreakpoint;
@@ -27,14 +31,28 @@ class BreakpointAllele {
         this.insertedSequence = insertedSequence;
         this.homology = homology;
         this.inversionType = getInversionType(fiveToThree, threeToFive);
-        this.insertionMappings = insertionMappings;
+    }
+
+    @SuppressWarnings("unchecked")
+    public BreakpointAllele(final Kryo kryo, final Input input) {
+        final String contig1 = input.readString();
+        final int start1 = input.readInt();
+        final int end1 = input.readInt();
+        this.leftAlignedLeftBreakpoint = new SimpleInterval(contig1, start1, end1);
+        final String contig2 = input.readString();
+        final int start2 = input.readInt();
+        final int end2 = input.readInt();
+        this.leftAlignedRightBreakpoint = new SimpleInterval(contig2, start2, end2);
+        this.insertedSequence = input.readString();
+        this.homology = input.readString();
+        this.inversionType = InversionType.values()[input.readInt()];
     }
 
     public boolean isInversion() {
         return leftAlignedLeftBreakpoint.getContig().equals(leftAlignedRightBreakpoint.getContig()) && (getInversionType() == INV_3_TO_5 || getInversionType() == INV_5_TO_3);
     }
 
-    public enum InversionType{
+    public enum InversionType  {
         INV_3_TO_5, INV_5_TO_3, INV_NONE
     }
 
@@ -51,20 +69,51 @@ class BreakpointAllele {
         return InversionType.INV_NONE;
     }
 
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final BreakpointAllele that = (BreakpointAllele) o;
-        return inversionType == that.inversionType &&
-                Objects.equals(leftAlignedLeftBreakpoint, that.leftAlignedLeftBreakpoint) &&
-                Objects.equals(leftAlignedRightBreakpoint, that.leftAlignedRightBreakpoint) &&
-                Objects.equals(insertedSequence, that.insertedSequence) &&
-                Objects.equals(homology, that.homology);
+
+        if (leftAlignedLeftBreakpoint != null ? !leftAlignedLeftBreakpoint.equals(that.leftAlignedLeftBreakpoint) : that.leftAlignedLeftBreakpoint != null)
+            return false;
+        if (leftAlignedRightBreakpoint != null ? !leftAlignedRightBreakpoint.equals(that.leftAlignedRightBreakpoint) : that.leftAlignedRightBreakpoint != null)
+            return false;
+        if (insertedSequence != null ? !insertedSequence.equals(that.insertedSequence) : that.insertedSequence != null)
+            return false;
+        if (homology != null ? !homology.equals(that.homology) : that.homology != null) return false;
+        return inversionType == that.inversionType;
+
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(leftAlignedLeftBreakpoint, leftAlignedRightBreakpoint, insertedSequence, homology, inversionType);
+        return Objects.hash(leftAlignedLeftBreakpoint, leftAlignedRightBreakpoint, insertedSequence, homology, 2659*inversionType.ordinal());
+    }
+
+    public static final class Serializer extends com.esotericsoftware.kryo.Serializer<BreakpointAllele> {
+        @Override
+        public void write(final Kryo kryo, final Output output, final BreakpointAllele breakpointAllele ) {
+            breakpointAllele.serialize(kryo, output);
+        }
+
+        @Override
+        public BreakpointAllele read(final Kryo kryo, final Input input, final Class<BreakpointAllele> klass ) {
+            return new BreakpointAllele(kryo, input);
+        }
+
+    }
+
+    private void serialize(final Kryo kryo, final Output output) {
+        output.writeString(leftAlignedLeftBreakpoint.getContig());
+        output.writeInt(leftAlignedLeftBreakpoint.getStart());
+        output.writeInt(leftAlignedLeftBreakpoint.getEnd());
+        output.writeString(leftAlignedRightBreakpoint.getContig());
+        output.writeInt(leftAlignedRightBreakpoint.getStart());
+        output.writeInt(leftAlignedRightBreakpoint.getEnd());
+        output.writeString(insertedSequence);
+        output.writeString(homology);
+        output.writeInt(inversionType.ordinal());
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointEvidence.java
@@ -153,7 +153,7 @@ public class BreakpointEvidence implements Comparable<BreakpointEvidence> {
         result = mult * result + eventStartPosition;
         result = mult * result + eventWidth;
         result = mult * result + templateName.hashCode();
-        result = mult * result + templateEnd.hashCode();
+        result = mult * result + templateEnd.ordinal();
         result = mult * result + getClass().getSimpleName().hashCode();
         return mult * result;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/GATKSVVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/GATKSVVCFHeaderLines.java
@@ -47,7 +47,7 @@ public class GATKSVVCFHeaderLines {
         vcfHeaderLines.put(CONTIG_IDS, new VCFInfoHeaderLine(CONTIG_IDS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "IDs of the contigs that produced each alignment"));
 
         vcfHeaderLines.put(INSERTED_SEQUENCE, new VCFInfoHeaderLine(INSERTED_SEQUENCE, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Inserted sequence at the breakpoint"));
-        vcfHeaderLines.put(INSERTED_SEQUENCE, new VCFInfoHeaderLine(INSERTED_SEQUENCE_MAPPINGS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Alignments of inserted sequence"));
+        vcfHeaderLines.put(INSERTED_SEQUENCE_MAPPINGS, new VCFInfoHeaderLine(INSERTED_SEQUENCE_MAPPINGS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Alignments of inserted sequence"));
 
         vcfHeaderLines.put(HOMOLOGY, new VCFInfoHeaderLine(HOMOLOGY, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Homologous sequence from contig at the breakpoint"));
         vcfHeaderLines.put(HOMOLOGY_LENGTH, new VCFInfoHeaderLine(HOMOLOGY_LENGTH, 1, VCFHeaderLineType.Integer, "Length of homologous sequence"));

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/CallVariantsFromAlignedContigsSparkTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/CallVariantsFromAlignedContigsSparkTest.java
@@ -121,7 +121,7 @@ public class CallVariantsFromAlignedContigsSparkTest extends BaseTest {
         Assert.assertEquals(breakpointAlignment.homology, "");
         Assert.assertEquals(breakpointAlignment.insertedSequence, "TGAGAGTTGGCCCGAACACTGCTGGATTCCACTTCA");
         Assert.assertEquals(breakpointAlignment.insertionMappings.size(), 1);
-        Assert.assertEquals(breakpointAlignment.insertionMappings.get(0), "484-525:20,23103196,-,483S42M968S,60,2");
+        Assert.assertEquals(breakpointAlignment.insertionMappings.get(0), "1-contig-1:484-525:20,23103196,-,483S42M968S,60,2");
     }
 
     @Test


### PR DESCRIPTION
This PR primarily fixes a bug in the hashCode method of BreakpointAllele that was causing Spark's groupByKey() method to not group identical inversion events together, resulting in duplicate variant calls in the output VCF. 

All changes:

- Fix hashCode of BreakpointAllele to use the ordinal of the InversionType enum, which is consistent across executors
- Added Kryo Serializers to several SV classes
- Made the INSERTED_SEQUENCE_MAPPINGS VCF annotation include the assembly id and contig name for each mapping, which is necessary to read them.