### PR TITLE
Fix test assertion that fails on newer versions of testNG.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AlleleFrequencyCalculatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AlleleFrequencyCalculatorUnitTest.java
@@ -98,7 +98,7 @@ public class AlleleFrequencyCalculatorUnitTest extends BaseTest {
             final VariantContext vc = pair.getLeft();
             final int[] expected = pair.getRight();
             final int[] actual = afCalc.getLog10PNonRef(vc).getAlleleCountsOfMLE();
-            Assert.assertEquals(Arrays.asList(expected), Arrays.asList(actual));
+            Assert.assertEquals(actual, expected);
         }
     }
 


### PR DESCRIPTION
The version of testNG that we're using has some [inconsistencies](https://github.com/cbeust/testng/pull/790) in how nested arrays/collections are handled, and they've resolved them in newer versions by implementing changes that are not backward compatible. The AlleleFrequencyCalculatorUnitTest tests fail with newer versions of testNG that have these changes, since they were wrapping an array in a single element List (not sure if that was intentional or not).

The testNG issues seem to suggest using assertEqualsDeep for [some cases](https://github.com/cbeust/testng/issues/1342) but even the newest version doesn't seem to have an overload for Collections. For AlleleFrequencyCalculatorUnitTest though, the collection wrapping was unnecessary anyway, so the array comparisons can be made directly.
