### PR TITLE
Pass Java options to gatk-launch

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -166,7 +166,8 @@ def getLocalGatkRunCommand():
 
 
 def formatLocalJarCommand(localJar):
-    return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS  + [ "-jar", localJar]
+    env_jvm_opts = os.environ.get("GATK_JVM_OPTS", "").split()
+    return ["java"] + env_jvm_opts + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
 
 def getGatkWrapperScript(throwIfNotFound=True):
     if not os.path.exists(GATK_RUN_SCRIPT):


### PR DESCRIPTION
Thank you for all the work on GATK4 and for including a wrapper script to help in setting up Java options. I've included GATK4 in bioconda (https://anaconda.org/bioconda/gatk4) with the `gatk-launch` wrapper and wanted a way to be able to pass java options to the local run.

This PR uses the `GATK_JVM_OPTS` environmental variable to pass Java options like memory specification to the gatk-launch script.

Thanks for considering this change