### PR TITLE
improving error message in GATKSparkTool.writeReads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -17,15 +17,14 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
+import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -250,7 +249,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
                     reads, readsHeader, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                     getRecommendedNumReducers());
         } catch (IOException e) {
-            throw new GATKException("unable to write bam: " + e);
+            throw new UserException.CouldNotCreateOutputFile(outputFile,"writing failed", e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -52,7 +52,7 @@ public class UserException extends RuntimeException {
         private static final long serialVersionUID = 0L;
 
         public CouldNotReadInputFile(String message, Exception e) {
-            super(String.format("Couldn't read file. Error was: %s with exception: %s", message, getMessage(e)));
+            super(String.format("Couldn't read file. Error was: %s with exception: %s", message, getMessage(e)), e);
         }
 
         public CouldNotReadInputFile(File file) {
@@ -68,11 +68,11 @@ public class UserException extends RuntimeException {
         }
 
         public CouldNotReadInputFile(File file, String message, Exception e) {
-            super(String.format("Couldn't read file %s. Error was: %s with exception: %s", file.getAbsolutePath(), message, getMessage(e)));
+            super(String.format("Couldn't read file %s. Error was: %s with exception: %s", file.getAbsolutePath(), message, getMessage(e)), e);
         }
 
         public CouldNotReadInputFile(File file, Exception e) {
-            this(file, getMessage(e));
+            this(file, getMessage(e), e);
         }
 
         public CouldNotReadInputFile(String message) {
@@ -105,7 +105,7 @@ public class UserException extends RuntimeException {
 
 
         public CouldNotCreateOutputFile(File file, String message, Exception e) {
-            super(String.format("Couldn't write file %s because %s with exception %s", file.getAbsolutePath(), message, getMessage(e)));
+            super(String.format("Couldn't write file %s because %s with exception %s", file.getAbsolutePath(), message, getMessage(e)), e);
         }
 
         public CouldNotCreateOutputFile(File file, String message) {
@@ -113,11 +113,11 @@ public class UserException extends RuntimeException {
         }
 
         public CouldNotCreateOutputFile(String filename, String message, Exception e) {
-            super(String.format("Couldn't write file %s because %s with exception %s", filename, message, getMessage(e)));
+            super(String.format("Couldn't write file %s because %s with exception %s", filename, message, getMessage(e)), e);
         }
 
         public CouldNotCreateOutputFile(File file, Exception e) {
-            super(String.format("Couldn't write file %s because exception %s", file.getAbsolutePath(), getMessage(e)));
+            super(String.format("Couldn't write file %s because exception %s", file.getAbsolutePath(), getMessage(e)), e);
         }
 
         public CouldNotCreateOutputFile(String message, Exception e) {
@@ -192,7 +192,7 @@ public class UserException extends RuntimeException {
         }
 
         public MalformedFile(File f, String message, Exception e) {
-            super(String.format("File %s is malformed: %s caused by %s", f.getAbsolutePath(), message, getMessage(e)));
+            super(String.format("File %s is malformed: %s caused by %s", f.getAbsolutePath(), message, getMessage(e)), e);
         }
     }
 


### PR DESCRIPTION
changing from GATKException to the more appropriate UserException.CouldNotCreateOutputFile
updating user exceptions that take an exception to properly pass the exception on as their cause so they don't show incomplete stack traces