### PR TITLE
making kryo respect our log level

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/LoggingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/LoggingUtils.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
@@ -86,8 +87,9 @@ public class LoggingUtils {
         return javaUtilLevelNamespaceMap.get(picardLevel);
     }
 
+
     /**
-     * Propagate the verbosity level to Picard, log4j, and the java built in logger
+     * Propagate the verbosity level to Picard, log4j, the java built in logger, and Kryo's MinLog
      */
     public static void setLoggingLevel(final Log.LogLevel verbosity) {
 
@@ -100,6 +102,8 @@ public class LoggingUtils {
         // set the java.util.logging Level
         setJavaUtilLoggingLevel(verbosity);
 
+        // set the esotericsoft MinLog level, this is used by kryo
+        setMinLogLoggingLevel(verbosity);
     }
 
     private static void setLog4JLoggingLevel(Log.LogLevel verbosity) {
@@ -112,5 +116,19 @@ public class LoggingUtils {
 
         loggerConfig.setLevel(levelToLog4jLevel(verbosity));
         loggerContext.updateLoggers();
+    }
+
+    /**
+     * set the logging level for {@link com.esotericsoftware.minlog.Log}, the logger used by Kryo
+     */
+    private static void setMinLogLoggingLevel(Log.LogLevel verbosity) {
+        switch (verbosity) {
+            case DEBUG: com.esotericsoftware.minlog.Log.DEBUG(); break;
+            case INFO: com.esotericsoftware.minlog.Log.INFO(); break;
+            case WARNING: com.esotericsoftware.minlog.Log.WARN(); break;
+            case ERROR: com.esotericsoftware.minlog.Log.ERROR(); break;
+            default:
+                throw new GATKException("This log level is not implemented properly: " + verbosity);
+        }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -500,11 +500,12 @@ public final class UtilsUnitTest extends BaseTest {
     }
 
     /**
-     * Test setting the global logging level for Picard and Log4j and java.util.logging.
+     * Test setting the global logging level for Picard, Log4j, MinLog and java.util.logging.
      *
      * Note that there are three very similar, but not identical, logging level enums from different namespaces
      * being used here. The one used by Picard (and Hellbender --verbosity) of type "Log.LogLevel", the parallel
      * one used by log4j of type "Level", and the one used by java.utils.logging.
+     *
      */
     @Test
     public void testSetLoggingLevel() {


### PR DESCRIPTION
kryo uses com.esotericsoft.MinLog which is a yet another logger
making LoggingUtils.setLoggingLevel() set MinLog's level