### PR TITLE
changing nCopies registration to use FieldSerializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     compile('org.apache.hadoop:hadoop-client:2.7.2') // should be a 'provided' dependency
     compile('com.github.jsr203hadoop:jsr203hadoop:1.0.3')
 
-    compile('de.javakaffee:kryo-serializers:0.37') {
+    compile('de.javakaffee:kryo-serializers:0.41') {
         exclude module: 'kryo' // use Spark's version
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -6,6 +6,10 @@ import com.esotericsoftware.kryo.serializers.JavaSerializer;
 import com.google.api.services.genomics.model.Read;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.FastGenotype;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
@@ -34,7 +38,7 @@ public class GATKRegistrator implements KryoRegistrator {
 
         //relatively inefficient serialization of Collections created with Collections.nCopies(), without this
         //any Collection created with Collections.nCopies fails to serialize at run time
-        kryo.register(Collections.nCopies(2, "").getClass(), new JavaSerializer());
+        kryo.register(Collections.nCopies(2, "").getClass(), new FieldSerializer<>(kryo, Collections.nCopies(2, "").getClass()));
 
         // htsjdk.variant.variantcontext.CommonInfo has a Map<String, Object> that defaults to
         // a Collections.unmodifiableMap. This can't be handled by the version of kryo used in Spark, it's fixed
@@ -52,6 +56,9 @@ public class GATKRegistrator implements KryoRegistrator {
         //register to avoid writing the full name of this class over and over
         kryo.register(PairedEnds.class, new FieldSerializer<>(kryo, PairedEnds.class));
 
+        kryo.register(Allele.class, new FieldSerializer<>(kryo, Allele.class));
+        kryo.register(FastGenotype.class, new FieldSerializer<>(kryo, FastGenotype.class));
+        kryo.register(VariantContext.class, new FieldSerializer<>(kryo, VariantContext.class));
         // register the ADAM data types using Avro serialization, including:
         //     AlignmentRecord
         //     Genotype

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -56,9 +56,6 @@ public class GATKRegistrator implements KryoRegistrator {
         //register to avoid writing the full name of this class over and over
         kryo.register(PairedEnds.class, new FieldSerializer<>(kryo, PairedEnds.class));
 
-        kryo.register(Allele.class, new FieldSerializer<>(kryo, Allele.class));
-        kryo.register(FastGenotype.class, new FieldSerializer<>(kryo, FastGenotype.class));
-        kryo.register(VariantContext.class, new FieldSerializer<>(kryo, VariantContext.class));
         // register the ADAM data types using Avro serialization, including:
         //     AlignmentRecord
         //     Genotype


### PR DESCRIPTION
this seems to fix an issue with serializing Genotypes in haplotype caller
updating kryo-serializers:0.37 -> 0.41 just in case

I couldn't come up with a test case that fails when run locally.  It only seems to fail when run with spark-submit.  