### PR TITLE
Convert ReadsDataSource to use Paths, so it can read inputs from the cloud

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -2,8 +2,10 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +24,15 @@ public final class OptionalReadInputArgumentCollection extends ReadInputArgument
         ArrayList<File> ret = new ArrayList<>();
         for (String fn : readFilesNames) {
             ret.add(new File(fn));
+        }
+        return ret;
+    }
+
+    @Override
+    public List<Path> getReadPaths() {
+        ArrayList<Path> ret = new ArrayList<>();
+        for (String fn : readFilesNames) {
+            ret.add(IOUtils.getPath(fn));
         }
         return ret;
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 
@@ -25,6 +26,12 @@ public abstract class ReadInputArgumentCollection implements ArgumentCollectionD
             common=true,
             optional=true)
     public ValidationStringency readValidationStringency = ReadConstants.DEFAULT_READ_VALIDATION_STRINGENCY;
+
+    /**
+     * Get the list of BAM/SAM/CRAM files specified at the command line.
+     * Paths are the preferred format, as this can handle both local disk and NIO direct access to cloud storage.
+     */
+    public abstract List<Path> getReadPaths();
 
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
@@ -2,8 +2,10 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +23,15 @@ public final class RequiredReadInputArgumentCollection extends ReadInputArgument
         ArrayList<File> ret = new ArrayList<>();
         for (String fn : readFilesNames) {
             ret.add(new File(fn));
+        }
+        return ret;
+    }
+
+    @Override
+    public List<Path> getReadPaths() {
+        ArrayList<Path> ret = new ArrayList<>();
+        for (String fn : readFilesNames) {
+            ret.add(IOUtils.getPath(fn));
         }
         return ret;
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -142,7 +142,7 @@ public abstract class GATKTool extends CommandLineProgram {
             else if (hasCramInput()) {
                 throw new UserException.MissingReference("A reference file is required when using CRAM files.");
             }
-            reads = new ReadsDataSource(readArguments.getReadFiles(), factory);
+            reads = new ReadsDataSource(readArguments.getReadPaths(), factory);
         }
         else {
             reads = null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceHadoopSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceHadoopSource.java
@@ -28,14 +28,14 @@ public class ReferenceHadoopSource implements ReferenceSource, Serializable {
     }
 
     @Override
-    public ReferenceBases getReferenceBases(final PipelineOptions pipelineOptions, final SimpleInterval interval) throws IOException {
+    public ReferenceBases getReferenceBases(final PipelineOptions pipelineOptions, final SimpleInterval interval) {
         ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(IOUtils.getPath(referencePath));
         ReferenceSequence sequence = referenceSequenceFile.getSubsequenceAt(interval.getContig(), interval.getStart(), interval.getEnd());
         return new ReferenceBases(sequence.getBases(), interval);
     }
 
     @Override
-    public SAMSequenceDictionary getReferenceSequenceDictionary(final SAMSequenceDictionary optReadSequenceDictionaryToMatch) throws IOException {
+    public SAMSequenceDictionary getReferenceSequenceDictionary(final SAMSequenceDictionary optReadSequenceDictionaryToMatch) {
         ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(IOUtils.getPath(referencePath));
         return referenceSequenceFile.getSequenceDictionary();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleNioCountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleNioCountReads.java
@@ -35,8 +35,7 @@ public class ExampleNioCountReads extends SparkCommandLineProgram {
     @Argument(fullName = "parts", doc = "number of partitions", optional = false)
     private int parts = 3;
 
-    private void countReads(JavaSparkContext ctx) throws IOException {
-
+    private void countReads(JavaSparkContext ctx) {
         PrintStream outputStream;
 
         try {
@@ -58,10 +57,6 @@ public class ExampleNioCountReads extends SparkCommandLineProgram {
      */
     @Override
     protected void runPipeline(JavaSparkContext ctx) {
-        try {
-            countReads(ctx);
-        } catch (IOException x) {
-            System.err.println(x);
-        }
+        countReads(ctx);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -380,6 +380,7 @@ public final class BucketUtils {
     /**
      * String -> Path. This *should* not be necessary (use Paths.get(URI.create(...)) instead) , but it currently is
      * on Spark because using the fat, shaded jar breaks the registration of the GCS FilesystemProvider.
+     * To transform other types of string URLs into Paths, use IOUtils.getPath instead.
      */
     public static java.nio.file.Path getPathOnGcs(String gcsUrl) {
         final String[] split = gcsUrl.split("/");
@@ -387,7 +388,6 @@ public final class BucketUtils {
         final String pathWithoutBucket = String.join("/", Arrays.copyOfRange(split, 3, split.length));
         return CloudStorageFileSystem.forBucket(BUCKET).getPath(pathWithoutBucket);
     }
-
 
     /**
      * Get an authenticated GCS-backed NIO FileSystem object representing the selected projected and bucket.

--- a/src/main/java/org/broadinstitute/hellbender/utils/nio/ReadsIterable.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/nio/ReadsIterable.java
@@ -11,6 +11,7 @@ import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.CloseableIterator;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -40,7 +41,7 @@ public class ReadsIterable implements Iterable<SAMRecord>, Serializable {
         private boolean done = false;
 
         public ReadsIterator() throws IOException {
-            Path fpath = BucketUtils.getPathOnGcs(path);
+            Path fpath = IOUtils.getPath(path);
             byte[] indexData = index;
             SeekableStream indexInMemory = new ByteArraySeekableStream(indexData);
             SeekableByteChannelPrefetcher chan = new SeekableByteChannelPrefetcher(Files.newByteChannel(fpath), BUFSIZE);

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -315,6 +316,15 @@ public abstract class BaseTest {
         final File tempDir = createTempDir("nonExistentFileHolder");
         final File nonExistingFile = new File(tempDir, fileNameWithExtension);
         return nonExistingFile;
+    }
+
+    /**
+     * Return a Path object representing a file with the given name and extension that is guaranteed not to exist.
+     * @param fileNameWithExtension
+     * @return Path object representing a file that is guaranteed not to exist
+     */
+    public static Path getSafeNonExistentPath(final String fileNameWithExtension) {
+        return getSafeNonExistentFile(fileNameWithExtension).toPath();
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
@@ -11,6 +11,8 @@ import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.activityprofile.ActivityProfileState;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -21,6 +23,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 
 
@@ -394,7 +398,7 @@ public final class AssemblyRegionUnitTest extends BaseTest {
 
     @Test
     public void testCreateFromReadShard() {
-        final File testBam = new File(NA12878_20_21_WGS_bam);
+        final Path testBam = IOUtils.getPath(NA12878_20_21_WGS_bam);
         final File reference = new File(b37_reference_20_21);
         final SimpleInterval shardInterval = new SimpleInterval("20", 10000000, 10001000);
         final SimpleInterval paddedShardInterval = new SimpleInterval(shardInterval.getContig(), shardInterval.getStart() - 100, shardInterval.getEnd() + 100);

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocalReadShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocalReadShardUnitTest.java
@@ -6,13 +6,14 @@ import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +23,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "InvalidConstructionTestData")
     public Object[][] invalidConstructionTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 { new SimpleInterval("1", 200, 250), new SimpleInterval("1", 200, 250), null },
@@ -43,7 +44,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardBoundsTestData")
     public Object[][] shardBoundsTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 {new LocalReadShard(new SimpleInterval("1", 200, 250), readsSource), new SimpleInterval("1", 200, 250), new SimpleInterval("1", 200, 250), "1", 200, 250, 0, 0 },
@@ -67,7 +68,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardContainsTestData")
     public Object[][] shardContainsTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 // Tests with no padding
@@ -90,7 +91,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardIterationTestData")
     public Object[][] shardIterationTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         final ReadFilter keepReadBOnly = new ReadFilter() {
             private static final long serialVersionUID = 1l;
@@ -143,7 +144,7 @@ public class LocalReadShardUnitTest extends BaseTest {
     @DataProvider(name = "DivideIntervalIntoShardsTestData")
     public Object[][] divideIntervalIntoShardsTestData() {
         // Doesn't matter which bam we use to back the reads source for the purposes of these tests.
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Arrays.asList(new SAMSequenceRecord("1", 16000)));
 
         return new Object[][] {
@@ -289,7 +290,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "DivideIntervalIntoShardsInvalidTestData")
     public Object[][] divideIntervalIntoShardsInvalidTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Arrays.asList(new SAMSequenceRecord("1", 16000)));
 
         return new Object[][] {

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
@@ -1,12 +1,15 @@
 package org.broadinstitute.hellbender.engine;
 
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class ReadsContextUnitTest extends BaseTest {
 
@@ -18,7 +21,7 @@ public final class ReadsContextUnitTest extends BaseTest {
                 { new ReadsContext() },
                 { new ReadsContext(null, null) },
                 { new ReadsContext(null, new SimpleInterval("1", 1, 1) ) },
-                { new ReadsContext(new ReadsDataSource(new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
+                { new ReadsContext(new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -9,9 +9,12 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
@@ -235,7 +238,7 @@ public class ReadsSparkSourceUnitTest extends BaseTest {
             samReaderFactory = SamReaderFactory.makeDefault().validationStringency(validationStringency);
         }
 
-        ReadsDataSource bam2 = new ReadsDataSource(new File(bam), samReaderFactory);
+        ReadsDataSource bam2 = new ReadsDataSource(IOUtils.getPath(bam), samReaderFactory);
         bam2.setTraversalBounds(intervals);
         List<GATKRead> records = Lists.newArrayList();
         for ( GATKRead read : bam2 ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
@@ -27,7 +27,7 @@ public class ConvertHeaderlessHadoopBamShardToBamIntegrationTest extends Command
         runCommandLine(args);
 
         int actualCount = 0;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(output) ) {
+        try ( final ReadsDataSource readsSource = new ReadsDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -206,7 +206,7 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
 
         runCommandLine(args);
 
-        try ( final ReadsDataSource outputReadsSource = new ReadsDataSource(outFile) ) {
+        try ( final ReadsDataSource outputReadsSource = new ReadsDataSource(outFile.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 actualReads.add(read);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
@@ -105,7 +105,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try ( final ReadsDataSource outputReads = new ReadsDataSource(outputFile) ) {
+        try ( final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath()) ) {
             for ( GATKRead read : outputReads ) {
                 ++totalReads;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
@@ -12,6 +12,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -178,4 +180,17 @@ public final class IOUtilsUnitTest extends BaseTest {
         IOUtils.assertFileIsReadable(new File(publicTestDir + "foo/bar/NON_EXISTENT_FILE_FOR_IOUTILS_AssertFileIsReadableNonExistentFile"));
     }
 
+
+    @Test(groups={"bucket"})
+    public void testGetPath() throws IOException {
+        innerTestGetPath(getGCPTestInputPath() + "large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam");
+        innerTestGetPath("file://" + NA12878_20_21_WGS_bam);
+        innerTestGetPath(NA12878_20_21_WGS_bam);
+    }
+
+    private void innerTestGetPath(String s) throws IOException {
+        Path p = IOUtils.getPath(s);
+        long size = Files.size(p);
+        Assert.assertTrue(size>0);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
@@ -2,6 +2,8 @@ package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,7 +32,7 @@ public final class ReadCoordinateComparatorUnitTest extends BaseTest{
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header = null;
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(new File(inputBam)) ) {
+        try ( final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(inputBam)) ) {
             header = readsSource.getHeader();
 
             for ( GATKRead read : readsSource ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -27,7 +27,7 @@ public class SparkUtilsUnitTest extends BaseTest {
         final int expectedReadCount = 11;
 
         boolean shardIsNotValidBam = false;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bamShard) ) {
+        try ( final ReadsDataSource readsSource = new ReadsDataSource(bamShard.toPath()) ) {
             for ( final GATKRead read : readsSource ) {}
         }
         catch ( SAMFormatException e ) {
@@ -47,7 +47,7 @@ public class SparkUtilsUnitTest extends BaseTest {
         SparkUtils.convertHeaderlessHadoopBamShardToBam(bamShard, header, output);
 
         int actualCount = 0;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(output) ) {
+        try ( final ReadsDataSource readsSource = new ReadsDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 


### PR DESCRIPTION
As a result, every walker that takes a BAM as input can now read it from
the cloud directly.

Sample use: ./gatk-launch CountReads -I
"gs://.../CEUTrio.HiSeq.WGS.b37.ch20.4m-12m.NA12878.bam"
(...)
Tool returned:
7275701

Note that this CL doesn't add a prefetcher or multithreading, so the
performance is inferior to that of the NIO proof of concept which was
using both.

cc: @droazen 
