### PR TITLE
splitting tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ jdk:
 - oraclejdk8
 env:
   matrix:
-  - CLOUD=mandatory
-  - CLOUD=false
+  - TEST_TYPE=cloud
+  - TEST_TYPE=integration TEST_VERBOSITY=minimal
+  - TEST_TYPE=unit TEST_VERBOSITY=minimal
   global:
   #for genomics db
   - LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/dependencies/libcsv/.libs
@@ -36,8 +37,6 @@ env:
   - secure: "E0LWXgX3aWSE/DWHXXDx4vrAq4uX6vKg402wToaZ5otbHQ/UP0H7/FA5jomavAXoC46oMVHZcEltZ5OVhuJ0NW8yYxUCecJ1D/YvVQmnfFABcV/qLM+k4e2rYQOKVw/pejB2gG8XdTA+XE2WyTeENbmIkputS8f1ndKWCmZxuuk="
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: CLOUD=todo
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:
@@ -61,26 +60,25 @@ before_install:
 - sudo apt-get install -y --force-yes r-base
 - R --version
 install:
-- if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
+- if [[ $TRAVIS_SECURE_ENV_VARS == false && $TEST_TYPE == cloud ]]; then
     echo "Can't run cloud tests without keys so don't bother building";
   else
     ./gradlew assemble;
     ./gradlew installDist;
   fi
 script:
-#basic sanity test to check that gatk-launch actually runs something
-- ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam
 #run tests
 #install git-lfs
-- if [[ $TRAVIS_SECURE_ENV_VARS == false && $CLOUD == mandatory ]]; then
+- if [[ $TRAVIS_SECURE_ENV_VARS == false && $TEST_TYPE == cloud ]]; then
     echo "Can't run cloud tests without keys so don't run tests";
   else
+    ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     bash scripts/install_git_lfs.sh;
     travis_wait 30 ./gradlew jacocoTestReport;
   fi
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- if [[ $TRAVIS_BRANCH == master && $CLOUD == false ]]; then ./gradlew uploadArchives; fi
+- if [[ $TRAVIS_BRANCH == master && $TEST_TYPE == integration ]]; then ./gradlew uploadArchives; fi
 after_failure:
 - dmesg | tail -100
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,11 +67,13 @@ install:
     ./gradlew installDist;
   fi
 script:
-#run tests
-#install git-lfs
+# run a basic sanity check to be sure that gatk-launch doesn't explode
+# install git-lfs
+# run tests
 - if [[ $TRAVIS_SECURE_ENV_VARS == false && $TEST_TYPE == cloud ]]; then
     echo "Can't run cloud tests without keys so don't run tests";
   else
+
     ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     bash scripts/install_git_lfs.sh;
     travis_wait 30 ./gradlew jacocoTestReport;

--- a/README.md
+++ b/README.md
@@ -199,15 +199,24 @@ If you are looking for the codebase of the current production version of GATK, p
 
 ##Testing GATK4
 
-* To run all tests, run **`./gradlew test`**.
-    * Test report is in `build/reports/tests/index.html`.
-    * What will happen depends on the value of the `CLOUD` environment variable: if it's `false` or
-      unset then only local tests are run, if it's `mandatory` then it'll run only the cloud tests,
-      and if it's `together` it will run both sets of tests.
+* To run the tests, run **`./gradlew test`**.
+    * Test report is in `build/reports/tests/test/index.html`.
+    * What will happen depends on the value of the `TEST_TYPE` environment variable: 
+       * unset or any other value         : run non-cloud unit and integration tests, this is the default
+       * `cloud`, `unit`, `integration`   : run only the cloud, unit, or integration tests
+       * `all`                            : run the entire test suite
+
+         
     * Note that `git lfs` must be installed and set up as described in the "Requirements" section above
       in order for all tests to pass.
     * Cloud tests require being logged into `gcloud` and authenticated with a project that has access
-      to the test data.
+      to the test data.  They also require setting several certain environment variables.
+      * `HELLBENDER_TEST_PROJECT` : your google cloud project 
+      * `HELLBENDER_TEST_APIKEY` : your google cloud API key
+      * `HELLBENDER_TEST_STAGING` : a gs:// path to a writable location
+      * `HELLBENDER_TEST_INPUTS` : path to cloud test data, ex: gs://hellbender/test/resources/
+      
+    * setting the environment variable `TEST_VERBOSITY=minimal` will produce much less output from the test suite 
 
 * To run a subset of tests, use gradle's test filtering (see [gradle doc](https://docs.gradle.org/current/userguide/java_plugin.html)), e.g.,
     * `./gradlew test --tests *SomeSpecificTestClass`
