### PR TITLE
Adding in ability to pass options to the Java JVM in gatk-launch via --javaOptions flag

### DIFF
--- a/gatk-launch
+++ b/gatk-launch
@@ -15,8 +15,6 @@
 #     -Otherwise uses the newest Spark jar in the same directory as the script or the BIN_PATH
 #      (in that order of precedence)
 #
-#
-#
 
 import sys
 from subprocess import check_call, CalledProcessError, call
@@ -58,13 +56,25 @@ PACKAGED_LOCAL_JAR_OPTIONS= ["-Dsamjdk.use_async_io_read_samtools=false",
                   "-Dsamjdk.compression_level=1",
                   "-Dsnappy.disable=true"]
 
-DEFAULT_SPARK_ARGS = ["--conf", "spark.kryoserializer.buffer.max=512m",
-"--conf", "spark.driver.maxResultSize=0",
-"--conf", "spark.driver.userClassPathFirst=true",
-"--conf", "spark.io.compression.codec=lzf",
-"--conf", "spark.yarn.executor.memoryOverhead=600",
-"--conf", "spark.driver.extraJavaOptions=" + EXTRA_JAVA_OPTIONS_SPARK,
-"--conf", "spark.executor.extraJavaOptions=" + EXTRA_JAVA_OPTIONS_SPARK]
+DEFAULT_SPARK_ARGS_PREFIX = '--conf'
+DEFAULT_SPARK_ARGS = {
+    "spark.kryoserializer.buffer.max" : "512m",
+    "spark.driver.maxResultSize" : "0",
+    "spark.driver.userClassPathFirst" : "true",
+    "spark.io.compression.codec" : "lzf",
+    "spark.yarn.executor.memoryOverhead" : "600",
+    "spark.driver.extraJavaOptions" : EXTRA_JAVA_OPTIONS_SPARK,
+    "spark.executor.extraJavaOptions" : EXTRA_JAVA_OPTIONS_SPARK
+}
+
+def createSparkConfArgs(javaOptions):
+    sparkConfArgs = DEFAULT_SPARK_ARGS
+
+    if javaOptions is not None:
+        sparkConfArgs["spark.driver.extraJavaOptions"] = sparkConfArgs["spark.driver.extraJavaOptions"] + ' ' + javaOptions
+        sparkConfArgs["spark.executor.extraJavaOptions"] = sparkConfArgs["spark.executor.extraJavaOptions"] + ' ' + javaOptions
+
+    return DEFAULT_SPARK_ARGS_PREFIX, sparkConfArgs
 
 class GATKLaunchException(Exception):
     pass
@@ -108,8 +118,9 @@ def main(args):
             print("                 to dataproc equivalents")
             print("")
             print("   --dryRun      may be specified to output the generated command line without running it")
-            print("   --javaOptions 'OPTION1=X[, OPTION2=Y ... ]'   optional - pass the given string of options to the ")
-            print("                 java JVM at runtime (for local runs only)")
+            print("   --javaOptions 'OPTION1[ OPTION2=Y ... ]'   optional - pass the given string of options to the ")
+            print("                 java JVM at runtime.  ")
+            print("                 Java options MUST be passed inside a single string with space-separated values.")
             sys.exit(0)
 
         if len(args) is 1 and args[0] == "--list":
@@ -171,7 +182,7 @@ def getLocalGatkRunCommand(javaOptions):
 
         # Add java options to our packaged local jar options
         if javaOptions is not None:
-            PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split(' '))
+            PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split())
 
         return formatLocalJarCommand(localJarFromEnv)
 
@@ -182,7 +193,7 @@ def getLocalGatkRunCommand(javaOptions):
         if javaOptions is not None:
             envJavaOpts = os.environ.get('JAVA_OPTS')
             if envJavaOpts is not None:
-                envJavaOpts + ' ' + javaOptions
+                envJavaOpts = envJavaOpts + ' ' + javaOptions
             else:
                 envJavaOpts = javaOptions
             os.environ['JAVA_OPTS'] = envJavaOpts
@@ -191,7 +202,7 @@ def getLocalGatkRunCommand(javaOptions):
 
     # Add java options to our packaged local jar options
     if javaOptions is not None:
-        PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split(' '))
+        PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split())
 
     return formatLocalJarCommand(getLocalJar())  # will throw if local jar not found
 
@@ -313,19 +324,29 @@ def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs
         runCommand(cmd, dryrun)
     elif sparkRunner == "SPARK":
         sparkSubmitCmd = getSparkSubmitCommand(suppliedSparkSubmitCommand)
+
+        sparkConfArgsPrefix, sparkConfArgs = createSparkConfArgs(javaOptions)
+        sparkConfArgList = [[sparkConfArgsPrefix, "%s=%s" % (a, sparkConfArgs[a])] for a in sparkConfArgs];
+
         cmd = [ sparkSubmitCmd,
           "--master", getSparkMasterSpecified(gatkArgs)] \
