### PR TITLE
Remove authHolder from metric-related classes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetricsCollector.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetricsCollector.java
@@ -8,7 +8,6 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.IOUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.MappingQualityReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
@@ -134,12 +133,10 @@ public final class InsertSizeMetricsCollector
      * Finish the metrics collection by saving any results to a metrics file.
      * @param metricsFile a metricsFile where the collected metrics should be stored. May not be null.
      * @param inputName the name of the input, for optional inclusion in the metrics file. May not be null.
-     * @param authHolder Authentication info for this context.
      */
     public void finish(
             final MetricsFile<InsertSizeMetrics, Integer> metricsFile,
-            final String inputName,
-            final AuthHolder authHolder)
+            final String inputName)
     {
         Utils.nonNull(metricsFile);
 
@@ -155,12 +152,7 @@ public final class InsertSizeMetricsCollector
                     allReadsCollector.getTotalInserts()));
         }
         else {
-            if (null != authHolder) {
-                MetricsUtils.saveMetrics(metricsFile, inputArgs.output, authHolder);
-            }
-            else {
-                metricsFile.write(new File(inputArgs.output));
-            }
+            MetricsUtils.saveMetrics(metricsFile, inputArgs.output);
             if (inputArgs.producePlot) {
                 writeHistogramPDF(inputName);
             }

--- a/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.metrics;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.metrics.MetricsFile;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 
@@ -19,9 +18,8 @@ public final class MetricsUtils {
      * Write a {@link MetricsFile} to the given path, can be any destination supported by {@link BucketUtils#createFile(String)}
      * @param metricsFile a {@link MetricsFile} object to write to disk
      * @param metricsOutputPath the path (or uri) to write the metrics to
-     * @param authHolder authentication for remote paths, can be null if the path is not remote
      */
-    public static void saveMetrics(final MetricsFile<?, ?> metricsFile, String metricsOutputPath, AuthHolder authHolder) {
+    public static void saveMetrics(final MetricsFile<?, ?> metricsFile, String metricsOutputPath) {
         try(PrintWriter out = new PrintWriter(BucketUtils.createFile(metricsOutputPath))) {
             metricsFile.write(out);
         } catch (SAMException e ){

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleCollectMultiMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleCollectMultiMetricsSpark.java
@@ -9,7 +9,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.tools.spark.pipelines.metrics.MetricsCollectorSparkTool;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -117,10 +116,9 @@ public final class ExampleCollectMultiMetricsSpark
     /**
      * Finish the collection process and save any results.
      * @param inputName The name of the input source for optional inclusion in the saved metrics file.
-     * @param authHolder authentication info. May be null.
      */
     @Override
-    protected void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        exampleMultiCollector.saveMetrics(inputName, authHolder);
+    protected void saveMetrics(final String inputName) {
+        exampleMultiCollector.saveMetrics(inputName);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleMultiMetricsCollector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleMultiMetricsCollector.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.metrics.*;
@@ -123,23 +122,16 @@ public final class ExampleMultiMetricsCollector
     /**
      * Finish the metrics collection and save any results to the metrics file.
      * @param metricsFile a metricsFile where the collected metrics should be stored. May not be null.
-     * @param authHolder Authentication info for this context.
      */
     public void saveMetrics(
-            final MetricsFile<ExampleMultiMetrics, Integer> metricsFile,
-            final AuthHolder authHolder)
+            final MetricsFile<ExampleMultiMetrics, Integer> metricsFile)
     {
         Utils.nonNull(metricsFile);
 
         finish();
 
         addAllLevelsToFile(metricsFile);
-        if (null != authHolder) {
-            MetricsUtils.saveMetrics(metricsFile, inputArgs.output, authHolder);
-        }
-        else {
-            metricsFile.write(new File(inputArgs.output));
-        }
+        MetricsUtils.saveMetrics(metricsFile, inputArgs.output);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleMultiMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleMultiMetricsCollectorSpark.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.spark.pipelines.metrics.MetricsCollectorSpark;
@@ -95,11 +94,10 @@ public class ExampleMultiMetricsCollectorSpark
      * Save the metrics out to a file.
      * @param inputName name of the input from which metrics were collected; unused here
      *                  but optionally used by some collectors to label output plots, etc.
-     * @param authHolder authentication info. May be null.
      */
     @Override
-    public void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        reducedResultMetrics.saveMetrics(metricsFile, authHolder);
+    public void saveMetrics(final String inputName) {
+        reducedResultMetrics.saveMetrics(metricsFile);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleCollectSingleMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleCollectSingleMetricsSpark.java
@@ -6,7 +6,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.tools.spark.pipelines.metrics.MetricsCollectorSparkTool;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -116,10 +115,9 @@ public final class ExampleCollectSingleMetricsSpark
     /**
      * Finish the collection process and save any results.
      * @param inputName The name of the input source for optional inclusion in the saved metrics file.
-     * @param authHolder authentication info. May be null.
      */
     @Override
-    protected void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        exampleSingleCollector.saveMetrics(inputName, authHolder);
+    protected void saveMetrics(final String inputName) {
+        exampleSingleCollector.saveMetrics(inputName);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleSingleMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleSingleMetricsCollectorSpark.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.metrics.MetricsUtils;
 import org.broadinstitute.hellbender.tools.spark.pipelines.metrics.MetricsCollectorSpark;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -62,11 +61,10 @@ public class ExampleSingleMetricsCollectorSpark
     /**
      * Write out the results of the metrics collection
      * @param inputBaseName base name of the input file
-     * @param authHolder
      */
     @Override
-    public void saveMetrics(final String inputBaseName, final AuthHolder authHolder) {
-        MetricsUtils.saveMetrics(metricsFile, args.output, authHolder);
+    public void saveMetrics(final String inputBaseName) {
+        MetricsUtils.saveMetrics(metricsFile, args.output);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
@@ -86,6 +86,6 @@ public final class CollectInsertSizeMetrics extends SinglePassSamProgram {
     @Override
     protected void finish() {
         final MetricsFile<InsertSizeMetrics, Integer> metricsFile = getMetricsFile();
-        insertSizeCollector.finish(metricsFile, INPUT.getName(), null);
+        insertSizeCollector.finish(metricsFile, INPUT.getName());
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectBaseDistributionByCycleSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectBaseDistributionByCycleSpark.java
@@ -208,7 +208,7 @@ public final class CollectBaseDistributionByCycleSpark extends GATKSparkTool {
     }
 
     protected void saveResults(final MetricsFile<?, Integer> metrics, final SAMFileHeader readsHeader, final String inputFileName) {
-        MetricsUtils.saveMetrics(metrics, out, getAuthHolder());
+        MetricsUtils.saveMetrics(metrics, out);
 
         if (metrics.getAllHistograms().isEmpty()) {
             logger.warn("No valid bases found in input file.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSpark.java
@@ -8,7 +8,6 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.metrics.InsertSizeMetricsArgumentCollection;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -67,7 +66,7 @@ public final class CollectInsertSizeMetricsSpark
     }
 
     @Override
-    protected void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        insertSizeCollector.saveMetrics(inputName, authHolder);
+    protected void saveMetrics(final String inputName) {
+        insertSizeCollector.saveMetrics(inputName);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSpark.java
@@ -156,7 +156,7 @@ public final class CollectMultipleMetricsSpark extends GATKSparkTool {
                     unFilteredReads.filter(r -> readFilter.test(r)),
                     getHeaderForReads()
             );
-            metricsCollector.saveMetrics(getReadSourceName(), getAuthHolder());
+            metricsCollector.saveMetrics(getReadSourceName());
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSpark.java
@@ -8,7 +8,6 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.metrics.QualityYieldMetricsArgumentCollection;
@@ -66,8 +65,8 @@ public final class CollectQualityYieldMetricsSpark extends MetricsCollectorSpark
     }
 
     @Override
-    protected void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        qualityYieldCollector.saveMetrics(inputName, authHolder);
+    protected void saveMetrics(final String inputName) {
+        qualityYieldCollector.saveMetrics(inputName);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSpark.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.metrics.InsertSizeMetrics;
@@ -78,8 +77,8 @@ public class InsertSizeMetricsCollectorSpark
     }
 
     @Override
-    public void saveMetrics(final String inputName, final AuthHolder authHolder) {
-        resultMetrics.finish(metricsFile, inputName, authHolder);
+    public void saveMetrics(final String inputName) {
+        resultMetrics.finish(metricsFile, inputName);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSpark.java
@@ -221,7 +221,7 @@ public final class MeanQualityByCycleSpark extends GATKSparkTool {
     }
 
     private void saveResults(final MetricsFile<?, Integer> metrics, final SAMFileHeader readsHeader, final String inputFileName){
-        MetricsUtils.saveMetrics(metrics, out, getAuthHolder());
+        MetricsUtils.saveMetrics(metrics, out);
 
         if (metrics.getAllHistograms().isEmpty()) {
             logger.warn("No valid bases found in input file.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSpark.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.metrics.Header;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.metrics.MetricsArgumentCollection;
@@ -83,7 +82,7 @@ import java.util.List;
  *         getReads().filter(filter),
  *         samFileHeader
  *     );
- *     collector.saveMetrics(getReadSourceName(), getAuthHolder());
+ *     collector.saveMetrics(getReadSourceName());
  *
  */
 public interface MetricsCollectorSpark<T extends MetricsArgumentCollection> extends Serializable
@@ -146,7 +145,6 @@ public interface MetricsCollectorSpark<T extends MetricsArgumentCollection> exte
      * gives the collector to serialize the resulting metrics, usually
      * to a metrics file.
      * @param inputBaseName base name of the input file
-     * @param authHolder authentication info. May be null.
      */
-     void saveMetrics(String inputBaseName, AuthHolder authHolder);
+     void saveMetrics(String inputBaseName);
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MetricsCollectorSparkTool.java
@@ -8,7 +8,6 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.barclay.argparser.CommandLinePluginProvider;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.metrics.MetricsArgumentCollection;
@@ -44,7 +43,7 @@ public abstract class MetricsCollectorSparkTool<T extends MetricsArgumentCollect
     abstract protected SortOrder getExpectedSortOrder();
     abstract protected void initialize(T inputArgs, SAMFileHeader samHeader, List<Header> defaultHeaders);
     abstract protected void collectMetrics(JavaRDD<GATKRead> filteredReads, SAMFileHeader samHeader);
-    abstract protected void saveMetrics(String inputBaseName, AuthHolder authHolder);
+    abstract protected void saveMetrics(String inputBaseName);
 
     /**
      * To be implemented by subclasses; return the fully initialized and populated
@@ -85,7 +84,7 @@ public abstract class MetricsCollectorSparkTool<T extends MetricsArgumentCollect
         initialize(collectorArgs, getHeaderForReads(), getDefaultHeaders());
         final JavaRDD<GATKRead> filteredReads = getReads();
         collectMetrics(filteredReads, getHeaderForReads());
-        saveMetrics(getReadSourceName(), getAuthHolder());
+        saveMetrics(getReadSourceName());
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSpark.java
@@ -155,7 +155,7 @@ public final class QualityScoreDistributionSpark extends GATKSparkTool {
     }
 
     private void saveResults(final MetricsFile<?, Byte> metrics,  final SAMFileHeader readsHeader, final String inputFileName) {
-        MetricsUtils.saveMetrics(metrics, out, getAuthHolder());
+        MetricsUtils.saveMetrics(metrics, out);
 
         if (metrics.getAllHistograms().isEmpty()) {
             logger.warn("No valid bases found in input file.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityYieldMetricsCollectorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityYieldMetricsCollectorSpark.java
@@ -4,9 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.AuthHolder;
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.metrics.MetricsUtils;
 import org.broadinstitute.hellbender.metrics.QualityYieldMetrics;
 import org.broadinstitute.hellbender.metrics.QualityYieldMetricsArgumentCollection;
@@ -62,11 +59,10 @@ public class QualityYieldMetricsCollectorSpark
     /**
      * Write out the results of the metrics collection
      * @param inputBaseName base name of the input file
-     * @param authHolder
      */
     @Override
-    public void saveMetrics(final String inputBaseName, final AuthHolder authHolder) {
-        MetricsUtils.saveMetrics(metricsFile, args.output, authHolder);
+    public void saveMetrics(final String inputBaseName) {
+        MetricsUtils.saveMetrics(metricsFile, args.output);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -18,7 +18,6 @@ import scala.Tuple2;
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * Utility classes and functions for Mark Duplicates.
@@ -345,7 +344,7 @@ public class MarkDuplicatesSparkUtils {
             result.setHistogram(nonEmptyMetricsByLibrary.values().iterator().next().calculateRoiHistogram());
         }
 
-        MetricsUtils.saveMetrics(result, metricsOutputPath, authHolder );
+        MetricsUtils.saveMetrics(result, metricsOutputPath);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -162,10 +162,6 @@ public abstract class BaseTest {
         return value;
     }
 
-    public static AuthHolder getAuthentication(){
-        return new AuthHolder("test-app",getGCPTestApiKey());
-    }
-
     @BeforeClass
     public void initGenomeLocParser() throws FileNotFoundException {
         hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));

--- a/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/metrics/MetricsUtilsTest.java
@@ -53,7 +53,7 @@ public class MetricsUtilsTest extends BaseTest {
 
         final MetricsFile<TestMetric, ?> metrics = new MetricsFile<>();
         metrics.addMetric(testMetric);
-        MetricsUtils.saveMetrics(metrics, outputPath,getAuthentication());
+        MetricsUtils.saveMetrics(metrics, outputPath);
         Assert.assertTrue(BucketUtils.fileExists(outputPath));
         File localCopy = copyFileToLocalTmpFile(outputPath);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSparkIntegrationTest.java
@@ -5,7 +5,6 @@ import htsjdk.samtools.metrics.Header;
 import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.AuthHolder;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.metrics.MetricsArgumentCollection;
 import org.broadinstitute.hellbender.metrics.QualityYieldMetrics;
@@ -128,7 +127,7 @@ public final class CollectMultipleMetricsSparkIntegrationTest extends CommandLin
             count = filteredReads.count();
         }
         @Override
-        public void saveMetrics(String inputBaseName, AuthHolder authHolder) {
+        public void saveMetrics(String inputBaseName) {
             //no-op
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
@@ -94,7 +94,7 @@ public class InsertSizeMetricsCollectorSparkUnitTest extends CommandLineProgramT
         rddParallelReads = rddParallelReads.repartition(2);
         isSpark.collectMetrics(rddParallelReads.filter(r -> rf.test(r)), samHeader);
 
-        isSpark.saveMetrics(fileName, null);
+        isSpark.saveMetrics(fileName);
 
         IntegrationTestSpec.assertEqualTextFiles(
                 outfile,


### PR DESCRIPTION
Also remove imports and update comments.

Metrics are saved using NIO so we don't need authHolder.

This work is part of #2402.