### PR TITLE
(Do not merge) Create a snapshot of gatk-public based on 4.alpha.2-188-g7332d10 with TandemRepeat fix applied

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
@@ -35,7 +35,7 @@ public final class TandemRepeat extends InfoFieldAnnotation {
             return Collections.emptyMap();
         }
 
-        final Pair<List<Integer>,byte[]> result = GATKVariantContextUtils.getNumTandemRepeatUnits(vc, ref.getForwardBases());
+        final Pair<List<Integer>,byte[]> result = GATKVariantContextUtils.getNumTandemRepeatUnits(vc, getRefBasesStartingAtVariantLocus(ref, vc));
         if (result == null) {
             return Collections.emptyMap();
         }
@@ -56,6 +56,12 @@ public final class TandemRepeat extends InfoFieldAnnotation {
                 GATKVCFConstants.STR_PRESENT_KEY,
                 GATKVCFConstants.REPEAT_UNIT_KEY,
                 GATKVCFConstants.REPEATS_PER_ALLELE_KEY);
+    }
+
+    private static byte[] getRefBasesStartingAtVariantLocus(final ReferenceContext ref, final VariantContext vc) {
+        final byte[] bases = ref.getBases();
+        final int startIndex = vc.getStart() - ref.getWindow().getStart();
+        return new String(bases).substring(startIndex).getBytes();
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeatUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeatUnitTest.java
@@ -36,13 +36,15 @@ public final class TandemRepeatUnitTest extends BaseTest {
         // A*,ATC, context = ATC ATC ATC : (ATC)3 -> (ATC)4
         final VariantContext vc = new VariantContextBuilder("foo", insLoc, insLocStart, insLocStop, Arrays.asList(nullR,atc)).make();
 
-        final SimpleInterval interval= new SimpleInterval(insLoc, insLocStart, insLocStop);
+        // we test that the interval from which the ReferenceContext is constructed does not need to exactly overlap
+        // the VariantContext.  The annotation should be able to handle this.
+        final SimpleInterval interval= new SimpleInterval(insLoc, insLocStart + 3, insLocStop + 4);
 
         final SimpleInterval interval1 = new SimpleInterval(insLoc, 1, refBytes.length);
         final ReferenceBases ref1 = new ReferenceBases(refBytes, interval1);
 
         final SAMSequenceDictionary dict = new SAMSequenceDictionary(Arrays.asList(new SAMSequenceRecord(insLoc, refBytes.length)));
-        final ReferenceContext ref = new ReferenceContext(ReferenceDataSource.of(ref1, dict), interval, 0, 20);
+        final ReferenceContext ref = new ReferenceContext(ReferenceDataSource.of(ref1, dict), interval, 20, 20);
         final InfoFieldAnnotation ann = new TandemRepeat();
         final Map<String, Object> a = ann.annotate(ref, vc, null);
 


### PR DESCRIPTION
This branch takes the version of gatk-public that gatk-protected currently depends on (4.alpha.2-188-g7332d10) and applies @davidbenjamin 's fix to the `TandemRepeat` annotation to it. The only purpose of this PR is to cause a snapshot to be generated -- do not merge!

This is necessary to unblock @davidbenjamin 's work, because the `HaplotypeCaller` tests are failing if we update protected to the latest public head, and although we've fixed some of the issues there are some unexplained failures in the concordance tests.