### PR TITLE
Added support for receiving parameters for GKL VectorLoglessPairHMM: implement…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -23,11 +23,23 @@ import java.util.Map;
  */
 public final class VectorLoglessPairHMM extends LoglessPairHMM {
 
+    /**
+     * Type for implementation of VectorLoglessPairHMM
+     */
+    public enum Implementation {
+        /**
+         * AVX-accelerated version of PairHMM
+         */
+        AVX,
+        /**
+         * OpenMP multi-threaded AVX-accelerated version of PairHMM
+         */
+        OMP
+    }
+
     private static final Logger logger = LogManager.getLogger(VectorLoglessPairHMM.class);
     private long threadLocalSetupTimeDiff = 0;
     private long pairHMMSetupTime = 0;
-
-    public enum Implementation {AVX, OMP}
 
     private final PairHMMNativeBinding pairHmm;
 
@@ -36,6 +48,12 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
     private final Map<Haplotype, Integer> haplotypeToHaplotypeListIdxMap = new LinkedHashMap<>();
     private HaplotypeDataHolder[] mHaplotypeDataArray;
 
+    /**
+     * Create a VectorLoglessPairHMM
+     *
+     * @param implementation    which implementation to use (AVX or OMP)
+     * @param args              arguments to the native GKL implementation
+     */
     public VectorLoglessPairHMM(Implementation implementation, PairHMMNativeArguments args) throws UserException.HardwareFeatureException {
         final boolean isSupported;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
@@ -14,6 +14,8 @@ import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -25,23 +27,25 @@ public final class VectorPairHMMUnitTest extends BaseTest {
     private static final String pairHMMTestData = publicTestDir + "pairhmm-testdata.txt";
 
     // Return a list of supported VectorLoglessPairHMM implementations, skip the test if none are supported
-    private List<N2MemoryPairHMM> getHMMs() {
-        List<N2MemoryPairHMM> list = new ArrayList<>();
+    private List<Pair<PairHMM, Boolean> > getHMMs() {
+        List<Pair<PairHMM, Boolean> > list = new ArrayList<>();
         PairHMMNativeArguments args = new PairHMMNativeArguments();
         args.useDoublePrecision = false;
         args.maxNumberOfThreads = 1;
 
         for (VectorLoglessPairHMM.Implementation imp : VectorLoglessPairHMM.Implementation.values()) {
+            boolean loaded = true;
+            PairHMM avxPairHMM = null;
             try {
-                final N2MemoryPairHMM avxPairHMM = new VectorLoglessPairHMM(imp, args);
-                avxPairHMM.doNotUseTristateCorrection();
-                list.add(avxPairHMM);
+                avxPairHMM = new VectorLoglessPairHMM(imp, args);
+                //avxPairHMM.doNotUseTristateCorrection();
             }
-            catch (UserException.HardwareFeatureException e ) {}
-        }
+            catch (UserException.HardwareFeatureException e ) {
+                loaded = false;
+            }
 
-        if (list.size() == 0) {
-            throw new SkipException("AVX PairHMM is not supported on this system or the library is not available");
+            final Pair<PairHMM, Boolean> hmm_load = new ImmutablePair<PairHMM, Boolean>(avxPairHMM, new Boolean(loaded));
+            list.add(hmm_load);
         }
 
         return list;
@@ -57,15 +61,20 @@ public final class VectorPairHMMUnitTest extends BaseTest {
     public Object[][] makeJustHMMProvider() {
         List<Object[]> tests = new ArrayList<>();
 
-        for ( final PairHMM hmm : getHMMs() ) {
-            tests.add(new Object[]{hmm});
+        for ( final Pair<PairHMM, Boolean> hmm_load : getHMMs() ) {
+            tests.add(new Object[]{hmm_load.getLeft(), hmm_load.getRight()});
         }
 
         return tests.toArray(new Object[][]{});
     }
 
     @Test(dataProvider = "JustHMMProvider")
-    public void testLikelihoodsFromHaplotypes(final PairHMM hmm){
+    public void testLikelihoodsFromHaplotypes(final PairHMM hmm, Boolean loaded){
+
+        // skip if not loaded
+        if(!loaded.booleanValue()) {
+            throw new SkipException("AVX PairHMM is not supported on this system or the library is not available");
+        }
 
         BasicInputParser parser = null;
         try {


### PR DESCRIPTION
…ation (AVX vs AVX-OMP), max num threads, and toggle using double precision

The changes are based off of [the lb_connect_pairhmmargs branch](https://github.com/broadinstitute/gatk/tree/lb_connect_pairhmmargs), which, apparently, never got merged. The main difference between that branch and this fork is that the PairHMMNativeArguments object is passed all the way through to VectorLoglessPairHMM, which was not the case in the lb_connect_pairhmmargs branch.

There is a corresponding [fork of gatk-protected](https://github.com/erniebrau/gatk-protected-1) which defines the new CLI arguments that talk to the changes in this PR. There should be a PR from that fork to gatk-protected, if and when this one is merged.