-              + DEFAULT_SPARK_ARGS \
+              + [s for args in sparkConfArgList for s in args] \
               + sparkArgs \
               + [getSparkJar()] \
               + gatkArgs
+
         try:
             runCommand(cmd, dryrun)
         except OSError:
             raise GATKLaunchException("Tried to run %s but failed.\nMake sure %s is available in your path" % (sparkSubmitCmd, sparkSubmitCmd))
     elif sparkRunner == "GCS":
         jarPath = cacheJarOnGCS(getSparkJar(), dryrun)
-        dataprocargs = convertSparkSubmitToDataprocArgs(DEFAULT_SPARK_ARGS + sparkArgs)
+
+        # Note: For GCS we don't need the prefix for the sparkConfArgs, so we ignore it and only grab the second
+        # return value of createSparkConfArgs
+        sparkConfArgs = createSparkConfArgs(javaOptions)[1]
+
+        dataprocargs = convertSparkSubmitToDataprocArgs(sparkConfArgs, sparkArgs)
 
         sys.stderr.write("\nReplacing spark-submit style args with dataproc style args\n\n" + " ".join(sparkArgs) +" -> " + " ".join(dataprocargs) +"\n" )
 
@@ -396,7 +417,7 @@ def getSparkMasterSpecified(args):
 
 
 # translate select spark-submit parameters to their gcloud equivalent
-def convertSparkSubmitToDataprocArgs(args):
+def convertSparkSubmitToDataprocArgs(sparkConfArgs, sparkArgs):
     replacements = {"--driver-memory": "spark.driver.memory",
                     "--driver-cores": "spark.driver.cores",
                     "--executor-memory": "spark.executor.memory",
@@ -407,9 +428,16 @@ def convertSparkSubmitToDataprocArgs(args):
     filesToAdd = []
     properties = []
     try:
+
+        # Arguments passed as the sparkConfArgs should be passed through as properties.
+        # In practice yarn files will be added through the 'sparkArgs' argument that is parsed below,
+        # so we don't need to check for them up here.
+        properties.extend(['%s=%s' % (p, sparkConfArgs[p]) for p in sparkConfArgs])
+
+        # Iterate through sparkArgs
         i = 0
-        while i < len(args):
-            arg = args[i]
+        while i < len(sparkArgs):
+            arg = sparkArgs[i]
             if arg == "--conf":
                 i += 1
                 property = args[i]
@@ -418,10 +446,12 @@ def convertSparkSubmitToDataprocArgs(args):
                     filesToAdd = filesToAdd + files.split(",")
                 else:
                     properties.append(args[i])
+
             elif not replacements.get(arg) is None:
                 i += 1
                 propertyname = replacements.get(arg)
-                properties.append(propertyname + "=" + args[i])
+                properties.append(propertyname + "=" + sparkArgs[i])
+
             else:
                 dataprocargs.append(arg)
             i +=1

--- a/gatk-launch
+++ b/gatk-launch
@@ -15,6 +15,8 @@
 #     -Otherwise uses the newest Spark jar in the same directory as the script or the BIN_PATH
 #      (in that order of precedence)
 #
+#
+#
 
 import sys
 from subprocess import check_call, CalledProcessError, call
@@ -94,17 +96,20 @@ def main(args):
             print("")
             print("   --sparkRunner <target>    controls how spark tools are run")
             print("     valid targets are:")
-            print("     LOCAL:   run using the in-memory spark runner")
-            print("     SPARK:   run using spark-submit on an existing cluster ")
-            print("              --sparkMaster must be specified")
-            print("              --sparkSubmitCommand may be specified to control the Spark submit command")
-            print("              arguments to spark-submit may optionally be specified after -- ")
-            print("     GCS:     run using Google cloud dataproc")
-            print("              commands after the -- will be passed to dataproc")
-            print("              --cluster <your-cluster> must be specified after the --")
-            print("              spark properties and some common spark-submit parameters will be translated to dataproc equivalents")
+            print("     LOCAL:      run using the in-memory spark runner")
+            print("     SPARK:      run using spark-submit on an existing cluster ")
+            print("                 --sparkMaster must be specified")
+            print("                 --sparkSubmitCommand may be specified to control the Spark submit command")
+            print("                 arguments to spark-submit may optionally be specified after -- ")
+            print("     GCS:        run using Google cloud dataproc")
+            print("                 commands after the -- will be passed to dataproc")
+            print("                 --cluster <your-cluster> must be specified after the --")
+            print("                 spark properties and some common spark-submit parameters will be translated ")
+            print("                 to dataproc equivalents")
             print("")
-            print("   --dryRun    may be specified to output the generated command line without running it")
+            print("   --dryRun      may be specified to output the generated command line without running it")
+            print("   --javaOptions 'OPTION1=X[, OPTION2=Y ... ]'   optional - pass the given string of options to the ")
+            print("                 java JVM at runtime (for local runs only)")
             sys.exit(0)
 
         if len(args) is 1 and args[0] == "--list":
@@ -114,6 +119,12 @@ def main(args):
         if dryRun:
             dryRun = True
             args.remove("--dryRun")
+
+        javaOptions = getValueForArgument(args, "--javaOptions")
+        if javaOptions is not None:
+            i = args.index("--javaOptions")
+            del args[i] #remove javaOptions
+            del args[i] #and its parameter
 
         sparkRunner = getValueForArgument(args, "--sparkRunner")
         if sparkRunner is not None:
@@ -136,7 +147,8 @@ def main(args):
             del sparkArgs[i] #and its parameter
             gatkArgs += ["--sparkMaster", sparkMaster]
 
-        runGATK(sparkRunner, sparkSubmitCommand, dryRun, gatkArgs, sparkArgs)
+        runGATK(sparkRunner, sparkSubmitCommand, dryRun, gatkArgs, sparkArgs, javaOptions)
+
     except GATKLaunchException as e:
         sys.stderr.write(str(e)+"\n")
         sys.exit(3)
@@ -153,20 +165,39 @@ def getSparkSubmitCommand(sparkSubmitCommand):
     else:
         return sparkSubmitCommand
 
-def getLocalGatkRunCommand():
+def getLocalGatkRunCommand(javaOptions):
     localJarFromEnv = getJarFromEnv(GATK_LOCAL_JAR_ENV_VARIABLE)
     if localJarFromEnv is not None:
+
+        # Add java options to our packaged local jar options
+        if javaOptions is not None:
+            PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split(' '))
+
         return formatLocalJarCommand(localJarFromEnv)
 
     wrapperScript = getGatkWrapperScript(throwIfNotFound=False)
     if wrapperScript is not None:
