### PR TITLE
Fix an oversight in recent refactoring of annotation code

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySampleUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySampleUnitTest.java
@@ -68,7 +68,7 @@ public final class DepthPerAlleleBySampleUnitTest extends BaseTest {
         Assert.assertFalse(gb1.make().hasAD());
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBlowUp(){
         final int dpDepth = 30; //Note: using a different value on purpose so that we can check that reads are preferred over DP
         final Genotype gAC = new GenotypeBuilder(SAMPLE, ALLELES).DP(dpDepth).make();


### PR DESCRIPTION
Two annotations, allele depth and total depth, consider whether reads are informative relative to the alleles in the output `VariantContext`, which is in general a subset of the alleles contains in the `ReadLikelihoods`.  In PR #2185 I overlooked this and forgot to subset the likelihoods' alleles to those of the vc, which was the previous behavior (see the diff from that PR for the two annotations in this PR).  This PR duplicates the old behavior.  This fixes failures in the HaplotypeCaller integration tests introduced by the previous PR.
