### PR TITLE
setting STANDARD_CONFIDENCE_FOR_CALLING = 10.0 to match gatk3

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -103,7 +103,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * will then be performed in the subsequent GenotypeGVCFs command.
      */
     @Argument(fullName = "standard_min_confidence_threshold_for_calling", shortName = "stand_call_conf", doc = "The minimum phred-scaled confidence threshold at which variants should be called", optional = true)
-    public double STANDARD_CONFIDENCE_FOR_CALLING = 30.0;
+    public double STANDARD_CONFIDENCE_FOR_CALLING = 10.0;
 
     /**
      * If there are more than this number of alternate alleles presented to the genotyper (either through discovery or GENOTYPE_GIVEN ALLELES),


### PR DESCRIPTION
GenotypeCalculationArgumentCollection.STANDARD_CONFIDENCE_FOR_CALLING now defaults to 10.0 instead of 30.0