### PR TITLE
updating gcloud command on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
     scripts/install_gcloud.sh;
     printf 'y\n' | $GCLOUD/gcloud components update app;
     $GCLOUD/gcloud config set project broad-dsde-dev;
-    $GCLOUD/gcloud auth activate-service-account --key servicekey.json;
+    $GCLOUD/gcloud auth activate-service-account --key-file servicekey.json;
   fi
 #install R
 - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9


### PR DESCRIPTION
they seem to have changed the gcloud cli to use --key-file instead of
--key in authentication

this was causing travis to fail on the cloud tests