### PR TITLE
fix for issue 2502 "SV called variants.vcf ASSEMBLY_IDS and CONTIG_IDS uses % rather than , to separate elements"

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 class AlignmentRegion {
 
     static final String STRING_REP_SEPARATOR= "\t";
+    static final String PACKED_STRING_REP_SEPARATOR= "_";
     static final String DUMMY_ASM_ID = "ASSEMBLY";
 
     final String assemblyId;
@@ -120,7 +121,10 @@ class AlignmentRegion {
      *          Note that the format is NOT the same as that used in {@link #toString()}.
      */
     String toPackedString() {
-        return assemblyId + "-" + contigId + ":" + startInAssembledContig + "-" + endInAssembledContig + ":" + referenceInterval.getContig() + ',' + referenceInterval.getStart() + ',' + (forwardStrand ? '+' : '-') + ',' + TextCigarCodec.encode(cigarAlong5to3DirectionOfContig) + ',' + mapQual + ',' + mismatches;
+        return assemblyId + PACKED_STRING_REP_SEPARATOR + contigId + PACKED_STRING_REP_SEPARATOR +
+                startInAssembledContig + PACKED_STRING_REP_SEPARATOR + endInAssembledContig + PACKED_STRING_REP_SEPARATOR +
+                referenceInterval.getContig() + PACKED_STRING_REP_SEPARATOR + referenceInterval.getStart() + PACKED_STRING_REP_SEPARATOR + (forwardStrand ? '+' : '-') + PACKED_STRING_REP_SEPARATOR +
+                TextCigarCodec.encode(cigarAlong5to3DirectionOfContig) + PACKED_STRING_REP_SEPARATOR + mapQual + PACKED_STRING_REP_SEPARATOR + mismatches;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
@@ -121,10 +121,14 @@ class AlignmentRegion {
      *          Note that the format is NOT the same as that used in {@link #toString()}.
      */
     String toPackedString() {
-        return assemblyId + PACKED_STRING_REP_SEPARATOR + contigId + PACKED_STRING_REP_SEPARATOR +
-                startInAssembledContig + PACKED_STRING_REP_SEPARATOR + endInAssembledContig + PACKED_STRING_REP_SEPARATOR +
-                referenceInterval.getContig() + PACKED_STRING_REP_SEPARATOR + referenceInterval.getStart() + PACKED_STRING_REP_SEPARATOR + (forwardStrand ? '+' : '-') + PACKED_STRING_REP_SEPARATOR +
-                TextCigarCodec.encode(cigarAlong5to3DirectionOfContig) + PACKED_STRING_REP_SEPARATOR + mapQual + PACKED_STRING_REP_SEPARATOR + mismatches;
+        return String.join(PACKED_STRING_REP_SEPARATOR,
+                assemblyId, contigId, String.valueOf(startInAssembledContig), String.valueOf(endInAssembledContig),
+                referenceInterval.getContig(), String.valueOf(referenceInterval.getStart()), (forwardStrand ? "+" : "-"),
+                TextCigarCodec.encode(cigarAlong5to3DirectionOfContig), String.valueOf(mapQual), String.valueOf(mismatches));
+//        return assemblyId + PACKED_STRING_REP_SEPARATOR + contigId + PACKED_STRING_REP_SEPARATOR +
+//                startInAssembledContig + PACKED_STRING_REP_SEPARATOR + endInAssembledContig + PACKED_STRING_REP_SEPARATOR +
+//                referenceInterval.getContig() + PACKED_STRING_REP_SEPARATOR + referenceInterval.getStart() + PACKED_STRING_REP_SEPARATOR + (forwardStrand ? '+' : '-') + PACKED_STRING_REP_SEPARATOR +
+//                TextCigarCodec.encode(cigarAlong5to3DirectionOfContig) + PACKED_STRING_REP_SEPARATOR + mapQual + PACKED_STRING_REP_SEPARATOR + mismatches;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/GATKSVVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/GATKSVVCFHeaderLines.java
@@ -12,8 +12,6 @@ public class GATKSVVCFHeaderLines {
 
     public static Map<String, VCFHeaderLine> vcfHeaderLines = new HashMap<>();
 
-    public static final String FORMAT_FIELD_SEPARATOR = "%";
-
     // VCF standard SV header lines
     // todo: add these and the other standard SV info fields from the VCF spec to htsjdk VCFStandardHeaderLines
     public static final String SVTYPE = "SVTYPE";

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCall.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCall.java
@@ -196,16 +196,16 @@ class SVVariantConsensusCall implements Serializable {
         final Map<String, Object> attributeMap = new HashMap<>();
         attributeMap.put(GATKSVVCFHeaderLines.TOTAL_MAPPINGS, annotations.size());
         attributeMap.put(GATKSVVCFHeaderLines.HQ_MAPPINGS, annotations.stream().filter(annotation -> annotation.minMQ == SVConstants.CallingStepConstants.CHIMERIC_ALIGNMENTS_HIGHMQ_THRESHOLD).count());// todo: should use == or >=?
-        attributeMap.put(GATKSVVCFHeaderLines.MAPPING_QUALITIES, annotations.stream().map(annotation -> String.valueOf(annotation.minMQ)).collect(Collectors.joining(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR)));
-        attributeMap.put(GATKSVVCFHeaderLines.ALIGN_LENGTHS, annotations.stream().map(annotation -> String.valueOf(annotation.minAL)).collect(Collectors.joining(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR)));
+        attributeMap.put(GATKSVVCFHeaderLines.MAPPING_QUALITIES, annotations.stream().map(annotation -> String.valueOf(annotation.minMQ)).collect(Collectors.joining(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)));
+        attributeMap.put(GATKSVVCFHeaderLines.ALIGN_LENGTHS, annotations.stream().map(annotation -> String.valueOf(annotation.minAL)).collect(Collectors.joining(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)));
         attributeMap.put(GATKSVVCFHeaderLines.MAX_ALIGN_LENGTH, annotations.stream().map(annotation -> annotation.minAL).max(Comparator.naturalOrder()).orElse(0));
-        attributeMap.put(GATKSVVCFHeaderLines.ASSEMBLY_IDS, annotations.stream().map(annotation -> annotation.asmID).collect(Collectors.joining(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR)));
-        attributeMap.put(GATKSVVCFHeaderLines.CONTIG_IDS, annotations.stream().map(annotation -> annotation.contigID).collect(Collectors.joining(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR)));
+        attributeMap.put(GATKSVVCFHeaderLines.ASSEMBLY_IDS, annotations.stream().map(annotation -> annotation.asmID).collect(Collectors.joining(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)));
+        attributeMap.put(GATKSVVCFHeaderLines.CONTIG_IDS, annotations.stream().map(annotation -> annotation.contigID).collect(Collectors.joining(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)));
 
         final List<String> insertionMappings = annotations.stream().map(annotation -> annotation.insSeqMappings).flatMap(List::stream).sorted().collect(Collectors.toList());
 
         if (!insertionMappings.isEmpty()) {
-            attributeMap.put(GATKSVVCFHeaderLines.INSERTED_SEQUENCE_MAPPINGS, insertionMappings.stream().collect(Collectors.joining(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR)));
+            attributeMap.put(GATKSVVCFHeaderLines.INSERTED_SEQUENCE_MAPPINGS, insertionMappings.stream().collect(Collectors.joining(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)));
         }
         return attributeMap;
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/NovelAdjacencyReferenceLocationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/NovelAdjacencyReferenceLocationsUnitTest.java
@@ -158,7 +158,8 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
         Assert.assertEquals(chimericAlignment.regionWithLowerCoordOnContig, region1);
         Assert.assertEquals(chimericAlignment.regionWithHigherCoordOnContig, region3);
         Assert.assertEquals(chimericAlignment.insertionMappings.size(), 1);
-        Assert.assertEquals(chimericAlignment.insertionMappings.get(0), "1_contig-1_484_525_20_23103196_-_483S42M968S_60_2");
+        final String expectedInsertionMappingsString = String.join(AlignmentRegion.PACKED_STRING_REP_SEPARATOR, "1", "contig-1", "484", "525", "20", "23103196", "-", "483S42M968S", "60", "2");
+        Assert.assertEquals(chimericAlignment.insertionMappings.get(0), expectedInsertionMappingsString);//"1_contig-1_484_525_20_23103196_-_483S42M968S_60_2");
         final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment);
         Assert.assertTrue(breakpoints.complication.homologyForwardStrandRep.isEmpty());
         Assert.assertEquals(breakpoints.complication.insertedSequenceForwardStrandRep, "TGAGAGTTGGCCCGAACACTGCTGGATTCCACTTCA");

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/NovelAdjacencyReferenceLocationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/NovelAdjacencyReferenceLocationsUnitTest.java
@@ -158,7 +158,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
         Assert.assertEquals(chimericAlignment.regionWithLowerCoordOnContig, region1);
         Assert.assertEquals(chimericAlignment.regionWithHigherCoordOnContig, region3);
         Assert.assertEquals(chimericAlignment.insertionMappings.size(), 1);
-        Assert.assertEquals(chimericAlignment.insertionMappings.get(0), "1-contig-1:484-525:20,23103196,-,483S42M968S,60,2");
+        Assert.assertEquals(chimericAlignment.insertionMappings.get(0), "1_contig-1_484_525_20_23103196_-_483S42M968S_60_2");
         final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment);
         Assert.assertTrue(breakpoints.complication.homologyForwardStrandRep.isEmpty());
         Assert.assertEquals(breakpoints.complication.insertedSequenceForwardStrandRep, "TGAGAGTTGGCCCGAACACTGCTGGATTCCACTTCA");

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCallUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVVariantConsensusCallUnitTest.java
@@ -123,9 +123,9 @@ public class SVVariantConsensusCallUnitTest extends BaseTest {
         final Map<String, Object> attributeMap =
                 SVVariantConsensusCall.getEvidenceRelatedAnnotations(Collections.singletonList(new ChimericAlignment(region1, region2, contigSeq, Collections.emptyList())));
 
-        Assert.assertEquals(((String)attributeMap.get(GATKSVVCFHeaderLines.MAPPING_QUALITIES)).split(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR),
+        Assert.assertEquals(((String)attributeMap.get(GATKSVVCFHeaderLines.MAPPING_QUALITIES)).split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR),
                             expectedMappingQualitiesAsStrings);
-        Assert.assertEquals(((String)attributeMap.get(GATKSVVCFHeaderLines.ALIGN_LENGTHS)).split(GATKSVVCFHeaderLines.FORMAT_FIELD_SEPARATOR),
+        Assert.assertEquals(((String)attributeMap.get(GATKSVVCFHeaderLines.ALIGN_LENGTHS)).split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR),
                             expectedAlignmentLengthsAsStrings);
     }
 


### PR DESCRIPTION
#2502 