### PR TITLE
reducing size of travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 git:
   depth: 9999999
 jdk:
-- oraclejdk8
 - openjdk8
 env:
   matrix:
@@ -40,6 +39,9 @@ env:
   - secure: "E0LWXgX3aWSE/DWHXXDx4vrAq4uX6vKg402wToaZ5otbHQ/UP0H7/FA5jomavAXoC46oMVHZcEltZ5OVhuJ0NW8yYxUCecJ1D/YvVQmnfFABcV/qLM+k4e2rYQOKVw/pejB2gG8XdTA+XE2WyTeENbmIkputS8f1ndKWCmZxuuk="
 matrix:
   fast_finish: true
+  include:
+     - jdk: oraclejdk8
+       env: TEST_TYPE=integration TEST_VERBOSITY=minimal
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:


### PR DESCRIPTION
removing redundant builds:
we will now have:
   openJDK builds for cloud, integration, and unit tests
   docker builds for integration and unit tests
   an oracleJDK build for integration tests