### PR TITLE
Limit NIO buffer size to file size

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/nio/SeekableByteChannelPrefetcher.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/nio/SeekableByteChannelPrefetcher.java
@@ -152,8 +152,12 @@ public final class SeekableByteChannelPrefetcher implements SeekableByteChannel 
         if (bufSize <= 0) {
             throw new IllegalArgumentException("bufSize must be positive");
         }
-        this.bufSize = bufSize;
         this.size = chan.size();
+        if (bufSize > this.size) {
+            this.bufSize = (int)this.size;
+        } else {
+            this.bufSize = bufSize;
+        }
         this.open = true;
         exec = Executors.newFixedThreadPool(1);
     }


### PR DESCRIPTION
After all, there's no point in having a larger buffer than that.