### PR TITLE
Allowing GenomicsDBImport to skip header merging

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -454,7 +454,7 @@ public final class GenomicsDBImport extends GATKTool {
         final String arrayName,
         final long variantContextBufferSize,
         final long segmentSize,
-        final  long lbSampleIndex,
+        final long lbSampleIndex,
         final long ubSampleIndex) {
 
         final GenomicsDBImportConfiguration.Partition.Builder pBuilder =

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -213,8 +213,9 @@ public final class GenomicsDBImport extends GATKTool {
     }
 
     private void initializeHeaderAndSampleMappings() {
-        //Only one of
+        // Only one of -V and -sampleNameToPathFile may be specified
         if (sampleNameToPathFile == null) {
+            // -V was specified
             final List<VCFHeader> headers = new ArrayList<>(variantPaths.size());
 
             for (final String variantPath : variantPaths) {
@@ -235,6 +236,7 @@ public final class GenomicsDBImport extends GATKTool {
             mergedHeaderLines = VCFUtils.smartMergeHeaders(headers, true);
             mergedHeaderSequenceDictionary = new VCFHeader(mergedHeaderLines).getSequenceDictionary();
         } else {
+            // -sampleNameMap was specified
             sampleNameToVcfUri.putAll(loadSampleNameMapFile(IOUtils.getPath(sampleNameToPathFile)));
             sampleNames.addAll(sampleNameToVcfUri.keySet());
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intel.genomicsdb.ChromosomeInterval;
 import com.intel.genomicsdb.GenomicsDBCallsetsMapProto;
 import com.intel.genomicsdb.GenomicsDBImportConfiguration;
@@ -13,7 +14,9 @@ import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFUtils;
+import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
@@ -28,8 +31,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.FileNotFoundException;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -54,27 +60,19 @@ public final class GenomicsDBImport extends GATKTool {
     private static final int DEFAULT_ZERO_BATCH_SIZE = 0;
 
     public static final String WORKSPACE_ARG_NAME = "genomicsDBWorkspace";
-    private static final String SEGMENT_SIZE_ARG_NAME = "genomicsDBSegmentSize";
-    private static final String OVERWRITE_WORKSPACE_NAME = "overwriteExistingGenomicsDBWorkspace";
+    public static final String SEGMENT_SIZE_ARG_NAME = "genomicsDBSegmentSize";
+    public static final String OVERWRITE_WORKSPACE_NAME = "overwriteExistingGenomicsDBWorkspace";
 
-    private static final String VCF_BUFFER_SIZE_ARG_NAME = "genomicsDBVCFBufferSize";
-    private static final String ARRAY_ARG_NAME = "genomicsDBArray";
-    private static final String VID_MAP_FILE_ARG_NAME = "genomicsDBVidMapFile";
+    public static final String VCF_BUFFER_SIZE_ARG_NAME = "genomicsDBVCFBufferSize";
 
-    private static final String CALLSET_MAP_FILE_ARG_NAME = "genomicsDBCallsetMapFile";
-    private static final String BATCHSIZE_ARG_NAME = "batchSize";
-    private static final String CONSOLIDATE_ARG_NAME = "consolidate";
+    public static final String BATCHSIZE_ARG_NAME = "batchSize";
+    public static final String CONSOLIDATE_ARG_NAME = "consolidate";
+    public static final String SAMPLE_NAME_MAP_LONG_NAME = "sampleNameMap";
 
     @Argument(fullName = WORKSPACE_ARG_NAME,
               shortName = WORKSPACE_ARG_NAME,
               doc = "Workspace for GenomicsDB. Has to be a POSIX file system path")
     private String workspace;
-
-//    @Argument(fullName = ARRAY_ARG_NAME,
-//              shortName = ARRAY_ARG_NAME,
-//              doc = "TileDB array name used by GenomicsDB. Defaults to " + ARRAY_ARG_NAME,
-//              optional = true)
-    private final String arrayName = GenomicsDBConstants.DEFAULT_ARRAY_NAME;
 
     @Argument(fullName = SEGMENT_SIZE_ARG_NAME,
               shortName = SEGMENT_SIZE_ARG_NAME,
@@ -87,7 +85,10 @@ public final class GenomicsDBImport extends GATKTool {
     @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME,
               shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME,
               doc = "GVCF files to be imported to GenomicsDB. Each file must contain" +
-                    "data for only a single sample")
+                    "data for only a single sample. Either this or " + SAMPLE_NAME_MAP_LONG_NAME +
+                    " must be specified.",
+              optional = true,
+              mutex = {SAMPLE_NAME_MAP_LONG_NAME})
     private List<String> variantPaths;
 
     @Argument(fullName = VCF_BUFFER_SIZE_ARG_NAME,
@@ -95,25 +96,9 @@ public final class GenomicsDBImport extends GATKTool {
               doc = "Buffer size in bytes to store variant contexts." +
                     " Larger values are better as smaller values cause frequent disk writes." +
                     " Defaults to " + DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE,
-              optional = true)
+              optional = true,
+              minValue = 1024L)
     private long vcfBufferSizePerSample = DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE;
-
-//    @Argument(fullName = CALLSET_MAP_FILE_ARG_NAME,
-//              shortName = CALLSET_MAP_FILE_ARG_NAME,
-//              doc = "Path to callset JSON file to be created. " +
-//                    "The file contains row mappings to sample names."
-//                    + " Defaults to " + DEFAULT_CALLSETMAP_FILE_NAME +
-//                    " file is written to GenomicsDB workspace",
-//              optional = true)
-    private final String callsetMapJSONFileName = GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME;
-
-//    @Argument(fullName = VID_MAP_FILE_ARG_NAME,
-//              shortName = VID_MAP_FILE_ARG_NAME,
-//              doc = "Path to vid map JSON file to be created. Includes contig maps and INFO/FORMAT/FILTER" +
-//                    "fields from headers. Defaults to " + DEFAULT_VIDMAP_FILE_NAME +
-//                    " file is written to GenomicsDB workspace",
-//              optional = true)
-    private final String vidMapJSONFileName = GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME;
 
     @Argument(fullName = OVERWRITE_WORKSPACE_NAME,
               shortName = OVERWRITE_WORKSPACE_NAME,
@@ -140,10 +125,22 @@ public final class GenomicsDBImport extends GATKTool {
                     "to open ~20x as many files. Also, internally GenomicsDB would consume more memory to maintain " +
                     "bookkeeping data from all fragments. Use this flag to merge all fragments into one. " +
                     "Merging can potentially improve read performance, however overall benefit might not be noticeable " +
-                    "as the top Java layers has significantly higher overheads. This flag have no effect if only one " +
+                    "as the top Java layers have significantly higher overheads. This flag has no effect if only one " +
                     "batch is used. Defaults to false",
               optional = true)
     private Boolean doConsolidation = false;
+
+    @Advanced
+    @Argument(fullName = SAMPLE_NAME_MAP_LONG_NAME,
+            shortName = SAMPLE_NAME_MAP_LONG_NAME,
+            doc = "Path to file containing a mapping of sample name to file name in tab delimited format.  If this is " +
+                    "specified then the header from the first sample will be used as the header template rather than " +
+                    "merging the headers, and the sample names will taken from this file.  This is a performance optimization " +
+                    "that relaxes the normal checks for consistent headers.  Using vcfs with incompatible headers may result " +
+                    "in silent data corruption.",
+            optional = true,
+            mutex = {StandardArgumentDefinitions.VARIANT_LONG_NAME})
+    private String sampleNameToPathFile;
 
     @Override
     public boolean requiresIntervals() { return true; }
@@ -174,16 +171,16 @@ public final class GenomicsDBImport extends GATKTool {
     private List<ChromosomeInterval> intervals;
 
     // List of all sample names
-    private List<String> sampleNames = new ArrayList<>();
+    private final Set<String> sampleNames = new LinkedHashSet<>();
 
     // Linked hash map between sample names and corresponding GVCF file name
-    private Map<String, String> sampleNameToVcfUri = new LinkedHashMap<>();
+    private final Map<String, String> sampleNameToVcfUri = new LinkedHashMap<>();
 
     // Needed as smartMergeHeaders() returns a set of VCF header lines
-    private Set<VCFHeaderLine> mergedHeader = null;
+    private Set<VCFHeaderLine> mergedHeaderLines = null;
 
     // VCFHeader created from the merged header
-    private VCFHeader mergedVCFHeader;
+    private SAMSequenceDictionary mergedHeaderSequenceDictionary;
 
     // Path to vidmap file to be written by GenomicsDBImporter
     private File vidMapJSONFile;
@@ -202,41 +199,95 @@ public final class GenomicsDBImport extends GATKTool {
      */
     @Override
     public void onStartup() {
-
-        List<VCFHeader> headers = new ArrayList<>(variantPaths.size());
-
-        for (String variantPath : variantPaths) {
-
-            final AbstractFeatureReader<VariantContext, LineIterator> reader = getReaderFromVCFUri(variantPath);
-            VCFHeader header = (VCFHeader)reader.getHeader();
-
-            // A GVCF file must contain only one sample, throw an exception otherwise
-            if (header.getNGenotypeSamples() != 1) {
-                throw new UserException("Input GVCF: " + variantPath + " should contain data for one sample");
-            }
-            String sampleName = header.getGenotypeSamples().get(0);
-            headers.add(header);
-            sampleNames.add(sampleName);
-            if (sampleNameToVcfUri.put(sampleName, variantPath) != null) {
-                throw new UserException("Duplicate sample " + sampleName);
-            }
-
-            // Import occurs in batches. By closing all readers here we release resources
-            // and preserve memory for later stages where readers are allocated
-            // for samples in a given batch
-            try {
-                reader.close();
-            } catch (IOException e) {
-                throw new GATKException("FeatureReader close() failed for " + sampleName, e);
-            }
-        }
-
-        mergedHeader = VCFUtils.smartMergeHeaders(headers, true);
-        mergedVCFHeader = new VCFHeader(mergedHeader);
-
+        assertVariantPathsOrSampleNameFileWasSpecified();
+        initializeHeaderAndSampleMappings();
         initializeIntervals();
         super.onStartup();
     }
+
+    private void assertVariantPathsOrSampleNameFileWasSpecified(){
+        if ( (variantPaths == null || variantPaths.isEmpty()) && sampleNameToPathFile == null) {
+            throw new CommandLineException.MissingArgument(StandardArgumentDefinitions.VARIANT_LONG_NAME,
+                                                       "One of " + StandardArgumentDefinitions.VARIANT_LONG_NAME + " or " + SAMPLE_NAME_MAP_LONG_NAME + " must be specified" );
+        }
+    }
+
+    private void initializeHeaderAndSampleMappings() {
+        //Only one of
+        if (sampleNameToPathFile == null) {
+            final List<VCFHeader> headers = new ArrayList<>(variantPaths.size());
+
+            for (final String variantPath : variantPaths) {
+                final  VCFHeader header = loadHeaderFromVCFUri(variantPath);
+
+                // A GVCF file must contain only one sample, throw an exception otherwise
+                assertGVCFHasOnlyOneSample(variantPath, header);
+                headers.add(header);
+
+                final String sampleName = header.getGenotypeSamples().get(0);
+                sampleNames.add(sampleName);
+                final String previousPath = sampleNameToVcfUri.put(sampleName, variantPath);
+                if (previousPath != null) {
+                    throw new UserException("Duplicate sample: " + sampleName + ". Sample was found in both "
+                                                    + variantPath + " and " + previousPath + ".");
+                }
+            }
+            mergedHeaderLines = VCFUtils.smartMergeHeaders(headers, true);
+            mergedHeaderSequenceDictionary = new VCFHeader(mergedHeaderLines).getSequenceDictionary();
+        } else {
+            sampleNameToVcfUri.putAll(loadSampleNameMapFile(IOUtils.getPath(sampleNameToPathFile)));
+            sampleNames.addAll(sampleNameToVcfUri.keySet());
+
+            final String firstHeaderPath = sampleNameToVcfUri.entrySet().iterator().next().getValue();
+            final VCFHeader header = loadHeaderFromVCFUri(firstHeaderPath);
+            mergedHeaderLines = header.getMetaDataInInputOrder();
+            mergedHeaderSequenceDictionary = header.getSequenceDictionary();
+        }
+    }
+
+    private VCFHeader loadHeaderFromVCFUri(final String variantPath) {
+        try(final AbstractFeatureReader<VariantContext, LineIterator> reader = getReaderFromVCFUri(variantPath)) {
+            return (VCFHeader) reader.getHeader();
+        } catch (final IOException e) {
+            throw new UserException("Error while reading vcf header from " + variantPath, e);
+        }
+    }
+
+    private static void assertGVCFHasOnlyOneSample(String variantPath, VCFHeader header) {
+        // A GVCF file must contain only one sample, throw an exception otherwise
+        final int numberOfSamples = header.getNGenotypeSamples();
+        if (numberOfSamples != 1) {
+            throw new UserException("Input GVCF: " + variantPath + " was expected to contain a single sample but actually contained " + numberOfSamples + ".");
+        }
+    }
+
+    @VisibleForTesting
+    static Map<String, String> loadSampleNameMapFile(final Path sampleToFileMapPath) {
+        try {
+            final Map<String, String> sampleToFilename = Files.lines(sampleToFileMapPath)
+                    .map(line -> {
+                        final String[] split = line.split("\\s");
+                        if (split.length != 2) {
+                            throw new UserException.BadInput(
+                                    "Expected a file of format\nSample\tFile\n but found line: " + line);
+                        }
+                        return split;
+                    })
+                    .collect(Collectors.toMap(split -> split[0],
+                                             split -> split[1],
+                                              (a, b) -> { throw new UserException.BadInput("Found two mappings for the same sample:\n" + a + "\n" + b); },
+                                              HashMap::new));
+
+            if (sampleToFilename.entrySet().isEmpty()) {
+                throw new UserException.BadInput(
+                        "At least 1 sample is required but none were found in the sample mapping file");
+            }
+            return sampleToFilename;
+        } catch (final IOException e) {
+            throw new UserException.CouldNotReadInputFile(sampleToFileMapPath, "exception while reading sample->filename mapping file",  e);
+        }
+    }
+
 
     /**
      * Before traversal, fix configuration parameters and initialize
@@ -247,29 +298,16 @@ public final class GenomicsDBImport extends GATKTool {
 
         File workspaceDir = overwriteOrCreateWorkspace();
 
-        // If provided buffer size is less 1KB it is considered to be too small
-        // Either use default 16KB or any value larger than 10KB
-        if (vcfBufferSizePerSample < 1024L) {
-            throw new UserException("Buffer size per column partition per sample is too small." +
-                    " Either use default value " + DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE +
-                    " or larger values than 10KB");
-        }
-
-        vidMapJSONFile = (vidMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME)) ?
-            new File(workspaceDir + "/" + vidMapJSONFileName) :
-            new File(vidMapJSONFileName);
-
-        callsetMapJSONFile = (callsetMapJSONFileName.equals(GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME)) ?
-            new File (workspaceDir + "/" + callsetMapJSONFileName) :
-            new File(callsetMapJSONFileName);
+        vidMapJSONFile = new File(workspaceDir + "/" + GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME);
+        callsetMapJSONFile = new File (workspaceDir + "/" + GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME);
 
         logger.info("Vid Map JSON file will be written to " + vidMapJSONFile);
         logger.info("Callset Map JSON file will be written to " + callsetMapJSONFile);
-        logger.info("Importing to array - " + workspace + "/" + arrayName);
+        logger.info("Importing to array - " + workspace + "/" + GenomicsDBConstants.DEFAULT_ARRAY_NAME);
 
         // Passing in false here so that sample names will be sorted.
         // This is needed for consistent ordering across partitions/machines
-        callsetMappingPB = GenomicsDBImporter.generateSortedCallSetMap(sampleNames, false);
+        callsetMappingPB = GenomicsDBImporter.generateSortedCallSetMap(new ArrayList<>(sampleNames), false);
     }
 
     /**
@@ -279,34 +317,34 @@ public final class GenomicsDBImport extends GATKTool {
     @Override
     public void traverse() {
 
-        int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleNames.size() : batchSize;
-        int sampleCount = sampleNames.size();
-        int totalBatchCount = (sampleCount/updatedBatchSize) + (sampleCount%updatedBatchSize==0 ? 0 : 1);
+        final int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleNames.size() : batchSize;
+        final int sampleCount = sampleNames.size();
+        final int totalBatchCount = (sampleCount/updatedBatchSize) + (sampleCount%updatedBatchSize==0 ? 0 : 1);
 
         GenomicsDBImporter importer;
 
         for (int i = 0, batchCount = 1; i < sampleCount; i += updatedBatchSize, ++batchCount) {
 
-            Map<String, FeatureReader<VariantContext>> sampleToReaderMap =
-                getFeatureReaders(sampleNames, sampleNameToVcfUri, updatedBatchSize, sampleCount, i);
+            final Map<String, FeatureReader<VariantContext>> sampleToReaderMap =
+                getFeatureReaders(new ArrayList<>(sampleNames), sampleNameToVcfUri, updatedBatchSize, sampleCount, i);
 
             logger.info("Importing batch " + batchCount + " with " + sampleToReaderMap.size() + " samples");
             final long variantContextBufferSize = vcfBufferSizePerSample * sampleToReaderMap.size();
 
-            GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
-                    createImportConfiguration(workspace, arrayName,
+            final GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
+                    createImportConfiguration(workspace, GenomicsDBConstants.DEFAULT_ARRAY_NAME,
                             variantContextBufferSize, segmentSize,
                             i, (i+updatedBatchSize-1));
 
             try {
-                importer = new GenomicsDBImporter(sampleToReaderMap, mergedHeader, intervals.get(0), importConfiguration);
-            } catch (IOException e) {
+                importer = new GenomicsDBImporter(sampleToReaderMap, mergedHeaderLines, intervals.get(0), importConfiguration);
+            } catch (final IOException e) {
                 throw new UserException("Error initializing GenomicsDBImporter in batch " + batchCount, e);
             }
 
             try {
                 importer.importBatch();
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 throw new UserException("GenomicsDB import failed in batch " + batchCount, e);
             }
 
@@ -325,19 +363,19 @@ public final class GenomicsDBImport extends GATKTool {
 
         // Write the vid and callset map JSON files
         try {
-            GenomicsDBImporter.writeVidMapJSONFile(vidMapJSONFile.getAbsolutePath(), mergedHeader);
-        } catch (FileNotFoundException fe) {
+            GenomicsDBImporter.writeVidMapJSONFile(vidMapJSONFile.getAbsolutePath(), mergedHeaderLines);
+        } catch (final FileNotFoundException fe) {
             throw new UserException("Unable to write vid map JSON file " + vidMapJSONFile.getAbsolutePath(), fe);
         }
         try {
             GenomicsDBImporter.writeCallsetMapJSONFile(callsetMapJSONFile.getAbsolutePath(), callsetMappingPB);
-        } catch (FileNotFoundException fe) {
+        } catch (final FileNotFoundException fe) {
             throw new UserException("Unable to write callset map JSON file " + callsetMapJSONFile.getAbsolutePath(), fe);
         }
 
         if (doConsolidation) {
             logger.info("GenomicsDB consolidation started");
-            GenomicsDBImporter.consolidateTileDBArray(workspace, arrayName);
+            GenomicsDBImporter.consolidateTileDBArray(workspace, GenomicsDBConstants.DEFAULT_ARRAY_NAME);
             logger.info("GenomicsDB consolidation completed");
         }
 
@@ -355,8 +393,8 @@ public final class GenomicsDBImport extends GATKTool {
      * @param lowerSampleIndex  0-based Lower bound of sample index -- inclusive
      * @return  Feature readers to be imported in the current batch
      */
-    private Map<String, FeatureReader<VariantContext>> getFeatureReaders(List<String> sampleNames, Map<String, String> sampleNameToFileName, int batchSize, int sampleCount, int lowerSampleIndex) {
-        Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
+    private Map<String, FeatureReader<VariantContext>> getFeatureReaders(final List<String> sampleNames, final Map<String, String> sampleNameToFileName, final int batchSize, int sampleCount, int lowerSampleIndex) {
+        final Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
 
         for(int i = lowerSampleIndex; i < sampleCount && i < lowerSampleIndex+batchSize; ++i) {
             final String sampleName = sampleNames.get(i);
@@ -395,12 +433,12 @@ public final class GenomicsDBImport extends GATKTool {
      * @param ubSampleIndex  Upper bound of sample index -- inclusive (0-based)
      * @return  GenomicsDB import configuration object
      */
-    private GenomicsDBImportConfiguration.ImportConfiguration createImportConfiguration(
+    private static GenomicsDBImportConfiguration.ImportConfiguration createImportConfiguration(
         final String workspace,
         final String arrayName,
         final long variantContextBufferSize,
         final long segmentSize,
-        final long lbSampleIndex,
+        final  long lbSampleIndex,
         final long ubSampleIndex) {
 
         GenomicsDBImportConfiguration.Partition.Builder pBuilder =
@@ -528,7 +566,7 @@ public final class GenomicsDBImport extends GATKTool {
      */
     @Override
     public SAMSequenceDictionary getBestAvailableSequenceDictionary() {
-        final SAMSequenceDictionary sequenceDictionary = mergedVCFHeader.getSequenceDictionary();
+        final SAMSequenceDictionary sequenceDictionary = mergedHeaderSequenceDictionary;
         if (sequenceDictionary == null) {
             return super.getBestAvailableSequenceDictionary();
         } else {

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.hellbender.tools.genomicsdb;
+
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.mockito.internal.util.io.IOUtil;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GenomicsDBImportUnitTest extends BaseTest{
+
+    @DataProvider
+    public Object[][] getBadTestFiles(){
+        return new Object[][]{
+                {"Sample1\tsamplePath\n"
+                +"Sample1\tsamplePath"},  //duplicate sample name
+                {""}, // empty file
+                {"Sample1\tSample2\tFile"}, //various wrong numbers of inputs
+                {"Sample1\t"},
+                {"Sample1"}
+        };
+    }
+
+    @Test(dataProvider = "getBadTestFiles", expectedExceptions = UserException.BadInput.class)
+    public void testBadInputFiles(final String text){
+        final File sampleFile = IOUtils.writeTempFile(text, "badSampleMapping", ".txt");
+        GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath()  );
+    }
+
+    @Test
+    public void testSampleNameToFileMap(){
+        final File sampleFile = IOUtils.writeTempFile("Sample1\tfile1\nSample2\tfile2", "sampleMapping", ".txt");
+        final Map<String, String> expected = new HashMap<>();
+        expected.put("Sample1", "file1");
+        expected.put("Sample2", "file2");
+        Assert.assertEquals(GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath()), expected);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenomicsDBImportUnitTest extends BaseTest{
@@ -18,11 +19,18 @@ public class GenomicsDBImportUnitTest extends BaseTest{
     public Object[][] getBadTestFiles(){
         return new Object[][]{
                 {"Sample1\tsamplePath\n"
-                +"Sample1\tsamplePath"},  //duplicate sample name
-                {""}, // empty file
-                {"Sample1\tSample2\tFile"}, //various wrong numbers of inputs
-                {"Sample1\t"},
-                {"Sample1"}
+                +"Sample1\tsamplePath"},        // duplicate sample name
+                {""},                           // empty file
+                {"Sample1\tSample2\tFile"},     // 3 columns
+                {"Sample1\t"},                  // 1 column
+                {"Sample1"},                    // 1 column no delimiter
+                {"\tfile"},                     // empty first token
+                {" \tfile"},                    // first token only whitespace
+                {"Sample1\tfile1\t"},           // extra tab
+                {"Sample1\nfile"},              // newline instead of tab
+                {"\t"},                         // only tab
+                {"Sample1 file1"},              // non-tab whitespace
+                {"Sample 1\tfile1"},            // white space in a token
         };
     }
 
@@ -34,10 +42,17 @@ public class GenomicsDBImportUnitTest extends BaseTest{
 
     @Test
     public void testSampleNameToFileMap(){
-        final File sampleFile = IOUtils.writeTempFile("Sample1\tfile1\nSample2\tfile2", "sampleMapping", ".txt");
-        final Map<String, String> expected = new HashMap<>();
+        final String content =
+                "Sample1\tfile1\n" +
+                "Sample2\tfile2\n" +
+                "Sample3\tfile3";
+        final File sampleFile = IOUtils.writeTempFile(content, "sampleMapping", ".txt");
+        final Map<String, String> expected = new LinkedHashMap<>();
         expected.put("Sample1", "file1");
         expected.put("Sample2", "file2");
-        Assert.assertEquals(GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath()), expected);
+        expected.put("Sample3", "file3");
+        final LinkedHashMap<String, String> actual = GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath());
+        Assert.assertEquals(actual, expected);
+        Assert.assertEquals(actual.keySet().iterator().next(), "Sample1");
     }
 }


### PR DESCRIPTION
Adding an advanced option --sampleNameMap to GenomicsDBImport which can be specified instead of -V
* This allows providing a file mapping samples to their vcf uri which is used instead of loading each header and checking the sample names.
* The first file in the mapping is chosen to act as the header template.

If the headers are not consistent there may be data corruption.

A mapping file is a tab seperated file with no header in the format

Sample1	file1
Sample2 file2
Sample3 file3
...