### PR TITLE
Remove AuthHolder and dataflow import from BucketUtil 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -268,7 +268,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         if (numReducers != 0) {
             return numReducers;
         }
-        return 1 + (int) (BucketUtils.dirSize(getReadSourceName(), getAuthenticatedGCSOptions()) / getTargetPartitionSize());
+        return 1 + (int) (BucketUtils.dirSize(getReadSourceName()) / getTargetPartitionSize());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSource.java
@@ -38,7 +38,7 @@ public class ReferenceTwoBitSource implements ReferenceSource, Serializable {
     public ReferenceTwoBitSource(PipelineOptions popts, String referenceURL) throws IOException {
         this.referenceURL = referenceURL;
         Utils.validateArg(isTwoBit(this.referenceURL), "ReferenceTwoBitSource can only take .2bit files");
-        byte[] bytes = ByteStreams.toByteArray(BucketUtils.openFile(this.referenceURL, popts));
+        byte[] bytes = ByteStreams.toByteArray(BucketUtils.openFile(this.referenceURL));
         ByteAccess byteAccess = new DirectFullByteArrayByteAccess(bytes);
         this.twoBitFile = new TwoBitFile(byteAccess);
         this.twoBitSeqEntries = JavaConversions.mapAsJavaMap(twoBitFile.seqRecords());

--- a/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
@@ -16,13 +16,13 @@ public final class MetricsUtils {
     private MetricsUtils(){} //don't instantiate this utility class
 
     /**
-     * Write a {@link MetricsFile} to the given path, can be any destination supported by {@link BucketUtils#createFile(String, AuthHolder)}
+     * Write a {@link MetricsFile} to the given path, can be any destination supported by {@link BucketUtils#createFile(String)}
      * @param metricsFile a {@link MetricsFile} object to write to disk
      * @param metricsOutputPath the path (or uri) to write the metrics to
      * @param authHolder authentication for remote paths, can be null if the path is not remote
      */
     public static void saveMetrics(final MetricsFile<?, ?> metricsFile, String metricsOutputPath, AuthHolder authHolder) {
-        try(PrintWriter out = new PrintWriter(BucketUtils.createFile(metricsOutputPath, authHolder))) {
+        try(PrintWriter out = new PrintWriter(BucketUtils.createFile(metricsOutputPath))) {
             metricsFile.write(out);
         } catch (SAMException e ){
             throw new UserException.CouldNotCreateOutputFile("Could not write metrics to file: " + metricsOutputPath, e);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
@@ -46,7 +46,7 @@ public final class ApplyBQSRSpark extends GATKSparkTool {
     protected void runTool(JavaSparkContext ctx) {
         JavaRDD<GATKRead> initialReads = getReads();
         final GCSOptions gcsOptions = getAuthenticatedGCSOptions(); // null if we have no api key
-        Broadcast<RecalibrationReport> recalibrationReportBroadCast = ctx.broadcast(new RecalibrationReport(BucketUtils.openFile(bqsrRecalFile, gcsOptions)));
+        Broadcast<RecalibrationReport> recalibrationReportBroadCast = ctx.broadcast(new RecalibrationReport(BucketUtils.openFile(bqsrRecalFile)));
         final JavaRDD<GATKRead> recalibratedReads = ApplyBQSRSparkFn.apply(initialReads, recalibrationReportBroadCast, getHeaderForReads(), applyBQSRArgs);
         writeReads(ctx, output, recalibratedReads);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -95,7 +95,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
         // TODO: broadcast the reads header?
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getReferenceSequenceDictionary(), bqsrArgs);
 
-        try ( final PrintStream reportStream = new PrintStream(BucketUtils.createFile(outputTablesPath, getAuthenticatedGCSOptions())) ) {
+        try ( final PrintStream reportStream = new PrintStream(BucketUtils.createFile(outputTablesPath)) ) {
             RecalUtils.outputRecalibrationReport(reportStream, bqsrArgs, bqsrReport.getQuantizationInfo(), bqsrReport.getRecalibrationTables(), bqsrReport.getCovariates());
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkSharded.java
@@ -147,7 +147,7 @@ public class BaseRecalibratorSparkSharded extends SparkCommandLineProgram {
                 PipelineOptions popts = auth.asPipelineOptionsDeprecated();
                 String d = IOUtils.createTempFile("knownVariants-"+i,".vcf").getAbsolutePath();
                 try {
-                    BucketUtils.copyFile(v, popts, d);
+                    BucketUtils.copyFile(v, d);
                 } catch (IOException x) {
                     throw new UserException.CouldNotReadInputFile(v,x);
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSpark.java
@@ -174,7 +174,7 @@ public class ParallelCopyGCSDirectoryIntoHDFSSpark extends GATKSparkTool {
         final String chunkPath = outputPath + "/" + basename + ".chunk." + chunkNum;
 
         try (SeekableByteChannel channel = Files.newByteChannel(gcsPath);
-             final OutputStream outputStream = new BufferedOutputStream(BucketUtils.createNonGCSFile(chunkPath))){
+             final OutputStream outputStream = new BufferedOutputStream(BucketUtils.createFile(chunkPath))){
 
             final long start = chunkSize * (long) chunkNum;
             channel.position(start);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -79,10 +78,10 @@ public final class PSUtils {
      * Same as GATKSparkTool's getRecommendedNumReducers(), but can specify input BAM path (for when --input is not used)
      */
     public static int pathseqGetRecommendedNumReducers(final String inputPath, final int numReducers,
-                                                       final PipelineOptions options, final int targetPartitionSize) {
+                                                       final int targetPartitionSize) {
         if (numReducers != 0) {
             return numReducers;
         }
-        return 1 + (int) (BucketUtils.dirSize(inputPath, options) / targetPartitionSize);
+        return 1 + (int) (BucketUtils.dirSize(inputPath) / targetPartitionSize);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
@@ -222,7 +222,7 @@ public final class PathSeqFilterSpark extends GATKSparkTool {
     private JavaRDD<GATKRead> doKmerFiltering(final JavaSparkContext ctx, final JavaRDD<GATKRead> reads) {
 
         final PipelineOptions options = getAuthenticatedGCSOptions();
-        Input input = new Input(BucketUtils.openFile(KMER_LIB_PATH, options));
+        Input input = new Input(BucketUtils.openFile(KMER_LIB_PATH));
         Kryo kryo=new Kryo();
         kryo.setReferences(false);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqKmerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqKmerSpark.java
@@ -61,7 +61,7 @@ public final class PathSeqKmerSpark extends GATKSparkTool {
         final List<SVKmer> kmerList = findKmers(ctx, KMER_SIZE, referenceMultiSource, options, dict);
         final HopscotchSet<SVKmer> kmerSet = new HopscotchSet<>(kmerList);
 
-        final Output output = new Output(BucketUtils.createFile(OUTPUT_FILE, options));
+        final Output output = new Output(BucketUtils.createFile(OUTPUT_FILE));
         final Kryo kryo=new Kryo();
         kryo.setReferences(false);
         kryo.writeClassAndObject(output, kmerSet);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
@@ -37,7 +37,7 @@ public final class CountBasesSpark extends GATKSparkTool {
         System.out.println(count);
 
         if( out != null) {
-            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
+            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out)) ) {
                 ps.print(count);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -37,7 +37,7 @@ public final class CountReadsSpark extends GATKSparkTool {
         System.out.println(count);
 
         if(out != null) {
-            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions()))) {
+            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out))) {
                 ps.print(count);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
@@ -55,7 +55,7 @@ public final class CountVariantsSpark extends GATKSparkTool {
         System.out.println(count);
 
         if( out != null) {
-            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions()))) {
+            try (final PrintStream ps = new PrintStream(BucketUtils.createFile(out))) {
                 ps.print(count);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
@@ -38,7 +38,7 @@ public final class FlagStatSpark extends GATKSparkTool {
         System.out.println(result);
 
         if(out != null ) {
-            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out, getAuthenticatedGCSOptions())) ) {
+            try ( final PrintStream ps = new PrintStream(BucketUtils.createFile(out)) ) {
                 ps.print(result);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedAssemblyOrExcuse.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedAssemblyOrExcuse.java
@@ -120,10 +120,10 @@ public final class AlignedAssemblyOrExcuse {
     /**
      * write a SAM file containing records for each aligned contig
      */
-    static void writeSAMFile( final String samFile, final PipelineOptions pOpts,
-                              final SAMFileHeader header,
-                              final List<AlignedAssemblyOrExcuse> alignedAssemblyOrExcuseList ) {
-        try ( final OutputStream os = BucketUtils.createFile(samFile, pOpts) ) {
+    static void writeSAMFile( final String samFile,
+                                     final SAMFileHeader header,
+                                     final List<AlignedAssemblyOrExcuse> alignedAssemblyOrExcuseList ) {
+        try ( final OutputStream os = BucketUtils.createFile(samFile) ) {
             final SAMTextWriter writer = new SAMTextWriter(os);
             writer.setSortOrder(SAMFileHeader.SortOrder.queryname, true);
             writer.setHeader(header);
@@ -188,7 +188,6 @@ public final class AlignedAssemblyOrExcuse {
      * write a file describing each interval
      */
     public static void writeIntervalFile( final String intervalFile,
-                                          final PipelineOptions pOpts,
                                           final SAMFileHeader header,
                                           final List<SVInterval> intervals,
                                           final List<AlignedAssemblyOrExcuse> intervalDispositions ) {
@@ -197,7 +196,7 @@ public final class AlignedAssemblyOrExcuse {
                 resultsMap.put(alignedAssemblyOrExcuse.getAssemblyId(), alignedAssemblyOrExcuse));
 
         try ( final OutputStreamWriter writer =
-                      new OutputStreamWriter(new BufferedOutputStream(BucketUtils.createFile(intervalFile,pOpts))) ) {
+                      new OutputStreamWriter(new BufferedOutputStream(BucketUtils.createFile(intervalFile))) ) {
             final List<SAMSequenceRecord> contigs = header.getSequenceDictionary().getSequences();
             final int nIntervals = intervals.size();
             for ( int intervalId = 0; intervalId != nIntervals; ++intervalId ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
@@ -198,8 +198,8 @@ public final class FindBadGenomicKmersSpark extends GATKSparkTool {
                                                          final int maxDUSTScore,
                                                          final String fastaFilename,
                                                          final PipelineOptions options ) {
-        try ( BufferedReader rdr = new BufferedReader(new InputStreamReader(BucketUtils.openFile(fastaFilename, options))) ) {
-            final List<SVKmer> kmers = new ArrayList<>((int) BucketUtils.fileSize(fastaFilename, options));
+        try ( BufferedReader rdr = new BufferedReader(new InputStreamReader(BucketUtils.openFile(fastaFilename))) ) {
+            final List<SVKmer> kmers = new ArrayList<>((int) BucketUtils.fileSize(fastaFilename));
             String line;
             final StringBuilder sb = new StringBuilder();
             final SVKmer kmerSeed = new SVKmerLong();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
@@ -73,7 +73,7 @@ public final class FindBadGenomicKmersSpark extends GATKSparkTool {
             killList = uniquify(killList, processFasta(kSize, maxDUSTScore, highCopyFastaFilename, options));
         }
 
-        SVUtils.writeKmersFile(kSize, outputFile, options, killList);
+        SVUtils.writeKmersFile(kSize, outputFile, killList);
     }
 
     /** Find high copy number kmers in the reference sequence */

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
@@ -206,12 +206,11 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
 
     /** Read a file of contig names that will be ignored when checking for inter-contig pairs. */
     private static Set<Integer> readCrossContigsToIgnoreFile( final String crossContigsToIgnoreFile,
-                                                              final PipelineOptions pipelineOptions,
                                                               final SAMSequenceDictionary dictionary ) {
         final Set<Integer> ignoreSet = new HashSet<>();
         try ( final BufferedReader rdr =
                       new BufferedReader(
-                              new InputStreamReader(BucketUtils.openFile(crossContigsToIgnoreFile,pipelineOptions))) ) {
+                              new InputStreamReader(BucketUtils.openFile(crossContigsToIgnoreFile))) ) {
             String line;
             while ( (line = rdr.readLine()) != null ) {
                 final int tigId = dictionary.getSequenceIndex(line);
@@ -488,7 +487,7 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
         // record the kmers with their interval IDs
         if ( locations.kmerFile != null ) {
             try (final OutputStreamWriter writer = new OutputStreamWriter(new BufferedOutputStream(
-                    BucketUtils.createFile(locations.kmerFile, pipelineOptions)))) {
+                    BucketUtils.createFile(locations.kmerFile)))) {
                 for (final KmerAndInterval kmerAndInterval : filteredKmerIntervals) {
                     writer.write(kmerAndInterval.toString(kSize) + " " + kmerAndInterval.getIntervalId() + "\n");
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
@@ -136,12 +136,12 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
 
         // record the intervals
         if ( locations.intervalFile != null ) {
-            AlignedAssemblyOrExcuse.writeIntervalFile(locations.intervalFile, pipelineOptions, header, intervals, alignedAssemblyOrExcuseList);
+            AlignedAssemblyOrExcuse.writeIntervalFile(locations.intervalFile, header, intervals, alignedAssemblyOrExcuseList);
         }
 
         // write the output file
         final SAMFileHeader cleanHeader = new SAMFileHeader(header.getSequenceDictionary());
-        AlignedAssemblyOrExcuse.writeSAMFile(outputSAM, pipelineOptions, cleanHeader, alignedAssemblyOrExcuseList);
+        AlignedAssemblyOrExcuse.writeSAMFile(outputSAM, cleanHeader, alignedAssemblyOrExcuseList);
         log("Wrote SAM file of aligned contigs.", toolLogger);
 
         return alignedAssemblyOrExcuseList;
@@ -167,7 +167,6 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
         final Set<Integer> crossContigsToIgnoreSet;
         if ( locations.crossContigsToIgnoreFile == null ) crossContigsToIgnoreSet = Collections.emptySet();
         else crossContigsToIgnoreSet = readCrossContigsToIgnoreFile(locations.crossContigsToIgnoreFile,
-                                                                    pipelineOptions,
                                                                     header.getSequenceDictionary());
         final JavaRDD<GATKRead> mappedReads =
                 unfilteredReads.filter(read ->
@@ -197,7 +196,7 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
         broadcastMetadata.destroy();
 
         if ( locations.qNamesMappedFile != null ) {
-            QNameAndInterval.writeQNames(locations.qNamesMappedFile, pipelineOptions, qNamesMultiMap);
+            QNameAndInterval.writeQNames(locations.qNamesMappedFile, qNamesMultiMap);
         }
         log("Discovered " + qNamesMultiMap.size() + " mapped template names.", logger);
 
@@ -258,7 +257,7 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
                         goodPrimaryLines));
 
         if ( locations.qNamesAssemblyFile != null ) {
-            QNameAndInterval.writeQNames(locations.qNamesAssemblyFile, pipelineOptions, qNamesMultiMap);
+            QNameAndInterval.writeQNames(locations.qNamesAssemblyFile, qNamesMultiMap);
         }
 
         log("Discovered "+qNamesMultiMap.size()+" unique template names for assembly.", logger);
@@ -379,7 +378,7 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
             final FermiLiteAssembly assembly = new FermiLiteAssembler().createAssembly(readsList);
             if ( gfaDir != null ) {
                 final String gfaName = String.format("%s/assembly%06d.gfa",gfaDir,intervalAndReads._1());
-                try ( final OutputStream os = BucketUtils.createFile(gfaName, pipelineOptions) ) {
+                try ( final OutputStream os = BucketUtils.createFile(gfaName) ) {
                     assembly.writeGFA(os);
                 }
                 catch ( final IOException ioe ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/QNameAndInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/QNameAndInterval.java
@@ -88,10 +88,9 @@ public final class QNameAndInterval implements Map.Entry<String, Integer> {
      * write template names and interval IDs to a file.
      */
     public static void writeQNames( final String qNameFile,
-                                    final PipelineOptions pOpts,
                                     final Iterable<QNameAndInterval> qNames ) {
         try ( final OutputStreamWriter writer =
-                      new OutputStreamWriter(new BufferedOutputStream(BucketUtils.createFile(qNameFile, pOpts))) ) {
+                      new OutputStreamWriter(new BufferedOutputStream(BucketUtils.createFile(qNameFile))) ) {
             for ( final QNameAndInterval qnameAndInterval : qNames ) {
                 writer.write(qnameAndInterval.toString() + "\n");
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ReadMetadata.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ReadMetadata.java
@@ -4,7 +4,6 @@ import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
@@ -220,8 +219,7 @@ public class ReadMetadata {
     }
 
     public static void writeMetadata( final ReadMetadata readMetadata,
-                                      final String filename,
-                                      final PipelineOptions pipelineOptions ) {
+                                      final String filename ) {
         try ( final Writer writer =
                       new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(filename))) ) {
             writer.write("#reads:\t" + readMetadata.getNReads() + "\n");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ReadMetadata.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/ReadMetadata.java
@@ -223,7 +223,7 @@ public class ReadMetadata {
                                       final String filename,
                                       final PipelineOptions pipelineOptions ) {
         try ( final Writer writer =
-                      new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(filename, pipelineOptions))) ) {
+                      new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(filename))) ) {
             writer.write("#reads:\t" + readMetadata.getNReads() + "\n");
             writer.write("#partitions:\t" + readMetadata.getNPartitions() + "\n");
             writer.write("max reads/partition:\t" + readMetadata.getMaxReadsInPartition() + "\n");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
@@ -66,10 +66,10 @@ public class SVFastqUtils {
         }
     }
 
-    public static List<FastqRead> readFastqFile( final String fileName, final PipelineOptions options ) {
+    public static List<FastqRead> readFastqFile( final String fileName ) {
         final int INITIAL_CAPACITY = 10000; // absolute guess, just something not too crazy small
         final List<FastqRead> reads = new ArrayList<>(INITIAL_CAPACITY);
-        try ( final BufferedReader reader = new BufferedReader(new InputStreamReader(BucketUtils.openFile(fileName, options))) ) {
+        try ( final BufferedReader reader = new BufferedReader(new InputStreamReader(BucketUtils.openFile(fileName))) ) {
             String seqIdLine;
             int lineNo = 0;
             while ( (seqIdLine = reader.readLine()) != null ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
@@ -4,7 +4,6 @@ import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.SAMUtils;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.fermi.FermiLiteAssembler;
@@ -124,7 +123,6 @@ public class SVFastqUtils {
     /** Write a list of FASTQ records into a file. */
     public static void writeFastqFile(
             final String fileName,
-            final PipelineOptions pipelineOptions,
             final Iterator<FastqRead> fastqReadItr ) {
         try ( final OutputStream writer =
                       new BufferedOutputStream(BucketUtils.createFile(fileName)) ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVFastqUtils.java
@@ -127,7 +127,7 @@ public class SVFastqUtils {
             final PipelineOptions pipelineOptions,
             final Iterator<FastqRead> fastqReadItr ) {
         try ( final OutputStream writer =
-                      new BufferedOutputStream(BucketUtils.createFile(fileName, pipelineOptions)) ) {
+                      new BufferedOutputStream(BucketUtils.createFile(fileName)) ) {
             writeFastqStream(writer, fastqReadItr);
         } catch ( final IOException ioe ) {
             throw new GATKException("Can't write "+fileName, ioe);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
@@ -31,7 +31,7 @@ public final class SVUtils {
      * Read a file of kmers.
      * Each line must be exactly SVConstants.KMER_SIZE characters long, and must match [ACGT]*.
      */
-    public static Set<SVKmer> readKmersFile(final int kSize, final String kmersFile, final PipelineOptions popts,
+    public static Set<SVKmer> readKmersFile(final int kSize, final String kmersFile,
                                             final SVKmer kmer ) {
         final Set<SVKmer> kmers;
 
@@ -62,7 +62,7 @@ public final class SVUtils {
     }
 
     /** Write kmers to file. */
-    public static <KType extends SVKmer> void writeKmersFile(final int kSize, final String kmersFile, final PipelineOptions popts,
+    public static <KType extends SVKmer> void writeKmersFile(final int kSize, final String kmersFile,
                                                              final Collection<KType> kmers ) {
         try ( final Writer writer =
                       new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(kmersFile))) ) {
@@ -77,7 +77,7 @@ public final class SVUtils {
     }
 
     /** Read intervals from file. */
-    public static List<SVInterval> readIntervalsFile(final String intervalsFile, final PipelineOptions popts,
+    public static List<SVInterval> readIntervalsFile(final String intervalsFile,
                                                      final Map<String, Integer> contigNameMap ) {
         final List<SVInterval> intervals;
         try ( final BufferedReader rdr =
@@ -116,7 +116,7 @@ public final class SVUtils {
     }
 
     /** Write intervals to a file. */
-    public static void writeIntervalsFile( final String intervalsFile, final PipelineOptions popts,
+    public static void writeIntervalsFile( final String intervalsFile,
                                            final Collection<SVInterval> intervals, final List<String> contigNames ) {
         try (final OutputStreamWriter writer = new OutputStreamWriter(new BufferedOutputStream(
                 BucketUtils.createFile(intervalsFile)))) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVUtils.java
@@ -36,8 +36,8 @@ public final class SVUtils {
         final Set<SVKmer> kmers;
 
         try ( final BufferedReader rdr =
-                      new BufferedReader(new InputStreamReader(BucketUtils.openFile(kmersFile, popts))) ) {
-            final long fileLength = BucketUtils.fileSize(kmersFile, popts);
+                      new BufferedReader(new InputStreamReader(BucketUtils.openFile(kmersFile))) ) {
+            final long fileLength = BucketUtils.fileSize(kmersFile);
             kmers = new HopscotchSet<>((int)(fileLength/(kSize+1)));
             String line;
             while ( (line = rdr.readLine()) != null ) {
@@ -65,7 +65,7 @@ public final class SVUtils {
     public static <KType extends SVKmer> void writeKmersFile(final int kSize, final String kmersFile, final PipelineOptions popts,
                                                              final Collection<KType> kmers ) {
         try ( final Writer writer =
-                      new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(kmersFile, popts))) ) {
+                      new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(kmersFile))) ) {
             for ( final KType kmer : kmers ) {
                 writer.write(kmer.toString(kSize));
                 writer.write('\n');
@@ -81,9 +81,9 @@ public final class SVUtils {
                                                      final Map<String, Integer> contigNameMap ) {
         final List<SVInterval> intervals;
         try ( final BufferedReader rdr =
-                      new BufferedReader(new InputStreamReader(BucketUtils.openFile(intervalsFile, popts))) ) {
+                      new BufferedReader(new InputStreamReader(BucketUtils.openFile(intervalsFile))) ) {
             final int INTERVAL_FILE_LINE_LENGTH_GUESS = 25;
-            final long sizeGuess = BucketUtils.fileSize(intervalsFile, popts)/INTERVAL_FILE_LINE_LENGTH_GUESS;
+            final long sizeGuess = BucketUtils.fileSize(intervalsFile)/INTERVAL_FILE_LINE_LENGTH_GUESS;
             intervals = new ArrayList<>((int)sizeGuess);
             String line;
             int lineNo = 0;
@@ -119,7 +119,7 @@ public final class SVUtils {
     public static void writeIntervalsFile( final String intervalsFile, final PipelineOptions popts,
                                            final Collection<SVInterval> intervals, final List<String> contigNames ) {
         try (final OutputStreamWriter writer = new OutputStreamWriter(new BufferedOutputStream(
-                BucketUtils.createFile(intervalsFile, popts)))) {
+                BucketUtils.createFile(intervalsFile)))) {
             for (final SVInterval interval : intervals) {
                 final String seqName = contigNames.get(interval.getContig());
                 writer.write(seqName + "\t" + (interval.getStart()+1) + "\t" + interval.getEnd() + "\n");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A utility class that writes out variants to a VCF file.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A utility class that writes out variants to a VCF file.
@@ -76,7 +75,7 @@ public class SVVCFWriter {
     private static void writeVariants(final PipelineOptions pipelineOptions, final String fileName,
                                       final List<VariantContext> variantsArrayList, final SAMSequenceDictionary referenceSequenceDictionary) {
         try (final OutputStream outputStream
-                     = new BufferedOutputStream(BucketUtils.createFile(fileName, pipelineOptions))) {
+                     = new BufferedOutputStream(BucketUtils.createFile(fileName))) {
 
             final VariantContextWriter vcfWriter = getVariantContextWriter(outputStream, referenceSequenceDictionary);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -70,7 +70,7 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
         // gather evidence, run assembly, and align
         final List<AlignedAssemblyOrExcuse> alignedAssemblyOrExcuseList =
                 FindBreakpointEvidenceSpark
-                        .gatherEvidenceAndWriteContigSamFile(ctx, pipelineOptions, evidenceAndAssemblyArgs, header, getUnfilteredReads(),
+                        .gatherEvidenceAndWriteContigSamFile(ctx, evidenceAndAssemblyArgs, header, getUnfilteredReads(),
                                 outputSAM, localLogger);
         if (alignedAssemblyOrExcuseList.isEmpty()) return;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/bqsr/BaseRecalibratorEngineSparkWrapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/bqsr/BaseRecalibratorEngineSparkWrapper.java
@@ -56,7 +56,7 @@ public final class BaseRecalibratorEngineSparkWrapper implements Serializable {
 
     // saves to output
     public static void saveTextualReport(String output, SAMFileHeader header, RecalibrationTables rt, RecalibrationArgumentCollection recalArgs, AuthHolder auth) throws IOException {
-        OutputStream oStream = BucketUtils.createFile(output, auth);
+        OutputStream oStream = BucketUtils.createFile(output);
         QuantizationInfo qi = new QuantizationInfo(rt, recalArgs.QUANTIZING_LEVELS);
         if (recalArgs.FORCE_PLATFORM != null) {
             recalArgs.DEFAULT_PLATFORM = recalArgs.FORCE_PLATFORM;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -1,27 +1,18 @@
 package org.broadinstitute.hellbender.utils.gcs;
 
-import com.google.api.services.storage.Storage;
-import com.google.cloud.HttpTransportOptions;
-import com.google.cloud.dataflow.sdk.options.GcsOptions;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
-import com.google.cloud.dataflow.sdk.util.GcsUtil;
-import com.google.cloud.dataflow.sdk.util.Transport;
-import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
-import com.google.cloud.storage.StorageOptions;
-import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration;
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
 import com.google.common.io.ByteStreams;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.util.TabixUtils;
+import java.nio.file.Files;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -31,10 +22,7 @@ import shaded.cloud_nio.com.google.auth.Credentials;
 import shaded.cloud_nio.org.joda.time.Duration;
 
 import java.io.*;
-import java.nio.channels.Channels;
-import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -98,16 +86,15 @@ public final class BucketUtils {
      * If the file ends with .gz will attempt to wrap it in an appropriate unzipping stream
      *
      * @param path the GCS, HDFS or local path to read from. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
-     * @param popts the pipeline's options, with authentication information.
      * @return an InputStream that reads from the specified file.
      */
-    public static InputStream openFile(String path, PipelineOptions popts) {
+    public static InputStream openFile(String path) {
         try {
             Utils.nonNull(path);
             InputStream inputStream;
-            if (BucketUtils.isCloudStorageUrl(path)) {
-                Utils.nonNull(popts, "Cannot load from a GCS path without authentication.");
-                inputStream = Channels.newInputStream(new GcsUtil.GcsUtilFactory().create(popts).open(GcsPath.fromUri(path)));
+            if (isCloudStorageUrl(path)) {
+                java.nio.file.Path p = getPathOnGcs(path);
+                inputStream = Files.newInputStream(p);
             } else if (isHadoopUrl(path)) {
                 Path file = new org.apache.hadoop.fs.Path(path);
                 FileSystem fs = file.getFileSystem(new Configuration());
@@ -131,14 +118,14 @@ public final class BucketUtils {
      * For writing to GCS it'll use the application/octet-stream MIME type.
      *
      * @param path the GCS or local path to write to. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
-     * @param popts the pipeline's options, with authentication information.
      * @return an OutputStream that writes to the specified file.
      */
-    public static OutputStream createFile(String path, PipelineOptions popts) {
+    public static OutputStream createFile(String path) {
         Utils.nonNull(path);
         try {
             if (isCloudStorageUrl(path)) {
-                return Channels.newOutputStream(new GcsUtil.GcsUtilFactory().create(popts).create(GcsPath.fromUri(path), "application/octet-stream"));
+                java.nio.file.Path p = getPathOnGcs(path);
+                return Files.newOutputStream(p);
             } else if (isHadoopUrl(path)) {
                 Path file = new Path(path);
                 FileSystem fs = file.getFileSystem(new Configuration());
@@ -152,57 +139,29 @@ public final class BucketUtils {
     }
 
     /**
-     * Open a binary file for writing regardless of whether it's on GCS, HDFS or local disk.
-     * For writing to GCS it'll use the application/octet-stream MIME type.
-     *
-     * @param path the GCS , HDFS, or local path to write to. If HDFS, it must start with "hdfs://".
-     *             If GCS, it must start with "gs://" and you must be using API Key authentication.
-     * @param auth authentication information.
-     * @return an OutputStream that writes to the specified file.
-     */
-    public static OutputStream createFile(String path, AuthHolder auth) {
-        PipelineOptions popts = auth.asPipelineOptionsDeprecated();
-        return createFile(path, popts);
-    }
-
-    /**
-     * Open a binary file for writing regardless of whether it's on HDFS or local disk.
-     *
-     * @param path the local path to write to.
-     * @return an OutputStream that writes to the specified file.
-     */
-    public static OutputStream createNonGCSFile(String path) {
-        return createFile(path, (PipelineOptions)null);
-    }
-
-    /**
      * Copies a file. Can be used to copy e.g. from GCS to local.
      *
      * @param sourcePath the path to read from. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
-     * @param popts the pipeline's options, with authentication information.
      * @param destPath the path to copy to. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
      * @throws IOException
      */
-    public static void copyFile(String sourcePath, PipelineOptions popts, String destPath) throws IOException {
+    public static void copyFile(String sourcePath, String destPath) throws IOException {
         try (
-            InputStream in = openFile(sourcePath, popts);
-            OutputStream fout = createFile(destPath, popts)) {
+            InputStream in = openFile(sourcePath);
+            OutputStream fout = createFile(destPath)) {
             ByteStreams.copy(in, fout);
         }
     }
 
     /**
      * Deletes a file: local, GCS or HDFS.
+     *  @param pathToDelete the path to delete. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
      *
-     * @param pathToDelete the path to delete. If GCS, it must start with "gs://", or "hdfs://" for HDFS.
-     * @param popts the pipeline's options, with authentication information.
      */
-    public static void deleteFile(String pathToDelete, PipelineOptions popts) throws IOException {
-        if (BucketUtils.isCloudStorageUrl(pathToDelete)) {
-            GcsPath path = GcsPath.fromUri(pathToDelete);
-            GcsOptions gcsOptions = popts.as(GcsOptions.class);
-            Storage storage = Transport.newStorageClient(gcsOptions).build();
-            storage.objects().delete(path.getBucket(), path.getObject()).execute();
+    public static void deleteFile(String pathToDelete) throws IOException {
+        if (isCloudStorageUrl(pathToDelete)) {
+            java.nio.file.Path p = getPathOnGcs(pathToDelete);
+            Files.delete(p);
         } else if (isHadoopUrl(pathToDelete)) {
             Path file = new Path(pathToDelete);
             FileSystem fs = file.getFileSystem(new Configuration());
@@ -221,18 +180,17 @@ public final class BucketUtils {
      *               for remote paths this should be a valid URI to root the temporary file in (ie. gcs://hellbender/staging/)
      *               there is no guarantee that this will be used as the root of the tmp file name, a local prefix may be placed in the tmp folder for exapmle
      * @param extension and extension for the temporary file path, the resulting path will end in this
-     * @param authHolder authentication for remote file paths, may be null
      * @return a path to use as a temporary file, on remote file systems which don't support an atomic tmp file reservation a path is chosen with a long randomized name
      *
      */
-    public static String getTempFilePath(String prefix, String extension, AuthHolder authHolder){
-        if (BucketUtils.isCloudStorageUrl(prefix) || (BucketUtils.isHadoopUrl(prefix))){
+    public static String getTempFilePath(String prefix, String extension){
+        if (isCloudStorageUrl(prefix) || (isHadoopUrl(prefix))){
             final String path = randomRemotePath(prefix, "", extension);
-            deleteOnExit(path, authHolder);
-            deleteOnExit(path + Tribble.STANDARD_INDEX_EXTENSION, authHolder);
-            deleteOnExit(path + TabixUtils.STANDARD_INDEX_EXTENSION, authHolder);
-            deleteOnExit(path + ".bai", authHolder);
-            deleteOnExit(path.replaceAll(extension + "$", ".bai"), authHolder); //if path ends with extension, replace it with .bai
+            deleteOnExit(path);
+            deleteOnExit(path + Tribble.STANDARD_INDEX_EXTENSION);
+            deleteOnExit(path + TabixUtils.STANDARD_INDEX_EXTENSION);
+            deleteOnExit(path + ".bai");
+            deleteOnExit(path.replaceAll(extension + "$", ".bai")); //if path ends with extension, replace it with .bai
             return path;
         } else {
             return IOUtils.createTempFile(prefix, extension).getAbsolutePath();
@@ -242,14 +200,14 @@ public final class BucketUtils {
     /**
      * Schedule a file to be deleted on JVM shutdown.
      * @param fileToDelete the path to the file to be deleted
-     * @param authHolder authentication for remote files
+     *
      */
-    public static void deleteOnExit(String fileToDelete, AuthHolder authHolder){
+    public static void deleteOnExit(String fileToDelete){
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 try {
-                    deleteFile(fileToDelete, authHolder.asPipelineOptionsDeprecated());
+                    deleteFile(fileToDelete);
                 } catch (IOException e) {
                     logger.warn("Failed to delete file: " + fileToDelete+ ".", e);
                 }
@@ -266,7 +224,8 @@ public final class BucketUtils {
      */
     public static String randomRemotePath(String stagingLocation, String prefix, String suffix) {
         if (isCloudStorageUrl(stagingLocation)) {
-            return GcsPath.fromUri(stagingLocation).resolve(prefix + UUID.randomUUID().toString() + suffix).toString();
+            // Go through URI because Path.toString isn't guaranteed to include the "gs://" prefix.
+            return getPathOnGcs(stagingLocation).resolve(prefix + UUID.randomUUID().toString() + suffix).toUri().toString();
         } else if (isHadoopUrl(stagingLocation)) {
             return new Path(stagingLocation, prefix + UUID.randomUUID().toString() + suffix).toString();
         } else {
@@ -276,14 +235,13 @@ public final class BucketUtils {
 
     /**
      * Returns true if we can read the first byte of the file.
+     *  @param path The folder where you want the file to be (local, GCS or HDFS).
      *
-     * @param path The folder where you want the file to be (local, GCS or HDFS).
-     * @param popts the pipeline's options, with authentication information.
      */
-    public static boolean fileExists(String path, PipelineOptions popts) {
+    public static boolean fileExists(String path) {
         final boolean MAYBE = false;
         try {
-            InputStream inputStream = BucketUtils.openFile(path, popts);
+            InputStream inputStream = openFile(path);
             int ignored = inputStream.read();
         } catch (UserException.CouldNotReadInputFile notthere) {
             // file isn't there
@@ -302,13 +260,13 @@ public final class BucketUtils {
      * Returns the file size of a file pointed to by a GCS/HDFS/local path
      *
      * @param path The URL to the file whose size to return
-     * @param popts PipelineOptions for GCS (if relevant; otherwise pass null)
      * @return the file size in bytes
      * @throws IOException
      */
-    public static long fileSize(String path, PipelineOptions popts) throws IOException {
+    public static long fileSize(String path) throws IOException {
         if (isCloudStorageUrl(path)) {
-            return new GcsUtil.GcsUtilFactory().create(popts).fileSize(GcsPath.fromUri(path));
+            java.nio.file.Path p = getPathOnGcs(path);
+            return Files.size(p);
         } else if (isHadoopUrl(path)) {
             Path hadoopPath = new Path(path);
             FileSystem fs = hadoopPath.getFileSystem(new Configuration());
@@ -324,25 +282,22 @@ public final class BucketUtils {
      * Only supports HDFS and local paths.
      *
      * @param path The URL to the file or directory whose size to return
-     * @param popts PipelineOptions for GCS (if relevant; otherwise pass null)
      * @return the total size of all files in bytes
      */
-    public static long dirSize(String path, PipelineOptions popts) {
+    public static long dirSize(String path) {
         try {
-            // GCS case
+            // GCS case (would work with local too)
             if (isCloudStorageUrl(path)) {
-                final GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
-                final List<GcsPath> pathsInDir = gcsUtil.expand(GcsPath.fromUri(path));
-                return pathsInDir.stream().mapToLong((path1) -> {
-                    try {
-                        return gcsUtil.fileSize(path1);
-                    } catch( final NoSuchFileException e) {
-                        return 0;
-                    } catch( final IOException e) {
-                        throw new RuntimeIOException(e);
+                java.nio.file.Path p = getPathOnGcs(path);
+                return Files.list(p).mapToLong(
+                    q -> {
+                        try {
+                            return (Files.isRegularFile(q) ? Files.size(q) : 0);
+                        } catch (IOException e) {
+                            throw new RuntimeIOException(e);
+                        }
                     }
-                }).sum();
-
+                ).sum();
             }
             // local file or HDFS case
             Path hadoopPath = new Path(path);

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -24,6 +24,9 @@ import shaded.cloud_nio.org.joda.time.Duration;
 import java.io.*;
 import java.util.Arrays;
 import java.util.UUID;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.HttpTransportOptions;
+import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration;
 
 /**
  * Utilities for dealing with google buckets.

--- a/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReport.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReport.java
@@ -44,7 +44,7 @@ public final class GATKReport {
      * @param filename the path to the file to load
      */
     public GATKReport(String filename) {
-        this(BucketUtils.openFile(filename, null));
+        this(BucketUtils.openFile(filename));
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
@@ -46,7 +46,7 @@ public class MetricsUtilsTest extends BaseTest {
 
     @Test(dataProvider = "metricsPaths", groups = "cloud")
     public void testSaveMetrics(String destinationPrefix) throws IOException {
-        final String outputPath = BucketUtils.getTempFilePath(destinationPrefix, ".txt", getAuthentication());
+        final String outputPath = BucketUtils.getTempFilePath(destinationPrefix, ".txt");
         TestMetric testMetric = new TestMetric();
         testMetric.value1 = 10;
         testMetric.value2 = 5;
@@ -54,7 +54,7 @@ public class MetricsUtilsTest extends BaseTest {
         final MetricsFile<TestMetric, ?> metrics = new MetricsFile<>();
         metrics.addMetric(testMetric);
         MetricsUtils.saveMetrics(metrics, outputPath,getAuthentication());
-        Assert.assertTrue(BucketUtils.fileExists(outputPath, getAuthenticatedPipelineOptions()));
+        Assert.assertTrue(BucketUtils.fileExists(outputPath));
         File localCopy = copyFileToLocalTmpFile(outputPath);
 
         final File expectedMetrics = createTempFile("expectedMetrics", ".txt");
@@ -65,7 +65,7 @@ public class MetricsUtilsTest extends BaseTest {
 
     private File copyFileToLocalTmpFile(String outputPath) throws IOException {
         File localCopy = createTempFile("local_metrics_copy",".txt");
-        BucketUtils.copyFile(outputPath, getAuthenticatedPipelineOptions(), localCopy.getAbsolutePath());
+        BucketUtils.copyFile(outputPath, localCopy.getAbsolutePath());
         return localCopy;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest.java
@@ -58,12 +58,12 @@ public class ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest extends Comman
                 Assert.assertTrue(fileSizeOnGCS > chunkSize);
             }
 
-            Assert.assertEquals(BucketUtils.fileSize(hdfsPath, null),
+            Assert.assertEquals(BucketUtils.fileSize(hdfsPath),
                     fileSizeOnGCS);
 
             final File tempDir = createTempDir("ParallelCopy");
 
-            BucketUtils.copyFile(hdfsPath, null, tempDir + "fileFromHDFS.bam.bai");
+            BucketUtils.copyFile(hdfsPath, tempDir + "fileFromHDFS.bam.bai");
             Assert.assertEquals(Utils.calculateFileMD5(new File(tempDir + "fileFromHDFS.bam.bai")), "1a6baa5332e98ef1358ac0fb36f46aaf");
         } finally {
             MiniClusterUtils.stopCluster(cluster);
@@ -103,7 +103,7 @@ public class ParallelCopyGCSDirectoryIntoHDFSSparkIntegrationTest extends Comman
                 while (hdfsCopies.hasNext()) {
                     final FileStatus next =  hdfsCopies.next();
                     final Path path = next.getPath();
-                    BucketUtils.copyFile(path.toString(), null, tempDir + "/" + path.getName());
+                    BucketUtils.copyFile(path.toString(), tempDir + "/" + path.getName());
                     filesFound ++;
                 }
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtilsTest.java
@@ -87,7 +87,7 @@ public class PSUtilsTest extends BaseTest {
 
         final Kryo kryo = new Kryo();
         kryo.setReferences(false);
-        final Input input = new Input(BucketUtils.openFile(tempFile.getPath(), null));
+        final Input input = new Input(BucketUtils.openFile(tempFile.getPath()));
         final Integer int_out = (Integer) kryo.readClassAndObject(input);
         final String str_out = (String) kryo.readClassAndObject(input);
         input.close();

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSparkUnitTest.java
@@ -76,7 +76,7 @@ public final class FindBreakpointEvidenceSparkUnitTest extends BaseTest {
 
         // an empty qname map should produce a "too few kmers" disposition for the interval
         final List<AlignedAssemblyOrExcuse> alignedAssemblyOrExcuseList =
-                FindBreakpointEvidenceSpark.getKmerIntervals(params, ctx, qNameMultiMap, 1, Collections.emptySet(), reads, locations, null)._1();
+                FindBreakpointEvidenceSpark.getKmerIntervals(params, ctx, qNameMultiMap, 1, Collections.emptySet(), reads, locations)._1();
         Assert.assertEquals(alignedAssemblyOrExcuseList.size(), 1);
         Assert.assertTrue(alignedAssemblyOrExcuseList.get(0).getErrorMessage().contains("too few"));
 
@@ -86,8 +86,8 @@ public final class FindBreakpointEvidenceSparkUnitTest extends BaseTest {
         final HopscotchUniqueMultiMap<SVKmer, Integer, KmerAndInterval> actualKmerAndIntervalSet =
                 new HopscotchUniqueMultiMap<>(
                         FindBreakpointEvidenceSpark.getKmerIntervals(params, ctx, qNameMultiMap, 1, new HopscotchSet<>(0),
-                                reads, locations, null)._2());
-        final Set<SVKmer> expectedKmers = SVUtils.readKmersFile(params.kSize, kmersFile, null, kmer);
+                                reads, locations)._2());
+        final Set<SVKmer> expectedKmers = SVUtils.readKmersFile(params.kSize, kmersFile, kmer);
         Assert.assertEquals(actualKmerAndIntervalSet.size(), expectedKmers.size());
         for ( final KmerAndInterval kmerAndInterval : actualKmerAndIntervalSet ) {
             Assert.assertTrue(expectedKmers.contains(kmerAndInterval.getKey()));
@@ -96,7 +96,7 @@ public final class FindBreakpointEvidenceSparkUnitTest extends BaseTest {
 
     @Test(groups = "spark")
     public void getAssemblyQNamesTest() throws FileNotFoundException {
-        final Set<SVKmer> expectedKmers = SVUtils.readKmersFile(params.kSize, kmersFile, null, new SVKmerLong(params.kSize));
+        final Set<SVKmer> expectedKmers = SVUtils.readKmersFile(params.kSize, kmersFile, new SVKmerLong(params.kSize));
         final HopscotchUniqueMultiMap<SVKmer, Integer, KmerAndInterval> kmerAndIntervalSet =
                 new HopscotchUniqueMultiMap<>(expectedKmers.size());
         expectedKmers.stream().

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
@@ -153,7 +153,7 @@ public class StructuralVariationDiscoveryPipelineSparkIntegrationTest extends Co
         if (onHDFS) {
             final File tempLocalVCF = BaseTest.createTempFile("variants", "vcf");
             tempLocalVCF.deleteOnExit();
-            BucketUtils.copyFile(generatedVCFPath, null, tempLocalVCF.getAbsolutePath());
+            BucketUtils.copyFile(generatedVCFPath, tempLocalVCF.getAbsolutePath());
             fileReader = new VCFFileReader(tempLocalVCF, false);
         } else {
             fileReader = new VCFFileReader(new File(generatedVCFPath), false);

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.utils.gcs;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.util.IOUtil;
 import java.net.URI;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
@@ -59,7 +58,7 @@ public final class BucketUtilsTest extends BaseTest {
         final String src = publicTestDir+"empty.vcf";
         File dest = createTempFile("copy-empty",".vcf");
 
-        BucketUtils.copyFile(src, null, dest.getPath());
+        BucketUtils.copyFile(src, dest.getPath());
         IOUtil.assertFilesEqual(new File(src), dest);
     }
 
@@ -69,7 +68,7 @@ public final class BucketUtilsTest extends BaseTest {
         try (FileWriter fw = new FileWriter(dest)){
             fw.write("Goodbye, cruel world!");
         }
-        BucketUtils.deleteFile(dest.getPath(), null);
+        BucketUtils.deleteFile(dest.getPath());
         Assert.assertFalse(dest.exists(), "File '"+dest.getPath()+"' was not properly deleted as it should.");
     }
 
@@ -80,12 +79,12 @@ public final class BucketUtilsTest extends BaseTest {
         final String intermediate = BucketUtils.randomRemotePath(getGCPTestStaging(), "test-copy-empty", ".vcf");
         Assert.assertTrue(BucketUtils.isCloudStorageUrl(intermediate), "!BucketUtils.isCloudStorageUrl(intermediate)");
         PipelineOptions popts = getAuthenticatedPipelineOptions();
-        BucketUtils.copyFile(src, popts, intermediate);
-        BucketUtils.copyFile(intermediate, popts, dest.getPath());
+        BucketUtils.copyFile(src, intermediate);
+        BucketUtils.copyFile(intermediate, dest.getPath());
         IOUtil.assertFilesEqual(new File(src), dest);
-        Assert.assertTrue(BucketUtils.fileExists(intermediate, popts));
-        BucketUtils.deleteFile(intermediate, popts);
-        Assert.assertFalse(BucketUtils.fileExists(intermediate, popts));
+        Assert.assertTrue(BucketUtils.fileExists(intermediate));
+        BucketUtils.deleteFile(intermediate);
+        Assert.assertFalse(BucketUtils.fileExists(intermediate));
     }
 
     @Test
@@ -105,12 +104,12 @@ public final class BucketUtilsTest extends BaseTest {
             Assert.assertTrue(BucketUtils.isHadoopUrl(intermediate), "!BucketUtils.isHadoopUrl(intermediate)");
 
             PipelineOptions popts = null;
-            BucketUtils.copyFile(src, popts, intermediate);
-            BucketUtils.copyFile(intermediate, popts, dest.getPath());
+            BucketUtils.copyFile(src, intermediate);
+            BucketUtils.copyFile(intermediate, dest.getPath());
             IOUtil.assertFilesEqual(new File(src), dest);
-            Assert.assertTrue(BucketUtils.fileExists(intermediate, popts));
-            BucketUtils.deleteFile(intermediate, popts);
-            Assert.assertFalse(BucketUtils.fileExists(intermediate, popts));
+            Assert.assertTrue(BucketUtils.fileExists(intermediate));
+            BucketUtils.deleteFile(intermediate);
+            Assert.assertFalse(BucketUtils.fileExists(intermediate));
         });
     }
 
@@ -129,9 +128,9 @@ public final class BucketUtilsTest extends BaseTest {
             }
         }
 
-        long fileSize = BucketUtils.fileSize(file1.getAbsolutePath(), null);
+        long fileSize = BucketUtils.fileSize(file1.getAbsolutePath());
         Assert.assertTrue(fileSize > 0);
-        long dirSize = BucketUtils.dirSize(dir.getAbsolutePath(), null);
+        long dirSize = BucketUtils.dirSize(dir.getAbsolutePath());
         Assert.assertEquals(dirSize, fileSize * 2);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.utils.gcs;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.util.IOUtil;
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -57,7 +57,7 @@ public class ReferenceUtilsUnitTest extends BaseTest {
         final String bucketDictionary = getGCPTestInputPath() + "org/broadinstitute/hellbender/utils/ReferenceUtilsTest.dict";
         final PipelineOptions popts = getAuthenticatedPipelineOptions();
 
-        try ( final InputStream referenceDictionaryStream = BucketUtils.openFile(bucketDictionary, popts) ) {
+        try ( final InputStream referenceDictionaryStream = BucketUtils.openFile(bucketDictionary) ) {
             final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);
 
             Assert.assertNotNull(dictionary, "Sequence dictionary null after loading");


### PR DESCRIPTION
Since NIO reportedly now works from Spark clients, this bit of
authentication is unnecessary. Removing it greatly simplifies
BucketUtils, and also stops users having to worry about where
to get the AuthHolder from.

This work is part of #2402