### PR TITLE
CNV GetBayesianHetCoverage: format at signs in example header so javadocs can represent literally

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverage.java
@@ -70,9 +70,9 @@ import java.io.File;
  * </p>
  *
  * <pre>
- *     @HD	VN:1.4	SO:unsorted
- *     @SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
- *     @SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
+ *     {@literal @}HD	VN:1.4	SO:unsorted
+ *     {@literal @}SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
+ *     {@literal @}SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
  *     1	10736	10736	+	normal
  *     1	11522	11522	+	normal
  *     1	12098	12098	+	normal


### PR DESCRIPTION
The doc generation system was abruptly stopping the docs at the `@` signs in the example data header. Solution is to use `{@literal @}`.