### PR TITLE
Pileup on Spark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetAddress;
 import java.text.DecimalFormat;
@@ -44,7 +45,13 @@ import java.util.List;
  *
  */
 public abstract class CommandLineProgram {
-    protected final Logger logger = LogManager.getLogger(this.getClass());
+    protected transient Logger logger = LogManager.getLogger(this.getClass());
+
+    private void readObject(java.io.ObjectInputStream in)
+            throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        logger = LogManager.getLogger(this.getClass()); // Logger is not serializable (even by Kryo)
+    }
 
     @Argument(common=true, optional=true)
     public List<File> TMP_DIR = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -23,7 +24,13 @@ import java.util.stream.Collectors;
  */
 public class GATKReadFilterPluginDescriptor extends GATKCommandLinePluginDescriptor<ReadFilter> {
 
-    protected final Logger logger = LogManager.getLogger(this.getClass());
+    protected transient Logger logger = LogManager.getLogger(this.getClass());
+
+    private void readObject(java.io.ObjectInputStream in)
+            throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        logger = LogManager.getLogger(this.getClass()); // Logger is not serializable (even by Kryo)
+    }
 
     private static final String pluginPackageName = "org.broadinstitute.hellbender.engine.filters";
     private static final Class<?> pluginBaseClass = org.broadinstitute.hellbender.engine.filters.ReadFilter.class;

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -35,7 +36,9 @@ import java.util.Map;
  *
  * @param <T> the type of Feature that this FeatureInput file contains (eg., VariantContext, BEDFeature, etc.)
  */
