### PR TITLE
Added batchsize and consolidation parameters to GenomicsDBImporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 final htsjdkVersion = System.getProperty('htsjdk.version','2.9.1')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.8.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.5.0-proto-3.0.0-beta-1')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.6.2-proto-3.0.0-beta-1')
 final testNGVersion = '6.11'
 
 configurations.all {

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
 import com.intel.genomicsdb.ChromosomeInterval;
+import com.intel.genomicsdb.GenomicsDBCallsetsMapProto;
+import com.intel.genomicsdb.GenomicsDBImportConfiguration;
 import com.intel.genomicsdb.GenomicsDBImporter;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -24,9 +26,11 @@ import org.broadinstitute.hellbender.utils.nio.SeekableByteChannelPrefetcher;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.*;
 import java.util.function.Function;
+
 
 /**
  * This tool imports GVCFs to GenomicsDB. To run this tool,
@@ -47,6 +51,7 @@ public final class GenomicsDBImport extends GATKTool {
 
     private static final long DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE = 16*1024L;
     private static final long DEFAULT_SEGMENT_SIZE = 1048576L;
+    private static final int DEFAULT_ZERO_BATCH_SIZE = 0;
 
     public static final String WORKSPACE_ARG_NAME = "genomicsDBWorkspace";
     private static final String SEGMENT_SIZE_ARG_NAME = "genomicsDBSegmentSize";
@@ -57,6 +62,8 @@ public final class GenomicsDBImport extends GATKTool {
     private static final String VID_MAP_FILE_ARG_NAME = "genomicsDBVidMapFile";
 
     private static final String CALLSET_MAP_FILE_ARG_NAME = "genomicsDBCallsetMapFile";
+    private static final String BATCHSIZE_ARG_NAME = "batchSize";
+    private static final String CONSOLIDATE_ARG_NAME = "consolidate";
 
     @Argument(fullName = WORKSPACE_ARG_NAME,
               shortName = WORKSPACE_ARG_NAME,
@@ -81,7 +88,7 @@ public final class GenomicsDBImport extends GATKTool {
               shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME,
               doc = "GVCF files to be imported to GenomicsDB. Each file must contain" +
                     "data for only a single sample")
-    private List<String> variantFilePaths;
+    private List<String> variantPaths;
 
     @Argument(fullName = VCF_BUFFER_SIZE_ARG_NAME,
               shortName = VCF_BUFFER_SIZE_ARG_NAME,
@@ -116,6 +123,28 @@ public final class GenomicsDBImport extends GATKTool {
               optional = true)
     private Boolean overwriteExistingWorkspace = false;
 
+    @Argument(fullName = BATCHSIZE_ARG_NAME,
+              shortName = BATCHSIZE_ARG_NAME,
+              doc = "Batch size controls the number of samples for which readers are open at once " +
+                    "and therefore provides a way to minimize memory consumption. However, it can take longer to complete. " +
+                    "Use the consolidate flag if more than a hundred batches were used. This will improve feature read time. " +
+                    "batchSize=0 means no batching (i.e. readers for all samples will be opened at once) " +
+                    "Defaults to " + DEFAULT_ZERO_BATCH_SIZE,
+              optional = true)
+    private int batchSize = DEFAULT_ZERO_BATCH_SIZE;
+
+    @Argument(fullName = CONSOLIDATE_ARG_NAME,
+              shortName = CONSOLIDATE_ARG_NAME,
+              doc = "Boolean flag to enable consolidation. If importing data in batches, a new fragment is created for " +
+                    "each batch. In case thousands of fragments are created, GenomicsDB feature readers will try " +
+                    "to open ~20x as many files. Also, internally GenomicsDB would consume more memory to maintain " +
+                    "bookkeeping data from all fragments. Use this flag to merge all fragments into one. " +
+                    "Merging can potentially improve read performance, however overall benefit might not be noticeable " +
+                    "as the top Java layers has significantly higher overheads. This flag have no effect if only one " +
+                    "batch is used. Defaults to false",
+              optional = true)
+    private Boolean doConsolidation = false;
+
     @Override
     public boolean requiresIntervals() { return true; }
 
@@ -127,19 +156,30 @@ public final class GenomicsDBImport extends GATKTool {
       return false;
     }
 
-    // The GenomicsDB importer object
-    private GenomicsDBImporter importer = null;
-
     // Intervals from command line (singleton for now)
     private List<ChromosomeInterval> intervals;
 
-    private final Map<String, FeatureReader<VariantContext>> sampleToVCFMap = new HashMap<>();
+    // List of all sample names
+    private List<String> sampleNames = new ArrayList<>();
+
+    // Linked hash map between sample names and corresponding GVCF file name
+    private Map<String, String> sampleNameToVcfUri = new LinkedHashMap<>();
 
     // Needed as smartMergeHeaders() returns a set of VCF header lines
     private Set<VCFHeaderLine> mergedHeader = null;
 
-    // VCFHeader object created from mergedHeader
-    private VCFHeader mergedVCFHeader = null;
+    // VCFHeader created from the merged header
+    private VCFHeader mergedVCFHeader;
+
+    // Path to vidmap file to be written by GenomicsDBImporter
+    private File vidMapJSONFile;
+
+    // Path to callsetmap file to be written by GenomicsDBImporter
+    private File callsetMapJSONFile;
+
+    // GenomicsDB callset map protobuf structure containing all callset names
+    // used to write the callset json file on traversal success
+    private GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB;
 
     /**
      * Before traversal starts, create the feature readers
@@ -149,26 +189,38 @@ public final class GenomicsDBImport extends GATKTool {
     @Override
     public void onStartup() {
 
-        for (final String variantPath : variantFilePaths) {
+        List<VCFHeader> headers = new ArrayList<>(variantPaths.size());
 
-            final String variantURI = IOUtils.getPath(variantPath).toAbsolutePath().toUri().toString();
-            final Function<SeekableByteChannel, SeekableByteChannel> cloudWrapper = (cloudPrefetchBuffer > 0 ? is -> SeekableByteChannelPrefetcher.addPrefetcher(cloudPrefetchBuffer, is) : Function.identity());
-            final Function<SeekableByteChannel, SeekableByteChannel> cloudIndexWrapper = (cloudIndexPrefetchBuffer > 0 ? is -> SeekableByteChannelPrefetcher.addPrefetcher(cloudIndexPrefetchBuffer, is) : Function.identity());
-            final AbstractFeatureReader<VariantContext, LineIterator> reader = AbstractFeatureReader.getFeatureReader(variantURI, null, new VCFCodec(), true, cloudWrapper, cloudIndexWrapper);
+        for (String variantPath : variantPaths) {
+
+            final AbstractFeatureReader<VariantContext, LineIterator> reader = getReaderFromVCFUri(variantPath);
+            VCFHeader header = (VCFHeader)reader.getHeader();
 
             // A GVCF file must contain only one sample, throw an exception otherwise
-            if (((VCFHeader)reader.getHeader()).getNGenotypeSamples() != 1) {
+            if (header.getNGenotypeSamples() != 1) {
                 throw new UserException("Input GVCF: " + variantPath + " should contain data for one sample");
             }
+            String sampleName = header.getGenotypeSamples().get(0);
+            headers.add(header);
+            sampleNames.add(sampleName);
+            if (sampleNameToVcfUri.put(sampleName, variantPath) != null) {
+                throw new UserException("Duplicate sample " + sampleName);
+            }
 
-            final String sampleName = ((VCFHeader) reader.getHeader()).getGenotypeSamples().get(0);
-            sampleToVCFMap.put(sampleName, reader);
+            // Import occurs in batches. By closing all readers here we release resources
+            // and preserve memory for later stages where readers are allocated
+            // for samples in a given batch
+            try {
+                reader.close();
+            } catch (IOException e) {
+                throw new GATKException("FeatureReader close() failed for " + sampleName, e);
+            }
         }
 
-        createMergedHeader();
+        mergedHeader = VCFUtils.smartMergeHeaders(headers, true);
+        mergedVCFHeader = new VCFHeader(mergedHeader);
 
         initializeIntervals();
-
         super.onStartup();
     }
 
@@ -184,35 +236,26 @@ public final class GenomicsDBImport extends GATKTool {
         // If provided buffer size is less 1KB it is considered to be too small
         // Either use default 16KB or any value larger than 10KB
         if (vcfBufferSizePerSample < 1024L) {
-            logger.warn("Buffer size per column partition per sample is too small." +
-                " Either use default value " + DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE +
-                " or larger values than 10KB");
+            throw new UserException("Buffer size per column partition per sample is too small." +
+                    " Either use default value " + DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE +
+                    " or larger values than 10KB");
         }
 
-        final File vidMapJSONFile = (vidMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME)) ?
+        vidMapJSONFile = (vidMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME)) ?
             new File(workspaceDir + "/" + vidMapJSONFileName) :
             new File(vidMapJSONFileName);
 
-        final File callsetMapJSONFile = (callsetMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME)) ?
+        callsetMapJSONFile = (callsetMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME)) ?
             new File (workspaceDir + "/" + callsetMapJSONFileName) :
             new File(callsetMapJSONFileName);
 
         logger.info("Vid Map JSON file will be written to " + vidMapJSONFile);
         logger.info("Callset Map JSON file will be written to " + callsetMapJSONFile);
-        
-        final long variantContextBufferSize = vcfBufferSizePerSample * sampleToVCFMap.size();
+        logger.info("Importing to array - " + workspace + "/" + arrayName);
 
-        logger.info("Writing data to array - " + workspace + "/" + arrayName);
-
-        try {
-            logger.info("GenomicsDB import batch started");
-            importer = new GenomicsDBImporter(sampleToVCFMap, mergedHeader, intervals.get(0), workspace,
-                                              arrayName, variantContextBufferSize, segmentSize,
-                                              vidMapJSONFile.getAbsolutePath(),
-                                              callsetMapJSONFile.getAbsolutePath());
-        } catch (IOException e) {
-            throw new UserException("Error initializing GenomicsDBImporter", e);
-        }
+        // Passing in false here so that sample names will be sorted.
+        // This is needed for consistent ordering across partitions/machines
+        callsetMappingPB = GenomicsDBImporter.generateSortedCallSetMap(sampleNames, false);
     }
 
     /**
@@ -221,24 +264,172 @@ public final class GenomicsDBImport extends GATKTool {
      */
     @Override
     public void traverse() {
-        try {
-            importer.importBatch();
-        } catch (IOException e) {
-            throw new UserException("GenomicsDB importBatch raised exception", e);
+
+        int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleNames.size() : batchSize;
+        int sampleCount = sampleNames.size();
+        int totalBatchCount = (sampleCount/updatedBatchSize) + (sampleCount%updatedBatchSize==0 ? 0 : 1);
+
+        GenomicsDBImporter importer;
+
+        for (int i = 0, batchCount = 1; i < sampleCount; i += updatedBatchSize, ++batchCount) {
+
+            Map<String, FeatureReader<VariantContext>> sampleToReaderMap =
+                getFeatureReaders(sampleNames, sampleNameToVcfUri, updatedBatchSize, sampleCount, i);
+
+            logger.info("Importing batch " + batchCount + " with " + sampleToReaderMap.size() + " samples");
+            final long variantContextBufferSize = vcfBufferSizePerSample * sampleToReaderMap.size();
+
+            GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
+                    createImportConfiguration(workspace, arrayName,
+                            variantContextBufferSize, segmentSize,
+                            i, (i+updatedBatchSize-1));
+
+            try {
+                importer = new GenomicsDBImporter(sampleToReaderMap, mergedHeader, intervals.get(0), importConfiguration);
+            } catch (IOException e) {
+                throw new UserException("Error initializing GenomicsDBImporter in batch " + batchCount, e);
+            }
+
+            try {
+                importer.importBatch();
+            } catch (IOException e) {
+                throw new UserException("GenomicsDB import failed in batch " + batchCount, e);
+            }
+
+            closeReaders(sampleToReaderMap);
+            logger.info("Done importing batch " + batchCount + "/" + totalBatchCount);
         }
     }
 
     @Override
     public Object onTraversalSuccess() {
-        logger.info("Import completed!");
-        return importer.isDone();
+        if (batchSize==DEFAULT_ZERO_BATCH_SIZE) {
+            logger.info("Import completed!");
+        } else {
+            logger.info("Import of all batches to GenomicsDB completed!");
+        }
+
+        // Write the vid and callset map JSON files
+        try {
+            GenomicsDBImporter.writeVidMapJSONFile(vidMapJSONFile.getAbsolutePath(), mergedHeader);
+        } catch (FileNotFoundException fe) {
+            throw new UserException("Unable to write vid map JSON file " + vidMapJSONFile.getAbsolutePath(), fe);
+        }
+        try {
+            GenomicsDBImporter.writeCallsetMapJSONFile(callsetMapJSONFile.getAbsolutePath(), callsetMappingPB);
+        } catch (FileNotFoundException fe) {
+            throw new UserException("Unable to write callset map JSON file " + callsetMapJSONFile.getAbsolutePath(), fe);
+        }
+
+        if (doConsolidation) {
+            logger.info("GenomicsDB consolidation started");
+            GenomicsDBImporter.consolidateTileDBArray(workspace, arrayName);
+            logger.info("GenomicsDB consolidation completed");
+        }
+
+        return true;
     }
 
-    @Override
-    public void closeTool() {
-        for (Map.Entry<String, FeatureReader<VariantContext>> reader : sampleToVCFMap.entrySet()) {
+    /**
+     * Method to create feature readers for input files or GCS URLs
+     * in the current batch
+     *
+     * @param sampleNames  List of all sample names
+     * @param sampleNameToFileName  Sample name to file name mapping
+     * @param batchSize  Current batch size
+     * @param sampleCount  total samples in this import
+     * @param lowerSampleIndex  0-based Lower bound of sample index -- inclusive
+     * @return  Feature readers to be imported in the current batch
+     */
+    private Map<String, FeatureReader<VariantContext>> getFeatureReaders(List<String> sampleNames, Map<String, String> sampleNameToFileName, int batchSize, int sampleCount, int lowerSampleIndex) {
+        Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
+
+        for(int i = lowerSampleIndex; i < sampleCount && i < lowerSampleIndex+batchSize; ++i) {
+            final String sampleName = sampleNames.get(i);
+            assert sampleNameToFileName.containsKey(sampleName);
+
+            final AbstractFeatureReader<VariantContext, LineIterator> reader = getReaderFromVCFUri(sampleNameToFileName.get(sampleName));
+
+            assert sampleName.equals(((VCFHeader) reader.getHeader()).getGenotypeSamples().get(0));
+            sampleToReaderMap.put(sampleName, reader);
+        }
+        return sampleToReaderMap;
+    }
+
+    /**
+     * Creates a feature reader object from a given VCF URI (can also be
+     * a local file path) and returns it
+     * @param variantPath  URI or file path
+     * @return  Feature reader
+     */
+    private AbstractFeatureReader<VariantContext, LineIterator> getReaderFromVCFUri(String variantPath) {
+        final String variantURI = IOUtils.getPath(variantPath).toAbsolutePath().toUri().toString();
+        final Function<SeekableByteChannel, SeekableByteChannel> cloudWrapper = (cloudPrefetchBuffer > 0 ? is -> SeekableByteChannelPrefetcher.addPrefetcher(cloudPrefetchBuffer, is) : Function.identity());
+        final Function<SeekableByteChannel, SeekableByteChannel> cloudIndexWrapper = (cloudIndexPrefetchBuffer > 0 ? is -> SeekableByteChannelPrefetcher.addPrefetcher(cloudIndexPrefetchBuffer, is) : Function.identity());
+        return AbstractFeatureReader.getFeatureReader(variantURI, null, new VCFCodec(), true, cloudWrapper, cloudIndexWrapper);
+    }
+
+    /**
+     * Creates a GenomicsDB configuration data structure
+     * instead of sending a long list of parameters to the constructor call
+     *
+     * @param workspace  GenomicsDB workspace
+     * @param arrayName  GenomicsDB array
+     * @param variantContextBufferSize  Buffer size to store VCF records for all samples
+     * @param segmentSize  Buffer size to store columnar data to be serialized to disk
+     * @param lbSampleIndex  Lower bound of sample index -- inclusive (0-based)
+     * @param ubSampleIndex  Upper bound of sample index -- inclusive (0-based)
+     * @return  GenomicsDB import configuration object
+     */
+    private GenomicsDBImportConfiguration.ImportConfiguration createImportConfiguration(
+        final String workspace,
+        final String arrayName,
+        final long variantContextBufferSize,
+        final long segmentSize,
+        final long lbSampleIndex,
+        final long ubSampleIndex) {
+
+        GenomicsDBImportConfiguration.Partition.Builder pBuilder =
+            GenomicsDBImportConfiguration.Partition.newBuilder();
+
+        // Since, there is one partition for this import, the
+        // begin column partition index is 0
+        GenomicsDBImportConfiguration.Partition partition =
+            pBuilder
+                .setWorkspace(workspace)
+                .setArray(arrayName)
+                .setBegin(0)
+                .build();
+
+        GenomicsDBImportConfiguration.GATK4Integration.Builder gBuilder =
+            GenomicsDBImportConfiguration.GATK4Integration.newBuilder();
+
+        GenomicsDBImportConfiguration.GATK4Integration gatk4Parameters =
+            gBuilder
+                .setLowerSampleIndex(lbSampleIndex)
+                .setUpperSampleIndex(ubSampleIndex)
+                .build();
+
+        GenomicsDBImportConfiguration.ImportConfiguration.Builder cBuilder =
+            GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
+
+        return cBuilder
+                .addColumnPartitions(0, partition)
+                .setGatk4IntegrationParameters(gatk4Parameters)
+                .setSizePerColumnPartition(variantContextBufferSize)
+                .setSegmentSize(segmentSize)
+                .build();
+    }
+
+    /**
+     * Close all readers in the current batch
+     *
+     * @param sampleToReaderMap  Map of sample names to readers
+     */
+    private void closeReaders(Map<String, FeatureReader<VariantContext>> sampleToReaderMap) {
+        for (Map.Entry<String, FeatureReader<VariantContext>> reader : sampleToReaderMap.entrySet()) {
             try {
-               reader.getValue().close();
+                reader.getValue().close();
             } catch (IOException e) {
                 throw new GATKException("FeatureReader close() failed for " + reader.getKey(), e);
             }
@@ -280,21 +471,6 @@ public final class GenomicsDBImport extends GATKTool {
         if (!tempFile.exists()) {
             throw new UserException(workspaceDir.getAbsolutePath() + " is not a valid GenomicsDB workspace");
         }
-    }
-
-    /**
-     * Create merged header from input GVCFs
-     */
-    private void createMergedHeader() {
-        List<VCFHeader> headers = new ArrayList<>();
-        for (Map.Entry<String, FeatureReader<VariantContext>> sampleToVCF : sampleToVCFMap.entrySet()) {
-            FeatureReader<VariantContext> reader = sampleToVCF.getValue();
-            VCFHeader vcfHeader = (VCFHeader)reader.getHeader();
-            headers.add((VCFHeader)reader.getHeader());
-        }
-
-        mergedHeader = VCFUtils.smartMergeHeaders(headers, true);
-        mergedVCFHeader = new VCFHeader(mergedHeader);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/GenomicsDBImportIntegrationTest.java
@@ -9,6 +9,7 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBImport;
 import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBConstants;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
@@ -16,6 +17,8 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -26,66 +29,154 @@ import java.util.List;
 
 public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTest {
 
-  @Override
-  public String getTestedClassName() {
-    return GenomicsDBImport.class.getSimpleName();
-  }
-
-  @Test
-  public void testGenomicsDBImportFileInputs() throws IOException {
-    final String hg00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
-    final String hg00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
-    final String na19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
-    final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
-    final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
-
-    testGenomicsDBImporter(Arrays.asList(hg00096, hg00268, na19625), interval, combined);
-  }
-
-  @Test(groups = {"bucket"})
-  public void testGenomicsDBImportGCSInputs() throws IOException {
-    final String hg00096_cloud = getGCPTestInputPath() + "large/gvcfs/HG00096.g.vcf.gz";
-    final String hg00268_cloud = getGCPTestInputPath() + "large/gvcfs/HG00268.g.vcf.gz";
-    final String na19625_cloud = getGCPTestInputPath() + "large/gvcfs/NA19625.g.vcf.gz";
-    final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
-    final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
-
-    testGenomicsDBImporter(Arrays.asList(hg00096_cloud, hg00268_cloud, na19625_cloud), interval, combined);
-  }
-
-  private void testGenomicsDBImporter(final List<String> vcfInputs, final SimpleInterval interval, final String expectedCombinedVCF) throws IOException {
-    final String workspace = createTempDir("genomicsdb-tests-").getAbsolutePath() + "/workspace";
-    final ArgumentsBuilder args = new ArgumentsBuilder();
-    args.addArgument("genomicsDBWorkspace", workspace);
-    args.addArgument("L", IntervalUtils.locatableToString(interval));
-    vcfInputs.forEach(vcf -> args.addArgument("V", vcf));
-    runCommandLine(args);
-
-    final GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
-      new GenomicsDBFeatureReader<>(
-              new File(workspace, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME).getAbsolutePath(),
-              new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).getAbsolutePath(),
-              workspace,
-              GenomicsDBConstants.DEFAULT_ARRAY_NAME,
-              b38_reference_20_21, null, new BCF2Codec());
-
-    final AbstractFeatureReader<VariantContext, LineIterator> combinedVCFReader =
-      AbstractFeatureReader.getFeatureReader(expectedCombinedVCF, new VCFCodec(), true);
-
-    try (final CloseableTribbleIterator<VariantContext> actualVcs =
-                 genomicsDBFeatureReader.query(interval.getContig(), interval.getStart(), interval.getEnd());
-         final CloseableTribbleIterator<VariantContext> expectedVcs =
-                 combinedVCFReader.query(interval.getContig(), interval.getStart(), interval.getEnd()) ){
-      BaseTest.assertCondition(actualVcs, expectedVcs, (a, e) -> {
-        // TODO: Temporary hacks to make this test pass. Must be removed later
-        if ( // allele order
-             e.getStart() != 17967343 && e.getStart() != 17966384 &&
-             // split block
-             e.getEnd() != 17981447
-          ) {
-          VariantContextTestUtils.assertVariantContextsAreEqual(a, e, Collections.emptyList());
-        }
-      });
+    @Override
+    public String getTestedClassName() {
+        return GenomicsDBImport.class.getSimpleName();
     }
-  }
+
+    @DataProvider(name="batchSizes")
+    public Object[][] batchSizes() {
+        return new Object[][] {
+                new Object[]{1},
+                new Object[]{2},
+                new Object[]{3},
+                new Object[]{4},
+                new Object[]{100},
+        };
+    }
+
+    @Test
+    public void testGenomicsDBImportFileInputs() throws IOException {
+        final String hg00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
+        final String hg00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
+        final String na19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
+        final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+        final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
+
+        testGenomicsDBImporter(Arrays.asList(hg00096, hg00268, na19625), interval, combined);
+    }
+
+    @Test(groups = {"bucket"})
+    public void testGenomicsDBImportGCSInputs() throws IOException {
+        final String hg00096_cloud = getGCPTestInputPath() + "large/gvcfs/HG00096.g.vcf.gz";
+        final String hg00268_cloud = getGCPTestInputPath() + "large/gvcfs/HG00268.g.vcf.gz";
+        final String na19625_cloud = getGCPTestInputPath() + "large/gvcfs/NA19625.g.vcf.gz";
+        final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+        final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
+
+        testGenomicsDBImporter(Arrays.asList(hg00096_cloud, hg00268_cloud, na19625_cloud), interval, combined);
+    }
+
+    @Test(dataProvider = "batchSizes")
+    public void testGenomicsDBImportFileInputsInBatches(int batchSize) throws IOException {
+        final String hg00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
+        final String hg00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
+        final String na19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
+        final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+        final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
+
+        testGenomicsDBImporterWithBatchSize(Arrays.asList(hg00096, hg00268, na19625), interval, combined, batchSize);
+    }
+
+    @Test(groups = {"bucket"}, dataProvider = "batchSizes")
+    public void testGenomicsDBImportGCSInputsInBatches(int batchSize) throws IOException {
+        final String hg00096_cloud = getGCPTestInputPath() + "large/gvcfs/HG00096.g.vcf.gz";
+        final String hg00268_cloud = getGCPTestInputPath() + "large/gvcfs/HG00268.g.vcf.gz";
+        final String na19625_cloud = getGCPTestInputPath() + "large/gvcfs/NA19625.g.vcf.gz";
+        final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+        final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
+
+        testGenomicsDBImporterWithBatchSize(Arrays.asList(hg00096_cloud, hg00268_cloud, na19625_cloud), interval, combined, batchSize);
+    }
+
+    /**
+     * Check whether user exception is thrown with vcf
+     * buffer size < 1024 bytes
+     *
+     * @throws UserException  Value must be >1024 bytes
+     */
+    @Test(expectedExceptions = UserException.class)
+    public void testZeroVCFBufferSize() throws IOException {
+        final String hg00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
+        final String hg00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
+        final String na19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
+        final String combined = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+        final SimpleInterval interval = new SimpleInterval("chr20", 17960187, 17981445);
+
+        testGenomicsDBImportWithZeroBufferSize(Arrays.asList(hg00096, hg00268, na19625), interval, combined);
+    }
+
+    private void testGenomicsDBImporter(final List<String> vcfInputs, final SimpleInterval interval, final String expectedCombinedVCF) throws IOException {
+        final String workspace = createTempDir("genomicsdb-tests-").getAbsolutePath() + "/workspace";
+
+        writeToGenomicsDB(vcfInputs, interval, workspace, 0, false, 0);
+        checkJSONFilesAreWritten(workspace);
+        checkGenomicsDBAgainstExpected(workspace, interval, expectedCombinedVCF);
+    }
+
+    private void testGenomicsDBImporterWithBatchSize(final List<String> vcfInputs, final SimpleInterval interval, final String expectedCombinedVCF, int batchSize) throws IOException {
+        final String workspace = createTempDir("genomicsdb-batchsize-tests-").getAbsolutePath() + "/workspace-" + batchSize;
+
+        writeToGenomicsDB(vcfInputs, interval, workspace, batchSize, false, 0);
+        checkJSONFilesAreWritten(workspace);
+        checkGenomicsDBAgainstExpected(workspace, interval, expectedCombinedVCF);
+    }
+
+    private void testGenomicsDBImportWithZeroBufferSize(final List<String> vcfInputs, final SimpleInterval interval, final String expectedCombinedVCF) throws IOException {
+        final String workspace = createTempDir("genomicsdb-buffersize-tests-").getAbsolutePath() + "/workspace";
+
+        writeToGenomicsDB(vcfInputs, interval, workspace, 0, true, 0);
+        checkJSONFilesAreWritten(workspace);
+        checkGenomicsDBAgainstExpected(workspace, interval, expectedCombinedVCF);
+
+    }
+
+    private void writeToGenomicsDB(final List<String> vcfInputs, final SimpleInterval interval, final String workspace, int batchSize, final Boolean useBufferSize, int bufferSizePerSample) {
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addArgument("genomicsDBWorkspace", workspace);
+        args.addArgument("L", IntervalUtils.locatableToString(interval));
+        vcfInputs.forEach(vcf -> args.addArgument("V", vcf));
+        args.addArgument("batchSize", String.valueOf(batchSize));
+
+        if (useBufferSize)
+            args.addArgument("genomicsDBVCFBufferSize", String.valueOf(bufferSizePerSample));
+
+        runCommandLine(args);
+    }
+
+    private void checkJSONFilesAreWritten(String workspace) {
+        Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME).exists());
+        Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).exists());
+    }
+
+    private void checkGenomicsDBAgainstExpected(String workspace, final SimpleInterval interval, final String expectedCombinedVCF) throws IOException {
+        GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
+                new GenomicsDBFeatureReader<>(
+                        new File(workspace, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME).getAbsolutePath(),
+                        new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).getAbsolutePath(),
+                        workspace,
+                        GenomicsDBConstants.DEFAULT_ARRAY_NAME,
+                        b38_reference_20_21, null, new BCF2Codec());
+
+        AbstractFeatureReader<VariantContext, LineIterator> combinedVCFReader =
+                AbstractFeatureReader.getFeatureReader(expectedCombinedVCF, new VCFCodec(), true);
+
+        try (CloseableTribbleIterator<VariantContext> actualVcs =
+                     genomicsDBFeatureReader.query(interval.getContig(), interval.getStart(), interval.getEnd());
+
+             CloseableTribbleIterator<VariantContext> expectedVcs =
+                     combinedVCFReader.query(interval.getContig(), interval.getStart(), interval.getEnd())) {
+
+            BaseTest.assertCondition(actualVcs, expectedVcs, (a, e) -> {
+                // TODO: Temporary hacks to make this test pass. Must be removed later
+                if (// allele order
+                        e.getStart() != 17967343 && e.getStart() != 17966384 &&
+                                // split block
+                                e.getEnd() != 17981447
+                        ) {
+                    VariantContextTestUtils.assertVariantContextsAreEqual(a, e, Collections.emptyList());
+                }
+            });
+        }
+    }
 }


### PR DESCRIPTION
build will break because genomicsdb-0.6.0 hasn't been released yet and dependence on protobuf-java-format needs to be fixed!

@droazen, remember now that I added the dependence on protobuf-java-format to use protobuf.JsonFormat.printToString() method which converts a protobuf structure to JSON string. I want to use import configuration protocol buffers in this code which means this dependence will be back to bite us! Need to fix this cause I don't want to break the Spark build again