### PR TITLE
Modify cluster creation scripts to use ParallelCopyGCSDirectoryIntoHDFSSpark

### DIFF
--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -4,19 +4,21 @@
 
 set -eu
 
-if [[ "$#" -lt 5 ]]; then
+if [[ "$#" -lt 6 ]]; then
     echo -e "Please provide:"
-    echo -e "  [1] project name (required)"
-    echo -e "  [2] cluster name (required)"
-    echo -e "  [3] GCS directory containing the correct reference & indices (required)"
-    echo -e "  [4] GCS directory containing the BAM and its index (required), and"
+    echo -e "  [1] local directory of GATK build (required)"
+    echo -e "  [2] project name (required)"
+    echo -e "  [3] cluster name (required)"
+    echo -e "  [4] GCS directory containing the correct reference & indices (required)"
+    echo -e "  [5] GCS directory containing the BAM and its index (required), and"
     echo -e "either when a local initialization script is to be uploaded to a bucket:"
-    echo -e "  [5] local initialization script"
-    echo -e "  [6] GCS path to upload initialization script to (required as per Google)"
+    echo -e "  [6] local initialization script"
+    echo -e "  [7] GCS path to upload initialization script to (required as per Google)"
     echo -e "or when the initialization script is already in the cloud: "
-    echo -e "  [5] path to initialization script on GCS"
+    echo -e "  [6] path to initialization script on GCS"
     echo -e "\nExample when you have a local custom initialization script:"
     echo -e "  bash create_cluster.sh \\"
+    echo -e "       <GATK-DIR> \\"
     echo -e "       <PROJECT-NAME> \\"
     echo -e "       <CLUSTER-NAME> \\"
     echo -e "       <BUCKET-DIR-STORING-REFERENCE> \\"
@@ -27,6 +29,7 @@ if [[ "$#" -lt 5 ]]; then
     echo -e "If you don't need any custom initialization actions, use that."
     echo -e "\nExample 2 when a initialization script lives in a GCS bucket"
     echo -e "  bash create_cluster.sh \\"
+    echo -e "       <GATK-DIR> \\"
     echo -e "       <PROJECT-NAME> \\"
     echo -e "       <CLUSTER-NAME> \\"
     echo -e "       <BUCKET-DIR-STORING-REFERENCE> \\"
@@ -35,22 +38,25 @@ if [[ "$#" -lt 5 ]]; then
     exit 1
 fi
 
-PROJECT=$1
-CLUSTER_NAME=$2
-REF_DIR=$3
-SAMP_DIR=$4
+GATK_DIR=$1
+PROJECT=$2
+CLUSTER_NAME=$3
+REF_DIR=$4
+SAMP_DIR=$5
 
 INIT_ACTION=""
-if [[ "$#" -eq 5 ]]; then 
-    INIT_ACTION=$5
-else
-    gsutil cp $5 $6
+if [[ "$#" -eq 6 ]]; then
     INIT_ACTION=$6
+else
+    LOCAL_INIT_SCRIPT=$6
+    INIT_SCRIPT_BUCKET=$7
+    gsutil cp $LOCAL_INIT_SCRIPT ${INIT_SCRIPT_BUCKET}
+    INIT_ACTION=${INIT_SCRIPT_BUCKET}
     if [[ "$INIT_ACTION" =~ .+/$ ]]; then
-        INIT_ACTION+=$(basename $5)
+        INIT_ACTION+=$(basename $6)
     else
         INIT_ACTION+="/"
-        INIT_ACTION+=$(basename $5)
+        INIT_ACTION+=$(basename $6)
     fi
 fi
 
@@ -68,3 +74,27 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --project ${PROJECT} \
     --initialization-actions ${INIT_ACTION} \
     --initialization-action-timeout 60m
+
+MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
+
+if [[ ! $REF_DIR =~ .+/$ ]]; then
+    REF_DIR+="/"
+fi
+
+${GATK_DIR}/gatk-launch ParallelCopyGCSDirectoryIntoHDFSSpark \
+    --inputGCSPath "$REF_DIR" \
+    --outputHDFSDirectory "$MASTER_NODE"/reference \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \
+
+if [[ ! $SAMP_DIR =~ .+/$ ]]; then
+    SAMP_DIR+="/"
+fi
+
+${GATK_DIR}/gatk-launch ParallelCopyGCSDirectoryIntoHDFSSpark \
+    --inputGCSPath "$SAMP_DIR" \
+    --outputHDFSDirectory "$MASTER_NODE"/data \
+    -- \
+    --sparkRunner GCS \
+    --cluster "$CLUSTER_NAME" \

--- a/scripts/sv/default_init.sh
+++ b/scripts/sv/default_init.sh
@@ -5,26 +5,15 @@ set -eu
 # This script initializes the master and worker nodes on a Google Dataproc
 # Spark cluster to prepare them to run the GATK-SV pipeline.
 #
-# On the master node we launch a hadoop distcp command to copy 
-#    the reference, and
-#    data sets
-# down from a bucket to the hdfs file system on the cluster.
-#
-# On the worker nodes we copy the bwa index image file 
+# On the worker nodes we copy the bwa index image file
 # from a bucket to each node's local disk.
 
-NAME=$(/usr/share/google/get_metadata_value hostname)
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 REFLOC=$(/usr/share/google/get_metadata_value attributes/reference)
-SAMPLE=$(/usr/share/google/get_metadata_value attributes/sample)
 
-if [[ "${ROLE}" == 'Master' ]]; then
-    hadoop distcp "$REFLOC"/* hdfs://"$NAME":8020/reference/ &
-    hadoop distcp "$SAMPLE"/* hdfs://"$NAME":8020/data/
-else
-    if [[ "$REFLOC" =~ .+/$ ]]; then
-        mkdir -p /reference && gsutil -m cp "$REFLOC"*.img /reference/
-    else
-        mkdir -p /reference && gsutil -m cp "$REFLOC"/*.img /reference/
+if [[ ! "${ROLE}" == 'Master' ]]; then
+    if  [[ ! $REFLOC =~ .+/$ ]]; then
+      REFLOC+="/"
     fi
+    mkdir -p /reference && gsutil -m cp "$REFLOC"*.img /reference/
 fi


### PR DESCRIPTION
This PR removes the use of hadoop distcp to copy reference and sample data into HDFS, and replaces it with the new ParallelCopyGCSDirectoryIntoHDFSSpark tool.

Based on initial tests, cluster creation with reference and a 110GB sample BAM file now takes ~8 minutes with SGA installation on the worker nodes and ~5 minutes without SGA installation.

@SHuang-Broad can you review?