### PR TITLE
Ll emit empty loci

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -588,8 +588,7 @@ public final class AssemblyRegion implements Locatable {
 
         // Use the provided activity profile to determine the bounds of each assembly region:
         List<AssemblyRegion> assemblyRegions = new ArrayList<>();
-        final Iterable<AlignmentContext> locatableIterable = () -> locusIterator;
-        for ( final AlignmentContext pileup : locatableIterable ) {
+        locusIterator.forEachRemaining(pileup -> {
             if ( ! activityProfile.isEmpty() ) {
                 final boolean forceConversion = pileup.getLocation().getStart() != activityProfile.getEnd() + 1;
                 assemblyRegions.addAll(activityProfile.popReadyAssemblyRegions(assemblyRegionPadding, minRegionSize, maxRegionSize, forceConversion));
@@ -603,7 +602,8 @@ public final class AssemblyRegion implements Locatable {
                 final ActivityProfileState profile = evaluator.isActive(pileup, pileupRefContext, features);
                 activityProfile.add(profile);
             }
-        }
+        });
+
         assemblyRegions.addAll(activityProfile.popReadyAssemblyRegions(assemblyRegionPadding, minRegionSize, maxRegionSize, true));
 
         return assemblyRegions;

--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -588,7 +588,8 @@ public final class AssemblyRegion implements Locatable {
 
         // Use the provided activity profile to determine the bounds of each assembly region:
         List<AssemblyRegion> assemblyRegions = new ArrayList<>();
-        for ( final AlignmentContext pileup : locusIterator ) {
+        final Iterable<AlignmentContext> locatableIterable = () -> locusIterator;
+        for ( final AlignmentContext pileup : locatableIterable ) {
             if ( ! activityProfile.isEmpty() ) {
                 final boolean forceConversion = pileup.getLocation().getStart() != activityProfile.getEnd() + 1;
                 assemblyRegions.addAll(activityProfile.popReadyAssemblyRegions(assemblyRegionPadding, minRegionSize, maxRegionSize, forceConversion));

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -44,7 +44,7 @@ import java.util.stream.StreamSupport;
 public abstract class LocusWalker extends GATKTool {
 
     @Argument(fullName = "maxDepthPerSample", shortName = "maxDepthPerSample", doc = "Maximum number of reads to retain per sample per locus. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
-    protected long maxDepthPerSample = defaultMaxDepthPerSample();
+    protected int maxDepthPerSample = defaultMaxDepthPerSample();
 
     /**
      * Should the LIBS keep unique reads? Tools that do should override to return {@code true}.
@@ -98,7 +98,7 @@ public abstract class LocusWalker extends GATKTool {
      * Returns default value for the {@link #maxDepthPerSample} parameter, if none is provided on the command line.
      * Default implementation returns 0 (no downsampling by default).
      */
-    protected long defaultMaxDepthPerSample() {
+    protected int defaultMaxDepthPerSample() {
         return 0;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -84,6 +84,8 @@ public abstract class LocusWalker extends GATKTool {
      *
      * NOTE:  Typically, this should only be used when intervals are specified.
      * NOTE:  If MappedReadFilter is removed, then emitting empty loci will fail.
+     * NOTE:  If there is no available sequence dictionary and this is set to true, there should be a failure.  Please
+     *  consider requiring reads and/or references for all tools that wish to set this to {@code true}.
      *
      * @return {@code true} if this tool requires uncovered loci information to be emitted, {@code false} otherwise
      */
@@ -224,11 +226,6 @@ public abstract class LocusWalker extends GATKTool {
             if (!hasReference() && !hasIntervals()) {
                 logger.warn("****************************************");
                 logger.warn("* Running this tool without a reference nor intervals can yield unexpected results, since it will emit results for loci with no reads.  A sequence dictionary has been found.  The easiest way avoid this message is to specify a reference.");
-                logger.warn("****************************************");
-            }
-            if (!hasIntervals() && hasReference()) {
-                logger.warn("****************************************");
-                logger.warn("* Running this tool without intervals will cause this tool to run on the entire genome, since it will emit results for loci with no reads.");
                 logger.warn("****************************************");
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -2,13 +2,19 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
+import org.broadinstitute.hellbender.utils.iterators.IntervalAlignmentContextIterator;
+import org.broadinstitute.hellbender.utils.iterators.IntervalLocusIterator;
 import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
@@ -72,6 +78,19 @@ public abstract class LocusWalker extends GATKTool {
     public boolean includeNs() {
         return false;
     }
+
+    /**
+     * Does this tool emit information for uncovered loci? Tools that do should override to return {@code true}.
+     *
+     * NOTE:  Typically, this should only be used when intervals are specified.
+     * NOTE:  If MappedReadFilter is removed, then emitting empty loci will fail.
+     *
+     * @return {@code true} if this tool requires uncovered loci information to be emitted, {@code false} otherwise
+     */
+    public boolean emitEmptyLoci() {
+        return false;
+    }
+
 
     /**
      * Returns default value for the {@link #maxDepthPerSample} parameter, if none is provided on the command line.
@@ -140,8 +159,23 @@ public abstract class LocusWalker extends GATKTool {
         final Iterator<GATKRead> readIterator = getTransformedReadStream(countedFilter).iterator();
         // get the LIBS
         final LocusIteratorByState libs = new LocusIteratorByState(readIterator, getDownsamplingInfo(), keepUniqueReadListInLibs(), samples, header, includeDeletions(), includeNs());
-        // prepare the iterator
-        final Spliterator<AlignmentContext> iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
+        Spliterator<AlignmentContext> iterator;
+
+        validateEmitEmptyLociParameters();
+        if (emitEmptyLoci()) {
+
+            // If no intervals were specified, then use the entire reference (or best available sequence dictionary).
+            if (intervalsForTraversal == null) {
+                intervalsForTraversal = IntervalUtils.getAllIntervalsForReference(getBestAvailableSequenceDictionary());
+            }
+            final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervalsForTraversal.iterator());
+            iterator =  new IntervalAlignmentContextIterator(libs, intervalLocusIterator, header.getSequenceDictionary()).spliterator();
+
+        } else {
+            // prepare the iterator
+            iterator = (hasIntervals()) ? new IntervalOverlappingIterator<>(libs, intervalsForTraversal, header.getSequenceDictionary()).spliterator() : libs.spliterator();
+        }
+
         // iterate over each alignment, and apply the function
         StreamSupport.stream(iterator, false)
             .forEach(alignmentContext -> {
@@ -176,5 +210,27 @@ public abstract class LocusWalker extends GATKTool {
     protected final void onShutdown() {
         // Overridden only to make final so that concrete tool implementations don't override
         super.onShutdown();
+    }
+
+    /**
+     *  The emit empty loci parameter comes with several pitfalls when used incorrectly.  Here we check and either give
+     *   warnings or errors.
+     */
+    protected void validateEmitEmptyLociParameters() {
+        if (emitEmptyLoci()) {
+            if (getBestAvailableSequenceDictionary() == null) {
+                throw new UserException.MissingReference("Could not create a sequence dictionary nor find a reference.  Therefore, emitting empty loci is impossible and this tool cannot be run.  The easiest fix here is to specify a reference dictionary.");
+            }
+            if (!hasReference() && !hasIntervals()) {
+                logger.warn("****************************************");
+                logger.warn("* Running this tool without a reference nor intervals can yield unexpected results, since it will emit results for loci with no reads.  A sequence dictionary has been found.  The easiest way avoid this message is to specify a reference.");
+                logger.warn("****************************************");
+            }
+            if (!hasIntervals() && hasReference()) {
+                logger.warn("****************************************");
+                logger.warn("* Running this tool without intervals will cause this tool to run on the entire genome, since it will emit results for loci with no reads.");
+                logger.warn("****************************************");
+            }
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
@@ -19,9 +19,7 @@ import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -112,7 +110,8 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
                     .collect(Collectors.toSet());
             LocusIteratorByState libs = new LocusIteratorByState(readIterator, downsamplingInfo, false, samples, header, true, false);
             IntervalOverlappingIterator<AlignmentContext> alignmentContexts = new IntervalOverlappingIterator<>(libs, ImmutableList.of(interval), sequenceDictionary);
-            return StreamSupport.stream(alignmentContexts.spliterator(), false).map(alignmentContext -> {
+            final Spliterator<AlignmentContext> alignmentContextSpliterator = Spliterators.spliteratorUnknownSize(alignmentContexts, 0);
+            return StreamSupport.stream(alignmentContextSpliterator, false).map(alignmentContext -> {
                 final SimpleInterval alignmentInterval = new SimpleInterval(alignmentContext);
                 return new LocusWalkerContext(alignmentContext, new ReferenceContext(reference, alignmentInterval), new FeatureContext(fm, alignmentInterval));
             }).iterator();

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1009,6 +1009,9 @@ public final class IntervalUtils {
      * The shard boundaries lie at integer multiples of shardSize.
      *
      * chr2:1-200 -> chr2:1-100,chr2:101-200
+     *
+     * This method will return all intervals in RAM.  If you need a solution that is light on RAM usage, though it
+     *  returns an iterator, see {@link org.broadinstitute.hellbender.utils.iterators.ShardedIntervalIterator}
      */
     static public List<SimpleInterval> cutToShards(Iterable<SimpleInterval> intervals, int shardSize) {
         ArrayList<SimpleInterval> ret = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/LevelingDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/LevelingDownsampler.java
@@ -24,7 +24,7 @@ import java.util.*;
 public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler<T> {
     private final int minElementsPerStack;
 
-    private final int targetSize;
+    private final long targetSize;
 
     private List<T> groups;
 
@@ -39,7 +39,7 @@ public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler
      *                   this value -- if it does, items are removed from Lists evenly until the total size
      *                   is <= this value
      */
-    public LevelingDownsampler(final int targetSize ) {
+    public LevelingDownsampler(final long targetSize ) {
         this(targetSize, 1);
     }
 
@@ -53,7 +53,7 @@ public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler
      *                            if a stack has only 3 elements and minElementsPerStack is 3, no matter what
      *                            we'll not reduce this stack below 3.
      */
-    public LevelingDownsampler(final int targetSize, final int minElementsPerStack ) {
+    public LevelingDownsampler(final long targetSize, final int minElementsPerStack ) {
         Utils.validateArg( targetSize >= 0, "targetSize must be >= 0 but got " + targetSize);
         Utils.validateArg( minElementsPerStack >= 0, "minElementsPerStack must be >= 0 but got " + minElementsPerStack);
 
@@ -142,7 +142,7 @@ public final class LevelingDownsampler<T extends List<E>, E> extends Downsampler
 
         // We will try to remove exactly this many items, however we will refuse to allow any
         // one group to fall below size 1, and so might end up removing fewer items than this
-        int numItemsToRemove = totalSize - targetSize;
+        long numItemsToRemove = totalSize - targetSize;
 
         currentGroupIndex = 0;
         int numConsecutiveUmodifiableGroups = 0;

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
@@ -1,0 +1,109 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.engine.AlignmentContext;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * For special cases where we want to emit AlignmentContexts regardless of whether we have an overlap with a given interval.
+ *
+ * In other words, this will iterate over each base of each interval and emit an alignment context.  If no reads overlap,
+ *  it will emit an empty alignment context.  Each empty alignment context will be a new instance.
+ */
+public class IntervalAlignmentContextIterator implements Iterable<AlignmentContext>, Iterator<AlignmentContext> {
+    private Iterator<AlignmentContext> alignmentContextIterator;
+    private IntervalLocusIterator intervalLocusIterator;
+    private SimpleInterval currentInterval;
+    private AlignmentContext currentAlignmentContext;
+    private SAMSequenceDictionary dictionary;
+
+    public IntervalAlignmentContextIterator(Iterator<AlignmentContext> alignmentContextIterator, IntervalLocusIterator intervalLocusIterator, SAMSequenceDictionary dictionary) {
+        this.alignmentContextIterator = alignmentContextIterator;
+        this.intervalLocusIterator = intervalLocusIterator;
+        this.dictionary = dictionary;
+
+        // Iterate once.
+        advanceIntervalLocus();
+        advanceAlignmentContext();
+        advanceAlignmentContextToCurrentInterval(this.currentInterval);
+    }
+
+    @Override
+    public Iterator<AlignmentContext> iterator() {
+        return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return (intervalLocusIterator.hasNext()) || (currentInterval != null);
+    }
+
+    @Override
+    public AlignmentContext next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        final boolean isOverlaps = currentInterval.overlaps(currentAlignmentContext);
+        AlignmentContext result;
+
+        // Get ready to return result and determine what should go the next time next() is called.
+        if (isOverlaps) {
+            result = currentAlignmentContext;
+            advanceIntervalLocus();
+            advanceAlignmentContextToCurrentInterval(currentInterval);
+        } else {
+            result = createEmptyAlignmentContext(currentInterval);
+            advanceIntervalLocus();
+
+            if (currentInterval != null) {
+                final int comparison = IntervalUtils.compareLocatables(currentInterval, currentAlignmentContext, dictionary);
+                // Comparison should not be zero and if less than zero, we'd just advance the intervalLocus iterator,
+                //  which we are already doing.
+                //  Interval is after the next alignment context when comparison is greater than zero.
+                if (comparison > 0) {
+                    advanceAlignmentContextToCurrentInterval(currentInterval);
+                }
+            }
+        }
+
+        return result;
+
+    }
+
+    private AlignmentContext createEmptyAlignmentContext(final SimpleInterval interval) {
+        return new AlignmentContext(interval, new ReadPileup(interval, new ArrayList<>()));
+    }
+
+    private void advanceAlignmentContextToCurrentInterval(final SimpleInterval interval) {
+        if (interval == null) {
+            currentAlignmentContext = null;
+            return;
+        }
+        while (IntervalUtils.compareLocatables(currentInterval, currentAlignmentContext, dictionary) > 0) {
+            advanceAlignmentContext();
+        }
+    }
+
+    private void advanceAlignmentContext() {
+        if (alignmentContextIterator.hasNext()) {
+            currentAlignmentContext = this.alignmentContextIterator.next();
+        } else {
+            currentAlignmentContext = createEmptyAlignmentContext(currentInterval);
+        }
+    }
+
+    private void advanceIntervalLocus() {
+        if (intervalLocusIterator.hasNext()) {
+            currentInterval = intervalLocusIterator.next();
+        } else {
+            currentInterval = null;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
@@ -16,14 +16,14 @@ import java.util.NoSuchElementException;
  * In other words, this will iterate over each base of each interval and emit an alignment context.  If no reads overlap,
  *  it will emit an empty alignment context.  Each empty alignment context will be a new instance.
  */
-public class IntervalAlignmentContextIterator implements Iterable<AlignmentContext>, Iterator<AlignmentContext> {
+public class IntervalAlignmentContextIterator implements Iterator<AlignmentContext> {
     private Iterator<AlignmentContext> alignmentContextIterator;
     private IntervalLocusIterator intervalLocusIterator;
     private SimpleInterval currentInterval;
     private AlignmentContext currentAlignmentContext;
     private SAMSequenceDictionary dictionary;
 
-    public IntervalAlignmentContextIterator(Iterator<AlignmentContext> alignmentContextIterator, IntervalLocusIterator intervalLocusIterator, SAMSequenceDictionary dictionary) {
+    public IntervalAlignmentContextIterator(final Iterator<AlignmentContext> alignmentContextIterator, final IntervalLocusIterator intervalLocusIterator, final SAMSequenceDictionary dictionary) {
         this.alignmentContextIterator = alignmentContextIterator;
         this.intervalLocusIterator = intervalLocusIterator;
         this.dictionary = dictionary;
@@ -32,11 +32,6 @@ public class IntervalAlignmentContextIterator implements Iterable<AlignmentConte
         advanceIntervalLocus();
         advanceAlignmentContext();
         advanceAlignmentContextToCurrentInterval(this.currentInterval);
-    }
-
-    @Override
-    public Iterator<AlignmentContext> iterator() {
-        return this;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIterator.java
@@ -30,13 +30,17 @@ public class IntervalAlignmentContextIterator implements Iterator<AlignmentConte
 
         // Iterate once.
         advanceIntervalLocus();
+
+        // Just to make sure that current alignment context is not null.  We only want to do this during the initialization.
         advanceAlignmentContext();
-        advanceAlignmentContextToCurrentInterval(this.currentInterval);
+
+        // Advance the alignment context to overlap or be in front of the current interval.
+        advanceAlignmentContextToCurrentInterval();
     }
 
     @Override
     public boolean hasNext() {
-        return (intervalLocusIterator.hasNext()) || (currentInterval != null);
+        return currentInterval != null;
     }
 
     @Override
@@ -52,7 +56,7 @@ public class IntervalAlignmentContextIterator implements Iterator<AlignmentConte
         if (isOverlaps) {
             result = currentAlignmentContext;
             advanceIntervalLocus();
-            advanceAlignmentContextToCurrentInterval(currentInterval);
+            advanceAlignmentContextToCurrentInterval();
         } else {
             result = createEmptyAlignmentContext(currentInterval);
             advanceIntervalLocus();
@@ -63,7 +67,7 @@ public class IntervalAlignmentContextIterator implements Iterator<AlignmentConte
                 //  which we are already doing.
                 //  Interval is after the next alignment context when comparison is greater than zero.
                 if (comparison > 0) {
-                    advanceAlignmentContextToCurrentInterval(currentInterval);
+                    advanceAlignmentContextToCurrentInterval();
                 }
             }
         }
@@ -76,8 +80,8 @@ public class IntervalAlignmentContextIterator implements Iterator<AlignmentConte
         return new AlignmentContext(interval, new ReadPileup(interval, new ArrayList<>()));
     }
 
-    private void advanceAlignmentContextToCurrentInterval(final SimpleInterval interval) {
-        if (interval == null) {
+    private void advanceAlignmentContextToCurrentInterval() {
+        if (currentInterval == null) {
             currentAlignmentContext = null;
             return;
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+
+import java.util.*;
+
+/**
+ * Returns a SimpleInterval for each locus in a set of intervals.  I.e. returns each genomic point location in an interval list.
+ */
+public class IntervalLocusIterator implements Iterable<SimpleInterval>, Iterator<SimpleInterval> {
+
+    private Iterator<SimpleInterval> intervalIterator;
+
+    public SimpleInterval currentInterval = null;
+
+    /** Encoded as an interval that i of size 1 in the current interval */
+    private Iterator<SimpleInterval> baseLocationIterator;
+
+    public IntervalLocusIterator(final Iterator<SimpleInterval> intervalIterator) {
+        Utils.nonNull(intervalIterator, "Input iterator cannot be null");
+        this.intervalIterator = intervalIterator;
+        advanceCurrentInterval();
+    }
+
+    @Override
+    public Iterator<SimpleInterval> iterator() {
+        return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (currentInterval == null) {
+            return false;
+        }
+        if (!baseLocationIterator.hasNext()) {
+            if (!intervalIterator.hasNext()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public SimpleInterval next() {
+        if (baseLocationIterator.hasNext()) {
+            return baseLocationIterator.next();
+        }
+        if (intervalIterator.hasNext()) {
+            advanceCurrentInterval();
+            return baseLocationIterator.next();
+        }
+        throw new NoSuchElementException();
+    }
+
+    private void advanceCurrentInterval() {
+        if (intervalIterator.hasNext()) {
+            currentInterval = intervalIterator.next();
+        } else {
+            // Typically, this code block should only get hit when this class is
+            //  initalized with an empty interval list.
+            currentInterval = null;
+        }
+        baseLocationIterator = createBaseLocationIterator(currentInterval);
+    }
+
+
+    private Iterator<SimpleInterval> createBaseLocationIterator(final SimpleInterval fullInterval) {
+        if (fullInterval == null) {
+            return Collections.<SimpleInterval>emptyList().iterator();
+        }
+
+        List<SimpleInterval> dummyList = Collections.singletonList(fullInterval);
+        return IntervalUtils.cutToShards(dummyList, 1).iterator();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
@@ -10,7 +10,7 @@ import java.util.*;
 /**
  * Returns a SimpleInterval for each locus in a set of intervals.  I.e. returns each genomic point location in an interval list.
  */
-public class IntervalLocusIterator implements Iterable<SimpleInterval>, Iterator<SimpleInterval> {
+public class IntervalLocusIterator implements Iterator<SimpleInterval> {
 
     private Iterator<SimpleInterval> intervalIterator;
 
@@ -23,11 +23,6 @@ public class IntervalLocusIterator implements Iterable<SimpleInterval>, Iterator
         Utils.nonNull(intervalIterator, "Input iterator cannot be null");
         this.intervalIterator = intervalIterator;
         advanceCurrentInterval();
-    }
-
-    @Override
-    public Iterator<SimpleInterval> iterator() {
-        return this;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIterator.java
@@ -73,6 +73,6 @@ public class IntervalLocusIterator implements Iterable<SimpleInterval>, Iterator
         }
 
         List<SimpleInterval> dummyList = Collections.singletonList(fullInterval);
-        return IntervalUtils.cutToShards(dummyList, 1).iterator();
+        return new ShardedIntervalIterator(dummyList.iterator(), 1);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
@@ -16,7 +16,7 @@ import java.util.NoSuchElementException;
  *
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class IntervalOverlappingIterator<T extends Locatable> implements Iterable<T>, Iterator<T> {
+public class IntervalOverlappingIterator<T extends Locatable> implements Iterator<T> {
 
     // underlying iterator
     private final Iterator<T> iterator;
@@ -50,11 +50,6 @@ public class IntervalOverlappingIterator<T extends Locatable> implements Iterabl
         this.dictionary = dictionary;
         currentInterval = this.intervals.next();
         advance();
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-        return this;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
@@ -48,6 +48,8 @@ public class IntervalOverlappingIterator<T extends Locatable> implements Iterabl
         this.iterator = iterator;
         this.intervals = intervals.iterator();
         this.dictionary = dictionary;
+
+        //TODO: If the input intervals is empty, won't this throw an exception?  Is that planned?
         currentInterval = this.intervals.next();
         advance();
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
@@ -48,8 +48,6 @@ public class IntervalOverlappingIterator<T extends Locatable> implements Iterabl
         this.iterator = iterator;
         this.intervals = intervals.iterator();
         this.dictionary = dictionary;
-
-        //TODO: If the input intervals is empty, won't this throw an exception?  Is that planned?
         currentInterval = this.intervals.next();
         advance();
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIterator.java
@@ -1,0 +1,118 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator that will break up each input interval into shards.  The advantage of this iterator is that it is not RAM
+ *  intensive.
+ *
+ *  Empty iterator of intervals is supported.
+ *
+ * Developer note:  This class queues up the next interval to return and then has (minimal) code to detect when
+ *  an empty iterator was passed in for initialization.
+ */
+public class ShardedIntervalIterator implements Iterable<SimpleInterval>, Iterator<SimpleInterval> {
+
+    private Iterator<SimpleInterval> intervals;
+    private int shardSize;
+
+    /**
+     * The input interval that we are currently sharding.
+     */
+    private SimpleInterval currentInterval;
+
+    private int currentOffsetInCurrentInterval;
+
+    private int lastOffsetInCurrentInterval;
+    private SimpleInterval shardedInterval;
+
+    public ShardedIntervalIterator(Iterator<SimpleInterval> intervals, int shardSizeInBases) {
+        Utils.validate(shardSizeInBases > 0, "Invalid shard size.  Must be greater than zero.");
+        this.intervals = intervals;
+        this.shardSize = shardSizeInBases;
+        this.currentOffsetInCurrentInterval = 0;
+        this.lastOffsetInCurrentInterval = 0;
+        this.currentInterval = null;
+        this.shardedInterval = null;
+
+
+        // Queue up the next interval to shard or keep it as null if the interval iterator is exhausted.
+        advanceInterval();
+    }
+
+    /**
+     * This should only be called when the shards within an interval have been exhausted.  I.e. when starting a new
+     *   interval to be sharded.
+     */
+    private void advanceInterval() {
+
+        if (this.intervals.hasNext()) {
+            currentInterval = this.intervals.next();
+            currentOffsetInCurrentInterval = IntervalUtils.shardIndex(1, shardSize);
+            lastOffsetInCurrentInterval = IntervalUtils.shardIndex(this.currentInterval.size(), shardSize);
+            shardedInterval = calculateShardedInterval();
+
+        } else {
+            lastOffsetInCurrentInterval = 0;
+            currentInterval = null;
+            shardedInterval = null;
+        }
+    }
+
+    private SimpleInterval calculateShardedInterval() {
+        return new SimpleInterval(this.currentInterval.getContig(), currentInterval.getStart() + IntervalUtils.beginOfShard(currentOffsetInCurrentInterval, shardSize) - 1,
+                Integer.min(currentInterval.getStart() + IntervalUtils.endOfShard(currentOffsetInCurrentInterval, shardSize) - 1, currentInterval.getEnd()));
+    }
+
+    @Override
+    public Iterator<SimpleInterval> iterator() {
+        return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+        // if the current shard has exhausted the current interval AND there is no next interval, return false
+
+        if (shardedInterval != null) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public SimpleInterval next() {
+
+        if (shardedInterval == null) {
+            throw new NoSuchElementException();
+        }
+
+        final SimpleInterval result = shardedInterval;
+
+        // Advance the shard index and (if necessary) set it back to zero and get the next interval.
+        advanceShardInInterval();
+
+        return result;
+    }
+
+    /**
+     * This can also advance the interval if needed.
+     */
+    private void advanceShardInInterval() {
+        currentOffsetInCurrentInterval ++;
+        if (currentOffsetInCurrentInterval > lastOffsetInCurrentInterval) {
+
+            // Advance the interval.
+            advanceInterval();
+        }
+        if (currentInterval != null) {
+            shardedInterval = calculateShardedInterval();
+        } else {
+            shardedInterval = null;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIterator.java
@@ -16,7 +16,7 @@ import java.util.NoSuchElementException;
  * Developer note:  This class queues up the next interval to return and then has (minimal) code to detect when
  *  an empty iterator was passed in for initialization.
  */
-public class ShardedIntervalIterator implements Iterable<SimpleInterval>, Iterator<SimpleInterval> {
+public class ShardedIntervalIterator implements Iterator<SimpleInterval> {
 
     private Iterator<SimpleInterval> intervals;
     private int shardSize;
@@ -67,11 +67,6 @@ public class ShardedIntervalIterator implements Iterable<SimpleInterval>, Iterat
     private SimpleInterval calculateShardedInterval() {
         return new SimpleInterval(this.currentInterval.getContig(), currentInterval.getStart() + IntervalUtils.beginOfShard(currentOffsetInCurrentInterval, shardSize) - 1,
                 Integer.min(currentInterval.getStart() + IntervalUtils.endOfShard(currentOffsetInCurrentInterval, shardSize) - 1, currentInterval.getEnd()));
-    }
-
-    @Override
-    public Iterator<SimpleInterval> iterator() {
-        return this;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
@@ -13,13 +13,13 @@ public final class LIBSDownsamplingInfo implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final boolean performDownsampling;
-    private final long toCoverage;
+    private final int toCoverage;
 
     /**
      * @param performDownsampling whether to downsample
      * @param toCoverage what coverage to downsample to (or -1 if no downsampling)
      */
-    public LIBSDownsamplingInfo(final boolean performDownsampling, final long toCoverage) {
+    public LIBSDownsamplingInfo(final boolean performDownsampling, final int toCoverage) {
         Utils.validateArg(toCoverage >= -1, "toCoverage must be at least -1 (special value) but was " + toCoverage);
         this.performDownsampling = performDownsampling;
         this.toCoverage = toCoverage;
@@ -29,7 +29,7 @@ public final class LIBSDownsamplingInfo implements Serializable {
         return performDownsampling;
     }
 
-    public long getToCoverage() {
+    public int getToCoverage() {
         return toCoverage;
     }
 
@@ -38,7 +38,7 @@ public final class LIBSDownsamplingInfo implements Serializable {
                 downsamplingMethod.type == DownsampleType.BY_SAMPLE &&
                 downsamplingMethod.toCoverage != null;
 
-        final long toCoverage = performDownsampling ? downsamplingMethod.toCoverage : 0;
+        final int toCoverage = performDownsampling ? downsamplingMethod.toCoverage : 0;
 
         return new LIBSDownsamplingInfo(performDownsampling, toCoverage);
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LIBSDownsamplingInfo.java
@@ -13,13 +13,13 @@ public final class LIBSDownsamplingInfo implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final boolean performDownsampling;
-    private final int toCoverage;
+    private final long toCoverage;
 
     /**
      * @param performDownsampling whether to downsample
      * @param toCoverage what coverage to downsample to (or -1 if no downsampling)
      */
-    public LIBSDownsamplingInfo(final boolean performDownsampling, final int toCoverage) {
+    public LIBSDownsamplingInfo(final boolean performDownsampling, final long toCoverage) {
         Utils.validateArg(toCoverage >= -1, "toCoverage must be at least -1 (special value) but was " + toCoverage);
         this.performDownsampling = performDownsampling;
         this.toCoverage = toCoverage;
@@ -29,7 +29,7 @@ public final class LIBSDownsamplingInfo implements Serializable {
         return performDownsampling;
     }
 
-    public int getToCoverage() {
+    public long getToCoverage() {
         return toCoverage;
     }
 
@@ -38,7 +38,7 @@ public final class LIBSDownsamplingInfo implements Serializable {
                 downsamplingMethod.type == DownsampleType.BY_SAMPLE &&
                 downsamplingMethod.toCoverage != null;
 
-        final int toCoverage = performDownsampling ? downsamplingMethod.toCoverage : 0;
+        final long toCoverage = performDownsampling ? downsamplingMethod.toCoverage : 0;
 
         return new LIBSDownsamplingInfo(performDownsampling, toCoverage);
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByState.java
@@ -42,7 +42,7 @@ import java.util.*;
  * occurs, if requested.  This allows users of LIBS to see both a ReadPileup view of the data as well as
  * a stream of unique, sorted reads
  */
-public final class LocusIteratorByState implements Iterable<AlignmentContext>, Iterator<AlignmentContext> {
+public final class LocusIteratorByState implements Iterator<AlignmentContext> {
     /** Indicates that we shouldn't do any downsampling */
     public static final LIBSDownsamplingInfo NO_DOWNSAMPLING = new LIBSDownsamplingInfo(false, -1);
 
@@ -224,11 +224,6 @@ public final class LocusIteratorByState implements Iterable<AlignmentContext>, I
         this.includeReadsWithNsAtLoci = includeReadsWithNsAtLoci;
         this.samples = new ArrayList<>(samples);
         this.readStates = new ReadStateManager(samIterator, this.samples, downsamplingInfo, keepUniqueReadListInLIBS, header);
-    }
-
-    @Override
-    public Iterator<AlignmentContext> iterator() {
-        return this;
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocusWalkerUnitTest.java
@@ -103,4 +103,34 @@ public class LocusWalkerUnitTest extends CommandLineProgramTest {
         Assert.assertEquals(tool.totalPileup, 1);
     }
 
+    private static class TestEmitUncoveredLociTool extends LocusWalker {
+        public int totalApplyCalls = 0;
+
+        @Override
+        public boolean emitEmptyLoci() {
+            return true;
+        }
+
+        @Override
+        public void apply(AlignmentContext alignmentContext, ReferenceContext referenceContext, FeatureContext featureContext) {
+            totalApplyCalls++;
+        }
+    }
+
+    @Test
+    public void testEmitUncoveredLoci() {
+        // Most testing of this is in IntervalAlignmentContextIteratorUnitTest
+        final TestEmitUncoveredLociTool tool = new TestEmitUncoveredLociTool();
+
+        final String[] args = {
+                "-I", getTestDataDir()+ "/print_reads.sorted.bam",
+                "-R", getTestDataDir()+ "/print_reads.fasta",
+                "-L", "chr7:21-30"
+        };
+
+        tool.instanceMain(args);
+
+        Assert.assertEquals(tool.totalApplyCalls, 10);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIteratorUnitTest.java
@@ -1,0 +1,154 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.engine.AlignmentContext;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+
+public class IntervalAlignmentContextIteratorUnitTest extends BaseTest {
+
+    private static final File TEST_LARGE_DATA_DIR = new File("src/test/resources/large/");
+    private static final String BAM_FILE_NAME = TEST_LARGE_DATA_DIR.getAbsolutePath() + "/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam";
+    private static final File TEST_DATA_DIR = new File("src/test/resources/");
+    private static final File MINI_BAM = new File(TEST_DATA_DIR.getAbsolutePath() + "/NA12878.chr17_69k_70k.dictFix.bam");
+
+    @Test
+    public void testSimple() {
+
+        // Note: IGV was used to determine coverage in the input bam file. (chr20:9,999,875-9,999,945)
+        //   Make sure that viewing is *not* downsampled and *includes* dupe reads
+
+        // Totally uncovered
+        final SimpleInterval record_20_9999600_9999600 = new SimpleInterval("20:9999600-9999600");
+
+        // Partially covered
+        final SimpleInterval record_20_9999900_9999910 = new SimpleInterval("20:9999900-9999910");
+
+        // Totally covered
+        final SimpleInterval record_20_9999910_9999913 = new SimpleInterval("20:9999910-9999913");
+
+
+        final List<SimpleInterval> locusIntervals = new ArrayList<>(3);
+        locusIntervals.add(record_20_9999600_9999600);
+        locusIntervals.add(record_20_9999900_9999910);
+        locusIntervals.add(record_20_9999910_9999913);
+
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(locusIntervals, BAM_FILE_NAME);
+
+        Assert.assertEquals(allAlignmentContexts.size(), 16);
+        Assert.assertTrue(allAlignmentContexts.stream().allMatch(ac -> ac != null));
+
+        // No reads in the first three alignment contexts
+        Assert.assertEquals(allAlignmentContexts.get(0).getBasePileup().getReads().size(), 0);
+        Assert.assertEquals(allAlignmentContexts.get(1).getBasePileup().getReads().size(),  0);
+        Assert.assertEquals(allAlignmentContexts.get(2).getBasePileup().getReads().size(),  0);
+
+        // Make sure that at least one locus-interval has at least one read
+        Assert.assertTrue(allAlignmentContexts.stream().anyMatch(ac -> ac.getBasePileup().getReads().size() > 0));
+        Assert.assertTrue(allAlignmentContexts.stream().anyMatch(ac -> ac.getBasePileup().getReads().size() == 0));
+
+        Assert.assertEquals(allAlignmentContexts.get(3).getBasePileup().getReads().size(), 2);
+        Assert.assertEquals(allAlignmentContexts.get(4).getBasePileup().getReads().size(), 4);
+        Assert.assertEquals(allAlignmentContexts.get(13).getBasePileup().getReads().size(), 17);
+    }
+
+    @Test
+    public void testCoveredOnly() {
+
+        // This test is good at finding places where the alignment contexts start behind the interval.
+        // Totally covered
+        final SimpleInterval record_20_9999910_9999913 = new SimpleInterval("20:9999910-9999913");
+        final List<SimpleInterval> locusIntervals = new ArrayList<>(1);
+        locusIntervals.add(record_20_9999910_9999913);
+
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(locusIntervals, BAM_FILE_NAME);
+
+        Assert.assertEquals(allAlignmentContexts.size(), 4);
+        Assert.assertTrue(allAlignmentContexts.stream().allMatch(ac -> ac != null));
+    }
+
+    @Test
+    public void testUnCoveredOnly() {
+
+        final SimpleInterval record_20_9999900_9999901 = new SimpleInterval("20:9999900-9999901");
+        final List<SimpleInterval> locusIntervals = new ArrayList<>(1);
+        locusIntervals.add(record_20_9999900_9999901);
+
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(locusIntervals, BAM_FILE_NAME);
+
+        Assert.assertEquals(allAlignmentContexts.size(), 2);
+        Assert.assertTrue(allAlignmentContexts.stream().allMatch(ac -> ac != null));
+        Assert.assertEquals(allAlignmentContexts.get(0).getBasePileup().getReads().size(), 0);
+        Assert.assertEquals(allAlignmentContexts.get(1).getBasePileup().getReads().size(),  0);
+    }
+
+    @Test
+    public void testPileupToNextPileup(){
+        // Test reading the end of one pileup then no coverage then beginning of one pileup in one interval
+        //  IGV: chr20:10,098,446-10,098,587
+        final SimpleInterval record_20_10098490_10098560 = new SimpleInterval("20:10098490-10098560");
+        final List<SimpleInterval> locusIntervals = new ArrayList<>(1);
+        locusIntervals.add(record_20_10098490_10098560);
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(locusIntervals, BAM_FILE_NAME);
+
+        Assert.assertEquals(allAlignmentContexts.size(), 71);
+        Assert.assertTrue(allAlignmentContexts.stream().allMatch(ac -> ac.getBasePileup().getReads().size() < 2));
+        Assert.assertTrue(IntStream.range(0, 6).allMatch(i -> allAlignmentContexts.get(i).size() == 1));
+        Assert.assertTrue(IntStream.range(6, 62).allMatch(i -> allAlignmentContexts.get(i).size() == 0));
+        Assert.assertTrue(IntStream.range(62, 71).allMatch(i -> allAlignmentContexts.get(i).size() == 1));
+        Assert.assertTrue(allAlignmentContexts.stream().allMatch(ac -> ac != null));
+    }
+
+    @Test
+    public void testNoIntervals() {
+        // $ samtools view -H NA12878.chr17_69k_70k.dictFix.bam
+        // @HD	VN:1.5	GO:none	SO:coordinate
+        // @SQ	SN:17	LN:1000000	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:351f64d4f4f9ddd45b35336ad97aa6de	SP:Homo Sapiens
+
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(null, MINI_BAM.getAbsolutePath());
+
+        Assert.assertEquals(allAlignmentContexts.size(), 1000000);
+    }
+
+    private List<AlignmentContext> getAlignmentContexts(List<SimpleInterval> locusIntervals, String bamPath) {
+        final List<String> sampleNames = Collections.singletonList("NA12878");
+
+        final ReadsDataSource gatkReads = new ReadsDataSource(IOUtils.getPath(bamPath));
+        final SAMFileHeader header = gatkReads.getHeader();
+        final Stream<GATKRead> filteredReads = Utils.stream(gatkReads).filter(new WellformedReadFilter(header).and(new ReadFilterLibrary.MappedReadFilter()));
+
+        final SAMSequenceDictionary dictionary = header.getSequenceDictionary();
+
+        final LocusIteratorByState locusIteratorByState = new LocusIteratorByState(filteredReads.iterator(), LocusIteratorByState.NO_DOWNSAMPLING, false, sampleNames, header, true);
+
+
+        List<SimpleInterval> relevantIntervals = locusIntervals;
+        if (relevantIntervals == null) {
+            relevantIntervals = IntervalUtils.getAllIntervalsForReference(dictionary);
+        }
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(relevantIntervals.iterator());
+
+        final IntervalAlignmentContextIterator intervalAlignmentContextIterator = new IntervalAlignmentContextIterator(locusIteratorByState, intervalLocusIterator, dictionary);
+
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalAlignmentContextIterator, Spliterator.ORDERED), false).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalAlignmentContextIteratorUnitTest.java
@@ -119,7 +119,7 @@ public class IntervalAlignmentContextIteratorUnitTest extends BaseTest {
     }
 
     @Test
-    public void testNoIntervals() {
+    public void testNoIntervalsSpecified() {
         // $ samtools view -H NA12878.chr17_69k_70k.dictFix.bam
         // @HD	VN:1.5	GO:none	SO:coordinate
         // @SQ	SN:17	LN:1000000	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:351f64d4f4f9ddd45b35336ad97aa6de	SP:Homo Sapiens
@@ -129,7 +129,14 @@ public class IntervalAlignmentContextIteratorUnitTest extends BaseTest {
         Assert.assertEquals(allAlignmentContexts.size(), 1000000);
     }
 
-    private List<AlignmentContext> getAlignmentContexts(List<SimpleInterval> locusIntervals, String bamPath) {
+    @Test
+    public void testIntervalIteratorIsEmpty() {
+        // This test should not throw an exception.
+        final List<AlignmentContext> allAlignmentContexts = getAlignmentContexts(Collections.<SimpleInterval>emptyList(),MINI_BAM.getAbsolutePath());
+        Assert.assertEquals(allAlignmentContexts.size(), 0);
+    }
+
+    private List<AlignmentContext> getAlignmentContexts(final List<SimpleInterval> locusIntervals, final String bamPath) {
         final List<String> sampleNames = Collections.singletonList("NA12878");
 
         final ReadsDataSource gatkReads = new ReadsDataSource(IOUtils.getPath(bamPath));

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalLocusIteratorUnitTest.java
@@ -1,0 +1,106 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class IntervalLocusIteratorUnitTest extends BaseTest {
+
+    @Test
+    public void testSimple() {
+        final SimpleInterval record_1_1_100 = new SimpleInterval("1:1-100");
+        final SimpleInterval record_1_500_600 = new SimpleInterval("1:500-600");
+        final SimpleInterval record_1_800_800 = new SimpleInterval("1:800-800");
+        List<SimpleInterval> intervals = new ArrayList<>();
+        intervals.add(record_1_1_100);
+        intervals.add(record_1_500_600);
+        intervals.add(record_1_800_800);
+
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervals.iterator());
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalLocusIterator, Spliterator.ORDERED),
+                false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 202);
+        Assert.assertEquals(newIntervals.get(0).getStart(), 1);
+        Assert.assertEquals(newIntervals.get(1).getStart(), 2);
+        Assert.assertEquals(newIntervals.get(99).getStart(), 100);
+        Assert.assertEquals(newIntervals.get(100).getStart(), 500);
+        Assert.assertEquals(newIntervals.get(200).getStart(), 600);
+        Assert.assertEquals(newIntervals.get(201).getStart(), 800);
+
+        // Make sure that start = end for all intervals coming out of the LocusIntervalIterator, since each is only 1 bp
+        Assert.assertTrue(newIntervals.stream().allMatch(i -> i.getEnd() == i.getStart()));
+    }
+
+    @Test
+    public void testSimpleSinglePoints() {
+        final SimpleInterval record_1_1_1 = new SimpleInterval("1:1-1");
+        final SimpleInterval record_1_5_5 = new SimpleInterval("1:5-5");
+        List<SimpleInterval> intervals = new ArrayList<>();
+        intervals.add(record_1_1_1);
+        intervals.add(record_1_5_5);
+
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervals.iterator());
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalLocusIterator, Spliterator.ORDERED),
+                false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 2);
+        Assert.assertEquals(newIntervals.get(0).getStart(), 1);
+        Assert.assertEquals(newIntervals.get(1).getStart(), 5);
+        Assert.assertEquals(newIntervals.get(0).getEnd(), 1);
+        Assert.assertEquals(newIntervals.get(1).getEnd(), 5);
+    }
+
+    @Test
+    public void testEmpty() {
+        final List<SimpleInterval> intervals = new ArrayList<>();
+
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervals.iterator());
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalLocusIterator, Spliterator.ORDERED),
+                false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 0);
+    }
+
+    @Test
+    public void testSlightChallenge() {
+
+        final SimpleInterval record_20_9999600_9999800 = new SimpleInterval("20:9999600-9999600");
+        final SimpleInterval record_20_9999800_10000000 = new SimpleInterval("20:9999800-10000000");
+        final SimpleInterval record_20_10000050_10000100 = new SimpleInterval("20:10000050-10000100");
+        List<SimpleInterval> intervals = new ArrayList<>();
+        intervals.add(record_20_9999600_9999800);
+        intervals.add(record_20_9999800_10000000);
+        intervals.add(record_20_10000050_10000100);
+
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervals.iterator());
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalLocusIterator, Spliterator.ORDERED),
+                false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 253);
+    }
+
+    @Test
+    public void testSingleInterval() {
+        final SimpleInterval record_20_10000098_10000101 = new SimpleInterval("20:10000098-10000101");
+        final List<SimpleInterval> intervals = new ArrayList<>();
+        intervals.add(record_20_10000098_10000101);
+        final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(intervals.iterator());
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(intervalLocusIterator, Spliterator.ORDERED),
+                false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 4);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIteratorUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.iterators;
 
+import com.google.common.collect.Iterators;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.Locatable;
@@ -11,10 +12,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -59,13 +57,15 @@ public class IntervalOverlappingIteratorUnitTest extends BaseTest {
     @Test(dataProvider = "data")
     public void testIterator(List<SimpleInterval> intervals, SAMSequenceDictionary dictionary, Locatable[] records,	Locatable[] expected) {
         IntervalOverlappingIterator<Locatable> iterator = new IntervalOverlappingIterator<>(Arrays.asList(records).iterator(), intervals, dictionary);
-        int index = 0;
-        final Iterable<Locatable> iterable = () -> iterator;
-        for(Locatable loc: iterable) {
+
+        final Iterator<Locatable> expectedIterator = Arrays.asList(expected).iterator();
+        final List<Locatable> iteratorAsList = new ArrayList<>();
+        iterator.forEachRemaining(loc -> {
+            iteratorAsList.add(loc);
             // assert that the locations are the expected
-            Assert.assertEquals(loc, expected[index++]);
-        }
+            Assert.assertEquals(loc, expectedIterator.next());
+        });
         // assert that all the expected values are present
-        Assert.assertEquals(index, expected.length);
+        Assert.assertEquals(iteratorAsList.size(), expected.length);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIteratorUnitTest.java
@@ -13,6 +13,8 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -58,7 +60,8 @@ public class IntervalOverlappingIteratorUnitTest extends BaseTest {
     public void testIterator(List<SimpleInterval> intervals, SAMSequenceDictionary dictionary, Locatable[] records,	Locatable[] expected) {
         IntervalOverlappingIterator<Locatable> iterator = new IntervalOverlappingIterator<>(Arrays.asList(records).iterator(), intervals, dictionary);
         int index = 0;
-        for(Locatable loc: iterator) {
+        final Iterable<Locatable> iterable = () -> iterator;
+        for(Locatable loc: iterable) {
             // assert that the locations are the expected
             Assert.assertEquals(loc, expected[index++]);
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIteratorUnitTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -18,7 +19,7 @@ public class ShardedIntervalIteratorUnitTest extends BaseTest {
     public void testSimpleCount(List<SimpleInterval> intervals, int shardSize, int expectedCount) {
 
         final ShardedIntervalIterator shardedIntervalIterator1 = new ShardedIntervalIterator(intervals.iterator(), shardSize);
-        Assert.assertEquals(StreamSupport.stream(shardedIntervalIterator1.spliterator(), false).count(), expectedCount);
+        Assert.assertEquals(StreamSupport.stream(Spliterators.spliteratorUnknownSize(shardedIntervalIterator1, 0), false).count(), expectedCount);
     }
 
     @Test
@@ -29,7 +30,7 @@ public class ShardedIntervalIteratorUnitTest extends BaseTest {
         final int shardSizeInBases = 10;
         final ShardedIntervalIterator shardedIntervalIterator1 = new ShardedIntervalIterator(intervals.iterator(), shardSizeInBases);
 
-        final List<SimpleInterval> newIntervals = StreamSupport.stream(shardedIntervalIterator1.spliterator(), false).collect(Collectors.toList());
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(Spliterators.spliteratorUnknownSize(shardedIntervalIterator1, 0), false).collect(Collectors.toList());
 
         Assert.assertEquals(newIntervals.size(), 6);
         Assert.assertEquals(newIntervals.get(0).size(), shardSizeInBases);

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/ShardedIntervalIteratorUnitTest.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import com.google.common.math.IntMath;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+public class ShardedIntervalIteratorUnitTest extends BaseTest {
+    @Test(dataProvider = "simpleData")
+    public void testSimpleCount(List<SimpleInterval> intervals, int shardSize, int expectedCount) {
+
+        final ShardedIntervalIterator shardedIntervalIterator1 = new ShardedIntervalIterator(intervals.iterator(), shardSize);
+        Assert.assertEquals(StreamSupport.stream(shardedIntervalIterator1.spliterator(), false).count(), expectedCount);
+    }
+
+    @Test
+    public void testNonOneValue(){
+        final List<SimpleInterval> intervals = new ArrayList<>(1);
+        intervals.add(new SimpleInterval("1", 500, 551));
+
+        final int shardSizeInBases = 10;
+        final ShardedIntervalIterator shardedIntervalIterator1 = new ShardedIntervalIterator(intervals.iterator(), shardSizeInBases);
+
+        final List<SimpleInterval> newIntervals = StreamSupport.stream(shardedIntervalIterator1.spliterator(), false).collect(Collectors.toList());
+
+        Assert.assertEquals(newIntervals.size(), 6);
+        Assert.assertEquals(newIntervals.get(0).size(), shardSizeInBases);
+        Assert.assertEquals(newIntervals.get(0).getStart(), intervals.get(0).getStart());
+        Assert.assertEquals(newIntervals.get(0).getEnd(), intervals.get(0).getStart() + shardSizeInBases - 1);
+
+        // The last shard should only be of length 2 (base 550 & 551)
+        final SimpleInterval lastInterval = newIntervals.get(newIntervals.size() - 1);
+        Assert.assertEquals(lastInterval.size(), 2);
+        Assert.assertEquals(lastInterval.getStart(), intervals.get(0).getEnd() - 1);
+        Assert.assertEquals(lastInterval.getEnd(), intervals.get(0).getEnd());
+
+    }
+
+
+
+    @DataProvider(name="simpleData")
+    public Object[][] getData() {
+        final List<SimpleInterval> intervals = new ArrayList<>(2);
+        intervals.add(new SimpleInterval("1", 100, 200));
+        intervals.add(new SimpleInterval("1", 500, 550));
+        return new Object[][] {
+                {intervals, 1, 152},
+                {intervals, 10, 11 + 6}
+        };
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/LocusIteratorByStateUnitTest.java
@@ -22,19 +22,6 @@ import java.util.*;
 
 public final class LocusIteratorByStateUnitTest extends LocusIteratorByStateBaseTest {
 
-    @Test
-    public void testIterator() {
-        final int readLength = 10;
-        final GATKRead mapped1 = ArtificialReadUtils.createArtificialRead(header, "mapped1", 0, 1, readLength);
-        final GATKRead mapped2 = ArtificialReadUtils.createArtificialRead(header, "mapped2", 0, 1, readLength);
-
-        final List<GATKRead> reads = Arrays.asList(mapped1, mapped2);
-
-        final LocusIteratorByState li;
-        li = makeLIBS(reads, DownsamplingMethod.NONE, true, header);
-        Assert.assertSame(li.iterator(), li);
-    }
-
     @Test(expectedExceptions = NoSuchElementException.class)
     public void testIteratingBeyondElements() {
         final int readLength = 3;


### PR DESCRIPTION
- Changes LocusWalker to emit uncovered loci if requested.  Default is previous behavior.
- Needed when there needs to be differentiation between "we do not care about this locus" versus "this locus has no coverage".
