### PR TITLE
Supporting empty loci emission for Spark tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.hellbender.engine.spark;
 
-import com.google.common.collect.ImmutableList;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -14,7 +12,7 @@ import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
+import org.broadinstitute.hellbender.utils.locusiterator.AlignmentContextIteratorBuilder;
 import org.broadinstitute.hellbender.utils.locusiterator.LIBSDownsamplingInfo;
 import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -66,6 +64,20 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
     }
 
     /**
+     * Does this tool emit information for uncovered loci? Tools that do should override to return {@code true}.
+     *
+     * NOTE:  Typically, this should only be used when intervals are specified.
+     * NOTE:  If MappedReadFilter is removed, then emitting empty loci will fail.
+     * NOTE:  If there is no available sequence dictionary and this is set to true, there should be a failure.  Please
+     *  consider requiring reads and/or references for all tools that wish to set this to {@code true}.
+     *
+     * @return {@code true} if this tool requires uncovered loci information to be emitted, {@code false} otherwise
+     */
+    public boolean emitEmptyLoci() {
+        return false;
+    }
+
+    /**
      * Loads alignments and the corresponding reference and features into a {@link JavaRDD} for the intervals specified.
      *
      * If no intervals were specified, returns all the alignments.
@@ -82,7 +94,7 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
         JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, getReads(), GATKRead.class, sequenceDictionary, intervalShards, maxLocatableSize, shuffle);
         Broadcast<ReferenceMultiSource> bReferenceSource = hasReference() ? ctx.broadcast(getReference()) : null;
         Broadcast<FeatureManager> bFeatureManager = features == null ? null : ctx.broadcast(features);
-        return shardedReads.flatMap(getAlignmentsFunction(bReferenceSource, bFeatureManager, sequenceDictionary, getHeaderForReads(), getDownsamplingInfo()));
+        return shardedReads.flatMap(getAlignmentsFunction(bReferenceSource, bFeatureManager, sequenceDictionary, getHeaderForReads(), getDownsamplingInfo(), emitEmptyLoci()));
     }
 
     /**
@@ -96,7 +108,7 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
      */
     private static FlatMapFunction<Shard<GATKRead>, LocusWalkerContext> getAlignmentsFunction(
             Broadcast<ReferenceMultiSource> bReferenceSource, Broadcast<FeatureManager> bFeatureManager,
-            SAMSequenceDictionary sequenceDictionary, SAMFileHeader header, LIBSDownsamplingInfo downsamplingInfo) {
+            SAMSequenceDictionary sequenceDictionary, SAMFileHeader header, LIBSDownsamplingInfo downsamplingInfo, boolean isEmitEmptyLoci) {
         return (FlatMapFunction<Shard<GATKRead>, LocusWalkerContext>) shardedRead -> {
             SimpleInterval interval = shardedRead.getInterval();
             SimpleInterval paddedInterval = shardedRead.getPaddedInterval();
@@ -105,13 +117,20 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
                     new ReferenceMemorySource(bReferenceSource.getValue().getReferenceBases(null, paddedInterval), sequenceDictionary);
             FeatureManager fm = bFeatureManager == null ? null : bFeatureManager.getValue();
 
-            final Set<String> samples = header.getReadGroups().stream()
-                    .map(SAMReadGroupRecord::getSample)
-                    .collect(Collectors.toSet());
-            LocusIteratorByState libs = new LocusIteratorByState(readIterator, downsamplingInfo, false, samples, header, true, false);
-            IntervalOverlappingIterator<AlignmentContext> alignmentContexts = new IntervalOverlappingIterator<>(libs, ImmutableList.of(interval), sequenceDictionary);
-            final Spliterator<AlignmentContext> alignmentContextSpliterator = Spliterators.spliteratorUnknownSize(alignmentContexts, 0);
-            return StreamSupport.stream(alignmentContextSpliterator, false).map(alignmentContext -> {
+            final SAMSequenceDictionary referenceDictionary = reference == null? null : reference.getSequenceDictionary();
+
+            final AlignmentContextIteratorBuilder alignmentContextIteratorBuilder = new AlignmentContextIteratorBuilder();
+            alignmentContextIteratorBuilder.setDownsamplingInfo(downsamplingInfo);
+            alignmentContextIteratorBuilder.setEmitEmptyLoci(isEmitEmptyLoci);
+            alignmentContextIteratorBuilder.setIncludeDeletions(true);
+            alignmentContextIteratorBuilder.setKeepUniqueReadListInLibs(false);
+            alignmentContextIteratorBuilder.setIncludeNs(false);
+
+            final Iterator<AlignmentContext> alignmentContextIterator = alignmentContextIteratorBuilder.build(
+                    readIterator, header, Collections.singletonList(interval), sequenceDictionary,
+                    reference != null);
+
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(alignmentContextIterator, 0), false).map(alignmentContext -> {
                 final SimpleInterval alignmentInterval = new SimpleInterval(alignmentContext);
                 return new LocusWalkerContext(alignmentContext, new ReferenceContext(reference, alignmentInterval), new FeatureContext(fm, alignmentInterval));
             }).iterator();

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/AlignmentContextIteratorBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/AlignmentContextIteratorBuilder.java
@@ -1,0 +1,176 @@
+package org.broadinstitute.hellbender.utils.locusiterator;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.AlignmentContext;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.iterators.IntervalLocusIterator;
+import org.broadinstitute.hellbender.utils.iterators.IntervalOverlappingIterator;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Create an iterator for traversing alignment contexts in a specified manner.  This class should be able to support both spark and non-spark LocusWalker
+ */
+public class AlignmentContextIteratorBuilder {
+
+    protected static final Logger logger = LogManager.getLogger(AlignmentContextIteratorBuilder.class);
+
+    private boolean isEmitEmptyLoci;
+    private boolean isKeepUniqueReadListInLibs;
+    private boolean isIncludeDeletions;
+    private boolean isIncludeNs;
+    private LIBSDownsamplingInfo downsamplingInfo;
+
+    public boolean isEmitEmptyLoci() {
+        return isEmitEmptyLoci;
+    }
+
+    public void setEmitEmptyLoci(boolean emitEmptyLoci) {
+        isEmitEmptyLoci = emitEmptyLoci;
+    }
+
+    public boolean isKeepUniqueReadListInLibs() {
+        return isKeepUniqueReadListInLibs;
+    }
+
+    public void setKeepUniqueReadListInLibs(boolean keepUniqueReadListInLibs) {
+        isKeepUniqueReadListInLibs = keepUniqueReadListInLibs;
+    }
+
+    public boolean isIncludeDeletions() {
+        return isIncludeDeletions;
+    }
+
+    public void setIncludeDeletions(boolean includeDeletions) {
+        isIncludeDeletions = includeDeletions;
+    }
+
+    public boolean isIncludeNs() {
+        return isIncludeNs;
+    }
+
+    public void setIncludeNs(boolean includeNs) {
+        isIncludeNs = includeNs;
+    }
+
+    public LIBSDownsamplingInfo getDownsamplingInfo() {
+        return downsamplingInfo;
+    }
+
+    public void setDownsamplingInfo(LIBSDownsamplingInfo downsamplingInfo) {
+        this.downsamplingInfo = downsamplingInfo;
+    }
+
+    public AlignmentContextIteratorBuilder() {
+        isEmitEmptyLoci = false;
+        isKeepUniqueReadListInLibs = false;
+        isIncludeDeletions = true;
+        isIncludeNs = false;
+        downsamplingInfo = LocusIteratorByState.NO_DOWNSAMPLING;
+    }
+
+    /**
+     *  Have this builder return an instance of the iterator as specified by the caller.
+     *
+     * @param readIterator iterator of sorted GATK reads.  Not {@code null}
+     * @param header SAM file header to use.  Not {@code null}
+     * @param intervalsForTraversal the intervals to generate alignment contexts over.
+     * @param dictionary the SAMSequenceDictionary being used for this traversal.  This can be the same as the reference.  {@code null} is supported, but will often lead to invalid parameter combinations.
+     * @param isReference {@code true} if the specified dictionary came from a reference.  {@code false} otherwise.  If dictionary is {@code null}, this parameter is ignored.
+     * @return iterator that produces AlignmentContexts ready for consumption (e.g. by a {@link org.broadinstitute.hellbender.engine.LocusWalker})
+     */
+    public Iterator<AlignmentContext> build(final Iterator<GATKRead> readIterator, final SAMFileHeader header, final List<SimpleInterval> intervalsForTraversal, final SAMSequenceDictionary dictionary, final boolean isReference) {
+        Utils.nonNull(header, "Header cannot be null");
+        Utils.nonNull(readIterator, "Read iterator cannot be null");
+        final boolean isDefinitelyReference = (dictionary != null) && isReference ;
+        return createAlignmentContextIterator(intervalsForTraversal, header, readIterator, dictionary, downsamplingInfo,
+                isDefinitelyReference, isEmitEmptyLoci, isKeepUniqueReadListInLibs, isIncludeDeletions, isIncludeNs);
+    }
+
+    /**
+     *  Create the appropriate instance of an alignment context spliterator based on the input parameters.
+     *
+     *  Please note that this wrapper is still tied to {@link LocusIteratorByState} and some parameters are being passed directly to that class.
+     *
+     * @param intervalsForTraversal the intervals to generate alignment contexts over.
+     * @param header SAM file header to use
+     * @param readIterator iterator of sorted GATK reads
+     * @param dictionary the SAMSequenceDictionary being used for this traversal.  This can be the same as the reference.  {@code null} is supported, but will often lead to invalid parameter combinations.
+     * @param downsamplingInfo how to downsample (for {@link LocusIteratorByState})
+     * @param isReference the dictionary specified above is a reference, {@code false} if no reference being used or it is not a reference.
+     * @param emitEmptyLoci whether loci with no coverage should be emitted.  In this case, the AlignmentContext will be empty (not null).
+     * @param isKeepUniqueReadListInLibs if true, we will keep the unique reads from the samIterator and make them
+     *                                       available via the transferReadsFromAllPreviousPileups interface (this parameter is specific to {@link LocusIteratorByState})
+     * @param isIncludeDeletions include reads with deletion on the loci in question
+     * @param isIncludeNs include reads with N on the loci in question
+     * @return iterator that produces AlignmentContexts ready for consumption (e.g. by a {@link org.broadinstitute.hellbender.engine.LocusWalker})
+     */
+    private static Iterator<AlignmentContext> createAlignmentContextIterator(final List<SimpleInterval> intervalsForTraversal,
+                                                                            final SAMFileHeader header,
+                                                                               final Iterator<GATKRead> readIterator,
+                                                                               final SAMSequenceDictionary dictionary,
+                                                                               final LIBSDownsamplingInfo downsamplingInfo,
+                                                                               final boolean isReference,
+                                                                               boolean emitEmptyLoci,
+                                                                               boolean isKeepUniqueReadListInLibs,
+                                                                               boolean isIncludeDeletions,
+                                                                               boolean isIncludeNs) {
+
+        // get the samples from the read groups
+        final Set<String> samples = header.getReadGroups().stream()
+                .map(SAMReadGroupRecord::getSample)
+                .collect(Collectors.toSet());
+
+        // get the LIBS
+        final LocusIteratorByState libs = new LocusIteratorByState(readIterator, downsamplingInfo, isKeepUniqueReadListInLibs, samples, header, isIncludeDeletions, isIncludeNs);
+
+        List<SimpleInterval> finalIntervals = intervalsForTraversal;
+        validateEmitEmptyLociParameters(emitEmptyLoci, dictionary, intervalsForTraversal, isReference);
+        if (emitEmptyLoci) {
+
+            // If no intervals were specified, then use the entire reference (or best available sequence dictionary).
+            if (!areIntervalsSpecified(finalIntervals)) {
+                finalIntervals = IntervalUtils.getAllIntervalsForReference(dictionary);
+            }
+            final IntervalLocusIterator intervalLocusIterator = new IntervalLocusIterator(finalIntervals.iterator());
+            return new IntervalAlignmentContextIterator(libs, intervalLocusIterator, header.getSequenceDictionary());
+        } else if (areIntervalsSpecified(finalIntervals)) {
+            return new IntervalOverlappingIterator<>(libs, finalIntervals, header.getSequenceDictionary());
+        } else {
+            // prepare the iterator
+            return libs;
+        }
+    }
+
+    private static boolean areIntervalsSpecified(final List<SimpleInterval> finalIntervals) {
+        return finalIntervals != null;
+    }
+
+    /**
+     *  The emit empty loci parameter comes with several pitfalls when used incorrectly.  Here we check and either give
+     *   warnings or errors.
+     */
+    static private void validateEmitEmptyLociParameters(boolean emitEmptyLoci, final SAMSequenceDictionary dictionary, final List<SimpleInterval> intervals, final boolean isReference) {
+        if (emitEmptyLoci) {
+            if ((dictionary == null) && !isReference) {
+                throw new UserException.MissingReference("No sequence dictionary nor reference specified.  Therefore, emitting empty loci is impossible and this tool cannot be run.  The easiest fix here is to specify a reference dictionary.");
+            }
+            if (!isReference && !areIntervalsSpecified(intervals)) {
+                logger.warn("****************************************");
+                logger.warn("* Running this tool without a reference nor intervals can yield unexpected results, since it will emit results for loci with no reads.  A sequence dictionary has been found and the intervals will be derived from this.  The easiest way avoid this message is to specify a reference.");
+                logger.warn("****************************************");
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIterator.java
@@ -1,9 +1,11 @@
-package org.broadinstitute.hellbender.utils.iterators;
+package org.broadinstitute.hellbender.utils.locusiterator;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.iterators.IntervalLocusIterator;
+import org.broadinstitute.hellbender.utils.locusiterator.AlignmentContextIteratorBuilder;
 import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
 
 import java.util.ArrayList;
@@ -23,7 +25,15 @@ public class IntervalAlignmentContextIterator implements Iterator<AlignmentConte
     private AlignmentContext currentAlignmentContext;
     private SAMSequenceDictionary dictionary;
 
-    public IntervalAlignmentContextIterator(final Iterator<AlignmentContext> alignmentContextIterator, final IntervalLocusIterator intervalLocusIterator, final SAMSequenceDictionary dictionary) {
+
+    /**
+     *  Note:  Typically, if you are calling this from a walker tool, you want to use {@link AlignmentContextIteratorBuilder}
+     *
+     * @param alignmentContextIterator iterator for alignment context
+     * @param intervalLocusIterator an iterator that will traverse all relevant loci
+     * @param dictionary reference or best available dictionary.
+     */
+    IntervalAlignmentContextIterator(Iterator<AlignmentContext> alignmentContextIterator, IntervalLocusIterator intervalLocusIterator, SAMSequenceDictionary dictionary) {
         this.alignmentContextIterator = alignmentContextIterator;
         this.intervalLocusIterator = intervalLocusIterator;
         this.dictionary = dictionary;

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.iterators;
+package org.broadinstitute.hellbender.utils.locusiterator;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
@@ -10,7 +10,7 @@ import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
+import org.broadinstitute.hellbender.utils.iterators.IntervalLocusIterator;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;


### PR DESCRIPTION
Introducing the IntervalLocusIterator which will traverse every locus in intervals, regardless of coverage.

Minor changes

Removed imports.

AlignmentContextLocusIterator first cut.  Still needs unit tests.

Putting in the walker.  Still needs unit tests

Adding tests (and fixes) so that we can get AlignmentContexts.

Adding tests (and fixes) so that we can get AlignmentContexts.

Working tests.  Beginning migration to a LocusWalker change rather than a separate walker.

Merging the emit empty loci into locus walker.  Still need warnings and validation of parameters.

Next step is the LocusWalker testing.

Simple test of the new LocusWalker when it emit empty loci

Addressing PR requests and added ShardedIntervalIterator to save RAM on big intervals.

Addressing the rest of the PR comments

Rolling back to int from long.

Addressing second round of PR comments.

Wrapped LIBS in a factory so that we can encapsulate the retrieval of the best alignment context iterator.

Spark empty loci traversal being supported.

Rebasing based off of the other emit loci branch.