### PR TITLE
Bump GKL to 0.4.3 and fix IntelInflaterDeflaterIntegrationTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.4.1') {
+    compile('com.intel.gkl:gkl:0.4.3') {
         exclude module: 'htsjdk'
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
@@ -93,7 +93,6 @@ public class IntelInflaterDeflaterIntegrationTest extends CommandLineProgramTest
         final ArrayList<String> args = new ArrayList<>();
         args.add("--input"); args.add(ORIG_BAM.getAbsolutePath());
         args.add("--output"); args.add(outFile.getAbsolutePath());
-        args.add("--verbosity"); args.add("DEBUG");
         args.add("--use_jdk_inflater"); args.add(String.valueOf(use_jdk_inflater));
         args.add("--use_jdk_deflater"); args.add(String.valueOf(use_jdk_deflater));
 


### PR DESCRIPTION
* Bump GKL version to 0.4.3 which addresses some GC and memory leak issues.
* Remove DEBUG verbosity setting in `IntelInflaterDeflaterIntegrationTest`, which caused subsequent tests to generate huge amounts of debug info and run out of memory on some systems.

Resolves #2490 and resolves #2535.