### PR TITLE
Added FPGA support to PairHMM via GKL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.4.3') {
+    compile('com.intel.gkl:gkl:0.5.2') {
         exclude module: 'htsjdk'
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
@@ -65,6 +65,13 @@ public abstract class PairHMM implements Closeable{
             logger.info("Using the OpenMP multi-threaded AVX-accelerated native PairHMM implementation");
             return hmm;
         }),
+        /* FPGA implementation of LOGLESS_CACHING called through JNI. Throws if FPGA is not available */
+        EXPERIMENTAL_FPGA_LOGLESS_CACHING(args -> {
+            // Constructor will throw a UserException if FPGA is not available
+            final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.FPGA, args);
+            logger.info("Using the FPGA-accelerated native PairHMM implementation");
+            return hmm;
+        }),
         /* Uses the fastest available PairHMM implementation supported on the platform.
            Order of precedence:
             1. AVX_LOGLESS_CACHING_OMP
@@ -72,6 +79,17 @@ public abstract class PairHMM implements Closeable{
             3. LOGLESS_CACHING
          */
         FASTEST_AVAILABLE(args -> {
+            // This try block is temporarily commented out becuase FPGA support is experimental for the time being. Once
+            // FPGA support has matured/been properly tested, we can easily add it back the "fastest available" logic
+            // by uncommenting this block
+            // try {
+            //    final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.FPGA, args);
+            //    logger.info("Using the FPGA-accelerated native PairHMM implementation");
+            //    return hmm;
+            //}
+            //catch ( UserException.HardwareFeatureException e ) {
+            //    logger.info("FPGA-accelerated native PairHMM implementation is not supported");
+            //}
             try {
                 final VectorLoglessPairHMM hmm = new VectorLoglessPairHMM(VectorLoglessPairHMM.Implementation.OMP, args);
                 logger.info("Using the OpenMP multi-threaded AVX-accelerated native PairHMM implementation");

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.pairhmm;
 
 import com.intel.gkl.pairhmm.IntelPairHmm;
 import com.intel.gkl.pairhmm.IntelPairHmmOMP;
+import com.intel.gkl.pairhmm.IntelPairHmmFpga;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.pairhmm.HaplotypeDataHolder;
@@ -34,7 +35,11 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
         /**
          * OpenMP multi-threaded AVX-accelerated version of PairHMM
          */
-        OMP
+        OMP,
+        /**
+         * FPGA-accelerated version of PairHMM
+         */
+        FPGA
     }
 
     private static final Logger logger = LogManager.getLogger(VectorLoglessPairHMM.class);
@@ -72,7 +77,14 @@ public final class VectorLoglessPairHMM extends LoglessPairHMM {
                 if (!isSupported) {
                     throw new UserException.HardwareFeatureException("Machine does not support OpenMP AVX PairHMM.");
                 }
-                logger.info("Maximum number of OpenMP threads for AVX : " + args.maxNumberOfThreads);
+                break;
+
+            case FPGA:
+                pairHmm = new IntelPairHmmFpga();
+                isSupported = pairHmm.load(null);
+                if (!isSupported) {
+                    throw new UserException.HardwareFeatureException("Machine does not support FPGA PairHMM.");
+                }
                 break;
 
             default:


### PR DESCRIPTION
This also includes:
* Added FPGA to ```Implementation``` enum of ```VectorLoglessPairHMM```
* Added FPGA to ```Implementation``` enum of ```PairHMM```
* Updated ```FASTEST_AVAILABLE``` value to try FPGA first (then AVX+OMP, then AVX, then regular)