### PR TITLE
Utils method to map a function over a list

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 
@@ -55,7 +56,7 @@ public abstract class ReadInputArgumentCollection implements Serializable {
             return null;
         }
 
-        return readIndices.stream().map(index -> IOUtils.getPath(index)).collect(Collectors.toList());
+        return Utils.map(readIndices, IOUtils::getPath);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -374,7 +375,7 @@ public final class FeatureManager implements AutoCloseable {
         // If featureType was specified, subset to only codecs that produce the requested type of Feature,
         // and throw an error if there are no such codecs.
         if ( featureType != null ) {
-            final List<String> discoveredCodecsFeatureTypes = candidateCodecs.stream().map(codec -> codec.getFeatureType().getSimpleName()).collect(Collectors.toList());
+            final List<String> discoveredCodecsFeatureTypes = Utils.map(candidateCodecs, codec -> codec.getFeatureType().getSimpleName());
             candidateCodecs.removeIf(codec -> ! featureType.isAssignableFrom(codec.getFeatureType()));
 
             if ( candidateCodecs.isEmpty() ) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantDataSource.java
@@ -189,7 +189,7 @@ public final class MultiVariantDataSource implements GATKDataSource<VariantConte
      */
     public String getName() {
         return "MultiVariantDataSource: ("
-                + Utils.join(", ", featureDataSources.stream().map(fds -> fds.getName()).collect(Collectors.toList()))
+                + Utils.join(", ", Utils.map(featureDataSources, fds -> fds.getName()))
                 + ")";
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.ArrayList;
@@ -130,9 +131,7 @@ public abstract class AssemblyRegionWalkerSpark extends GATKSparkTool {
         intervalShards = intervals.stream()
                 .flatMap(interval -> Shard.divideIntervalIntoShards(interval, readShardSize, readShardPadding, sequenceDictionary).stream())
                 .collect(Collectors.toList());
-        List<SimpleInterval> paddedIntervalsForReads =
-                intervals.stream().map(interval -> interval.expandWithinContig(readShardPadding, sequenceDictionary)).collect(Collectors.toList());
-        return paddedIntervalsForReads;
+        return Utils.map(intervals, interval -> interval.expandWithinContig(readShardPadding, sequenceDictionary));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkSharder.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkSharder.java
@@ -21,6 +21,7 @@ import org.broadinstitute.hellbender.engine.ShardBoundary;
 import org.broadinstitute.hellbender.engine.ShardBoundaryShard;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import scala.Option;
 import scala.Tuple2;
 import scala.reflect.ClassTag;
@@ -71,7 +72,7 @@ public class SparkSharder {
                                                                 SAMSequenceDictionary sequenceDictionary, List<ShardBoundary> intervals,
                                                                 int maxLocatableLength, boolean useShuffle) {
 
-        List<ShardBoundary> paddedIntervals = intervals.stream().map(sb -> new ShardBoundary(sb.getInterval(), sb.getPaddedInterval()) {
+        List<ShardBoundary> paddedIntervals = Utils.map(intervals, sb -> new ShardBoundary(sb.getInterval(), sb.getPaddedInterval()) {
             private static final long serialVersionUID = 1L;
             @Override
             public String getContig() {
@@ -85,7 +86,7 @@ public class SparkSharder {
             public int getEnd() {
                 return getPaddedInterval().getEnd();
             }
-        }).collect(Collectors.toList());
+        });
         if (useShuffle) {
             OverlapDetector<ShardBoundary> overlapDetector = OverlapDetector.create(paddedIntervals);
             Broadcast<OverlapDetector<ShardBoundary>> overlapDetectorBroadcast = ctx.broadcast(overlapDetector);

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.tools.readersplitters.LibraryNameSplitter;
 import org.broadinstitute.hellbender.tools.readersplitters.ReadGroupIdSplitter;
 import org.broadinstitute.hellbender.tools.readersplitters.ReaderSplitter;
 import org.broadinstitute.hellbender.tools.readersplitters.SampleNameSplitter;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 
@@ -131,9 +132,7 @@ public final class SplitReads extends ReadWalker {
         final SAMFileHeader samFileHeaderIn = getHeaderForReads();
 
         // Build up a list of key options at each level.
-        final List<List<?>> splitKeys = splitters.stream()
-                .map(splitter -> splitter.getSplitsBy(samFileHeaderIn))
-                .collect(Collectors.toList());
+        final List<List<?>> splitKeys = Utils.map(splitters, splitter -> splitter.getSplitsBy(samFileHeaderIn));
 
         // For every combination of keys, add a SAMFileWriter.
         addKey(splitKeys, 0, "", key -> {

--- a/src/main/java/org/broadinstitute/hellbender/tools/readersplitters/ReadGroupSplitter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/readersplitters/ReadGroupSplitter.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.readersplitters;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
@@ -21,7 +22,7 @@ public abstract class ReadGroupSplitter<T> extends ReaderSplitter<T> {
 
     @Override
     public List<T> getSplitsBy(final SAMFileHeader header) {
-        return header.getReadGroups().stream().map(getSplitByFunction()).collect(Collectors.toList());
+        return Utils.map(header.getReadGroups(), getSplitByFunction());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ChimericAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ChimericAlignment.java
@@ -88,7 +88,7 @@ class ChimericAlignment {
     static List<ChimericAlignment> fromSplitAlignments(final Tuple2<Iterable<AlignmentRegion>, byte[]> input) {
 
         final byte[] sequence = input._2;
-        final List<AlignmentRegion> alignmentRegionsSortedByContigCoord = StreamSupport.stream(input._1().spliterator(), false).sorted(Comparator.comparing(a -> a.startInAssembledContig)).collect(Collectors.toList());
+        final List<AlignmentRegion> alignmentRegionsSortedByContigCoord = Utils.stream(input._1()).sorted(Comparator.comparing(a -> a.startInAssembledContig)).collect(Collectors.toList());
         if (alignmentRegionsSortedByContigCoord.size() < 2) {
             return new ArrayList<>();
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCall.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCall.java
@@ -254,7 +254,7 @@ class SVVariantConsensusCall implements Serializable {
     @VisibleForTesting
     static Map<String, Object> getEvidenceRelatedAnnotations(final Iterable<ChimericAlignment> splitAlignmentEvidence) {
 
-        final List<BreakpointEvidenceAnnotations> annotations = StreamSupport.stream(splitAlignmentEvidence.spliterator(), false)
+        final List<BreakpointEvidenceAnnotations> annotations = Utils.stream(splitAlignmentEvidence)
                 .sorted((final ChimericAlignment o1, final ChimericAlignment o2) -> { // sort by assembly id, then sort by contig id
                     if (o1.regionWithLowerCoordOnContig.assemblyId.equals(o2.regionWithLowerCoordOnContig.assemblyId)) return o1.regionWithLowerCoordOnContig.contigId.compareTo(o2.regionWithLowerCoordOnContig.contigId);
                     else return o1.regionWithLowerCoordOnContig.assemblyId.compareTo(o2.regionWithLowerCoordOnContig.assemblyId);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
@@ -250,7 +250,7 @@ public final class VariantAnnotatorEngine {
 
         private static List<String> getAllAnnotationNames() {
             final Set<VariantAnnotation> union = Sets.union(new LinkedHashSet<>(makeAllGenotypeAnnotations()), new LinkedHashSet<>(AnnotationManager.makeAllInfoFieldAnnotations()));
-            return union.stream().map(a -> a.getClass().getSimpleName()).collect(Collectors.toList());
+            return Utils.map(union, a -> a.getClass().getSimpleName());
         }
 
         /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -627,7 +627,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
 
     private List<Double> calculateMLEAlleleFrequencies(final List<Integer> alleleCountsofMLE, final GenotypesContext genotypes) {
         final long AN = genotypes.stream().flatMap(g -> g.getAlleles().stream()).filter(Allele::isCalled).count();
-        return alleleCountsofMLE.stream().map(AC -> Math.min(1.0, (double) AC / AN)).collect(Collectors.toList());
+        return Utils.map(alleleCountsofMLE, AC -> Math.min(1.0, (double) AC / AN));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -201,7 +201,7 @@ public class OverhangFixingManager {
             writeReads(targetQueueSize);
         }
 
-        List<SplitRead> newReadGroup = readGroup.stream().map(SplitRead::new).collect(Collectors.toList());
+        List<SplitRead> newReadGroup = Utils.map(readGroup, SplitRead::new);
 
         // Check every stored read for an overhang with the new splice
         for ( final Splice splice : splices) {
@@ -342,9 +342,7 @@ public class OverhangFixingManager {
 
             // Repair the supplementary groups together and add them into the writer
             if (outputToFile) {
-                SplitNCigarReads.repairSupplementaryTags(waitingGroup.stream()
-                        .map( r -> r.read )
-                        .collect(Collectors.toList()), header);
+                SplitNCigarReads.repairSupplementaryTags(Utils.map(waitingGroup, r -> r.read), header);
                 for (SplitRead splitRead : waitingGroup) {
                     writer.addRead(splitRead.read);
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -815,7 +815,7 @@ public final class SelectVariants extends VariantWalker {
         if (file != null) {
             Set<String> ids = new LinkedHashSet<>();
             try (final XReadLines xrl = new XReadLines(file)) {
-                ids.addAll(xrl.readLines().stream().map(String::trim).collect(Collectors.toList()));
+                ids.addAll(Utils.map(xrl.readLines(), String::trim));
                 logger.info("Selecting only variants with one of " + ids.size() + " IDs from " + file);
             } catch (IOException e) {
                 throw new UserException.CouldNotReadInputFile(file, e);
@@ -1030,8 +1030,8 @@ public final class SelectVariants extends VariantWalker {
                 AlleleSubsettingUtils.subsetAlleles(oldGs, 0, vc.getAlleles(), sub.getAlleles(), GenotypeAssignmentMethod.DO_NOT_ASSIGN_GENOTYPES);
 
         if (fractionGenotypes > 0) {
-            final List<Genotype> genotypes = newGC.stream().map(genotype -> randomGenotypes.nextDouble() > fractionGenotypes ? genotype :
-                    new GenotypeBuilder(genotype).alleles(getNoCallAlleles(genotype.getPloidy())).noGQ().make()).collect(Collectors.toList());
+            final List<Genotype> genotypes = Utils.map(newGC, genotype -> randomGenotypes.nextDouble() > fractionGenotypes
+                    ? genotype : new GenotypeBuilder(genotype).alleles(getNoCallAlleles(genotype.getPloidy())).noGQ().make());
             newGC = GenotypesContext.create(new ArrayList<>(genotypes));
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/ClassUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/ClassUtils.java
@@ -66,7 +66,7 @@ public final class ClassUtils {
     public static List<String> knownSubInterfaceSimpleNames(final Class<?> iface) {
         Utils.nonNull(iface);
         Utils.validateArg(iface.isInterface(), iface + " is not an interface");
-        return knownSubInterfaces(iface).stream().map(c ->c.getSimpleName()).collect(Collectors.toList());
+        return Utils.map(knownSubInterfaces(iface), c ->c.getSimpleName());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -887,10 +887,7 @@ public final class IntervalUtils {
             return Collections.emptyList();
         }
 
-        final List<GenomeLoc> expanded = locs.stream()
-                .map(loc -> parser.createPaddedGenomeLoc(loc, basePairs))
-                .collect(Collectors.toList());
-
+        final List<GenomeLoc> expanded = Utils.map(locs, loc -> parser.createPaddedGenomeLoc(loc, basePairs));
         return sortAndMergeIntervals(parser, expanded, IntervalMergingRule.ALL).toList();
     }
 
@@ -929,22 +926,16 @@ public final class IntervalUtils {
      */
     public static List<GenomeLoc> genomeLocsFromLocatables(final GenomeLocParser parser, final Collection<? extends Locatable> locatables) {
         Utils.nonNull(parser, "the input genome-loc parser cannot be null");
-
         Utils.nonNull(locatables, "the input locatable collection cannot be null");
         Utils.containsNoNull(locatables, "some element in the locatable input collection is null");
-
-        final List<GenomeLoc> result = locatables.stream().map(parser::createGenomeLoc).collect(Collectors.toList());
-        return Collections.unmodifiableList(result);
+        return Collections.unmodifiableList(Utils.map(locatables, parser::createGenomeLoc));
     }
 
     /**
      * Builds a list of intervals that cover the whole given sequence.
      */
     public static List<SimpleInterval> getAllIntervalsForReference(final SAMSequenceDictionary sequenceDictionary) {
-        return GenomeLocSortedSet.createSetFromSequenceDictionary(sequenceDictionary)
-                .stream()
-                .map(SimpleInterval::new)
-                .collect(Collectors.toList());
+        return Utils.map(GenomeLocSortedSet.createSetFromSequenceDictionary(sequenceDictionary), SimpleInterval::new);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -1053,6 +1053,12 @@ public final class Utils {
         return stream(() -> iterator);
     }
 
+    public static <T, R> List<R> map(final Collection<T> input, final Function<T, R> function) {
+        final List<R> result = new ArrayList<R>(input.size());
+        input.forEach(element -> result.add(function.apply(element)));
+        return result;
+    }
+
     /**
      * Like Guava's {@link Iterators#transform(Iterator, com.google.common.base.Function)}, but runs a fixed number
      * ({@code numThreads}) of transformations in parallel, while maintaining ordering of the output iterator.

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadGroupCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ReadGroupCovariate.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.recalibration.covariates;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -90,6 +91,6 @@ public final class ReadGroupCovariate implements Covariate {
     }
 
     public static List<String> getReadGroupIDs(final SAMFileHeader header) {
-        return header.getReadGroups().stream().map(rg -> getID(rg)).collect(Collectors.toList());
+        return Utils.map(header.getReadGroups(), rg -> getID(rg));
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/StandardCovariateList.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.recalibration.covariates;
 
 import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -63,7 +64,7 @@ public final class StandardCovariateList implements Iterable<Covariate>, Seriali
      * For example CycleCovariate.
      */
     public List<String> getStandardCovariateClassNames() {
-        return Collections.unmodifiableList(allCovariates.stream().map(cov -> cov.getClass().getSimpleName()).collect(Collectors.toList()));
+        return Collections.unmodifiableList(Utils.map(allCovariates, cov -> cov.getClass().getSimpleName()));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/samples/SampleUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/samples/SampleUtils.java
@@ -25,8 +25,7 @@ public class SampleUtils {
         if (files != null) {
             for (final File file : files) {
                 try (XReadLines reader = new XReadLines(file)) {
-                    List<String> lines = reader.readLines();
-                    samplesFromFiles.addAll(lines.stream().collect(Collectors.toList()));
+                    reader.readLines().forEach(samplesFromFiles::add);
                 } catch (IOException e) {
                     throw new UserException.CouldNotReadInputFile(file, e);
                 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1193,10 +1193,7 @@ public final class GATKVariantContextUtils {
         public Allele remap(Allele a)                   { return map != null && map.containsKey(a) ? map.get(a) : a; }
 
         public List<Allele> remap(List<Allele> as) {
-            List<Allele> newAs = as.stream()
-                    .map(this::remap)
-                    .collect(Collectors.toList());
-            return newAs;
+            return Utils.map(as, this::remap);
         }
 
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VcfUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VcfUtils.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.File;
 import java.util.*;
@@ -28,8 +29,8 @@ public final class VcfUtils {
         final SortedSet<String> samples = new TreeSet<>();
         for (final Map.Entry<String, VCFHeader> val : headers.entrySet()) {
             VCFHeader header = val.getValue();
-            samples.addAll(header.getGenotypeSamples().stream().map(sample -> GATKVariantContextUtils.mergedSampleName(val.getKey(), sample,
-                    mergeOption == GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY)).collect(Collectors.toList()));
+            samples.addAll(Utils.map(header.getGenotypeSamples(), sample -> GATKVariantContextUtils.mergedSampleName(val.getKey(), sample,
+                    mergeOption == GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY)));
         }
 
         return samples;
@@ -96,7 +97,7 @@ public final class VcfUtils {
                                                                    final File referenceFile) {
         final List<VCFContigHeaderLine> lines = new ArrayList<>();
         final String assembly = referenceFile != null ? referenceFile.getName() : null;
-        lines.addAll(refDict.getSequences().stream().map(contig -> makeContigHeaderLine(contig, assembly)).collect(Collectors.toList()));
+        lines.addAll(Utils.map(refDict.getSequences(), contig -> makeContigHeaderLine(contig, assembly)));
         return lines;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -732,4 +732,14 @@ public final class UtilsUnitTest extends BaseTest {
         final int[] array = new int[] {1,3,5,7,9};
         Assert.assertEquals(array, Utils.stream(Ints.asList(array).iterator()).mapToInt(n -> n).toArray());
     }
+
+    @Test
+    public void testMap() {
+        final List<Integer> input = Arrays.asList(1,2,3);
+        final List<Integer> output = Utils.map(input, n -> n*n);
+        Assert.assertTrue(output.size() == input.size());
+        Assert.assertEquals(output.get(0).intValue(), 1);
+        Assert.assertEquals(output.get(1).intValue(), 4);
+        Assert.assertEquals(output.get(2).intValue(), 9);
+    }
 }


### PR DESCRIPTION
@lbergelson Here's another attempt to write functional code without all that Java boilerplate.  Instead of `list.stream().map(func).collect(Collectors.toList())` it's `Utils.map(list, func)`.  This saves 30 characters in a very common pattern and renders a lot of crowded one-liners much more readable.  If you approve, can you review or suggest someone trustworthy?