### PR TITLE
Scripts running the whole sv-pipeline as exists now from birth to termination

### DIFF
--- a/scripts/sv/alignAssembly.sh
+++ b/scripts/sv/alignAssembly.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu
+
+if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PROJECT_OUTPUT_DIR+x} ]]; then 
+    if [[ "$#" -ne 3 ]]; then
+        echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    exit 1
+    fi
+    GATK_DIR=$1
+    CLUSTER_NAME=$2
+    OUTPUT_DIR=$3
+    MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+    PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
+fi
+
+cd "$GATK_DIR" 
+
+./gatk-launch AlignAssembledContigsSpark \
+    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
+    --inputFile "$PROJECT_OUTPUT_DIR"/assembly_0 \
+    -O "$PROJECT_OUTPUT_DIR"/aligned_assemblies \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \
+    --driver-memory 30G \
+    --executor-memory 30G \
+    --num-executors 20 \
+    --conf spark.yarn.executor.memoryOverhead=16000

--- a/scripts/sv/alignAssembly.sh
+++ b/scripts/sv/alignAssembly.sh
@@ -14,7 +14,7 @@ if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PR
     PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
 fi
 
-REFERENCE_IMG_LOCATION="$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta.64.img
+REFERENCE_IMG_LOCATION=/reference/Homo_sapiens_assembly19.fasta.64.img
 
 echo "Assuming reference image: " "$REFERENCE_IMG_LOCATION"
 

--- a/scripts/sv/alignAssembly.sh
+++ b/scripts/sv/alignAssembly.sh
@@ -14,10 +14,14 @@ if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PR
     PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
 fi
 
+REFERENCE_IMG_LOCATION="$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta.64.img
+
+echo "Assuming reference image: " "$REFERENCE_IMG_LOCATION"
+
 cd "$GATK_DIR" 
 
 ./gatk-launch AlignAssembledContigsSpark \
-    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
+    --bwamemIndexImage "$REFERENCE_IMG_LOCATION" \
     --inputFile "$PROJECT_OUTPUT_DIR"/assembly_0 \
     -O "$PROJECT_OUTPUT_DIR"/aligned_assemblies \
     -- \

--- a/scripts/sv/assembly.sh
+++ b/scripts/sv/assembly.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu
+
+if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PROJECT_OUTPUT_DIR+x} ]]; then 
+    if [[ "$#" -ne 3 ]]; then
+        echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    exit 1
+    fi
+    GATK_DIR=$1
+    CLUSTER_NAME=$2
+    OUTPUT_DIR=$3
+    MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+    PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
+fi
+
+cd "$GATK_DIR" 
+
+./gatk-launch RunSGAViaProcessBuilderOnSpark \
+    --fullPathToSGA /usr/local/bin/sga \
+    --inDir "$PROJECT_OUTPUT_DIR"/fastq \
+    --outDirPrefix "$PROJECT_OUTPUT_DIR"/assembly \
+    --subStringToStrip assembly \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \
+    --driver-memory 30G \
+    --executor-memory 8G \
+    --conf spark.yarn.executor.memoryOverhead=5000

--- a/scripts/sv/callVariants.sh
+++ b/scripts/sv/callVariants.sh
@@ -14,14 +14,19 @@ if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PR
     PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
 fi
 
+REFERENCE_LOCATION="$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta
+TWOBIT_REFERENCE_LOCATION="$MASTER_NODE"/reference/Homo_sapiens_assembly19.2bit
+echo "Assuming reference: " "$REFERENCE_LOCATION"
+echo "Assuming 2-bit reference: " "$TWOBIT_REFERENCE_LOCATION"
+
 cd "$GATK_DIR" 
 
 ./gatk-launch CallVariantsFromAlignedContigsSpark \
     --inputAlignments "$PROJECT_OUTPUT_DIR"/aligned_assemblies \
     --inputAssemblies "$PROJECT_OUTPUT_DIR"/assembly_0 \
     --outputPath "$PROJECT_OUTPUT_DIR"/variants \
-    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.2bit \
-    -fastaReference "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
+    -R "$TWOBIT_REFERENCE_LOCATION" \
+    -fastaReference "$REFERENCE_LOCATION" \
     -- \
     --sparkRunner GCS \
     --cluster "$CLUSTER_NAME" \

