### PR TITLE
Cache the codec used for a FeatureInput so we only have to discover it once.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -273,8 +273,12 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
             }
         } else {
             final Path featurePath = IOUtils.getPath(featureInput.getFeaturePath());
-            IOUtils.assertFileIsReadable(featurePath);
-            final FeatureCodec<T, ?> codec = (FeatureCodec<T, ?>) FeatureManager.getCodecForFile(featurePath, targetFeatureType);
+            FeatureCodec<T, ?> codec = featureInput.getFeatureCodec();
+            if (codec == null) {
+                IOUtils.assertFileIsReadable(featurePath);
+                codec = (FeatureCodec<T, ?>) FeatureManager.getCodecForFile(featurePath, targetFeatureType);
+                featureInput.setFeatureCodec(codec);
+            }
             return getTribbleFeatureReader(featureInput, codec, cloudWrapper, cloudIndexWrapper);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -2,14 +2,12 @@ package org.broadinstitute.hellbender.engine;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.tribble.Feature;
+import htsjdk.tribble.FeatureCodec;
 import org.broadinstitute.barclay.argparser.CommandLineException;
-import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Arrays;
@@ -58,6 +56,11 @@ public final class FeatureInput<T extends Feature> implements Serializable {
      * File containing Features as specified by the user on the command line
      */
     private final String featureFile;
+
+    /**
+     * Cache the codec for this feature input the first time we discover it, so we only do it once
+     */
+    private transient FeatureCodec<T, ?> featureCodec;
 
     /**
      * Delimiter between the logical name and the file name in the --argument_name logical_name:feature_file syntax
@@ -213,6 +216,21 @@ public final class FeatureInput<T extends Feature> implements Serializable {
         this.name = name;
         this.keyValueMap = Collections.unmodifiableMap(new LinkedHashMap<>(keyValueMap));   //make a unmodifiable copy
         this.featureFile = featureFile;
+    }
+
+    /**
+     * Remember the FeatureCodec for this input the first time it is discovered so we can bypass dynamic codec
+     * discovery when multiple FeatureDataSources are created for the same input.
+     */
+    public void setFeatureCodec(final FeatureCodec<T, ?> featureCodec) {
+        this.featureCodec = featureCodec;
+    }
+
+    /**
+     * @return The previously established FeatureCodec to use for this input, if any. May return {@code null}.
+     */
+    public FeatureCodec<T, ?>  getFeatureCodec() {
+        return this.featureCodec;
     }
 
     /**


### PR DESCRIPTION
VariantWalker/MultiVariantWalker create two FeatureDataSources for each input, which results in redundant dynamic discovery of which codec to use. For a MultiVariantWalker with a lot of inputs, like VariantRecalibrator, this can be a lot of path/stream opening/closing. Propose this small change to cache the codec in the FeatureInput. Ideally FeatureManager would keep track of this, but thats bigger refactor as not all of the FeatureDataSources are created by FeatureManager.