### PR TITLE
Check for bad sequence dictionaries in ReferenceUtils.loadFastaDictionary

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtils.java
@@ -73,10 +73,10 @@ public final class ReferenceUtils {
         final SAMFileHeader header = codec.decode(reader, fastaDictionaryStream.toString());
 
         // Make sure we have a valid sequence dictionary before continuing:
-        if (header.getSequenceDictionary().isEmpty()) {
+        if (header.getSequenceDictionary() == null || header.getSequenceDictionary().isEmpty()) {
             throw new UserException.MalformedFile (
                     "Could not read sequence dictionary from given fasta stream " +
-                            fastaDictionaryStream.toString()
+                            fastaDictionaryStream
             );
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtils.java
@@ -49,6 +49,12 @@ public final class ReferenceUtils {
         catch ( IOException e ) {
             throw new UserException.CouldNotReadInputFile("Error loading fasta dictionary file " + fastaDictionaryFile, e);
         }
+        catch ( UserException.MalformedFile e ) {
+            throw new UserException.MalformedFile(
+                    "Could not read sequence dictionary from given fasta file " +
+                            fastaDictionaryFile
+            );
+        }
     }
 
     /**
@@ -65,6 +71,15 @@ public final class ReferenceUtils {
 
         final SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
         final SAMFileHeader header = codec.decode(reader, fastaDictionaryStream.toString());
+
+        // Make sure we have a valid sequence dictionary before continuing:
+        if (header.getSequenceDictionary().isEmpty()) {
+            throw new UserException.MalformedFile (
+                    "Could not read sequence dictionary from given fasta stream " +
+                            fastaDictionaryStream.toString()
+            );
+        }
+
         return header.getSequenceDictionary();
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -7,6 +7,10 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
+import java.lang.reflect.Method;
+import java.util.*;
 
 import java.io.*;
 
@@ -53,22 +57,31 @@ public class ReferenceUtilsUnitTest extends BaseTest {
         }
     }
 
-    @Test
-    public void testLoadFastaDictionaryWithFastaFile() throws IOException {
+    @DataProvider(name = "testData_testLoadWrongFormatFastaDictionary")
+    public Object[][] testData_testLoadWrongFormatFastaDictionary(final Method testMethod) {
 
-        File testFastaFile = new File(hg19MiniReference);
+        Object[][] tests = {
+                {hg19MiniReference, true},
+                {hg19MiniReference, false}
+        };
 
-        // Test loadFastaDictionary with File argument:
-        Assert.assertThrows(UserException.MalformedFile.class, () -> {
-            ReferenceUtils.loadFastaDictionary(testFastaFile);
-        });
+        return tests;
+    }
 
-        // Test loadFastaDictionary with Stream argument:
-        try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(testFastaFile) ) {
+    @Test(expectedExceptions = UserException.MalformedFile.class, dataProvider = "testData_testLoadWrongFormatFastaDictionary")
+    public void testLoadWrongFormatFastaDictionary(final String fastaFileName, boolean doLoadAsStream ) throws IOException {
 
-            Assert.assertThrows(UserException.MalformedFile.class, () -> {
+        File testFastaFile = new File(fastaFileName);
+
+        if ( doLoadAsStream ) {
+            // Test loadFastaDictionary with Stream argument:
+            try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(testFastaFile) ) {
                 ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);
-            });
+            }
+        }
+        else {
+            // Test loadFastaDictionary with File argument:
+            ReferenceUtils.loadFastaDictionary(testFastaFile);
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -57,23 +57,22 @@ public class ReferenceUtilsUnitTest extends BaseTest {
         }
     }
 
-    @DataProvider(name = "testData_testLoadWrongFormatFastaDictionary")
-    public Object[][] testData_testLoadWrongFormatFastaDictionary(final Method testMethod) {
+    @DataProvider
+    public Object[][] testData_testLoadWrongFormatFastaDictionary() {
 
-        Object[][] tests = {
+        // Trying to ingest a fasta file as a dict file to induce a MalformedFile Exception.
+        return new Object[][] {
                 {hg19MiniReference, true},
                 {hg19MiniReference, false}
         };
-
-        return tests;
     }
 
     @Test(expectedExceptions = UserException.MalformedFile.class, dataProvider = "testData_testLoadWrongFormatFastaDictionary")
-    public void testLoadWrongFormatFastaDictionary(final String fastaFileName, boolean doLoadAsStream ) throws IOException {
+    public void testLoadWrongFormatFastaDictionary(final String fastaFileName, boolean loadAsStream ) throws IOException {
 
         File testFastaFile = new File(fastaFileName);
 
-        if ( doLoadAsStream ) {
+        if ( loadAsStream ) {
             // Test loadFastaDictionary with Stream argument:
             try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(testFastaFile) ) {
                 ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.reference;
 
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -49,6 +50,25 @@ public class ReferenceUtilsUnitTest extends BaseTest {
             Assert.assertEquals(dictionary.size(), 4, "Wrong sequence dictionary size after loading");
 
             Assert.assertFalse(referenceDictionaryStream.isClosed(), "InputStream was improperly closed by ReferenceUtils.loadFastaDictionary()");
+        }
+    }
+
+    @Test
+    public void testLoadFastaDictionaryWithFastaFile() throws IOException {
+
+        File testFastaFile = new File(hg19MiniReference);
+
+        // Test loadFastaDictionary with File argument:
+        Assert.assertThrows(UserException.MalformedFile.class, () -> {
+            ReferenceUtils.loadFastaDictionary(testFastaFile);
+        });
+
+        // Test loadFastaDictionary with Stream argument:
+        try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(testFastaFile) ) {
+
+            Assert.assertThrows(UserException.MalformedFile.class, () -> {
+                ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);
+            });
         }
     }
 


### PR DESCRIPTION
Now throws a UserException.MalformedFile if the resulting header has no
dictionary.

Added testLoadFastaDictionaryWithFastaFile to test this case.

resolves #2609