### PR TITLE
VariantRecalibrator optimizations

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GaussianMixtureModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GaussianMixtureModel.java
@@ -26,12 +26,12 @@ class GaussianMixtureModel {
     public boolean isModelReadyForEvaluation;
     public boolean failedToConverge = false;
 
-    public GaussianMixtureModel( final int numGaussians, final int numAnnotations,
+    public GaussianMixtureModel( final int numGaussians, final int numVariantData, final int numAnnotations,
                                  final double shrinkage, final double dirichletParameter, final double priorCounts ) {
 
         gaussians = new ArrayList<>( numGaussians );
         for( int iii = 0; iii < numGaussians; iii++ ) {
-            final MultivariateGaussian gaussian = new MultivariateGaussian( numAnnotations );
+            final MultivariateGaussian gaussian = new MultivariateGaussian( numVariantData, numAnnotations );
             gaussians.add( gaussian );
         }
         this.shrinkage = shrinkage;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
@@ -313,10 +313,10 @@ public class VariantRecalibrator extends MultiVariantWalker {
     private VariantDataManager dataManager;
     private VariantContextWriter recalWriter;
     private PrintStream tranchesStream;
-    private ArrayList<Double> replicate = new ArrayList<>();
+    private ArrayList<Double> replicate = new ArrayList<>(REPLICATE * 2);
     private final Set<String> ignoreInputFilterSet = new TreeSet<>();
     private final VariantRecalibratorEngine engine = new VariantRecalibratorEngine( VRAC );
-    private ExpandingArrayList<VariantDatum> reduceSum = new ExpandingArrayList<>();
+    private ExpandingArrayList<VariantDatum> reduceSum = new ExpandingArrayList<>(2000);
     private List<ImmutablePair<VariantContext, FeatureContext>> variantsAtLocus = new ArrayList<>();
 
     //---------------------------------------------------------------------------------------------------------------
@@ -382,8 +382,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
             hInfo = VcfUtils.updateHeaderContigLines(hInfo, null, sequenceDictionary, true);
         }
 
-        //TODO: integrate lenient argument
-        recalWriter = GATKVariantContextUtils.createVCFWriter(new File(output), sequenceDictionary, true);
+        recalWriter = createVCFWriter(new File(output));
         recalWriter.writeHeader( new VCFHeader(hInfo) );
 
         for( int iii = 0; iii < REPLICATE * 2; iii++ ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorEngine.java
@@ -39,6 +39,7 @@ public class VariantRecalibratorEngine {
 
         final GaussianMixtureModel model = new GaussianMixtureModel(
                 maxGaussians,
+                data.size(),
                 data.get(0).annotations.length,
                 VRAC.SHRINKAGE,
                 VRAC.DIRICHLET_PARAMETER,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorModelOutputUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorModelOutputUnitTest.java
@@ -25,15 +25,15 @@ public class VariantRecalibratorModelOutputUnitTest {
         final double epsilon = 1e-6;
 
         Random rand = new Random(12878);
-        MultivariateGaussian goodGaussian1 = new MultivariateGaussian(numAnnotations);
+        MultivariateGaussian goodGaussian1 = new MultivariateGaussian(1, numAnnotations);
         goodGaussian1.initializeRandomMu(rand);
         goodGaussian1.initializeRandomSigma(rand);
 
-        MultivariateGaussian goodGaussian2 = new MultivariateGaussian(numAnnotations);
+        MultivariateGaussian goodGaussian2 = new MultivariateGaussian(1, numAnnotations);
         goodGaussian2.initializeRandomMu(rand);
         goodGaussian2.initializeRandomSigma(rand);
 
-        MultivariateGaussian badGaussian1 = new MultivariateGaussian(numAnnotations);
+        MultivariateGaussian badGaussian1 = new MultivariateGaussian(1, numAnnotations);
         badGaussian1.initializeRandomMu(rand);
         badGaussian1.initializeRandomSigma(rand);
 


### PR DESCRIPTION
A handful of simple optimizations for VariantRecalibrator:
- Preallocate arrays when the size is known
- Eliminate unnecessary boxing of doubles
- Lift some loop invariants with unnecessary allocations (this eliminates millions of array allocations on the full SNP test used by GATK3)

The current GATK4 (multi-variant walker) implementation is about 3% faster than GATK3 without these; these bring it to about 6% faster.
