### PR TITLE
ValidateVariants is smarter about when a reference is and is not required. Closes #2509.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ValidateVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ValidateVariants.java
@@ -177,8 +177,8 @@ public final class ValidateVariants extends VariantWalker {
         final Allele reportedRefAllele = vc.getReference();
         final int refLength = reportedRefAllele.length();
 
-        final byte[] observedRefBases = Arrays.copyOf(ref.getBases(), refLength);
-        final Allele observedRefAllele = Allele.create(observedRefBases);
+        final Allele observedRefAllele = hasReference() ? Allele.create(Arrays.copyOf(ref.getBases(), refLength)) : null;
+
         final Set<String> rsIDs = getRSIDs(featureContext);
 
         for (final ValidationType t : validationTypes) {
@@ -229,6 +229,9 @@ public final class ValidateVariants extends VariantWalker {
         } else {
            final Set<ValidationType> result = new LinkedHashSet<>(ValidationType.CONCRETE_TYPES);
            result.removeAll(excludeTypeSet);
+            if (result.contains(ValidationType.REF) && !hasReference()) {
+                throw new UserException.MissingReference("Validation type " + ValidationType.REF.name() + " was selected but no reference was provided.");
+            }
            return result;
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
@@ -27,6 +27,12 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
         return "-R " + reference + intervals + " --variant " + filePath + typeArgString;
     }
 
+    public String baseTestStringWithoutReference(boolean sharedFile, String file, boolean exclude, ValidateVariants.ValidationType type) {
+        final String filePath = sharedFile ? file: getToolTestDataDir() + file;
+        final String typeArgString = exclude ? " --validationTypeToExclude " + type.name() : excludeValidationTypesButString(type);
+        return " --variant " + filePath + typeArgString;
+    }
+
     private static String excludeValidationTypesButString(ValidateVariants.ValidationType type) {
         if (type.equals(ALL)) {
             return "";
@@ -66,6 +72,17 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
                 baseTestString(false, "validationExampleBad.vcf", false, REF),
                 0,
                 UserException.FailsStrictValidation.class
+        );
+
+        spec.executeTest("test bad ref base #1", this);
+    }
+
+    @Test
+    public void testMissingReference() throws IOException {
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                baseTestStringWithoutReference(false, "validationExampleBad.vcf", false, REF),
+                0,
+                UserException.MissingReference.class
         );
 
         spec.executeTest("test bad ref base #1", this);


### PR DESCRIPTION
@lbergelson Here you go.