### PR TITLE
Trivial formatting update for skip interval file parser

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
  */
 public final class SVUtils {
 
+    private static final String REFERENCE_GAP_INTERVAL_FILE_COMMENT_LINE_PROMPT = "#";
+
     /**
      * Read a file of kmers.
      * Each line must be exactly SVConstants.KMER_SIZE characters long, and must match [ACGT]*.
@@ -83,6 +85,9 @@ public final class SVUtils {
             int lineNo = 0;
             while ( (line = rdr.readLine()) != null ) {
                 ++lineNo;
+                if (line.startsWith(REFERENCE_GAP_INTERVAL_FILE_COMMENT_LINE_PROMPT)) {
+                    continue;
+                }
                 final String[] tokens = line.split("\t");
                 if ( tokens.length != 3 ) {
                     throw new GATKException("Interval file "+intervalsFile+" line "+


### PR DESCRIPTION
@tedsharpe please kindly review.
The skip interval that has the corresponding format lives here:
gs://sv-data-dsde-dev/reference/GRCh38.kill.intervals

and was generated by 
gs://sv-data-dsde-dev/extra_input_generator_scripts