### PR TITLE
fixing InbreedingCoeff calculation to match GATK3

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
@@ -28,6 +28,8 @@ import java.util.Map;
  */
 public final class ExcessHet extends InfoFieldAnnotation implements StandardAnnotation {
     private static final double MIN_NEEDED_VALUE = 1.0E-16;
+    private static final boolean ROUND_GENOTYPE_COUNTS = true;
+    
     public static final double PHRED_SCALED_MIN_P_VALUE = -10.0 * Math.log10(MIN_NEEDED_VALUE);
 
     @Override
@@ -50,7 +52,7 @@ public final class ExcessHet extends InfoFieldAnnotation implements StandardAnno
 
     @VisibleForTesting
     static Pair<Integer, Double> calculateEH(final VariantContext vc, final GenotypesContext genotypes) {
-        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, true);
+        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, ROUND_GENOTYPE_COUNTS);
 
         final int refCount = (int)t.getRefs();
         final int hetCount = (int)t.getHets();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
@@ -49,12 +49,12 @@ public final class ExcessHet extends InfoFieldAnnotation implements StandardAnno
     }
 
     @VisibleForTesting
-    Pair<Integer, Double> calculateEH(final VariantContext vc, final GenotypesContext genotypes) {
-        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes);
+    static Pair<Integer, Double> calculateEH(final VariantContext vc, final GenotypesContext genotypes) {
+        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, true);
 
-        final int refCount = t.getRefs();
-        final int hetCount = t.getHets();
-        final int homCount = t.getHoms();
+        final int refCount = (int)t.getRefs();
+        final int hetCount = (int)t.getHets();
+        final int homCount = (int)t.getHoms();
         // number of samples that have likelihoods
         final int sampleCount = (int) genotypes.stream().filter(g->GenotypeUtils.isDiploidWithLikelihoods(g)).count();
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -69,16 +69,16 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
             logger.warn("Annotation will not be calculated, must provide at least " + MIN_SAMPLES + " samples");
             return Collections.emptyMap();
         }
-        return Collections.singletonMap(getKeyNames().get(0), (Object) String.format("%.4f", F));
+        return Collections.singletonMap(getKeyNames().get(0), String.format("%.4f", F));
     }
 
     @VisibleForTesting
-    Pair<Integer, Double> calculateIC(final VariantContext vc, final GenotypesContext genotypes) {
-        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes);
+    static Pair<Integer, Double> calculateIC(final VariantContext vc, final GenotypesContext genotypes) {
+        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, false);
 
-        final int refCount = t.getRefs();
-        final int hetCount = t.getHets();
-        final int homCount = t.getHoms();
+        final double refCount = t.getRefs();
+        final double hetCount = t.getHets();
+        final double homCount = t.getHoms();
         // number of samples that have likelihoods
         final int sampleCount = (int) genotypes.stream().filter(g-> GenotypeUtils.isDiploidWithLikelihoods(g)).count();
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -42,6 +42,7 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
 
     private static final Logger logger = LogManager.getLogger(InbreedingCoeff.class);
     private static final int MIN_SAMPLES = 10;
