### PR TITLE
Make GATKReadFilterPluginDescriptor extensible

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.cmdline.GATKPlugin;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+
+import java.util.*;
+
+/**
+ * {@link GATKReadFilterArgumentCollection} for optional read filters in the command line. It allows:
+ *
+ * - Provide a list of read filters to apply.
+ * - Disable some and/or all read filters.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = StandardArgumentDefinitions.READ_FILTER_LONG_NAME,
+            shortName = StandardArgumentDefinitions.READ_FILTER_SHORT_NAME,
+            doc="Read filters to be applied before analysis", optional=true, common = true)
+    public final List<String> userEnabledReadFilterNames = new ArrayList<>(); // preserve order
+
+    @Argument(fullName = StandardArgumentDefinitions.DISABLE_READ_FILTER_LONG_NAME,
+            shortName = StandardArgumentDefinitions.DISABLE_READ_FILTER_SHORT_NAME,
+            doc="Read filters to be disabled before analysis", optional=true, common = true)
+    public final List<String> userDisabledReadFilterNames = new ArrayList<>();
+
+    @Argument(fullName = StandardArgumentDefinitions.DISABLE_TOOL_DEFAULT_READ_FILTERS,
+            shortName = StandardArgumentDefinitions.DISABLE_TOOL_DEFAULT_READ_FILTERS,
+            doc = "Disable all tool default read filters", common = true, optional = true)
+    public boolean disableToolDefaultReadFilters = false;
+
+    /** Returns a list with the read filters provided by the user, preserving the order. */
+    @Override
+    public Collection<String> getUserEnabledReadFilterNames() {
+        return userEnabledReadFilterNames;
+    }
+
+    /** Returns a set of filters disabled by the user. */
+    @Override
+    public Collection<String> getUserDisabledReadFilterNames() {
+        return userDisabledReadFilterNames;
+    }
+
+    /** {@inheritDoc}. */
+    @Override
+    public boolean disableToolDefaultReadFilters() {
+        return disableToolDefaultReadFilters;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
@@ -6,7 +6,8 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import java.util.*;
 
 /**
- * {@link GATKReadFilterArgumentCollection} for optional read filters in the command line. It allows:
+ * Default {@link GATKReadFilterArgumentCollection} applied in GATK for optional read filters in the command line.
+ * It contains arguments that allow the user to:
  *
  * - Provide a list of read filters to apply.
  * - Disable some and/or all read filters.
@@ -31,21 +32,21 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
             doc = "Disable all tool default read filters", common = true, optional = true)
     public boolean disableToolDefaultReadFilters = false;
 
-    /** Returns a list with the read filters provided by the user, preserving the order. */
+    /** Returns the list with the read filters provided by the user, preserving the order. */
     @Override
-    public Collection<String> getUserEnabledReadFilterNames() {
+    public List<String> getUserEnabledReadFilterNames() {
         return userEnabledReadFilterNames;
     }
 
-    /** Returns a set of filters disabled by the user. */
+    /** Returns the set of filters disabled by the user. */
     @Override
-    public Collection<String> getUserDisabledReadFilterNames() {
+    public List<String> getUserDisabledReadFilterNames() {
         return userDisabledReadFilterNames;
     }
 
     /** {@inheritDoc}. */
     @Override
-    public boolean disableToolDefaultReadFilters() {
+    public boolean getDisableToolDefaultReadFilters() {
         return disableToolDefaultReadFilters;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
@@ -1,8 +1,7 @@
 package org.broadinstitute.hellbender.cmdline.GATKPlugin;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 /**
  * An abstract ArgumentCollection for defining the set of read filter descriptor plugin arguments that are exposed to the user on the command line.
@@ -17,25 +16,17 @@ public abstract class GATKReadFilterArgumentCollection implements Serializable {
 
     /**
      * Returns the enabled filter names. Order should be honored.
-     *
-     * Default implementation returns an empty list.
      */
-    public Collection<String> getUserEnabledReadFilterNames() {
-        return Collections.emptyList();
-    }
+    public abstract List<String> getUserEnabledReadFilterNames();
 
     /**
      * Returns the disabled read filter names. Order should be honored.
-     *
-     * Default implementation returns an empty list.
      */
-    public Collection<String> getUserDisabledReadFilterNames() {
-        return Collections.emptyList();
-    }
+    public abstract List<String> getUserDisabledReadFilterNames();
 
     /**
      * Returns {@code true} if all default filters are disabled; {@code false} otherwise.
      */
-    public abstract boolean disableToolDefaultReadFilters();
+    public abstract boolean getDisableToolDefaultReadFilters();
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.hellbender.cmdline.GATKPlugin;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * An abstract ArgumentCollection for defining the set of read filter descriptor plugin arguments that are exposed to the user on the command line.
+ *
+ * Subclasses should provide {@link org.broadinstitute.barclay.argparser.Argument} annotations for the arguments that should be exposed.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ * @see org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor
+ */
+public abstract class GATKReadFilterArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Returns the enabled filter names. Order should be honored.
+     *
+     * Default implementation returns an empty list.
+     */
+    public Collection<String> getUserEnabledReadFilterNames() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns the disabled read filter names. Order should be honored.
+     *
+     * Default implementation returns an empty list.
+     */
+    public Collection<String> getUserDisabledReadFilterNames() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns {@code true} if all default filters are disabled; {@code false} otherwise.
+     */
+    public abstract boolean disableToolDefaultReadFilters();
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -1,9 +1,10 @@
 package org.broadinstitute.hellbender.cmdline.GATKPlugin;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -33,20 +34,10 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
     private static final String pluginPackageName = "org.broadinstitute.hellbender.engine.filters";
     private static final Class<?> pluginBaseClass = org.broadinstitute.hellbender.engine.filters.ReadFilter.class;
 
-    @Argument(fullName = StandardArgumentDefinitions.READ_FILTER_LONG_NAME,
-            shortName = StandardArgumentDefinitions.READ_FILTER_SHORT_NAME,
-            doc="Read filters to be applied before analysis", optional=true, common = true)
-    public final List<String> userEnabledReadFilterNames = new ArrayList<>(); // preserve order
-
-    @Argument(fullName = StandardArgumentDefinitions.DISABLE_READ_FILTER_LONG_NAME,
-            shortName = StandardArgumentDefinitions.DISABLE_READ_FILTER_SHORT_NAME,
-            doc="Read filters to be disabled before analysis", optional=true, common = true)
-    public final List<String> userDisabledReadFilterNames = new ArrayList<>();
-
-    @Argument(fullName = StandardArgumentDefinitions.DISABLE_TOOL_DEFAULT_READ_FILTERS,
-            shortName = StandardArgumentDefinitions.DISABLE_TOOL_DEFAULT_READ_FILTERS,
-            doc = "Disable all tool default read filters", common = true, optional = true)
-    public boolean disableToolDefaultReadFilters = false;
+    // the purpose of this argument collection is to allow the caller to control the exposure of the command line arguments
+    @VisibleForTesting
+    @ArgumentCollection
+    public GATKReadFilterArgumentCollection userArgs;
 
     // Map of read filter (simple) class names to the corresponding discovered plugin instance
     private final Map<String, ReadFilter> allDiscoveredReadFilters = new HashMap<>();
@@ -61,10 +52,12 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
     private final Set<String> requiredPredecessors = new HashSet<>();
 
     /**
+     * @param userArgs           Argument collection to control the exposure of the command line arguments.
      * @param toolDefaultFilters Default filters that may be supplied with arguments
      *                           on the command line. May be null.
      */
-    public GATKReadFilterPluginDescriptor(final List<ReadFilter> toolDefaultFilters) {
+    public GATKReadFilterPluginDescriptor(final GATKReadFilterArgumentCollection userArgs, final List<ReadFilter> toolDefaultFilters) {
+        this.userArgs = userArgs;
         if (null != toolDefaultFilters) {
             toolDefaultFilters.forEach(f -> {
                 final Class<? extends ReadFilter> rfClass = f.getClass();
@@ -79,6 +72,14 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
                 toolDefaultReadFilters.put(className, f);
             });
         }
+    }
+
+    /**
+     * @param toolDefaultFilters Default filters that may be supplied with arguments
+     *                           on the command line. May be null.
+     */
+    public GATKReadFilterPluginDescriptor(final List<ReadFilter> toolDefaultFilters) {
+        this(new DefaultGATKReadFilterArgumentCollection(), toolDefaultFilters);
     }
 
     /////////////////////////////////////////////////////////
@@ -155,7 +156,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         // for the user to subsequently disable the required predecessor. That case is caught during final
         // validation done by the validateArguments method.
         String predecessorName = predecessorClass.getSimpleName();
-        boolean isAllowed = userEnabledReadFilterNames.contains(predecessorName)
+        boolean isAllowed = userArgs.getUserEnabledReadFilterNames().contains(predecessorName)
                 || (toolDefaultReadFilters.get(predecessorName) != null);
         if (isAllowed) {
             // Keep track of the ones we allow so we can validate later that they weren't subsequently disabled
@@ -175,8 +176,8 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      */
     @Override
     public List<ReadFilter> getAllInstances() {
-        final ArrayList<ReadFilter> filters = new ArrayList<>(userEnabledReadFilterNames.size());
-        userEnabledReadFilterNames.forEach(s -> {
+        final ArrayList<ReadFilter> filters = new ArrayList<>(userArgs.getUserEnabledReadFilterNames().size());
+        userArgs.getUserEnabledReadFilterNames().forEach(s -> {
             ReadFilter rf = allDiscoveredReadFilters.get(s);
             filters.add(rf);
         });
@@ -227,7 +228,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
     @Override
     public void validateArguments() {
         // throw if a filter is *enabled* more than once by the user
-        final Set<String> duplicateUserEnabledFilterNames = Utils.getDuplicatedItems(userEnabledReadFilterNames);
+        final Set<String> duplicateUserEnabledFilterNames = Utils.getDuplicatedItems(userArgs.getUserEnabledReadFilterNames());
         if (!duplicateUserEnabledFilterNames.isEmpty()) {
             throw new CommandLineException.BadArgumentValue(
                     String.format("The read filter(s) are enabled more than once: %s",
@@ -235,7 +236,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         }
 
         // throw if a filter is *disabled* more than once by the user
-        final Set<String> duplicateDisabledUserFilterNames = Utils.getDuplicatedItems(userDisabledReadFilterNames);
+        final Set<String> duplicateDisabledUserFilterNames = Utils.getDuplicatedItems(userArgs.getUserDisabledReadFilterNames());
         if (!duplicateDisabledUserFilterNames.isEmpty()) {
             throw new CommandLineException.BadArgumentValue(
                     String.format("The read filter(s) are disabled more than once: %s",
@@ -243,8 +244,8 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         }
 
         // throw if a filter is both enabled *and* disabled by the user
-        final Set<String> enabledAndDisabled = new HashSet<>(userEnabledReadFilterNames);
-        enabledAndDisabled.retainAll(userDisabledReadFilterNames);
+        final Set<String> enabledAndDisabled = new HashSet<>(userArgs.getUserEnabledReadFilterNames());
+        enabledAndDisabled.retainAll(userArgs.getUserDisabledReadFilterNames());
         if (!enabledAndDisabled.isEmpty()) {
             final String badFiltersList = Utils.join(", ", enabledAndDisabled);
             throw new CommandLineException(
@@ -252,7 +253,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         }
 
         // throw if a disabled filter doesn't exist; warn if it wasn't enabled by the tool in the first place
-        userDisabledReadFilterNames.forEach(s -> {
+        userArgs.getUserDisabledReadFilterNames().forEach(s -> {
             if (!allDiscoveredReadFilters.containsKey(s)) {
                 throw new CommandLineException.BadArgumentValue(String.format("Disabled filter (%s) does not exist", s));
             } else if (!toolDefaultReadFilters.containsKey(s)) {
@@ -262,7 +263,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
 
         // warn if a filter is both default and enabled by the user
         final Set<String> redundant = new HashSet<>(toolDefaultReadFilters.keySet());
-        redundant.retainAll(userEnabledReadFilterNames);
+        redundant.retainAll(userArgs.getUserEnabledReadFilterNames());
         redundant.forEach(
             s -> {
                 logger.warn(String.format("Redundant enabled filter (%s) is enabled for this tool by default", s));
@@ -278,7 +279,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         // enabled read filter. However, its possible for the user to subsequently try to disable that
         // predecessor, which is what we want to catch here.
         //
-        userDisabledReadFilterNames.forEach(s -> {
+        userArgs.getUserDisabledReadFilterNames().forEach(s -> {
             if (requiredPredecessors.contains(s)) {
                 String message = String.format("Values were supplied for (%s) that is also disabled", s);
                 if (toolDefaultReadFilters.containsKey(s)) {
@@ -295,7 +296,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
 
         // throw if a filter name was specified that has no corresponding instance
         final Map<String, ReadFilter> requestedReadFilters = new HashMap<>();
-        userEnabledReadFilterNames.forEach(s -> {
+        userArgs.getUserEnabledReadFilterNames().forEach(s -> {
             ReadFilter trf = allDiscoveredReadFilters.get(s);
             if (null == trf) {
                 if (!toolDefaultReadFilters.containsKey(s)) {
@@ -318,8 +319,8 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      * the user and all tool defaults are disabled; {@code false} otherwise.
      */
     public boolean isDisabledFilter(final String filterName) {
-        return userDisabledReadFilterNames.contains(filterName)
-                || (disableToolDefaultReadFilters && !userEnabledReadFilterNames.contains(filterName));
+        return userArgs.getUserDisabledReadFilterNames().contains(filterName)
+                || (userArgs.disableToolDefaultReadFilters() && !userArgs.getUserEnabledReadFilterNames().contains(filterName));
     }
 
     /**
@@ -329,7 +330,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      * @param samHeader - a SAMFileHeader to use to initialize read filter instances
      * @return Single merged read filter.
      */
-    public ReadFilter getMergedReadFilter(final SAMFileHeader samHeader) {
+    public final ReadFilter getMergedReadFilter(final SAMFileHeader samHeader) {
         Utils.nonNull(samHeader);
         return getMergedReadFilter(
                 samHeader,
@@ -344,7 +345,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      * @param samHeader - a SAMFileHeader to use to initialize read filter instances
      * @return Single merged counting read filter.
      */
-    public CountingReadFilter getMergedCountingReadFilter(final SAMFileHeader samHeader) {
+    public final CountingReadFilter getMergedCountingReadFilter(final SAMFileHeader samHeader) {
         Utils.nonNull(samHeader);
         return getMergedReadFilter(
                 samHeader,
@@ -374,8 +375,8 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         // on the command line
         // if --disableToolDefaultReadFilters is specified, just initialize an empty list with initial capacity of user filters
         final List<ReadFilter> finalFilters =
-                disableToolDefaultReadFilters ?
-                        new ArrayList<>(userEnabledReadFilterNames.size()) :
+                userArgs.disableToolDefaultReadFilters() ?
+                        new ArrayList<>(userArgs.getUserEnabledReadFilterNames().size()) :
                         toolDefaultReadFilters.entrySet()
                                 .stream()
                                 .filter(e -> !isDisabledFilter(e.getKey()))

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -37,7 +37,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
     // the purpose of this argument collection is to allow the caller to control the exposure of the command line arguments
     @VisibleForTesting
     @ArgumentCollection
-    public GATKReadFilterArgumentCollection userArgs;
+    public final GATKReadFilterArgumentCollection userArgs;
 
     // Map of read filter (simple) class names to the corresponding discovered plugin instance
     private final Map<String, ReadFilter> allDiscoveredReadFilters = new HashMap<>();
@@ -320,7 +320,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      */
     public boolean isDisabledFilter(final String filterName) {
         return userArgs.getUserDisabledReadFilterNames().contains(filterName)
-                || (userArgs.disableToolDefaultReadFilters() && !userArgs.getUserEnabledReadFilterNames().contains(filterName));
+                || (userArgs.getDisableToolDefaultReadFilters() && !userArgs.getUserEnabledReadFilterNames().contains(filterName));
     }
 
     /**
@@ -375,7 +375,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         // on the command line
         // if --disableToolDefaultReadFilters is specified, just initialize an empty list with initial capacity of user filters
         final List<ReadFilter> finalFilters =
-                userArgs.disableToolDefaultReadFilters() ?
+                userArgs.getDisableToolDefaultReadFilters() ?
                         new ArrayList<>(userArgs.getUserEnabledReadFilterNames().size()) :
                         toolDefaultReadFilters.entrySet()
                                 .stream()

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
@@ -349,7 +349,7 @@ public class ReadFilterPluginUnitTest {
         clp.parseArguments(nullMessageStream, args);
 
         GATKReadFilterPluginDescriptor readFilterPlugin = clp.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
-        Assert.assertTrue(readFilterPlugin.userArgs.disableToolDefaultReadFilters());
+        Assert.assertTrue(readFilterPlugin.userArgs.getDisableToolDefaultReadFilters());
 
         // no instances because no readFilter was provided
         List<ReadFilter> readFilters = readFilterPlugin.getAllInstances();

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
@@ -259,8 +259,8 @@ public class ReadFilterPluginUnitTest {
         Assert.assertEquals(readFilters.get(1).getClass().getSimpleName(),
                 ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS.getClass().getSimpleName());
 
-        Assert.assertEquals(readFilterPlugin.userDisabledReadFilterNames.size(), 1);
-        Assert.assertTrue(readFilterPlugin.userDisabledReadFilterNames.contains(
+        Assert.assertEquals(readFilterPlugin.userArgs.getUserDisabledReadFilterNames().size(), 1);
+        Assert.assertTrue(readFilterPlugin.userArgs.getUserDisabledReadFilterNames().contains(
                 ReadFilterLibrary.GOOD_CIGAR.getClass().getSimpleName()));
         Assert.assertTrue(readFilterPlugin.isDisabledFilter(
                 ReadFilterLibrary.GOOD_CIGAR.getClass().getSimpleName()));
@@ -276,7 +276,7 @@ public class ReadFilterPluginUnitTest {
                 "-disableReadFilter", filterName
         });
         // Make sure mapped filter got disabled with no exception
-        Assert.assertTrue(rfDesc.userDisabledReadFilterNames.contains(filterName));
+        Assert.assertTrue(rfDesc.userArgs.getUserDisabledReadFilterNames().contains(filterName));
         Assert.assertTrue(rfDesc.isDisabledFilter(filterName));
     }
 
@@ -309,10 +309,10 @@ public class ReadFilterPluginUnitTest {
         Assert.assertEquals(readFilters.get(0).getClass().getSimpleName(),
                 ReadFilterLibrary.MAPPED.getClass().getSimpleName());
 
-        Assert.assertEquals(readFilterPlugin.userDisabledReadFilterNames.size(), 2);
-        Assert.assertTrue(readFilterPlugin.userDisabledReadFilterNames.contains(
+        Assert.assertEquals(readFilterPlugin.userArgs.getUserDisabledReadFilterNames().size(), 2);
+        Assert.assertTrue(readFilterPlugin.userArgs.getUserDisabledReadFilterNames().contains(
                 ReadFilterLibrary.GOOD_CIGAR.getClass().getSimpleName()));
-        Assert.assertTrue(readFilterPlugin.userDisabledReadFilterNames.contains(
+        Assert.assertTrue(readFilterPlugin.userArgs.getUserDisabledReadFilterNames().contains(
                 ReadFilterLibrary.HAS_MATCHING_BASES_AND_QUALS.getClass().getSimpleName()));
 
         ReadFilter rf = instantiateFilter(clp, createHeaderWithReadGroups());
@@ -349,7 +349,7 @@ public class ReadFilterPluginUnitTest {
         clp.parseArguments(nullMessageStream, args);
 
         GATKReadFilterPluginDescriptor readFilterPlugin = clp.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
-        Assert.assertTrue(readFilterPlugin.disableToolDefaultReadFilters);
+        Assert.assertTrue(readFilterPlugin.userArgs.disableToolDefaultReadFilters());
 
         // no instances because no readFilter was provided
         List<ReadFilter> readFilters = readFilterPlugin.getAllInstances();
@@ -395,7 +395,7 @@ public class ReadFilterPluginUnitTest {
                 "-disableReadFilter", filterName});
 
         // Make sure ReadLengthReadFilter got disabled without an exception
-        Assert.assertTrue(rfDesc.userDisabledReadFilterNames.contains(filterName));
+        Assert.assertTrue(rfDesc.userArgs.getUserDisabledReadFilterNames().contains(filterName));
         Assert.assertTrue(rfDesc.isDisabledFilter(filterName));
     }
 


### PR DESCRIPTION
I would like to use the implementation of `GATKReadFilterPluginDescriptor` with some minor changes, but the current design of the class does not allow it. In this PR I include the following changes (divided in commits):

- Argument collection to apply to `GATKReadFilterPluginDescriptor` added on construction. This allow to modify the argument descriptions/behaviour depending on the usages.
-  Make fields protected, and a couple of final keywords to methods that are not expected to be modified.