### PR TITLE
Allow tests to fail gracefully if HELLBENDER_TEST_INPUTS isn't set.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerGCSSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerGCSSupportIntegrationTest.java
@@ -17,8 +17,8 @@ import java.util.List;
  */
 public class VariantWalkerGCSSupportIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_VCF_ON_GCS = getGCPTestInputPath() + "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf";
-    private static final String TEST_BGZIPPED_VCF_ON_GCS = getGCPTestInputPath() + "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf.block.gz";
+    private static final String TEST_VCF_ON_GCS = "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf";
+    private static final String TEST_BGZIPPED_VCF_ON_GCS = "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf.block.gz";
     private static final String EXPECTED_OUTPUT_DIR = publicTestDir + "org/broadinstitute/hellbender/engine/GCSTests/";
 
     @Override
@@ -58,7 +58,7 @@ public class VariantWalkerGCSSupportIntegrationTest extends CommandLineProgramTe
         }
 
         final IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -V " + vcf +
+                " -V " + getGCPTestInputPath() + vcf +
                 intervalArg +
                 " -O %s",
                 Collections.singletonList(expectedOutput)


### PR DESCRIPTION
The entire test suite aborts if HELLBENDER_TEST_INPUTS isn't set because an exception is thrown when loading the VariantWalkerGCSSupportIntegrationTest class.

With this change, the tests will still fail, but the rest of the test suite will run. Depending on what the intent for these tests is, another possibility would be to add a dependsOn method with a hard dependency so the tests would be skipped in the case of no env variable.