### PR TITLE
Move to the latest version of google-cloud-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.5.1:shaded'
+    compile 'com.google.cloud:google-cloud-nio:0.10.0-alpha:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -396,7 +396,8 @@ public final class BucketUtils {
         return CloudStorageFileSystem.forBucket(BUCKET).getPath(pathWithoutBucket);
     }
 
-    // TODO(jpmartin): uncomment once shaded.cloud_nio.com.google.auth.Credentials is visible
+    // TODO(jpmartin): uncomment once shaded.cloud_nio.com.google.auth.Credentials is visible.
+    // Then also uncomment in GcsNioIntegrationTest.
     /**
      * Get an authenticated GCS-backed NIO FileSystem object representing the selected projected and bucket.
      * Credentials are found automatically when running on Compute/App engine, logged into gcloud, or

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.hellbender.utils.gcs;
 
 import com.google.api.services.storage.Storage;
-import com.google.cloud.AuthCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.HttpTransportOptions;
 import com.google.cloud.RetryParams;
 import com.google.cloud.dataflow.sdk.options.GcsOptions;
@@ -395,6 +396,7 @@ public final class BucketUtils {
         return CloudStorageFileSystem.forBucket(BUCKET).getPath(pathWithoutBucket);
     }
 
+    // TODO(jpmartin): uncomment once shaded.cloud_nio.com.google.auth.Credentials is visible
     /**
      * Get an authenticated GCS-backed NIO FileSystem object representing the selected projected and bucket.
      * Credentials are found automatically when running on Compute/App engine, logged into gcloud, or
@@ -404,12 +406,14 @@ public final class BucketUtils {
      *
      * Note that most of the time it's enough to just open a file via
      * Files.newInputStream(Paths.get(URI.create( path ))).
-     */
+     *
     public static java.nio.file.FileSystem getAuthenticatedGcs(String projectId, String bucket, byte[] credentials) throws IOException {
         StorageOptions.Builder builder = StorageOptions.newBuilder()
                 .setProjectId(projectId);
         if (null != credentials) {
-            builder = builder.setAuthCredentials((AuthCredentials.createForJson(new ByteArrayInputStream(credentials))));
+            com.google.auth.Credentials c = GoogleCredentials.fromStream(new ByteArrayInputStream(credentials));
+            (shaded.cloud_nio.com.google.auth.Credentials) sc = c;
+            builder = builder.setCredentials(sc);
         }
         // generous timeouts, to avoid tests failing when not warranted.
         StorageOptions storageOptions = builder
@@ -428,5 +432,5 @@ public final class BucketUtils {
 
         // 2. Create GCS filesystem object with those credentials
         return CloudStorageFileSystem.forBucket(bucket, CloudStorageConfiguration.DEFAULT, storageOptions);
-    }
+    }*/
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.gcs;
 
 import com.google.api.services.storage.Storage;
 import com.google.cloud.AuthCredentials;
+import com.google.cloud.HttpTransportOptions;
 import com.google.cloud.RetryParams;
 import com.google.cloud.dataflow.sdk.options.GcsOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
@@ -411,8 +412,11 @@ public final class BucketUtils {
             builder = builder.setAuthCredentials((AuthCredentials.createForJson(new ByteArrayInputStream(credentials))));
         }
         // generous timeouts, to avoid tests failing when not warranted.
-        StorageOptions storageOptions = builder.setConnectTimeout(60000)
-            .setReadTimeout(60000)
+        StorageOptions storageOptions = builder
+            .setTransportOptions(HttpTransportOptions.newBuilder()
+                .setConnectTimeout(60000)
+                .setReadTimeout(60000)
+                .build())
             .setRetryParams(RetryParams.newBuilder()
                     .setRetryMaxAttempts(10)
                     .setRetryMinAttempts(6)

--- a/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.utils.nio;
 
-import com.google.cloud.AuthCredentials;
 import com.google.cloud.RetryParams;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
@@ -60,10 +59,11 @@ public final class GcsNioIntegrationTest extends BaseTest {
         }
     }
 
+    // TODO(jpmartin):uncomment once getAuthenticatedGcs is back
     /**
      * Opening the private file even when the user is not logged in on gcloud should work
      * when we provide explicit credentials.
-     */
+     *
     @Test(groups = {"cloud"})
     public void openPrivateFileWithExplicitCredentials() throws IOException {
         // this file, potentially unlike the others in the set, is not marked as "Public link".
@@ -88,7 +88,7 @@ public final class GcsNioIntegrationTest extends BaseTest {
      * That means that you must NOT set $GOOGLE_APPLICATION_CREDENTIALS
      * Yet you must set getGoogleServiceAccountKeyPath() (you may have to switch it to a different
      * environment variable).
-     */
+     *
     @Test(enabled = false, groups = {"cloud"}, expectedExceptions = {StorageException.class})
     public void explicitCredentialsAreNotKept() throws IOException {
         // this file, potentially unlike the others in the set, is not marked as "Public link".
@@ -110,7 +110,7 @@ public final class GcsNioIntegrationTest extends BaseTest {
         byte[] creds = Files.readAllBytes(Paths.get(getGoogleServiceAccountKeyPath()));
         return BucketUtils.getAuthenticatedGcs(getGCPTestProject(), bucket, creds);
     }
-
+*/
 
     private void helpDebugAuthError() {
         final String key = "GOOGLE_APPLICATION_CREDENTIALS";


### PR DESCRIPTION
Main motivation: it includes fixes we need for writing to
Google Cloud Storage buckets via NIO.

However this comes with some API changes too so we must agree
on what to do there.