### PR TITLE
Performance improvements for stratified/sorted ReadPileup

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.utils.fragments;
 
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.pileup.PileupElementTracker;
 import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -127,6 +129,11 @@ public final class FragmentCollection<T> {
             throw new IllegalArgumentException("Pileup cannot be null");
         }
         return create(rbp::sortedIterator, rbp.size(), pileup -> pileup.getRead());
+    }
+
+    public static FragmentCollection<PileupElement> create(final PileupElementTracker tracker) {
+        Utils.nonNull(tracker, "PileupElementTracker cannot be null");
+        return create(tracker::sortedIterator, tracker.size(), pileup -> pileup.getRead());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -342,7 +342,8 @@ public final class LocusIteratorByState implements Iterator<AlignmentContext> {
                 }
 
                 if (!pile.isEmpty()) { // if this pileup added at least one base, add it to the full pileup
-                    fullPileupPerSample.put(sample, new ReadPileup(location, pile));
+                    // the pileup for LIBS is sorted by coordinate, because it comes from a sorted BAM file
+                    fullPileupPerSample.put(sample, new ReadPileup(location, pile, true));
                 }
             }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
@@ -18,12 +18,26 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
+ * Pileup tracker where the elements comes from multiple samples
+ *
+ * <p>This tracker is used when the all the pileup elements are already split by sample, providing more
+ * efficient implementation for:
+ *
+ * <ul>
+ *     <li>{@link #sortedIterator()}</li>
+ *     <li>{@link #splitBySample(SAMFileHeader)}</li>
+ *     <li>{@link #getSamples(SAMFileHeader)}</li>
+ *     <li>{@link #fixOverlaps()}</li>
+ *     <li>{@link #getTrackerForSample(String, SAMFileHeader)}</li>
+ * </ul>
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 class PerSamplePileupElementTracker extends PileupElementTracker {
 
     private final Map<String, PileupElementTracker> stratified;
 
+    /** Instantiates a per-sample element tracker. */
     PerSamplePileupElementTracker(final Map<String, PileupElementTracker> stratified) {
         Utils.nonNull(stratified, "null stratified PileupElementTracker");
         Utils.nonEmpty(stratified.keySet(), "empty stratified PileupElementTracker");

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
@@ -1,0 +1,71 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.MergingIterator;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+class PerSamplePileupElementTracker extends PileupElementTracker {
+
+    private final Map<String, PileupElementTracker> stratified;
+
+    PerSamplePileupElementTracker(final Map<String, PileupElementTracker> stratified) {
+        Utils.nonNull(stratified, "null stratified PileupElementTracker");
+        Utils.nonEmpty(stratified.keySet(), "empty stratified PileupElementTracker");
+        this.stratified = stratified;
+    }
+
+    @Override
+    public Stream<PileupElement> getElementStream() {
+        return stratified.values().stream().flatMap(PileupElementTracker::getElementStream);
+    }
+
+    @Override
+    public Iterator<PileupElement> sortedIterator() {
+        return stratified.values().stream()
+                // it is pre-sorted
+                .flatMap(v -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(v.sortedIterator(), Spliterator.SORTED), false))
+                .sorted(READ_START_COMPARATOR).iterator();
+    }
+
+    @Override
+    public Set<String> getSamples(final SAMFileHeader header) {
+        return stratified.keySet();
+    }
+
+    @Override
+    public PileupElementTracker splitBySample(final SAMFileHeader header) {
+        return this;
+    }
+
+    @Override
+    public void fixOverlaps() {
+        stratified.values().forEach(PileupElementTracker::fixOverlaps);
+    }
+
+    @Override
+    public PileupElementTracker makeFilteredTracker(final Predicate<PileupElement> filter) {
+        return new PerSamplePileupElementTracker(stratified.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().makeFilteredTracker(filter)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    public PileupElementTracker getTrackerForSample(final String sample, final SAMFileHeader header) {
+        return stratified.getOrDefault(sample, new SingleSamplePileupElementTracker(sample));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PerSamplePileupElementTracker.java
@@ -31,6 +31,10 @@ import java.util.stream.StreamSupport;
  *     <li>{@link #getTrackerForSample(String, SAMFileHeader)}</li>
  * </ul>
  *
+ * <p>Note: this classes is fairly low-level, developers should probably confirm that their changes do not belong in
+ * a higher-level class such as {@link org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState}
+ * or {@link ReadPileup}.
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 class PerSamplePileupElementTracker extends PileupElementTracker {

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
@@ -1,0 +1,142 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.fragments.FragmentCollection;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Abstract class for tracking the pileup elements from different sources.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class PileupElementTracker implements Iterable<PileupElement> {
+
+    /** Constant used by samtools to downgrade a quality for overlapping reads that disagrees in their base. */
+    public static final double SAMTOOLS_OVERLAP_LOW_CONFIDENCE = 0.8;
+
+    /** Comparator for sorting by start read position*/
+    protected static final Comparator<PileupElement> READ_START_COMPARATOR = (l, r) -> Integer.compare(l.getRead().getStart(), r.getRead().getStart());
+
+    /**
+     * Gets a stream over the elements in this tracker without any specific order.
+     */
+    public abstract Stream<PileupElement> getElementStream();
+
+    /** Returns the number of elements in the tracker. */
+    public final int size() {
+        return (int) getElementStream().count();
+    }
+
+    /**
+     * Iterates over the PileupElements without assuming any specific ordering.
+     *
+     * @return the iterator over the elements in this tracker.
+     */
+    @Override
+    public final Iterator<PileupElement> iterator() {
+        return getElementStream().iterator();
+    }
+
+    /**
+     * Iterator over sorted by read start PileupElements.
+     */
+    public abstract Iterator<PileupElement> sortedIterator();
+
+    /**
+     * Gets a set of the samples represented in this pileup.
+     * Note: contains null if a read has a null read group or a null sample name.
+     */
+    public abstract Set<String> getSamples(final SAMFileHeader header);
+
+    /**
+     * Splits the tracker by sample.
+     *
+     * @param header            the header to retrieve the samples from
+     * @return an element tracker splitted by sample (including empty trackers for a sample)
+     */
+    public abstract PileupElementTracker splitBySample(final SAMFileHeader header);
+
+    /**
+     * Make a new tracker consisting of elements that satisfy the predicate.
+     * NOTE: the new tracker will not be independent of the old one (no deep copy of the underlying data is performed).
+     */
+    public abstract PileupElementTracker makeFilteredTracker(final Predicate<PileupElement> filter);
+
+    /**
+     * Make a new tracker from elements whose reads belong to the given sample.
+     *
+     * Passing null sample as an argument retrieves reads whose read group or sample name is {@code null}
+     * NOTE: the new tracker will not be independent of the old one (no deep copy of the underlying data is performed).
+     */
+    public abstract PileupElementTracker getTrackerForSample(final String sample, final SAMFileHeader header);
+
+    /**
+     * Fixes the quality of all the elements that come from an overlapping pair in the same way as
+     * samtools does {@see tweak_overlap_quality function in
+     * <a href="https://github.com/samtools/htslib/blob/master/sam.c">samtools</a>}.
+     * <p>
+     * Setting the quality of one of the bases to 0 effectively removes the redundant base for
+     * calling. In addition, if the bases overlap we have increased confidence if they agree (or
+     * reduced if they don't). Thus, the algorithm proceeds as following:
+     * <p>
+     * 1. If the bases are the same, the quality of the first element is the sum of both qualities
+     * and the quality of the second is reduced to 0.
+     * 2. If the bases are different, the base with the highest quality is reduced with a factor of
+     * 0.8, and the quality of the lowest is reduced to 0.
+     * <p>
+     * Note: Resulting qualities higher than {@link QualityUtils#MAX_SAM_QUAL_SCORE} are capped.
+     */
+    public void fixOverlaps() {
+        final FragmentCollection<PileupElement> fragments = FragmentCollection.create(this);
+        fragments.getOverlappingPairs().stream()
+                .forEach(
+                        elements -> fixPairOverlappingQualities(elements.get(0), elements.get(1))
+                );
+    }
+
+    /**
+     * Fixes the quality of two elements that come from an overlapping pair in the same way as
+     * samtools does {@see tweak_overlap_quality function in
+     * <a href="https://github.com/samtools/htslib/blob/master/sam.c">samtools</a>}.
+     * The only difference with the samtools API is the cap for high values ({@link QualityUtils#MAX_SAM_QUAL_SCORE}).
+     */
+    @VisibleForTesting
+    static void fixPairOverlappingQualities(final PileupElement firstElement,
+            final PileupElement secondElement) {
+        // only if they do not represent deletions
+        if (!secondElement.isDeletion() && !firstElement.isDeletion()) {
+            final byte[] firstQuals = firstElement.getRead().getBaseQualities();
+            final byte[] secondQuals = secondElement.getRead().getBaseQualities();
+            if (firstElement.getBase() == secondElement.getBase()) {
+                // if both have the same base, extra confidence in the firts of them
+                firstQuals[firstElement.getOffset()] =
+                        (byte) (firstQuals[firstElement.getOffset()] + secondQuals[secondElement
+                                .getOffset()]);
+                // cap to maximum byte value
+                if (firstQuals[firstElement.getOffset()] < 0
+                        || firstQuals[firstElement.getOffset()] > QualityUtils.MAX_SAM_QUAL_SCORE) {
+                    firstQuals[firstElement.getOffset()] = QualityUtils.MAX_SAM_QUAL_SCORE;
+                }
+                secondQuals[secondElement.getOffset()] = 0;
+            } else {
+                // if not, we lost confidence in the one with higher quality
+                if (firstElement.getQual() >= secondElement.getQual()) {
+                    firstQuals[firstElement.getOffset()] =
+                            (byte) (SAMTOOLS_OVERLAP_LOW_CONFIDENCE * firstQuals[firstElement.getOffset()]);
+                    secondQuals[secondElement.getOffset()] = 0;
+                } else {
+                    secondQuals[secondElement.getOffset()] =
+                            (byte) (SAMTOOLS_OVERLAP_LOW_CONFIDENCE * secondQuals[secondElement.getOffset()]);
+                    firstQuals[firstElement.getOffset()] = 0;
+                }
+            }
+            firstElement.getRead().setBaseQualities(firstQuals);
+            secondElement.getRead().setBaseQualities(secondQuals);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
@@ -12,6 +12,10 @@ import java.util.stream.Stream;
 /**
  * Abstract class for tracking the pileup elements from different sources.
  *
+ * <p>Note: these classes are fairly low-level, developers should probably confirm that their changes do not belong in
+ * a higher-level class such as {@link org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState}
+ * or {@link ReadPileup}.
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public abstract class PileupElementTracker implements Iterable<PileupElement> {

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTracker.java
@@ -20,7 +20,7 @@ public abstract class PileupElementTracker implements Iterable<PileupElement> {
     public static final double SAMTOOLS_OVERLAP_LOW_CONFIDENCE = 0.8;
 
     /** Comparator for sorting by start read position*/
-    protected static final Comparator<PileupElement> READ_START_COMPARATOR = (l, r) -> Integer.compare(l.getRead().getStart(), r.getRead().getStart());
+    protected static final Comparator<PileupElement> READ_START_COMPARATOR = Comparator.comparingInt(l -> l.getRead().getStart());
 
     /**
      * Gets a stream over the elements in this tracker without any specific order.

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
@@ -43,7 +43,7 @@ public class ReadPileup implements Iterable<PileupElement> {
     }
 
     /**
-     * Create a new pileup at loc, using an stratified pileup
+     * Create a new pileup at loc, using a stratified pileup.
      */
     public ReadPileup(final Locatable loc, final Map<String, ReadPileup> stratifiedPileup) {
         this.loc = loc;

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
@@ -23,23 +23,47 @@ import java.util.stream.Collectors;
  *
  * <p>Note: this tracker inherits from {@link UnifiedPileupElementTracker} for re-use the implementation for iterator methods.
  *
+ * <p>Note: this classes is fairly low-level, developers should probably confirm that their changes do not belong in
+ * a higher-level class such as {@link org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState}
+ * or {@link ReadPileup}.
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 class SingleSamplePileupElementTracker extends UnifiedPileupElementTracker {
 
     private final String sampleName;
 
-    /** Instantiates an empty element tracker for the sample. */
+    /**
+     * Instantiates an empty element tracker for the sample.
+     *
+     * @param sampleName the name of this sample.
+     */
     SingleSamplePileupElementTracker(final String sampleName) {
         this(sampleName, Collections.emptyList(), true);
     }
 
-    /** Instantiates an unsorted element tracker for the sample. */
+    /**
+     * Instantiates an unsorted element tracker for the sample.
+     *
+     * <p>Note: if a {@link #sortedIterator()} is requested, sorting would be performed an cached into the tracker.
+     *
+     * @param sampleName the name of this sample.
+     * @param sampleElements list of pileup elements.
+     */
     SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements) {
         this(sampleName, sampleElements, false);
     }
 
-    /** Instantiates a sorted/unsorted element tracker for them sample. The sample may be {@code null}. */
+    /**
+     * Instantiates a sorted/unsorted element tracker for them sample. The sample may be {@code null}.
+     *
+     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting would be performed
+     * an cached into the tracker.
+     *
+     * @param sampleName the name of this sample.
+     * @param sampleElements list of pileup elements.
+     * @param preSorted {@code true} if the elements are already sorted; {@code false} otherwise.
+     */
     SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements, final boolean preSorted) {
         super(sampleElements, preSorted);
         this.sampleName = sampleName;

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
@@ -45,7 +45,7 @@ class SingleSamplePileupElementTracker extends UnifiedPileupElementTracker {
     /**
      * Instantiates an unsorted element tracker for the sample.
      *
-     * <p>Note: if a {@link #sortedIterator()} is requested, sorting would be performed an cached into the tracker.
+     * <p>Note: if a {@link #sortedIterator()} is requested, sorting will be performed and cached into the tracker.
      *
      * @param sampleName the name of this sample.
      * @param sampleElements list of pileup elements.
@@ -57,8 +57,8 @@ class SingleSamplePileupElementTracker extends UnifiedPileupElementTracker {
     /**
      * Instantiates a sorted/unsorted element tracker for them sample. The sample may be {@code null}.
      *
-     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting would be performed
-     * an cached into the tracker.
+     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting will be performed
+     * and cached into the tracker.
      *
      * @param sampleName the name of this sample.
      * @param sampleElements list of pileup elements.

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import htsjdk.samtools.SAMFileHeader;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+class SingleSamplePileupElementTracker extends UnifiedPileupElementTracker {
+
+    private final String sampleName;
+
+    SingleSamplePileupElementTracker(final String sampleName) {
+        this(sampleName, Collections.emptyList(), true);
+    }
+
+    SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements) {
+        this(sampleName, sampleElements, false);
+    }
+
+    SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements, final boolean preSorted) {
+        super(sampleElements, preSorted);
+        this.sampleName = sampleName;
+    }
+
+    @Override
+    public PileupElementTracker splitBySample(final SAMFileHeader header) {
+        return this;
+    }
+
+    @Override
+    public PileupElementTracker makeFilteredTracker(final Predicate<PileupElement> filter) {
+        return new SingleSamplePileupElementTracker(sampleName, getElementStream().filter(filter).collect(Collectors.toList()), sorted);
+    }
+
+    @Override
+    public Set<String> getSamples(final SAMFileHeader header) {
+        return Collections.singleton(sampleName);
+    }
+
+    @Override
+    public PileupElementTracker getTrackerForSample(final String sample,
+            final SAMFileHeader header) {
+        return (Objects.equals(sampleName, sample)) ? this : new SingleSamplePileupElementTracker(sample, null);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/SingleSamplePileupElementTracker.java
@@ -10,20 +10,36 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
+ * Pileup tracker where the elements comes from a single sample.
+ *
+ * <p>This tracker is used when the all the pileup elements are known to come from a single sample, providing more
+ * efficient implementation for:
+ *
+ * <ul>
+ *     <li>{@link #splitBySample(SAMFileHeader)}</li>
+ *     <li>{@link #getSamples(SAMFileHeader)}</li>
+ *     <li>{@link #getTrackerForSample(String, SAMFileHeader)}</li>
+ * </ul>
+ *
+ * <p>Note: this tracker inherits from {@link UnifiedPileupElementTracker} for re-use the implementation for iterator methods.
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 class SingleSamplePileupElementTracker extends UnifiedPileupElementTracker {
 
     private final String sampleName;
 
+    /** Instantiates an empty element tracker for the sample. */
     SingleSamplePileupElementTracker(final String sampleName) {
         this(sampleName, Collections.emptyList(), true);
     }
 
+    /** Instantiates an unsorted element tracker for the sample. */
     SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements) {
         this(sampleName, sampleElements, false);
     }
 
+    /** Instantiates a sorted/unsorted element tracker for them sample. The sample may be {@code null}. */
     SingleSamplePileupElementTracker(final String sampleName, final List<PileupElement> sampleElements, final boolean preSorted) {
         super(sampleElements, preSorted);
         this.sampleName = sampleName;

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
@@ -49,7 +49,7 @@ class UnifiedPileupElementTracker extends PileupElementTracker {
 
     /** Instantiates an unsorted element tracker.
      *
-     * <p>Note: if  {@link #sortedIterator()} is requested, sorting would be performed an cached into the tracker.
+     * <p>Note: if {@link #sortedIterator()} is requested, sorting will be performed and cached into the tracker.
      *
      * @param pileup list of pileup elements.
      */
@@ -60,8 +60,8 @@ class UnifiedPileupElementTracker extends PileupElementTracker {
     /**
      * Instantiates a sorted/unsorted element tracker.
      *
-     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting would be performed
-     * an cached into the tracker.
+     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting will be performed
+     * and cached into the tracker.
      *
      * @param pileup list of pileup elements.
      * @param preSorted {@code true} if the elements are already sorted; {@code false} otherwise.

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
@@ -1,0 +1,94 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+class UnifiedPileupElementTracker extends PileupElementTracker {
+
+    /** If {@code true}, the tracker is already sorted by {@link #READ_START_COMPARATOR}. */
+    protected boolean sorted;
+
+    private List<PileupElement> elements;
+
+    UnifiedPileupElementTracker() {
+        this(Collections.emptyList(), true);
+    }
+
+    UnifiedPileupElementTracker(final List<PileupElement> pileup) {
+        this(pileup, false);
+    }
+
+    UnifiedPileupElementTracker(final List<PileupElement> pileup, final boolean preSorted) {
+        this.elements = pileup;
+        this.sorted = false;
+    }
+
+    @Override
+    public Stream<PileupElement> getElementStream() {
+        return elements.stream();
+    }
+
+    @Override
+    public Iterator<PileupElement> sortedIterator() {
+        sortTracker();
+        return iterator();
+    }
+
+    protected void sortTracker() {
+        // only sort if it is not sorted yet
+        if (!sorted) {
+            elements = getElementStream()
+                    .sorted(READ_START_COMPARATOR)
+                    .collect(Collectors.toList());
+            sorted = true;
+        }
+    }
+
+    @Override
+    public PileupElementTracker splitBySample(final SAMFileHeader header) {
+        final Set<String> samples = getSamples(header);
+        switch (samples.size()) {
+            case 0: // no samples means empty pileup
+                return this;
+            case 1: // only one sample
+                return new SingleSamplePileupElementTracker(samples.iterator().next(), elements, sorted);
+            default: // more than one sample
+                return new PerSamplePileupElementTracker(
+                        samples.stream().collect(Collectors.toMap(s -> s, s -> getTrackerForSample(s, header))));
+        }
+    }
+
+    @Override
+    public PileupElementTracker makeFilteredTracker(final Predicate<PileupElement> filter) {
+        return new UnifiedPileupElementTracker(getElementStream().filter(filter).collect(Collectors.toList()), sorted);
+    }
+
+    @Override
+    public PileupElementTracker getTrackerForSample(final String sample,
+            final SAMFileHeader header) {
+        return new SingleSamplePileupElementTracker(sample,
+                getElementStream().filter(pe -> Objects.equals(ReadUtils.getSampleName(pe.getRead(), header), sample))
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Set<String> getSamples(final SAMFileHeader header) {
+        return getElementStream().map(PileupElement::getRead)
+                .map(r -> ReadUtils.getSampleName(r, header))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/UnifiedPileupElementTracker.java
@@ -29,6 +29,10 @@ import java.util.stream.Stream;
  *     <li>{@link #splitBySample(SAMFileHeader)} returns a {@link PerSamplePileupElementTracker} if a multiple samples are present (more efficient implementation of some methods)</li>
  * </ul>
  *
+ * <p>Note: this classes is fairly low-level, developers should probably confirm that their changes do not belong in
+ * a higher-level class such as {@link org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState}
+ * or {@link ReadPileup}.
+ *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 class UnifiedPileupElementTracker extends PileupElementTracker {
@@ -43,12 +47,25 @@ class UnifiedPileupElementTracker extends PileupElementTracker {
         this(Collections.emptyList(), true);
     }
 
-    /** Instantiates an unsorted element tracker.  */
+    /** Instantiates an unsorted element tracker.
+     *
+     * <p>Note: if  {@link #sortedIterator()} is requested, sorting would be performed an cached into the tracker.
+     *
+     * @param pileup list of pileup elements.
+     */
     UnifiedPileupElementTracker(final List<PileupElement> pileup) {
         this(pileup, false);
     }
 
-    /** Instantiates a sorted/unsorted element tracker. */
+    /**
+     * Instantiates a sorted/unsorted element tracker.
+     *
+     * <p>Note: if {@code preSorted=true} and a {@link #sortedIterator()} is requested, sorting would be performed
+     * an cached into the tracker.
+     *
+     * @param pileup list of pileup elements.
+     * @param preSorted {@code true} if the elements are already sorted; {@code false} otherwise.
+     */
     UnifiedPileupElementTracker(final List<PileupElement> pileup, final boolean preSorted) {
         this.elements = Utils.nonNull(pileup);
         this.sorted = preSorted;

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTrackerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/PileupElementTrackerUnitTest.java
@@ -1,0 +1,144 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import htsjdk.samtools.SAMUtils;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class PileupElementTrackerUnitTest extends BaseTest {
+
+    @DataProvider(name = "FixPairOverlappingQualitiesTest")
+    public static Object[][] overlappingElementsToFix() throws Exception {
+        final byte highQual = 60;
+        final byte lowQual = 10;
+        final byte qualitySum = 70;
+        final byte reducedQuality = 48; // 80% of 60
+        final byte zeroQuality = 0;
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead("6M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("6M");
+        // set the paired and mate state
+        read1.setIsPaired(true);
+        read1.setMatePosition(read2);
+        // set bases and qualities
+        read1.setBases(new byte[] {'A', 'A', 'A', 'A', 'T', 'T'});
+        read1.setBaseQualities(new byte[] {highQual, highQual, highQual, lowQual,
+                highQual, SAMUtils.MAX_PHRED_SCORE});
+        // set the paired and mate state
+        read2.setIsPaired(true);
+        read2.setMatePosition(read1);
+        // set bases and qualities
+        read2.setBases(new byte[] {'A', 'T', 'T', 'T', 'T', 'T'});
+        read2.setBaseQualities(new byte[] {lowQual, highQual, lowQual, highQual,
+                highQual, SAMUtils.MAX_PHRED_SCORE});
+        return new Object[][] {
+                // Same base, first element with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 0),
+                        PileupElement.createPileupForReadAndOffset(read2, 0),
+                        qualitySum, zeroQuality},
+                // Different base, both with same quality
+                {PileupElement.createPileupForReadAndOffset(read1, 1),
+                        PileupElement.createPileupForReadAndOffset(read2, 1),
+                        reducedQuality, zeroQuality},
+                // Different base, first with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 2),
+                        PileupElement.createPileupForReadAndOffset(read2, 2),
+                        reducedQuality, zeroQuality},
+                // Different base, second with higher quality
+                {PileupElement.createPileupForReadAndOffset(read1, 3),
+                        PileupElement.createPileupForReadAndOffset(read2, 3),
+                        zeroQuality, reducedQuality},
+                // Same base, high quality for both (simple cap)
+                {PileupElement.createPileupForReadAndOffset(read1, 4),
+                        PileupElement.createPileupForReadAndOffset(read2, 4),
+                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
+                // Same base, maximum qualities for both (simple cap)
+                {PileupElement.createPileupForReadAndOffset(read1, 5),
+                        PileupElement.createPileupForReadAndOffset(read2, 5),
+                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
+        };
+    }
+
+    @Test(dataProvider = "FixPairOverlappingQualitiesTest")
+    public void testFixPairOverlappingQualities(final PileupElement first,
+            final PileupElement second, final byte expectedQualFirst,
+            final byte expectedQualSecond) throws Exception {
+        PileupElementTracker.fixPairOverlappingQualities(first, second);
+        Assert.assertEquals(first.getQual(), expectedQualFirst);
+        Assert.assertEquals(second.getQual(), expectedQualSecond);
+    }
+
+    @Test
+    public void testFixOverlappingQualitiesDeletedElements() throws Exception {
+        // Create two reads with deletion
+        final GATKRead read = ArtificialReadUtils.createArtificialRead("1M1D1M");
+        read.setBases(new byte[] {'A', 'A'});
+        read.setBaseQualities(new byte[] {60, 60});
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("1M1D1M");
+        read.setBases(new byte[] {'A', 'A'});
+        read2.setBaseQualities(new byte[] {40, 40});
+        // Creates PileupElement with a copy of the reads to keep the original read unmodified, because the read from
+        // the PileupElement is a reference to the Object passed to the constructor. This is required
+        // because fixing the overlapping qualities change the read stored into PileupElement and we have to check that
+        // it does not change anything from the read.
+        final GATKRead copy = read.deepCopy();
+        final GATKRead copy2 = read2.deepCopy();
+        final PileupElement deleted = new PileupElement(copy, 1, copy.getCigarElement(1), 1, 0);
+        final PileupElement normal = new PileupElement(copy2, 0, copy.getCigarElement(0), 0, 0);
+        PileupElementTracker.fixPairOverlappingQualities(deleted, normal);
+        // Copy reads are a reference to the read into the PileupElement, and thus should not be modified.
+        // Thus, we use them to test if it is not modified. This could be checked uncommenting the next two lines:
+        // Assert.assertSame(deleted.getRead(), copy);
+        // Assert.assertSame(normal.getRead(), copy2);
+        Assert.assertEquals(copy, read);
+        Assert.assertEquals(copy2, read2);
+        PileupElementTracker.fixPairOverlappingQualities(normal, deleted);
+        Assert.assertEquals(copy, read);
+        Assert.assertEquals(copy2, read2);
+    }
+
+    @Test
+    public void testFixPairOverlappingQualitiesCap() {
+        final PileupElement element1 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element1.getRead().setName("read1");
+        element1.getRead().setBases(new byte[] {'A'});
+        final PileupElement element2 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element2.getRead().setName("read2");
+        element2.getRead().setBases(new byte[] {'A'});
+        final PileupElement element3 = PileupElement
+                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
+        element3.getRead().setName("read3");
+        element2.getRead().setBases(new byte[] {'A'});
+        element3.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
+        // Check all possible combinations that goes beyond the maximum value
+        for (byte i = 0; i < Byte.MAX_VALUE; i++) {
+            final byte[] iArray = new byte[] {i};
+            final byte j = (byte) (Byte.MAX_VALUE - i);
+            element1.getRead().setBaseQualities(iArray);
+            element2.getRead().setBaseQualities(new byte[] {j});
+            logger.debug("Test: fixing ({}) and ({})", element1, element2);
+            PileupElementTracker.fixPairOverlappingQualities(element1, element2);
+            Assert.assertEquals(element1.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+            Assert.assertEquals(element2.getQual(), 0);
+            element1.getRead().setBaseQualities(iArray);
+            logger.debug("Test: fixing ({}) and ({})", element3, element1);
+            PileupElementTracker.fixPairOverlappingQualities(element3, element1);
+            Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+            Assert.assertEquals(element1.getQual(), 0);
+        }
+        // Finally, check what happens if both are the maximum value
+        element1.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
+        logger.debug("Test: fixing ({}) and ({})", element3, element1);
+        PileupElementTracker.fixPairOverlappingQualities(element3, element1);
+        Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
+        Assert.assertEquals(element1.getQual(), 0);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
@@ -492,68 +492,7 @@ public final class ReadPileupUnitTest extends BaseTest {
         Assert.assertTrue(pu.makeFilteredPileup(p -> p.getMappingQual() >= 10).isEmpty());
     }
 
-    @DataProvider(name = "FixPairOverlappingQualitiesTest")
-    public Object[][] overlappingElementsToFix() throws Exception {
-        final byte highQual = 60;
-        final byte lowQual = 10;
-        final byte qualitySum = 70;
-        final byte reducedQuality = 48; // 80% of 60
-        final byte zeroQuality = 0;
-        final GATKRead read1 = ArtificialReadUtils.createArtificialRead("6M");
-        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("6M");
-        // set the paired and mate state
-        read1.setIsPaired(true);
-        read1.setMatePosition(read2);
-        // set bases and qualities
-        read1.setBases(new byte[] {'A', 'A', 'A', 'A', 'T', 'T'});
-        read1.setBaseQualities(new byte[] {highQual, highQual, highQual, lowQual,
-                highQual, SAMUtils.MAX_PHRED_SCORE});
-        // set the paired and mate state
-        read2.setIsPaired(true);
-        read2.setMatePosition(read1);
-        // set bases and qualities
-        read2.setBases(new byte[] {'A', 'T', 'T', 'T', 'T', 'T'});
-        read2.setBaseQualities(new byte[] {lowQual, highQual, lowQual, highQual,
-                highQual, SAMUtils.MAX_PHRED_SCORE});
-        return new Object[][] {
-                // Same base, first element with higher quality
-                {PileupElement.createPileupForReadAndOffset(read1, 0),
-                        PileupElement.createPileupForReadAndOffset(read2, 0),
-                        qualitySum, zeroQuality},
-                // Different base, both with same quality
-                {PileupElement.createPileupForReadAndOffset(read1, 1),
-                        PileupElement.createPileupForReadAndOffset(read2, 1),
-                        reducedQuality, zeroQuality},
-                // Different base, first with higher quality
-                {PileupElement.createPileupForReadAndOffset(read1, 2),
-                        PileupElement.createPileupForReadAndOffset(read2, 2),
-                        reducedQuality, zeroQuality},
-                // Different base, second with higher quality
-                {PileupElement.createPileupForReadAndOffset(read1, 3),
-                        PileupElement.createPileupForReadAndOffset(read2, 3),
-                        zeroQuality, reducedQuality},
-                // Same base, high quality for both (simple cap)
-                {PileupElement.createPileupForReadAndOffset(read1, 4),
-                        PileupElement.createPileupForReadAndOffset(read2, 4),
-                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
-                // Same base, maximum qualities for both (simple cap)
-                {PileupElement.createPileupForReadAndOffset(read1, 5),
-                        PileupElement.createPileupForReadAndOffset(read2, 5),
-                        QualityUtils.MAX_SAM_QUAL_SCORE, zeroQuality},
-        };
-    }
-
-    @Test(dataProvider = "FixPairOverlappingQualitiesTest")
-    public void testFixPairOverlappingQualities(final PileupElement first,
-                                                final PileupElement second, final byte expectedQualFirst,
-                                                final byte expectedQualSecond) throws Exception {
-        ReadPileup.fixPairOverlappingQualities(first, second);
-        Assert.assertEquals(first.getQual(), expectedQualFirst);
-        Assert.assertEquals(second.getQual(), expectedQualSecond);
-    }
-
-
-    @Test(dataProvider = "FixPairOverlappingQualitiesTest")
+    @Test(dataProvider = "FixPairOverlappingQualitiesTest", dataProviderClass = PileupElementTrackerUnitTest.class)
     public void testFixPairOverlappingQualitiesFromReadPileup(final PileupElement first,
             final PileupElement second, final byte expectedQualFirst,
             final byte expectedQualSecond) throws Exception {
@@ -562,74 +501,6 @@ public final class ReadPileupUnitTest extends BaseTest {
         pileup.fixOverlaps();
         Assert.assertEquals(elements.get(0).getQual(), expectedQualFirst);
         Assert.assertEquals(elements.get(1).getQual(), expectedQualSecond);
-    }
-
-    @Test
-    public void testFixPairOverlappingQualitiesCap() {
-        final PileupElement element1 = PileupElement
-                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
-        element1.getRead().setName("read1");
-        element1.getRead().setBases(new byte[] {'A'});
-        final PileupElement element2 = PileupElement
-                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
-        element2.getRead().setName("read2");
-        element2.getRead().setBases(new byte[] {'A'});
-        final PileupElement element3 = PileupElement
-                .createPileupForReadAndOffset(ArtificialReadUtils.createArtificialRead("1M"), 0);
-        element3.getRead().setName("read3");
-        element2.getRead().setBases(new byte[] {'A'});
-        element3.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
-        // Check all possible combinations that goes beyond the maximum value
-        for (byte i = 0; i < Byte.MAX_VALUE; i++) {
-            final byte[] iArray = new byte[] {i};
-            final byte j = (byte) (Byte.MAX_VALUE - i);
-            element1.getRead().setBaseQualities(iArray);
-            element2.getRead().setBaseQualities(new byte[] {j});
-            logger.debug("Test: fixing ({}) and ({})", element1, element2);
-            ReadPileup.fixPairOverlappingQualities(element1, element2);
-            Assert.assertEquals(element1.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
-            Assert.assertEquals(element2.getQual(), 0);
-            element1.getRead().setBaseQualities(iArray);
-            logger.debug("Test: fixing ({}) and ({})", element3, element1);
-            ReadPileup.fixPairOverlappingQualities(element3, element1);
-            Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
-            Assert.assertEquals(element1.getQual(), 0);
-        }
-        // Finally, check what happens if both are the maximum value
-        element1.getRead().setBaseQualities(new byte[] {Byte.MAX_VALUE});
-        logger.debug("Test: fixing ({}) and ({})", element3, element1);
-        ReadPileup.fixPairOverlappingQualities(element3, element1);
-        Assert.assertEquals(element3.getQual(), QualityUtils.MAX_SAM_QUAL_SCORE);
-        Assert.assertEquals(element1.getQual(), 0);
-    }
-
-    @Test
-    public void testFixOverlappingQualitiesDeletedElements() throws Exception {
-        // Create two reads with deletion
-        final GATKRead read = ArtificialReadUtils.createArtificialRead("1M1D1M");
-        read.setBases(new byte[] {'A', 'A'});
-        read.setBaseQualities(new byte[] {60, 60});
-        final GATKRead read2 = ArtificialReadUtils.createArtificialRead("1M1D1M");
-        read.setBases(new byte[] {'A', 'A'});
-        read2.setBaseQualities(new byte[] {40, 40});
-        // Creates PileupElement with a copy of the reads to keep the original read unmodified, because the read from
-        // the PileupElement is a reference to the Object passed to the constructor. This is required
-        // because fixing the overlapping qualities change the read stored into PileupElement and we have to check that
-        // it does not change anything from the read.
-        final GATKRead copy = read.deepCopy();
-        final GATKRead copy2 = read2.deepCopy();
-        final PileupElement deleted = new PileupElement(copy, 1, copy.getCigarElement(1), 1, 0);
-        final PileupElement normal = new PileupElement(copy2, 0, copy.getCigarElement(0), 0, 0);
-        ReadPileup.fixPairOverlappingQualities(deleted, normal);
-        // Copy reads are a reference to the read into the PileupElement, and thus should not be modified.
-        // Thus, we use them to test if it is not modified. This could be checked uncommenting the next two lines:
-        // Assert.assertSame(deleted.getRead(), copy);
-        // Assert.assertSame(normal.getRead(), copy2);
-        Assert.assertEquals(copy, read);
-        Assert.assertEquals(copy2, read2);
-        ReadPileup.fixPairOverlappingQualities(normal, deleted);
-        Assert.assertEquals(copy, read);
-        Assert.assertEquals(copy2, read2);
     }
 
     @Test


### PR DESCRIPTION
This PR includes the following improvements for `ReadPileup` by using a new class for store `PileupElement` (`PileupElementTracker`):

* If sorting by alignment start is necessary, maintain a sorted `PileupElementTracker`
* If splitting by sample is already done, keep the stratified `PileupElementTracker`

Because pre-sorting and stratification is implemented in `LocusIteratorByState`, this will improve performance in `LocusWalker` and other tools using it. Other methods, `ReadPileup.fixOverlaps()` will benefit for these improvements.

This closes https://github.com/broadinstitute/gatk/issues/2309 and https://github.com/broadinstitute/gatk/issues/2245 (although the latest was already fixed, but it is rather inefficient).