### PR TITLE
Handles edge case of Fisher Exact Test

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/FisherExactTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/FisherExactTest.java
@@ -4,15 +4,7 @@ import org.apache.commons.math3.distribution.AbstractIntegerDistribution;
 import org.apache.commons.math3.distribution.HypergeometricDistribution;
 
 import java.util.Arrays;
-import java.util.function.DoubleUnaryOperator;
 import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
-
-import static java.lang.Math.*;
-import static org.apache.commons.math3.util.MathArrays.ebeAdd;
-import static org.broadinstitute.hellbender.utils.MathUtils.arrayMax;
-import static org.broadinstitute.hellbender.utils.MathUtils.promote;
-import static org.broadinstitute.hellbender.utils.MathUtils.sum;
 
 /**
  * Implements the Fisher's exact test for 2x2 tables
@@ -21,59 +13,35 @@ import static org.broadinstitute.hellbender.utils.MathUtils.sum;
 public final class FisherExactTest {
 
     /**
-     * Computes the 2-sided pvalue of the Fisher's exact test.
+     * Computes the 2-sided pvalue of the Fisher's exact test on a normalized table that ensures that the sum of
+     * all four entries is less than 2 * 200.
      */
     public static double twoSidedPValue(final int[][] normalizedTable) {
         Utils.nonNull(normalizedTable);
-        Utils.validateArg(normalizedTable.length == 2, "input must be 2x2 " + Arrays.deepToString(normalizedTable));
-        Utils.validateArg(normalizedTable[0] != null && normalizedTable[0].length == 2, "input must be 2x2 " + Arrays.deepToString(normalizedTable));
-        Utils.validateArg(normalizedTable[1] != null && normalizedTable[1].length == 2, "input must be 2x2 " + Arrays.deepToString(normalizedTable));
+        Utils.validateArg(normalizedTable.length == 2, () -> "input must be 2x2 " + Arrays.deepToString(normalizedTable));
+        Utils.validateArg(normalizedTable[0] != null && normalizedTable[0].length == 2, () -> "input must be 2x2 " + Arrays.deepToString(normalizedTable));
+        Utils.validateArg(normalizedTable[1] != null && normalizedTable[1].length == 2, () -> "input must be 2x2 " + Arrays.deepToString(normalizedTable));
 
         //Note: this implementation follows the one in R base package
         final int[][] x= normalizedTable;
-        final int m = addExact(x[0][0], x[0][1]);
-        final int n = addExact(x[1][0], x[1][1]);
+        final int m = x[0][0] + x[0][1];
+        final int n = x[1][0] + x[1][1];
+        final int k = x[0][0] + x[1][0];
+        final int lo = Math.max(0, k - n);
+        final int hi = Math.min(k, m);
+        final IndexRange support = new IndexRange(lo, hi + 1);
 
-        if (m+n == 0){     //special case, all entries zero
+        if (support.size() <= 1){     //special case, support has only one value
             return 1.0;
         }
 
-        final int k = addExact(x[0][0], x[1][0]);
-        final int lo = max(0, k - n);
-        final int hi = min(k, m);
-        final int[] support = range(lo, hi);
         final AbstractIntegerDistribution dist = new HypergeometricDistribution(null, m+n, m, k);
-        final double[] logdc = IntStream.of(support).mapToDouble(i -> dist.logProbability(i)).toArray();
-        final double oddsRatioAtNull = 1.0;
-        final double[] ds = dnHyper(oddsRatioAtNull, logdc, support);
-        final double relErr = 1 + pow(10, -7);
-
-        final double threshold= ds[x[0][0] - lo] * relErr;
-        final double pValue = DoubleStream.of(ds).filter(d -> d <= threshold).sum();
+        final double[] logds = support.mapToDouble(dist::logProbability);
+        final double threshold = logds[x[0][0] - lo];
+        final double[] log10ds = DoubleStream.of(logds).filter(d -> d <= threshold).map(MathUtils::logToLog10).toArray();
+        final double pValue = MathUtils.sumLog10(log10ds);
 
         // min is necessary as numerical precision can result in pValue being slightly greater than 1.0
-        return min(pValue, 1.0);
-    }
-
-    private static double[] dnHyper(final double ncp, final double[] logdc, final int[] support){
-        final double[] d1 = ebeAdd(logdc, apply(promote(support), d -> d * log(ncp)));
-        final double maxD1 = arrayMax(d1);
-
-        final double[] d2 = apply(apply(d1, d -> d - maxD1), d -> exp(d));
-        final double sumD2 = sum(d2);
-
-        return apply(d2,  d -> d/sumD2);
-    }
-
-    private static double[] apply(final double[] arr, final DoubleUnaryOperator op){
-        return DoubleStream.of(arr).map(op).toArray();
-    }
-
-    private static int[] range(final int from, final int to){
-        final int[] support = new int[to-from+1];
-        for (int i = 0; i < support.length; i++){
-            support[i] = from + i;
-        }
-        return support;
+        return Math.min(pValue, 1.0);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrandUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrandUnitTest.java
@@ -48,11 +48,14 @@ public final class FisherStrandUnitTest {
         tests.add(new Object[]{9, 11, 12, 10, 0.7578618});
         tests.add(new Object[]{12, 10, 9, 11, 0.7578618});
         tests.add(new Object[]{9, 10, 12, 10, 0.7578618});
-        tests.add(new Object[]{9, 10, 12, 10, 0.7578618});
         tests.add(new Object[]{9, 9, 12, 10, 1.0});
         tests.add(new Object[]{9, 13, 12, 10, 0.5466948});
         tests.add(new Object[]{12, 10, 9, 13, 0.5466948});
         tests.add(new Object[]{9, 12, 11, 9, 0.5377362});
+
+        tests.add(new Object[]{0, 0, 0, 3,                     1.0});
+        tests.add(new Object[]{9, 0, 0, 0,                     1.0});
+        tests.add(new Object[]{0, 200, 200, 0,                 1.942643e-119});
 
         tests.add(new Object[]{0, 0, 0, 0, 1.0});
         tests.add(new Object[]{100000, 100000, 100000, 100000, 1.0});


### PR DESCRIPTION
Even though the Fisher Exact Test here is based on the R implementation, there was an edge case when the hypergeometric distribution we're getting the probabilities from only has one possible value. The difference in resulting p-value was coming from the fact that the apache Math3 HypergeometricDistribution behaves differently at this edge case than dhyper in R. 

Adresses #2292 