### PR TITLE
GATKReadFilterPluginDescriptor fixes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -77,7 +77,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
                     className = rfClass.getName();
                 }
                 // we want to remember the order in which these were provided, and also keep the
-                // actual instances in case they have any additiona any state provided by the tool
+                // actual instances in case they have any additional state provided by the tool
                 // when they were created
                 toolDefaultReadFilterNamesInOrder.add(className);
                 toolDefaultReadFilters.put(className, f);
@@ -189,7 +189,10 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
 
     /**
      * Get the list of default plugins used for this instance of this descriptor. Used for help/doc generation.
-     * @return List of T
+     *
+     * NOTE: this method does not account for disabled default filters and just return ALL default instances.
+     * The refactored interface in Barclay changes it's contract to allows returning a list with only 'enabled' default
+     * instances. We'll change the implementation when we integrate the updated interface.
      */
     @Override
     public List<Object> getDefaultInstances() { return new ArrayList<>(toolDefaultReadFilters.values()); }
@@ -261,7 +264,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
             }
         });
 
-        // warn on redundant enabling of filters already enabled by default
+        // warn if a filter is both default and enabled by the user
         final Set<String> redundant = new HashSet<>(toolDefaultReadFilters.keySet());
         redundant.retainAll(userEnabledReadFilterNames);
         redundant.forEach(

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -20,6 +20,7 @@ public final class StandardArgumentDefinitions {
     public static final String ASSUME_SORTED_LONG_NAME = "assumeSorted";
     public static final String READ_FILTER_LONG_NAME = "readFilter";
     public static final String DISABLE_READ_FILTER_LONG_NAME = "disableReadFilter";
+    public static final String DISABLE_TOOL_DEFAULT_READ_FILTERS = "disableToolDefaultReadFilters";
     public static final String CREATE_OUTPUT_BAM_INDEX_LONG_NAME = "createOutputBamIndex";
     public static final String CREATE_OUTPUT_BAM_MD5_LONG_NAME = "createOutputBamMD5";
     public static final String CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME = "createOutputVariantIndex";

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -224,10 +224,10 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
     public Object[][] testReadFilterData() {
         return new Object[][]{
                 {"print_reads_one_malformed_read.sam", null, ".sam", Collections.emptyList(), 7},
-                {"print_reads_one_malformed_read.sam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads_one_malformed_read.sam", null, ".sam", Arrays.asList("--disableToolDefaultReadFilters"), 8},
                 {"print_reads_one_malformed_read.sam", null, ".sam",
                         Arrays.asList("--disableReadFilter", "WellformedReadFilter"), 8},
-                {"print_reads.sorted.sam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads.sorted.sam", null, ".sam", Arrays.asList("--disableToolDefaultReadFilters"), 8},
                 {"print_reads.sorted.sam", null, ".sam",
                         Arrays.asList(
                                 "--readFilter", ReadNameReadFilter.class.getSimpleName(),
@@ -253,7 +253,7 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
                                 "--minReadLength", "100",
                                 "--maxReadLength", "101"),
                         2},
-                {"print_reads.sorted.bam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads.sorted.bam", null, ".sam", Arrays.asList("--disableToolDefaultReadFilters"), 8},
                 {"print_reads.sorted.bam", null, ".sam",
                         Arrays.asList(
                                 "--readFilter", ReadNameReadFilter.class.getSimpleName(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -227,7 +227,7 @@ public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest
     public Object[][] testReadFilterData() {
         return new Object[][]{
                 {"print_reads_one_malformed_read.sam", null, ".sam", Collections.emptyList(), 7},
-                {"print_reads_one_malformed_read.sam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads_one_malformed_read.sam", null, ".sam", Arrays.asList("--disableToolDefaultReadFilters"), 8},
                 {"print_reads_one_malformed_read.sam", null, ".sam",
                         Arrays.asList("--disableReadFilter", "WellformedReadFilter"), 8},
                 {"print_reads.sorted.sam", null, ".sam",
@@ -255,7 +255,7 @@ public final class PrintReadsSparkIntegrationTest extends CommandLineProgramTest
                                 "--minReadLength", "100",
                                 "--maxReadLength", "101"),
                         2},
-                {"print_reads.sorted.bam", null, ".sam", Arrays.asList("--disableAllReadFilters"), 8},
+                {"print_reads.sorted.bam", null, ".sam", Arrays.asList("--disableToolDefaultReadFilters"), 8},
                 {"print_reads.sorted.bam", null, ".sam",
                         Arrays.asList(
                                 "--readFilter", ReadNameReadFilter.class.getSimpleName(),


### PR DESCRIPTION
- Disable default read filter with arguments does not longer blows up  but log a warning (fixes #2357)
- Improved help message for read filter (fixes #2358 and #2398)
- `--disableAllReadFilters` changed to `--disableToolDefaultReadFilters` and `isDisabledFilter()` honor this behavior (fixes #2361 and #2363)
- Add test for exercise the path of logging a warning when disabling a  not enabled filter (as proposed in #2377)
- Disabling a non-existent read filter throws a `CommandLineException`  (fixes #2397)