### PR TITLE
Update to GKL 0.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.1.2') {
+    compile('com.intel.gkl:gkl:0.3.1') {
         exclude module: 'htsjdk'
     }
     

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import htsjdk.variant.variantcontext.Allele;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -16,7 +17,7 @@ import java.io.Closeable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * Class for performing the pair HMM for local alignment. Figure 4.3 in Durbin 1998 book.
@@ -31,56 +32,84 @@ public abstract class PairHMM implements Closeable{
     protected byte[] previousHaplotypeBases;
     protected int hapStartIndex;
 
+    private static void logPairHmmArgs(PairHMMNativeArguments args) {
+        logger.info("Threads : " + args.maxNumberOfThreads);
+        logger.info("Floating-point precision : " + (args.useDoublePrecision ? "double" : "single"));
+    }
+
     public enum Implementation {
         /* Very slow implementation which uses very accurate log10 sum functions. Only meant to be used as a reference test implementation */
-        EXACT(() -> {
+        EXACT(args -> {
             final Log10PairHMM hmm = new Log10PairHMM(true);
-            logger.info("Using the non-hardware accelerated Java EXACT PairHMM implementation");
+            logger.info("Using the single-threaded, non-hardware accelerated, double-precision Java EXACT PairHMM implementation");
             return hmm;
         }),
         /* PairHMM as implemented for the UnifiedGenotyper. Uses log10 sum functions accurate to only 1E-4 */
-        ORIGINAL(() -> {
+        ORIGINAL(args -> {
             final Log10PairHMM hmm = new Log10PairHMM(false);
-            logger.info("Using the non-hardware-accelerated Java ORIGINAL PairHMM implementation");
+            logger.info("Using the single-threaded, non-hardware-accelerated, double-precision Java ORIGINAL PairHMM implementation");
             return hmm;
         }),
         /* Optimized version of the PairHMM which caches per-read computations and operations in real space to avoid costly sums of log10'ed likelihoods */
-        LOGLESS_CACHING(() -> {
+        LOGLESS_CACHING(arg -> {
             final LoglessPairHMM hmm = new LoglessPairHMM();
-            logger.info("Using the non-hardware-accelerated Java LOGLESS_CACHING PairHMM implementation");
+            logger.info("Using the single-threaded, non-hardware-accelerated, double-precision Java LOGLESS_CACHING PairHMM implementation");
             return hmm;
         }),
         /* Optimized AVX implementation of LOGLESS_CACHING called through JNI. Throws if AVX is not available */
-        AVX_LOGLESS_CACHING(() -> {
+        AVX_LOGLESS_CACHING(args -> {
             // Constructor will throw a UserException if AVX is not available
-            // TODO: connect PairHMMNativeArguments
-            final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(null);
-            logger.info("Using the AVX-accelerated native PairHMM implementation");
+            final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.AVX, args);
+            logger.info("Using the single-threaded AVX-accelerated native PairHMM implementation");
+            logPairHmmArgs(args);
             return hmm;
         }),
-        /* Uses the fastest available PairHMM implementation (AVX if AVX is available, otherwise LOGLESS_CACHING */
-        FASTEST_AVAILABLE(() -> {
+        /* OpenMP Multi-threaded AVX implementation of LOGLESS_CACHING called through JNI. Throws if OpenMP AVX is not available */
+        AVX_LOGLESS_CACHING_OMP(args -> {
+            // Constructor will throw a UserException if OpenMP AVX is not available
+            final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.OMP, args);
+            logger.info("Using the OpenMP multi-threaded AVX-accelerated native PairHMM implementation");
+            logPairHmmArgs(args);
+            return hmm;
+        }),
+        /* Uses the fastest available PairHMM implementation supported on the platform.
+           Order of precedence:
+            1. AVX_LOGLESS_CACHING_OMP
+            2. AVX_LOGLESS_CACHING
+            3. LOGLESS_CACHING
+         */
+        FASTEST_AVAILABLE(args -> {
             try {
-                // TODO: connect PairHMMNativeArguments
-                final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(null);
-                logger.info("Using the AVX-accelerated native PairHMM implementation");
+                final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.OMP, args);
+                logger.info("Using the OpenMP multi-threaded AVX-accelerated native PairHMM implementation");
+                logPairHmmArgs(args);
+                return hmm;
+            }
+            catch ( UserException.HardwareFeatureException e ) {
+                logger.info("OpenMP multi-threaded AVX-accelerated native PairHMM implementation is not supported");
+            }
+            try {
+                final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.AVX, args);
+                logger.info("Using the single-threaded AVX-accelerated native PairHMM implementation");
+                logPairHmmArgs(args);
                 return hmm;
             }
             catch ( UserException.HardwareFeatureException e ) {
                 logger.warn("***WARNING: Machine does not have the AVX instruction set support needed for the accelerated AVX PairHmm. " +
                             "Falling back to the MUCH slower LOGLESS_CACHING implementation!");
+                logger.info("Using the single-threaded, non-hardware-accelerated, double-precision Java LOGLESS_CACHING PairHMM implementation");
                 return new LoglessPairHMM();
             }
         });
 
-        private final Supplier<PairHMM> makeHmm;
+        private final Function<PairHMMNativeArguments, PairHMM> makeHmm;
 
-        private Implementation(final Supplier<PairHMM> makeHmm){
+        private Implementation(final Function<PairHMMNativeArguments, PairHMM> makeHmm){
             this.makeHmm = makeHmm;
         }
 
-        public PairHMM makeNewHMM() {
-            return makeHmm.get();
+        public PairHMM makeNewHMM(PairHMMNativeArguments args) {
+            return makeHmm.apply(args);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -1,13 +1,16 @@
 package org.broadinstitute.hellbender.utils.pairhmm;
 
 import com.intel.gkl.pairhmm.IntelPairHmm;
+import com.intel.gkl.pairhmm.IntelPairHmmOMP;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.pairhmm.HaplotypeDataHolder;
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeBinding;
 import org.broadinstitute.gatk.nativebindings.pairhmm.ReadDataHolder;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -26,6 +29,8 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
     private long threadLocalSetupTimeDiff = 0;
     private long pairHMMSetupTime = 0;
 
+    public enum Implementation {AVX, OMP}
+
     private final PairHMMNativeBinding pairHmm;
 
     //Hold the mapping between haplotype and index in the list of Haplotypes passed to initialize
@@ -33,17 +38,35 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
     private final Map<Haplotype, Integer> haplotypeToHaplotypeListIdxMap = new LinkedHashMap<>();
     private HaplotypeDataHolder[] mHaplotypeDataArray;
 
-    public VectorLoglessPairHMM(PairHMMNativeArguments args) throws UserException.HardwareFeatureException {
-        // TODO: connect GATK temp directory
-        final boolean isSupported = new IntelPairHmm().load(null);
+    public VectorLoglessPairHMM(Implementation implementation,
+                                PairHMMNativeArguments pairHmmArgs) throws UserException.HardwareFeatureException {
 
-        if (!isSupported) {
-            throw new UserException.HardwareFeatureException("Machine does not support AVX PairHMM.");
+        // require non-null implementation and pairHmmArgs
+        Utils.nonNull(implementation);
+        Utils.nonNull(pairHmmArgs);
+
+        switch (implementation) {
+            case AVX:
+                final boolean isAvxSupported = new IntelPairHmm().load();
+                if (!isAvxSupported) {
+                    throw new UserException.HardwareFeatureException("Machine does not support AVX PairHMM.");
+                }
+                pairHmm = new IntelPairHmm();
+                break;
+
+            case OMP:
+                final boolean isOmpSupported = new IntelPairHmmOMP().load();
+                if (!isOmpSupported) {
+                    throw new UserException.HardwareFeatureException("Machine does not support OpenMP AVX PairHMM.");
+                }
+                pairHmm = new IntelPairHmmOMP();
+                break;
+
+            default:
+                throw new GATKException("Unknown PairHMM implementation : " + implementation.name());
         }
 
-        // instantiate and initialize IntelPairHmm
-        pairHmm = new IntelPairHmm();
-        pairHmm.initialize(args);
+        pairHmm.initialize(pairHmmArgs);
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.pairhmm;
 
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -23,24 +24,6 @@ public final class VectorPairHMMUnitTest extends BaseTest {
 
     private static final String pairHMMTestData = publicTestDir + "pairhmm-testdata.txt";
 
-   @BeforeClass
-    public void initialize() {
-       try {
-           new VectorLoglessPairHMM(null);
-       } catch (final Exception e) {
-           throw new SkipException("AVX PairHMM is not supported on this system or the library is not available");
-       }
-    }
-
-    private List<N2MemoryPairHMM> getHMMs() {
-        final PairHMMNativeArguments args = new PairHMMNativeArguments();
-        args.useDoublePrecision = false;
-        args.maxNumberOfThreads = 1;
-        final N2MemoryPairHMM avxPairHMM = new VectorLoglessPairHMM(args);
-        avxPairHMM.doNotUseTristateCorrection();
-        return Collections.singletonList(avxPairHMM);
-    }
-
     // --------------------------------------------------------------------------------
     //
     // Provider
@@ -51,15 +34,27 @@ public final class VectorPairHMMUnitTest extends BaseTest {
     public Object[][] makeJustHMMProvider() {
         List<Object[]> tests = new ArrayList<>();
 
-        for ( final PairHMM hmm : getHMMs() ) {
-            tests.add(new Object[]{hmm});
+        for (VectorLoglessPairHMM.Implementation imp : VectorLoglessPairHMM.Implementation.values()) {
+            tests.add(new Object[]{imp});
         }
 
         return tests.toArray(new Object[][]{});
     }
 
     @Test(dataProvider = "JustHMMProvider")
-    public void testLikelihoodsFromHaplotypes(final PairHMM hmm){
+    public void testLikelihoodsFromHaplotypes(final VectorLoglessPairHMM.Implementation imp){
+        final PairHMM hmm;
+
+        try {
+            final PairHMMNativeArguments args = new PairHMMNativeArguments();
+            args.maxNumberOfThreads = 1;
+            args.useDoublePrecision = false;
+            hmm = new VectorLoglessPairHMM(imp, args);
+            hmm.doNotUseTristateCorrection();
+        }
+        catch (UserException.HardwareFeatureException e ) {
+            throw new SkipException("PairHMM is not supported on this system or the library is not available for implementation : " + imp.name());
+        }
 
         BasicInputParser parser = null;
         try {


### PR DESCRIPTION
Update to GKL 0.3.1 which provides the following features compared to GKL 0.1.2 currently used by GATK:

1. Improved performance for Level 1 compression.
1. OpenMP AVX PairHMM with fallback to non-OpenMP support logic in GATK.
1. Individual shared library objects for each native binding.
1. Flush-to-zero get/set support.

Updated `VectorPairHMMUnitTest` to test all supported implementations of `VectorLoglessPairHMM` and skip the test if no implementations are supported.

**Note**
The default number of threads used by OpenMP AVX PairHMM is set to 1, and the command line argument to change the number of threads is not connected yet (see #1946). So, the OpenMP and non-OpenMP PairHMM currently have the same performance.

Resolves #1819
First step for #1946 
