### PR TITLE
Simple GATKConf (NO MERGE)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -17,6 +17,8 @@ import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineParser;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
+import org.broadinstitute.hellbender.conf.GATKConf;
+import org.broadinstitute.hellbender.conf.GATKConfBuilder;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 
@@ -71,6 +73,11 @@ public abstract class CommandLineProgram {
     * own validation, and then print usage using commandLineParser.
     */
     protected CommandLineParser commandLineParser;
+
+    /**
+     * It could be only set once. If not set, it is initialized on demand.
+     */
+    protected GATKConf configuration = null;
 
     private final List<Header> defaultHeaders = new ArrayList<>();
 
@@ -294,4 +301,23 @@ public abstract class CommandLineProgram {
         return this.defaultHeaders;
     }
 
+    /** Returns the configuration for the GATK CommandLineProgram. */
+    public final GATKConf getConfiguration() {
+        if (configuration == null) {
+            configuration = GATKConfBuilder.getDefaultConfiguration();
+        }
+        return configuration;
+    }
+
+    /**
+     * Sets the configuration for the CommandLineProgram.
+     *
+     * @throws IllegalStateException if the configuration is already set.
+     */
+    public synchronized final void setConfiguration(final GATKConf configuration) {
+        if (this.configuration != null) {
+            throw new IllegalStateException("Configuration already set");
+        }
+        this.configuration = configuration;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/conf/GATKConf.java
+++ b/src/main/java/org/broadinstitute/hellbender/conf/GATKConf.java
@@ -1,18 +1,17 @@
 package org.broadinstitute.hellbender.conf;
 
 import org.apache.commons.configuration.Configuration;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Configuration for GATK. Properties are prefixed by {@link #GATK_PROPERTY_PREFIX}.
- *
- * - {@link #TOOLS_PACKAGES_KEY}: list of java packages in which to search for classes that extend CommandLineProgram.
- * - {@link #TOOL_CLASSES_KEY}: list of single classes to include (e.g. required input pre-processing tools).
- * - {@link #CODEC_PACKAGES_KEY}: packages to search at startup to look for FeatureCodecs.
+ * <p>
+ * - {@link #TOOL_PACKAGE_LIST_KEY}: list of java packages in which to search for classes that extend CommandLineProgram.
+ * - {@link #TOOL_CLASS_LIST_KEY}: list of single classes to include (e.g. required input pre-processing tools).
+ * - {@link #CODEC_PACKAGE_LIST_KEY}: packages to search at startup to look for FeatureCodecs.
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
@@ -20,9 +19,20 @@ public class GATKConf {
 
     public static final String GATK_PROPERTY_PREFIX = "gatk.";
 
-    public final static String TOOLS_PACKAGES_KEY = "toolsPackages";
-    public final static String TOOL_CLASSES_KEY = "toolClasses";
-    public final static String CODEC_PACKAGES_KEY = "codecPackages";
+    /**
+     * The packages we wish to include in our command line.
+     */
+    public final static String TOOL_PACKAGE_LIST_KEY = "toolsPackages";
+
+    /**
+     * The single classes we wish to include in our command line.
+     */
+    public final static String TOOL_CLASS_LIST_KEY = "toolClasses";
+
+    /**
+     * We will search these packages at startup to look for FeatureCodecs.
+     */
+    public final static String CODEC_PACKAGE_LIST_KEY = "codecPackages";
 
     final Configuration configuration;
 
@@ -31,28 +41,8 @@ public class GATKConf {
         this.configuration = configuration;
     }
 
-    /**
-     * The packages we wish to include in our command line.
-     */
     @SuppressWarnings("unchecked")
-    public List<String> getToolPackages() {
-        return configuration.getList(GATK_PROPERTY_PREFIX +  TOOLS_PACKAGES_KEY);
+    public List<String> getGATKProperty(final String propertyKey) {
+        return Collections.unmodifiableList(configuration.getList(GATK_PROPERTY_PREFIX + propertyKey));
     }
-
-    /**
-     * The single classes we wish to include in our command line.
-     */
-    @SuppressWarnings("unchecked")
-    public List<Class<? extends CommandLineProgram>> getToolClasses() {
-        return configuration.getList(GATK_PROPERTY_PREFIX +  TOOL_CLASSES_KEY);
-    }
-
-    /**
-     * We will search these packages at startup to look for FeatureCodecs.
-     */
-    @SuppressWarnings("unchecked")
-    public List<String> getCodecPackages() {
-        return configuration.getList(GATK_PROPERTY_PREFIX +  CODEC_PACKAGES_KEY);
-    }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/conf/GATKConf.java
+++ b/src/main/java/org/broadinstitute/hellbender/conf/GATKConf.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.hellbender.conf;
+
+import org.apache.commons.configuration.Configuration;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration for GATK. Properties are prefixed by {@link #GATK_PROPERTY_PREFIX}.
+ *
+ * - {@link #TOOLS_PACKAGES_KEY}: list of java packages in which to search for classes that extend CommandLineProgram.
+ * - {@link #TOOL_CLASSES_KEY}: list of single classes to include (e.g. required input pre-processing tools).
+ * - {@link #CODEC_PACKAGES_KEY}: packages to search at startup to look for FeatureCodecs.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class GATKConf {
+
+    public static final String GATK_PROPERTY_PREFIX = "gatk.";
+
+    public final static String TOOLS_PACKAGES_KEY = "toolsPackages";
+    public final static String TOOL_CLASSES_KEY = "toolClasses";
+    public final static String CODEC_PACKAGES_KEY = "codecPackages";
+
+    final Configuration configuration;
+
+    GATKConf(final Configuration configuration) {
+        Utils.nonNull(configuration);
+        this.configuration = configuration;
+    }
+
+    /**
+     * The packages we wish to include in our command line.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> getToolPackages() {
+        return configuration.getList(GATK_PROPERTY_PREFIX +  TOOLS_PACKAGES_KEY);
+    }
+
+    /**
+     * The single classes we wish to include in our command line.
+     */
+    @SuppressWarnings("unchecked")
+    public List<Class<? extends CommandLineProgram>> getToolClasses() {
+        return configuration.getList(GATK_PROPERTY_PREFIX +  TOOL_CLASSES_KEY);
+    }
+
+    /**
+     * We will search these packages at startup to look for FeatureCodecs.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> getCodecPackages() {
+        return configuration.getList(GATK_PROPERTY_PREFIX +  CODEC_PACKAGES_KEY);
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/conf/GATKConfBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/conf/GATKConfBuilder.java
@@ -2,9 +2,7 @@ package org.broadinstitute.hellbender.conf;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.CombinedConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 
@@ -47,46 +45,22 @@ public class GATKConfBuilder {
     }
 
     public GATKConfBuilder setDefaults() {
-        return setToolsPackages(new ArrayList<>(DEFAULT_TOOLS_PACKAGES))
-                .setClpClasses(new ArrayList<>())
-                .setCodecPackages(new ArrayList<>(DEFAULT_CODEC_PACKAGES));
+        return setGATKPropertyList(GATKConf.GATK_PROPERTY_PREFIX, new ArrayList<>(DEFAULT_TOOLS_PACKAGES))
+                .setGATKPropertyList(GATKConf.TOOL_CLASS_LIST_KEY, new ArrayList<>())
+                .setGATKPropertyList(GATKConf.CODEC_PACKAGE_LIST_KEY, new ArrayList<>(DEFAULT_CODEC_PACKAGES));
     }
 
     public GATKConf getConfiguration() {
         return new GATKConf(configuration);
     }
 
-    private GATKConfBuilder setProperty(final String key, final Object value) {
+    public GATKConfBuilder setGATKPropertyList(final String key, final List<String> value) {
         configuration.setProperty(GATKConf.GATK_PROPERTY_PREFIX + key, value);
         return this;
     }
 
-    private GATKConfBuilder addProperty(final String key, final Object value) {
+    public GATKConfBuilder addGATKProperty(final String key, final String value) {
         configuration.addProperty(GATKConf.GATK_PROPERTY_PREFIX + key, value);
         return this;
-    }
-
-    public GATKConfBuilder setToolsPackages(final List<String> toolsPackages) {
-        return setProperty(GATKConf.TOOLS_PACKAGES_KEY, toolsPackages);
-    }
-
-    public GATKConfBuilder addToolsPackage(final String toolsPackage) {
-        return addProperty(GATKConf.TOOLS_PACKAGES_KEY, toolsPackage);
-    }
-
-    public GATKConfBuilder setClpClasses(final List<Class<? extends CommandLineProgram>> toolClpClasses) {
-        return setProperty(GATKConf.TOOL_CLASSES_KEY, toolClpClasses);
-    }
-
-    public GATKConfBuilder addClpClasses(final String toolClpClass) {
-        return setProperty(GATKConf.TOOL_CLASSES_KEY, toolClpClass);
-    }
-
-    public GATKConfBuilder setCodecPackages(final List<String> codecPackages) {
-        return setProperty(GATKConf.CODEC_PACKAGES_KEY, codecPackages);
-    }
-
-    public GATKConfBuilder addCodecPackage(final String codecPackage) {
-        return addProperty(GATKConf.CODEC_PACKAGES_KEY, codecPackage);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/conf/GATKConfBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/conf/GATKConfBuilder.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.hellbender.conf;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.CombinedConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class GATKConfBuilder {
+
+    public static final List<String> DEFAULT_TOOLS_PACKAGES =
+            Collections.singletonList("org.broadinstitute.hellbender");
+
+    public static final List<String> DEFAULT_CODEC_PACKAGES = Arrays.asList("htsjdk.variant",
+            "htsjdk.tribble",
+            "org.broadinstitute.hellbender.utils.codecs");
+
+    private AbstractConfiguration configuration;
+
+    private boolean loadFile = false;
+
+    public GATKConfBuilder() {
+        this.configuration = new BaseConfiguration();
+    }
+
+    public GATKConfBuilder(final File file) {
+        this.configuration = new DefaultConfigurationBuilder(file);
+    }
+
+    public static final GATKConf getDefaultConfiguration() {
+        return new GATKConfBuilder().setDefaults().getConfiguration();
+    }
+
+    public static final GATKConf useConfiguration(final Configuration configuration) {
+        return new GATKConf(configuration);
+    }
+
+    public GATKConfBuilder setDefaults() {
+        return setToolsPackages(new ArrayList<>(DEFAULT_TOOLS_PACKAGES))
+                .setClpClasses(new ArrayList<>())
+                .setCodecPackages(new ArrayList<>(DEFAULT_CODEC_PACKAGES));
+    }
+
+    public GATKConf getConfiguration() {
+        return new GATKConf(configuration);
+    }
+
+    private GATKConfBuilder setProperty(final String key, final Object value) {
+        configuration.setProperty(GATKConf.GATK_PROPERTY_PREFIX + key, value);
+        return this;
+    }
+
+    private GATKConfBuilder addProperty(final String key, final Object value) {
+        configuration.addProperty(GATKConf.GATK_PROPERTY_PREFIX + key, value);
+        return this;
+    }
+
+    public GATKConfBuilder setToolsPackages(final List<String> toolsPackages) {
+        return setProperty(GATKConf.TOOLS_PACKAGES_KEY, toolsPackages);
+    }
+
+    public GATKConfBuilder addToolsPackage(final String toolsPackage) {
+        return addProperty(GATKConf.TOOLS_PACKAGES_KEY, toolsPackage);
+    }
+
+    public GATKConfBuilder setClpClasses(final List<Class<? extends CommandLineProgram>> toolClpClasses) {
+        return setProperty(GATKConf.TOOL_CLASSES_KEY, toolClpClasses);
+    }
+
+    public GATKConfBuilder addClpClasses(final String toolClpClass) {
+        return setProperty(GATKConf.TOOL_CLASSES_KEY, toolClpClass);
+    }
+
+    public GATKConfBuilder setCodecPackages(final List<String> codecPackages) {
+        return setProperty(GATKConf.CODEC_PACKAGES_KEY, codecPackages);
+    }
+
+    public GATKConfBuilder addCodecPackage(final String codecPackage) {
+        return addProperty(GATKConf.CODEC_PACKAGES_KEY, codecPackage);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -60,16 +60,15 @@ public final class FeatureManager implements AutoCloseable {
     private static final Class<FeatureInput> FEATURE_ARGUMENT_CLASS = FeatureInput.class;
 
     /**
-     * Walk through the packages in {@link GATKConf#getCodecPackages()}, and save any (concrete) FeatureCodecs discovered
+     * Walk through the packages in {@code codecPackages}, and save any (concrete) FeatureCodecs discovered
      * in DISCOVERED_CODECS.
      *
      * @throws IllegalStateException if codecs were alredy initialized.
      */
-    public synchronized static void setConfiguration(final GATKConf configuration) {
+    public synchronized static void setCodecPackages(final List<String> codecPackages) {
         if (DISCOVERED_CODECS != null) {
             throw new IllegalStateException("Codecs already initialized");
         }
-        final List<String> codecPackages = configuration.getCodecPackages();
         final ClassFinder finder = new ClassFinder();
         for (final String codecPackage : codecPackages) {
             finder.find(codecPackage, CODEC_BASE_CLASS);
@@ -410,7 +409,7 @@ public final class FeatureManager implements AutoCloseable {
      */
     private static List<FeatureCodec<? extends Feature, ?>> getCandidateCodecsForFile( final File featureFile )  {
         if (DISCOVERED_CODECS == null) {
-            setConfiguration(GATKConfBuilder.getDefaultConfiguration());
+            setCodecPackages(GATKConfBuilder.getDefaultConfiguration().getGATKProperty(GATKConf.CODEC_PACKAGE_LIST_KEY));
         }
 
         final List<FeatureCodec<? extends Feature, ?>> candidateCodecs = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/GATKException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/GATKException.java
@@ -84,5 +84,18 @@ public class GATKException extends RuntimeException {
             super(String.format("Attribute %s not of (or convertible to) type %s", attributeName, targetType), throwable);
         }
     }
+
+    public static class ConfigurationException extends GATKException {
+        private static final long serialVersionUID = 0L;
+
+        public ConfigurationException(final String property, final String msg) {
+            super(String.format("Wrong GATK configuration for %s property: %s", property, msg));
+        }
+
+        public ConfigurationException(final String property, final String msg, final Throwable throwable) {
+            super(String.format("Wrong GATK configuration for %s property: %s",  property, msg), throwable);
+        }
+    }
+
 }
 


### PR DESCRIPTION
Very simple implementation of #2297 using a custom `GATKConf` class to allow both promatically (`GATKConfBuilder`) and by commons-configuration API (constructor). Only includes:

* Packages/Classes to include in the CLP on startup.
* Packages to look for codecs on startup.