--- a/scripts/sv/callVariants.sh
+++ b/scripts/sv/callVariants.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eu
+
+if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PROJECT_OUTPUT_DIR+x} ]]; then 
+    if [[ "$#" -ne 3 ]]; then
+        echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    exit 1
+    fi
+    GATK_DIR=$1
+    CLUSTER_NAME=$2
+    OUTPUT_DIR=$3
+    MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+    PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
+fi
+
+cd "$GATK_DIR" 
+
+./gatk-launch CallVariantsFromAlignedContigsSpark \
+    --inputAlignments "$PROJECT_OUTPUT_DIR"/aligned_assemblies \
+    --inputAssemblies "$PROJECT_OUTPUT_DIR"/assembly_0 \
+    --outputPath "$PROJECT_OUTPUT_DIR"/variants \
+    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.2bit \
+    -fastaReference "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \
+    --driver-memory 30G \
+    --executor-memory 8G \
+    --conf spark.yarn.executor.memoryOverhead=5000

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -22,6 +22,6 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --num-workers 10 \
     --image-version preview \
     --project ${PROJECT} \
-    --initialization-actions gs://${INITIALIZATION_BUCKET}/initialization_scripts/dataproc_initialization_new_bucket.sh \
+    --initialization-actions gs://${INITIALIZATION_BUCKET}/initialization_scripts/dataproc_initialization_new_bucket_copy_ref_img.sh \
     --initialization-action-timeout 60m
 

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script creates a Google Dataproc cluster suitable for running the GATK-SV pipeline.
+# This script deletes a Google Dataproc cluster used for running the GATK-SV pipeline.
 
 set -eu
 if [[ "$#" -ne 3 ]]; then

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script creates a Google Dataproc cluster suitable for running the GATK-SV pipeline.
+
+set -eu
+if [[ "$#" -ne 3 ]]; then
+    echo "Please provide the project, the name of cluster, and the bucket where the data lives"
+    exit 1
+fi
+
+PROJECT=$1
+CLUSTER_NAME=$2
+INITIALIZATION_BUCKET=$3
+
+gcloud dataproc clusters create ${CLUSTER_NAME} \
+    --zone us-central1-a \
+    --master-machine-type n1-highmem-8 \
+    --num-worker-local-ssds 1 \
+    --worker-machine-type n1-highmem-16 \
+    --master-boot-disk-size 500 \
+    --worker-boot-disk-size 500 \
+    --num-workers 10 \
+    --image-version preview \
+    --project ${PROJECT} \
+    --initialization-actions gs://${INITIALIZATION_BUCKET}/initialization_scripts/dataproc_initialization_new_bucket.sh \
+    --initialization-action-timeout 60m
+

--- a/scripts/sv/delete_cluster.sh
+++ b/scripts/sv/delete_cluster.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script creates a Google Dataproc cluster suitable for running the GATK-SV pipeline.
+
+set -eu
+if [ "$#" -ne 1 ]; then
+    echo "Please provide name of cluster to be shutdown"
+    exit 1
+fi
+
+CLUSTER_NAME=$1
+
+gcloud dataproc clusters delete "$CLUSTER_NAME" --async

--- a/scripts/sv/scanBam.sh
+++ b/scripts/sv/scanBam.sh
@@ -14,13 +14,21 @@ if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PR
     PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
 fi
 
+REFERENCE_LOCATION="$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta
+INPUT_BAM="$MASTER_NODE"/data/NA12878_PCR-_30X.bam
+SKIP_INTERVAL_LIST="$MASTER_NODE"/reference/GRCh37.kill.intervals
+
+echo "Assuming reference: " "$REFERENCE_LOCATION"
+echo "Assuming input bam: " "$INPUT_BAM"
+echo "Assuming reference skip list: " "$SKIP_INTERVAL_LIST"
+
 cd "$GATK_DIR" 
 
 ./gatk-launch FindBreakpointEvidenceSpark \
-    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
-    -I "$MASTER_NODE"/data/NA12878_PCR-_30X.bam \
+    -R "$REFERENCE_LOCATION" \
+    -I "$INPUT_BAM" \
     -O "$PROJECT_OUTPUT_DIR"/fastq \
-    --exclusionIntervals "$MASTER_NODE"/reference/GRCh37.kill.intervals \
+    --exclusionIntervals "$SKIP_INTERVAL_LIST" \
     --kmersToIgnore "$MASTER_NODE"/reference/Homo_sapiens_assembly38.dups \
     --kmerIntervals "$PROJECT_OUTPUT_DIR"/kmerIntervals \
     --breakpointEvidenceDir "$PROJECT_OUTPUT_DIR"/evidence \

