### PR TITLE
Add LocalVariantShard use in the same way as LocalReadShard

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/LocalReadShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocalReadShard.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -12,10 +11,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * A class to represent a shard of reads data, optionally expanded by a configurable amount of padded data.
@@ -101,38 +97,6 @@ public final class LocalReadShard implements Shard<GATKRead> {
     }
 
     /**
-     * @return number of bases of padding to the left of our interval
-     */
-    public int numLeftPaddingBases() {
-        return interval.getStart() - paddedInterval.getStart();
-    }
-
-    /**
-     * @return number of bases of padding to the right of our interval
-     */
-    public int numRightPaddingBases() {
-        return paddedInterval.getEnd() - interval.getEnd();
-    }
-
-    /**
-     * @param loc Locatable to test
-     * @return true if loc is completely contained within this shard's interval, otherwise false
-     */
-    public boolean contains(final Locatable loc) {
-        Utils.nonNull(loc);
-        return interval.contains(loc);
-    }
-
-    /**
-     * @param loc Locatable to test
-     * @return true if loc starts within this shard's interval, otherwise false
-     */
-    public boolean containsStartPosition(final Locatable loc) {
-        Utils.nonNull(loc);
-        return interval.contains(new SimpleInterval(loc.getContig(), loc.getStart(), loc.getStart()));
-    }
-
-    /**
      * @return an iterator over reads in this shard, as filtered using the configured read filter
      *         and downsampled using the configured downsampler; reads are lazily loaded rather than pre-loaded
      *
@@ -162,7 +126,7 @@ public final class LocalReadShard implements Shard<GATKRead> {
      * Note that any read filtering is always performed before any downsampling.
      */
     public List<GATKRead> loadAllReads() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(), Spliterator.ORDERED), false).collect(Collectors.toList());
