### PR TITLE
enabling bam index caching in memory for GATKTool

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -27,7 +27,7 @@ public final class StandardArgumentDefinitions {
     public static final String METRIC_ACCUMULATION_LEVEL_LONG_NAME = "metricAccumulationLevel";
     public static final String CLOUD_PREFETCH_BUFFER_LONG_NAME = "cloudPrefetchBuffer";
     public static final String CLOUD_INDEX_PREFETCH_BUFFER_LONG_NAME = "cloudIndexPrefetchBuffer";
-
+    public static final String DISABLE_BAM_INDEX_CACHING_LONG_NAME = "disableBamIndexCaching";
     public static final String DISABLE_SEQUENCE_DICT_VALIDATION_NAME = "disableSequenceDictionaryValidation";
     public static final String ADD_OUTPUT_SAM_PROGRAM_RECORD = "addOutputSAMProgramRecord";
 
@@ -61,7 +61,7 @@ public final class StandardArgumentDefinitions {
     public static final String METRIC_ACCUMULATION_LEVEL_SHORT_NAME = "LEVEL";
     public static final String CLOUD_PREFETCH_BUFFER_SHORT_NAME = "CPB";
     public static final String CLOUD_INDEX_PREFETCH_BUFFER_SHORT_NAME = "CIPB";
-
+    public static final String DISABLE_BAM_INDEX_CACHING_SHORT_NAME = "DBIC";
 
     public static final String SPARK_PROPERTY_NAME = "conf";
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -93,7 +93,7 @@ public abstract class GATKTool extends CommandLineProgram {
 
     @Argument(fullName = StandardArgumentDefinitions.DISABLE_BAM_INDEX_CACHING_LONG_NAME,
             shortName = StandardArgumentDefinitions.DISABLE_BAM_INDEX_CACHING_SHORT_NAME,
-            doc = "If true, don't cache bam indexes, this will save memory but may decrease performance if many intervals are specified.",
+            doc = "If true, don't cache bam indexes, this will reduce memory requirements but may harm performance if many intervals are specified.  Caching is automatically disabled if there are no intervals specified.",
             optional = true)
     public boolean disableBamIndexCaching = false;
 
@@ -204,16 +204,16 @@ public abstract class GATKTool extends CommandLineProgram {
      */
     void initializeReads() {
         if (! readArguments.getReadFiles().isEmpty()) {
-            final SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(readArguments.getReadValidationStringency());
+            SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(readArguments.getReadValidationStringency());
             if (hasReference()) { // pass in reference if available, because CRAM files need it
-                factory.referenceSequence(referenceArguments.getReferenceFile());
+                factory = factory.referenceSequence(referenceArguments.getReferenceFile());
             }
             else if (hasCramInput()) {
                 throw new UserException.MissingReference("A reference file is required when using CRAM files.");
             }
 
             if(bamIndexCachingShouldBeEnabled()) {
-                factory.enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES);
+                factory = factory.enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES);
             }
 
             reads = new ReadsDataSource(readArguments.getReadPaths(), readArguments.getReadIndexPaths(), factory, cloudPrefetchBuffer,


### PR DESCRIPTION
this seems to resolve the extremely slow runtimes when using large interval lists #2356