--- a/scripts/sv/scanBam.sh
+++ b/scripts/sv/scanBam.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+if [[ -z ${GATK_DIR+x} || -z ${CLUSTER_NAME+x} || -z ${MASTER_NODE+x} || -z ${PROJECT_OUTPUT_DIR+x} ]]; then 
+    if [[ "$#" -ne 3 ]]; then
+        echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    exit 1
+    fi
+    GATK_DIR=$1
+    CLUSTER_NAME=$2
+    OUTPUT_DIR=$3
+    MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+    PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
+fi
+
+cd "$GATK_DIR" 
+
+./gatk-launch FindBreakpointEvidenceSpark \
+    -R "$MASTER_NODE"/reference/Homo_sapiens_assembly19.fasta \
+    -I "$MASTER_NODE"/data/NA12878_PCR-_30X.bam \
+    -O "$PROJECT_OUTPUT_DIR"/fastq \
+    --exclusionIntervals "$MASTER_NODE"/reference/GRCh37.kill.intervals \
+    --kmersToIgnore "$MASTER_NODE"/reference/Homo_sapiens_assembly38.dups \
+    --kmerIntervals "$PROJECT_OUTPUT_DIR"/kmerIntervals \
+    --breakpointEvidenceDir "$PROJECT_OUTPUT_DIR"/evidence \
+    --breakpointIntervals "$PROJECT_OUTPUT_DIR"/intervals \
+    --qnameIntervalsMapped "$PROJECT_OUTPUT_DIR"/qnameIntervalsMapped \
+    --qnameIntervalsForAssembly "$PROJECT_OUTPUT_DIR"/qnameIntervalsForAssembly\
+    --maxFASTQSize 10000000 \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \
+    --num-executors 20 \
+    --driver-memory 30G \
+    --executor-memory 30G \
+    --conf spark.yarn.executor.memoryOverhead=5000

--- a/scripts/sv/svCall.sh
+++ b/scripts/sv/svCall.sh
@@ -2,9 +2,12 @@
 
 set -eu
 
-if [[ "$#" -ne 3 ]]; then
+if [[ "$#" -lt 3 ]]; then
     echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    echo "                reference location, "
     exit 1
+else
+    echo "assuming default reference, sample and reference image locations (see below)"
 fi
 
 GATK_DIR=$1
@@ -18,6 +21,7 @@ export GATK_DIR
 export CLUSTER_NAME
 export MASTER_NODE
 export PROJECT_OUTPUT_DIR
+
 
 ./scanBam.sh
 

--- a/scripts/sv/svCall.sh
+++ b/scripts/sv/svCall.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+if [[ "$#" -ne 3 ]]; then
+    echo "Please provide: local directory of GATK build, cluster name, output dir on the cluster"
+    exit 1
+fi
+
+GATK_DIR=$1
+CLUSTER_NAME=$2
+MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+OUTPUT_DIR=$3
+
+PROJECT_OUTPUT_DIR="$MASTER_NODE"/"$OUTPUT_DIR"
+
+export GATK_DIR
+export CLUSTER_NAME
+export MASTER_NODE
+export PROJECT_OUTPUT_DIR
+
+./scanBam.sh
+
+./assembly.sh
+
+./alignAssembly.sh
+
+./callVariants.sh


### PR DESCRIPTION
@cwhelan @tedsharpe @vruano @mwalker174 , I've organized the scripts for running the whole sv pipeline as it exists right now. There used to be a PR (if I recall correctly) but since that's outdated, why not an up-to-date one.

Here's how to run it

1. To create the cluster

```
./create_cluster.sh broad-dsde-methods sv-methods-1 broad-dsde-methods/sv
```
where the 1st argument is the project name, 2nd argument is the cluster name, and the 3rd name is the place where input data lives.

2. To run the whole pipeline

```
./svCall.sh /Users/shuang/GATK/gatk sv-methods-1 /user/shuang/NA12878_PCR-_30X
```
where the 1st argument is the location of my GATK directory and the 3rd argument is the location of all outputs on the cluster. So change them as necessary. The different stages called by the master script `svCall.sh` are (in order) `scanBam.sh` -> `assembly.sh` -> `alignAssembly.sh` -> `callVariants.sh`, which all take the same arguments.

3. To delete the whole cluster

```
./delete_cluster.sh sv-methods-1
```
This avoids having to wait for the web-based Console's confirmation.

One thing to note though, is that I've copied everything to a bucket at
```
gs://broad-dsde-methods/sv/
```
under a different project. We used to be developing under the project "broad-dsde-dev", but we are asked to move to project "broad-dsde-methods". So to run these scripts, you might need to switch to a different project via

```
gcloud config set project broad-dsde-methods
```