### PR TITLE
Remove some uses of dataflow.sdk.options.PipelineOptions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriter.java
@@ -45,7 +45,7 @@ public class SVVCFWriter {
 
         logNumOfVarByTypes(sortedVariantsList, logger);
 
-        writeVariants(pipelineOptions, vcfFileName, sortedVariantsList, referenceSequenceDictionary);
+        writeVariants(vcfFileName, sortedVariantsList, referenceSequenceDictionary);
     }
 
     private static void logNumOfVarByTypes(final List<VariantContext> sortedVariantsList, final Logger logger) {
@@ -73,7 +73,7 @@ public class SVVCFWriter {
         }).collect(SVUtils.arrayListCollector(variants.size()));
     }
 
-    private static void writeVariants(final PipelineOptions pipelineOptions, final String fileName,
+    private static void writeVariants(final String fileName,
                                       final List<VariantContext> variantsArrayList, final SAMSequenceDictionary referenceSequenceDictionary) {
         try (final OutputStream outputStream
                      = new BufferedOutputStream(BucketUtils.createFile(fileName))) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -1,8 +1,5 @@
 package org.broadinstitute.hellbender.utils.test;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
-import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
-import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.LogManager;
@@ -165,23 +162,10 @@ public abstract class BaseTest {
         return value;
     }
 
-    /**
-     * Gets a PipelineOptions object containing our API key as specified in the HELLBENDER_TEST_APIKEY
-     * environment variable. Useful for tests that need to access data in a GCS bucket via the
-     * methods in the {@link org.broadinstitute.hellbender.utils.gcs.BucketUtils} class,
-     * but don't need to run an actual dataflow pipeline.
-     *
-     * @return a PipelineOptions object containing our API key
-     */
-    public static PipelineOptions getAuthenticatedPipelineOptions() {
-        final GCSOptions popts = PipelineOptionsFactory.as(GCSOptions.class);
-        popts.setApiKey(getGCPTestApiKey());
-        return popts;
-    }
-
     public static AuthHolder getAuthentication(){
         return new AuthHolder("test-app",getGCPTestApiKey());
     }
+
     @BeforeClass
     public void initGenomeLocParser() throws FileNotFoundException {
         hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.utils.gcs;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.util.IOUtil;
 import java.net.URI;
 import java.nio.file.Path;
@@ -79,7 +78,6 @@ public final class BucketUtilsTest extends BaseTest {
         File dest = createTempFile("copy-empty", ".vcf");
         final String intermediate = BucketUtils.randomRemotePath(getGCPTestStaging(), "test-copy-empty", ".vcf");
         Assert.assertTrue(BucketUtils.isCloudStorageUrl(intermediate), "!BucketUtils.isCloudStorageUrl(intermediate)");
-        PipelineOptions popts = getAuthenticatedPipelineOptions();
         BucketUtils.copyFile(src, intermediate);
         BucketUtils.copyFile(intermediate, dest.getPath());
         IOUtil.assertFilesEqual(new File(src), dest);
@@ -104,7 +102,6 @@ public final class BucketUtilsTest extends BaseTest {
             final String intermediate = BucketUtils.randomRemotePath(MiniClusterUtils.getWorkingDir(cluster).toString(), "test-copy-empty", ".vcf");
             Assert.assertTrue(BucketUtils.isHadoopUrl(intermediate), "!BucketUtils.isHadoopUrl(intermediate)");
 
-            PipelineOptions popts = null;
             BucketUtils.copyFile(src, intermediate);
             BucketUtils.copyFile(intermediate, dest.getPath());
             IOUtil.assertFilesEqual(new File(src), dest);

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.utils.reference;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -55,7 +54,6 @@ public class ReferenceUtilsUnitTest extends BaseTest {
     @Test(groups = {"bucket"})
     public void testLoadFastaDictionaryFromGCSBucket() throws IOException {
         final String bucketDictionary = getGCPTestInputPath() + "org/broadinstitute/hellbender/utils/ReferenceUtilsTest.dict";
-        final PipelineOptions popts = getAuthenticatedPipelineOptions();
 
         try ( final InputStream referenceDictionaryStream = BucketUtils.openFile(bucketDictionary) ) {
             final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);


### PR DESCRIPTION
Those options are used to carry auth for the ReferenceAPISource,
so we can't remove all instances without changing those.

This work is part of #963.