### PR TITLE
Add ShardingArgumentCollection for shard intervals in differtent tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/AssemblyRegionWalkerShardingArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/AssemblyRegionWalkerShardingArgumentCollection.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.barclay.argparser.Argument;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class AssemblyRegionWalkerShardingArgumentCollection extends ShardingArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+
+    @Argument(fullName="readShardSize", shortName="readShardSize", doc = "Maximum size of each read shard, in bases. For good performance, this should be much larger than the maximum assembly region size.", optional = true)
+    protected int readShardSize;
+
+    @Argument(fullName="readShardPadding", shortName="readShardPadding", doc = "Each read shard has this many bases of extra context on each side. Read shards must have as much or more padding than assembly regions.", optional = true)
+    protected int readShardPadding;
+
+    public AssemblyRegionWalkerShardingArgumentCollection(final int defaultReadShardSize, final int defaultReadShardPadding) {
+        this.readShardSize = defaultReadShardSize;
+        this.readShardPadding = defaultReadShardPadding;
+    }
+
+    @Override
+    public int getShardSize() {
+        return readShardSize;
+    }
+
+    @Override
+    public int getShardPadding() {
+        return readShardPadding;
+    }
+
+    @Override
+    public int getShardStep() {
+        return readShardSize;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ShardingArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ShardingArgumentCollection.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineException;
+
+import java.io.Serializable;
+
+/**
+ * Argument collection for shard intervals.
+ *
+ * Note: it does not include any specific AssemblyRegionWalker parameter, just parameters to generate {@link org.broadinstitute.hellbender.engine.Shard}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class ShardingArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * If readShardSize is set to this value, we will not shard the user's intervals. Instead,
+     * we'll create one shard per interval (or one shard per contig, if intervals are not explicitly specified)
+     */
+    public static final int NO_INTERVAL_SHARDING = -1;
+
+    public abstract int getShardSize();
+
+    public abstract int getShardPadding();
+
+    public abstract int getShardStep();
+
+    /**
+     * Validates the arguments.
+     * @throws CommandLineException.BadArgumentValue if they are not valid
+     */
+    public final void validateArguments() {
+        if ( getShardSize() <= 0 && getShardSize() != NO_INTERVAL_SHARDING) {
+            throw new CommandLineException.BadArgumentValue("read shard size must be > 0 or " + NO_INTERVAL_SHARDING + " for no sharding");
+        }
+
+        if ( getShardStep() <= 0 ) {
+            throw new CommandLineException.BadArgumentValue("shard step must be > 0");
+        }
+
+        if ( getShardPadding() < 0 ) {
+            throw new CommandLineException.BadArgumentValue("shard padding must be >= 0");
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalker.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.ShardingArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.ExampleProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -36,7 +37,7 @@ public final class ExampleAssemblyRegionWalker extends AssemblyRegionWalker {
     private PrintStream outputStream = null;
 
     @Override
-    protected int defaultReadShardSize() { return NO_INTERVAL_SHARDING; }
+    protected int defaultReadShardSize() { return ShardingArgumentCollection.NO_INTERVAL_SHARDING; }
 
     @Override
     protected int defaultReadShardPadding() { return 100; }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -10,6 +10,7 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReferenceInputArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.ShardingArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
@@ -139,7 +140,7 @@ import java.util.List;
 @BetaFeature
 public final class HaplotypeCaller extends AssemblyRegionWalker {
 
-    public static final int DEFAULT_READSHARD_SIZE = NO_INTERVAL_SHARDING;
+    public static final int DEFAULT_READSHARD_SIZE = ShardingArgumentCollection.NO_INTERVAL_SHARDING;
     public static final int DEFAULT_READSHARD_PADDING = 100;
     public static final int DEFAULT_MIN_ASSEMBLY_REGION_SIZE = 50;
     public static final int DEFAULT_MAX_ASSEMBLY_REGION_SIZE = 300;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -10,6 +10,7 @@ import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.ShardingArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
@@ -196,7 +197,7 @@ public final class Mutect2 extends AssemblyRegionWalker {
     private Mutect2Engine m2Engine;
 
     @Override
-    protected int defaultReadShardSize() { return NO_INTERVAL_SHARDING; }
+    protected int defaultReadShardSize() { return ShardingArgumentCollection.NO_INTERVAL_SHARDING; }
 
     @Override
     protected int defaultReadShardPadding() { return 100; }


### PR DESCRIPTION
As part of my work to do a walker for sliding-window processing, I implemented a very simple argument collection for sharding intervals. As an example, I included in the `AssemblyRegionWalker`to allow users to also set the shard step in case they want to apply it.

It also allows to specify a window-step to `AssemblyRegionWalker`.