### PR TITLE
Replace MannWhitneyU with updated version from GATK3

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.tools.walkers.annotator;
 
+import com.google.common.primitives.Doubles;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.commons.lang.ArrayUtils;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.MannWhitneyU;
 import org.broadinstitute.hellbender.utils.QualityUtils;
@@ -67,12 +69,16 @@ public abstract class RankSumTest extends InfoFieldAnnotation {
             return Collections.emptyMap();
         }
 
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
+
         // we are testing that set1 (the alt bases) have lower quality scores than set2 (the ref bases)
-        final double p = MannWhitneyU.runOneSidedTest(useDithering, altQuals, refQuals).getLeft();
-        if (Double.isNaN(p)) {
+        final MannWhitneyU.Result result = mannWhitneyU.test(Doubles.toArray(altQuals), Doubles.toArray(refQuals), MannWhitneyU.TestType.FIRST_DOMINATES);
+        final double zScore = result.getZ();
+
+        if (Double.isNaN(zScore)) {
             return Collections.emptyMap();
         } else {
-            return Collections.singletonMap(getKeyNames().get(0), String.format("%.3f", p));
+            return Collections.singletonMap(getKeyNames().get(0), String.format("%.3f", zScore));
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/MannWhitneyU.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MannWhitneyU.java
@@ -1,293 +1,546 @@
 package org.broadinstitute.hellbender.utils;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
+import htsjdk.samtools.util.Histogram;
 import org.apache.commons.math3.distribution.NormalDistribution;
-import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.apache.log4j.Logger;
 
-import java.io.Serializable;
-import java.util.Comparator;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
-public final class MannWhitneyU {
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
-    private static final NormalDistribution STANDARD_NORMAL = new NormalDistribution(0.0,1.0);
-    private static final NormalDistribution APACHE_NORMAL = new NormalDistribution(0.0,1.0,1e-2);
-    private static final double LNSQRT2PI = Math.log(Math.sqrt(2.0 * Math.PI));
+/**
+ * Imported with changes from Picard private.
+ *
+ * @author Tim Fennell
+ */
+public class MannWhitneyU {
 
-    private final SortedSet<Pair<Number,USet>> observations;
-    private int sizeSet1;
-    private int sizeSet2;
-    private final ExactMode exactMode;
+    protected static Logger logger = Logger.getLogger(MannWhitneyU.class);
 
-    public MannWhitneyU(final ExactMode mode, final boolean dither) {
-        if ( dither ) {
-            observations = new TreeSet<>(new DitheringComparator());
-        } else {
-            observations = new TreeSet<>(new NumberedPairComparator());
+    private static final class Rank implements Comparable<Rank> {
+        final double value;
+        float rank;
+        final int series;
+
+        private Rank(double value, float rank, int series) {
+            this.value = value;
+            this.rank = rank;
+            this.series = series;
         }
-        sizeSet1 = 0;
-        sizeSet2 = 0;
-        exactMode = mode;
-    }
 
-    public MannWhitneyU(final boolean dither) {
-        this(ExactMode.POINT, dither);
-    }
+        @Override
+        public int compareTo(Rank that) {
+            return (int) (this.value - that.value);
+        }
 
-    /**
-     * Add an observation into the observation tree
-     * @param n: the observation (a number)
-     * @param set: whether the observation comes from set 1 or set 2
-     */
-    public void add(final Number n, final USet set) {
-        observations.add(new MutablePair<>(n, set));
-        if ( set == USet.SET1 ) {
-            ++sizeSet1;
-        } else {
-            ++sizeSet2;
+        @Override
+        public String toString() {
+            return "Rank{" +
+                    "value=" + value +
+                    ", rank=" + rank +
+                    ", series=" + series +
+                    '}';
         }
     }
 
     /**
-     * Runs the one-sided test under the hypothesis that the data in set "lessThanOther" stochastically
-     * dominates the other set
-     * @param lessThanOther - either Set1 or Set2
-     * @return - u-based z-approximation, and p-value associated with the test (p-value is exact for small n,m)
+     * The results of performing a rank sum test.
      */
-    public Pair<Double,Double> runOneSidedTest(final USet lessThanOther) {
-        final long u = calculateOneSidedU(observations, lessThanOther);
-        final int n = lessThanOther == USet.SET1 ? sizeSet1 : sizeSet2;
-        final int m = lessThanOther == USet.SET1 ? sizeSet2 : sizeSet1;
-        if ( n == 0 || m == 0 ) {
-            // test is uninformative as one or both sets have no observations
-            return new MutablePair<>(Double.NaN, Double.NaN);
+    public static class Result {
+        private final double u;
+        private final double z;
+        private final double p;
+        private final double medianShift;
+
+        public Result(double u, double z, double p, double medianShift) {
+            this.u = u;
+            this.z = z;
+            this.p = p;
+            this.medianShift = medianShift;
         }
 
-        // the null hypothesis is that {N} is stochastically less than {M}, so U has counted
-        // occurrences of {M}s before {N}s. We would expect that this should be less than (n*m+1)/2 under
-        // the null hypothesis, so we want to integrate from K=0 to K=U for cumulative cases. Always.
-        return calculateP(n, m, u, false, exactMode);
-    }
-
-
-    /**
-     * Runs the one-sided test under the hypothesis that the data in set "vals2" stochastically
-     * dominates the vals1 set
-     * @return - u-based z-approximation, and p-value associated with the test (p-value is exact for small n,m)
-     */
-    public static Pair<Double,Double> runOneSidedTest(final boolean dithering, final List<? extends Number> vals1, final List<? extends Number> vals2) {
-        Utils.nonNull(vals1);
-        Utils.nonNull(vals2);
-        final MannWhitneyU mannWhitneyU = new MannWhitneyU(dithering);
-        for (final Number qual : vals1) {
-            mannWhitneyU.add(qual, MannWhitneyU.USet.SET1);
-        }
-        for (final Number qual : vals2) {
-            mannWhitneyU.add(qual, MannWhitneyU.USet.SET2);
-        }
-        return mannWhitneyU.runOneSidedTest(MannWhitneyU.USet.SET1);
-    }
-
-    /**
-     * Given a u statistic, calculate the p-value associated with it, dispatching to approximations where appropriate
-     * @param n - The number of entries in the stochastically smaller (dominant) set
-     * @param m - The number of entries in the stochastically larger (dominated) set
-     * @param u - the Mann-Whitney U value
-     * @param twoSided - is the test twosided
-     * @return the (possibly approximate) p-value associated with the MWU test, and the (possibly approximate) z-value associated with it
-     * todo -- there must be an approximation for small m and large n
-     */
-    private static Pair<Double,Double> calculateP(final int n, final int m, final long u, final boolean twoSided, final ExactMode exactMode) {
-        final Pair<Double,Double> zandP;
-        if ( n > 8 && m > 8 ) {
-            // large m and n - normal approx
-            zandP = calculatePNormalApproximation(n,m,u, twoSided);
-        } else if ( n > 5 && m > 7 ) {
-            // large m, small n - sum uniform approx
-            // todo -- find the appropriate regimes where this approximation is actually better enough to merit slowness
-            // pval = calculatePUniformApproximation(n,m,u);
-            zandP = calculatePNormalApproximation(n, m, u, twoSided);
-        } else if ( n > 8 || m > 8 ) {
-            zandP = calculatePFromTable(n, m, u, twoSided);
-        } else {
-            // small m and n - full approx
-            zandP = calculatePRecursively(n,m,u,twoSided,exactMode);
+        public double getU() {
+            return u;
         }
 
-        return zandP;
-    }
+        public double getZ() {
+            return z;
+        }
 
-    public static Pair<Double,Double> calculatePFromTable(final int n, final int m, final long u, final boolean twoSided) {
-        // todo -- actually use a table for:
-        // todo      - n large, m small
-        return calculatePNormalApproximation(n, m, u, twoSided);
-    }
+        public double getP() {
+            return p;
+        }
 
-    /**
-     * Uses a normal approximation to the U statistic in order to return a cdf p-value. See Mann, Whitney [1947]
-     * @param n - The number of entries in the stochastically smaller (dominant) set
-     * @param m - The number of entries in the stochastically larger (dominated) set
-     * @param u - the Mann-Whitney U value
-     * @param twoSided - whether the test should be two sided
-     * @return p-value associated with the normal approximation
-     */
-    public static Pair<Double,Double> calculatePNormalApproximation(final int n, final int m, final long u, final boolean twoSided) {
-        final double z = getZApprox(n,m,u);
-        if ( twoSided ) {
-            return new MutablePair<>(z,2.0*(z < 0 ? STANDARD_NORMAL.cumulativeProbability(z) : 1.0-STANDARD_NORMAL.cumulativeProbability(z)));
-        } else {
-            return new MutablePair<>(z,STANDARD_NORMAL.cumulativeProbability(z));
+        public double getMedianShift() {
+            return medianShift;
         }
     }
 
     /**
-     * Calculates the Z-score approximation of the u-statistic
-     * @param n - The number of entries in the stochastically smaller (dominant) set
-     * @param m - The number of entries in the stochastically larger (dominated) set
-     * @param u - the Mann-Whitney U value
-     * @return the asymptotic z-approximation corresponding to the MWU p-value for n < m
+     * The values of U1, U2 and the transformed number of ties needed for the calculation of sigma
+     * in the normal approximation.
      */
-    private static double getZApprox(final int n, final int m, final long u) {
-        final double mean = ( ((long)m)*n+1.0)/2;
-        final double var = (((long) n)*m*(n+m+1.0))/12;
-        final double z = ( u - mean )/ Math.sqrt(var);
-        return z;
+    public static class TestStatistic {
+        private final double u1;
+        private final double u2;
+        private final double trueU;
+        private final double numOfTiesTransformed;
+
+        public TestStatistic(double u1, double u2, double numOfTiesTransformed) {
+            this.u1 = u1;
+            this.u2 = u2;
+            this.numOfTiesTransformed = numOfTiesTransformed;
+            this.trueU = Double.NaN;
+        }
+
+        public TestStatistic(double trueU, double numOfTiesTransformed) {
+            this.trueU = trueU;
+            this.numOfTiesTransformed = numOfTiesTransformed;
+            this.u1 = Double.NaN;
+            this.u2 = Double.NaN;
+        }
+
+        public double getU1() {
+            return u1;
+        }
+
+        public double getU2() {
+            return u2;
+        }
+
+        public double getTies() {
+            return numOfTiesTransformed;
+        }
+
+        public double getTrueU() {
+            return trueU;
+        }
     }
 
     /**
-     * Calculates the U-statistic associated with the one-sided hypothesis that "dominator" stochastically dominates
-     * the other U-set. Note that if S1 dominates S2, we want to count the occurrences of points in S2 coming before points in S1.
-     * @param observed - the observed data points, tagged by each set
-     * @param dominator - the set that is hypothesized to be stochastically dominating
-     * @return the u-statistic associated with the hypothesis that dominator stochastically dominates the other set
+     * The ranked data in one list and a list of the number of ties.
      */
-    public static long calculateOneSidedU(final SortedSet<Pair<Number,USet>> observed, final USet dominator) {
-        long otherBeforeDominator = 0l;
-        int otherSeenSoFar = 0;
-        for ( final Pair<Number,USet> dataPoint : observed ) {
-            if ( dataPoint.getRight() != dominator ) {
-                ++otherSeenSoFar;
-            } else {
-                otherBeforeDominator += otherSeenSoFar;
+    public static class RankedData {
+        private final Rank[] rank;
+        private final ArrayList<Integer> numOfTies;
+
+        public RankedData(Rank[] rank, ArrayList<Integer> numOfTies) {
+            this.rank = rank;
+            this.numOfTies = numOfTies;
+        }
+
+        public Rank[] getRank() {
+            return rank;
+        }
+
+        public ArrayList<Integer> getNumOfTies() {
+            return numOfTies;
+        }
+    }
+
+    /**
+     * Key for the map from Integer[] to set of all permutations of that array.
+     */
+    private static class Key {
+        final Integer[] listToPermute;
+
+        private Key(Integer[] listToPermute) {
+            this.listToPermute = listToPermute;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Key that = (Key) o;
+            return (Arrays.deepEquals(this.listToPermute, that.listToPermute));
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 17;
+            for (Integer i : listToPermute) {
+                result = 31 * result + listToPermute[i];
             }
+            return result;
         }
+    }
 
-        return otherBeforeDominator;
+    // Constructs a normal distribution; this needs to be a standard normal in order to get a Z-score in the exact case
+    private static final double NORMAL_MEAN = 0;
+    private static final double NORMAL_SD = 1;
+    private static final NormalDistribution NORMAL = new NormalDistribution(NORMAL_MEAN, NORMAL_SD);
+
+    /**
+     * A map of an Integer[] of the labels to the set of all possible permutations of those labels.
+     */
+    private static Map<Key, Set<List<Integer>>> PERMUTATIONS = new ConcurrentHashMap<Key, Set<List<Integer>>>();
+
+    /**
+     * The minimum length for both data series in order to use a normal distribution
+     * to calculate Z and p. If both series are shorter than this value then a permutation test
+     * will be used.
+     */
+    private int minimumNormalN = 10;
+
+    /**
+     * Sets the minimum number of values in each data series to use the normal distribution approximation.
+     */
+    public void setMinimumSeriesLengthForNormalApproximation(final int n) {
+        this.minimumNormalN = n;
     }
 
     /**
-     * The Mann-Whitney U statistic follows a recursive equation (that enumerates the proportion of possible
-     * binary strings of "n" zeros, and "m" ones, where a one precedes a zero "u" times). This accessor
-     * calls into that recursive calculation.
-     * @param n: number of set-one entries (hypothesis: set one is stochastically less than set two)
-     * @param m: number of set-two entries
-     * @param u: number of set-two entries that precede set-one entries (e.g. 0,1,0,1,0 -> 3 )
-     * @param twoSided: whether the test is two sided or not. The recursive formula is symmetric, multiply by two for two-sidedness.
-     * @param  mode: whether the mode is a point probability, or a cumulative distribution
-     * @return the probability under the hypothesis that all sequences are equally likely of finding a set-two entry preceding a set-one entry "u" times.
+     * A variable that indicates if the test is one sided or two sided and if it's one sided
+     * which group is the dominator in the null hypothesis.
      */
-    public static Pair<Double,Double> calculatePRecursively(final int n, final int m, final long u, final boolean twoSided, final ExactMode mode) {
-        if ( m > 8 && n > 5 ) { throw new GATKException(String.format("Please use the appropriate (normal or sum of uniform) approximation. Values n: %d, m: %d", n, m)); }
-        final double p = mode == ExactMode.POINT ? cpr(n,m,u) : cumulativeCPR(n,m,u);
-        //p *= twoSided ? 2.0 : 1.0;
-        final double z;
-        if ( mode == ExactMode.CUMULATIVE ) {
-            z = APACHE_NORMAL.inverseCumulativeProbability(p);
-        } else {
-            final double sd = Math.sqrt((1.0 + 1.0 / (1 + n + m)) * (n * m) * (1.0 + n + m) / 12); // biased variance empirically better fit to distribution then asymptotic variance
-            //System.out.printf("SD is %f and Max is %f and prob is %f%n",sd,1.0/Math.sqrt(sd*sd*2.0*Math.PI),p);
-            if ( p > 1.0/ Math.sqrt(sd * sd * 2.0 * Math.PI) ) { // possible for p-value to be outside the range of the normal. Happens at the mean, so z is 0.
-                z = 0.0;
-            } else {
-                if ( u >= n*m/2 ) {
-                    z = Math.sqrt(-2.0 * (Math.log(sd) + Math.log(p) + LNSQRT2PI));
+    public enum TestType {
+        FIRST_DOMINATES,
+        SECOND_DOMINATES,
+        TWO_SIDED
+    }
+
+    public RankedData calculateRank(final double[] series1, final double[] series2) {
+        Arrays.sort(series1);
+        Arrays.sort(series2);
+
+        // Make a merged ranks array
+        final Rank[] ranks = new Rank[series1.length + series2.length];
+        {
+            int i = 0, j = 0, r = 0;
+            while (r < ranks.length) {
+                if (i >= series1.length) {
+                    ranks[r++] = new Rank(series2[j++], r, 2);
+                } else if (j >= series2.length) {
+                    ranks[r++] = new Rank(series1[i++], r, 1);
+                } else if (series1[i] <= series2[j]) {
+                    ranks[r++] = new Rank(series1[i++], r, 1);
                 } else {
-                    z = -Math.sqrt(-2.0 * (Math.log(sd) + Math.log(p) + LNSQRT2PI));
+                    ranks[r++] = new Rank(series2[j++], r, 2);
                 }
             }
         }
 
-        return new MutablePair<>(z,(twoSided ? 2.0*p : p));
+        ArrayList<Integer> numOfTies = new ArrayList<>();
+
+        // Now sort out any tie bands
+        for (int i = 0; i < ranks.length; ) {
+            float rank = ranks[i].rank;
+            int count = 1;
+
+            for (int j = i + 1; j < ranks.length && ranks[j].value == ranks[i].value; ++j) {
+                rank += ranks[j].rank;
+                ++count;
+            }
+
+            if (count > 1) {
+                rank /= count;
+                for (int j = i; j < i + count; ++j) {
+                    ranks[j].rank = rank;
+                }
+                numOfTies.add(count);
+            }
+
+            // Skip forward the right number of items
+            i += count;
+        }
+
+        return new RankedData(ranks, numOfTies);
     }
 
     /**
-     * : just a shorter name for calculatePRecursively. See Mann, Whitney, [1947]
-     * @param n: number of set-1 entries
-     * @param m: number of set-2 entries
-     * @param u: number of times a set-2 entry as preceded a set-1 entry
-     * @return recursive p-value
+     * Rank both groups together and return a TestStatistic object that includes U1, U2 and number of ties for sigma
      */
-    private static double cpr(final int n, final int m, final long u) {
-        if ( u < 0 ) {
-            return 0.0;
-        }
-        if ( m == 0 || n == 0 ) {
-            // there are entries in set 1 or set 2, so no set-2 entry can precede a set-1 entry; thus u must be zero.
-            // note that this exists only for edification, as when we reach this point, the coefficient on this term is zero anyway
-            return ( u == 0 ) ? 1.0 : 0.0;
+    public TestStatistic calculateU1andU2(final double[] series1, final double[] series2) {
+        RankedData ranked = calculateRank(series1, series2);
+        Rank[] ranks = ranked.getRank();
+        ArrayList<Integer> numOfTies = ranked.getNumOfTies();
+        int lengthOfRanks = ranks.length;
+
+        double numOfTiesForSigma = transformTies(lengthOfRanks, numOfTies);
+
+        // Calculate R1 and R2 and U.
+        float r1 = 0, r2 = 0;
+        for (Rank rank : ranks) {
+            if (rank.series == 1) r1 += rank.rank;
+            else r2 += rank.rank;
         }
 
+        double n1 = series1.length;
+        double n2 = series2.length;
+        double u1 = r1 - ((n1 * (n1 + 1)) / 2);
+        double u2 = r2 - ((n2 * (n2 + 1)) / 2);
 
-        return (((double)n)/(n+m))*cpr(n-1,m,u-m) + (((double)m)/(n+m))*cpr(n,m-1,u);
+        TestStatistic result = new TestStatistic(u1, u2, numOfTiesForSigma);
+        return result;
     }
 
-    private static double cumulativeCPR(final int n, final int m, final long u ) {
-        // from above:
-        // the null hypothesis is that {N} is stochastically less than {M}, so U has counted
-        // occurrences of {M}s before {N}s. We would expect that this should be less than (n*m+1)/2 under
-        // the null hypothesis, so we want to integrate from K=0 to K=U for cumulative cases. Always.
-        double p = 0.0;
-        // optimization using symmetry, use the least amount of sums possible
-        final long uSym = ( u <= n*m/2 ) ? u : ((long)n)*m-u;
-        for ( long uu = 0; uu < uSym; uu++ ) {
-            p += cpr(n,m,uu);
+    public double transformTies(int numOfRanks, ArrayList<Integer> numOfTies) {
+        //Calculate number of ties transformed for formula for Sigma to calculate Z-score
+        ArrayList<Double> transformedTies = new ArrayList<>();
+        for (int count : numOfTies) {
+            //If every single datapoint is tied then we want to return a p-value of .5 and
+            //the formula for sigma that includes the number of ties breaks down. Setting
+            //the number of ties to 0 in this case gets the desired result in the normal
+            //approximation case.
+            if (count != numOfRanks) {
+                transformedTies.add((Math.pow(count, 3)) - count);
+            }
         }
-        // correct by 1.0-p if the optimization above was used (e.g. 1-right tail = left tail)
-        return (u <= n*m/2) ? p : 1.0-p;
+
+        double numOfTiesForSigma = 0.0;
+        for (double count : transformedTies) {
+            numOfTiesForSigma += count;
+        }
+
+        return(numOfTiesForSigma);
+    }
+    /**
+     * Calculates the rank-sum test statisic U (sometimes W) from two sets of input data for a one-sided test
+     * with an int indicating which group is the dominator. Returns a test statistic object with trueU and number of
+     * ties for sigma.
+     */
+    public TestStatistic calculateOneSidedU(final double[] series1, final double[] series2, final TestType whichSeriesDominates) {
+        TestStatistic stat = calculateU1andU2(series1, series2);
+        TestStatistic result;
+        if (whichSeriesDominates == TestType.FIRST_DOMINATES) {
+            result = new TestStatistic(stat.getU1(), stat.getTies());
+        } else {
+            result = new TestStatistic(stat.getU2(), stat.getTies());
+        }
+        return result;
     }
 
     /**
-     * hook into the data tree, for testing purposes only
-     * @return  observations
+     * Calculates the two-sided rank-sum test statisic U (sometimes W) from two sets of input data.
+     * Returns a test statistic object with trueU and number of ties for sigma.
      */
-    @VisibleForTesting
-    SortedSet<Pair<Number,USet>> getObservations() {
-        return observations;
+    public TestStatistic calculateTwoSidedU(final double[] series1, final double[] series2) {
+        TestStatistic u1AndU2 = calculateU1andU2(series1, series2);
+        double u = Math.min(u1AndU2.getU1(), u1AndU2.getU2());
+        TestStatistic result = new TestStatistic(u, u1AndU2.getTies());
+        return result;
     }
 
     /**
-     * A comparator class which uses dithering on tie-breaking to ensure that the internal treeset drops no values
-     * and to ensure that rank ties are broken at random.
+     * Calculates the Z score (i.e. standard deviations from the mean) of the rank sum
+     * test statistics given input data of lengths n1 and n2 respectively, as well as the number of ties, for normal
+     * approximation only.
      */
-    private static class DitheringComparator implements Comparator<Pair<Number,USet>>, Serializable {
-        private static final long serialVersionUID = 0L;
+    public double calculateZ(final double u, final int n1, final int n2, final double nties, final TestType whichSide) {
+        double m = (n1 * n2) / 2d;
 
-        @Override
-        public int compare(final Pair<Number,USet> left, final Pair<Number,USet> right) {
-            final double comp = Double.compare(left.getLeft().doubleValue(), right.getLeft().doubleValue());
-            if ( comp > 0 ) { return 1; }
-            if ( comp < 0 ) { return -1; }
-            return Utils.getRandomGenerator().nextBoolean() ? -1 : 1;
+        //Adds a continuity correction
+        double correction;
+        if (whichSide == TestType.TWO_SIDED) {
+            correction = (u - m) >= 0 ? .5 : -.5;
+        } else {
+            correction = whichSide == TestType.FIRST_DOMINATES ? -.5 : .5;
+        }
+
+        //If all the data is tied, the number of ties for sigma is set to 0. In order to get a p-value of .5 we need to
+        //remove the continuity correction.
+        if (nties == 0) {
+            correction = 0;
+        }
+
+        double sigma = Math.sqrt((n1 * n2 / 12d) * ((n1 + n2 + 1) - nties / ((n1 + n2) * (n1 + n2 - 1))));
+        return (u - m - correction) / sigma;
+    }
+
+    /**
+     * Finds or calculates the median value of a sorted array of double.
+     */
+    public double median(final double[] data) {
+        final int len = data.length;
+        final int mid = len / 2;
+        if (data.length % 2 == 0) {
+            return (data[mid] + data[mid - 1]) / 2d;
+        } else {
+            return data[mid];
+        }
+    }
+
+
+    /**
+     * Constructs a new rank sum test with the given data.
+     *
+     * @param series1   group 1 data
+     * @param series2   group 2 data
+     * @param whichSide indicator of two sided test, 0 for two sided, 1 for series1 as dominator, 2 for series2 as dominator
+     * @return Result including U statistic, Z score, p-value, and difference in medians.
+     */
+    public Result test(final double[] series1, final double[] series2, final TestType whichSide) {
+        final int n1 = series1.length;
+        final int n2 = series2.length;
+
+        //If one of the groups is empty we return NaN
+        if (n1 == 0 || n2 == 0) {
+            return new Result(Float.NaN, Float.NaN, Float.NaN, Float.NaN);
+        }
+
+        double u;
+        double nties;
+
+        if (whichSide == TestType.TWO_SIDED) {
+            TestStatistic result = calculateTwoSidedU(series1, series2);
+            u = result.getTrueU();
+            nties = result.getTies();
+        } else {
+            TestStatistic result = calculateOneSidedU(series1, series2, whichSide);
+            u = result.getTrueU();
+            nties = result.getTies();
+        }
+
+        double z;
+        double p;
+
+        if (n1 >= this.minimumNormalN || n2 >= this.minimumNormalN) {
+            z = calculateZ(u, n1, n2, nties, whichSide);
+            p = 2 * NORMAL.cumulativeProbability(NORMAL_MEAN + z * NORMAL_SD);
+            if (whichSide != TestType.TWO_SIDED) {
+                p = p / 2;
+            }
+        } else {
+            // TODO -- This exact test is only implemented for the one sided test, but we currently don't call the two sided version
+            if (whichSide != TestType.FIRST_DOMINATES) {
+                logger.warn("An exact two-sided MannWhitneyU test was called. Only the one-sided exact test is implemented, use the approximation instead by setting minimumNormalN to 0.");
+            }
+            p = permutationTest(series1, series2, u);
+            z = NORMAL.inverseCumulativeProbability(p);
+        }
+
+        return new Result(u, z, p, Math.abs(median(series1) - median(series2)));
+    }
+
+    private void swap(Integer[] arr, int i, int j) {
+        int temp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = temp;
+    }
+
+    /**
+     * Uses a method that generates permutations in lexicographic order. (https://en.wikipedia.org/wiki/Permutation#Generation_in_lexicographic_order)
+     * @param temp Sorted list of elements to be permuted.
+     * @param allPermutations Empty set that will hold all possible permutations.
+     */
+    private void calculatePermutations(Integer[] temp, Set<List<Integer>> allPermutations) {
+        allPermutations.add(new ArrayList<>(Arrays.asList(temp)));
+        while (true) {
+            int k = -1;
+            for (int i = temp.length - 2; i >= 0; i--) {
+                if (temp[i] < temp[i + 1]) {
+                    k = i;
+                    break;
+                }
+            }
+
+            if (k == -1) {
+                break;
+            }
+
+            int l = -1;
+            for (int i = temp.length - 1; i >= k + 1; i--) {
+                if (temp[k] < temp[i]) {
+                    l = i;
+                    break;
+                }
+            }
+
+            swap(temp, k, l);
+
+            int end = temp.length - 1;
+            for (int begin = k + 1; begin < end; begin++) {
+                swap(temp, begin, end);
+                end--;
+            }
+            allPermutations.add(new ArrayList<>(Arrays.asList(temp)));
         }
     }
 
     /**
-     * A comparator that reaches into the pair and compares numbers without tie-braking.
+     * Checks to see if the permutations have already been computed before creating them from scratch.
+     * @param listToPermute List of tags in numerical order to be permuted
+     * @param numOfPermutations The number of permutations this list will have (n1+n2 choose n1)
+     * @return Set of all possible permutations for the given list.
      */
-    private static class NumberedPairComparator implements Comparator<Pair<Number,USet>>, Serializable {
-        private static final long serialVersionUID = 0L;
-
-        @Override
-        public int compare(final Pair<Number,USet> left, final Pair<Number,USet> right ) {
-            return Double.compare(left.getLeft().doubleValue(), right.getLeft().doubleValue());
+    Set<List<Integer>> getPermutations(final Integer[] listToPermute, int numOfPermutations) {
+        Key key = new Key(listToPermute);
+        Set<List<Integer>> permutations = PERMUTATIONS.get(key);
+        if (permutations == null) {
+            permutations = new HashSet<>(numOfPermutations);
+            calculatePermutations(listToPermute, permutations);
+            PERMUTATIONS.put(key, permutations);
         }
+        return permutations;
     }
 
-    public enum USet { SET1, SET2 }
-    public enum ExactMode { POINT, CUMULATIVE }
+    /**
+     * Creates histogram of test statistics from a permutation test.
+     *
+     * @param series1 Data from group 1
+     * @param series2 Data from group 2
+     * @param testStatU Test statistic U from observed data
+     * @return P-value based on histogram with u calculated for every possible permutation of group tag.
+     */
+    public double permutationTest(final double[] series1, final double[] series2, final double testStatU) {
+        final Histogram<Double> histo = new Histogram<>();
+        final int n1 = series1.length;
+        final int n2 = series2.length;
+
+        RankedData rankedGroups = calculateRank(series1, series2);
+        Rank[] ranks = rankedGroups.getRank();
+
+        Integer[] firstPermutation = new Integer[n1 + n2];
+
+        for (int i = 0; i < firstPermutation.length; i++) {
+            if (i < n1) {
+                firstPermutation[i] = 0;
+            } else {
+                firstPermutation[i] = 1;
+            }
+        }
+
+        final int numOfPerms = (int) MathUtils.binomialCoefficient(n1 + n2, n2);
+        Set<List<Integer>> allPermutations = getPermutations(firstPermutation, numOfPerms);
+
+        double[] newSeries1 = new double[n1];
+        double[] newSeries2 = new double[n2];
+
+        //iterate over all permutations
+        for (List<Integer> currPerm : allPermutations) {
+            int series1End = 0;
+            int series2End = 0;
+            for (int i = 0; i < currPerm.size(); i++) {
+                int grouping = currPerm.get(i);
+                if (grouping == 0) {
+                    newSeries1[series1End] = ranks[i].rank;
+                    series1End++;
+                } else {
+                    newSeries2[series2End] = ranks[i].rank;
+                    series2End++;
+                }
+            }
+            assert (series1End == n1);
+            assert (series2End == n2);
+
+            double newU = MathUtils.sum(newSeries1) - ((n1 * (n1 + 1)) / 2.0);
+            histo.increment(newU);
+        }
+
+        /**
+         * In order to deal with edge cases where the observed value is also the most extreme value, we are taking half
+         * of the count in the observed bin plus everything more extreme (in the FIRST_DOMINATES case the smaller bins)
+         * and dividing by the total count of everything in the histogram. Just using getCumulativeDistribution() gives
+         * a p-value of 1 in the most extreme case which doesn't result in a usable z-score.
+         */
+        double sumOfAllSmallerBins = histo.get(testStatU).getValue() / 2.0;
+
+        for (final Histogram.Bin<Double> bin : histo.values()) {
+            if (bin.getId() < testStatU) sumOfAllSmallerBins += bin.getValue();
+        }
+
+        return sumOfAllSmallerBins / histo.getCount();
+    }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
@@ -520,6 +520,19 @@ public final class MathUtils {
     }
 
     /**
+     * Calculates the binomial coefficient. Designed to prevent
+     * overflows even with very large numbers.
+     *
+     * @param n total number of trials
+     * @param k number of successes
+     * @return the binomial coefficient
+     */
+    public static double binomialCoefficient(final int n, final int k) {
+        return Math.pow(10, log10BinomialCoefficient(n, k));
+    }
+
+    /**
+     * @see #binomialCoefficient(int, int) with log10 applied to result
      */
     public static double log10BinomialCoefficient(final int n, final int k) {
         Utils.validateArg(n >= 0, "Must have non-negative number of trials");

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTestUnitTest.java
@@ -50,6 +50,7 @@ public final class BaseQualityRankSumTestUnitTest {
     public void testBaseQual() {
         final InfoFieldAnnotation ann = new BaseQualityRankSumTest();
         final String key = GATKVCFConstants.BASE_QUAL_RANK_SUM_KEY;
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
 
         final int[] altBaseQuals = {10, 20};
         final int[] refBaseQuals = {50, 60};
@@ -63,11 +64,9 @@ public final class BaseQualityRankSumTestUnitTest {
 
         final Map<String, Object> annotate = ann.annotate(ref, vc, likelihoods);
 
-        final double val = MannWhitneyU.runOneSidedTest(false,
-                Arrays.asList(altBaseQuals[0], altBaseQuals[1]),
-                Arrays.asList(refBaseQuals[0], refBaseQuals[1])).getLeft();
-        final String valStr = String.format("%.3f", val);
-        Assert.assertEquals(annotate.get(key), valStr);
+        final double zScore = mannWhitneyU.test(new double[]{altBaseQuals[0], altBaseQuals[1]}, new double[]{refBaseQuals[0], refBaseQuals[1]}, MannWhitneyU.TestType.FIRST_DOMINATES).getZ();
+        final String zScoreStr = String.format("%.3f", zScore);
+        Assert.assertEquals(annotate.get(key), zScoreStr);
 
         Assert.assertEquals(ann.getDescriptions().size(), 1);
         Assert.assertEquals(ann.getDescriptions().get(0).getID(), key);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ClippingRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ClippingRankSumTestUnitTest.java
@@ -55,13 +55,13 @@ public final class ClippingRankSumTestUnitTest {
         final ReferenceContext ref= null;
         final VariantContext vc= makeVC(REF, ALT);
         final InfoFieldAnnotation ann = new ClippingRankSumTest();
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
 
         final Map<String, Object> annotate = ann.annotate(ref, vc, likelihoods);
 
-        final double val= MannWhitneyU.runOneSidedTest(false, Arrays.asList(altHardClips[0], altHardClips[1]),
-                                                              Arrays.asList(refHardClips[0], refHardClips[1])).getLeft();
-        final String valStr= String.format("%.3f", val);
-        Assert.assertEquals(annotate.get(GATKVCFConstants.CLIPPING_RANK_SUM_KEY), valStr);
+        final double zScore = mannWhitneyU.test(new double[]{altHardClips[0], altHardClips[1]}, new double[]{refHardClips[0], refHardClips[1]}, MannWhitneyU.TestType.FIRST_DOMINATES).getZ();
+        final String zScoreStr = String.format("%.3f", zScore);
+        Assert.assertEquals(annotate.get(GATKVCFConstants.CLIPPING_RANK_SUM_KEY), zScoreStr);
 
         Assert.assertEquals(ann.getDescriptions().size(), 1);
         Assert.assertEquals(ann.getDescriptions().get(0).getID(), GATKVCFConstants.CLIPPING_RANK_SUM_KEY);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/LikelihoodRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/LikelihoodRankSumTestUnitTest.java
@@ -48,6 +48,7 @@ public final class LikelihoodRankSumTestUnitTest extends BaseTest {
     public void testReadPos(){
         final double[] altBestAlleleLL = {-1.0, -2.0};
         final double[] refBestAlleleLL = {-5.0, -7.0};
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
 
         final List<GATKRead> refReads = Arrays.asList(makeRead(), makeRead());
         final List<GATKRead> altReads = Arrays.asList(makeRead(), makeRead());
@@ -62,9 +63,7 @@ public final class LikelihoodRankSumTestUnitTest extends BaseTest {
         matrix.set(0, 1, refBestAlleleLL[1]);
         matrix.set(1, 2, altBestAlleleLL[0]);
         matrix.set(1, 3, altBestAlleleLL[1]);
-
-
-
+        
         final InfoFieldAnnotation ann = new LikelihoodRankSumTest();
         Assert.assertEquals(ann.getDescriptions().size(), 1);
         Assert.assertEquals(ann.getDescriptions().get(0).getID(), GATKVCFConstants.LIKELIHOOD_RANK_SUM_KEY);
@@ -77,12 +76,9 @@ public final class LikelihoodRankSumTestUnitTest extends BaseTest {
         final VariantContext vc= makeVC(CONTIG, position, REF, ALT);
 
         final Map<String, Object> annotate = ann.annotate(ref, vc, likelihoods);
-        final double val= MannWhitneyU.runOneSidedTest(false,
-                Arrays.asList(altBestAlleleLL[0], altBestAlleleLL[1]),
-                Arrays.asList(refBestAlleleLL[0], refBestAlleleLL[1])).getLeft();
-        final String valStr= String.format("%.3f", val);
-        Assert.assertEquals(annotate.get(GATKVCFConstants.LIKELIHOOD_RANK_SUM_KEY), valStr);
-
+        final double zScore = mannWhitneyU.test(new double[]{altBestAlleleLL[0], altBestAlleleLL[1]}, new double[]{refBestAlleleLL[0], refBestAlleleLL[1]}, MannWhitneyU.TestType.FIRST_DOMINATES).getZ();
+        final String zScoreStr= String.format("%.3f", zScore);
+        Assert.assertEquals(annotate.get(GATKVCFConstants.LIKELIHOOD_RANK_SUM_KEY), zScoreStr);
     }
 
     @Test(expectedExceptions = IllegalStateException.class)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityRankSumTestUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityRankSumTestUnitTest.java
@@ -49,6 +49,7 @@ public final class MappingQualityRankSumTestUnitTest {
     public void testMQ(){
         final InfoFieldAnnotation ann = new MappingQualityRankSumTest();
         final String key = GATKVCFConstants.MAP_QUAL_RANK_SUM_KEY;
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
 
         final int[] altMappingQualities = {10, 20};
         final int[] refMappingQualities = {100, 110};
@@ -60,10 +61,9 @@ public final class MappingQualityRankSumTestUnitTest {
 
         final Map<String, Object> annotate = ann.annotate(null, vc, likelihoods);
 
-        final double val= MannWhitneyU.runOneSidedTest(false, Arrays.asList(altMappingQualities[0], altMappingQualities[1]),
-                                                              Arrays.asList(refMappingQualities[0], refMappingQualities[1])).getLeft();
-        final String valStr= String.format("%.3f", val);
-        Assert.assertEquals(annotate.get(key), valStr);
+        final double zScore = mannWhitneyU.test(new double[]{altMappingQualities[0], altMappingQualities[1]}, new double[]{refMappingQualities[0], refMappingQualities[1]}, MannWhitneyU.TestType.FIRST_DOMINATES).getZ();
+        final String zScoreStr = String.format("%.3f", zScore);
+        Assert.assertEquals(annotate.get(key), zScoreStr);
 
         Assert.assertEquals(ann.getDescriptions().size(), 1);
         Assert.assertEquals(ann.getDescriptions().get(0).getID(), key);

--- a/src/test/java/org/broadinstitute/hellbender/utils/MannWhitneyUUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/MannWhitneyUUnitTest.java
@@ -1,50 +1,178 @@
 package org.broadinstitute.hellbender.utils;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.testng.Assert;
+import com.google.common.primitives.Doubles;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.Assert;
 
-import static org.broadinstitute.hellbender.utils.MathUtils.promote;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-public final class MannWhitneyUUnitTest {
+public class MannWhitneyUUnitTest extends BaseTest {
+    private static double DELTA_PRECISION = 0.00001;
+
+    private static final MannWhitneyU rst = new MannWhitneyU();
+
+    @DataProvider(name="rankSumTestData")
+    public Object[][] dataProvider() {
+        return new Object[][] {
+                new Object[] {"test1", new double[] {20,20,20,20,20}, new double[] {20,20,20,20,21}, 10d},
+                new Object[] {"test2", new double[] {20,20,20,20,21}, new double[] {20,20,20,20,21}, 12.5d},
+                new Object[] {"test3", new double[] {13,14,15,15,16}, new double[] {16,20,20,21,21}, 0.5d},
+                new Object[] {"test4", new double[] {13,14,15,15,16}, new double[] {16,20,20,21,21,21,21,22,23,27}, 0.5d},
+                new Object[] {"test5", new double[] {13,14,15,15,16,18,20,22,25,24,25,26,27,28,22,23,19,30,28,22,17},
+                        new double[] {16,20,20,21,21,21,21,22,23,27,26,28,29,32,31,22,21,19,16,24,29},
+                        180.5d},
+                new Object[] {"test6", new double[] {13,14,15,15,16,18,13,14,15,15,16,18,13,14,15,15,16,18,13,14,15,15,16,18},
+                        new double[] {21,22,23,27,26,28,29,21,22,23,27,26,28,29,21,22,23,27,26,28,29,21,22,23,27,26,28,29},
+                        0d},
+                new Object[] {"test7", new double[] {11,11,12,12,13,13,14,14,15,15,16,16,17,17,18,18,19,19,20},
+                        new double[] {12,12,13,13,14,14,15,15,16,16,17,17,18,18,19,19,20,20,21},
+                        145d},
+                new Object[] {"test7", new double[] {11,11,12,12,13,13,14,14,15,15,16,16,17,17,18,18,19,19,20,20},
+                        new double[] {12,12,13,13,14,14,15,15,16,16,17,17,18,18,19,19,20,20,21,21},
+                        162d},
+                new Object[] {"test8", new double[] {20,20,20,20,20}, new double[] {20,20,20,20,20,20,20,20,20,20}, 25d},
+        };
+    }
+
+    @Test(dataProvider = "rankSumTestData")
+    public void testSimpleU(String name, double[] series1, double[] series2, double U) {
+        MannWhitneyU.Result test = rst.test(series1, series2, MannWhitneyU.TestType.TWO_SIDED);
+        Assert.assertEquals(test.getU(), U, name);
+    }
+
+    @DataProvider(name="oneSidedPTestData")
+    public Object[][] oneSidedDataProvider() {
+        return new Object[][] {
+                new Object[] {"test0", new double[] {0,0}, new double[] {1,1}, 0.083333333},
+                new Object[] {"test1", new double[] {20,20,20,20,20}, new double[] {20,20,20,20,21}, .25},
+                new Object[] {"test2", new double[] {20,20,20,20,21}, new double[] {20,20,20,20,21}, .5},
+                new Object[] {"test3", new double[] {13,14,15,15,16}, new double[] {16,20,20,21,21}, 0.00396825},
+                new Object[] {"test4", new double[] {13,14,15,15,16}, new double[] {16,20,20,21,21,21,21,22,23,27}, 0.001469192},
+                new Object[] {"test5", new double[] {20,20,20,20,20}, new double[] {20,20,20,20,20,20,20,20,20,20}, .5},
+                new Object[] {"test6", new double[] {1,2,3,4,5}, new double[] {6,7,8,9,10}, 0.001984},
+                new Object[] {"test7", new double[] {6,7,8,9,10}, new double[] {1,2,3,4,5}, 0.99801587},
+                new Object[] {"test8", new double[] {16,20,20,21,21,21,21,22,23,27,16,20,20,21,21,21,21,22,23,27},
+                        new double[] {22,23,27,16,20,20,21,21,21,21,22,23,27,60,60}, .08303102},
+                new Object[] {"test9", new double[] {16,20,20,21,21,21,21,21,20},
+                        new double[] {22,23,27,16,20,20,20,20,21}, 0.388204},
+        };
+    }
+
+    @Test(dataProvider = "oneSidedPTestData")
+    public void testOnesidedP(String name, double[] series1, double[] series2, double P) {
+        MannWhitneyU.Result test = rst.test(series1, series2, MannWhitneyU.TestType.FIRST_DOMINATES);
+        Assert.assertEquals(test.getP(), P, DELTA_PRECISION, name);
+    }
+
+    @DataProvider(name="oneSidedZTestData")
+    public Object[][] oneSidedZDataProvider() {
+        return new Object[][] {
+                new Object[] {"test1", new double[] {20}, new double[] {20,20,20}, 0},
+                new Object[] {"test2", new double[] {1}, new double[] {1,2,3}, -0.67448975},
+                new Object[] {"test3", new double[] {1,2,3}, new double[] {3}, -0.67448975},
+                new Object[] {"test4", new double[] {1,2,3}, new double[] {1}, 0.67448975},
+                new Object[] {"test5", new double[] {3,3}, new double[] {1,2,3}, 1.036433},
+                new Object[] {"test6", new double[] {20,20,20}, new double[] {20,20,20}, 0},
+                new Object[] {"test7", new double[] {20,20,20,20,20}, new double[] {20,20,20,20,20,20,20,20,20,20,20,20,20}, 0},
+                new Object[] {"test8", new double[] {1}, new double[] {2}, -0.67448975},
+                new Object[] {"test9", new double[] {1}, new double[] {1}, 0},
+                new Object[] {"test10", new double[] {60,70,70,60,60,60,60,60}, new double[] {60,60,60,60,60}, .91732119}
+        };
+    }
+
+    @Test(dataProvider = "oneSidedZTestData")
+    public void testOnesidedZ(String name, double[] series1, double[] series2, double Z) {
+        MannWhitneyU.Result test = rst.test(series1, series2, MannWhitneyU.TestType.FIRST_DOMINATES);
+        Assert.assertEquals(test.getZ(), Z, DELTA_PRECISION, name);
+    }
 
     @Test
-    public void testMWU() {
-//        final int[] i0  = new int[]{0,6,7,8,9,10};
-//        final int[] i00 = new int[]{1,2,3,4,5,11};
-//
-//        Assert.assertEquals(z(todouble(i0), todouble(i00), false), 1.072, 0.001);
-//        Assert.assertEquals(z(todouble(i0), todouble(i00), true), 1.072, 0.001);
-//        Assert.assertEquals(z(todouble(i00), todouble(i0), false), -1.072, 0.001);
-//        Assert.assertEquals(z(todouble(i00), todouble(i0), true),  -1.072, 0.001);
-
-
-        final int[] i1 = {2,4,5,6,8};
-        final int[] i2 = {1,3,7,9,10,11,12,13};
-
-        Assert.assertEquals(z(promote(i1), promote(i2), false), -1.3805, 0.001);
-
-        Assert.assertEquals(z(promote(i1), promote(i2), true), -1.3805, 0.001);
-        Assert.assertEquals(z(promote(i2), promote(i1), false),  1.3805, 0.001);
-        Assert.assertEquals(z(promote(i2), promote(i1), true),  1.3805, 0.001);
-
-        final int[] i3 = {0,2,4};
-        final int[] i4 = {1,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34};
-
-        Assert.assertEquals(z(promote(i3), promote(i4), false), -2.7240756662204, 0.001);
-        Assert.assertEquals(z(promote(i3), promote(i4), true),  -2.7240756662204, 0.001);
+    public void testTooManyTies(){
+        ArrayList<Integer> listOfNumberOfTies = new ArrayList<>(Arrays.asList(26,3,6,4,13,18,29,36,60,58,87,63,98,125,158,185,193,171,17592,115,100,141,216,298,451,719,1060,1909,3210,5167,7135,10125,11035,3541,732,9));
+        Assert.assertEquals(rst.transformTies(64890, listOfNumberOfTies), 8.41378729572e+12);
     }
 
-    private static double z(final double[] d1, final double[] d2, final boolean dither){
-        MannWhitneyU mwu = new MannWhitneyU(dither);
-        for ( double dp : d1 ) {
-            mwu.add(dp,MannWhitneyU.USet.SET1);
+    @DataProvider(name = "DistributionData")
+    public Object[][] makeDistributionData() {
+        List<Object[]> tests = new ArrayList<>();
+
+        final int observations = 100;
+        final int skew = 3;
+        final List<Double> distribution20 = new ArrayList<>(observations);
+        final List<Double> distribution30 = new ArrayList<>(observations);
+        final List<Double> distribution20_40 = new ArrayList<>(observations);
+
+        makeDistribution(distribution20, 20, skew, observations);
+        makeDistribution(distribution30, 30, skew, observations);
+        makeDistribution(distribution20_40, 20, skew, observations/2);
+        makeDistribution(distribution20_40, 40, skew, observations/2);
+
+        // shuffle the observations
+        Utils.resetRandomGenerator();
+        Collections.shuffle(distribution20, Utils.getRandomGenerator());
+        Collections.shuffle(distribution30, Utils.getRandomGenerator());
+        Collections.shuffle(distribution20_40, Utils.getRandomGenerator());
+
+        for ( final int numToReduce : Arrays.asList(0, 10, 50, 100) ) {
+            tests.add(new Object[]{distribution20, distribution20, numToReduce, true, observations, "20-20"});
+            tests.add(new Object[]{distribution30, distribution30, numToReduce, true, observations, "30-30"});
+            tests.add(new Object[]{distribution20_40, distribution20_40, numToReduce, true, observations, "20/40-20/40"});
+
+            tests.add(new Object[]{distribution20, distribution30, numToReduce, false, observations, "20-30"});
+            tests.add(new Object[]{distribution30, distribution20, numToReduce, false, observations, "30-20"});
+
+            tests.add(new Object[]{distribution20, distribution20_40, numToReduce, false, observations, "20-20/40"});
+            tests.add(new Object[]{distribution30, distribution20_40, numToReduce, true, observations, "30-20/40"});
         }
-        for ( double dp : d2 ) {
-            mwu.add(dp,MannWhitneyU.USet.SET2);
-        }
-        final Pair<Double, Double> pair = mwu.runOneSidedTest(MannWhitneyU.USet.SET1);
-        return pair.getLeft();
+
+        return tests.toArray(new Object[][]{});
     }
 
+    private static void makeDistribution(final List<Double> result, final int target, final int skew, final int numObservations) {
+        final int rangeStart = target - skew;
+        final int rangeEnd = target + skew;
+
+        double current = rangeStart;
+        for ( int i = 0; i < numObservations; i++ ) {
+            result.add(current++);
+            if ( current > rangeEnd )
+                current = rangeStart;
+        }
+    }
+
+    @Test(dataProvider = "DistributionData")
+    public void testDistribution(final List<Double> distribution1, final List<Double> distribution2, final int numToReduceIn2, final boolean distributionsShouldBeEqual, final int observations, final String debugString) {
+        final MannWhitneyU mannWhitneyU = new MannWhitneyU();
+
+        final List<Double> dist2 = new ArrayList<>(distribution2);
+        if ( numToReduceIn2 > 0 ) {
+            Double counts = 0.0;
+            Double quals = 0.0;
+
+            for ( int i = 0; i < numToReduceIn2; i++ ) {
+                counts++;
+                quals += dist2.remove(0);
+            }
+
+            final Double qual = quals / counts;
+            for ( int i = 0; i < numToReduceIn2; i++ )
+                dist2.add(qual);
+        }
+
+        final Double result = mannWhitneyU.test(Doubles.toArray(distribution1), Doubles.toArray(dist2), MannWhitneyU.TestType.TWO_SIDED).getP();
+        Assert.assertFalse(Double.isNaN(result));
+
+        if ( distributionsShouldBeEqual ) {
+            if ( numToReduceIn2 >= observations / 2 )
+                return;
+            Assert.assertTrue(result > 0.1, String.format("%f %d %f", result, numToReduceIn2, dist2.get(0)));
+        } else {
+            Assert.assertTrue(result < 0.01, String.format("%f %d %f", result, numToReduceIn2, dist2.get(0)));
+        }
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/MathUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/MathUtilsUnitTest.java
@@ -185,6 +185,15 @@ public final class MathUtilsUnitTest extends BaseTest {
     }
 
     @Test
+    public void testBinomialCoefficient() {
+        // results from Wolfram Alpha
+        Assert.assertEquals(MathUtils.binomialCoefficient(4, 2), 6.0, 1e-6);
+        Assert.assertEquals(MathUtils.binomialCoefficient(10, 3), 120.0, 1e-6);
+        Assert.assertEquals(MathUtils.binomialCoefficient(20, 3), 1140.0, 1e-6);
+        Assert.assertEquals(MathUtils.binomialCoefficient(100, 4), 3921225.0, 1e-6);
+    }
+
+    @Test
     public void testLog10BinomialCoefficient() {
         // note that we can test the binomial coefficient calculation indirectly via Newton's identity
         // (1+z)^m = sum (m choose k)z^k


### PR DESCRIPTION
MannWhitneyU was re-written from scratch in 2016 in GATK3,
but these changes never got ported to GATK4. This new version
produces significantly different results from the version
currently in GATK4, resulting in VERY different values for the
RankSumTest annotations in HaplotypeCaller output.

@meganshand informs me that the updated GATK3 version has been
validated in R, and has much better tests than the old version.

This is a straightforward port of that version with minimal changes:

-Merged "MWUnitTest" and "RankSumUnitTest" from GATK3 into a single
 test class MannWhitneyUUnitTest
-Ported MathUtils.binomialCoefficient() and wrote new test for it
-Updated RankSumTest class and tests as appropriate

I've confirmed that with this change, the RankSum annotations produced
by the GATK4 HaplotypeCaller closely match those produced by the GATK3
HaplotypeCaller

Resolves #2604