### PR TITLE
change qss's count type to R

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -88,7 +88,7 @@ public class GATKVCFHeaderLines {
         addFormatLine(new VCFFormatHeaderLine(OXOG_REF_F1R2_KEY, 1, VCFHeaderLineType.Integer, "Count of reads in F1R2 pair orientation supporting the reference allele"));
         addFormatLine(new VCFFormatHeaderLine(OXOG_REF_F2R1_KEY, 1, VCFHeaderLineType.Integer, "Count of reads in F2R1 pair orientation supporting the reference allele"));
         addFormatLine(new VCFFormatHeaderLine(OXOG_FRACTION_KEY, 1, VCFHeaderLineType.Float, "Fraction of alt reads indicating OxoG error"));
-        addFormatLine(new VCFFormatHeaderLine(QUALITY_SCORE_SUM_KEY, 1, VCFHeaderLineType.Integer, "Sum of base quality scores for each allele"));
+        addFormatLine(new VCFFormatHeaderLine(QUALITY_SCORE_SUM_KEY, VCFHeaderLineCount.R, VCFHeaderLineType.Integer, "Sum of base quality scores for each allele"));
 
 
         addInfoLine(new VCFInfoHeaderLine(MLE_ALLELE_COUNT_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed"));


### PR DESCRIPTION
The quality score sum (QSS) format field reports the sum of base qualities for ref and alt allele, and its correct format field count type is 'R' (see 1.2.2 in the [vcf spec](http://samtools.github.io/hts-specs/VCFv4.2.pdf)). We used to use the wrong count type of 1 and that caused a parsing error in the dream challenge evaluation script.