### PR TITLE
CommandLineException is no longer silent #2324

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -112,7 +112,8 @@ public class Main {
             return program.instanceMain(mainArgs);
         } catch (final CommandLineException e){
             //Print usage in the case of a CommandLineException
-            System.err.print(program.getUsage());
+            System.err.println(program.getUsage());
+            throw e;
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -142,9 +142,7 @@ public class Main {
             handleResult(result);
             System.exit(0);
         } catch (final CommandLineException e){
-            if (program != null) { //program can be null if th
-                System.err.println(program.getUsage());
-            }
+            System.err.println(program.getUsage());
             handleUserException(e);
             System.exit(COMMANDLINE_EXCEPTION_EXIT_VALUE);
         } catch (final UserException e){

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -20,6 +20,7 @@ import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.net.InetAddress;
@@ -66,11 +67,7 @@ public abstract class CommandLineProgram {
     @Argument(fullName = "use_jdk_deflater", shortName = "jdk_deflater", doc = "Whether to use the JdkDeflater (as opposed to IntelDeflater)", common=true)
     public boolean useJdkDeflater = false;
 
-    /**
-    * Initialized in parseArgs.  Subclasses may want to access this to do their
-    * own validation, and then print usage using commandLineParser.
-    */
-    protected CommandLineParser commandLineParser;
+    private CommandLineParser commandLineParser;
 
     private final List<Header> defaultHeaders = new ArrayList<>();
 
@@ -155,7 +152,7 @@ public abstract class CommandLineProgram {
                         " on " + System.getProperty("os.name") + " " + System.getProperty("os.version") +
                         " " + System.getProperty("os.arch") + "; " + System.getProperty("java.vm.name") +
                         " " + System.getProperty("java.runtime.version") +
-                        "; Version: " + commandLineParser.getVersion());
+                        "; Version: " + getCommandLineParser().getVersion());
 
                 Defaults.allDefaults().entrySet().stream().forEach(e->
                         logger.info(Defaults.class.getSimpleName() + "." + e.getKey() + " : " + e.getValue())
@@ -187,7 +184,6 @@ public abstract class CommandLineProgram {
             return 0;
         }
         return instanceMainPostParseArgs();
-
     }
 
     /**
@@ -204,34 +200,25 @@ public abstract class CommandLineProgram {
 
     /**
     *
-    * @return true if command line is valid
+    * @return true if program should be executed, false if an information only argument like {@link SpecialArgumentsCollection#HELP_FULLNAME} was specified
     */
     protected boolean parseArgs(final String[] argv) {
 
-        commandLineParser = new CommandLineArgumentParser(this, getPluginDescriptors());
-        try{
-            final boolean ret = commandLineParser.parseArguments(System.err, argv);
-            commandLine = commandLineParser.getCommandLine();
-            if (!ret) {
-                return false;
-            }
-            final String[] customErrorMessages = customCommandLineValidation();
-            if (customErrorMessages != null) {
-                for (final String msg : customErrorMessages) {
-                    System.err.println(msg);
-                }
-                commandLineParser.usage(System.err, false);
-                return false;
-            }
-            return true;
-        } catch (final CommandLineException e){
-            //The CommandLineException is treated specially - we display help and no blow up
-            commandLineParser.usage(System.err, true);
-            printDecoratedUserExceptionMessage(System.err, e);
-            //rethrow e - this will be caught upstream and the right exit code will be used.
-            //we don't exit here though - only Main.main is allowed to call System.exit.
-            throw e;
+        final boolean ret = getCommandLineParser().parseArguments(System.err, argv);
+        commandLine = getCommandLineParser().getCommandLine();
+        if (!ret) {
+            return false;
         }
+        final String[] customErrorMessages = customCommandLineValidation();
+        if (customErrorMessages != null) {
+            for (final String msg : customErrorMessages) {
+                System.err.println(msg);
+            }
+            getCommandLineParser().usage(System.err, false);
+            return false;
+        }
+        return true;
+
     }
 
     /**
@@ -239,19 +226,6 @@ public abstract class CommandLineProgram {
      * Default implementation returns null. Subclasses can override this to return a custom list.
      */
     protected List<? extends CommandLinePluginDescriptor<?>> getPluginDescriptors() { return new ArrayList<>(); }
-
-    /**
-     * Prints the given message (may be null) to the provided stream, adding adornments and formatting.
-     */
-    public static void printDecoratedUserExceptionMessage(final PrintStream ps, final Exception e){
-        Utils.nonNull(ps, "stream");
-        Utils.nonNull(e, "exception");
-        ps.println("***********************************************************************");
-        ps.println();
-        ps.println(e.getMessage());
-        ps.println();
-        ps.println("***********************************************************************");
-    }
 
     /** Gets a MetricsFile with default headers already written into it. */
     protected <A extends MetricBase,B extends Comparable<?>> MetricsFile<A,B> getMetricsFile() {
@@ -267,14 +241,24 @@ public abstract class CommandLineProgram {
      * Returns the version of this tool. It is the version stored in the manifest of the jarfile.
      */
     public final String getVersion() {
-        return commandLineParser == null ? "SNAPSHOT" : commandLineParser.getVersion();
+        return getCommandLineParser().getVersion();
     }
 
     /**
-     * Returns the commandline used to run this program.
+     * @return the commandline used to run this program, will be null if arguments have not yet been parsed
      */
     public final String getCommandLine() {
         return commandLine;
+    }
+
+    /**
+     * @return get usage and help information for this command line program if it is available
+     *
+     */
+    public final String getUsage(){
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        getCommandLineParser().usage(new PrintStream(baos), true);
+        return baos.toString();
     }
 
     /**
@@ -294,4 +278,13 @@ public abstract class CommandLineProgram {
         return this.defaultHeaders;
     }
 
+    /**
+    * @return this programs CommandLineParser.  If one is not initialized yet this will initialize it.
+    */
+    protected final CommandLineParser getCommandLineParser() {
+        if( commandLineParser == null) {
+            commandLineParser = new CommandLineArgumentParser(this, getPluginDescriptors());
+        }
+        return commandLineParser;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -167,7 +167,7 @@ public abstract class GATKTool extends CommandLineProgram {
      */
      public CountingReadFilter makeReadFilter(){
         final GATKReadFilterPluginDescriptor readFilterPlugin =
-                commandLineParser.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
+                getCommandLineParser().getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
         return hasReads() ?
                 readFilterPlugin.getMergedCountingReadFilter(getHeaderForReads()) :
                 new CountingReadFilter(ReadFilterLibrary.ALLOW_ALL_READS);

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -305,7 +305,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      */
     public ReadFilter makeReadFilter() {
         final GATKReadFilterPluginDescriptor readFilterPlugin =
-                commandLineParser.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
+                getCommandLineParser().getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
         return readFilterPlugin.getMergedReadFilter(getHeaderForReads());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -26,11 +26,11 @@ public class UserException extends RuntimeException {
     }
 
     public UserException(final String msg) {
-        super("A USER ERROR has occurred: " + msg);
+        super(msg);
     }
 
     public UserException(final String message, final Throwable throwable) {
-        super("A USER ERROR has occurred: " + message, throwable);
+        super(message, throwable);
     }
 
     protected static String getMessage(final Throwable t) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -309,16 +309,9 @@ public final class VariantFiltration extends VariantWalker {
         }
 
         for ( final JexlVCMatchExp exp : filterExps ) {
-            try {
-                if ( invertLogic(VariantContextUtils.match(vc, exp), invertFilterExpression) ) {
+                if ( invertLogic(VariantContextUtils.match(vc, exp), invertFilterExpression, JexlMissingValueTreatment.TREAT_AS_MATCH) ) {
                     filters.add(exp.name);
                 }
-            } catch (final Exception e) {
-                // do nothing unless specifically asked to; it just means that the expression isn't defined for this context
-                if ( failMissingValues  ) {
-                    filters.add(exp.name);
-                }
-            }
         }
 
         if ( filters.isEmpty() ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -309,9 +309,16 @@ public final class VariantFiltration extends VariantWalker {
         }
 
         for ( final JexlVCMatchExp exp : filterExps ) {
-                if ( invertLogic(VariantContextUtils.match(vc, exp), invertFilterExpression, JexlMissingValueTreatment.TREAT_AS_MATCH) ) {
+            try {
+                if ( invertLogic(VariantContextUtils.match(vc, exp), invertFilterExpression) ) {
                     filters.add(exp.name);
                 }
+            } catch (final Exception e) {
+                // do nothing unless specifically asked to; it just means that the expression isn't defined for this context
+                if ( failMissingValues  ) {
+                    filters.add(exp.name);
+                }
+            }
         }
 
         if ( filters.isEmpty() ) {

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -1,0 +1,33 @@
+package org.broadinstitute.hellbender.cmdline;
+
+
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+public class CommandLineProgramUnitTest extends BaseTest {
+
+    @Test
+    public void testGetUsage(){
+        final CommandLineProgram clp = getClp();
+        String usage = clp.getUsage();
+        BaseTest.assertContains(usage, "Usage:");
+    }
+
+    @Test
+    public void testGetCommandLine(){
+        final CommandLineProgram clp = getClp();
+        Assert.assertNull(clp.getCommandLine()); //should be null since no args were specified
+        Assert.assertFalse(clp.parseArgs(new String[]{"--" + SpecialArgumentsCollection.HELP_FULLNAME}));
+        assertContains(clp.getCommandLine(), SpecialArgumentsCollection.HELP_FULLNAME); //now it should be filed in
+    }
+
+    private static CommandLineProgram getClp() {
+        return new CommandLineProgram() {
+            @Override
+            protected Object doWork() {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.cmdline;
 
 
+import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.junit.Assert;
 import org.testng.annotations.Test;
@@ -20,6 +21,34 @@ public class CommandLineProgramUnitTest extends BaseTest {
         Assert.assertNull(clp.getCommandLine()); //should be null since no args were specified
         Assert.assertFalse(clp.parseArgs(new String[]{"--" + SpecialArgumentsCollection.HELP_FULLNAME}));
         assertContains(clp.getCommandLine(), SpecialArgumentsCollection.HELP_FULLNAME); //now it should be filed in
+    }
+
+    private static class ValidationFailer extends CommandLineProgram{
+        public static final String ERROR1 = "first error";
+        public static final String ERROR2 = "second error";
+
+        @Override
+        protected Object doWork() {
+            return null;
+        }
+
+        @Override
+        protected String[] customCommandLineValidation(){
+            return new String[]{ERROR1, ERROR2};
+        }
+    }
+
+    @Test
+    public void testCustomValidationFailThrowsCommandLineException(){
+        ValidationFailer clp = new ValidationFailer();
+        try{
+            clp.parseArgs(new String[] {});
+            Assert.fail("Should have thrown an exception");
+        } catch (final CommandLineException e){
+            final String message = e.getMessage();
+            assertContains(message, ValidationFailer.ERROR1);
+            assertContains(message, ValidationFailer.ERROR2);
+        }
     }
 
     private static CommandLineProgram getClp() {


### PR DESCRIPTION
fixes the issue where CommandLineExceptions produced no error message

added a public getUsage() method to CommandLineProgram
added a catch for these in instanceMain(), where the CommandLineProgram is in scope for printing the usage message
added a protected accessor getCommandLineParser to CommandLineProgram which guards against having an uninitialized CommandLineParser
moved the "A USER ERROR HAS OCCURRED" text out of the actual user exception and into the pretty printing