### PR TITLE
publishing a master-snapshot update on every push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,11 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - if [[ $TRAVIS_BRANCH == master && $TEST_TYPE == integration ]]; then ./gradlew uploadArchives; fi
+# if this is actually a commit to master and not a pull request build into master, then publish master-snapshot
+- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && $TEST_TYPE == integration ]]; then 
+    git tag master;
+    ./gradlew uploadArchives; 
+  fi
 after_failure:
 - dmesg | tail -100
 after_script:


### PR DESCRIPTION
This would publish master-SNAPSHOT on every commit to master.  It would give people a single moving snapshot to build off of if they wanted to be on the bleeding edge.

Fixes #1995 

It's hard to test that it pushes only on commits to master without committing to master... but I think it should work.