### PR TITLE
adding ReadFilterPluginDescriptor to AssemblyRegionWalker

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import org.broadinstitute.hellbender.cmdline.Advanced;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKCommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
@@ -169,6 +170,15 @@ public abstract class AssemblyRegionWalker extends GATKTool {
         }
 
         return shards;
+    }
+
+    /**
+     * Return the list of GATKCommandLinePluginDescriptors to be used for this tool.
+     * Uses the read filter plugin.
+     */
+    @Override
+    protected List<? extends GATKCommandLinePluginDescriptor<?>> getPluginDescriptors() {
+        return Collections.singletonList(new GATKReadFilterPluginDescriptor(getDefaultReadFilters()));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -67,6 +67,7 @@ public abstract class LocusWalker extends GATKTool {
      * Return the list of GATKCommandLinePluginDescriptors to be used for this CLP.
      * Uses the read filter plugin.
      */
+    @Override
     protected List<? extends GATKCommandLinePluginDescriptor<?>> getPluginDescriptors() {
         return Collections.singletonList(new GATKReadFilterPluginDescriptor(getDefaultReadFilters()));
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -39,6 +39,7 @@ public abstract class ReadWalker extends GATKTool {
      * Return the list of GATKCommandLinePluginDescriptors to be used for this tool.
      * Uses the read filter plugin.
      */
+    @Override
     protected List<? extends GATKCommandLinePluginDescriptor<?>> getPluginDescriptors() {
         return Collections.singletonList(new GATKReadFilterPluginDescriptor(getDefaultReadFilters()));
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -97,6 +97,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * Return the list of GATKCommandLinePluginDescriptor objects to be used for this CLP.
      * Use the read filter plugin.
      */
+    @Override
     protected List<? extends GATKCommandLinePluginDescriptor<?>> getPluginDescriptors() {
         return Collections.singletonList(new GATKReadFilterPluginDescriptor(getDefaultReadFilters()));
     }


### PR DESCRIPTION
AssemblyRegionWalker didn't override getPluginDescriptors() and didn't have a ReadFilterPluginDescriptor
this caused an NPR on every invocation of the haplotype caller