### PR TITLE
Use a per-JVM cache of known sites (variants) rather than broadcast which fails for >2GB

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -187,6 +187,22 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
     }
 
     /**
+     * Creates a FeatureDataSource backed by the resource at the provided path.
+     *
+     * @param featurePath path to file or GenomicsDB url containing features
+     * @param name logical name for this data source (may be null)
+     * @param queryLookaheadBases look ahead this many bases during queries that produce cache misses
+     * @param targetFeatureType When searching for a {@link FeatureCodec} for this data source, restrict the search to codecs
+     *                          that produce this type of Feature. May be null, which results in an unrestricted search.
+     * @param cloudPrefetchBuffer  MB size of caching/prefetching wrapper for the data, if on Google Cloud (0 to disable).
+     * @param cloudIndexPrefetchBuffer MB size of caching/prefetching wrapper for the index, if on Google Cloud (0 to disable).
+     */
+    public FeatureDataSource(final String featurePath, final String name, final int queryLookaheadBases, final Class<? extends Feature> targetFeatureType,
+                             final int cloudPrefetchBuffer, final int cloudIndexPrefetchBuffer ) {
+        this(new FeatureInput<>(featurePath, name != null ? name : featurePath), queryLookaheadBases, targetFeatureType, cloudPrefetchBuffer, cloudIndexPrefetchBuffer);
+    }
+
+    /**
      * Creates a FeatureDataSource backed by the provided FeatureInput. We will look ahead the specified number of bases
      * during queries that produce cache misses.
      *

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/KnownSitesCache.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/KnownSitesCache.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.collections.IntervalsSkipList;
+import org.broadinstitute.hellbender.utils.variant.GATKVariant;
+import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A cache of known sites by file path, with the property that there is only one copy of each collection of known sites per JVM.
+ * This class is an alternative for cases that can't use a Spark broadcast due to its 2GB limitation.
+ */
+class KnownSitesCache {
+
+    private static final Logger log = LogManager.getLogger(KnownSitesCache.class);
+
+    private static final Map<List<String>, IntervalsSkipList<GATKVariant>> PATHS_TO_VARIANTS = new HashMap<>();
+
+    public static synchronized IntervalsSkipList<GATKVariant> getVariants(List<String> paths) {
+        if (PATHS_TO_VARIANTS.containsKey(paths)) {
+            return PATHS_TO_VARIANTS.get(paths);
+        }
+        IntervalsSkipList<GATKVariant> variants = retrieveVariants(paths);
+        PATHS_TO_VARIANTS.put(paths, variants);
+        return variants;
+    }
+
+    private static IntervalsSkipList<GATKVariant> retrieveVariants(List<String> paths) {
+        return new IntervalsSkipList<>(paths
+                .stream()
+                .map(KnownSitesCache::loadFromFeatureDataSource)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+    }
+
+    private static List<GATKVariant> loadFromFeatureDataSource(String path) {
+        try ( final FeatureDataSource<VariantContext> dataSource = new FeatureDataSource<>(path, null, 0, null) ) {
+            return wrapQueryResults(dataSource.iterator());
+        }
+    }
+
+    private static List<GATKVariant> wrapQueryResults(final Iterator<VariantContext> queryResults ) {
+        final List<GATKVariant> wrappedResults = new ArrayList<>();
+        long count = 0;
+        while ( queryResults.hasNext() ) {
+            if (count++ % 100000 == 0) {
+                log.info("Number of variants read: " + count);
+            }
+            wrappedResults.add(VariantContextVariantAdapter.sparkVariantAdapter(queryResults.next()));
+        }
+        return wrappedResults;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/KnownSitesCache.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/KnownSitesCache.java
@@ -39,7 +39,8 @@ class KnownSitesCache {
     }
 
     private static List<GATKVariant> loadFromFeatureDataSource(String path) {
-        try ( final FeatureDataSource<VariantContext> dataSource = new FeatureDataSource<>(path, null, 0, null) ) {
+        int cloudPrefetchBuffer = 40; // only used for GCS
+        try ( final FeatureDataSource<VariantContext> dataSource = new FeatureDataSource<>(path, null, 0, null, cloudPrefetchBuffer, cloudPrefetchBuffer) ) {
             return wrapQueryResults(dataSource.iterator());
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -90,7 +90,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
 
         // TODO: Look into broadcasting the reference to all of the workers. This would make AddContextDataToReadSpark
         // TODO: and ApplyBQSRStub simpler (#855).
-        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, initialReads, getReference(), bqsrKnownVariants, joinStrategy, getReferenceSequenceDictionary(), readShardSize, readShardPadding);
+        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, initialReads, getReference(), bqsrKnownVariants, knownVariants, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
 
         // TODO: broadcast the reads header?
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getReferenceSequenceDictionary(), bqsrArgs);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -102,7 +102,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
         final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
 
-        final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, filteredReadsForBQSR, getReference(), bqsrKnownVariants, joinStrategy, getReferenceSequenceDictionary(), readShardSize, readShardPadding);
+        final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, filteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariants, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
         //note: we use the reference dictionary from the reads themselves.
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getHeaderForReads().getSequenceDictionary(), bqsrArgs);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -50,7 +50,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
     public boolean requiresReference() { return true; }
 
     @Argument(doc = "the known variants", shortName = "knownSites", fullName = "knownSites", optional = false)
-    protected List<String> baseRecalibrationKnownVariants;
+    protected List<String> baseRecalibrationKnownVariantPaths;
 
     @Argument(doc = "the output bam", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
@@ -100,9 +100,9 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         final JavaRDD<GATKRead> filteredReadsForBQSR = initialReads.filter(read -> bqsrReadFilter.test(read));
 
         final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
+        final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariantPaths, getIntervals());
 
-        final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, filteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariants, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
+        final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, filteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariantPaths, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
         //note: we use the reference dictionary from the reads themselves.
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getHeaderForReads().getSequenceDictionary(), bqsrArgs);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -116,7 +116,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
         JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
 
-        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, markedFilteredReadsForBQSR, getReference(), bqsrKnownVariants, joinStrategy, getReferenceSequenceDictionary(), readShardSize, readShardPadding);
+        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, markedFilteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariants, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getReferenceSequenceDictionary(), bqsrArgs);
 
         final Broadcast<RecalibrationReport> reportBroadcast = ctx.broadcast(bqsrReport);

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
@@ -70,7 +70,7 @@ public class AddContextDataToReadSparkUnitTest extends BaseTest {
         SAMSequenceDictionary sd = new SAMSequenceDictionary(Lists.newArrayList(new SAMSequenceRecord("1", 100000), new SAMSequenceRecord("2", 100000)));
         when(mockSource.getReferenceSequenceDictionary(null)).thenReturn(sd);
 
-        JavaPairRDD<GATKRead, ReadContextData> rddActual = AddContextDataToReadSpark.add(ctx, rddReads, mockSource, rddVariants, joinStrategy,
+        JavaPairRDD<GATKRead, ReadContextData> rddActual = AddContextDataToReadSpark.add(ctx, rddReads, mockSource, rddVariants, null, joinStrategy,
                 sd, 10000, 1000);
         Map<GATKRead, ReadContextData> actual = rddActual.collectAsMap();
 


### PR DESCRIPTION
This is needed to get BQSR running on an exome with a 10GB known sites VCF. See https://github.com/broadinstitute/gatk/blob/tw_spark_eval/q4_spark_eval/test_case_exome_pipeline.sh