### PR TITLE
fixing the spark failures introduced by #2389

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,8 @@ tasks.withType(ShadowJar) {
     relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
     zip64 true
     exclude 'log4j.properties' // from adam jar as it clashes with hellbender's log4j2.xml
+    exclude '**/*.SF' // these are Manifest signature files and
+    exclude '**/*.RSA' // keys which may accidentally be imported from other signed projects and then fail at runtime
 }
 
 


### PR DESCRIPTION
We were seeing failures on spark clusters that manifested as being
unable to find the Main class while running spark submit.

The caused was the accidental introduction of a jar signature file
and key from the transitive gnu.getopt dependency. This was causing
signature validation failures since our uber jar did not match the
expected hashes.

Fixed by excluding .SF and .RSA files from our jars.