### PR TITLE
CreateSequenceDictionary default output file name

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
@@ -36,7 +37,7 @@ public final class CreateSequenceDictionary extends PicardCommandLineProgram {
     @Argument(
 	    shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
-            doc = "Output a dict file containing only the sequence dictionary")
+            doc = "Output a dict file containing only the sequence dictionary. By default it will use the base name of the input reference with the .dict extension", optional = true)
     public File OUTPUT;
 
     @Argument(doc = "Put into AS field of sequence dictionary entry if supplied", optional = true)
@@ -54,6 +55,8 @@ public final class CreateSequenceDictionary extends PicardCommandLineProgram {
 
     /**
      * Use reference filename to create URI to go into header if URI was not passed on cmd line.
+     * Use default name for output if not specified, being the same as the input but with
+     * {@link IOUtil#DICT_FILE_EXTENSION} extension instead of the FASTA ones (.fa or .fasta).
      */
     @Override
     protected String[] customCommandLineValidation() {
@@ -62,6 +65,11 @@ public final class CreateSequenceDictionary extends PicardCommandLineProgram {
         }
         if (URI == null) {
             URI = "file:" + REFERENCE_SEQUENCE.getAbsolutePath();
+        }
+        if (OUTPUT == null) {
+            // determine the name for the dict file in the same way as CachingIndexedFastaSequenceFile.checkAndCreate
+            final String fastaExt = REFERENCE_SEQUENCE.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
+            OUTPUT = new File(REFERENCE_SEQUENCE.getAbsolutePath().replaceAll(fastaExt, IOUtil.DICT_FILE_EXTENSION));
         }
         return null;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
@@ -68,11 +68,9 @@ public final class CreateSequenceDictionary extends PicardCommandLineProgram {
             URI = "file:" + REFERENCE_SEQUENCE.getAbsolutePath();
         }
         if (OUTPUT == null) {
-            if (OUTPUT == null) {
-                // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
-                OUTPUT = getDefaultDictionaryForReferenceSequence(REFERENCE_SEQUENCE);
-                logger.info("Output dictionary will be written in ", OUTPUT);
-            }
+            // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
+            OUTPUT = getDefaultDictionaryForReferenceSequence(REFERENCE_SEQUENCE);
+            logger.info("Output dictionary will be written in ", OUTPUT);
         }
         return null;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionary.java
@@ -68,8 +68,11 @@ public final class CreateSequenceDictionary extends PicardCommandLineProgram {
         }
         if (OUTPUT == null) {
             // determine the name for the dict file in the same way as CachingIndexedFastaSequenceFile.checkAndCreate
-            final String fastaExt = REFERENCE_SEQUENCE.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
-            OUTPUT = new File(REFERENCE_SEQUENCE.getAbsolutePath().replaceAll(fastaExt, IOUtil.DICT_FILE_EXTENSION));
+            final String name = REFERENCE_SEQUENCE.getName();
+            final String fastaExt = ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream()
+                    .filter(name::endsWith).findFirst().orElseGet(() -> "");
+            OUTPUT = new File(REFERENCE_SEQUENCE.getParentFile(),
+                    REFERENCE_SEQUENCE.getName().replace(fastaExt, IOUtil.DICT_FILE_EXTENSION));
         }
         return null;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.FastaSequenceIndex;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -159,7 +160,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
 
         // determine the name for the dict file
         final String fastaExt = fastaFile.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
-        final File dictFile = new File(fastaFile.getAbsolutePath().replaceAll(fastaExt, ".dict"));
+        final File dictFile = new File(fastaFile.getAbsolutePath().replaceAll(fastaExt, IOUtil.DICT_FILE_EXTENSION));
 
         // It's an error if either the fai or dict file does not exist. The user is now responsible
         // for creating these files.

--- a/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
@@ -159,6 +159,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
         final File indexFile = new File(fastaFile.getAbsolutePath() + ".fai");
 
         // determine the name for the dict file
+        // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
         final String fastaExt = fastaFile.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
         final File dictFile = new File(fastaFile.getAbsolutePath().replaceAll(fastaExt, IOUtil.DICT_FILE_EXTENSION));
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
@@ -37,7 +37,7 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
     }
 
     @Test
-    public void testNoOutput() throws Exception {
+    public void testDefaultOutputFile() throws Exception {
         final File expectedDict = new File(TEST_DATA_DIR, "basic.dict");
         Assert.assertFalse(expectedDict.exists());
         final String[] argv = {

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
@@ -36,6 +36,22 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
         IntegrationTestSpec.assertEqualTextFiles(outputDict, new File(BASIC_FASTA.getAbsolutePath() + ".dict"));
     }
 
+    @Test
+    public void testNoOutput() throws Exception {
+        final File expectedDict = new File(TEST_DATA_DIR, "basic.dict");
+        Assert.assertFalse(expectedDict.exists());
+        final String[] argv = {
+                "--reference", BASIC_FASTA.getAbsolutePath(),
+                "--URI", BASIC_FASTA.getName()
+        };
+        runCommandLine(argv);
+        Assert.assertTrue(expectedDict.exists());
+        // mark as delete on exit
+        expectedDict.deleteOnExit();
+        // and compare if it is the same as the expected
+        IntegrationTestSpec.assertEqualTextFiles(expectedDict, new File(BASIC_FASTA.getAbsolutePath() + ".dict"));
+    }
+
     /**
      * Should throw an exception because sequence names are not unique.
      */

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.picard.sam;
 
+import com.google.common.io.Files;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -38,10 +39,13 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
 
     @Test
     public void testDefaultOutputFile() throws Exception {
-        final File expectedDict = new File(TEST_DATA_DIR, "basic.dict");
+        final File tempDir = createTempDir("CreateSequenceDictionaryTest");
+        final File fastaCopy = new File(tempDir, "basic.fasta");
+        Files.copy(BASIC_FASTA, fastaCopy);
+        final File expectedDict = new File(tempDir, "basic.dict");
         Assert.assertFalse(expectedDict.exists());
         final String[] argv = {
-                "--reference", BASIC_FASTA.getAbsolutePath(),
+                "--reference", fastaCopy.getAbsolutePath(),
                 "--URI", BASIC_FASTA.getName()
         };
         runCommandLine(argv);


### PR DESCRIPTION
This solves partially #2177, although generating the _.fai_ is not implemented yet.

* Use `IOUtil.DICT_FILE_EXTENSION` as dictionary extension in `CachingIndexedFastaSequenceFile.checkAndCreate`
* No required output argument for `CreateSequenceDictionary`, using as default the name that is used internally in the GATK framework (e.g., __basic.dict__ for __basic.fa__).