### PR TITLE
removing GenomicsDB dependencies from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,20 +60,6 @@ before_install:
 - sudo apt-get update
 - sudo apt-get install -y --force-yes r-base
 - R --version
-###### necessary for running the dynamically linked GenomicsDB binaries in src/test/resources/large
-#Install lcov and MPICH
-- sudo apt-get -y install lcov mpich zlib1g-dev libssl-dev
-- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-- sudo apt-get update -q
-- sudo apt-get install g++-4.9 -y
-- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 60
-#Install libcsv
-- cd $TRAVIS_BUILD_DIR
-- mkdir dependencies
-- wget -O dependencies/libcsv.tar.gz http://downloads.sourceforge.net/project/libcsv/libcsv/libcsv-3.0.3/libcsv-3.0.3.tar.gz
-- mkdir -p dependencies/libcsv && tar xzf dependencies/libcsv.tar.gz  -C dependencies/libcsv --strip-components=1 && cd dependencies/libcsv && ./configure && make
-- cd $TRAVIS_BUILD_DIR
-###### end GenomicsDB stuff
 install:
 - if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
     echo "Can't run cloud tests without keys so don't bother building";


### PR DESCRIPTION
these should no longer be necessary and were causing problems because
one of the URL's no longer exists