### PR TITLE
Fixing ReadPileup constructor for multiple samples

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
@@ -126,7 +126,7 @@ public final class FragmentCollection<T> {
         if ( rbp == null ) {
             throw new IllegalArgumentException("Pileup cannot be null");
         }
-        return create(rbp, rbp.size(), pileup -> pileup.getRead());
+        return create(rbp::sortedIterator, rbp.size(), pileup -> pileup.getRead());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
@@ -44,7 +44,9 @@ public final class ReadPileup implements Iterable<PileupElement> {
      * Note: the current implementation of ReadPileup does not efficiently retrieve the stratified pileup
      */
     public ReadPileup(final Locatable loc, final Map<String, ReadPileup> stratifiedPileup) {
-        this(loc, stratifiedPileup.values().stream().flatMap(ReadPileup::getElementStream).collect(Collectors.toList()));
+        this(loc, stratifiedPileup.values().stream().flatMap(ReadPileup::getElementStream)
+                .sorted((l, r) -> Integer.compare(l.getRead().getStart(), r.getRead().getStart()))
+                .collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
@@ -44,9 +44,7 @@ public final class ReadPileup implements Iterable<PileupElement> {
      * Note: the current implementation of ReadPileup does not efficiently retrieve the stratified pileup
      */
     public ReadPileup(final Locatable loc, final Map<String, ReadPileup> stratifiedPileup) {
-        this(loc, stratifiedPileup.values().stream().flatMap(ReadPileup::getElementStream)
-                .sorted((l, r) -> Integer.compare(l.getRead().getStart(), r.getRead().getStart()))
-                .collect(Collectors.toList()));
+        this(loc, stratifiedPileup.values().stream().flatMap(ReadPileup::getElementStream).collect(Collectors.toList()));
     }
 
     /**
@@ -200,6 +198,15 @@ public final class ReadPileup implements Iterable<PileupElement> {
     @Override
     public Iterator<PileupElement> iterator() {
         return Collections.unmodifiableList(pileupElements).iterator();
+    }
+
+    /**
+     * Iterator over sorted by read start PileupElements.
+     */
+    public Iterator<PileupElement> sortedIterator() {
+        return getElementStream()
+                .sorted((l, r) -> Integer.compare(l.getRead().getStart(), r.getRead().getStart()))
+                .iterator();
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollectionUnitTest.java
@@ -1,0 +1,45 @@
+package org.broadinstitute.hellbender.utils.fragments;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.Locatable;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class FragmentCollectionUnitTest extends BaseTest {
+
+    private static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+    private static final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "10M");
+    private static final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "10M");
+    static {
+        read1.setPosition(new SimpleInterval("22", 200, 210));
+        read2.setPosition(new SimpleInterval("22", 208, 218));
+        read1.setMatePosition(read2);
+        read2.setMatePosition(read1);
+    }
+
+    @Test
+    public void createFromMultiSamplePileup() throws Exception {
+        final Locatable loc = new SimpleInterval("22", 208, 208);
+        final Map<String, ReadPileup> stratified = new LinkedHashMap<>();
+        stratified.put("sample1", new ReadPileup(loc, Arrays.asList(read2), 0));
+        stratified.put("sample2", new ReadPileup(loc, Arrays.asList(read1), 9));
+        final ReadPileup combined = new ReadPileup(loc, stratified);
+        final FragmentCollection<PileupElement> elements = FragmentCollection.create(combined);
+        Assert.assertTrue(elements.getSingletonReads().isEmpty());
+        Assert.assertEquals(elements.getOverlappingPairs().size(), 1);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollectionUnitTest.java
@@ -20,18 +20,15 @@ import java.util.Map;
  */
 public class FragmentCollectionUnitTest extends BaseTest {
 
-    private static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
-    private static final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "10M");
-    private static final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "10M");
-    static {
+    @Test
+    public void createFromMultiSamplePileup() throws Exception {
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "10M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "10M");
         read1.setPosition(new SimpleInterval("22", 200, 210));
         read2.setPosition(new SimpleInterval("22", 208, 218));
         read1.setMatePosition(read2);
         read2.setMatePosition(read1);
-    }
-
-    @Test
-    public void createFromMultiSamplePileup() throws Exception {
         final Locatable loc = new SimpleInterval("22", 208, 208);
         final Map<String, ReadPileup> stratified = new LinkedHashMap<>();
         stratified.put("sample1", new ReadPileup(loc, Arrays.asList(read2), 0));

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
@@ -632,4 +632,22 @@ public final class ReadPileupUnitTest extends BaseTest {
         Assert.assertEquals(copy2, read2);
     }
 
+    @Test
+    public void testSortedIterator() throws Exception {
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "10M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "10M");
+        read1.setPosition(new SimpleInterval("22", 200, 210));
+        read2.setPosition(new SimpleInterval("22", 208, 218));
+        read1.setMatePosition(read2);
+        read2.setMatePosition(read1);
+        final Locatable loc = new SimpleInterval("22", 208, 208);
+        final Map<String, ReadPileup> stratified = new LinkedHashMap<>();
+        stratified.put("sample1", new ReadPileup(loc, Arrays.asList(read2), 0));
+        stratified.put("sample2", new ReadPileup(loc, Arrays.asList(read1), 9));
+        final ReadPileup combined = new ReadPileup(loc, stratified);
+        final Iterator<PileupElement> sortedIterator = combined.sortedIterator();
+        Assert.assertSame(sortedIterator.next().getRead(), read1);
+        Assert.assertSame(sortedIterator.next().getRead(), read2);
+    }
 }


### PR DESCRIPTION
`FragmentCollection.create(ReadPileup)` assumes a `ReadPileup` sorted by start position and thus it throws an exception (#2245) while trying to fix a multi-sample `ReadPileup` constructed with an stratified one (like in LIBS).

For solving the issue, I just implemented a simple fix from the constructor (sorting the stratified pielup) and a simple test for check if #2245 is solved.