### PR TITLE
Throw CommandLineException for enabling twice the same read filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -204,6 +204,18 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      */
     @Override
     public void validateArguments() {
+        // throw if any filter is specified twice
+        final List<String> moreThanOnce = userReadFilterNames.stream()
+                .collect(Collectors.groupingBy(e -> e, Collectors.counting()))
+                .entrySet().stream().filter(e -> e.getValue() != 1)
+                .map(e -> e.getKey() + " (" + e.getValue() + ")")
+                .collect(Collectors.toList());
+        if (!moreThanOnce.isEmpty()) {
+            throw new CommandLineException.BadArgumentValue(
+                    String.format("The read filter(s) are specified more than once: %s",
+                            Utils.join(", ", moreThanOnce)));
+        }
+
         // throw if any filter is both enabled *and* disabled by the user
         final Set<String> enabledAndDisabled = new HashSet<>(userReadFilterNames);
         enabledAndDisabled.retainAll(disableFilters);

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -204,16 +204,15 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      */
     @Override
     public void validateArguments() {
-        // throw if any filter is specified twice
-        final List<String> moreThanOnce = userReadFilterNames.stream()
-                .collect(Collectors.groupingBy(e -> e, Collectors.counting()))
-                .entrySet().stream().filter(e -> e.getValue() != 1)
-                .map(e -> e.getKey() + " (" + e.getValue() + ")")
-                .collect(Collectors.toList());
-        if (!moreThanOnce.isEmpty()) {
+        // throw if any filter is duplicated
+        final Set<String> uniqueUserFiltersNames = new HashSet<>();
+        final Set<String> duplicateUserFilterNames = userReadFilterNames
+                .stream().filter(name -> !uniqueUserFiltersNames.add(name))
+                .collect(Collectors.toSet());
+        if (!duplicateUserFilterNames.isEmpty()) {
             throw new CommandLineException.BadArgumentValue(
                     String.format("The read filter(s) are specified more than once: %s",
-                            Utils.join(", ", moreThanOnce)));
+                            Utils.join(", ", duplicateUserFilterNames)));
         }
 
         // throw if any filter is both enabled *and* disabled by the user

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
@@ -164,13 +164,25 @@ public class ReadFilterPluginUnitTest {
         clp.parseArguments(System.out, new String[] {"--RF", "fakeFilter"});
     }
 
-    @Test(expectedExceptions = CommandLineException.BadArgumentValue.class)
-    public void testEnableTwiceFilter() {
+    @DataProvider(name = "duplicateFilters")
+    public Object[][] duplicateFilters() {
+        return new Object[][] {
+                {new String[] {
+                        "--RF", ReadLengthReadFilter.class.getSimpleName(),
+                        "--RF", ReadLengthReadFilter.class.getSimpleName()}},
+                {new String[] {
+                        "--RF", ReadFilterLibrary.MAPPED.getClass().getSimpleName(),
+                        "--RF", ReadLengthReadFilter.class.getSimpleName(),
+                        "--RF", ReadLengthReadFilter.class.getSimpleName()}
+                }
+        };
+    }
+
+    @Test(dataProvider = "duplicateFilters", expectedExceptions = CommandLineException.BadArgumentValue.class)
+    public void testEnableDuplicateFilter(final String[] arguments) {
         CommandLineParser clp = new CommandLineArgumentParser(new Object(),
                 Collections.singletonList(new GATKReadFilterPluginDescriptor(null)));
-        clp.parseArguments(System.out, new String[] {
-                "--RF", ReadLengthReadFilter.class.getSimpleName(),
-                "--RF", ReadLengthReadFilter.class.getSimpleName()});
+        clp.parseArguments(System.out, arguments);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterPluginUnitTest.java
@@ -164,6 +164,15 @@ public class ReadFilterPluginUnitTest {
         clp.parseArguments(System.out, new String[] {"--RF", "fakeFilter"});
     }
 
+    @Test(expectedExceptions = CommandLineException.BadArgumentValue.class)
+    public void testEnableTwiceFilter() {
+        CommandLineParser clp = new CommandLineArgumentParser(new Object(),
+                Collections.singletonList(new GATKReadFilterPluginDescriptor(null)));
+        clp.parseArguments(System.out, new String[] {
+                "--RF", ReadLengthReadFilter.class.getSimpleName(),
+                "--RF", ReadLengthReadFilter.class.getSimpleName()});
+    }
+
     @Test
     public void testDisableOneFilter() {
         CommandLineParser clp = new CommandLineArgumentParser(


### PR DESCRIPTION
Only for no default filters. If not, the composed filter will contain twice the filter one after the other.