### PR TITLE
removing two redundant travis matrix entries to save vms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ jdk:
 env:
   matrix:
   - TEST_TYPE=cloud
-  - TEST_TYPE=integration TEST_VERBOSITY=minimal
-  - TEST_TYPE=unit TEST_VERBOSITY=minimal
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
   - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
   - RUN_CNV_SOMATIC_WDL=true


### PR DESCRIPTION
removing the non-docker unit and integration test matrix entries because
they were redundant with the docker ones