### PR TITLE
GenotypeAnnotations without called genotype constraint

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
@@ -45,7 +45,7 @@ public final class DepthPerAlleleBySample extends GenotypeAnnotation implements 
         Utils.nonNull(gb, "gb is null");
         Utils.nonNull(vc, "vc is null");
 
-        if ( g == null || !g.isCalled() || likelihoods == null) {
+        if ( g == null || likelihoods == null) {
             return;
         }
         final Set<Allele> alleles = new LinkedHashSet<>(vc.getAlleles());

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -49,8 +49,8 @@ public final class DepthPerSampleHC extends GenotypeAnnotation implements Standa
         Utils.nonNull(g);
         Utils.nonNull(gb);
 
-        if ( likelihoods == null || !g.isCalled() ) {
-            logger.warn("Annotation will not be calculated, genotype is not called or alleleLikelihoodMap is null");
+        if ( likelihoods == null ) {
+            logger.warn("Annotation will not be calculated, alleleLikelihoodMap is null");
             return;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
@@ -60,8 +60,8 @@ public final class StrandBiasBySample extends GenotypeAnnotation {
         Utils.nonNull(g);
         Utils.nonNull(gb);
 
-        if ( likelihoods == null || !g.isCalled() ) {
-            logger.warn("Annotation will not be calculated, genotype is not called or alleleLikelihoodMap is null");
+        if ( likelihoods == null ) {
+            logger.warn("Annotation will not be calculated, alleleLikelihoodMap is null");
             return;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
@@ -163,18 +163,20 @@ public final class VariantAnnotatorEngine {
      * @param ref the reference context of the variant to annotate or null if there is none
      * @param likelihoods likelihoods indexed by sample, allele, and read within sample. May be null
      * @param addAnnot function that indicates if the given annotation type should be added to the variant
+     * @param annotGenotype function that indicates if the given genotype should be annotated
      */
     public VariantContext annotateContext(final VariantContext vc,
                                           final FeatureContext features,
                                           final ReferenceContext ref,
                                           final ReadLikelihoods<Allele> likelihoods,
-                                          final Predicate<VariantAnnotation> addAnnot) {
+                                          final Predicate<VariantAnnotation> addAnnot,
+                                          final Predicate<Genotype> annotGenotype) {
         Utils.nonNull(vc, "vc cannot be null");
         Utils.nonNull(features, "features cannot be null");
 
         // annotate genotypes, creating another new VC in the process
         final VariantContextBuilder builder = new VariantContextBuilder(vc);
-        builder.genotypes(annotateGenotypes(ref, vc, likelihoods, addAnnot));
+        builder.genotypes(annotateGenotypes(ref, vc, likelihoods, addAnnot, annotGenotype));
         final VariantContext newGenotypeAnnotatedVC = builder.make();
 
         final Map<String, Object> infoAnnotMap = new LinkedHashMap<>(newGenotypeAnnotatedVC.getAttributes());
@@ -194,10 +196,24 @@ public final class VariantAnnotatorEngine {
         return variantOverlapAnnotator.annotateOverlaps(features, variantOverlapAnnotator.annotateRsID(features, annotated));
     }
 
+    /**
+     * Annotates the given variant context for called Genotypes - adds all annotations that satisfy the predicate.
+     *
+     * @see #annotateContext(VariantContext, FeatureContext, ReferenceContext, ReadLikelihoods, Predicate, Predicate)
+     */
+    public VariantContext annotateContext(final VariantContext vc,
+                                          final FeatureContext features,
+                                          final ReferenceContext ref,
+                                          final ReadLikelihoods<Allele> likelihoods,
+                                          final Predicate<VariantAnnotation> addAnnot) {
+        return annotateContext(vc, features, ref, likelihoods, addAnnot, Genotype::isCalled);
+    }
+
     private GenotypesContext annotateGenotypes(final ReferenceContext ref,
                                                final VariantContext vc,
                                                final ReadLikelihoods<Allele> likelihoods,
-                                               final Predicate<VariantAnnotation> addAnnot) {
+                                               final Predicate<VariantAnnotation> addAnnot,
+                                               final Predicate<Genotype> annotGenotype) {
         if ( genotypeAnnotations.isEmpty() ) {
             return vc.getGenotypes();
         }
@@ -206,7 +222,7 @@ public final class VariantAnnotatorEngine {
         for ( final Genotype genotype : vc.getGenotypes() ) {
             final GenotypeBuilder gb = new GenotypeBuilder(genotype);
             for ( final GenotypeAnnotation annotation : genotypeAnnotations) {
-                if (addAnnot.test(annotation)) {
+                if (addAnnot.test(annotation) && annotGenotype.test(genotype)) {
                     annotation.annotate(ref, vc, genotype, gb, likelihoods);
                 }
             }


### PR DESCRIPTION
This is a fix for #1730, which includes:

* New method param in` VariantAnnotatorEngine` to filter genotypes to annotate (first commit). Previous method signature is maintained using a filter for called genotypes. 
* Remove the `!g.isCalled()` check in all the `GenotypeAnnotation` from GATK (second commit), to allow annotation of non-called genotypes. All of the genotype annotations does not require this constraint, and in my personal usage I would need to use annotations from GATK with non-called genotypes.