### PR TITLE
Change command line collection argument behavior from "append" to "replace". 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -543,9 +543,20 @@ public final class CommandLineParser {
                 throw new UserException.CommandLineException("Argument '" + argumentDefinition.getNames() + "' cannot be specified more than once.");
         }
 
+        if (argumentDefinition.isCollection) {
+            // if this is a collection then we only want to clear it once at the beginning, before we process
+            // all of the values
+            @SuppressWarnings("rawtypes")
+            final Collection c = (Collection) argumentDefinition.getFieldValue();
+            c.clear();
+        }
         for (String stringValue: values) {
             final Object value;
             if (stringValue.equals(NULL_STRING)) {
+                if (argumentDefinition.isCollection && values.size() > 1) {
+                    // multiple values for a collection were passed, and at least one of them is null
+                    throw new UserException.CommandLineException("A value of \"null\" can only be provided for a collection if it is the only value provided. Multiple values were provided for: " + argumentDefinition.getNames() + ".");
+                }
                 //"null" is a special value that allows the user to override any default
                 //value set for this arg
                 if (argumentDefinition.optional) {

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -529,7 +529,7 @@ public final class CommandLineParserTest {
         Assert.assertEquals(o.LIST.size(), 0);
     }
 
-    @Test
+    @Test(expectedExceptions = UserException.CommandLineException.class)
     public void testClearDefaultValuesFromListArgumentAndAddNew() {
         final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
         final CommandLineParser clp = new CommandLineParser(o);
@@ -539,12 +539,21 @@ public final class CommandLineParserTest {
     }
 
     @Test
-    public void testDefaultValuesListArgument() {
+    public void testReplaceListArgument() {
         final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
         final CommandLineParser clp = new CommandLineParser(o);
         final String[] args = {"--LIST","baz", "--LIST","frob"};
         Assert.assertTrue(clp.parseArguments(System.err, args));
-        Assert.assertEquals(o.LIST, CollectionUtil.makeList("foo", "bar", "baz", "frob"));
+        Assert.assertEquals(o.LIST, CollectionUtil.makeList("baz", "frob"));
+    }
+
+    @Test
+    public void testRetainDefaultListArgument() {
+        final CollectionWithDefaultValuesArguments o = new CollectionWithDefaultValuesArguments();
+        final CommandLineParser clp = new CommandLineParser(o);
+        final String[] args = {};
+        Assert.assertTrue(clp.parseArguments(System.err, args));
+        Assert.assertEquals(o.LIST, CollectionUtil.makeList("foo", "bar"));
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleCollectMultiMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleCollectMultiMetricsIntegrationTest.java
@@ -47,6 +47,7 @@ public final class ExampleCollectMultiMetricsIntegrationTest extends CommandLine
         args.addOutput(textOut);
 
         if (allLevels) {
+            args.addArgument("LEVEL", MetricAccumulationLevel.ALL_READS.toString());
             args.addArgument("LEVEL", MetricAccumulationLevel.SAMPLE.toString());
             args.addArgument("LEVEL", MetricAccumulationLevel.LIBRARY.toString());
             args.addArgument("LEVEL", MetricAccumulationLevel.READ_GROUP.toString());

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsIntegrationTest.java
@@ -63,6 +63,8 @@ public final class CollectInsertSizeMetricsIntegrationTest extends CommandLinePr
         if (allLevels) {
             // accumulation level options (all included for better test coverage)
             args.add("-" + "LEVEL");
+            args.add(MetricAccumulationLevel.ALL_READS.toString());
+            args.add("-" + "LEVEL");
             args.add(MetricAccumulationLevel.SAMPLE.toString());
             args.add("-" + "LEVEL");
             args.add(MetricAccumulationLevel.LIBRARY.toString());

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetricsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetricsTest.java
@@ -138,7 +138,6 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
                 "--RIBOSOMAL_INTERVALS", rRnaIntervalsFile.getAbsolutePath(),
                 "--STRAND_SPECIFICITY", "SECOND_READ_TRANSCRIPTION_STRAND",
                 "--IGNORE_SEQUENCE", ignoredSequence,
-                "--LEVEL", "null",
                 "--LEVEL", "SAMPLE",
                 "--LEVEL", "LIBRARY"
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSamIntegrationTest.java
@@ -117,8 +117,12 @@ public final class RevertSamIntegrationTest extends CommandLineProgramTest {
     public Object[][] getPostitiveTestData() {
         return new Object[][] {
                 {null, true, true, true, null, null, Collections.EMPTY_LIST},
-                {SAMFileHeader.SortOrder.queryname, true, true, true, "Hey,Dad!", null, Arrays.asList("XT")},
-                {null, false, true, false, "Hey,Dad!", "NewLibraryName", Arrays.asList("XT")},
+                {SAMFileHeader.SortOrder.queryname, true, true, true, "Hey,Dad!", null,
+                        Arrays.asList("XT", SAMTag.NM.name(), SAMTag.UQ.name(), SAMTag.PG.name(), SAMTag.MD.name(),
+                                SAMTag.MQ.name(), SAMTag.SA.name(), SAMTag.MC.name())},
+                {null, false, true, false, "Hey,Dad!", "NewLibraryName",
+                        Arrays.asList("XT", SAMTag.NM.name(), SAMTag.UQ.name(), SAMTag.PG.name(), SAMTag.MD.name(),
+                        SAMTag.MQ.name(), SAMTag.SA.name(), SAMTag.MC.name())},
                 {null, false, false, false, null, null, Collections.EMPTY_LIST}
         };
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
@@ -81,6 +81,8 @@ public final class CollectInsertSizeMetricsSparkIntegrationTest extends CommandL
         if (allLevels) {
             // accumulation level options (all included for better test coverage)
             args.add("-" + "LEVEL");
+            args.add(MetricAccumulationLevel.ALL_READS.toString());
+            args.add("-" + "LEVEL");
             args.add(MetricAccumulationLevel.SAMPLE.toString());
             args.add("-" + "LEVEL");
             args.add(MetricAccumulationLevel.LIBRARY.toString());


### PR DESCRIPTION
Also reject 'null' for collection arguments when used as one of several values for the same option.

Fixes https://github.com/broadinstitute/gatk/issues/2274.