### PR TITLE
allow null-likelihoods in  RankSumTest annotate

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
@@ -33,7 +33,7 @@ public abstract class RankSumTest extends InfoFieldAnnotation {
                                         final VariantContext vc,
                                         final ReadLikelihoods<Allele> likelihoods) {
         Utils.nonNull(vc, "vc is null");
-        Utils.nonNull(likelihoods, "likelihoods has to be non-null");
+
         final GenotypesContext genotypes = vc.getGenotypes();
         if (genotypes == null || genotypes.isEmpty()) {
             return Collections.emptyMap();
@@ -44,17 +44,19 @@ public abstract class RankSumTest extends InfoFieldAnnotation {
 
         final int refLoc = vc.getStart();
 
-        for (final ReadLikelihoods<Allele>.BestAllele bestAllele : likelihoods.bestAlleles()) {
-            final GATKRead read = bestAllele.read;
-            final Allele allele = bestAllele.allele;
-            if (bestAllele.isInformative() && isUsableRead(read, refLoc)) {
-                final OptionalDouble value = getElementForRead(read, refLoc, bestAllele);
-                // Bypass read if the clipping goal is not reached or the refloc is inside a spanning deletion
-                if ( value.isPresent() && value.getAsDouble() != INVALID_ELEMENT_FROM_READ ) {
-                    if (allele.isReference()) {
-                        refQuals.add(value.getAsDouble());
-                    } else if (vc.hasAllele(allele)) {
-                        altQuals.add(value.getAsDouble());
+        if( likelihoods != null) {
+            for (final ReadLikelihoods<Allele>.BestAllele bestAllele : likelihoods.bestAlleles()) {
+                final GATKRead read = bestAllele.read;
+                final Allele allele = bestAllele.allele;
+                if (bestAllele.isInformative() && isUsableRead(read, refLoc)) {
+                    final OptionalDouble value = getElementForRead(read, refLoc, bestAllele);
+                    // Bypass read if the clipping goal is not reached or the refloc is inside a spanning deletion
+                    if (value.isPresent() && value.getAsDouble() != INVALID_ELEMENT_FROM_READ) {
+                        if (allele.isReference()) {
+                            refQuals.add(value.getAsDouble());
+                        } else if (vc.hasAllele(allele)) {
+                            altQuals.add(value.getAsDouble());
+                        }
                     }
                 }
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTestUnitTest.java
@@ -118,9 +118,9 @@ public final class BaseQualityRankSumTestUnitTest {
         Assert.assertTrue(annotate.isEmpty());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMapNotNull() {
+    @Test
+    public void testNullLikelihoodsReturnsEmpty() {
         final BaseQualityRankSumTest ann = new BaseQualityRankSumTest();
-        ann.annotate(null, mock(VariantContext.class), null);
+        Assert.assertEquals(ann.annotate(null, mock(VariantContext.class), null), Collections.emptyMap());
     }
 }


### PR DESCRIPTION
previously RankSumTest disallowed null likelihoods in it's annotate method
this was different from GATK3 and causes problems in GenotypeGVCFs

relaxing this constraint so annotate will now return Collections.emptyMap() if likelihoods is null