### PR TITLE
Fix GenomeLocParser error reporting.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocParser.java
@@ -317,8 +317,10 @@ public final class GenomeLocParser {
             }
 
             return createGenomeLoc(contig, getContigIndex(contig), start, stop, true);
-        } catch (IllegalArgumentException | UserException e){
-            throw new UserException.MalformedGenomeLoc("Failed to parse Genome Location string: " + str, e);
+        } catch (UserException.MalformedGenomeLoc e) {
+            throw e;
+        } catch (IllegalArgumentException | UserException e) {
+            throw new UserException.MalformedGenomeLoc("Failed to parse Genome Location string: " + str + ": " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
The current error handling swallows the detailed part of the error string that gets reported to the user, i.e., without this change you see:
A USER ERROR has occurred: Badly formed genome unclippedLoc: Failed to parse Genome Location string: 20:10000000-10010000

With this change:
A USER ERROR has occurred: Badly formed genome unclippedLoc: Parameters to GenomeLocParser are incorrect:The genome loc coordinates 10000000-10010000 exceed the contig size (200000)

I originally removed the entire try/catch block, but there is downstream code that throws IllegalArgumentException, which can benefit from being decorated with the context info.