### PR TITLE
ProgressMeter: allow labels to be configurable per-traversal/tool, and hook up to GenomicsDBImport

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -117,6 +117,9 @@ public abstract class AssemblyRegionWalker extends GATKTool {
     @Override
     public final boolean requiresReference() { return true; }
 
+    @Override
+    public String getProgressMeterRecordLabel() { return "regions"; }
+    
     private List<LocalReadShard> readShards;
     private Shard<GATKRead> currentReadShard;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
@@ -29,6 +29,9 @@ public abstract class FeatureWalker<F extends Feature> extends GATKTool {
     public boolean requiresFeatures(){
         return true;
     }
+    
+    @Override
+    public String getProgressMeterRecordLabel() { return "features"; }
 
     @Override
     void initializeFeatures() {

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -139,7 +139,7 @@ public abstract class GATKTool extends CommandLineProgram {
      * {@link ProgressMeter#update(Locatable)} after each record processed from
      * the primary input in their {@link #traverse} method.
      */
-    ProgressMeter progressMeter;
+    protected ProgressMeter progressMeter;
 
     /**
      * Return the list of GATKCommandLinePluginDescriptors to be used for this tool.
@@ -258,6 +258,12 @@ public abstract class GATKTool extends CommandLineProgram {
     public int getDefaultCloudIndexPrefetchBufferSize() {
         return -1;
     }
+
+    /**
+     * @return String label to use for records in progress meter output. Defaults to {@link ProgressMeter#DEFAULT_RECORD_LABEL},
+     *         but tools may override to provide a more appropriate label (like "reads" or "regions")
+     */
+    public String getProgressMeterRecordLabel() { return ProgressMeter.DEFAULT_RECORD_LABEL; }
 
     /**
      * Initialize our source of reference data (or set it to null if no reference argument was provided).
@@ -516,6 +522,7 @@ public abstract class GATKTool extends CommandLineProgram {
         checkToolRequirements();
 
         progressMeter = new ProgressMeter(secondsBetweenProgressUpdates);
+        progressMeter.setRecordLabel(getProgressMeterRecordLabel());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/IntervalWalker.java
@@ -25,6 +25,9 @@ public abstract class IntervalWalker extends GATKTool {
         return true;
     }
 
+    @Override
+    public String getProgressMeterRecordLabel() { return "intervals"; }
+
     /**
      * Customize initialization of the Feature data source for this traversal type to disable query lookahead.
      */

--- a/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/LocusWalker.java
@@ -55,6 +55,9 @@ public abstract class LocusWalker extends GATKTool {
         return true;
     }
 
+    @Override
+    public String getProgressMeterRecordLabel() { return "loci"; }
+
     /**
      * Does this tool require deletions in the AlignmentContext? Tools that don't should override to return {@code false}.
      *

--- a/src/main/java/org/broadinstitute/hellbender/engine/ProgressMeter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ProgressMeter.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.util.Locatable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -50,6 +51,11 @@ public final class ProgressMeter {
      * Number of milliseconds in a minute
      */
     public static final long MILLISECONDS_PER_MINUTE = MILLISECONDS_PER_SECOND * 60L;
+
+    /**
+     * Default label for records in logger messages. For display purposes only.
+     */
+    public static final String DEFAULT_RECORD_LABEL = "records";
 
     /**
      * We output a line to the logger after this many seconds have elapsed
@@ -115,6 +121,11 @@ public final class ProgressMeter {
     private boolean stopped;
 
     /**
+     * Label for records in logger messages. For display purposes only.
+     */
+    private String recordLabel = DEFAULT_RECORD_LABEL;
+
+    /**
      * Create a progress meter with the default update interval of {@link #DEFAULT_SECONDS_BETWEEN_UPDATES} seconds
      * and the default time function {@link #DEFAULT_TIME_FUNCTION}.
      */
@@ -158,6 +169,16 @@ public final class ProgressMeter {
      */
     public void setRecordsBetweenTimeChecks( final long recordsBetweenTimeChecks ) {
         this.recordsBetweenTimeChecks = recordsBetweenTimeChecks;
+    }
+
+    /**
+     * Change the label used for records in logger messages. Default label is {@link #DEFAULT_RECORD_LABEL}
+     *
+     * @param label Label to use for records in logger messages. Not null.
+     */
+    public void setRecordLabel( final String label ) {
+        Utils.nonNull(label);
+        this.recordLabel = label;
     }
 
     /**
@@ -210,7 +231,9 @@ public final class ProgressMeter {
         Utils.validate( !stopped, "the progress meter has been stopped already");
         this.stopped = true;
         currentTimeMs = timeFunction.getAsLong();
-        logger.info(String.format("Traversal complete. Processed %d total records in %.1f minutes.", numRecordsProcessed, elapsedTimeInMinutes()));
+        // Output progress a final time at the end
+        printProgress();
+        logger.info(String.format("Traversal complete. Processed %d total %s in %.1f minutes.", numRecordsProcessed, recordLabel, elapsedTimeInMinutes()));
     }
 
     /**
@@ -218,7 +241,9 @@ public final class ProgressMeter {
      */
     private void printHeader() {
         logger.info(String.format("%20s  %15s  %20s  %15s",
-                                  "Current Locus", "Elapsed Minutes", "Records Processed", "Records/Minute"));
+                                  "Current Locus", "Elapsed Minutes",
+                                  StringUtils.capitalize(recordLabel) + " Processed",
+                                  StringUtils.capitalize(recordLabel) + "/Minute"));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -36,6 +36,9 @@ public abstract class ReadWalker extends GATKTool {
         return true;
     }
 
+    @Override
+    public String getProgressMeterRecordLabel() { return "reads"; }
+
     /**
      * This number controls the size of the cache for our FeatureInputs
      * (specifically, the number of additional bases worth of overlapping records to cache when querying feature sources).

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
@@ -35,6 +35,9 @@ public abstract class VariantWalkerBase extends GATKTool {
     public boolean requiresFeatures() { return true; }
 
     @Override
+    public String getProgressMeterRecordLabel() { return "variants"; }
+
+    @Override
     void initializeFeatures() {
 
         //Note: we override this method because we don't want to set feature manager to null if there are no FeatureInputs.

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -169,6 +169,9 @@ public final class GenomicsDBImport extends GATKTool {
         return 2;
     }
 
+    @Override
+    public String getProgressMeterRecordLabel() { return "batches"; }
+
     // Intervals from command line (singleton for now)
     private List<ChromosomeInterval> intervals;
 
@@ -331,6 +334,8 @@ public final class GenomicsDBImport extends GATKTool {
      */
     @Override
     public void traverse() {
+        // Force the progress meter to update after every batch
+        progressMeter.setRecordsBetweenTimeChecks(1L);
 
         final int sampleCount = sampleNameToVcfUri.size();
         final int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleCount : batchSize;
@@ -364,6 +369,7 @@ public final class GenomicsDBImport extends GATKTool {
             }
 
             closeReaders(sampleToReaderMap);
+            progressMeter.update(intervals.get(0));
             logger.info("Done importing batch " + batchCount + "/" + totalBatchCount);
         }
     }


### PR DESCRIPTION
-Tools can now customize the progress meter to use a different word than
 "records" in its output (eg., "reads", "regions", etc.)

-Updated standard walker classes to specify appropriate labels

-Hooked up GenomicsDBImport to the progress meter (it was always reporting
 "Processed 0 records" at traversal end)

Resolves #1943
Resolves #2683