-public final class FeatureInput<T extends Feature> {
+public final class FeatureInput<T extends Feature> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /**
      * Logical name for this source of Features optionally provided by the user on the command line

--- a/src/main/java/org/broadinstitute/hellbender/engine/ShardBoundary.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ShardBoundary.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * Holds the bounds of a {@link Shard}, both with and without padding
  */
-public final class ShardBoundary implements Locatable, Serializable {
+public class ShardBoundary implements Locatable, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final SimpleInterval interval;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ShardBoundaryShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ShardBoundaryShard.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.hellbender.engine;
+
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+
+import java.util.Iterator;
+
+/**
+ * A {@link Shard} backed by a {@link ShardBoundary} and a collection of records.
+ */
+public final class ShardBoundaryShard<T> implements Shard<T> {
+    private static final long serialVersionUID = 1L;
+
+    private final ShardBoundary shardBoundary;
+    private final Iterable<T> locatables;
+
+    /**
+     * Create a new {@link ShardBoundaryShard} from the given {@link ShardBoundary} and records.
+     * @param shardBoundary the boundary defining the shard
+     * @param locatables the records overlapping  the shard
+     */
+    public ShardBoundaryShard(ShardBoundary shardBoundary, Iterable<T> locatables) {
+        this.shardBoundary = shardBoundary;
+        this.locatables = locatables;
+    }
+
+    @Override
+    public SimpleInterval getInterval() {
+        return shardBoundary.getInterval();
+    }
+
+    @Override
+    public SimpleInterval getPaddedInterval() {
+        return shardBoundary.getPaddedInterval();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return locatables.iterator();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSpark.java
@@ -1,15 +1,32 @@
 package org.broadinstitute.hellbender.engine.spark;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.engine.ReadContextData;
+import org.broadinstitute.hellbender.engine.Shard;
+import org.broadinstitute.hellbender.engine.ShardBoundary;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.collections.IntervalsSkipList;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.variant.GATKVariant;
 import scala.Tuple2;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * AddContextDataToRead pairs reference bases and overlapping variants with each GATKRead in the RDD input.
@@ -24,9 +41,24 @@ import scala.Tuple2;
  * {@link org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions} for examples.
  */
 public class AddContextDataToReadSpark {
+    /**
+     * Add context data ({@link ReadContextData}) to reads.
+     * @param ctx the Spark context
+     * @param reads the coordinate-sorted reads
+     * @param referenceSource the reference source
+     * @param variants the coordinate-sorted variants
+     * @param joinStrategy the strategy to use to join context data to reads
+     * @param sequenceDictionary the sequence dictionary for the reads (only used for OVERLAPS_PARTITIONER join strategy, use null otherwise)
+     * @param shardSize the maximum size of each shard, in bases (only used for OVERLAPS_PARTITIONER join strategy, use 0 otherwise)
+     * @param shardPadding amount of extra context around each shard, in bases (only used for OVERLAPS_PARTITIONER join strategy, use 0 otherwise)
+     * @return a RDD of read-context pairs, in coordinate-sorted order
+     */
     public static JavaPairRDD<GATKRead, ReadContextData> add(
-            final JavaRDD<GATKRead> reads, final ReferenceMultiSource referenceDataflowSource,
-            final JavaRDD<GATKVariant> variants, final JoinStrategy joinStrategy) {
+            final JavaSparkContext ctx,
+            final JavaRDD<GATKRead> reads, final ReferenceMultiSource referenceSource,
+            final JavaRDD<GATKVariant> variants, final JoinStrategy joinStrategy,
+            final SAMSequenceDictionary sequenceDictionary,
+            final int shardSize, final int shardPadding) {
         // TODO: this static method should not be filtering the unmapped reads.  To be addressed in another issue.
         JavaRDD<GATKRead> mappedReads = reads.filter(read -> ReadFilterLibrary.MAPPED.test(read));
         JavaPairRDD<GATKRead, Tuple2<Iterable<GATKVariant>, ReferenceBases>> withVariantsWithRef;
@@ -34,15 +66,75 @@ public class AddContextDataToReadSpark {
             // Join Reads and Variants
             JavaPairRDD<GATKRead, Iterable<GATKVariant>> withVariants = BroadcastJoinReadsWithVariants.join(mappedReads, variants);
             // Join Reads with ReferenceBases
-            withVariantsWithRef = BroadcastJoinReadsWithRefBases.addBases(referenceDataflowSource, withVariants);
+            withVariantsWithRef = BroadcastJoinReadsWithRefBases.addBases(referenceSource, withVariants);
         } else if (joinStrategy.equals(JoinStrategy.SHUFFLE)) {
             // Join Reads and Variants
             JavaPairRDD<GATKRead, Iterable<GATKVariant>> withVariants = ShuffleJoinReadsWithVariants.join(mappedReads, variants);
             // Join Reads with ReferenceBases
-            withVariantsWithRef = ShuffleJoinReadsWithRefBases.addBases(referenceDataflowSource, withVariants);
+            withVariantsWithRef = ShuffleJoinReadsWithRefBases.addBases(referenceSource, withVariants);
+        } else if (joinStrategy.equals(JoinStrategy.OVERLAPS_PARTITIONER)) {
+            return addUsingOverlapsPartitioning(ctx, reads, referenceSource, variants, sequenceDictionary, shardSize, shardPadding);
         } else {
             throw new UserException("Unknown JoinStrategy");
         }
         return withVariantsWithRef.mapToPair(in -> new Tuple2<>(in._1(), new ReadContextData(in._2()._2(), in._2()._1())));
+    }
+
+    /**
+     * Add context data ({@link ReadContextData}) to reads, using overlaps partitioning to avoid a shuffle.
+     * @param ctx the Spark context
+     * @param mappedReads the coordinate-sorted reads
+     * @param referenceSource the reference source
+     * @param variants the coordinate-sorted variants
+     * @param sequenceDictionary the sequence dictionary for the reads
+     * @param shardSize the maximum size of each shard, in bases
+     * @param shardPadding amount of extra context around each shard, in bases
+     * @return a RDD of read-context pairs, in coordinate-sorted order
+     */
+    private static JavaPairRDD<GATKRead, ReadContextData> addUsingOverlapsPartitioning(
+            final JavaSparkContext ctx,
+            final JavaRDD<GATKRead> mappedReads, final ReferenceMultiSource referenceSource,
+            final JavaRDD<GATKVariant> variants, final SAMSequenceDictionary sequenceDictionary,
+            final int shardSize, final int shardPadding) {
+        final List<SimpleInterval> intervals = IntervalUtils.getAllIntervalsForReference(sequenceDictionary);
+        // use unpadded shards (padding is only needed for reference bases)
+        final List<ShardBoundary> intervalShards = intervals.stream()
+                .flatMap(interval -> Shard.divideIntervalIntoShards(interval, shardSize, 0, sequenceDictionary).stream())
+                .collect(Collectors.toList());
+
+        final Broadcast<ReferenceMultiSource> bReferenceSource = ctx.broadcast(referenceSource);
+        final IntervalsSkipList<GATKVariant> variantSkipList = new IntervalsSkipList<>(variants.collect());
+        final Broadcast<IntervalsSkipList<GATKVariant>> variantsBroadcast = ctx.broadcast(variantSkipList);
+
+        int maxLocatableSize = Math.min(shardSize, shardPadding);
+        JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, mappedReads, GATKRead.class, sequenceDictionary, intervalShards, maxLocatableSize);
+        return shardedReads.flatMapToPair(new PairFlatMapFunction<Shard<GATKRead>, GATKRead, ReadContextData>() {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public Iterable<Tuple2<GATKRead, ReadContextData>> call(Shard<GATKRead> shard) throws Exception {
+                // get reference bases for this shard (padded)
+                SimpleInterval paddedInterval = shard.getInterval().expandWithinContig(shardPadding, sequenceDictionary);
+                ReferenceBases referenceBases = bReferenceSource.getValue().getReferenceBases(null, paddedInterval);
+                final IntervalsSkipList<GATKVariant> intervalsSkipList = variantsBroadcast.getValue();
+                Iterator<Tuple2<GATKRead, ReadContextData>> transform = Iterators.transform(shard.iterator(), new Function<GATKRead, Tuple2<GATKRead, ReadContextData>>() {
+                    @Nullable
+                    @Override
+                    public Tuple2<GATKRead, ReadContextData> apply(@Nullable GATKRead r) {
+                        List<GATKVariant> overlappingVariants;
+                        if (SimpleInterval.isValid(r.getContig(), r.getStart(), r.getEnd())) {
+                            overlappingVariants = intervalsSkipList.getOverlapping(new SimpleInterval(r));
+                        } else {
+                            //Sometimes we have reads that do not form valid intervals (reads that do not consume any ref bases, eg CIGAR 61S90I
+                            //In those cases, we'll just say that nothing overlaps the read
+                            overlappingVariants = Collections.emptyList();
+                        }
+                        return new Tuple2<>(r, new ReadContextData(referenceBases, overlappingVariants));
+                    }
+                });
+                // only include reads that start in the shard
+                return () -> Iterators.filter(transform, r -> r._1().getStart() >= shard.getStart()
+                        && r._1().getStart() <= shard.getEnd());
+            }
+        });
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/CoalescedRDD.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/CoalescedRDD.java
@@ -1,0 +1,96 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.primitives.Ints;
+
+import java.util.List;
+
+import org.apache.spark.Dependency;
+import org.apache.spark.NarrowDependency;
+import org.apache.spark.Partition;
+import org.apache.spark.TaskContext;
+import org.apache.spark.rdd.PartitionGroup;
+import org.apache.spark.rdd.RDD;
+import scala.collection.Iterator;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+/**
+ * Represents a coalesced RDD that has fewer partitions than its parent RDD.
+ * A backport of Spark's CoalescedRDD from Spark 2.0 to work with Spark 1.6.
+ * @param <T> the type of the objects in the RDD.
+ */
+class CoalescedRDD<T> extends RDD<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient RDD<T> prev;
+    private final int maxPartitions;
+    private final PartitionCoalescer partitionCoalescer;
+    private Class<T> cls;
+
+    public CoalescedRDD(RDD<T> prev, int maxPartitions, PartitionCoalescer
+            partitionCoalescer, Class<T> cls) {
+        super(prev.context(), null, ClassTag$.MODULE$.apply(cls));
+
+        this.prev = prev;
+        this.maxPartitions = maxPartitions;
+        this.partitionCoalescer = partitionCoalescer;
+        this.cls = cls;
+    }
+
+    @Override
+    public Partition[] getPartitions() {
+        PartitionGroup[] partitionGroups = partitionCoalescer.coalesce(maxPartitions, prev);
+        Partition[] partitions = new Partition[partitionGroups.length];
+        for (int i = 0; i < partitions.length; i++) {
+            PartitionGroup pg = partitionGroups[i];
+            List<Partition> partitionList = JavaConversions.asJavaList(partitionGroups[i].arr());
+            int[] ids = partitionList.stream().mapToInt(Partition::index).toArray();
+            partitions[i] = new CoalescedRDDPartition(i, prev, ids, pg.prefLoc());
+        }
+        return partitions;
+    }
+
+    @Override
+    public Iterator<T> compute(Partition split, TaskContext context) {
+        java.util.Iterator<java.util.Iterator<T>> iterators =
+                ((CoalescedRDDPartition) split).getParents().stream().map(p -> {
+                            ClassTag<T> tag = ClassTag$.MODULE$.apply(cls);
+                            RDD<T> objectRDD = firstParent(tag);
+                            return JavaConversions.asJavaIterator(objectRDD.iterator(p, context));
+                        }
+                ).iterator();
+        return JavaConversions.asScalaIterator(Iterators.concat(iterators));
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Seq<Dependency<?>> getDependencies() {
+        return JavaConversions.asScalaBuffer(ImmutableList.of(
+                new NarrowDependency(prev) {
+                    private static final long serialVersionUID = 1L;
+                    @Override
+                    public Seq<Integer> getParents(int partitionId) {
+                        List<Integer> i = Ints.asList(
+                                ((CoalescedRDDPartition) partitions()[partitionId]).getParentsIndices());
+                        return JavaConversions.asScalaBuffer(i);
+                    }
+                }
+        ));
+    }
+
+    @Override
+    public void clearDependencies() {
+        super.clearDependencies();
+        prev = null;
+    }
+
+    @Override
+    public Seq<String> getPreferredLocations(Partition partition) {
+        return ((CoalescedRDDPartition) partition).getPreferredLocation().toList();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/CoalescedRDDPartition.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/CoalescedRDDPartition.java
@@ -1,0 +1,62 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.Partition;
+import org.apache.spark.rdd.RDD;
+import scala.Option;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class that captures a coalesced RDD by essentially keeping track of parent partitions.
+ * A backport of Spark's CoalescedRDDPartition from Spark 2.0 to work with Spark 1.6.
+ */
+class CoalescedRDDPartition implements Partition {
+
+    private static final long serialVersionUID = 1L;
+
+    private int index;
+    private transient RDD<?> rdd;
+    private int[] parentsIndices;
+    private transient Option<String> preferredLocation;
+    private List<Partition> parents;
+
+    public CoalescedRDDPartition(int index, RDD<?> rdd, int[] parentsIndices,
+                                 Option<String> preferredLocation) {
+        this.index = index;
+        this.rdd = rdd;
+        this.parentsIndices = parentsIndices;
+        this.preferredLocation = preferredLocation;
+        parents = Arrays.stream(parentsIndices)
+                .mapToObj(i -> rdd.partitions()[i])
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public int index() {
+        return index;
+    }
+
+    public int[] getParentsIndices() {
+        return parentsIndices;
+    }
+
+    public Option<String> getPreferredLocation() {
+        return preferredLocation;
+    }
+
+    public List<Partition> getParents() {
+        return parents;
+    }
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+        // Update the reference to parent partition at the time of task serialization
+        parents = Arrays.stream(parentsIndices)
+                .mapToObj(i -> rdd.partitions()[i])
+                .collect(Collectors.toList());
+        oos.defaultWriteObject();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinStrategy.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinStrategy.java
@@ -10,6 +10,11 @@ public enum JoinStrategy {
     BROADCAST,
 
     /**
+     * Use an overlaps partitioner strategy, where one side of the join is sharded in partitions and the other side is broadcast.
+     */
+    OVERLAPS_PARTITIONER,
+
+    /**
      * Use a shuffle join strategy, where both sides of join are shuffled across the workers.
      */
     SHUFFLE

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
@@ -1,0 +1,136 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.downsampling.DownsamplingMethod;
+import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
+import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
+import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import scala.Tuple3;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class LocusWalkerSpark extends GATKSparkTool {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = "maxDepthPerSample", shortName = "maxDepthPerSample", doc = "Maximum number of reads to retain per sample per locus. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
+    protected int maxDepthPerSample = defaultMaxDepthPerSample();
+
+    /**
+     * Returns default value for the {@link #maxDepthPerSample} parameter, if none is provided on the command line.
+     * Default implementation returns 0 (no downsampling by default).
+     */
+    protected int defaultMaxDepthPerSample() {
+        return 0;
+    }
+
+    @Argument(fullName="readShardSize", shortName="readShardSize", doc = "Maximum size of each read shard, in bases.", optional = true)
+    public int readShardSize = 10000;
+
+    @Argument(fullName="readShardPadding", shortName="readShardPadding", doc = "Each read shard has this many bases of extra context on each side.", optional = true)
+    public int readShardPadding = 1000;
+
+    @Argument(doc = "whether to use the shuffle implementation or overlaps partitioning (the default)", shortName = "shuffle", fullName = "shuffle", optional = true)
+    public boolean shuffle = false;
+
+    private FeatureManager features; // TODO: move up to GATKSparkTool?
+
+    @Override
+    protected void runPipeline(JavaSparkContext sparkContext) {
+        initializeFeatures();
+        super.runPipeline(sparkContext);
+    }
+
+    void initializeFeatures() {
+        features = new FeatureManager(this);
+        if ( features.isEmpty() ) {  // No available sources of Features discovered for this tool
+            features = null;
+        }
+    }
+
+    /** Returns the downsampling info using {@link #maxDepthPerSample} as target coverage. */
+    protected final LIBSDownsamplingInfo getDownsamplingInfo() {
+        if (maxDepthPerSample < 0) {
+            throw new UserException.BadArgumentValue("maxDepthPerSample",
+                    String.valueOf(maxDepthPerSample),
+                    "should be a positive number");
+        }
+        return (maxDepthPerSample == 0) ? LocusIteratorByState.NO_DOWNSAMPLING : new LIBSDownsamplingInfo(true, maxDepthPerSample);
+    }
+
+    /**
+     * Loads alignments and the corresponding reference and features into a {@link JavaRDD} for the intervals specified.
+     *
+     * If no intervals were specified, returns all the alignments.
+     *
+     * @return all alignments from as a {@link JavaRDD}, bounded by intervals if specified.
+     */
+    public JavaRDD<Tuple3<AlignmentContext, ReferenceContext, FeatureContext>> getAlignments(JavaSparkContext ctx) {
+        SAMSequenceDictionary sequenceDictionary = getBestAvailableSequenceDictionary();
+        List<SimpleInterval> intervals = hasIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(sequenceDictionary);
+        final List<ShardBoundary> intervalShards = intervals.stream()
+                .flatMap(interval -> Shard.divideIntervalIntoShards(interval, readShardSize, readShardPadding, sequenceDictionary).stream())
+                .collect(Collectors.toList());
+        int maxLocatableSize = Math.min(readShardSize, readShardPadding);
+        JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, getReads(), GATKRead.class, sequenceDictionary, intervalShards, maxLocatableSize, shuffle);
+        Broadcast<ReferenceMultiSource> bReferenceSource = hasReference() ? ctx.broadcast(getReference()) : null;
+        Broadcast<FeatureManager> bFeatureManager = features == null ? null : ctx.broadcast(features);
+        return shardedReads.flatMap(getAlignmentsFunction(bReferenceSource, bFeatureManager, sequenceDictionary, getHeaderForReads(), getDownsamplingInfo()));
+    }
+
+    /**
+     * Return a function that maps a {@link Shard} of reads into a tuple of alignments and their corresponding reference and features.
+     * @param bReferenceSource the reference source broadcast
+     * @param bFeatureManager the feature manager broadcast
+     * @param sequenceDictionary the sequence dictionary for the reads
+     * @param header the reads header
+     * @param downsamplingInfo the downsampling method for the reads
+     * @return a function that maps a {@link Shard} of reads into a tuple of alignments and their corresponding reference and features.
+     */
+    private static FlatMapFunction<Shard<GATKRead>, Tuple3<AlignmentContext, ReferenceContext, FeatureContext>> getAlignmentsFunction(
+            Broadcast<ReferenceMultiSource> bReferenceSource, Broadcast<FeatureManager> bFeatureManager,
+            SAMSequenceDictionary sequenceDictionary, SAMFileHeader header, LIBSDownsamplingInfo downsamplingInfo) {
+        return (FlatMapFunction<Shard<GATKRead>, Tuple3<AlignmentContext, ReferenceContext, FeatureContext>>) shardedRead -> {
+            SimpleInterval interval = shardedRead.getInterval();
+            SimpleInterval paddedInterval = shardedRead.getPaddedInterval();
+            Iterator<GATKRead> readIterator = shardedRead.iterator();
+            ReferenceDataSource reference = bReferenceSource == null ? null :
+                    new ReferenceMemorySource(bReferenceSource.getValue().getReferenceBases(null, paddedInterval), sequenceDictionary);
+            FeatureManager fm = bFeatureManager == null ? null : bFeatureManager.getValue();
+
+            final Set<String> samples = header.getReadGroups().stream()
+                    .map(SAMReadGroupRecord::getSample)
+                    .collect(Collectors.toSet());
+            LocusIteratorByState libs = new LocusIteratorByState(readIterator, downsamplingInfo, false, samples, header, true, false);
+            IntervalOverlappingIterator<AlignmentContext> alignmentContexts = new IntervalOverlappingIterator<>(libs, ImmutableList.of(interval), sequenceDictionary);
+            Iterator<Tuple3<AlignmentContext, ReferenceContext, FeatureContext>> transform = Iterators.transform(alignmentContexts, new Function<AlignmentContext, Tuple3<AlignmentContext, ReferenceContext, FeatureContext>>() {
+                @Nullable
+                @Override
+                public Tuple3<AlignmentContext, ReferenceContext, FeatureContext> apply(@Nullable AlignmentContext alignmentContext) {
+                    final SimpleInterval alignmentInterval = new SimpleInterval(alignmentContext);
+                    return new Tuple3<>(alignmentContext, new ReferenceContext(reference, alignmentInterval), new FeatureContext(fm, alignmentInterval));
+                }
+            });
+            return () -> transform;
+        };
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/PartitionCoalescer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/PartitionCoalescer.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.rdd.PartitionGroup;
+import org.apache.spark.rdd.RDD;
+
+/**
+ * A PartitionCoalescer defines how to coalesce the partitions of a given RDD.
+ * A backport of Spark's PartitionCoalescer from Spark 2.0 to work with Spark 1.6.
+ */
+interface PartitionCoalescer {
+    /**
+     * Coalesce the partitions of the given RDD.
+     *
+     * @param maxPartitions the maximum number of partitions to have after coalescing
+     * @param parent the parent RDD whose partitions to coalesce
+     * @return an array of [[PartitionGroup]]s, where each element is itself an array of
+     * [[Partition]]s and represents a partition after coalescing is performed.
+     */
+    PartitionGroup[] coalesce(int maxPartitions, RDD<?> parent);
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescer.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.Partition;
+import org.apache.spark.rdd.PartitionGroup;
+import org.apache.spark.rdd.RDD;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A {@link PartitionCoalescer} that allows a range of partitions to be coalesced into groups.
+ */
+class RangePartitionCoalescer implements PartitionCoalescer, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<Integer> maxEndPartitionIndexes;
+
+    /**
+     * @param maxEndPartitionIndexes the indexes of the end of each coalesced partition, so that
+     *                               coalesced partition {@code i} in the coalesced partitions is made up of partitions
+     *                               from index {@code i} to {@code maxEndPartitionIndexes.get(i)} (inclusive)
+     */
+    public RangePartitionCoalescer(List<Integer> maxEndPartitionIndexes) {
+        this.maxEndPartitionIndexes = maxEndPartitionIndexes;
+    }
+
+    @Override
+    public PartitionGroup[] coalesce(int maxPartitions, RDD<?> parent) {
+        if (maxPartitions != parent.getNumPartitions()) {
+            throw new IllegalArgumentException("Cannot use " + getClass().getSimpleName() +
+                    " with a different number of partitions to the parent RDD.");
+        }
+        List<Partition> partitions = Arrays.asList(parent.getPartitions());
+        PartitionGroup[] groups = new PartitionGroup[partitions.size()];
+
+        for (int i = 0; i < partitions.size(); i++) {
+            Seq<String> preferredLocations = parent.getPreferredLocations(partitions.get(i));
+            scala.Option<String> preferredLocation = scala.Option.apply
+                    (preferredLocations.isEmpty() ? null : preferredLocations.apply(0));
+            PartitionGroup group = new PartitionGroup(preferredLocation);
+            List<Partition> partitionsInGroup =
+                    partitions.subList(i, maxEndPartitionIndexes.get(i) + 1);
+            group.arr().append(JavaConversions.asScalaBuffer(partitionsInGroup));
+            groups[i] = group;
+        }
+        return groups;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkSharder.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkSharder.java
@@ -1,0 +1,408 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.base.Function;
+import com.google.common.collect.*;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.OverlapDetector;
+import org.apache.spark.Partitioner;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.FlatMapFunction2;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.rdd.RDD;
+import org.broadinstitute.hellbender.engine.Shard;
+import org.broadinstitute.hellbender.engine.ShardBoundary;
+import org.broadinstitute.hellbender.engine.ShardBoundaryShard;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import scala.Tuple2;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.broadinstitute.hellbender.utils.IntervalUtils.overlaps;
+
+/**
+ * Utility methods for sharding {@link Locatable} objects (such as reads) for given intervals, without using a shuffle.
+ */
+public class SparkSharder {
+    /**
+     * Create an RDD of {@link Shard} from an RDD of coordinate sorted {@link Locatable} <i>without using a shuffle</i>.
+     * Each shard contains the {@link Locatable} objects that overlap it (including overlapping only padding).
+     * @param ctx the Spark Context
+     * @param locatables the RDD of {@link Locatable}, must be coordinate sorted
+     * @param locatableClass the class of the {@link Locatable} objects in the RDD
+     * @param sequenceDictionary the sequence dictionary to use to find contig lengths
+     * @param intervals the {@link ShardBoundary} objects to create shards for, must be coordinate sorted
+     * @param maxLocatableLength the maximum length of a {@link Locatable}, if any is larger than this size then an exception will be thrown
+     * @param <L> the {@link Locatable} type
+     * @return an RDD of {@link Shard} of overlapping {@link Locatable} objects (including overlapping only padding)
+     */
+    public static <L extends Locatable> JavaRDD<Shard<L>> shard(JavaSparkContext ctx, JavaRDD<L> locatables, Class<L> locatableClass,
+                                                                SAMSequenceDictionary sequenceDictionary, List<ShardBoundary> intervals,
+                                                                int maxLocatableLength) {
+        return shard(ctx, locatables, locatableClass, sequenceDictionary, intervals, maxLocatableLength, false);
+    }
+
+    /**
+     * Create an RDD of {@link Shard} from an RDD of coordinate sorted {@link Locatable}, optionally using a shuffle.
+     * A shuffle is typically only needed for correctness testing, since it usually has a significant performance impact.
+     * @param ctx the Spark Context
+     * @param locatables the RDD of {@link Locatable}, must be coordinate sorted
+     * @param locatableClass the class of the {@link Locatable} objects in the RDD
+     * @param sequenceDictionary the sequence dictionary to use to find contig lengths
+     * @param intervals the {@link ShardBoundary} objects to create shards for, must be coordinate sorted
+     * @param maxLocatableLength the maximum length of a {@link Locatable}, if any is larger than this size then an exception will be thrown
+     * @param useShuffle whether to use a shuffle or not
+     * @param <L> the {@link Locatable} type
+     * @return an RDD of {@link Shard} of overlapping {@link Locatable} objects (including overlapping only padding)
+     */
+    public static <L extends Locatable> JavaRDD<Shard<L>> shard(JavaSparkContext ctx, JavaRDD<L> locatables, Class<L> locatableClass,
+                                                                SAMSequenceDictionary sequenceDictionary, List<ShardBoundary> intervals,
+                                                                int maxLocatableLength, boolean useShuffle) {
+
+        List<ShardBoundary> paddedIntervals = intervals.stream().map(sb -> new ShardBoundary(sb.getInterval(), sb.getPaddedInterval()) {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public String getContig() {
+                return getPaddedInterval().getContig();
+            }
+            @Override
+            public int getStart() {
+                return getPaddedInterval().getStart();
+            }
+            @Override
+            public int getEnd() {
+                return getPaddedInterval().getEnd();
+            }
+        }).collect(Collectors.toList());
+        if (useShuffle) {
+            OverlapDetector<ShardBoundary> overlapDetector = OverlapDetector.create(paddedIntervals);
+            Broadcast<OverlapDetector<ShardBoundary>> overlapDetectorBroadcast = ctx.broadcast(overlapDetector);
+            JavaPairRDD<ShardBoundary, L> intervalsToLocatables = locatables.flatMapToPair(locatable -> {
+                Set<ShardBoundary> overlaps = overlapDetectorBroadcast.getValue().getOverlaps(locatable);
+                return overlaps.stream().map(key -> new Tuple2<>(key, locatable)).collect(Collectors.toList());
+            });
+            JavaPairRDD<ShardBoundary, Iterable<L>> grouped = intervalsToLocatables.groupByKey();
+            return grouped.map((org.apache.spark.api.java.function.Function<Tuple2<ShardBoundary, Iterable<L>>, Shard<L>>) value -> new ShardBoundaryShard<>(value._1(), value._2()));
+        }
+        return joinOverlapping(ctx, locatables, locatableClass, sequenceDictionary, paddedIntervals, maxLocatableLength,
+                new MapFunction<Tuple2<ShardBoundary, Iterable<L>>, Shard<L>>() {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public Shard<L> call(Tuple2<ShardBoundary, Iterable<L>> value) throws Exception {
+                return new ShardBoundaryShard<>(value._1(), value._2());
+            }
+        });
+    }
+
+    /**
+     * Join an RDD of locatables with a set of intervals, and apply a function to process the locatables that overlap each interval.
+     * @param ctx the Spark Context
+     * @param locatables the locatables RDD, must be coordinate sorted
+     * @param locatableClass the class of the locatables, must be a subclass of {@link Locatable}
+     * @param sequenceDictionary the sequence dictionary to use to find contig lengths
+     * @param intervals the collection of intervals to apply the function to
+     * @param maxLocatableLength the maximum length of a {@link Locatable}, if any is larger than this size then an exception will be thrown
+     * @param f the function to process intervals and overlapping locatables with
+     * @param <L> the {@link Locatable} type
+     * @param <I> the interval type
+     * @param <T> the return type of <code>f</code>
+     * @return
+     */
+    private static <L extends Locatable, I extends Locatable, T> JavaRDD<T> joinOverlapping(JavaSparkContext ctx, JavaRDD<L> locatables, Class<L> locatableClass,
+                                                                                            SAMSequenceDictionary sequenceDictionary, List<I> intervals,
+                                                                                            int maxLocatableLength, MapFunction<Tuple2<I, Iterable<L>>, T> f) {
+        return joinOverlapping(ctx, locatables, locatableClass, sequenceDictionary, intervals, maxLocatableLength,
+                (FlatMapFunction2<Iterator<L>, Iterator<I>, T>) (locatablesIterator, shardsIterator) -> () -> Iterators.transform(locatablesPerShard(locatablesIterator, shardsIterator, sequenceDictionary, maxLocatableLength), new Function<Tuple2<I,Iterable<L>>, T>() {
+                    @Nullable
+                    @Override
+                    public T apply(@Nullable Tuple2<I, Iterable<L>> input) {
+                        try {
+                            return f.call(input);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }));
+    }
+
+    /**
+     * Join an RDD of locatables with a set of intervals, and apply a function to process the locatables that overlap each interval.
+     * This differs from {@link #joinOverlapping(JavaSparkContext, JavaRDD, Class, SAMSequenceDictionary, List, int, MapFunction)}
+     * in that the function to apply is given two iterators: one over intervals, and one over locatables (for the partition),
+     * and it is up to the function implemention to find overlaps between intervals and locatables.
+     * @param ctx the Spark Context
+     * @param locatables the locatables RDD, must be coordinate sorted
+     * @param locatableClass the class of the locatables, must be a subclass of {@link Locatable}
+     * @param sequenceDictionary the sequence dictionary to use to find contig lengths
+     * @param intervals the collection of intervals to apply the function to
+     * @param maxLocatableLength the maximum length of a {@link Locatable}, if any is larger than this size then an exception will be thrown
+     * @param f the function to process intervals and overlapping locatables with
+     * @param <L> the {@link Locatable} type
+     * @param <I> the interval type
+     * @param <T> the return type of <code>f</code>
+     * @return
+     */
+    private static <L extends Locatable, I extends Locatable, T> JavaRDD<T> joinOverlapping(JavaSparkContext ctx, JavaRDD<L> locatables, Class<L> locatableClass,
+                                                                                            SAMSequenceDictionary sequenceDictionary, List<I> intervals,
+                                                                                            int maxLocatableLength, FlatMapFunction2<Iterator<L>, Iterator<I>, T> f) {
+
+        List<PartitionLocatable<SimpleInterval>> partitionReadExtents = computePartitionReadExtents(locatables, sequenceDictionary, maxLocatableLength);
+
+        // For each interval find which partition it starts and ends in.
+        // An interval is processed in the partition it starts in. However, we need to make sure that
+        // subsequent partitions are coalesced if needed, so for each partition p find the latest subsequent
+        // partition that is needed to read all of the intervals that start in p.
+        List<Integer> maxEndPartitionIndexes = new ArrayList<>();
+        for (int i = 0; i < locatables.getNumPartitions(); i++) {
+            maxEndPartitionIndexes.add(i);
+        }
+        OverlapDetector<PartitionLocatable<SimpleInterval>> overlapDetector = OverlapDetector.create(partitionReadExtents);
+        List<PartitionLocatable<I>> indexedIntervals = new ArrayList<>();
+        for (I interval : intervals) {
+            int[] partitionIndexes = overlapDetector.getOverlaps(interval).stream()
+                    .mapToInt(PartitionLocatable::getPartitionIndex).toArray();
+            if (partitionIndexes.length == 0) {
+                // interval does not overlap any partition - skip it
+                continue;
+            }
+            Arrays.sort(partitionIndexes);
+            int startIndex = partitionIndexes[0];
+            int endIndex = partitionIndexes[partitionIndexes.length - 1];
+            indexedIntervals.add(new PartitionLocatable<I>(startIndex, interval));
+            if (endIndex > maxEndPartitionIndexes.get(startIndex)) {
+                maxEndPartitionIndexes.set(startIndex, endIndex);
+            }
+        }
+
+        JavaRDD<L> coalescedRdd = coalesce(locatables, locatableClass, new RangePartitionCoalescer(maxEndPartitionIndexes));
+
+        // Create an RDD of intervals with the same number of partitions as the locatables, and where each interval
+        // is in its start partition.
+        JavaRDD<I> intervalsRdd = ctx.parallelize(indexedIntervals)
+                .mapToPair(interval ->
+                        new Tuple2<>(interval.getPartitionIndex(), interval.getLocatable()))
+                .partitionBy(new KeyPartitioner(locatables.getNumPartitions())).values();
+
+        // zipPartitions on coalesced locatable partitions and intervals, and apply the function f
+        return coalescedRdd.zipPartitions(intervalsRdd, f);
+    }
+
+    /**
+     * Turn a pair of iterators over intervals and locatables, into a single iterator over pairs made up of an interval and
+     * the locatables that overlap it. Intervals with no overlapping locatables are dropped.
+     */
+    static <L extends Locatable, I extends Locatable> Iterator<Tuple2<I, Iterable<L>>> locatablesPerShard(Iterator<L> locatables, Iterator<I> shards, SAMSequenceDictionary sequenceDictionary, int maxLocatableLength) {
+        if (!shards.hasNext()) {
+            return Collections.emptyIterator();
+        }
+        PeekingIterator<L> peekingLocatables = Iterators.peekingIterator(locatables);
+        PeekingIterator<I> peekingShards = Iterators.peekingIterator(shards);
+        Iterator<Tuple2<I, Iterable<L>>> iterator = new AbstractIterator<Tuple2<I, Iterable<L>>>() {
+            // keep track of current and next, since locatables can overlap two shards
+            I currentShard = peekingShards.next();
+            I nextShard = peekingShards.hasNext() ? peekingShards.next() : null;
+            List<L> currentLocatables = Lists.newArrayList();
+            List<L> nextLocatables = Lists.newArrayList();
+
+            @Override
+            protected Tuple2<I, Iterable<L>> computeNext() {
+                if (currentShard == null) {
+                    return endOfData();
+                }
+                while (peekingLocatables.hasNext()) {
+                    if (toRightOf(currentShard, peekingLocatables.peek(), sequenceDictionary)) {
+                        break;
+                    }
+                    L locatable = peekingLocatables.next();
+                    if (locatable.getContig() != null) {
+                        int size = locatable.getEnd() - locatable.getStart() + 1;
+                        if (size > maxLocatableLength) {
+                            throw new UserException(String.format("Max size of locatable exceeded. Max size is %s, but locatable size is %s. Try increasing shard size and/or padding. Locatable: %s", maxLocatableLength, size, locatable));
+                        }
+                    }
+                    if (overlaps(currentShard, locatable)) {
+                        currentLocatables.add(locatable);
+                    }
+                    if (nextShard != null && overlaps(nextShard, locatable)) {
+                        nextLocatables.add(locatable);
+                    }
+                }
+                // current shard is finished, either because the current locatable is to the right of it, or there are no more locatables
+                Tuple2<I, Iterable<L>> tuple = new Tuple2<>(currentShard, currentLocatables);
+                currentShard = nextShard;
+                nextShard = peekingShards.hasNext() ? peekingShards.next() : null;
+                currentLocatables = nextLocatables;
+                nextLocatables = Lists.newArrayList();
+                return tuple;
+            }
+        };
+        return Iterators.filter(iterator, input -> input._2().iterator().hasNext());
+    }
+
+    /**
+     * @return <code>true</code> if the locatable is to the right of the given interval
+     */
+    private static <I extends Locatable, L extends Locatable> boolean toRightOf(I interval, L locatable, SAMSequenceDictionary sequenceDictionary) {
+        int intervalContigIndex = sequenceDictionary.getSequenceIndex(interval.getContig());
+        int locatableContigIndex = sequenceDictionary.getSequenceIndex(locatable.getContig());
+        return (intervalContigIndex == locatableContigIndex && interval.getEnd() < locatable.getStart()) // locatable on same contig, to the right
+                || intervalContigIndex < locatableContigIndex; // locatable on subsequent contig
+    }
+
+    /**
+     * For each partition, find the interval that spans it.
+     */
+    static <L extends Locatable> List<PartitionLocatable<SimpleInterval>> computePartitionReadExtents(JavaRDD<L> locatables, SAMSequenceDictionary sequenceDictionary, int maxLocatableLength) {
+        // Find the first locatable in each partition. This is very efficient since only the first record in each partition is read.
+        // If a partition is empty then set the locatable to null
+        List<PartitionLocatable<L>> allSplitPoints = locatables.mapPartitions(
+                (FlatMapFunction<Iterator<L>, PartitionLocatable<L>>) it -> ImmutableList.of(new PartitionLocatable<>(-1, it.hasNext() ? it.next() : null))
+        ).collect();
+        List<PartitionLocatable<L>> splitPoints = new ArrayList<>(); // fill in index and remove nulls (empty partitions)
+        for (int i = 0; i < allSplitPoints.size(); i++) {
+            L locatable = allSplitPoints.get(i).getLocatable();
+            if (locatable != null) {
+                splitPoints.add(new PartitionLocatable<L>(i, locatable));
+            }
+        }
+        List<PartitionLocatable<SimpleInterval>> extents = new ArrayList<>();
+        for (int i = 0; i < splitPoints.size(); i++) {
+            PartitionLocatable<L> splitPoint = splitPoints.get(i);
+            int partitionIndex = splitPoint.getPartitionIndex();
+            Locatable current = splitPoint.getLocatable();
+            int intervalContigIndex = sequenceDictionary.getSequenceIndex(current.getContig());
+            final Locatable next;
+            final int nextContigIndex;
+            if (i < splitPoints.size() - 1) {
+                next = splitPoints.get(i + 1);
+                nextContigIndex = sequenceDictionary.getSequenceIndex(next.getContig());
+            } else {
+                next = null;
+                nextContigIndex = sequenceDictionary.getSequences().size();
+            }
+            if (intervalContigIndex == nextContigIndex) { // same contig
+                addPartitionReadExtent(extents, partitionIndex, current.getContig(), current.getStart(), next.getStart() + maxLocatableLength);
+            } else {
+                // complete current contig
+                int contigEnd = sequenceDictionary.getSequence(current.getContig()).getSequenceLength();
+                addPartitionReadExtent(extents, partitionIndex, current.getContig(), current.getStart(), contigEnd);
+                // add any whole contigs up to next (exclusive)
+                for (int contigIndex = intervalContigIndex + 1; contigIndex < nextContigIndex; contigIndex++) {
+                    SAMSequenceRecord sequence = sequenceDictionary.getSequence(contigIndex);
+                    addPartitionReadExtent(extents, partitionIndex, sequence.getSequenceName(), 1, sequence.getSequenceLength());
+                }
+                // add start of next contig
+                if (next != null) {
+                    addPartitionReadExtent(extents, partitionIndex, next.getContig(), 1, next.getStart() + maxLocatableLength);
+                }
+            }
+        }
+        return extents;
+    }
+
+    private static void addPartitionReadExtent(List<PartitionLocatable<SimpleInterval>> extents, int partitionIndex, String contig, int start, int end) {
+        SimpleInterval extent = new SimpleInterval(contig, start, end);
+        extents.add(new PartitionLocatable<>(partitionIndex, extent));
+    }
+
+    private static <T> JavaRDD<T> coalesce(JavaRDD<T> rdd, Class<T> cls, PartitionCoalescer partitionCoalescer) {
+        RDD<T> coalescedRdd = new CoalescedRDD<>(rdd.rdd(), rdd.getNumPartitions(), partitionCoalescer, cls);
+        ClassTag<T> tag = ClassTag$.MODULE$.apply(cls);
+        return new JavaRDD<>(coalescedRdd, tag);
+    }
+
+    private static class KeyPartitioner extends Partitioner {
+
+        private static final long serialVersionUID = 1L;
+
+        private int numPartitions;
+
+        public KeyPartitioner(int numPartitions) {
+            this.numPartitions = numPartitions;
+        }
+
+        @Override
+        public int numPartitions() {
+            return numPartitions;
+        }
+
+        @Override
+        public int getPartition(Object key) {
+            return (Integer) key;
+        }
+
+    }
+
+    static class PartitionLocatable<L extends Locatable> implements Locatable {
+        private static final long serialVersionUID = 1L;
+
+        private final int partitionIndex;
+        private final L interval;
+
+
+        public PartitionLocatable(int partitionIndex, L interval) {
+            this.partitionIndex = partitionIndex;
+            this.interval = interval;
+        }
+
+        public int getPartitionIndex() {
+            return partitionIndex;
+        }
+
+        public L getLocatable() {
+            return interval;
+        }
+
+        @Override
+        public String getContig() {
+            return interval.getContig();
+        }
+
+        @Override
+        public int getStart() {
+            return interval.getStart();
+        }
+
+        @Override
+        public int getEnd() {
+            return interval.getEnd();
+        }
+
+        @Override
+        public String toString() {
+            return "PartitionLocatable{" +
+                    "partitionIndex=" + partitionIndex +
+                    ", interval='" + interval + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            PartitionLocatable<?> that = (PartitionLocatable<?>) o;
+
+            if (partitionIndex != that.partitionIndex) return false;
+            return interval.equals(that.interval);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = partitionIndex;
+            result = 31 * result + interval.hashCode();
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/PileupSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/PileupSpark.java
@@ -1,0 +1,142 @@
+package org.broadinstitute.hellbender.tools.spark;
+
+import htsjdk.tribble.Feature;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.Hidden;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.AlignmentContext;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
+import org.broadinstitute.hellbender.engine.spark.LocusWalkerSpark;
+import scala.Tuple3;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@CommandLineProgramProperties(summary = "This tool emulates the 'samtools pileup' command. It prints the alignment in a format that is very "
+        + "similar to the Samtools pileup format (see the documentation in http://samtools.sourceforge.net/pileup.shtml"
+        + "for more details about the original format). There is one line per genomic position, listing the chromosome "
+        + "name, coordinate, reference base, read bases, and read qualities. In addition to these default fields, "
+        + "additional information can be added to the output as extra columns; see options detailed below.",
+        oneLineSummary = "Print read alignments in Pileup-style format on Spark",
+        programGroup = SparkProgramGroup.class)
+public final class PileupSpark extends LocusWalkerSpark {
+    private static final long serialVersionUID = 1L;
+
+    private static final String VERBOSE_DELIMITER = "@"; // it's ugly to use "@" but it's literally the only usable character not allowed in read names
+
+    @Override
+    public boolean requiresReads() { return true; }
+
+    @Argument(shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, doc="The output directory, which the sharded output will be written to", optional = false)
+    protected String outputFile;
+
+    /**
+     * In addition to the standard pileup output, adds 'verbose' output too. The verbose output contains the number of
+     * spanning deletions, and for each read in the pileup it has the read name, offset in the base string, read length,
+     * and read mapping quality.  These per read items are delimited with an '@' character.
+     */
+    @Argument(fullName = "showVerbose", shortName = "verbose", doc = "Add an extra verbose section to the pileup output", optional = true)
+    public boolean showVerbose = false;
+
+    /**
+     * This enables annotating the pileup to show overlaps with metadata from a Feature file(s). For example, if you provide a
+     * VCF and there is a SNP at a given location covered by the pileup, the pileup output at that position will be
+     * annotated with the corresponding source Feature identifier.
+     */
+    @Argument(fullName = "metadata", shortName = "metadata", doc = "Features file(s) containing metadata", optional = true)
+    public List<FeatureInput<Feature>> metadata = new ArrayList<>();
+
+    /**
+     * Adds the length of the insert each base comes from to the output pileup. Here, "insert" refers to the DNA insert
+     * produced during library generation before sequencing.
+     */
+    @Hidden
+    @Argument(fullName = "outputInsertLength", shortName = "outputInsertLength", doc = "Output insert length", optional = true)
+    public boolean outputInsertLength = false;
+
+    @Override
+    public ReadFilter makeReadFilter(){
+        return ReadFilterLibrary.MAPPED
+                .and(ReadFilterLibrary.NOT_DUPLICATE)
+                .and(ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK)
+                .and(ReadFilterLibrary.PRIMARY_ALIGNMENT)
+                .and(new WellformedReadFilter(getHeaderForReads()));
+    }
+
+    @Override
+    protected void runTool(final JavaSparkContext ctx) {
+        getAlignments(ctx).map(pileupFunction(metadata, outputInsertLength, showVerbose)).saveAsTextFile(outputFile);
+    }
+
+    private static Function<Tuple3<AlignmentContext, ReferenceContext, FeatureContext>, String> pileupFunction(List<FeatureInput<Feature>> metadata,
+                                                                                                               boolean outputInsertLength, boolean showVerbose) {
+        return (Function<Tuple3<AlignmentContext, ReferenceContext, FeatureContext>, String>) t -> {
+            AlignmentContext alignmentContext = t._1();
+            ReferenceContext referenceContext = t._2();
+            FeatureContext featureContext = t._3();
+            final String features = getFeaturesString(featureContext, metadata);
+            final ReadPileup basePileup = alignmentContext.getBasePileup();
+            final StringBuilder s = new StringBuilder();
+            s.append(String.format("%s %s",
+                    basePileup.getPileupString((referenceContext.hasBackingDataSource()) ? (char) referenceContext.getBase() : 'N'),
+                    features));
+            if (outputInsertLength) {
+                s.append(" ").append(insertLengthOutput(basePileup));
+            }
+            if (showVerbose) {
+                s.append(" ").append(createVerboseOutput(basePileup));
+            }
+            s.append("\n");
+            return s.toString();
+        };
+    }
+
+    private static String getFeaturesString(final FeatureContext featureContext, List<FeatureInput<Feature>> metadata) {
+        String featuresString = featureContext.getValues(metadata).stream()
+                .map(Feature::toString).collect(Collectors.joining(", "));
+        if (!featuresString.isEmpty()) {
+            featuresString = "[Feature(s): " + featuresString + "]";
+        }
+        return featuresString;
+    }
+
+    private static String insertLengthOutput(final ReadPileup pileup) {
+        return pileup.getReads().stream()
+                .map(r -> String.valueOf(r.getFragmentLength()))
+                .collect(Collectors.joining(","));
+    }
+
+    private static String createVerboseOutput(final ReadPileup pileup) {
+        final StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        sb.append(pileup.getNumberOfElements(PileupElement::isDeletion));
+        sb.append(" ");
+        for (final PileupElement p : pileup) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                sb.append(",");
+            }
+            sb.append(p.getRead().getName());
+            sb.append(VERBOSE_DELIMITER);
+            sb.append(p.getOffset());
+            sb.append(VERBOSE_DELIMITER);
+            sb.append(p.getRead().getLength());
+            sb.append(VERBOSE_DELIMITER);
+            sb.append(p.getRead().getMappingQuality());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/DownsamplingMethod.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/DownsamplingMethod.java
@@ -2,10 +2,13 @@ package org.broadinstitute.hellbender.utils.downsampling;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 
+import java.io.Serializable;
+
 /**
  * Describes the method for downsampling reads at a given locus.
  */
-public final class DownsamplingMethod {
+public final class DownsamplingMethod implements Serializable {
+    private static final long serialVersionUID = 1L;
     /**
      * Type of downsampling to perform.
      */

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
@@ -4,10 +4,14 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.downsampling.DownsampleType;
 import org.broadinstitute.hellbender.utils.downsampling.DownsamplingMethod;
 
+import java.io.Serializable;
+
 /**
  * Simple wrapper about the information LIBS needs about downsampling
  */
-public final class LIBSDownsamplingInfo {
+public final class LIBSDownsamplingInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final boolean performDownsampling;
     private final int toCoverage;
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescerUnitTest.java
@@ -1,0 +1,56 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.spark.Partition;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.rdd.PartitionGroup;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import scala.collection.JavaConversions;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class RangePartitionCoalescerUnitTest extends BaseTest {
+    private JavaRDD<String> rdd;
+    private Partition[] partitions;
+
+    @BeforeTest
+    public void setup() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        rdd = ctx.parallelize(ImmutableList.of("a", "b", "c"), 3);
+        partitions = rdd.rdd().partitions();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testThrowsExceptionIfNumPartitionsDifferent() {
+        List<Integer> maxEndPartitionIndexes = ImmutableList.of(0, 1, 2);
+        RangePartitionCoalescer coalescer = new RangePartitionCoalescer(maxEndPartitionIndexes);
+        coalescer.coalesce(rdd.getNumPartitions() - 1, rdd.rdd());
+    }
+
+    @Test
+    public void testIdentity() {
+        List<Integer> maxEndPartitionIndexes = ImmutableList.of(0, 1, 2);
+        RangePartitionCoalescer coalescer = new RangePartitionCoalescer(maxEndPartitionIndexes);
+        PartitionGroup[] groups = coalescer.coalesce(rdd.getNumPartitions(), rdd.rdd());
+        assertEquals(groups.length, 3);
+        assertEquals(groups[0].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[0])));
+        assertEquals(groups[1].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[1])));
+        assertEquals(groups[2].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[2])));
+    }
+
+    @Test
+    public void testNonIdentity() {
+        List<Integer> maxEndPartitionIndexes = ImmutableList.of(1, 2, 2);
+        RangePartitionCoalescer coalescer = new RangePartitionCoalescer(maxEndPartitionIndexes);
+        PartitionGroup[] groups = coalescer.coalesce(rdd.getNumPartitions(), rdd.rdd());
+        assertEquals(groups.length, 3);
+        assertEquals(groups[0].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[0], partitions[1])));
+        assertEquals(groups[1].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[1], partitions[2])));
+        assertEquals(groups[2].arr(), JavaConversions.asScalaBuffer(ImmutableList.of(partitions[2])));
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkSharderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkSharderUnitTest.java
@@ -1,0 +1,409 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.*;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.OverlapDetector;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.broadinstitute.hellbender.engine.Shard;
+import org.broadinstitute.hellbender.engine.ShardBoundary;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.annotations.Test;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class SparkSharderUnitTest extends BaseTest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final int STANDARD_READ_LENGTH = 3;
+
+    private SAMSequenceDictionary sequenceDictionary = new SAMSequenceDictionary(
+            ImmutableList.of(new SAMSequenceRecord("1", 100), new SAMSequenceRecord("2", 50)));
+
+
+    @Test
+    public void testLocatablesPerShard() throws IOException {
+
+        // Consider the following reads (divided into four partitions), and intervals.
+        // This test checks that iterating over the reads and intervals at the same time produces the overlapping
+        // reads for each interval.
+
+        //                      1                   2
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+        // ---------------------------------------------------------
+        // Reads in partition 0
+        //   [-----]
+        //           [-----]
+        //               [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 1
+        //               [-----]
+        //               [-----]
+        //               [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 2
+        //               [-----]
+        //                       [-----]
+        //                         [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 3
+        //                                   [-----]
+        //                                           [-----]
+        //                                                   [-----]
+        // ---------------------------------------------------------
+        // Per-partition read extents
+        //   [-----------------]
+        //               [-----]
+        //               [---------------]
+        //                                   [---------------------]
+        // ---------------------------------------------------------
+        // Intervals
+        //     [-----]
+        //                 [---------]
+        //                       [-----------------------]
+        //
+        //                      1                   2
+        // ---------------------------------------------------------
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+
+        List<TestRead> reads = ImmutableList.of(
+                new TestRead(1, 3), new TestRead(5, 7), new TestRead(7, 9),
+                new TestRead(7, 9), new TestRead(7, 9), new TestRead(7, 9),
+                new TestRead(7, 9), new TestRead(11, 13), new TestRead(12, 14),
+                new TestRead(17, 19), new TestRead(21, 23), new TestRead(25, 27)
+        );
+
+        List<SimpleInterval> intervals = ImmutableList.of(
+                new SimpleInterval("1", 2, 4),
+                new SimpleInterval("1", 8, 12),
+                new SimpleInterval("1", 11, 22));
+
+        Iterator<Tuple2<SimpleInterval, Iterable<TestRead>>> it = SparkSharder.locatablesPerShard(reads.iterator(), intervals.iterator(), sequenceDictionary, STANDARD_READ_LENGTH);
+        assertTrue(it.hasNext());
+        Tuple2<SimpleInterval, Iterable<TestRead>> next = it.next();
+        assertEquals(next._1(), intervals.get(0));
+        assertEquals(next._2(), ImmutableList.of(reads.get(0)));
+
+        assertTrue(it.hasNext());
+        next = it.next();
+        assertEquals(next._1(), intervals.get(1));
+        assertEquals(next._2(), ImmutableList.of(reads.get(2), reads.get(3), reads.get(4), reads.get(5), reads.get(6), reads.get(7), reads.get(8)));
+
+        assertTrue(it.hasNext());
+        next = it.next();
+        assertEquals(next._1(), intervals.get(2));
+        assertEquals(next._2(), ImmutableList.of(reads.get(7), reads.get(8), reads.get(9), reads.get(10)));
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void testSingleContig() throws IOException {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+
+        // Consider the following reads (divided into four partitions), and intervals.
+        // This test counts the number of reads that overlap each interval.
+
+        //                      1                   2
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+        // ---------------------------------------------------------
+        // Reads in partition 0
+        //   [-----]
+        //           [-----]
+        //               [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 1
+        //               [-----]
+        //               [-----]
+        //               [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 2
+        //               [-----]
+        //                       [-----]
+        //                         [-----]
+        // ---------------------------------------------------------
+        // Reads in partition 3
+        //                                   [-----]
+        //                                           [-----]
+        //                                                   [-----]
+        // ---------------------------------------------------------
+        // Per-partition read extents
+        //   [-----------------]
+        //               [-----]
+        //               [---------------]
+        //                                   [---------------------]
+        // ---------------------------------------------------------
+        // Intervals
+        //     [-----]
+        //                 [---------]
+        //                       [-----------------------]
+        //
+        //                      1                   2
+        // ---------------------------------------------------------
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+
+        JavaRDD<TestRead> reads = ctx.parallelize(ImmutableList.of(
+                new TestRead(1, 3), new TestRead(5, 7), new TestRead(7, 9),
+                new TestRead(7, 9), new TestRead(7, 9), new TestRead(7, 9),
+                new TestRead(7, 9), new TestRead(11, 13), new TestRead(12, 14),
+                new TestRead(17, 19), new TestRead(21, 23), new TestRead(25, 27)
+        ), 4);
+
+        List<SimpleInterval> intervals = ImmutableList.of(
+                new SimpleInterval("1", 2, 4),
+                new SimpleInterval("1", 8, 12),
+                new SimpleInterval("1", 11, 22));
+
+        List<ShardBoundary> shardBoundaries = intervals.stream().map(si -> new ShardBoundary(si, si)).collect(Collectors.toList());
+
+        ImmutableMap<SimpleInterval, Integer> expectedReadsPerInterval = ImmutableMap.of(intervals.get(0), 1, intervals.get(1), 7, intervals.get(2), 4);
+
+        JavaPairRDD<Locatable, Integer> readsPerInterval =
+                SparkSharder.shard(ctx, reads, TestRead.class, sequenceDictionary, shardBoundaries, STANDARD_READ_LENGTH, false)
+                .flatMapToPair(new CountOverlappingReadsFunction());
+        assertEquals(readsPerInterval.collectAsMap(), expectedReadsPerInterval);
+
+        JavaPairRDD<Locatable, Integer> readsPerIntervalShuffle =
+                SparkSharder.shard(ctx, reads, TestRead.class, sequenceDictionary, shardBoundaries, STANDARD_READ_LENGTH, true)
+                .flatMapToPair(new CountOverlappingReadsFunction());
+        assertEquals(readsPerIntervalShuffle.collectAsMap(), expectedReadsPerInterval);
+
+        try {
+            int maxReadLength = STANDARD_READ_LENGTH - 1; // max read length less than actual causes exception
+            SparkSharder.shard(ctx, reads, TestRead.class, sequenceDictionary, shardBoundaries, maxReadLength, true)
+                    .flatMapToPair(new CountOverlappingReadsFunction()).collect();
+        } catch (Exception e) {
+            assertEquals(e.getCause().getClass(), UserException.class);
+        }
+    }
+
+    @Test
+    public void testContigBoundary() throws IOException {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+
+        // Consider the following reads (divided into four partitions), and intervals.
+        // This test counts the number of reads that overlap each interval.
+
+        //                      1                   2
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+        // ---------------------------------------------------------
+        // Reads in partition 0
+        //   [-----] chr 1
+        //           [-----] chr 1
+        //               [-----] chr 1
+        //   [-----] chr 2
+        //     [-----] chr 2
+        // ---------------------------------------------------------
+        // Per-partition read extents
+        //   [-----------------] chr 1
+        //   [-------] chr 2
+        // ---------------------------------------------------------
+        // Intervals
+        //     [-----] chr 1
+        //                 [---------] chr 1
+        //   [-----------------------] chr 2
+        // ---------------------------------------------------------
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+
+        JavaRDD<TestRead> reads = ctx.parallelize(ImmutableList.of(
+                new TestRead("1", 1, 3), new TestRead("1", 5, 7), new TestRead("1", 7, 9),
+                new TestRead("2", 1, 3), new TestRead("2", 2, 4)
+        ), 1);
+
+        List<SimpleInterval> intervals = ImmutableList.of(
+                new SimpleInterval("1", 2, 4),
+                new SimpleInterval("1", 8, 12),
+                new SimpleInterval("2", 1, 12));
+
+        List<ShardBoundary> shardBoundaries = intervals.stream().map(si -> new ShardBoundary(si, si)).collect(Collectors.toList());
+
+        ImmutableMap<SimpleInterval, Integer> expectedReadsPerInterval = ImmutableMap.of(intervals.get(0), 1, intervals.get(1), 1, intervals.get(2), 2);
+
+        JavaPairRDD<Locatable, Integer> readsPerInterval =
+                SparkSharder.shard(ctx, reads, TestRead.class, sequenceDictionary, shardBoundaries, STANDARD_READ_LENGTH, false)
+                        .flatMapToPair(new CountOverlappingReadsFunction());
+        assertEquals(readsPerInterval.collectAsMap(), expectedReadsPerInterval);
+
+        JavaPairRDD<Locatable, Integer> readsPerIntervalShuffle =
+                SparkSharder.shard(ctx, reads, TestRead.class, sequenceDictionary, shardBoundaries, STANDARD_READ_LENGTH, true)
+                        .flatMapToPair(new CountOverlappingReadsFunction());
+        assertEquals(readsPerIntervalShuffle.collectAsMap(), expectedReadsPerInterval);
+
+    }
+
+    @Test
+    public void testPartitionReadExtents() throws IOException {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+
+        // Consider the following reads.
+        // This test checks the partition read extents when the reads are divided into
+        // different numbers of partitions (1, 2, or 3), and with different sequence dictionaries.
+
+        //                      1                   2
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+        // ---------------------------------------------------------
+        // Reads
+        //   [-----] chr 1
+        //           [-----] chr 1
+        //               [-----] chr 1
+        //                       [-----] chr 2
+        //                         [-----] chr 2
+        //                           [-----] chr 2
+        // ---------------------------------------------------------
+        //    1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7
+
+        ImmutableList<TestRead> reads = ImmutableList.of(
+                new TestRead("1", 1, 3), new TestRead("1", 5, 7), new TestRead("1", 7, 9),
+                new TestRead("2", 11, 13), new TestRead("2", 12, 14), new TestRead("2", 13, 15)
+        );
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 1), sequenceDictionary, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 50))
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 2), sequenceDictionary, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 14)), // since last read of partition 0 _could_ end at start of first read in partition 1 + max read length
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 11, 50))
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 3), sequenceDictionary, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 10)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("1", 7, 100)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 1, 15)),
+                        new SparkSharder.PartitionLocatable<>(2, new SimpleInterval("2", 12, 50))
+                ));
+
+        // Use a different dictionary with contig 3 at the end
+        SAMSequenceDictionary sequenceDictionary123 = new SAMSequenceDictionary(
+                ImmutableList.of(new SAMSequenceRecord("1", 100), new SAMSequenceRecord("2", 50), new SAMSequenceRecord("3", 25)));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 1), sequenceDictionary123, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 50)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("3", 1, 25)) // partition could contain contig 3 reads
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 2), sequenceDictionary123, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 14)), // since last read of partition 0 _could_ end at start of first read in partition 1 + max read length
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 11, 50)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("3", 1, 25)) // partition could contain contig 3 reads
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 3), sequenceDictionary123, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 10)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("1", 7, 100)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 1, 15)),
+                        new SparkSharder.PartitionLocatable<>(2, new SimpleInterval("2", 12, 50)),
+                        new SparkSharder.PartitionLocatable<>(2, new SimpleInterval("3", 1, 25)) // partition could contain contig 3 reads
+                ));
+
+        // Use a different dictionary with contig X between contigs 1 and 2
+        SAMSequenceDictionary sequenceDictionary1X2 = new SAMSequenceDictionary(
+                ImmutableList.of(new SAMSequenceRecord("1", 100), new SAMSequenceRecord("X", 75), new SAMSequenceRecord("2", 50)));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 1), sequenceDictionary1X2, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("X", 1, 75)), // partition could contain contig X reads
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 50))
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 2), sequenceDictionary1X2, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 100)),
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("X", 1, 75)), // partition could contain contig X reads
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("2", 1, 14)), // since last read of partition 0 _could_ end at start of first read in partition 1 + max read length
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 11, 50))
+                ));
+
+        assertEquals(SparkSharder.computePartitionReadExtents(ctx.parallelize(reads, 3), sequenceDictionary1X2, STANDARD_READ_LENGTH),
+                ImmutableList.of(
+                        new SparkSharder.PartitionLocatable<>(0, new SimpleInterval("1", 1, 10)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("1", 7, 100)),
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("X", 1, 75)), // partition could contain contig X reads
+                        new SparkSharder.PartitionLocatable<>(1, new SimpleInterval("2", 1, 15)),
+                        new SparkSharder.PartitionLocatable<>(2, new SimpleInterval("2", 12, 50))
+                ));
+    }
+
+    private static class TestRead implements Locatable {
+        private static final long serialVersionUID = 1L;
+        private final String contig;
+        private final int start;
+        private final int end;
+
+        public TestRead(int start, int end) {
+            this("1", start, end);
+        }
+
+        public TestRead(String contig, int start, int end) {
+            this.contig = contig;
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public String getContig() {
+            return contig;
+        }
+
+        @Override
+        public int getStart() {
+            return start;
+        }
+
+        @Override
+        public int getEnd() {
+            return end;
+        }
+
+        @Override
+        public String toString() {
+            return "TestRead{" +
+                    "contig='" + contig + '\'' +
+                    ", start=" + start +
+                    ", end=" + end +
+                    '}';
+        }
+    }
+
+    private static class CountOverlappingReadsFunction implements PairFlatMapFunction<Shard<TestRead>, Locatable, Integer> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Iterable<Tuple2<Locatable, Integer>> call(Shard<TestRead> s) throws Exception {
+            Locatable interval = s.getInterval();
+            Iterator<TestRead> iterator = s.iterator();
+            int count = 0;
+            OverlapDetector<Locatable> overlapDetector = OverlapDetector.create(ImmutableList.of(interval));
+            while (iterator.hasNext()) {
+                count += overlapDetector.getOverlaps(iterator.next()).size();
+            }
+            return ImmutableList.of(new Tuple2<>(interval, count));
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -121,6 +121,20 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 //{new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqCram_20_21_100000, more20Sites, " -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.1m-1m100.recal.txt")},
 
                 //// //{new BQSRTest(b36Reference, origQualsBam, dbSNPb36, "-OQ", getResourceDir() + "expected.originalQuals.1kg.chr1.1-1K.1RG.dictFix.OQ.txt")},
+
+                // multiple known sites  with OVERLAPS_PARTITIONER; entire test case shared with walker version
+                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --joinStrategy OVERLAPS_PARTITIONER -knownSites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
+
+                // local input/computation, 2Bit Reference, OVERLAPS_PARTITIONER
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                // multiple known sites with 2bit OVERLAPS_PARTITIONER; same output used for multiple known sites SHUFFLE test above
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --joinStrategy OVERLAPS_PARTITIONER -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/PileupSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/PileupSparkIntegrationTest.java
@@ -1,0 +1,107 @@
+package org.broadinstitute.hellbender.tools.spark;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
+
+    private static final File TEST_DATA_DIR = new File(getTestDataDir(), "walkers/qc/pileup");
+
+    @DataProvider(name = "shuffle")
+    public Object[][] shuffleParameters() {
+        return new Object[][] { { false }, { true } };
+    }
+
+    private File createTempFile() throws IOException {
+        final File out = File.createTempFile("out", ".txt");
+        out.delete();
+        out.deleteOnExit();
+        return out;
+    }
+
+    @Test(dataProvider = "shuffle")
+    public void testSimplePileup(boolean useShuffle) throws Exception {
+        final File out = createTempFile();
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--input");
+        args.add(NA12878_20_21_WGS_bam);
+        args.add("--output");
+        args.add(out.getAbsolutePath());
+        args.add("--reference");
+        args.add(b37_reference_20_21);
+        args.add("-L 20:9999900-10000000");
+        if (useShuffle) {
+            args.add("--shuffle");
+        }
+        this.runCommandLine(args.getArgsArray());
+        File expected = new File(TEST_DATA_DIR, "expectedSimplePileup.txt");
+        IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);
+    }
+
+    @Test(dataProvider = "shuffle")
+    public void testVerbosePileup(boolean useShuffle) throws Exception {
+        final File out = createTempFile();
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--input");
+        args.add(NA12878_20_21_WGS_bam);
+        args.add("--output");
+        args.add(out.getAbsolutePath());
+        args.add("--reference");
+        args.add(b37_reference_20_21);
+        args.add("-L 20:9999990-10000000");
+        args.add("-verbose");
+        if (useShuffle) {
+            args.add("--shuffle");
+        }
+        this.runCommandLine(args.getArgsArray());
+        File expected = new File(TEST_DATA_DIR, "expectedVerbosePileup.txt");
+        IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);
+    }
+
+    @Test(dataProvider = "shuffle")
+    public void testFeaturesPileup(boolean useShuffle) throws Exception {
+        final File out = createTempFile();
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--input");
+        args.add(NA12878_20_21_WGS_bam);
+        args.add("--output");
+        args.add(out.getAbsolutePath());
+        args.add("--reference");
+        args.add(b37_reference_20_21);
+        args.add("-L 20:10000092-10000112");
+        args.add("-metadata " + dbsnp_138_b37_20_21_vcf);
+        if (useShuffle) {
+            args.add("--shuffle");
+        }
+        this.runCommandLine(args.getArgsArray());
+        File expected = new File(TEST_DATA_DIR, "expectedFeaturesPileup.txt");
+        IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);
+    }
+    
+    @Test(dataProvider = "shuffle")
+    public void testInsertLengthPileup(boolean useShuffle) throws Exception {
+        final File out = createTempFile();
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--input");
+        args.add(NA12878_20_21_WGS_bam);
+        args.add("--output");
+        args.add(out.getAbsolutePath());
+        args.add("--reference");
+        args.add(b37_reference_20_21);
+        args.add("-L 20:10000092-10000112");
+        args.add("-outputInsertLength");
+        if (useShuffle) {
+            args.add("--shuffle");
+        }
+        this.runCommandLine(args.getArgsArray());
+        File expected = new File(TEST_DATA_DIR, "expectedInsertLengthPileup.txt");
+        IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);
+    }
+
+}


### PR DESCRIPTION
This addresses #1558 by using an implementation of #1988.

Running on a 6.6GB BAM file:
- PileupSpark with a shuffle took 4.35 minutes on a 6 node cluster
- PileupSpark with no shuffle (using the overlaps partitioner) took 2.96 minutes (30% faster)
- Pileup took 39.2 minutes (on a single node)

@droazen, please take a look and let me know what you think.
