### PR TITLE
PathSeq common utilities class

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPairedUnpairedSplitterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPairedUnpairedSplitterSpark.java
@@ -1,0 +1,87 @@
+package org.broadinstitute.hellbender.tools.spark.pathseq;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import scala.Tuple2;
+
+import java.util.*;
+
+/**
+ * Class for separating paired and unpaired reads in an RDD
+ */
+public final class PSPairedUnpairedSplitterSpark {
+
+    protected final Logger logger = LogManager.getLogger(this.getClass());
+    private final JavaRDD<Tuple2<List<GATKRead>, List<GATKRead>>> repartitionedReads;
+    private boolean isCached;
+
+    /**
+     * Gets RDDs of the paired and unpaired reads
+     */
+    public PSPairedUnpairedSplitterSpark(final JavaRDD<GATKRead> reads, final int readsPerPartitionGuess) {
+
+        //Shuffle reads into partitions by read name hash code, then map each partition to a pair of lists, one
+        //  containing the paired reads and the other the unpaired reads
+        repartitionedReads = reads.mapToPair(read -> new Tuple2<>(read.getName(), read))
+                .partitionBy(new HashPartitioner(reads.getNumPartitions()))
+                .map(Tuple2::_2)
+                .mapPartitions(iter -> mapPartitionsToPairedAndUnpairedLists(iter, readsPerPartitionGuess));
+        repartitionedReads.cache();
+        isCached = true;
+    }
+
+    /**
+     * Maps each partition to a Tuple of two Lists, the first containing the paired reads, the second containing unpaired
+     */
+    private static Iterator<Tuple2<List<GATKRead>, List<GATKRead>>> mapPartitionsToPairedAndUnpairedLists(final Iterator<GATKRead> iter, final int readsPerPartitionGuess) {
+        //Find the paired and unpaired reads by scanning the partition for repeated names
+        final List<GATKRead> pairedReadsList = new ArrayList<>(readsPerPartitionGuess);
+        final Map<String, GATKRead> unpairedReads = new HashMap<>(readsPerPartitionGuess);
+        while (iter.hasNext()) {
+            final GATKRead read = iter.next();
+            final String readName = read.getName();
+            //If read's mate is already in unpairedReads then we have a pair, which gets added to the ordered List
+            if (unpairedReads.containsKey(readName)) {
+                pairedReadsList.add(read);
+                pairedReadsList.add(unpairedReads.remove(readName));
+            } else {
+                unpairedReads.put(readName, read);
+            }
+        }
+        //Get the unpaired reads out of the hashmap
+        final List<GATKRead> unpairedReadsList = new ArrayList<>(unpairedReads.values());
+
+        //Minimize unpairedReads memory footprint (don't rely on readsPerPartitionGuess)
+        final List<GATKRead> pairedReadsListResized = new ArrayList<>(pairedReadsList.size());
+        pairedReadsListResized.addAll(pairedReadsList);
+
+        //Wrap and return the result
+        return Collections.singletonList(new Tuple2<>(pairedReadsListResized, unpairedReadsList)).iterator();
+    }
+
+    public JavaRDD<GATKRead> getPairedReads() {
+        if (!isCached) {
+            logger.warn("Getting paired reads after call to close(). Performance may be reduced.");
+        }
+        return repartitionedReads.flatMap(tuple -> tuple._1.iterator());
+    }
+
+    public JavaRDD<GATKRead> getUnpairedReads() {
+        if (!isCached) {
+            logger.warn("Getting unpaired reads after call to close(). Performance may be reduced.");
+        }
+        return repartitionedReads.flatMap(tuple -> tuple._2.iterator());
+    }
+
+    /**
+     * Call only after Spark is done with all closures involving the paired/unpaired RDDs,
+     * i.e. an action like collect() has been called.
+     */
+    public void close() {
+        repartitionedReads.unpersist();
+        isCached = false;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -1,0 +1,119 @@
+package org.broadinstitute.hellbender.tools.spark.pathseq;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import org.apache.logging.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Common functions for PathSeq
+ */
+public final class PSUtils {
+
+    public static JavaRDD<GATKRead> primaryReads(final JavaRDD<GATKRead> reads) {
+        return reads.filter(read -> !(read.isSecondaryAlignment() || read.isSupplementaryAlignment()));
+    }
+
+    /**
+     * Groups pairs using read names
+     */
+    public static JavaRDD<Iterable<GATKRead>> groupReadPairs(final JavaRDD<GATKRead> reads) {
+        return reads.groupBy(GATKRead::getName).values();
+    }
+
+    /**
+     * Gets flattened RDD of reads that have a mate
+     */
+    public static JavaRDD<GATKRead> pairedReads(final JavaRDD<GATKRead> reads) {
+
+        return groupReadPairs(reads).filter(p -> {
+            final Iterator<GATKRead> itr = p.iterator();
+            itr.next();
+            return itr.hasNext();
+        }).flatMap(Iterable::iterator);
+    }
+
+    /**
+     * Gets flattened RDD of reads that do not have a mate
+     */
+    protected static JavaRDD<GATKRead> unpairedReads(final JavaRDD<GATKRead> reads) {
+        return PSUtils.groupReadPairs(reads).filter(p -> {
+            final Iterator<GATKRead> itr = p.iterator();
+            itr.next();
+            return !itr.hasNext();
+        }).flatMap(Iterable::iterator);
+    }
+
+    public static String[] parseCommaDelimitedArgList(final String arg) {
+        if (arg == null || arg.isEmpty()) {
+            return new String[0];
+        }
+        return arg.split(",");
+    }
+
+    /**
+     * Parses command-line option for specifying kmer spacing masks
+     */
+    public static byte[] parseMask(final String maskArg, final int kSize) {
+
+        final String[] kmerMaskString = parseCommaDelimitedArgList(maskArg);
+        final byte[] kmerMask = new byte[kmerMaskString.length];
+        Utils.validateArg((kmerMaskString.length & 1) == 0, "Needed kmer mask index list of even length, but found " + kmerMaskString.length);
+        for (int i = 0; i < kmerMaskString.length; i++) {
+            kmerMask[i] = (byte) Integer.parseInt(kmerMaskString[i]);
+            Utils.validateArg(kmerMask[i] >= 0 && kmerMask[i] < kSize, "Invalid kmer mask index: " + kmerMaskString[i]);
+        }
+        return kmerMask;
+    }
+
+    /**
+     * Prints warning message followed by a list of relevant items
+     */
+    public static void logItemizedWarning(final Logger logger, final Collection<String> items, final String warning) {
+        if (!items.isEmpty()) {
+            String str = "";
+            for (final String acc : items) str += acc + ", ";
+            str = str.substring(0,str.length() - 2);
+            logger.warn(warning + " : " + str);
+        }
+    }
+
+    /**
+     * Writes two objects using Kryo to specified local file path.
+     * NOTE: using setReferences(false), which must also be set when reading the file. Does not work with nested
+     * objects that reference its parent.
+     */
+    public static void writeKryoTwo(final String filePath, final Object obj1, final Object obj2) {
+        try {
+            final Kryo kryo = new Kryo();
+            kryo.setReferences(false);
+            Output output = new Output(new FileOutputStream(filePath));
+            kryo.writeClassAndObject(output, obj1);
+            kryo.writeClassAndObject(output, obj2);
+            output.close();
+        } catch (final FileNotFoundException e) {
+            throw new UserException.CouldNotCreateOutputFile("Could not serialize objects to file", e);
+        }
+    }
+
+    /**
+     * Same as GATKSparkTool's getRecommendedNumReducers(), but can specify input BAM path (for when --input is not used)
+     */
+    public static int pathseqGetRecommendedNumReducers(final String inputPath, final int numReducers,
+                                                       final PipelineOptions options, final int targetPartitionSize) {
+        if (numReducers != 0) {
+            return numReducers;
+        }
+        return 1 + (int) (BucketUtils.dirSize(inputPath, options) / targetPartitionSize);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -4,17 +4,15 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import org.apache.logging.log4j.Logger;
-import org.apache.spark.HashPartitioner;
 import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import scala.Tuple2;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.util.*;
+import java.util.Collection;
 
 /**
  * Common functions for PathSeq
@@ -25,58 +23,6 @@ public final class PSUtils {
         return reads.filter(read -> !(read.isSecondaryAlignment() || read.isSupplementaryAlignment()));
     }
 
-    /**
-     * Gets RDDs of the paired and unpaired reads
-     */
-    public static Tuple2<JavaRDD<GATKRead>, JavaRDD<GATKRead>> splitPairedAndUnpairedReads(final JavaRDD<GATKRead> reads, final int readsPerPartitionGuess) {
-
-        //Shuffle reads into partitions by read name hash code, then map each partition to a pair of lists, one
-        //  containing the paired reads and the other the unpaired reads
-        final JavaRDD<Tuple2<List<GATKRead>, List<GATKRead>>> repartitionedReads = reads.mapToPair(read -> new Tuple2<>(read.getName(), read))
-                .partitionBy(new HashPartitioner(reads.getNumPartitions()))
-                .map(Tuple2::_2)
-                .mapPartitions(iter -> mapPartitionsToPairedAndUnpairedLists(iter, readsPerPartitionGuess));
-
-        //Split the RDD into paired and unpaired reads
-        repartitionedReads.cache();
-        final JavaRDD<GATKRead> pairedReads = repartitionedReads.flatMap(tuple -> tuple._1.iterator());
-        final JavaRDD<GATKRead> unpairedReads = repartitionedReads.flatMap(tuple -> tuple._2.iterator());
-        repartitionedReads.unpersist();
-
-        return new Tuple2<>(pairedReads, unpairedReads);
-    }
-
-    /**
-     * Maps each partition to a Tuple of two Lists, the first containing the paired reads, the second containing unpaired
-     */
-    private static Iterator<Tuple2<List<GATKRead>, List<GATKRead>>> mapPartitionsToPairedAndUnpairedLists(final Iterator<GATKRead> iter, final int readsPerPartitionGuess) {
-        //Find the paired and unpaired reads by scanning the partition for repeated names
-        final List<GATKRead> pairedReadsList = new ArrayList<>(readsPerPartitionGuess);
-        final Map<String, GATKRead> unpairedReads = new HashMap<>(readsPerPartitionGuess);
-        while (iter.hasNext()) {
-            final GATKRead read = iter.next();
-            final String readName = read.getName();
-            //If read's mate is already in unpairedReads then we have a pair, which gets added to the ordered List
-            if (unpairedReads.containsKey(readName)) {
-                pairedReadsList.add(read);
-                pairedReadsList.add(unpairedReads.remove(readName));
-            } else {
-                unpairedReads.put(readName, read);
-            }
-        }
-        //Get the unpaired reads out of the hashmap
-        final List<GATKRead> unpairedReadsList = new ArrayList<>(unpairedReads.values());
-
-        //Minimize unpairedReads memory footprint (don't rely on readsPerPartitionGuess)
-        final List<GATKRead> pairedReadsListResized = new ArrayList<>(pairedReadsList.size());
-        pairedReadsListResized.addAll(pairedReadsList);
-
-        //Wrap the result
-        final Tuple2<List<GATKRead>, List<GATKRead>> lists = new Tuple2<>(pairedReadsListResized, unpairedReadsList);
-        final List<Tuple2<List<GATKRead>, List<GATKRead>>> listOfTuple = new ArrayList<>(1);
-        listOfTuple.add(lists);
-        return listOfTuple.iterator();
-    }
 
     public static String[] parseCommaDelimitedArgList(final String arg) {
         if (arg == null || arg.isEmpty()) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPairedUnpairedSplitterSparkTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPairedUnpairedSplitterSparkTest.java
@@ -1,0 +1,87 @@
+package org.broadinstitute.hellbender.tools.spark.pathseq;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by markw on 5/9/17.
+ */
+public class PSPairedUnpairedSplitterSparkTest {
+
+
+    @Test(groups = "spark")
+    public void testReadPairing() {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final List<GATKRead> readList = new ArrayList<>(2);
+
+        final SAMSequenceDictionary seq = new SAMSequenceDictionary();
+        seq.addSequence(new SAMSequenceRecord("test_seq", 1000));
+        final SAMFileHeader header = new SAMFileHeader(seq);
+
+        final int numReadPairs = 300;
+        final int numUnpairedReads = 205;
+        final int numFormerlyPairedReads = 400;
+        final List<String> pairedReadNames = new ArrayList<>(numReadPairs * 2);
+        final List<String> unpairedReadNames = new ArrayList<>(numUnpairedReads + numFormerlyPairedReads);
+
+        for (int i = 0; i < numReadPairs; i++) {
+            final String readName = "paired_" + i;
+            final List<GATKRead> readPair = ArtificialReadUtils.createPair(header, readName, 101, 1, 102, false, false);
+            readList.addAll(readPair);
+            pairedReadNames.add(readName);
+            pairedReadNames.add(readName);
+        }
+
+        for (int i = 0; i < numUnpairedReads; i++) {
+            final String readName = "unpaired_" + i;
+            final GATKRead unpairedRead = ArtificialReadUtils.createRandomRead(101);
+            unpairedRead.setName(readName);
+            readList.add(unpairedRead);
+            unpairedReadNames.add(readName);
+        }
+
+        for (int i = 0; i < numFormerlyPairedReads; i++) {
+            final String readName = "formerly_paired_" + i;
+            final List<GATKRead> readPair = ArtificialReadUtils.createPair(header, readName, 101, 1, 102, false, false);
+            final GATKRead formerlyPairedRead = readPair.get(0);
+            readList.add(formerlyPairedRead);
+            unpairedReadNames.add(readName);
+        }
+
+        Collections.shuffle(readList);
+        final int numPartitions = 3;
+        final JavaRDD<GATKRead> readRDD = ctx.parallelize(readList, numPartitions);
+        final int readsPerPartitionGuess = (numReadPairs + numUnpairedReads + numFormerlyPairedReads) / numPartitions;
+        final PSPairedUnpairedSplitterSpark splitter = new PSPairedUnpairedSplitterSpark(readRDD, readsPerPartitionGuess);
+
+        final List<GATKRead> resultPaired = splitter.getPairedReads().collect();
+        final List<GATKRead> resultUnpaired = splitter.getUnpairedReads().collect();
+        splitter.close();
+
+        Assert.assertEquals(resultPaired.size(), pairedReadNames.size());
+        for (final GATKRead read : resultPaired) {
+            final String readName = read.getName();
+            Assert.assertTrue(pairedReadNames.contains(readName));
+            pairedReadNames.remove(readName);
+        }
+
+        Assert.assertEquals(resultUnpaired.size(), unpairedReadNames.size());
+        for (final GATKRead read : resultUnpaired) {
+            final String readName = read.getName();
+            Assert.assertTrue(unpairedReadNames.contains(readName));
+            unpairedReadNames.remove(readName);
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtilsTest.java
@@ -1,0 +1,225 @@
+package org.broadinstitute.hellbender.tools.spark.pathseq;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class PSUtilsTest extends BaseTest {
+
+    @Override
+    public String getTestedClassName() {
+        return PSUtils.class.getSimpleName();
+    }
+
+    @DataProvider(name = "maskData")
+    public Object[][] getAlignmentData() {
+        return new Object[][]{
+                {"", 0, new byte[0], Boolean.FALSE},
+                {"0", 31, null, Boolean.TRUE},
+                {"0,1", 31, new byte[]{0, 1}, Boolean.FALSE},
+                {"0,1,", 31, new byte[]{0, 1}, Boolean.FALSE},
+                {"0,1,10,8", 31, new byte[]{0, 1, 10, 8}, Boolean.FALSE},
+                {"0,-1", 31, null, Boolean.TRUE},
+                {"0,31", 31, null, Boolean.TRUE}
+        };
+    }
+
+    @Test(dataProvider = "maskData")
+    public void testParseMask(final String maskArg, final int kSize, final byte[] expected, final Boolean throwsException) {
+        if (throwsException) {
+            try {
+                PSUtils.parseMask(maskArg, kSize);
+                Assert.fail("Did not throw error for mask " + maskArg + " and kSize " + kSize);
+            } catch (Exception e) {
+            }
+        } else {
+            byte[] result = PSUtils.parseMask(maskArg, kSize);
+            Assert.assertNotNull(result, "Parser should return empty array instead of null value");
+            Assert.assertEquals(result, expected);
+        }
+    }
+
+    @Test(groups = "spark")
+    public void testPrimaryReads() {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final List<GATKRead> readList = new ArrayList<>(2);
+
+        final GATKRead primaryRead = ArtificialReadUtils.createRandomRead(101);
+        readList.add(primaryRead);
+
+        final GATKRead secondaryRead = ArtificialReadUtils.createRandomRead(101);
+        secondaryRead.setIsSecondaryAlignment(true);
+        readList.add(secondaryRead);
+
+        final GATKRead supplementaryRead = ArtificialReadUtils.createRandomRead(101);
+        supplementaryRead.setIsSupplementaryAlignment(true);
+        readList.add(supplementaryRead);
+
+        final JavaRDD<GATKRead> readRDD = ctx.parallelize(readList);
+        final List<GATKRead> result = PSUtils.primaryReads(readRDD).collect();
+
+        Assert.assertTrue(result.contains(primaryRead));
+        Assert.assertTrue(result.size() == 1);
+
+    }
+
+    @Test(groups = "spark")
+    public void testGroupReadsByName() {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final List<GATKRead> readList = new ArrayList<>(2);
+
+        final SAMSequenceDictionary seq = new SAMSequenceDictionary();
+        seq.addSequence(new SAMSequenceRecord("test_seq", 1000));
+        final SAMFileHeader header = new SAMFileHeader(seq);
+
+        final List<GATKRead> readPair1 = ArtificialReadUtils.createPair(header, "paired_1", 101, 1, 102, false, false);
+        readList.addAll(readPair1);
+
+        final List<GATKRead> readPair2 = ArtificialReadUtils.createPair(header, "paired_2", 101, 1, 102, false, false);
+        readList.addAll(readPair2);
+
+        final GATKRead unpairedRead = ArtificialReadUtils.createRandomRead(101);
+        unpairedRead.setName("unpaired_1");
+        readList.add(unpairedRead);
+        final List<GATKRead> unpairedReadIterable = new ArrayList<>(1);
+        unpairedReadIterable.add(unpairedRead);
+
+        final JavaRDD<GATKRead> readRDD = ctx.parallelize(readList);
+        final List<Iterable<GATKRead>> result = PSUtils.groupReadPairs(readRDD).collect();
+
+        Assert.assertTrue(result.size() == 3);
+        for (final Iterable<GATKRead> group : result) {
+            String groupName = null;
+            for (final GATKRead read : group) {
+                final String readName = read.getName();
+                Assert.assertTrue(readName.equals("paired_1") || readName.equals("paired_2") || readName.equals("unpaired_1"),
+                        "Unrecognized read name: " + readName);
+                if (groupName == null) {
+                    groupName = readName;
+                } else {
+                    Assert.assertEquals(readName, groupName);
+                }
+            }
+            Assert.assertNotNull(groupName, "Returned an empty group");
+        }
+
+    }
+
+    @Test(groups = "spark")
+    public void testReadPairing() {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final List<GATKRead> readList = new ArrayList<>(2);
+
+        final SAMSequenceDictionary seq = new SAMSequenceDictionary();
+        seq.addSequence(new SAMSequenceRecord("test_seq", 1000));
+        final SAMFileHeader header = new SAMFileHeader(seq);
+
+        final List<GATKRead> readPair1 = ArtificialReadUtils.createPair(header, "paired_1", 101, 1, 102, false, false);
+        readList.addAll(readPair1);
+
+        final List<GATKRead> readPair2 = ArtificialReadUtils.createPair(header, "paired_2", 101, 1, 102, false, false);
+        readList.addAll(readPair2);
+
+        final GATKRead unpairedRead = ArtificialReadUtils.createRandomRead(101);
+        unpairedRead.setName("unpaired_1");
+        readList.add(unpairedRead);
+
+        final List<GATKRead> readPair3 = ArtificialReadUtils.createPair(header, "paired_3", 101, 1, 102, false, false);
+        final GATKRead formerlyPairedRead = readPair3.get(0);
+        readList.add(formerlyPairedRead);
+
+        final JavaRDD<GATKRead> readRDD = ctx.parallelize(readList);
+
+        final List<GATKRead> resultPaired = PSUtils.pairedReads(readRDD).collect();
+        Assert.assertEquals(resultPaired.size(), 4);
+        Assert.assertTrue(resultPaired.contains(readPair1.get(0)));
+        Assert.assertTrue(resultPaired.contains(readPair1.get(1)));
+        Assert.assertTrue(resultPaired.contains(readPair2.get(0)));
+        Assert.assertTrue(resultPaired.contains(readPair2.get(1)));
+
+        final List<GATKRead> resultUnpaired = PSUtils.unpairedReads(readRDD).collect();
+        Assert.assertEquals(resultUnpaired.size(), 2);
+        Assert.assertTrue(resultUnpaired.contains(unpairedRead));
+        Assert.assertTrue(resultUnpaired.contains(formerlyPairedRead));
+    }
+
+    @Test(groups = "spark")
+    public void testUnpairedReads() {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final List<GATKRead> readList = new ArrayList<>(2);
+
+        final SAMSequenceDictionary seq = new SAMSequenceDictionary();
+        seq.addSequence(new SAMSequenceRecord("test_seq", 1000));
+        final SAMFileHeader header = new SAMFileHeader(seq);
+
+        final List<GATKRead> readPair1 = ArtificialReadUtils.createPair(header, "paired_1", 101, 1, 102, false, false);
+        readList.addAll(readPair1);
+
+        final List<GATKRead> readPair2 = ArtificialReadUtils.createPair(header, "paired_2", 101, 1, 102, false, false);
+        readList.addAll(readPair2);
+
+        final GATKRead unpairedRead = ArtificialReadUtils.createRandomRead(101);
+        unpairedRead.setName("unpaired_1");
+        readList.add(unpairedRead);
+
+        final List<GATKRead> readPair3 = ArtificialReadUtils.createPair(header, "paired_3", 101, 1, 102, false, false);
+        final GATKRead formerlyPairedRead = readPair3.get(0);
+        readList.add(formerlyPairedRead);
+
+        final JavaRDD<GATKRead> readRDD = ctx.parallelize(readList);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWriteTwoKryo() throws Exception {
+        final File tempFile = createTempFile("test", ".dat");
+        final Integer int_in = 29382;
+        final String str_in = "test string";
+        PSUtils.writeKryoTwo(tempFile.getPath(), int_in, str_in);
+
+        final Kryo kryo = new Kryo();
+        kryo.setReferences(false);
+        final Input input = new Input(BucketUtils.openFile(tempFile.getPath(), null));
+        final Integer int_out = (Integer) kryo.readClassAndObject(input);
+        final String str_out = (String) kryo.readClassAndObject(input);
+        input.close();
+
+        Assert.assertEquals(int_in, int_out);
+        Assert.assertEquals(str_in, str_out);
+
+        try {
+            PSUtils.writeKryoTwo("/bad_dir", int_out, str_out);
+            Assert.fail("Did not throw UserException for bad path to writeKryoTwo()");
+        } catch (UserException e) {
+        }
+    }
+
+    @Test
+    public void testLogItemizedWarning() {
+        final Collection<String> items = new ArrayList<>(3);
+        PSUtils.logItemizedWarning(logger, items, "Test warning statement");
+        items.add("x");
+        items.add("y");
+        items.add("z");
+        PSUtils.logItemizedWarning(logger, items, "Test warning statement");
+    }
+
+}


### PR DESCRIPTION
@cwhelan @tedsharpe please review.

Miscellaneous utility functions used by two or more PathSeq tools.

Note pathseqGetRecommendedNumReducers is needed because some tools read 2 BAMs - one with paired reads one with unpaired reads - and the GATKTool's version will only let you call it on the BAM specified by --input.