### PR TITLE
Utils methods to stream Iterable/Iterator

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
@@ -4,6 +4,7 @@ import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
 import java.util.stream.StreamSupport;
@@ -64,8 +65,7 @@ public abstract class FeatureWalker<F extends Feature> extends GATKTool {
     @Override
     public void traverse() {
         // Process each feature in the input stream.
-        StreamSupport.stream(drivingFeatures.spliterator(), false)
-                .forEach(feature -> {
+        Utils.stream(drivingFeatures).forEach(feature -> {
                     final SimpleInterval featureInterval = new SimpleInterval(feature);
                     apply(feature,
                             new ReadsContext(reads, featureInterval),

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Collections;
@@ -87,7 +88,7 @@ public abstract class ReadWalker extends GATKTool {
         // Supply reference bases spanning each read, if a reference is available.
         final CountingReadFilter countedFilter = makeReadFilter();
 
-        StreamSupport.stream(reads.spliterator(), false)
+        Utils.stream(reads)
                 .filter(countedFilter)
                 .forEach(read -> {
                     final SimpleInterval readInterval = getReadInterval(read);

--- a/src/main/java/org/broadinstitute/hellbender/engine/TwoPassReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/TwoPassReadWalker.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.tools.walkers.rnaseq.SplitNCigarReads;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Collections;
@@ -55,7 +56,7 @@ public abstract class TwoPassReadWalker extends ReadWalker {
      * @param f function applied to each read, should produce some useful side effect
      */
     private void traverseReads(final CountingReadFilter countedFilter, final GATKApply f) {
-        StreamSupport.stream(reads.spliterator(), false)
+        Utils.stream(reads)
                 .filter(countedFilter)
                 .forEach(read -> {
                     final SimpleInterval readInterval = getReadInterval(read);

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/ShuffleJoinReadsWithRefBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/ShuffleJoinReadsWithRefBases.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.engine.ReferenceShard;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import scala.Tuple2;
@@ -79,7 +80,7 @@ public final class ShuffleJoinReadsWithRefBases {
 
             // Apply the reference window function to each read to produce a set of intervals representing
             // the desired reference bases for each read.
-            final List<SimpleInterval> readWindows = StreamSupport.stream(iReads.spliterator(), false).map(read -> windowFunction.apply(read)).collect(Collectors.toList());
+            final List<SimpleInterval> readWindows = Utils.stream(iReads).map(read -> windowFunction.apply(read)).collect(Collectors.toList());
 
             SimpleInterval interval = IntervalUtils.getSpanningInterval(readWindows);
             ReferenceBases bases = referenceDataflowSource.getReferenceBases(null, interval);
@@ -115,7 +116,7 @@ public final class ShuffleJoinReadsWithRefBases {
 
             // Apply the reference window function to each read to produce a set of intervals representing
             // the desired reference bases for each read.
-            final List<SimpleInterval> readWindows = StreamSupport.stream(iReads.spliterator(), false).map(pair -> windowFunction.apply(pair._1())).collect(Collectors.toList());
+            final List<SimpleInterval> readWindows = Utils.stream(iReads).map(pair -> windowFunction.apply(pair._1())).collect(Collectors.toList());
 
             SimpleInterval interval = IntervalUtils.getSpanningInterval(readWindows);
             // TODO: don't we need to support GCS PipelineOptions?

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmerizer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmerizer.java
@@ -57,7 +57,7 @@ public class SVKmerizer implements Iterator<SVKmer> {
     }
 
     public static Stream<SVKmer> stream(final CharSequence seq, final int kSize, SVKmer kmer) {
-        return StreamSupport.stream(((Iterable<SVKmer>)() -> new SVKmerizer(seq, kSize, kmer)).spliterator(), false);
+        return Utils.stream((Iterable<SVKmer>)() -> new SVKmerizer(seq, kSize, kmer));
     }
 
     public static Stream<SVKmer> stream(final byte[] seq, final int kSize, SVKmer kmer ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmerizerWithLowComplexityFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVKmerizerWithLowComplexityFilter.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.sv;
 
+import org.broadinstitute.hellbender.utils.Utils;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,13 +29,13 @@ public class SVKmerizerWithLowComplexityFilter extends SVKmerizer {
     }
 
     public static Stream<SVKmer> stream(final CharSequence seq, final int kSize, final double minEntropy ) {
-        return StreamSupport.stream(((Iterable<SVKmer>)() ->
-                new SVKmerizerWithLowComplexityFilter(seq, kSize, minEntropy)).spliterator(), false);
+        return Utils.stream((Iterable<SVKmer>)() ->
+                new SVKmerizerWithLowComplexityFilter(seq, kSize, minEntropy));
     }
 
     public static Stream<SVKmer> stream(final byte[] seq, final int kSize, final double minEntropy ) {
-        return StreamSupport.stream(((Iterable<SVKmer>)() ->
-                new SVKmerizerWithLowComplexityFilter(seq, kSize, minEntropy)).spliterator(), false);
+        return Utils.stream((Iterable<SVKmer>)() ->
+                new SVKmerizerWithLowComplexityFilter(seq, kSize, minEntropy));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
@@ -5,6 +5,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.tools.ApplyBQSRArgumentCollection;
 import org.broadinstitute.hellbender.transformers.BQSRReadTransformer;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 
@@ -18,7 +19,7 @@ public class ApplyBQSRSparkFn {
             final RecalibrationReport report = reportBroadcast.getValue();
             final BQSRReadTransformer transformer = new BQSRReadTransformer(readsHeader, report, args);//reuse this for all reads in the partition
             final Iterable<GATKRead> readsIterable = () -> readsIterator;
-            return StreamSupport.stream(readsIterable.spliterator(), false).map(read -> transformer.apply(read)).collect(Collectors.toList()).iterator();
+            return Utils.stream(readsIterable).map(read -> transformer.apply(read)).collect(Collectors.toList()).iterator();
         });
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -235,7 +235,7 @@ public class MarkDuplicatesSparkUtils {
 
         final Iterable<GATKRead> transform = Iterables.transform(pairedEnds, pair -> pair.first());
         Iterable<GATKRead> readsCopy = Iterables.transform(transform, GATKRead::copy);
-        final Map<Boolean, List<GATKRead>> byPairing = StreamSupport.stream(readsCopy.spliterator(), false).collect(Collectors.partitioningBy(
+        final Map<Boolean, List<GATKRead>> byPairing = Utils.stream(readsCopy).collect(Collectors.partitioningBy(
                 read -> ReadUtils.readHasMappedMate(read)
         ));
         // Note the we emit only fragments from this mapper.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/ExactAFCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/ExactAFCalculator.java
@@ -29,7 +29,7 @@ abstract class ExactAFCalculator extends AFCalculator {
             genotypeLikelihoods.add((new double[]{0.0, 0.0, 0.0}));
         }
 
-        StreamSupport.stream(GLs.iterateInSampleNameOrder().spliterator(), false)
+        Utils.stream(GLs.iterateInSampleNameOrder())
                 .filter(Genotype::hasLikelihoods)
                 .map(gt -> gt.getLikelihoods().getAsVector())
                 .filter(GATKVariantContextUtils::isInformative)

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class Utils {
 
@@ -1041,6 +1043,14 @@ public final class Utils {
                 return endOfData();
             }
         };
+    }
+
+    public static <T> Stream<T> stream(final Iterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    public static <T> Stream<T> stream(final Iterator<T> iterator) {
+        return stream(() -> iterator);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableColumnCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableColumnCollection.java
@@ -39,7 +39,7 @@ public final class TableColumnCollection {
      *                                  of names as determined by {@link #checkNames checkNames}.
      */
     public TableColumnCollection(final Iterable<String> names) {
-        this(StreamSupport.stream(Utils.nonNull(names, "the names cannot be null").spliterator(), false).toArray(String[]::new));
+        this(Utils.stream(Utils.nonNull(names, "the names cannot be null")).toArray(String[]::new));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableReader.java
@@ -461,7 +461,7 @@ public abstract class TableReader<R> implements Closeable, Iterable<R> {
      * @return never {@code null}.
      */
     public Stream<R> stream() {
-        return StreamSupport.stream(spliterator(), false);
+        return Utils.stream(this);
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.codecs.table.TableCodec;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -256,11 +257,8 @@ public final class FeatureManagerUnitTest extends BaseTest {
         final Iterator<VariantContext> vcIterator = manager.getFeatureIterator(toolInstance.variantContextFeatureInput);
         final Iterator<BEDFeature> bedIterator = manager.getFeatureIterator(toolInstance.bedListFeatureInput.get(0));
 
-        final List<VariantContext> variants = StreamSupport.stream(Spliterators.spliteratorUnknownSize(vcIterator,0),false)
-                .collect(Collectors.toList());
-
-        final List<BEDFeature> beds = StreamSupport.stream(Spliterators.spliteratorUnknownSize(bedIterator,0),false)
-                .collect(Collectors.toList());
+        final List<VariantContext> variants = Utils.stream(vcIterator).collect(Collectors.toList());
+        final List<BEDFeature> beds = Utils.stream(bedIterator).collect(Collectors.toList());
 
         Assert.assertEquals(variants.size(), 26);
         Assert.assertEquals(variants.get(4).getStart(),280);
@@ -278,8 +276,7 @@ public final class FeatureManagerUnitTest extends BaseTest {
         final FeatureManager manager = new FeatureManager(toolInstance);
         final Iterator<VariantContext> vcIterator = manager.getFeatureIterator(toolInstance.variantContextFeatureInput);
 
-        final List<VariantContext> variants = StreamSupport.stream(Spliterators.spliteratorUnknownSize(vcIterator,0),false)
-                .collect(Collectors.toList());
+        final List<VariantContext> variants = Utils.stream(vcIterator).collect(Collectors.toList());
 
         Assert.assertEquals(variants.size(), 26);
         Assert.assertEquals(variants.get(4).getStart(),280);

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -4,8 +4,10 @@ package org.broadinstitute.hellbender.utils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
 import htsjdk.samtools.util.Log.LogLevel;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.math3.util.MathArrays;
 import org.apache.logging.log4j.Level;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -717,5 +719,17 @@ public final class UtilsUnitTest extends BaseTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> Utils.nonEmpty((String)null, "deliberately empty"));
         Assert.assertThrows(IllegalArgumentException.class, () -> Utils.nonEmpty("", "deliberately empty" ));
         Utils.nonEmpty("this is not empty");
+    }
+
+    @Test
+    public void testStreamFromIterable() {
+        final int[] array = new int[] {1,3,5,7,9};
+        Assert.assertTrue(Arrays.equals(array, Utils.stream(Ints.asList(array)).mapToInt(n -> n).toArray()));
+    }
+
+    @Test
+    public void testStreamFromIterator() {
+        final int[] array = new int[] {1,3,5,7,9};
+        Assert.assertEquals(array, Utils.stream(Ints.asList(array).iterator()).mapToInt(n -> n).toArray());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateListUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateListUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.recalibration.covariates;
 
 import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -33,7 +34,7 @@ public final class StandardCovariateListUnitTest extends BaseTest {
     @Test
     public void testIterator() {
         StandardCovariateList scl = makeCovariateList();
-        Assert.assertEquals(StreamSupport.stream(scl.spliterator(), false).count(), 4);
+        Assert.assertEquals(Utils.stream(scl).count(), 4);
     }
 
     @Test
@@ -41,7 +42,7 @@ public final class StandardCovariateListUnitTest extends BaseTest {
         StandardCovariateList scl = makeCovariateList();
         Assert.assertEquals(scl.getReadGroupCovariate().parseNameForReport(), "ReadGroup");
         Assert.assertEquals(scl.getQualityScoreCovariate().parseNameForReport(), "QualityScore");
-        final List<Covariate> additionalCovars = StreamSupport.stream(scl.getAdditionalCovariates().spliterator(), false).collect(Collectors.toList());
+        final List<Covariate> additionalCovars = Utils.stream(scl.getAdditionalCovariates()).collect(Collectors.toList());
         Assert.assertEquals(additionalCovars.get(0).parseNameForReport(), "Context");
         Assert.assertEquals(additionalCovars.get(1).parseNameForReport(), "Cycle");
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -1807,6 +1807,7 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
         GATKVariantContextUtils.setFilteredGenotypeToNocall(builder, builder.make(), setFilteredGenotypesToNocall, this::getGenotypeFilters);
         VariantContext vc = builder.make();
         if ( vc.hasAttribute((VCFConstants.ALLELE_COUNT_KEY)) ) {
+            final int[] array = (int[]) vc.getAttribute(VCFConstants.ALLELE_COUNT_KEY);
             Assert.assertEquals(vc.getAttribute(VCFConstants.ALLELE_COUNT_KEY), calledAltAlleles.toArray());
         }
         if ( vc.hasAttribute((VCFConstants.ALLELE_NUMBER_KEY)) ) {


### PR DESCRIPTION
Because calling `StreamSupport.stream(iterable.spliterator(false))` is really ugly.