### PR TITLE
Minor changes to variant comparator test utility for GenomicsDB tests.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtilsUnitTest.java
@@ -6,8 +6,8 @@ import org.testng.annotations.Test;
 
 public class VariantContextTestUtilsUnitTest {
 
-    @DataProvider(name="valuesToNormalize")
-    public Object[][] getValuesToNormalize(){
+    @DataProvider(name="scientificNotationValuesToNormalize")
+    public Object[][] getScientificNotationValuesToNormalize(){
         final Object aSpecificObject = new Object();
         return new Object[][] {
                 {"-2.172e+00", -2.172},
@@ -21,8 +21,35 @@ public class VariantContextTestUtilsUnitTest {
         };
     }
 
-    @Test(dataProvider = "valuesToNormalize")
+    @Test(dataProvider = "scientificNotationValuesToNormalize")
     public void testNormalizeScientificNotation(Object toNormalize, Object expected){
         Assert.assertEquals(VariantContextTestUtils.normalizeScientificNotation(toNormalize), expected);
     }
+
+    @DataProvider(name="integerValuesToNormalize")
+    public Object[][] getIntegerValuesToNormalize(){
+        final Object aSpecificObject = new Object();
+        return new Object[][] {
+                {"27", new Integer(27)},
+                {"-27", new Integer(-27)},
+                {"0", new Integer(0)},
+                {"-27014", new Integer(-27014)},
+                {1, 1},
+                {1, 1},
+                {-1, -1},
+                {1, 1},
+                {"-2.172e+00", "-2.172e+00"},
+                {"-2.172", "-2.172"},
+                {-21.72, -21.72},
+                {10, 10},
+                {"SomeValue", "SomeValue"},
+                {aSpecificObject,  aSpecificObject}
+        };
+    }
+
+    @Test(dataProvider = "integerValuesToNormalize")
+    public void testNormalizeInteger(Object toNormalize, Object expected){
+        Assert.assertEquals(VariantContextTestUtils.normalizeToInteger(toNormalize), expected);
+    }
+
 }


### PR DESCRIPTION
Surgical changes to the VariantContextTestUtils to allow the GenomicsDB importer to tests to compare variants coming from a BCF stream with variants coming from a VCF stream.