### PR TITLE
Tool to read data in parallel from GCS to HDFS with Spark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSpark.java
@@ -1,0 +1,204 @@
+package org.broadinstitute.hellbender.tools.spark;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import scala.Tuple2;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This tool uses Spark to do a parallel copy of either a file or a directory from GCS into HDFS.
+ * Files are divided into chunks of size equal to the HDFS block size (with the exception of the final
+ * chunk) and each Spark task is responsible for copying one chunk. To copy all of the files in a GCS directory,
+ * provide the GCS directory path, including the trailing slash. Directory copies are non-recursive so
+ * subdirectories will be skipped. Within directories each file is divided into chunks independently (so this will be
+ * inefficient if you have lots of files smaller than the block size). After all chunks are copied, the HDFS
+ * concat method is used to stitch together chunks into single files without re-copying them.
+ */
+@CommandLineProgramProperties(summary="Parallel copy a file or directory (non-recursive) from GCS into HDFS",
+        oneLineSummary="Parallel copy a file or directory from GCS into HDFS.",
+        programGroup = SparkProgramGroup.class)
+public class ParallelCopyGCSDirectoryIntoHDFSSpark extends GATKSparkTool {
+    private static final long serialVersionUID = 1L;
+
+    // default buffer size for reading chunks is 64MiB based on performance profiling and what appears to be conventional
+    // wisdom to use a power of two for byte buffer sizes
+    public static final int SIXTY_FOUR_MIB = 67108864;
+
+    @Argument(doc = "input GCS file path (add trailing slash when specifying a directory)", fullName = "inputGCSPath")
+    private String inputGCSPath = null;
+
+    @Argument(doc = "output directory on HDFS", shortName = "outputHDFSDirectory",
+            fullName = "outputHDFSDirectory")
+    private String outputHDFSDirectory;
+
+    @Override
+    protected void runTool(final JavaSparkContext ctx) {
+
+        if (! BucketUtils.isCloudStorageUrl(inputGCSPath)) {
+            throw new UserException("Input path "+ inputGCSPath + " is not a GCS URI");
+        }
+
+        if (! BucketUtils.isHadoopUrl(outputHDFSDirectory)) {
+            throw new UserException("Output directory " + outputHDFSDirectory + " is not an HDFS URI");
+        }
+
+        final String inputGCSPathFinal = inputGCSPath;
+        final String outputDirectoryFinal = outputHDFSDirectory;
+
+        org.apache.hadoop.fs.Path outputHdfsDirectoryPath = new org.apache.hadoop.fs.Path(outputHDFSDirectory);
+
+        try(FileSystem fs = outputHdfsDirectoryPath.getFileSystem(new Configuration())) {
+
+            if (fs.exists(outputHdfsDirectoryPath)) {
+                throw new UserException("Specified output directory " + outputHdfsDirectoryPath + " already exists. Please specify a new directory name.");
+            }
+            fs.mkdirs(outputHdfsDirectoryPath);
+
+            final long chunkSize = getChunkSize(fs);
+
+            final List<Path> gcsNIOPaths = getGCSFilePathsToCopy(inputGCSPathFinal);
+
+            List<Tuple2<String, Integer>> chunkList = setupChunks(chunkSize, gcsNIOPaths);
+
+            if (chunkList.size() == 0) {
+                logger.info("no files found to copy");
+                return;
+            }
+
+            final JavaPairRDD<String, Integer> chunkRDD = ctx.parallelizePairs(chunkList, chunkList.size());
+            final JavaPairRDD<String, Tuple2<Integer, String>> chunkMappingRDD =
+                    chunkRDD.mapToPair(p -> new Tuple2<>(p._1(), readChunkToHdfs(p._1(), chunkSize, p._2(), outputDirectoryFinal)));
+            final Map<String, Iterable<Tuple2<Integer, String>>> chunksByFilePath = chunkMappingRDD.groupByKey().collectAsMap();
+
+            concatenateChunks(outputDirectoryFinal, fs, gcsNIOPaths, chunksByFilePath);
+
+        } catch (NoSuchFileException e) {
+            throw new UserException("Could not locate input path " + e.getFile() + ". If you are trying to copy an entire directory, please include a trailing slash on your path.");
+
+        } catch (IOException e) {
+            throw new GATKException(e.getMessage(), e);
+        }
+
+    }
+
+    private void concatenateChunks(final String outputDirectoryFinal, final FileSystem fs, final List<Path> gcsNIOPaths, final Map<String, Iterable<Tuple2<Integer, String>>> chunksByFilePath) throws IOException {
+        for (Path path : gcsNIOPaths) {
+
+            if (Files.isDirectory(path)) {
+                continue;
+            }
+
+            final String filePath = path.toUri().toString();
+            final Iterable<Tuple2<Integer, String>> chunkListForFile = chunksByFilePath.get(filePath);
+            final String basename = path.getName(path.getNameCount() - 1).toString();
+            final org.apache.hadoop.fs.Path outFilePath = new org.apache.hadoop.fs.Path(outputDirectoryFinal + "/" + basename);
+            fs.createNewFile(outFilePath);
+
+            SortedMap<Integer, String> chunkMap = new TreeMap<>();
+            for (Tuple2<Integer, String> entry : chunkListForFile) {
+                chunkMap.put(entry._1(), entry._2());
+            }
+
+            org.apache.hadoop.fs.Path[] chunkPaths = new org.apache.hadoop.fs.Path[chunkMap.size()];
+
+            final Iterator<Integer> iterator = chunkMap.keySet().iterator();
+            while (iterator.hasNext()) {
+                final Integer next = iterator.next();
+                final String chunkPath = chunkMap.get(next);
+                chunkPaths[next] = new org.apache.hadoop.fs.Path(chunkPath);
+            }
+
+            fs.concat(outFilePath, chunkPaths);
+        }
+    }
+
+    private List<Tuple2<String, Integer>> setupChunks(final long chunkSize, final List<Path> gcsNIOPaths) throws IOException {
+        List<Tuple2<String, Integer>> chunkList = new ArrayList<>();
+        for (Path path : gcsNIOPaths) {
+
+            if (Files.isDirectory(path)) {
+                logger.info("skipping directory " + path);
+                continue;
+            }
+
+            final long fileSize = Files.size(path);
+            final long chunks = fileSize / chunkSize + (fileSize % chunkSize == 0 ? 0 : 1);
+            logger.info("processing path " + path + ", size = " + fileSize + ", chunks = " + chunks);
+
+            for (int i = 0; i < chunks; i++) {
+                chunkList.add(new Tuple2<>(path.toUri().toString(), i));
+            }
+        }
+        return chunkList;
+    }
+
+    private List<Path> getGCSFilePathsToCopy(final String inputGCSPathFinal) throws IOException {
+        final List<Path> gcsNIOPaths;
+        final Path inputGCSNIOPath = IOUtils.getPath(inputGCSPathFinal);
+        if (Files.isDirectory(inputGCSNIOPath)) {
+            logger.info("transferring input directory: " + inputGCSPathFinal);
+            gcsNIOPaths = Files.list(inputGCSNIOPath).collect(Collectors.toList());
+        } else {
+            logger.info("transferring single file: " + inputGCSNIOPath);
+            gcsNIOPaths = Collections.singletonList(inputGCSNIOPath);
+        }
+        return gcsNIOPaths;
+    }
+
+    static long getChunkSize(final FileSystem fs) {
+        return Long.parseLong(fs.getConf().get("dfs.blocksize"));
+    }
+
+    private static final Tuple2<Integer, String> readChunkToHdfs(final String inputGCSPathFinal, final long chunkSize, final Integer chunkNum, final String outputDirectory) {
+        final Path gcsPath = IOUtils.getPath(inputGCSPathFinal);
+        final String basename = gcsPath.getName(gcsPath.getNameCount() - 1).toString();
+        org.apache.hadoop.fs.Path outputPath = new org.apache.hadoop.fs.Path(outputDirectory);
+        final String chunkPath = outputPath + "/" + basename + ".chunk." + chunkNum;
+
+        try (SeekableByteChannel channel = Files.newByteChannel(gcsPath);
+             final OutputStream outputStream = new BufferedOutputStream(BucketUtils.createNonGCSFile(chunkPath))){
+
+            final long start = chunkSize * (long) chunkNum;
+            channel.position(start);
+            ByteBuffer byteBuffer = ByteBuffer.allocateDirect((int) Math.min(SIXTY_FOUR_MIB, chunkSize));
+            long bytesRead = 0;
+            while(channel.read(byteBuffer) > 0) {
+                byteBuffer.flip();
+                while (byteBuffer.hasRemaining() && bytesRead < chunkSize) {
+                    byte b = byteBuffer.get();
+                    outputStream.write(b);
+                    bytesRead++;
+                }
+                if (bytesRead == chunkSize) {
+                    break;
+                }
+                if (bytesRead > chunkSize) {
+                    throw new GATKException("Encountered an unknown error condition and read too many bytes; output file may be corrupt");
+                }
+                byteBuffer.clear();
+            }
+        } catch (IOException e) {
+            throw new GATKException(e.getMessage() + "; inputGCSPathFinal = " + inputGCSPathFinal, e);
+        }
+        return new Tuple2<>(chunkNum, chunkPath);
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -390,7 +390,8 @@ public final class BucketUtils {
      * To transform other types of string URLs into Paths, use IOUtils.getPath instead.
      */
     public static java.nio.file.Path getPathOnGcs(String gcsUrl) {
-        final String[] split = gcsUrl.split("/");
+        // use a split limit of -1 to preserve empty split tokens, especially trailing slashes on directory names
+        final String[] split = gcsUrl.split("/", -1);
         final String BUCKET = split[2];
         final String pathWithoutBucket = String.join("/", Arrays.copyOfRange(split, 3, split.length));
         return CloudStorageFileSystem.forBucket(BUCKET).getPath(pathWithoutBucket);

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/MiniClusterUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/MiniClusterUtils.java
@@ -15,14 +15,27 @@ import java.util.UUID;
 public final class MiniClusterUtils {
 
     /**
+     * @return a new empty cluster with the given Configuration
+     * @throws IOException
+     */
+    public static MiniDFSCluster getMiniCluster(Configuration otherConf) throws IOException {
+        final File baseDir = BaseTest.createTempDir("minicluster_storage");
+        final Configuration configuration;
+        if (otherConf != null) {
+            configuration = new Configuration(otherConf);
+        } else {
+            configuration = new Configuration();
+        }
+        configuration.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+        return new MiniDFSCluster.Builder(configuration).build();
+    }
+
+    /**
      * @return a new empty cluster
      * @throws IOException
      */
     public static MiniDFSCluster getMiniCluster() throws IOException {
-        final File baseDir = BaseTest.createTempDir("minicluster_storage");
-        final Configuration conf = new Configuration();
-        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
-        return new MiniDFSCluster.Builder(conf).build();
+        return getMiniCluster(null);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.hellbender.tools.spark;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collections;
+
+
+public class ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest extends CommandLineProgramTest {
+
+    @Override
+    public String getTestedToolName() {
+        return ParallelCopyGCSDirectoryIntoHDFSSpark.class.getSimpleName();
+    }
+
+    @Test(groups = {"spark", "bucket"})
+    public void testCopyLargeFile() throws Exception {
+        MiniDFSCluster cluster = null;
+        try {
+            final Configuration conf = new Configuration();
+            // set the minicluster to have a very low block size so that we can test transferring a file in chunks without actually needing to move a big file
+            conf.set("dfs.blocksize", "1048576");
+            cluster = MiniClusterUtils.getMiniCluster(conf);
+
+            // copy a multi-block file
+            final Path tempPath = MiniClusterUtils.getTempPath(cluster, "test", "dir");
+            final String gcpInputPath = getGCPTestInputPath() + "huge/CEUTrio.HiSeq.WGS.b37.NA12878.chr1_4.bam.bai";
+            String args =
+                    "--inputGCSPath " + gcpInputPath +
+                            " --outputHDFSDirectory " + tempPath;
+            ArgumentsBuilder ab = new ArgumentsBuilder().add(args);
+            IntegrationTestSpec spec = new IntegrationTestSpec(
+                    ab.getString(),
+                    Collections.emptyList());
+            spec.executeTest("testCopyLargeFile-" + args, this);
+
+            final long fileSizeOnGCS = Files.size(IOUtils.getPath(gcpInputPath));
+
+
+            final String hdfsPath = tempPath + "/" + "CEUTrio.HiSeq.WGS.b37.NA12878.chr1_4.bam.bai";
+
+            org.apache.hadoop.fs.Path outputHdfsDirectoryPath = new org.apache.hadoop.fs.Path(tempPath.toUri());
+
+            try(FileSystem fs = outputHdfsDirectoryPath.getFileSystem(conf)) {
+                long chunkSize = ParallelCopyGCSDirectoryIntoHDFSSpark.getChunkSize(fs);
+                Assert.assertTrue(fileSizeOnGCS > chunkSize);
+            }
+
+            Assert.assertEquals(BucketUtils.fileSize(hdfsPath, null),
+                    fileSizeOnGCS);
+
+            final File tempDir = createTempDir("ParallelCopy");
+
+            BucketUtils.copyFile(hdfsPath, null, tempDir + "fileFromHDFS.bam.bai");
+            Assert.assertEquals(Utils.calculateFileMD5(new File(tempDir + "fileFromHDFS.bam.bai")), "1a6baa5332e98ef1358ac0fb36f46aaf");
+        } finally {
+            MiniClusterUtils.stopCluster(cluster);
+        }
+    }
+
+    @Test(groups = {"spark", "bucket"})
+    public void testCopyDirectory() throws Exception {
+        MiniDFSCluster cluster = null;
+        try {
+            final Configuration conf = new Configuration();
+            // set the minicluster to have a very low block size so that we can test transferring a file in chunks without actually needing to move a big file
+            conf.set("dfs.blocksize", "1048576");
+            cluster = MiniClusterUtils.getMiniCluster(conf);
+
+            // copy a directory
+            final Path tempPath = MiniClusterUtils.getTempPath(cluster, "test", "dir");
+
+            // directory contains two small files named foo.txt and bar.txt
+            final String gcpInputPath = getGCPTestInputPath() + "parallel_copy/";
+            String args =
+                    "--inputGCSPath " + gcpInputPath +
+                            " --outputHDFSDirectory " + tempPath;
+            ArgumentsBuilder ab = new ArgumentsBuilder().add(args);
+            IntegrationTestSpec spec = new IntegrationTestSpec(
+                    ab.getString(),
+                    Collections.emptyList());
+            spec.executeTest("testCopyDirectory-" + args, this);
+
+            org.apache.hadoop.fs.Path outputHdfsDirectoryPath = new org.apache.hadoop.fs.Path(tempPath.toUri());
+
+            final File tempDir = createTempDir("ParallelCopyDir");
+
+            int filesFound = 0;
+            try(FileSystem fs = outputHdfsDirectoryPath.getFileSystem(conf)) {
+                final RemoteIterator<LocatedFileStatus> hdfsCopies = fs.listFiles(outputHdfsDirectoryPath, false);
+                while (hdfsCopies.hasNext()) {
+                    final FileStatus next =  hdfsCopies.next();
+                    final Path path = next.getPath();
+                    BucketUtils.copyFile(path.toString(), null, tempDir + "/" + path.getName());
+                    filesFound ++;
+                }
+            }
+
+            Assert.assertEquals(filesFound, 2);
+
+
+            Assert.assertEquals(Utils.calculateFileMD5(new File(tempDir + "/foo.txt")), "d3b07384d113edec49eaa6238ad5ff00");
+            Assert.assertEquals(Utils.calculateFileMD5(new File(tempDir + "/bar.txt")), "c157a79031e1c40f85931829bc5fc552");
+        } finally {
+            MiniClusterUtils.stopCluster(cluster);
+        }
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -89,6 +89,13 @@ public final class BucketUtilsTest extends BaseTest {
     }
 
     @Test
+    public void testGetPathOnGcsDirectory() throws Exception {
+        final String dirPath = "gs://bucket/my/dir/";
+        final Path pathOnGcs = BucketUtils.getPathOnGcs(dirPath);
+        Assert.assertEquals(pathOnGcs.toUri().toString(), dirPath);
+    }
+
+    @Test
     public void testCopyAndDeleteHDFS() throws Exception {
         final String src = publicTestDir + "empty.vcf";
         File dest = createTempFile("copy-empty", ".vcf");


### PR DESCRIPTION
This tool copies single large files or directories from GCS into HDFS using Spark. Spark parallelization allows each task to copy a chunk in the size of the blocks of the target HDFS system simultaneously.

When copying a directory containing a 120GB WGS bam and its index, this takes approximately 1 minute on a 10 worker / 160 core cluster, as opposed to approximately 20 minutes using Hadoop distcp.

This may eventually be superseded by the NIO GCS integration work if that ends up performing comparably.

@lbergelson would you like to review? Or feel free to nominate someone else.