### PR TITLE
remove bad test that was causing tests to abort

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/MainTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/MainTest.java
@@ -10,10 +10,4 @@ public final class MainTest extends CommandLineProgramTest{
     public void testCommandNotFoundThrows(){
         this.runCommandLine(new String[]{"Brain"});
     }
-
-    @Test
-    public void testPrintReadsVersion() {
-        String out = BaseTest.captureStderr(() -> Main.main(new String[]{"PrintReads", "--version"}));
-        BaseTest.assertContains(out, "Version:");
-    }
 }


### PR DESCRIPTION
removing MainTest.printReadsVersionTest because it was causing the test
suite to exit early.

it wasn't a very good test to begin with so it's not much of a loss