### PR TITLE
Improve error message for no-access and disabled-account cases

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender;
 
+import com.google.cloud.storage.StorageException;
 import htsjdk.samtools.util.StringUtil;
 import org.broadinstitute.hellbender.cmdline.ClassFinder;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -148,6 +149,9 @@ public class Main {
         } catch (final UserException e){
             handleUserException(e);
             System.exit(USER_EXCEPTION_EXIT_VALUE);
+        } catch (final StorageException e) {
+            handleStorageException(e);
+            System.exit(ANY_OTHER_EXCEPTION_EXIT_VALUE);
         } catch (final Exception e){
             handleNonUserException(e);
             System.exit(ANY_OTHER_EXCEPTION_EXIT_VALUE);
@@ -188,6 +192,24 @@ public class Main {
      * @param exception the exception to handle (never an {@link UserException}).
      */
     protected void handleNonUserException(final Exception exception) {
+        exception.printStackTrace();
+    }
+
+    /**
+     * Handle any exception that does not come from the user. Default implementation prints the stack trace.
+     * @param exception the exception to handle (never an {@link UserException}).
+     */
+    protected void handleStorageException(final StorageException exception) {
+        // HTTP error code
+        System.out.println("code:      " + exception.getCode());
+        // user-friendly message
+        System.out.println("message:   " + exception.getMessage());
+        // short reason code, eg. "invalidArgument"
+        System.out.println("reason:    " + exception.getReason());
+        // eg. the name of the argument that was invalid
+        System.out.println("location:  " + exception.getLocation());
+        // true indicates the server thinks the same request may succeed later
+        System.out.println("retryable: " + exception.isRetryable());
         exception.printStackTrace();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -72,6 +72,10 @@ public class UserException extends RuntimeException {
             super(String.format("Couldn't read file %s. Error was: %s", file.toAbsolutePath().toUri(), message));
         }
 
+        public CouldNotReadInputFile(Path file, String message, Throwable cause) {
+            super(String.format("Couldn't read file %s. Error was: %s", file.toAbsolutePath().toUri(), message), cause);
+        }
+
         public CouldNotReadInputFile(String file, String message) {
             super(String.format("Couldn't read file %s. Error was: %s", file, message));
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -577,16 +577,6 @@ public final class IOUtils {
             }
         } catch (com.google.cloud.storage.StorageException cloudBoom) {
             // probably a permissions problem, or perhaps a disabled account.
-            logger.debug(cloudBoom.toString());
-            logger.debug("code: " + cloudBoom.getCode());
-            logger.debug("location: " + cloudBoom.getLocation());
-            logger.debug("reason: " + cloudBoom.getReason());
-            logger.debug("message: " + cloudBoom.getMessage());
-            String msg = "";
-            for (StackTraceElement x : cloudBoom.getStackTrace()) {
-                msg += x.toString() + "\n";
-            }
-            logger.debug("stack trace:\n" + msg);
             // Looks like this for a disabled bucket error:
             //   A USER ERROR has occurred: Couldn't read file gs://foo/bar. Error was:
             //   403: The account for bucket "foo" has been disabled.
@@ -594,6 +584,8 @@ public final class IOUtils {
             // (use `gcloud auth application-default revoke` to forget the default credentials)
             //   A USER ERROR has occurred: Couldn't read file gs://(...). Error was:
             //   401: Anonymous users does not have storage.objects.get access to object (...).
+            // The user can see the underlying exception by passing
+            // -DGATK_STACKTRACE_ON_USER_EXCEPTION=true
             throw new UserException.CouldNotReadInputFile(path, cloudBoom.getCode() + ": " + cloudBoom.getMessage(), cloudBoom);
         }
     }


### PR DESCRIPTION
*before*: GATK crashes with a stack trace. The stack trace contains useful
info, but:
 * it's hard to read
 * it doesn't include the name of the file we cannot access

*now*, a better message that addresses both issues:
> A USER ERROR has occurred: Couldn't read file gs://(...). Error was:
> 401: Anonymous users does not have storage.objects.get access to object (...).

Additional information (including a stack trace) is displayed if the
user specifies `--verbosity=DEBUG`