### PR TITLE
updating gatk-launch for spark 2.0 on gcloud

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -286,7 +286,7 @@ def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs
         cmd = [ "gcloud", "dataproc", "jobs", "submit", "spark"] \
               + dataprocargs \
               + ["--jar", jarPath] \
-              + gatkArgs + ["--sparkMaster", "yarn-client"]
+              + ["--"] + gatkArgs + ["--sparkMaster", "yarn"]
         try:
             runCommand(cmd, dryrun)
         except OSError:


### PR DESCRIPTION
2 changes to gatk-launch
- gcloud now requires arguments to the spark job to be separated from arguments to gcloud by `--`
- `--sparkMaster yarn-client` has been replaced with `--sparkMaster yarn --deploy-mode client`
  this only requires the sparkMaster to be changed in gatk-launch gcs because the client mode is set by gcloud