### PR TITLE
Extract disableAllReadFilters to StandardArgumentDefinitions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -43,8 +43,8 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
             doc="Read filters to be disabled before analysis", optional=true)
     public final Set<String> disableFilters = new HashSet<>();
 
-    @Argument(fullName = "disableAllReadFilters",
-            shortName = "disableAllReadFilters",
+    @Argument(fullName = StandardArgumentDefinitions.DISABLE_ALL_READ_FILTERS_NAME,
+            shortName = StandardArgumentDefinitions.DISABLE_ALL_READ_FILTERS_NAME,
             doc = "Disable all read filters", common = false, optional = true)
     public boolean disableAllReadFilters = false;
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -20,6 +20,7 @@ public final class StandardArgumentDefinitions {
     public static final String ASSUME_SORTED_LONG_NAME = "assumeSorted";
     public static final String READ_FILTER_LONG_NAME = "readFilter";
     public static final String DISABLE_READ_FILTER_LONG_NAME = "disableReadFilter";
+    public static final String DISABLE_ALL_READ_FILTERS_NAME = "disableAllReadFilters";
     public static final String CREATE_OUTPUT_BAM_INDEX_LONG_NAME = "createOutputBamIndex";
     public static final String CREATE_OUTPUT_BAM_MD5_LONG_NAME = "createOutputBamMD5";
     public static final String CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME = "createOutputVariantIndex";


### PR DESCRIPTION
To allow implementation of other `ReadFilter` plugins with the same parameter names.