### PR TITLE
fixes the error in computing contig span in BwaMemAlignment -> AlignmentRegion

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignmentRegion.java
@@ -59,8 +59,8 @@ class AlignmentRegion {
         this.mapQual = alignment.getMapQual();
         this.mismatches = alignment.getNMismatches();
         this.assembledContigLength = contigLen;
-        this.startInAssembledContig = alignment.getSeqStart()+1;
-        this.endInAssembledContig = alignment.getSeqEnd();
+        this.startInAssembledContig = startOfAlignmentInContig();
+        this.endInAssembledContig = endOfAlignmentInContig();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
which resulted in inversion call dropping
@tedsharpe , feel free to cherry pick this change in your PR #2444 
But it does indicate that the binding to bwa mem has an issue in template span inference, or there's mis-communication.