### PR TITLE
Remove obsolete dependency on JOpt.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ dependencies {
     compile 'org.apache.commons:commons-vfs2:2.0'
     compile 'commons-io:commons-io:2.4'
     compile 'org.reflections:reflections:0.9.10'
-    compile 'net.sf.jopt-simple:jopt-simple:5.0-beta-1'
     compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:0.4.150727'
     compile 'it.unimi.dsi:fastutil:7.0.6'
     compile 'com.google.apis:google-api-services-genomics:v1-rev90-1.22.0'


### PR DESCRIPTION
No longer needed due to Barclay dependency.