+        return loadAllRecords();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocalVariantShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocalVariantShard.java
@@ -1,0 +1,110 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.iterators.FilteringIterator;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A class to represent a shard of variant data, optionally expanded by a configurable amount of padded data.
+ *
+ * The reads are lazily loaded by default (when accessing the reads via {@link #iterator}. Loading all the
+ * reads in the shard at once is possible via {@link #loadAllRecords()}.
+ *
+ * The variants returned will overlap the expanded padded interval. It's possible to query whether they are within
+ * the main part of the shard via {@link #contains} and {@link #containsStartPosition}.
+ *
+ * The variants in the shard can be filtered via {@link #loadAllRecords()} (no filtering is performed by default).
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class LocalVariantShard implements Shard<VariantContext> {
+
+    private final SimpleInterval interval;
+    private final SimpleInterval paddedInterval;
+    private final GATKDataSource<VariantContext> variantSource;
+    private VariantFilter variantFilter;
+
+    /**
+     * Create a new Shard spanning the specified interval, with the specified amount of padding.
+     *
+     * @param interval       the genomic span covered by this shard
+     * @param paddedInterval the span covered by this shard, plus any additional padding on each side (must contain the un-padded interval)
+     * @param variantSource  source of variants from which to populate this shard
+     */
+    public LocalVariantShard(final SimpleInterval interval, final SimpleInterval paddedInterval, final GATKDataSource<VariantContext> variantSource) {
+        Utils.nonNull(interval);
+        Utils.nonNull(paddedInterval);
+        Utils.nonNull(variantSource);
+        Utils.validateArg(paddedInterval.contains(interval), "The padded interval must contain the un-padded interval");
+
+        this.interval = interval;
+        this.paddedInterval = paddedInterval;
+        this.variantSource = variantSource;
+    }
+
+    /**
+     * Create a new Shard spanning the specified interval, with no additional padding
+     *
+     * @param interval      the genomic span covered by this shard
+     * @param variantSource source of reads from which to populate this shard
+     */
+    public LocalVariantShard(final SimpleInterval interval, final GATKDataSource<VariantContext> variantSource) {
+        this(interval, interval, variantSource);
+    }
+
+    /**
+     * Variants in this shard will be filtered using this filter before being returned.
+     *
+     * @param filter filter to use (may be null, which signifies that no filtering is to be performed)
+     */
+    public void setVariantFilter(final VariantFilter filter) {
+        this.variantFilter = filter;
+    }
+
+    @Override
+    public SimpleInterval getInterval() {
+        return interval;
+    }
+
+    @Override
+    public SimpleInterval getPaddedInterval() {
+        return paddedInterval;
+    }
+
+    /**
+     * @return an iterator over variants in this shard, as filtered using the configured variant filter
+     * variants are lazily loaded rather than pre-loaded
+     */
+    @Override
+    public Iterator<VariantContext> iterator() {
+        final Iterator<VariantContext> iterator = variantSource.query(paddedInterval);
+        return (variantFilter == null) ? iterator : new FilteringIterator<>(iterator, variantFilter);
+    }
+
+    /**
+     * Divide an interval into LocalVariantShard. Each shard will cover up to shardSize bases, include shardPadding
+     * bases of extra padding on either side, and begin shardStep bases after the previous shard.
+     *
+     * @param interval interval to shard; must be on the contig according to the provided dictionary
+     * @param shardSize desired shard size; intervals larger than this will be divided into shards of up to this size
+     * @param shardStep each shard will begin this many bases away from the previous shard
+     * @param shardPadding desired shard padding; each shard's interval will be padded on both sides by this number of bases (may be 0)
+     * @param variantSource data source for variants
+     * @param dictionary sequence dictionary for variants
+     * @return List of {@link LocalReadShard} objects spanning the interval
+     */
+    public static List<LocalVariantShard> divideIntervalIntoShards(final SimpleInterval interval, final int shardSize, final int shardStep, final int shardPadding, final GATKDataSource<VariantContext> variantSource, final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(variantSource);
+        return Shard.divideIntervalIntoShards(interval, shardSize, shardStep, shardPadding, dictionary)
+                .stream().map(shardBoundary -> new LocalVariantShard(shardBoundary.getInterval(), shardBoundary.getPaddedInterval(), variantSource))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/FilteringIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/FilteringIterator.java
@@ -1,0 +1,65 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+/**
+ * An iterator that filters objects from an existing iterator of T.
+ */
+public class FilteringIterator<T> implements Iterator<T>, Iterable<T> {
+
+    private final Iterator<T> nestedIterator;
+    private final Predicate<T> filter;
+    private T next;
+
+    /**
+     * Create a FilteringIterator given a pre-existing iterator of T and a filter.
+     * Only objects that pass the filter will be returned from this iterator.
+     *
+     * @param nestedIterator underlying iterator from which to pull reads (may not be null)
+     * @param filter filter to apply to the iterator (may not be null)
+     */
+    public FilteringIterator( final Iterator<T> nestedIterator, final Predicate<T> filter ) {
+        Utils.nonNull(nestedIterator);
+        Utils.nonNull(filter);
+
+        this.nestedIterator = nestedIterator;
+        this.filter = filter;
+        this.next = loadNextRead();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    @Override
+    public T next() {
+        if ( ! hasNext() ) {
+            throw new NoSuchElementException("Iterator exhausted");
+        }
+
+        final T toReturn = next;
+        next = loadNextRead();
+        return toReturn;
+    }
+
+    private T loadNextRead() {
+        while ( nestedIterator.hasNext() ) {
+            final T candidate = nestedIterator.next();
+            if ( filter.test(candidate) ) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/ReadFilteringIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/ReadFilteringIterator.java
@@ -6,15 +6,12 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
 
 /**
  * An iterator that filters reads from an existing iterator of reads.
  */
-public class ReadFilteringIterator implements Iterator<GATKRead>, Iterable<GATKRead> {
-
-    private final Iterator<GATKRead> nestedIterator;
-    private final ReadFilter readFilter;
-    private GATKRead nextRead;
+public class ReadFilteringIterator extends FilteringIterator<GATKRead> {
 
     /**
      * Create a ReadFilteringIterator given a pre-existing iterator of reads and a read filter.
@@ -23,43 +20,8 @@ public class ReadFilteringIterator implements Iterator<GATKRead>, Iterable<GATKR
      * @param nestedIterator underlying iterator from which to pull reads (may not be null)
      * @param readFilter filter to apply to the reads (may not be null)
      */
-    public ReadFilteringIterator( final Iterator<GATKRead> nestedIterator, final ReadFilter readFilter ) {
-        Utils.nonNull(nestedIterator);
-        Utils.nonNull(readFilter);
-
-        this.nestedIterator = nestedIterator;
-        this.readFilter = readFilter;
-        this.nextRead = loadNextRead();
+    public ReadFilteringIterator(Iterator<GATKRead> nestedIterator, ReadFilter readFilter) {
+        super(nestedIterator, readFilter);
     }
 
-    @Override
-    public boolean hasNext() {
-        return nextRead != null;
-    }
-
-    @Override
-    public GATKRead next() {
-        if ( ! hasNext() ) {
-            throw new NoSuchElementException("Iterator exhausted");
-        }
-
-        final GATKRead toReturn = nextRead;
-        nextRead = loadNextRead();
-        return toReturn;
-    }
-
-    private GATKRead loadNextRead() {
-        while ( nestedIterator.hasNext() ) {
-            final GATKRead candidate = nestedIterator.next();
-            if ( readFilter.test(candidate) ) {
-                return candidate;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public Iterator<GATKRead> iterator() {
-        return this;
-    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/FilteringIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/FilteringIteratorUnitTest.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.TextCigarCodec;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.engine.filters.VariantFilterLibrary;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public class FilteringIteratorUnitTest extends BaseTest {
+
+    private Iterator<GATKRead> makeReadsIterator() {
+        return Arrays.asList(
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("50M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("30M")),
+            ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode("101M"))
+        ).iterator();
+    }
+
+    private Iterator<VariantContext> makeVariantIterator() {
+        final VariantContextBuilder builder = new VariantContextBuilder().source("test").chr("1").alleles(
+            Arrays.asList(Allele.create("A", true), Allele.create("T")));
+        int pos = 1;
+        return Arrays.asList(
+            // 3 biallelic
+            builder.start(pos).stop(pos++).make(),
+            builder.start(pos).stop(pos++).make(),
+            builder.start(pos).stop(pos++).make(),
+            // 2 no biallelic
+            builder.start(pos).stop(pos++).alleles(Collections.singleton(Allele.create("C", true))).make(),
+            builder.start(pos).stop(pos).make()
+        ).iterator();
+    }
+
+    @DataProvider(name = "FilteringIteratorTestData")
+    public Object[][] filteringIteratorTestData() {
+        // read filters
+        final Predicate<GATKRead> allowNoReadsFilter = read -> false;
+        final Predicate<GATKRead> allowLongReadsFilter = read -> read.getLength() > 100;
+        // variant filters
+        final VariantFilter allowNoVariantFilter = variant -> false;
+        final VariantFilter allowNoBiallelic = VariantContext::isBiallelic;
+
+        return new Object[][] {
+            // testing read filters
+            {makeReadsIterator(), ReadFilterLibrary.ALLOW_ALL_READS, 5},
+            {makeReadsIterator(), allowNoReadsFilter, 0},
+            {makeReadsIterator(), allowLongReadsFilter, 3},
+            {makeVariantIterator(), VariantFilterLibrary.ALLOW_ALL_VARIANTS, 5 },
+            {makeVariantIterator(), allowNoVariantFilter, 0 },
+            {makeVariantIterator(), allowNoBiallelic, 3 }};
+    }
+
+    @Test(dataProvider = "FilteringIteratorTestData")
+    public void testFilteringIterator(final Iterator<Object> iter, final Predicate<Object> filter, final int expectedReadCount) {
+        final FilteringIterator<Object> filteringIterator = new FilteringIterator<>(iter, filter);
+        int count = 0;
+        for (final Object obj : filteringIterator) {
+            ++count;
+        }
+        Assert.assertEquals(count, expectedReadCount, "Wrong number of reads from the ReadFilteringIterator");
+    }
+}


### PR DESCRIPTION
The `SlidingWindowWalker` variant implementation (#1198) requires a similar class to `LocalReadShard` to perform sharding over variants. Here is a simple implementation based on the read one, which also includes:

* Move up to `Shard<T>` some methods in the read shard implementation.
* Extract a common `FilteringIterator` from `ReadFilteringIterator`