### PR TITLE
IndexFeatureFile cleaning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ repositories {
 
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.6.1')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.7.0')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.7.0')
 
 configurations.all {


### PR DESCRIPTION
* Updates htsjdk to 2.7.0
* Use `Index.write(File)` for write the index independently of type
* Removed unused imports