### PR TITLE
Fix "no alleles" case in GenotypingEngine.calculateGenotypes() boolean expression

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.VCFConstants;
@@ -267,7 +268,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
         // skip this if we are already looking at a vc with NON_REF as the first alt allele i.e. if we are in GenotypeGVCFs
         if ( !passesEmitThreshold(phredScaledConfidence, outputAlternativeAlleles.siteIsMonomorphic)
                 && !forceSiteEmission()
-                && (outputAlternativeAlleles.alleles.size() > 0 && !outputAlternativeAlleles.alleles.get(0).equals(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE))) {
+                && noAllelesOrFirstAlleleIsNotNonRef(outputAlternativeAlleles.alleles)) {
             // technically, at this point our confidence in a reference call isn't accurately estimated
             //  because it didn't take into account samples with no data, so let's get a better estimate
             final double[] AFpriors = getAlleleFrequencyPriors(vc, defaultPloidy, model);
@@ -311,6 +312,12 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
         }
 
         return new VariantCallContext(vcCall, confidentlyCalled(phredScaledConfidence, probOfAtLeastOneAltAllele));
+    }
+
+    @VisibleForTesting
+    static boolean noAllelesOrFirstAlleleIsNotNonRef(List<Allele> altAlleles) {
+        Utils.nonNull(altAlleles);
+        return altAlleles.isEmpty() ||  altAlleles.get(0) != (GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -107,4 +107,21 @@ public class GenotypingEngineUnitTest extends BaseTest {
                 .genotypes(GenotypeBuilder.create(SAMPLES.getSample(0), Arrays.asList(refA, GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE))).make();
         Assert.assertNotNull(getGenotypingEngine().calculateGenotypes(vc, GenotypeLikelihoodsCalculationModel.SNP, null));
     }
+
+    @DataProvider
+    public Object[][] getAllelesLists(){
+        return new Object[][]{
+                {Collections.emptyList(), true},
+                {Arrays.asList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE), false},
+                {Arrays.asList(altT), true},
+                {Arrays.asList(altT, GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE), true},
+                {Arrays.asList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE, altT), false}
+        };
+    }
+
+    @Test(dataProvider = "getAllelesLists")
+    public void testNoAllelesOrFirstAlleleIsNotNonRef(List<Allele> alleles, boolean expectedValue){
+        Assert.assertEquals(GenotypingEngine.noAllelesOrFirstAlleleIsNotNonRef(alleles), expectedValue);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -112,10 +112,11 @@ public class GenotypingEngineUnitTest extends BaseTest {
     public Object[][] getAllelesLists(){
         return new Object[][]{
                 {Collections.emptyList(), true},
-                {Arrays.asList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE), false},
-                {Arrays.asList(altT), true},
+                {Collections.singletonList((Allele) null), true},
+                {Collections.singletonList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE), false},
+                {Collections.singletonList(altT), true},
                 {Arrays.asList(altT, GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE), true},
-                {Arrays.asList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE, altT), false}
+                {Arrays.asList(GATKVCFConstants.NON_REF_SYMBOLIC_ALLELE, altT), false},
         };
     }
 


### PR DESCRIPTION
Fix "no alleles" case in GenotypingEngine.calculateGenotypes() boolean expression