+    private static final boolean ROUND_GENOTYPE_COUNTS = true;
     private final Set<String> founderIds;
 
     public InbreedingCoeff(){
@@ -74,7 +75,7 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
 
     @VisibleForTesting
     static Pair<Integer, Double> calculateIC(final VariantContext vc, final GenotypesContext genotypes) {
-        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, false);
+        final GenotypeCounts t = GenotypeUtils.computeDiploidGenotypeCounts(vc, genotypes, ROUND_GENOTYPE_COUNTS);
 
         final double refCount = t.getRefs();
         final double hetCount = t.getHets();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -42,7 +42,7 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
 
     private static final Logger logger = LogManager.getLogger(InbreedingCoeff.class);
     private static final int MIN_SAMPLES = 10;
-    private static final boolean ROUND_GENOTYPE_COUNTS = true;
+    private static final boolean ROUND_GENOTYPE_COUNTS = false;
     private final Set<String> founderIds;
 
     public InbreedingCoeff(){

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenotypeCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenotypeCounts.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils;
 
 public final class GenotypeCounts {
 
+    //These are doubles instead of ints to match GATK3
     private final double ref;
     private final double het;
     private final double hom;

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenotypeCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenotypeCounts.java
@@ -2,25 +2,25 @@ package org.broadinstitute.hellbender.utils;
 
 public final class GenotypeCounts {
 
-    private final int ref;
-    private final int het;
-    private final int hom;
+    private final double ref;
+    private final double het;
+    private final double hom;
 
-    public GenotypeCounts(final int ref, final int het, final int hom ){
+    public GenotypeCounts(final double ref, final double het, final double hom ){
         this.ref = ref;
         this.het = het;
         this.hom = hom;
     }
 
-    public int getRefs() {
+    public double getRefs() {
         return ref;
     }
 
-    public int getHets() {
+    public double getHets() {
         return het;
     }
 
-    public int getHoms() {
+    public double getHoms() {
         return hom;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenotypeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenotypeUtils.java
@@ -17,24 +17,28 @@ public final class GenotypeUtils {
 
     /**
      * Returns a triple of ref/het/hom genotype counts. Skips non-diploid genotypes.
+     *
+     * @param roundContributionFromEachGenotype if this is true, the normalized likelihood from each genotype will be rounded before
+     *                                          adding to the total count
      */
-    public static GenotypeCounts computeDiploidGenotypeCounts(final VariantContext vc, final GenotypesContext genotypes){
+    public static GenotypeCounts computeDiploidGenotypeCounts(final VariantContext vc, final GenotypesContext genotypes,
+                                                              final boolean roundContributionFromEachGenotype){
         Utils.nonNull(vc, "vc");
         Utils.nonNull(genotypes, "genotypes");
         final boolean doMultiallelicMapping = !vc.isBiallelic();
 
         int idxAA = 0, idxAB = 1, idxBB = 2;
 
-        int refCount = 0;
-        int hetCount = 0;
-        int homCount = 0;
+        double refCount = 0;
+        double hetCount = 0;
+        double homCount = 0;
 
         for (final Genotype g : genotypes) {
             if (! isDiploidWithLikelihoods(g)){
                 continue;
             }
 
-            // Genotype::getLikelihoods returns a new array, so modification in-palce is safe
+            // Genotype::getLikelihoods returns a new array, so modification in-place is safe
             final double[] normalizedLikelihoods = MathUtils.normalizeFromLog10ToLinearSpace(g.getLikelihoods().getAsVector());
 
 
@@ -63,18 +67,16 @@ public final class GenotypeUtils {
                 }
             }
 
-            refCount += MathUtils.fastRound(normalizedLikelihoods[idxAA]);
-            hetCount += MathUtils.fastRound(normalizedLikelihoods[idxAB]);
-            homCount += MathUtils.fastRound(normalizedLikelihoods[idxBB]);
+            if( roundContributionFromEachGenotype ) {
+                refCount += MathUtils.fastRound(normalizedLikelihoods[idxAA]);
+                hetCount += MathUtils.fastRound(normalizedLikelihoods[idxAB]);
+                homCount += MathUtils.fastRound(normalizedLikelihoods[idxBB]);
+            } else {
+                refCount += normalizedLikelihoods[idxAA];
+                hetCount += normalizedLikelihoods[idxAB];
+                homCount += normalizedLikelihoods[idxBB];
+            }
         }
-
-        /*
-         * Note: all that likelihood normalization etc may have accumulated some error.
-         * We smooth it out my rounding the numbers to integers before the final computation.
-         */
-        refCount = Math.round(refCount);
-        hetCount = Math.round(hetCount);
-        homCount = Math.round(homCount);
         return new GenotypeCounts(refCount, hetCount, homCount);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenotypeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenotypeUtils.java
@@ -16,8 +16,17 @@ public final class GenotypeUtils {
     }
 
     /**
-     * Returns a triple of ref/het/hom genotype counts. Skips non-diploid genotypes.
+     * Returns a triple of ref/het/hom genotype "counts".
      *
+     * The exact meaning of the count is dependent on the rounding behavior.
+     * if {@code roundContributionFromEachGenotype}: the counts are discrete integer counts of the most probable genotype for each {@link Genotype}
+     * else: they are the sum of the normalized likelihoods of each genotype and will not be integers
+     *
+     * Skips non-diploid genotypes.
+     *
+     *
+     * @param vc the VariantContext that the {@link Genotype}s originated from, non-null
+     * @param genotypes a GenotypesContext containing genotypes to count, these must be a subset of {@code vc.getGenotypes()}, non-null
      * @param roundContributionFromEachGenotype if this is true, the normalized likelihood from each genotype will be rounded before
      *                                          adding to the total count
      */

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHetUnitTest.java
@@ -49,7 +49,7 @@ public final class ExcessHetUnitTest extends BaseTest {
                 makeG("s9", T, T, 7099, 2530, 0, 7099, 366, 3056),
                 makeG("s10", Aref, T, 2530, 0, 7099, 366, 3056, 14931));
 
-        final double result = new ExcessHet().calculateEH(test1, test1.getGenotypes()).getValue();
+        final double result = ExcessHet.calculateEH(test1, test1.getGenotypes()).getValue();
         Assert.assertEquals(result, 5.85, DELTA_PRECISION, "Pass");
     }
 
@@ -68,7 +68,7 @@ public final class ExcessHetUnitTest extends BaseTest {
                 makeG("s9", T, T, 7099, 2530, 0, 7099, 366, 3056),
                 makeG("s10", Aref, T, 2530, 0, 7099, 366, 3056, 14931));
 
-        final double result = new ExcessHet().calculateEH(test1, test1.getGenotypes()).getValue();
+        final double result = ExcessHet.calculateEH(test1, test1.getGenotypes()).getValue();
         Assert.assertEquals(result, 5.85, DELTA_PRECISION, "Pass");
     }
 
@@ -87,7 +87,7 @@ public final class ExcessHetUnitTest extends BaseTest {
                 makeG("s9", Aref, T, 5732, 0, 10876, 6394, 11408, 17802),
                 makeG("s10", Aref, T, 2780, 0, 25045, 824, 23330, 30939));
 
-        final double result2 = new ExcessHet().calculateEH(test2, test2.getGenotypes()).getValue();
+        final double result2 = ExcessHet.calculateEH(test2, test2.getGenotypes()).getValue();
         final double result = 25.573;
         Assert.assertEquals(result2, result, DELTA_PRECISION, "Pass");
 
@@ -111,7 +111,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         int numHetGTs = 1;
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double singletonValue = new ExcessHet().calculateEH(singleton, singleton.getGenotypes()).getValue();
+        final double singletonValue = ExcessHet.calculateEH(singleton, singleton.getGenotypes()).getValue();
 
         final int targetNumHetGTs = 20;
         for (int i = numHetGTs; i < targetNumHetGTs; i++) {
@@ -119,7 +119,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         }
 
         final VariantContext common = makeVC("common", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double EHcommon = new ExcessHet().calculateEH(common, common.getGenotypes()).getValue();
+        final double EHcommon = ExcessHet.calculateEH(common, common.getGenotypes()).getValue();
 
         Assert.assertTrue(Math.abs(singletonValue) < Math.abs(EHcommon), String.format("singleton=%f common=%f", singletonValue, EHcommon));
     }
@@ -137,7 +137,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         int numHetGTs = 1;
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double singletonValue = new ExcessHet().calculateEH(singleton, singleton.getGenotypes()).getValue();
+        final double singletonValue = ExcessHet.calculateEH(singleton, singleton.getGenotypes()).getValue();
 
         for (int i = numHetGTs; i < 100; i++) {
             allGTs.add(makeG("het" + i, Aref, T, hetPLs));
@@ -145,7 +145,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         }
 
         final VariantContext hundredton = makeVC("hundredton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double hundredtonValue = new ExcessHet().calculateEH(hundredton, hundredton.getGenotypes()).getValue();
+        final double hundredtonValue = ExcessHet.calculateEH(hundredton, hundredton.getGenotypes()).getValue();
 
         Assert.assertTrue(Math.abs(singletonValue) < Math.abs(hundredtonValue), String.format("singleton=%f hundredton=%f", singletonValue, hundredtonValue));
 
@@ -153,7 +153,7 @@ public final class ExcessHetUnitTest extends BaseTest {
             allGTs.add(makeG("het" + i, Aref, T, hetPLs));
 
         final VariantContext common = makeVC("common", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double commonValue = new ExcessHet().calculateEH(common, common.getGenotypes()).getValue();
+        final double commonValue = ExcessHet.calculateEH(common, common.getGenotypes()).getValue();
 
         Assert.assertTrue(Math.abs(hundredtonValue) < Math.abs(commonValue), String.format("hundredton=%f common=%f", hundredtonValue, commonValue));
     }
@@ -171,7 +171,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         singletonGTs.add(makeG("het0", Aref, T, hetPLs));
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), singletonGTs.toArray(new Genotype[singletonGTs.size()]));
-        final double singletonValue = new ExcessHet().calculateEH(singleton, singleton.getGenotypes()).getValue();
+        final double singletonValue = ExcessHet.calculateEH(singleton, singleton.getGenotypes()).getValue();
 
         final List<Genotype> allHetGTs = new ArrayList<>();
         for (int i = 0; i < numGTs; i++) {
@@ -179,7 +179,7 @@ public final class ExcessHetUnitTest extends BaseTest {
         }
 
         final VariantContext allHet = makeVC("allHet", Arrays.asList(Aref, T), allHetGTs.toArray(new Genotype[allHetGTs.size()]));
-        final double hetsValue = new ExcessHet().calculateEH(allHet, allHet.getGenotypes()).getValue();
+        final double hetsValue = ExcessHet.calculateEH(allHet, allHet.getGenotypes()).getValue();
 
         Assert.assertTrue(Math.abs(singletonValue) < Math.abs(hetsValue), String.format("singleton=%f allHets=%f", singletonValue, hetsValue));
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.AS_InbreedingCoeff;
 import org.broadinstitute.hellbender.utils.GenotypeUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 import org.testng.Assert;
@@ -14,7 +15,7 @@ import java.util.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class InbreedingCoeffUnitTest {
+public final class InbreedingCoeffUnitTest extends BaseTest {
     private static final double DELTA_PRECISION = 0.001;
     private static final Allele Aref = Allele.create("A", true);
     private static final Allele T = Allele.create("T");
@@ -459,13 +460,12 @@ public final class InbreedingCoeffUnitTest {
         final ArrayList<Genotype> genotypes = new ArrayList<>();
         final int numberOfSamples = 200;
         for(int i = 0; i< numberOfSamples; i++){
-            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(Aref, T)).PL(new int[]{40,10,0}).make();
+            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(T, T)).PL(new int[]{40,10,0}).make();
             Assert.assertTrue(GenotypeUtils.isDiploidWithLikelihoods(g));
             genotypes.add(g);
         }
 
-        final Pair<Integer, Double> sampleCountAndCoefficientPair = InbreedingCoeff.calculateIC(vc,
-                                                                                    GenotypesContext.create(genotypes));
+        final Pair<Integer, Double> sampleCountAndCoefficientPair = InbreedingCoeff.calculateIC(vc, GenotypesContext.create(genotypes));
         final int sampleCount = sampleCountAndCoefficientPair.getLeft();
         final double inbreedingCoefficient = sampleCountAndCoefficientPair.getRight();
         Assert.assertEquals(sampleCount, numberOfSamples);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.annotator;
 import htsjdk.variant.variantcontext.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.AS_InbreedingCoeff;
+import org.broadinstitute.hellbender.utils.GenotypeUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 import org.testng.Assert;
@@ -48,7 +49,7 @@ public final class InbreedingCoeffUnitTest {
                 makeG("s9",T,T,7099,2530,0,7099,366,3056,14931),
                 makeG("s10",Aref,T,2530,0,7099,366,3056,14931));
 
-        final Pair<Integer, Double> pair1 = new InbreedingCoeff().calculateIC(test1, test1.getGenotypes());
+        final Pair<Integer, Double> pair1 = InbreedingCoeff.calculateIC(test1, test1.getGenotypes());
         final int count1 = pair1.getLeft();
         final double ICresult1 = pair1.getRight();
         Assert.assertEquals(count1, 10, "count1");
@@ -67,7 +68,7 @@ public final class InbreedingCoeffUnitTest {
             makeG("s9",Aref,T,5732,0,10876,6394,11408,17802),
             makeG("s10",Aref,T,2780,0,25045,824,23330,30939));
 
-        final Pair<Integer, Double> pair2 = new InbreedingCoeff().calculateIC(test2, test2.getGenotypes());
+        final Pair<Integer, Double> pair2 = InbreedingCoeff.calculateIC(test2, test2.getGenotypes());
         final int count2 = pair2.getLeft();
         final double ICresult2 = pair2.getRight();
         Assert.assertEquals(ICresult2, -1.0, DELTA_PRECISION, "Pass");
@@ -195,7 +196,7 @@ public final class InbreedingCoeffUnitTest {
                 makeG("s9", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
                 makeG("s10", Aref, T, 2530, 0, 7099, 366, 3056, 14931));
 
-        final Pair<Integer, Double> pair1 = new InbreedingCoeff().calculateIC(test1, test1.getGenotypes());
+        final Pair<Integer, Double> pair1 = InbreedingCoeff.calculateIC(test1, test1.getGenotypes());
         final int count1 = pair1.getLeft();
         final double ICresult1 = pair1.getRight();
         Assert.assertEquals(count1, 10, "count1");
@@ -215,7 +216,7 @@ public final class InbreedingCoeffUnitTest {
         int numHetGTs = 1;
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final Pair<Integer, Double> p1 = new InbreedingCoeff().calculateIC(singleton, singleton.getGenotypes());
+        final Pair<Integer, Double> p1 = InbreedingCoeff.calculateIC(singleton, singleton.getGenotypes());
         final double ICsingleton = p1.getRight();
         final int IC1 = p1.getLeft();
 
@@ -225,7 +226,7 @@ public final class InbreedingCoeffUnitTest {
         }
 
         final VariantContext common = makeVC("common", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final Pair<Integer, Double> p2 = new InbreedingCoeff().calculateIC(common, common.getGenotypes());
+        final Pair<Integer, Double> p2 = InbreedingCoeff.calculateIC(common, common.getGenotypes());
         final double ICcommon = p2.getRight();
         final int IC2 = p1.getLeft();
 
@@ -276,7 +277,7 @@ public final class InbreedingCoeffUnitTest {
         int numHetGTs = 1;
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(T, Aref), allGTs.toArray(new Genotype[allGTs.size()]));
-        final Pair<Integer, Double> p1 = new InbreedingCoeff().calculateIC(singleton, singleton.getGenotypes());
+        final Pair<Integer, Double> p1 = InbreedingCoeff.calculateIC(singleton, singleton.getGenotypes());
         final double ICsingleton = p1.getRight();
         final int IC1 = p1.getLeft();
 
@@ -286,7 +287,7 @@ public final class InbreedingCoeffUnitTest {
         }
 
         final VariantContext common = makeVC("common", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final Pair<Integer, Double> p2 = new InbreedingCoeff().calculateIC(common, common.getGenotypes());
+        final Pair<Integer, Double> p2 = InbreedingCoeff.calculateIC(common, common.getGenotypes());
         final double ICcommon = p2.getRight();
         final int IC2 = p1.getLeft();
 
@@ -319,7 +320,7 @@ public final class InbreedingCoeffUnitTest {
         int numHetGTs = 1;
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double ICsingleton = new InbreedingCoeff().calculateIC(singleton, singleton.getGenotypes()).getRight();
+        final double ICsingleton = InbreedingCoeff.calculateIC(singleton, singleton.getGenotypes()).getRight();
 
         for ( int i = numHetGTs; i < 100; i++ ) {
             allGTs.add(makeG("het" + i, Aref, T, hetPLs));
@@ -327,7 +328,7 @@ public final class InbreedingCoeffUnitTest {
         }
 
         final VariantContext hundredton = makeVC("hundredton", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double IChundredton = new InbreedingCoeff().calculateIC(hundredton, hundredton.getGenotypes()).getRight();
+        final double IChundredton = InbreedingCoeff.calculateIC(hundredton, hundredton.getGenotypes()).getRight();
 
         Assert.assertTrue(Math.abs(ICsingleton) < Math.abs(IChundredton), String.format("singleton=%f hundredton=%f", ICsingleton, IChundredton));
 
@@ -335,7 +336,7 @@ public final class InbreedingCoeffUnitTest {
             allGTs.add(makeG("het" + i, Aref, T, hetPLs));
 
         final VariantContext common = makeVC("common", Arrays.asList(Aref, T), allGTs.toArray(new Genotype[allGTs.size()]));
-        final double ICcommon = new InbreedingCoeff().calculateIC(common, common.getGenotypes()).getRight();
+        final double ICcommon = InbreedingCoeff.calculateIC(common, common.getGenotypes()).getRight();
 
         Assert.assertTrue(Math.abs(IChundredton) < Math.abs(ICcommon), String.format("hundredton=%f common=%f", IChundredton, ICcommon));
     }
@@ -389,14 +390,14 @@ public final class InbreedingCoeffUnitTest {
         singletonGTs.add(makeG("het0", Aref, T, hetPLs));
 
         final VariantContext singleton = makeVC("singleton", Arrays.asList(Aref, T), singletonGTs.toArray(new Genotype[singletonGTs.size()]));
-        final double ICsingleton = new InbreedingCoeff().calculateIC(singleton, singleton.getGenotypes()).getRight();
+        final double ICsingleton = InbreedingCoeff.calculateIC(singleton, singleton.getGenotypes()).getRight();
 
         final List<Genotype> allHetGTs = new ArrayList<>();
         for ( int i = 0; i < numGTs; i++ )
             allHetGTs.add(makeG("het" + i, Aref, T, hetPLs));
 
         final VariantContext allHet = makeVC("allHet", Arrays.asList(Aref, T), allHetGTs.toArray(new Genotype[allHetGTs.size()]));
-        final double ICHets = new InbreedingCoeff().calculateIC(allHet, allHet.getGenotypes()).getRight();
+        final double ICHets = InbreedingCoeff.calculateIC(allHet, allHet.getGenotypes()).getRight();
 
         Assert.assertTrue(Math.abs(ICsingleton) < Math.abs(ICHets), String.format("singleton=%f allHets=%f", ICsingleton, ICHets));
     }
@@ -433,7 +434,6 @@ public final class InbreedingCoeffUnitTest {
         Assert.assertTrue(annotate.isEmpty());
     }
 
-
     @Test
     public void testTinyCohorts_AS() {
 
@@ -452,4 +452,24 @@ public final class InbreedingCoeffUnitTest {
     }
 
 
+    @Test
+    public void testRoundingIsntAppliedToEachGenotype() {
+        final VariantContext vc = new VariantContextBuilder("in memory", "1", 100, 100,
+                                                                 Arrays.asList(Aref, T)).make();
+        final ArrayList<Genotype> genotypes = new ArrayList<>();
+        final int numberOfSamples = 200;
+        for(int i = 0; i< numberOfSamples; i++){
+            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(Aref, T)).PL(new int[]{40,10,0}).make();
+            Assert.assertTrue(GenotypeUtils.isDiploidWithLikelihoods(g));
+            genotypes.add(g);
+        }
+
+        final Pair<Integer, Double> sampleCountAndCoefficientPair = InbreedingCoeff.calculateIC(vc,
+                                                                                    GenotypesContext.create(genotypes));
+        final int sampleCount = sampleCountAndCoefficientPair.getLeft();
+        final double inbreedingCoefficient = sampleCountAndCoefficientPair.getRight();
+        Assert.assertEquals(sampleCount, numberOfSamples);
+        final double expectedValueFromGATK3_7 = 0.0456;
+        Assert.assertEquals(inbreedingCoefficient, -0.0456, DELTA_PRECISION);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
@@ -1,0 +1,72 @@
+package org.broadinstitute.hellbender.utils;
+
+import htsjdk.variant.variantcontext.*;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GenotypeUtilsUnitTest {
+    private static final Allele Aref = Allele.create("A", true);
+    private static final Allele T = Allele.create("T");
+
+
+
+    @DataProvider
+    public Object[][] getGTsWithAndWithoutLikelihoods(){
+        final GenotypeBuilder builder = new GenotypeBuilder("sample", Arrays.asList(Aref, T));
+        final List<Allele> DIPLOID_ALLELES = Arrays.asList(Aref, T);
+        final List<Allele> HAPLOID_ALLELES = Arrays.asList(Aref);
+        final int[] SOME_PLS = {0, 4, 1};
+        final int[] HAPLOID_PL = {0, 4};
+        return new Object[][]{
+                {builder.noPL().alleles(DIPLOID_ALLELES).make(), false},
+                {builder.noPL().alleles(HAPLOID_ALLELES).make(), false},
+                {builder.PL(HAPLOID_PL).alleles(HAPLOID_ALLELES).make(), false},
+                {builder.PL(SOME_PLS).alleles(DIPLOID_ALLELES).make(), true},
+                {GenotypeBuilder.createMissing("sample", 2), false}
+        };
+    }
+
+    @Test(dataProvider = "getGTsWithAndWithoutLikelihoods")
+    public void testIsDiploidWithLikelihoods(Genotype g, boolean expected) throws Exception {
+        Assert.assertEquals(GenotypeUtils.isDiploidWithLikelihoods(g), expected);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIsDiploidWithLikelihoodsWithNull() {
+        GenotypeUtils.isDiploidWithLikelihoods(null);
+    }
+
+
+
+    @DataProvider
+    public Object[][] getGenotypeCountsParameters(){
+        final VariantContext vc = new VariantContextBuilder("in memory", "1", 100, 100,
+                                                                        Arrays.asList(Aref, T)).make();
+        final ArrayList<Genotype> genotypesArray = new ArrayList<>();
+        for(int i = 0; i<100; i++){
+            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(Aref, T)).PL(new int[]{100,10,0}).make();
+            genotypesArray.add(g);
+        }
+        final GenotypesContext genotypes = GenotypesContext.create(genotypesArray);
+
+        return new Object[][]{
+                {vc, genotypes, false, new GenotypeCounts(0, 9, 91)},
+                {vc, genotypes, true, new GenotypeCounts(0, 0, 100)},
+        };
+    }
+
+    @Test(dataProvider = "getGenotypeCountsParameters")
+    public void testRounding(VariantContext vc, GenotypesContext gt, boolean round, GenotypeCounts expected) {
+        final GenotypeCounts actual = GenotypeUtils.computeDiploidGenotypeCounts(vc, gt, round);
+        Assert.assertEquals(actual.getRefs(), expected.getRefs());
+        Assert.assertEquals(actual.getHets(), expected.getHets());
+        Assert.assertEquals(actual.getHoms(), expected.getHoms());
+    }
+
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class GenotypeUtilsUnitTest {
     private static final Allele Aref = Allele.create("A", true);
     private static final Allele T = Allele.create("T");
-
+    private static final double DELTA_PRECISION = .001;
 
 
     @DataProvider
@@ -55,17 +55,17 @@ public class GenotypeUtilsUnitTest {
         final GenotypesContext genotypes = GenotypesContext.create(genotypesArray);
 
         return new Object[][]{
-                {vc, genotypes, false, new GenotypeCounts(0, 9, 91)},
-                {vc, genotypes, true, new GenotypeCounts(0, 0, 100)},
+                {vc, genotypes, false, new GenotypeCounts(0.000, 9.091, 90.909)},
+                {vc, genotypes, true, new GenotypeCounts(0.000, 0.000, 100.000)},
         };
     }
 
     @Test(dataProvider = "getGenotypeCountsParameters")
     public void testRounding(VariantContext vc, GenotypesContext gt, boolean round, GenotypeCounts expected) {
         final GenotypeCounts actual = GenotypeUtils.computeDiploidGenotypeCounts(vc, gt, round);
-        Assert.assertEquals(actual.getRefs(), expected.getRefs());
-        Assert.assertEquals(actual.getHets(), expected.getHets());
-        Assert.assertEquals(actual.getHoms(), expected.getHoms());
+        Assert.assertEquals(actual.getRefs(), expected.getRefs(), DELTA_PRECISION);
+        Assert.assertEquals(actual.getHets(), expected.getHets(), DELTA_PRECISION);
+        Assert.assertEquals(actual.getHoms(), expected.getHoms(), DELTA_PRECISION);
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenotypeUtilsUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils;
 
 import htsjdk.variant.variantcontext.*;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -9,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class GenotypeUtilsUnitTest {
+public class GenotypeUtilsUnitTest extends BaseTest {
     private static final Allele Aref = Allele.create("A", true);
     private static final Allele T = Allele.create("T");
     private static final double DELTA_PRECISION = .001;
@@ -17,18 +18,21 @@ public class GenotypeUtilsUnitTest {
 
     @DataProvider
     public Object[][] getGTsWithAndWithoutLikelihoods(){
-        final GenotypeBuilder builder = new GenotypeBuilder("sample", Arrays.asList(Aref, T));
         final List<Allele> DIPLOID_ALLELES = Arrays.asList(Aref, T);
         final List<Allele> HAPLOID_ALLELES = Arrays.asList(Aref);
         final int[] SOME_PLS = {0, 4, 1};
         final int[] HAPLOID_PL = {0, 4};
         return new Object[][]{
-                {builder.noPL().alleles(DIPLOID_ALLELES).make(), false},
-                {builder.noPL().alleles(HAPLOID_ALLELES).make(), false},
-                {builder.PL(HAPLOID_PL).alleles(HAPLOID_ALLELES).make(), false},
-                {builder.PL(SOME_PLS).alleles(DIPLOID_ALLELES).make(), true},
+                {getGenotypeBuilder().noPL().alleles(DIPLOID_ALLELES).make(), false},
+                {getGenotypeBuilder().noPL().alleles(HAPLOID_ALLELES).make(), false},
+                {getGenotypeBuilder().PL(HAPLOID_PL).alleles(HAPLOID_ALLELES).make(), false},
+                {getGenotypeBuilder().PL(SOME_PLS).alleles(DIPLOID_ALLELES).make(), true},
                 {GenotypeBuilder.createMissing("sample", 2), false}
         };
+    }
+
+    private static GenotypeBuilder getGenotypeBuilder() {
+        return new GenotypeBuilder("sample", Arrays.asList(Aref, T));
     }
 
     @Test(dataProvider = "getGTsWithAndWithoutLikelihoods")
@@ -49,7 +53,7 @@ public class GenotypeUtilsUnitTest {
                                                                         Arrays.asList(Aref, T)).make();
         final ArrayList<Genotype> genotypesArray = new ArrayList<>();
         for(int i = 0; i<100; i++){
-            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(Aref, T)).PL(new int[]{100,10,0}).make();
+            final Genotype g = new GenotypeBuilder("sample" + i, Arrays.asList(T, T)).PL(new int[]{100,10,0}).make();
             genotypesArray.add(g);
         }
         final GenotypesContext genotypes = GenotypesContext.create(genotypesArray);


### PR DESCRIPTION
* changing GenotypeCounts to be doubles instead of ints, this is weird but it's how gatk3 is
* adding an additional boolean parameter to computeDiploidGenotypeCounts that controls rounding behavior
  ExcessHet needs rounding on
  InbreedingCoeff needs it off
* adding a new GenotypeUtilsUnitTest class
  these tests are not exhaustive and leave most conditions untested
* updating InbreedingCoeffUnitTest with a test that checks that we match gatk3 output for a previously divergent case