### PR TITLE
Make ReadPosRankSumTest.isUsableRead() account for deletions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
@@ -103,6 +103,7 @@ public abstract class RankSumTest extends InfoFieldAnnotation {
      * @return true if this read is meaningful for comparison, false otherwise
      */
     protected boolean isUsableRead(final GATKRead read, final int refLoc) {
+        Utils.nonNull(read);
         return !( read.getMappingQuality() == 0 ||
                 read.getMappingQuality() == QualityUtils.MAPPING_QUALITY_UNAVAILABLE );
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosRankSumTest.java
@@ -64,6 +64,6 @@ public final class ReadPosRankSumTest extends RankSumTest implements StandardAnn
     @Override
     protected boolean isUsableRead(final GATKRead read, final int refLoc) {
         Utils.nonNull(read);
-        return super.isUsableRead(read, refLoc) && ReadUtils.getSoftStart(read) + read.getCigar().getReadLength() > refLoc;
+        return super.isUsableRead(read, refLoc) && ReadUtils.getSoftEnd(read) >= refLoc;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
@@ -72,6 +72,6 @@ public class AS_ReadPosRankSumTest extends AS_RankSumTest implements AS_Standard
     @Override
     protected boolean isUsableRead(final GATKRead read, final int refLoc) {
         Utils.nonNull(read);
-        return super.isUsableRead(read, refLoc) && ReadUtils.getSoftStart(read) + read.getCigar().getReadLength() > refLoc;
+        return super.isUsableRead(read, refLoc) && ReadUtils.getSoftEnd(read) >= refLoc;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AlleleSpecificReadPosRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AlleleSpecificReadPosRankSumTestUnitTest.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.TextCigarCodec;
+import org.broadinstitute.hellbender.tools.walkers.annotator.ReadPosRankSumTest;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class AlleleSpecificReadPosRankSumTestUnitTest {
+
+    @DataProvider(name = "dataIsUsableRead")
+    private Object[][] dataIsUsableRead(){
+        return new Object[][]{
+                {"20M6D2M", 10, 1, 0, true},
+                {"20M6D2M", 10, 1, 27, true},
+                {"20M6D2M", 10, 1, 29, false},
+                {"1I20M1S", 10, 1, 0, true},
+                {"1I20M1S", 0, 1, 0, false},
+                {"1I20M1S", QualityUtils.MAPPING_QUALITY_UNAVAILABLE, 1, 0, false},
+                {"1I20M1S", 10, 1, 22, false},
+                {"1I20M1S", 10, 21, 42, false},
+                {"1I20M1H", 10, 1, 21, false},
+        };
+    }
+
+    @Test(dataProvider = "dataIsUsableRead")
+    public void testIsUsableRead(final String cigarString, final int mappingQuality, final int start, final int refLoc, final boolean isUsable ) {
+        final AS_ReadPosRankSumTest as_readPosRankSumTest = new AS_ReadPosRankSumTest();
+        final Cigar cigar = TextCigarCodec.decode(cigarString);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(cigar);
+        read.setMappingQuality(mappingQuality);
+        read.setPosition("1", start);
+        Assert.assertEquals(as_readPosRankSumTest.isUsableRead(read, refLoc), isUsable);
+    }
+}


### PR DESCRIPTION
Implement https://github.com/broadinstitute/gatk/issues/2147.

```
Change ReadPosRankSumTest.isUsableRead to take deletions into account. Previously, reads were skipped because the variant location was considered downstream from the read. 
```
The same fix was done to `AS_ReadPosRankSumTest`.