### PR TITLE
Minor fixes for CountingReadFilter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
@@ -82,7 +82,7 @@ public class CountingReadFilter extends ReadFilter {
 
     protected String getSummaryLineForLevel(final int indentLevel) {
         if (0 == filteredCount) {
-            return 0 == indentLevel ? "" : "No reads filtered by: " + getName();
+            return "No reads filtered by: " + getName();
         }
         else {
             return getIndentString(indentLevel) + Long.toString(filteredCount) + " read(s) filtered by: " + getName() + " \n";

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
@@ -188,6 +188,13 @@ public class CountingReadFilter extends ReadFilter {
         }
 
         @Override
+        public void resetFilteredCount() {
+            super.resetFilteredCount();
+            this.lhs.resetFilteredCount();
+            this.rhs.resetFilteredCount();
+        }
+
+        @Override
         public abstract String getName();
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
@@ -37,7 +37,7 @@ public final class CountingReadFilterUnitTest {
 
         if (expected) {
             Assert.assertTrue(0 == count);
-            Assert.assertEquals(-1, rfSummary.indexOf("0 read(s) filtered"));
+            Assert.assertEquals(0, rfSummary.indexOf("No reads filtered"));
         } else {
             Assert.assertTrue(1 == count);
             Assert.assertEquals(0, rfSummary.indexOf("1 read(s) filtered"));

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
@@ -246,6 +246,16 @@ public final class CountingReadFilterUnitTest {
         Assert.assertEquals(compoundFilter.getFilteredCount(), totalRejections);
         Assert.assertEquals(badStartAndEnd.getFilteredCount(), startEndRejections);
         Assert.assertEquals(isRayOrEgon.getFilteredCount(), nameRejections);
+
+        // test if reset filtered count is correctly propagated
+        compoundFilter.resetFilteredCount();
+        Assert.assertEquals(compoundFilter.getFilteredCount(), 0);
+        Assert.assertEquals(badStartAndEnd.getFilteredCount(), 0);
+        Assert.assertEquals(isRayOrEgon.getFilteredCount(), 0);
+        Assert.assertEquals(badStart.getFilteredCount(), 0);
+        Assert.assertEquals(badEnd.getFilteredCount(), 0);
+        Assert.assertEquals(isRay.getFilteredCount(), 0);
+        Assert.assertEquals(isEgon.getFilteredCount(), 0);
     }
 
     @Test


### PR DESCRIPTION
Found in https://github.com/broadinstitute/gatk/pull/2195:

* `getSummaryLineForLevel` fix for indentLevel = 0 (including tests)
* `resetFilterCount` now is propagated to lhs/rhs