+
+        # Add options to JAVA_OPTS environment var for dispatch script
+        if javaOptions is not None:
+            envJavaOpts = os.environ.get('JAVA_OPTS')
+            if envJavaOpts is not None:
+                envJavaOpts + ' ' + javaOptions
+            else:
+                envJavaOpts = javaOptions
+            os.environ['JAVA_OPTS'] = envJavaOpts
+
         return [wrapperScript]
+
+    # Add java options to our packaged local jar options
+    if javaOptions is not None:
+        PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split(' '))
 
     return formatLocalJarCommand(getLocalJar())  # will throw if local jar not found
 
 
 def formatLocalJarCommand(localJar):
-    return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS  + [ "-jar", localJar]
+    return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
 
 def getGatkWrapperScript(throwIfNotFound=True):
     if not os.path.exists(GATK_RUN_SCRIPT):
@@ -276,9 +307,9 @@ def cacheJarOnGCS(jar, dryRun):
             return jar
 
 
-def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs):
+def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs, javaOptions):
     if sparkRunner is None or sparkRunner == "LOCAL":
-        cmd = getLocalGatkRunCommand() + gatkArgs + sparkArgs
+        cmd = getLocalGatkRunCommand(javaOptions) + gatkArgs + sparkArgs
         runCommand(cmd, dryrun)
     elif sparkRunner == "SPARK":
         sparkSubmitCmd = getSparkSubmitCommand(suppliedSparkSubmitCommand)
@@ -311,7 +342,14 @@ def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs
 
 def runCommand(cmd, dryrun):
     if dryrun:
-        print( "\nDry run:\n")
+        print("\nDry run:\n")
+
+        # Display environment variables for dry run
+        if len(os.environ) != 0:
+            print("    Env:\n")
+            print( '\n'.join(['        %s = %s' % (v, os.environ[v]) for v in os.environ]) )
+
+        print("    Cmd:\n")
         print(("    " + " ".join(cmd)+"\n"))
     else:
         sys.stderr.write( "\nRunning:\n")

--- a/gatk-launch
+++ b/gatk-launch
@@ -178,12 +178,12 @@ def getSparkSubmitCommand(sparkSubmitCommand):
 
 def getLocalGatkRunCommand(javaOptions):
     localJarFromEnv = getJarFromEnv(GATK_LOCAL_JAR_ENV_VARIABLE)
+
+    # Add java options to our packaged local jar options
+    if javaOptions is not None:
+        PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split())
+
     if localJarFromEnv is not None:
-
-        # Add java options to our packaged local jar options
-        if javaOptions is not None:
-            PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split())
-
         return formatLocalJarCommand(localJarFromEnv)
 
     wrapperScript = getGatkWrapperScript(throwIfNotFound=False)
@@ -199,11 +199,7 @@ def getLocalGatkRunCommand(javaOptions):
             os.environ['JAVA_OPTS'] = envJavaOpts
 
         return [wrapperScript]
-
-    # Add java options to our packaged local jar options
-    if javaOptions is not None:
-        PACKAGED_LOCAL_JAR_OPTIONS.extend(javaOptions.split())
-
+    
     return formatLocalJarCommand(getLocalJar())  # will throw if local jar not found
 
 


### PR DESCRIPTION
Options only used when running locally.

Internally options are passed either by appending to java invocation directly with
command-line options or using the JAVA_OPTS environment variable.

Also added environment variable printout with --dryRun
Other minor formatting / whitespace changes.

resolves #2694