### PR TITLE
Track the target of applicable pieces of evidence, and allow an assem…

### DIFF
--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -50,4 +50,6 @@ REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
     --num-executors 20 \
     --driver-memory 30G \
     --executor-memory 30G \
-    --conf spark.yarn.executor.memoryOverhead=5000
+    --conf spark.yarn.executor.memoryOverhead=5000 \
+    --conf spark.network.timeout=300 \
+    --conf spark.executor.heartbeatInterval=60

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointClusterer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointClusterer.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.sv;
 
-import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
+import com.google.common.annotations.VisibleForTesting;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.*;
 
@@ -11,13 +11,17 @@ import java.util.*;
  */
 public final class BreakpointClusterer implements Iterator<BreakpointEvidence> {
     private final int minEvidenceCount;
+    private final int minCoherentEvidenceCount;
     private final SVIntervalTree<List<BreakpointEvidence>> evidenceTree;
+    private final ReadMetadata readMetadata;
     private Iterator<SVIntervalTree.Entry<List<BreakpointEvidence>>> treeItr;
     private Iterator<BreakpointEvidence> listItr;
 
-    public BreakpointClusterer( final int minEvidenceCount, final Iterator<BreakpointEvidence> evidenceItr ) {
+    public BreakpointClusterer(final ReadMetadata readMetadata, final int minEvidenceCount, final int minCoherentEvidenceCount,  final Iterator<BreakpointEvidence> evidenceItr ) {
         this.minEvidenceCount = minEvidenceCount;
+        this.minCoherentEvidenceCount = minCoherentEvidenceCount;
         this.evidenceTree = new SVIntervalTree<>();
+        this.readMetadata = readMetadata;
         buildTree(evidenceItr);
     }
 
@@ -61,15 +65,40 @@ public final class BreakpointClusterer implements Iterator<BreakpointEvidence> {
         treeItr = evidenceTree.iterator();
     }
 
-    private boolean hasEnoughOverlappers( final SVInterval interval ) {
+    @VisibleForTesting
+    protected boolean hasEnoughOverlappers( final SVInterval interval ) {
         final Iterator<SVIntervalTree.Entry<List<BreakpointEvidence>>> itr = evidenceTree.overlappers(interval);
-        int count = 0;
+        final SVIntervalTree<List<BreakpointEvidence>> targetIntervalTree = new SVIntervalTree<>();
+        int evidenceIntervalOverlapCount = 0;
         while ( itr.hasNext() ) {
-            count += itr.next().getValue().size();
-            if ( count >= minEvidenceCount ) {
+            final List<BreakpointEvidence> evidenceForInterval = itr.next().getValue();
+            evidenceIntervalOverlapCount += evidenceForInterval.size();
+            if ( evidenceIntervalOverlapCount >= minEvidenceCount ) {
+                return true;
+            }
+
+            for (final BreakpointEvidence evidence : evidenceForInterval) {
+                if (evidence.hasDistalTargets()) {
+                    for (final SVInterval target : evidence.getDistalTargets(readMetadata)) {
+                        if (targetIntervalTree.find(target) == null) {
+                            targetIntervalTree.put(target, new ArrayList<>(1));
+                        }
+                        targetIntervalTree.find(target).getValue().add(evidence);
+                    }
+                }
+            }
+        }
+
+        for (final SVIntervalTree.Entry<List<BreakpointEvidence>> targetTreeEntries : targetIntervalTree) {
+            final SVInterval target = targetTreeEntries.getInterval();
+            final int coherentEvidenceCount =
+                    Utils.stream(targetIntervalTree.overlappers(target))
+                            .mapToInt(overlapper -> overlapper.getValue().size()).sum();
+            if (coherentEvidenceCount >= minCoherentEvidenceCount) {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointEvidence.java
@@ -4,8 +4,14 @@ import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Various types of read anomalies that provide evidence of genomic breakpoints.
@@ -101,6 +107,24 @@ public class BreakpointEvidence {
         this.templateEnd = TemplateEnd.PAIRED_UNKNOWN;
     }
 
+    /**
+     * Returns true if this piece of evidence specifies a possible distal target for the breakpoint.
+     */
+    public boolean hasDistalTargets() {
+        return false;
+    }
+
+    /**
+     * Returns the distal interval implicated as a candidate adjacency to the breakpoint by this piece of evidence.
+     * For example, in the case of a discordant read pair, this would be the region adjacent to the mate of the current
+     * read. Returns null if the evidence does not specify or support a possible targeted region (for example, the case
+     * of an read with an unmapped mate).
+     * @param readMetadata
+     */
+    public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+        return null;
+    }
+
     protected void serialize( final Kryo kryo, final Output output ) {
         output.writeInt(eventLocation.getContig());
         output.writeInt(eventLocation.getStart());
@@ -136,14 +160,19 @@ public class BreakpointEvidence {
         public SplitRead( final GATKRead read, final ReadMetadata metadata, final boolean atStart ) {
             super(read, metadata, atStart ? read.getStart() : read.getEnd(), UNCERTAINTY);
             cigar = read.getCigar().toString();
-            if ( cigar == null ) throw new GATKException("Read has no cigar string.");
-            tagSA = read.getAttributeAsString(SA_TAG_NAME);
+            if ( cigar.isEmpty() ) throw new GATKException("Read has no cigar string.");
+            if (read.hasAttribute(SA_TAG_NAME)) {
+                tagSA = read.getAttributeAsString(SA_TAG_NAME);
+            } else {
+                tagSA = null;
+            }
         }
 
         private SplitRead( final Kryo kryo, final Input input ) {
             super(kryo, input);
             cigar = input.readString();
             tagSA = input.readString();
+
         }
 
         @Override
@@ -155,7 +184,53 @@ public class BreakpointEvidence {
 
         @Override
         public String toString() {
-            return super.toString() + " Split " + cigar + (tagSA == null ? " SA: None" : (" SA: " + tagSA));
+            final StringBuffer out = new StringBuffer();
+            out.append(super.toString());
+            out.append("\t");
+            out.append("Split");
+            out.append("\t");
+            out.append(cigar);
+            out.append("\t");
+            out.append((tagSA == null ? " SA: None" : (" SA: " + tagSA)));
+            return out.toString();
+        }
+
+        @Override
+        public boolean hasDistalTargets() {
+            return tagSA != null;
+        }
+
+        @Override
+        public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+            if (tagSA != null) {
+                final String[] saStrings = tagSA.split(";");
+                final List<SVInterval> supplementaryAlignments = new ArrayList<>(saStrings.length);
+                for (final String saString : saStrings) {
+                    SVInterval saInterval = saStringToSVInterval(readMetadata, saString);
+                    supplementaryAlignments.add(saInterval);
+                }
+                return supplementaryAlignments;
+            } else {
+                return null;
+            }
+        }
+
+        // todo: for now, taking the entire location of the supplementary alignment plus the uncertainty on each end
+        // A better solution might be to find the location of the actual clip on the other end of the reference,
+        // but that would be significantly more complex and possibly computationally expensive
+        private SVInterval saStringToSVInterval(final ReadMetadata readMetadata, final String saString) {
+            final String[] values = saString.split(",", -1);
+            if (values.length != 6) {
+                throw new GATKException("Could not parse SATag: "+ saString);
+            }
+            final String contigId = values[0];
+            final int pos = Integer.parseInt(values[1]) - 1;
+            final Cigar cigar = TextCigarCodec.decode(values[3]);
+
+            return new SVInterval( readMetadata.getContigID(contigId),
+                    pos - UNCERTAINTY,
+                    pos + cigar.getPaddedReferenceLength() + UNCERTAINTY);
+
         }
 
         public static final class Serializer extends com.esotericsoftware.kryo.Serializer<SplitRead> {
@@ -240,31 +315,39 @@ public class BreakpointEvidence {
 
     @DefaultSerializer(InterContigPair.Serializer.class)
     public static final class InterContigPair extends BreakpointEvidence {
-        private final int mateContigIndex;
-        private final int mateStartPosition;
+        private final SVInterval target;
 
         InterContigPair( final GATKRead read, final ReadMetadata metadata ) {
             super(read, metadata);
-            this.mateContigIndex = metadata.getContigID(read.getMateContig());
-            this.mateStartPosition = read.getMateStart();
+            target = getMateTargetInterval(read, metadata);
         }
 
         private InterContigPair( final Kryo kryo, final Input input ) {
             super(kryo, input);
-            mateContigIndex = input.readInt();
-            mateStartPosition = input.readInt();
+            target = new SVInterval(input.readInt(), input.readInt(), input.readInt());
+        }
+
+        @Override
+        public boolean hasDistalTargets() {
+            return true;
+        }
+
+        @Override
+        public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+            return Collections.singletonList(target);
         }
 
         @Override
         protected void serialize( final Kryo kryo, final Output output ) {
             super.serialize(kryo, output);
-            output.writeInt(mateContigIndex);
-            output.writeInt(mateStartPosition);
+            output.writeInt(target.getContig());
+            output.writeInt(target.getStart());
+            output.writeInt(target.getEnd());
         }
 
         @Override
         public String toString() {
-            return super.toString() + " IntercontigPair " + mateContigIndex;
+            return super.toString() + "\tIntercontigPair\t" + target;
         }
 
         public static final class Serializer extends com.esotericsoftware.kryo.Serializer<InterContigPair> {
@@ -280,17 +363,59 @@ public class BreakpointEvidence {
         }
     }
 
+    /**
+     * Finds the coordinates implicated by the read's mate as being part of the breakpoint, ie. the coordinates
+     * to the 3' end of the mate, where the breakpoint might lie. Given that we don't have the actual mate read here,
+     * we make two small assumptions: first, that the length of the mate is equal to the length of the read we are looking at.
+     * Second, since we don't have the mate's CIGAR we can't actually compute the end coordinates of the mate alignment,
+     * which might be pushed away from where we think it is by a large indel.
+     */
+    private static SVInterval getMateTargetInterval(final GATKRead read, final ReadMetadata metadata) {
+        final int mateContigIndex = metadata.getContigID(read.getMateContig());
+        final int mateStartPosition = read.getMateStart();
+        final boolean mateReverseStrand = read.mateIsReverseStrand();
+        final int medianFragmentSize = metadata.getStatistics(read.getReadGroup()).getMedianFragmentSize();
+        return new SVInterval(mateContigIndex,
+                mateReverseStrand ? mateStartPosition - medianFragmentSize : mateStartPosition + read.getLength(),
+                mateReverseStrand ? mateStartPosition : mateStartPosition + read.getLength() + medianFragmentSize);
+    }
+
     @DefaultSerializer(OutiesPair.Serializer.class)
     public static final class OutiesPair extends BreakpointEvidence {
+        private final SVInterval target;
+
         OutiesPair( final GATKRead read, final ReadMetadata metadata ) {
             super(read, metadata);
+            target = BreakpointEvidence.getMateTargetInterval(read, metadata);
         }
 
-        private OutiesPair( final Kryo kryo, final Input input ) { super(kryo, input); }
+        private OutiesPair( final Kryo kryo, final Input input ) {
+            super(kryo, input);
+            target = new SVInterval(input.readInt(), input.readInt(), input.readInt());
+        }
+
+
+        @Override
+        protected void serialize( final Kryo kryo, final Output output ) {
+            super.serialize(kryo, output);
+            output.writeInt(target.getContig());
+            output.writeInt(target.getStart());
+            output.writeInt(target.getEnd());
+        }
+
+        @Override
+        public boolean hasDistalTargets() {
+            return true;
+        }
+
+        @Override
+        public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+            return Collections.singletonList(target);
+        }
 
         @Override
         public String toString() {
-            return super.toString() + " OutiesPair";
+            return super.toString() + "\tOutiesPair\t" + target;
         }
 
         public static final class Serializer extends com.esotericsoftware.kryo.Serializer<OutiesPair> {
@@ -308,15 +433,39 @@ public class BreakpointEvidence {
 
     @DefaultSerializer(SameStrandPair.Serializer.class)
     public static final class SameStrandPair extends BreakpointEvidence {
+        private final SVInterval target;
+
         SameStrandPair( final GATKRead read, final ReadMetadata metadata ) {
             super(read, metadata);
+            target = BreakpointEvidence.getMateTargetInterval(read, metadata);
         }
 
-        private SameStrandPair( final Kryo kryo, final Input input ) { super(kryo, input); }
+        private SameStrandPair( final Kryo kryo, final Input input ) {
+            super(kryo, input);
+            target = new SVInterval(input.readInt(), input.readInt(), input.readInt());
+        }
+
+        @Override
+        public boolean hasDistalTargets() {
+            return true;
+        }
+
+        @Override
+        public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+            return Collections.singletonList(target);
+        }
+
+        @Override
+        protected void serialize( final Kryo kryo, final Output output ) {
+            super.serialize(kryo, output);
+            output.writeInt(target.getContig());
+            output.writeInt(target.getStart());
+            output.writeInt(target.getEnd());
+        }
 
         @Override
         public String toString() {
-            return super.toString() + " SameStrandPair";
+            return super.toString() + "\tSameStrandPair\t" + target;
         }
 
         public static final class Serializer extends com.esotericsoftware.kryo.Serializer<SameStrandPair> {
@@ -335,26 +484,50 @@ public class BreakpointEvidence {
     @DefaultSerializer(WeirdTemplateSize.Serializer.class)
     public static final class WeirdTemplateSize extends BreakpointEvidence {
         private final int templateSize;
+        private final int mateStartPosition;
+        private final boolean mateReverseStrand;
+        private final SVInterval target;
 
         WeirdTemplateSize( final GATKRead read, final ReadMetadata metadata ) {
             super(read, metadata);
+            target = BreakpointEvidence.getMateTargetInterval(read, metadata);
             this.templateSize = read.getFragmentLength();
+            this.mateStartPosition = read.getMateStart();
+            this.mateReverseStrand = read.mateIsReverseStrand();
         }
 
         private WeirdTemplateSize( final Kryo kryo, final Input input ) {
             super(kryo, input);
             templateSize = input.readInt();
+            mateStartPosition = input.readInt();
+            mateReverseStrand = input.readBoolean();
+            target = new SVInterval(input.readInt(), input.readInt(), input.readInt());
+        }
+
+        @Override
+        public boolean hasDistalTargets() {
+            return true;
+        }
+
+        @Override
+        public List<SVInterval> getDistalTargets(final ReadMetadata readMetadata) {
+            return Collections.singletonList(target);
         }
 
         @Override
         protected void serialize( final Kryo kryo, final Output output ) {
             super.serialize(kryo, output);
             output.writeInt(templateSize);
+            output.writeInt(mateStartPosition);
+            output.writeBoolean(mateReverseStrand);
+            output.writeInt(target.getContig());
+            output.writeInt(target.getStart());
+            output.writeInt(target.getEnd());
         }
 
         @Override
         public String toString() {
-            return super.toString() + " TemplateSize " + templateSize;
+            return super.toString() + "\tTemplateSize\t" + target + "\t" + templateSize;
         }
 
         public static final class Serializer extends com.esotericsoftware.kryo.Serializer<WeirdTemplateSize> {
@@ -369,4 +542,5 @@ public class BreakpointEvidence {
             }
         }
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVInterval.java
@@ -107,4 +107,5 @@ public final class SVInterval implements Comparable<SVInterval> {
             return new SVInterval(kryo, input);
         }
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -41,6 +41,10 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
                 fullName = "minEvidenceCount")
         public int minEvidenceCount = defaultParams.minEvidenceCount;
 
+        @Argument(doc = "Minimum number of reads in cluster that share the same target locus to declare an interval of interest.",
+                fullName = "minCoherentEvidenceCount")
+        public int minCoherentEvidenceCount = defaultParams.minCoherentEvidenceCount;
+
         @Argument(doc = "Minimum number of localizing kmers in a valid interval.", fullName="minKmersPerInterval")
         public int minKmersPerInterval = defaultParams.minKmersPerInterval;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointClustererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/BreakpointClustererUnitTest.java
@@ -1,0 +1,93 @@
+package org.broadinstitute.hellbender.tools.spark.sv;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class BreakpointClustererUnitTest extends BaseTest {
+
+    @DataProvider(name = "simpleEvidenceClusters")
+    public Object[][] simpleEvidence() {
+        final SAMFileHeader artificialSamHeader = ArtificialReadUtils.createArtificialSamHeaderWithGroups(2, 1, 1000000, 1);
+
+        final List<BreakpointEvidence> evidenceList = new ArrayList<>(5);
+
+        final ReadMetadata readMetadata = new ReadMetadata(new HashSet<Integer>(), artificialSamHeader,
+                new ReadMetadata.ReadGroupFragmentStatistics(350, 40, 40),
+                1, 100, 10, 30);
+
+        final BreakpointEvidence splitEvidence1 = new BreakpointEvidence.SplitRead(ArtificialReadUtils.createArtificialRead(artificialSamHeader,
+                "1", "1", 1000,
+                ArtificialReadUtils.createRandomReadBases(151, false),
+                ArtificialReadUtils.createRandomReadQuals(151),
+                "100M50S"), readMetadata, false);
+        evidenceList.add(splitEvidence1);
+
+        final BreakpointEvidence splitEvidence2 = new BreakpointEvidence.SplitRead(ArtificialReadUtils.createArtificialRead(artificialSamHeader,
+                "1", "1", 1010,
+                ArtificialReadUtils.createRandomReadBases(151, false),
+                ArtificialReadUtils.createRandomReadQuals(151),
+                "90M60S"), readMetadata, false);
+        evidenceList.add(splitEvidence2);
+
+        final List<GATKRead> pair1 = ArtificialReadUtils.createPair(artificialSamHeader, "pair1", 151, 1250, 500000, true, false);
+        evidenceList.add(new BreakpointEvidence.WeirdTemplateSize(pair1.get(0), readMetadata));
+
+        final List<GATKRead> pair2 = ArtificialReadUtils.createPair(artificialSamHeader, "pair1", 151, 1255, 500000, true, false);
+        evidenceList.add(new BreakpointEvidence.WeirdTemplateSize(pair2.get(0), readMetadata));
+
+        final List<GATKRead> pair3 = ArtificialReadUtils.createPair(artificialSamHeader, "pair1", 151, 1350, 500000, true, false);
+        evidenceList.add(new BreakpointEvidence.WeirdTemplateSize(pair3.get(0), readMetadata));
+
+        return new Object[][] {{readMetadata, evidenceList}};
+    }
+
+
+    @Test(dataProvider = "simpleEvidenceClusters")
+    public void testGetBreakpointClusters(final ReadMetadata readMetadata, final List<BreakpointEvidence> evidenceList) {
+
+        BreakpointClusterer breakpointClusterer = new BreakpointClusterer(readMetadata, 3, 3, evidenceList.iterator());
+
+        Assert.assertFalse(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(0).getLocation()));
+        Assert.assertFalse(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(1).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(2).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(3).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(4).getLocation()));
+
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(2));
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(3));
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(4));
+        Assert.assertFalse(breakpointClusterer.hasNext());
+    }
+
+    @Test(dataProvider = "simpleEvidenceClusters")
+    public void testGetBreakpointClustersWithCoherentEvidence(final ReadMetadata readMetadata, final List<BreakpointEvidence> evidenceList) {
+
+        BreakpointClusterer breakpointClusterer = new BreakpointClusterer(readMetadata, 5, 3, evidenceList.iterator());
+
+        Assert.assertFalse(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(0).getLocation()));
+        Assert.assertFalse(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(1).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(2).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(3).getLocation()));
+        Assert.assertTrue(breakpointClusterer.hasEnoughOverlappers(evidenceList.get(4).getLocation()));
+
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(2));
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(3));
+        Assert.assertTrue(breakpointClusterer.hasNext());
+        Assert.assertEquals(breakpointClusterer.next(), evidenceList.get(4));
+        Assert.assertFalse(breakpointClusterer.hasNext());
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ReadClassifierTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ReadClassifierTest.java
@@ -48,7 +48,6 @@ public class ReadClassifierTest extends BaseTest {
         checkClassification(classifier, read, Collections.singletonList(new BreakpointEvidence.OutiesPair(read, readMetadata)));
         read.setMatePosition(read.getContig(), read.getStart() + 2);
         checkClassification(classifier, read, Collections.emptyList());
-
         read.setMatePosition(read.getContig(), read.getStart() + 2 + ReadClassifier.ALLOWED_SHORT_FRAGMENT_OVERHANG);
         checkClassification(classifier, read, Collections.singletonList(new BreakpointEvidence.OutiesPair(read, readMetadata)));
 


### PR DESCRIPTION
…bly to be activated if a mininum number of pieces of evidence agree on the distal target.

Also:

- Some refactoring of the SATagAlignment and builder classes to support better treatment of SA tags.
- Increased the spark network timeout values for the SV pipeline to prevent nodes from losing heartbeats and being orphaned with running tasks. Since I made this change I have not had the issue.

On the performance of this change on our calls:

I compared this branch with master. Master's results on the CHM1/13 mix:

```
16:57:37.270 INFO  StructuralVariationDiscoveryPipelineSpark - Metadata retrieved.
16:58:20.436 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 25977 intervals.
16:58:20.517 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 377 intervals that were near reference gaps.
16:58:49.939 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 175 intervals that had >1000x coverage.
16:59:33.036 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 8773016 mapped template names.
17:00:07.058 INFO  StructuralVariationDiscoveryPipelineSpark - Ignoring 19200460 genomically common kmers.
17:05:25.896 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 34752266 kmers.
17:10:46.253 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 31945322 unique template names for assembly.
17:45:06.748 INFO  StructuralVariationDiscoveryPipelineSpark - Wrote SAM file of aligned contigs.
17:45:26.199 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 5716 variants.
17:45:26.210 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 231
17:45:26.210 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 3262
17:45:26.210 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 1065
17:45:26.210 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 1158
17:45:26.397 INFO  StructuralVariationDiscoveryPipelineSpark - Shutting down engine
[May 8, 2017 5:45:26 PM UTC] org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryPipelineSpark done. Elapsed time: 48.71 minutes.
Runtime.totalMemory()=17815830528
```

This branch with `minCoherentEvidence` set to 7 (and `minEvidenceCount` remaining at 15):

```
18:55:30.222 INFO  StructuralVariationDiscoveryPipelineSpark - Metadata retrieved.
18:56:15.451 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 30678 intervals.
18:56:15.547 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 387 intervals that were near reference gaps.
18:56:45.252 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 174 intervals that had >1000x coverage.
18:57:27.031 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 9424481 mapped template names.
18:58:07.742 INFO  StructuralVariationDiscoveryPipelineSpark - Ignoring 19200460 genomically common kmers.
19:03:21.960 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 39309565 kmers.
19:08:31.990 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 34034345 unique template names for assembly.
19:40:40.149 INFO  StructuralVariationDiscoveryPipelineSpark - Wrote SAM file of aligned contigs.
19:41:00.570 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 6239 variants.
19:41:00.582 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 238
19:41:00.582 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 3639
19:41:00.582 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 1119
19:41:00.582 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 1243
19:41:00.767 INFO  StructuralVariationDiscoveryPipelineSpark - Shutting down engine
[May 8, 2017 7:41:00 PM UTC] org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryPipelineSpark done. Elapsed time: 46.37 minutes.
```

This branch with `minCoherentEvidenceCount` set to 4:

```
19:48:13.982 INFO  StructuralVariationDiscoveryPipelineSpark - Metadata retrieved.
19:48:57.930 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 52918 intervals.
19:48:58.053 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 417 intervals that were near reference gaps.
19:49:27.873 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 177 intervals that had >1000x coverage.
19:50:09.183 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 12444440 mapped template names.
19:50:59.411 INFO  StructuralVariationDiscoveryPipelineSpark - Ignoring 19200460 genomically common kmers.
19:57:19.267 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 62077256 kmers.
20:03:43.231 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 42811284 unique template names for assembly.
21:11:03.427 INFO  StructuralVariationDiscoveryPipelineSpark - Wrote SAM file of aligned contigs.
21:11:24.841 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 6799 variants.
21:11:24.854 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 253
21:11:24.855 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 4002
21:11:24.855 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 1179
21:11:24.855 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 1365
21:11:25.045 INFO  StructuralVariationDiscoveryPipelineSpark - Shutting down engine
[May 8, 2017 9:11:25 PM UTC] org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryPipelineSpark done. Elapsed time: 84.05 minutes.
Runtime.totalMemory()=15439757312
```

Master with `minEvidenceCount` set to 7:

```
15:51:52.187 INFO  StructuralVariationDiscoveryPipelineSpark - Metadata retrieved.
15:52:34.778 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 185595 intervals.
15:52:34.923 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 434 intervals that were near reference gaps.
15:53:05.883 INFO  StructuralVariationDiscoveryPipelineSpark - Killed 188 intervals that had >1000x coverage.
15:54:13.400 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 29691982 mapped template names.
15:54:45.921 INFO  StructuralVariationDiscoveryPipelineSpark - Ignoring 19200460 genomically common kmers.
16:05:36.053 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 191872350 kmers.
```
Which I killed after 108 minutes since it seemed to be stalled.

When examining deletion calls from the run with `minCoherentEvidenceCount` set to 7:

There are 294 new deletion calls that don't have 50% reciprocal overlap with a call made by the master branch. Of those, 143 have 50% reciprocal overlap with a call made in the haploid assembly of CHM1, and 121 overlap with a PacBio call for CHM13. Manual inspection also suggests that most of these calls match a call in the truth set, most of them heterozygous.

The value to set for `minCoherentEvidence` should eventually be tuned, adjusted for coverage, etc, in our work to make a better evidence model, but for now this seems like a good way to add a number of good-quality het calls to our output without sacrificing too much performance (I got a faster runtime with this branch but that must be due to run-to-run-variance).

@tedsharpe  @SHuang-Broad please review.