### PR TITLE
Implement scala.Serializable for the PartitionCoalescer 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/RangePartitionCoalescer.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * A {@link PartitionCoalescer} that allows a range of partitions to be coalesced into groups.
  */
-class RangePartitionCoalescer implements PartitionCoalescer, Serializable {
+class RangePartitionCoalescer implements PartitionCoalescer, Serializable, scala.Serializable {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
This is needed for recent versions of Spark 2; see https:/issues.apache.org/jira/browse/SPARK-18051.