@@ -215,7 +224,7 @@ If you are looking for the codebase of the current production version of GATK, p
     * `./gradlew test --tests *SomeTest.someSpecificTestMethod`
 
 * To run tests and compute coverage reports, run **`./gradlew jacocoTestReport`**. The report is then in `build/reports/jacoco/test/html/index.html`.
-  (IntelliJ 14 has a good coverage tool that is preferable for development).
+  (IntelliJ has a good coverage tool that is preferable for development).
 
 * We use [Travis-CI](https://travis-ci.org/broadinstitute/gatk) as our continuous integration provider.
 

--- a/build.gradle
+++ b/build.gradle
@@ -211,16 +211,24 @@ tasks.withType(Jar) {
 test {
     outputs.upToDateWhen { false }  //tests will never be "up to date" so you can always rerun them
     String TEST_VERBOSITY = "$System.env.TEST_VERBOSITY"
+
+    /**
+     * Valid options for TEST_TYPE are:
+     * cloud, integration, unit  : run one of the three disjoint partitions of the test suite
+     * all                       : run all the tests
+     * anything else             : run the non-cloud tests
+     */
     String TEST_TYPE = "$System.env.TEST_TYPE"
+
     useTestNG {
         if (TEST_TYPE == "cloud") {
             // run only the cloud tests
             includeGroups 'cloud', 'bucket'
         } else if (TEST_TYPE == "integration"){
-            include "**/*IntegrationTest*"
+            include "**/*IntegrationTest.class"
             excludeGroups "cloud", "bucket"
         } else if (TEST_TYPE == "unit") {
-            exclude "**/*IntegrationTest*"
+            exclude "**/*IntegrationTest.class"
             excludeGroups "cloud", "bucket"
         } else if (TEST_TYPE == "all"){
             //include everything
@@ -228,7 +236,7 @@ test {
             excludeGroups "cloud", "bucket"
         }
     }
-    
+
     systemProperty "samjdk.use_async_io_read_samtools", "false"
     systemProperty "samjdk.use_async_io_write_samtools", "true"
     systemProperty "samjdk.use_async_io_write_tribble", "false"

--- a/build.gradle
+++ b/build.gradle
@@ -210,33 +210,25 @@ tasks.withType(Jar) {
 
 test {
     outputs.upToDateWhen { false }  //tests will never be "up to date" so you can always rerun them
-    String CI = "$System.env.CI"
-    String CLOUD = "$System.env.CLOUD"
-    String SPARK = "$System.env.SPARK"
-    useTestNG{
-        if (CLOUD =="mandatory") {
+    String TEST_VERBOSITY = "$System.env.TEST_VERBOSITY"
+    String TEST_TYPE = "$System.env.TEST_TYPE"
+    useTestNG {
+        if (TEST_TYPE == "cloud") {
             // run only the cloud tests
             includeGroups 'cloud', 'bucket'
-        } else if (CLOUD == "todo") {
-            // run only the in-development cloud tests
-            includeGroups 'cloud_todo', 'bucket_todo'
-        } else if (CLOUD == "together") {
-            // run both local tests and mandatory cloud tests, together.
-            // This is good when e.g. you are done for the day and want to run tests on your machine overnight.
-            excludeGroups 'cloud_todo', 'bucket_todo'
+        } else if (TEST_TYPE == "integration"){
+            include "**/*IntegrationTest*"
+            excludeGroups "cloud", "bucket"
+        } else if (TEST_TYPE == "unit") {
+            exclude "**/*IntegrationTest*"
+            excludeGroups "cloud", "bucket"
+        } else if (TEST_TYPE == "all"){
+            //include everything
         } else {
-            // run only the local tests
-            excludeGroups 'cloud', 'bucket', 'cloud_todo', 'bucket_todo'
-        }
-        if (SPARK == "false") {
-            // exclude Spark tests
-            doFirst {
-                println( "Skipping Spark Tests")
-            }
-            excludeGroups 'spark'
+            excludeGroups "cloud", "bucket"
         }
     }
-
+    
     systemProperty "samjdk.use_async_io_read_samtools", "false"
     systemProperty "samjdk.use_async_io_write_samtools", "true"
     systemProperty "samjdk.use_async_io_write_tribble", "false"
@@ -248,8 +240,7 @@ test {
     minHeapSize = "1G"
     maxHeapSize = "4G"
 
-
-    if (CI == "true" && CLOUD == "false" ) {
+    if (TEST_VERBOSITY == "minimal") {
         int count = 0
         // listen to events in the test execution lifecycle
 
@@ -283,8 +274,8 @@ test {
             }
         }
     }
-
 }
+
 
 task wrapper(type: Wrapper) {
     gradleVersion = '3.1'


### PR DESCRIPTION
tests will now run as cloud, integration, and unit on travis
this reduces our wallclock time from 30ish -> 20ish minutes

cleaned up some wierdness in the way things were specified as well