### PR TITLE
Document Mutect2: revamp documentation and example commands to reflect algorithmic changes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -20,78 +20,155 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Call somatic SNPs and indels via local re-assembly of haplotypes
+ * Call somatic short variants, both SNVs and indels, via local assembly of haplotypes
  *
- * <p>MuTect2 is a somatic SNP and indel caller that combines the DREAM challenge-winning somatic genotyping engine of the original MuTect (<a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>) with the assembly-based machinery of <a href="https://www.broadinstitute.org/gatk/documentation/tooldocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.</p>
+ * <p>
+ *     Mutect2 calls somatic single nucleotide (SNV) and insertion and deletion (indel) variants.
+ *     The caller combines the DREAM challenge-winning somatic genotyping engine of the original MuTect
+ *     (<a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>) with the
+ *     assembly-based machinery of <a href="https://www.broadinstitute.org/gatk/documentation/tooldocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.
+ *     Although we present the tool for somatic analyses, it may also apply to other contexts.
+ * </p>
  *
- * <h3>How MuTect2 works</h3>
- * <p>The basic operation of MuTect2 proceeds similarly to that of the HaplotypeCaller, with a few key differences.</p>
- * <p>While the HaplotypeCaller relies on a ploidy assumption (diploid by default) to inform its genotype likelihood and variant quality calculations, MuTect2 allows for a varying allelic fraction for each variant, as is often seen in tumors with purity less than 100%, multiple subclones, and/or copy number variation (either local or aneuploidy). MuTect2 also differs from the HaplotypeCaller in that it does apply some hard filters to variants before producing output. Finally, some of the parameters used for ActiveRegion determination and graph assembly are set to different default values in MuTect2 compared to HaplotypeCaller.</p>
- * <p>Note that MuTect2 is designed to produce somatic variant calls only, and includes some logic to skip variant sites that are very clearly germline based on the evidence present in the Normal sample compared to the Tumor sample. This is done at an early stage to avoid spending computational resources on germline events. As a result the tool is NOT capable of emitting records for variant calls that are clearly germline unless it is run in artifact-detection mode, which is used for Panel-Of-Normals creation.</p>
- * <p>Note also that the GVCF generation capabilities of HaplotypeCaller are NOT available in MuTect2, even though some of the relevant arguments are listed below. There are currently no plans to make GVCF calling available in MuTect2.</p>
+ * <h3>How GATK4 Mutect2 differs from GATK3 MuTect2</h3>
  *
- * <h3>Usage examples</h3>
- * <p>These are example commands that show how to run Mutect2 for typical use cases. Square brackets ("[ ]")
- * indicate optional arguments. Note that parameter values shown here may not be the latest recommended; see the
- * Best Practices documentation for detailed recommendations. </p>
+ * <dl>
+ *     <dd>(i) The filtering functionality is now a separate tool called {@link FilterMutectCalls}.
+ *     To filter further based on sequence context artifacts, additionally use {@link FilterByOrientationBias}.</dd>
+ *     <dd>(ii) If using a known germline variants resource, then it must contain population allele frequencies, e.g.
+ *     from gnomAD or the 1000 Genomes Project. See below or the GATK Resource bundle for an example.</dd>
+ *     <dd>(iii) To create the panel of normals (PoN), call on normal samples as if they are tumor samples with Mutect2 and then use GATK4's {@link CreateSomaticPanelOfNormals}.
+ *     This contrasts with the GATK3 workflow, which uses an artifact mode in MuTect2 and CombineVariants for PoN creation.</dd>
+ * </dl>
  *
- * <br />
- * <h4>Tumor/Normal variant calling</h4>
+ * <p>
+ *     What remains unchanged is that neither tool versions call on seeming loss of heterozygosity (LoH) events.
+ *     To detect LoH, see the Copy Number Variant (CNV) and AllelicCNV workflows.
+ * </p>
+ *
+ * <p>Here is an example of a known variants resource with populaton allele frequencies:</p>
+ *
  * <pre>
- *   java
- *     -jar GenomeAnalysisTK.jar \
- *     -T Mutect2 \
- *     -R reference.fasta \
- *     -I tumor.bam \
- *     -I normal.bam \
- *     -tumor tumorSampleName \ // as in the BAM header
- *     -normal normalSampleName \ // as in the BAM header
- *     [--dbsnp dbSNP.vcf] \
- *     [--cosmic COSMIC.vcf] \
- *     [-L targets.interval_list] \
- *     -o output.vcf
+ *     #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
+ *      1       10067   .       T       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCC      30.35   PASS    AC=3;AF=7.384E-5
+ *      1       10108   .       CAACCCT C       46514.32        PASS    AC=6;AF=1.525E-4
+ *      1       10109   .       AACCCTAACCCT    AAACCCT,*       89837.27        PASS    AC=48,5;AF=0.001223,1.273E-4
+ *      1       10114   .       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA  *,CAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA,T      36728.97        PASS    AC=55,9,1;AF=0.001373,2.246E-4,2.496E-5
+ *      1       10119   .       CT      C,*     251.23  PASS    AC=5,1;AF=1.249E-4,2.498E-5
+ *      1       10120   .       TA      CA,*    14928.74        PASS    AC=10,6;AF=2.5E-4,1.5E-4
+ *      1       10128   .       ACCCTAACCCTAACCCTAAC    A,*     285.71  PASS    AC=3,1;AF=7.58E-5,2.527E-5
+ *      1       10131   .       CT      C,*     378.93  PASS    AC=7,5;AF=1.765E-4,1.261E-4
+ *      1       10132   .       TAACCC  *,T     18025.11        PASS    AC=12,2;AF=3.03E-4,5.049E-5
  * </pre>
  *
- * <h4>Normal-only calling for panel of normals creation</h4>
+ * <h3>How Mutect2 works compared to HaplotypeCaller</h3>
+ * <p>Overall, Mutect2 works similarly to HaplotypeCaller, but with a few key differences. </p>
+ * <p>
+ *     (i) GVCF calling is not a feature of Mutect2.
+ *     (ii) While HaplotypeCaller relies on a fixed ploidy assumption to inform its genotype likelihoods that are the basis for genotype probabilities (PL),
+ *     Mutect2 allows for varying ploidy in the form of allele fractions for each variant.
+ *     Varying allele fractions is often seen within a tumor sample due to fractional purity, multiple subclones and/or copy number variation.
+ *     (iii) Mutect2 also differs from the HaplotypeCaller in that it can apply various prefilters to sites and variants depending on the use of
+ *     a matched normal (--normalSampleName), a panel of normals (PoN; --normal_panel) and/or a common population variant resource containing allele-specific frequencies (--germline_resource).
+ *     If provided, Mutect2 uses the PoN to filter sites and the germline resource and matched normal to filter alleles.
+ *     (iv) Mutect2 variant site annotations differ from that of HaplotypeCaller. See the --annotation parameter description for a list.
+ *     (v) Finally, Mutect2 has additional parameters not available to HaplotypeCaller that factor in the decision to reassemble a genomic region,
+ *     factor in likelihood calculations that then determine whether to emit a variant, or factor towards filtering.
+ *     These parameters include the following and are each described further in the arguments section.
+ * </p>
+ *
+ * <dl>
+ *     <dd>--min_variants_in_pileup ==> active region determination</dd>
+ *     <dd>--minNormalVariantFraction ==> active region determination</dd>
+ *     <dd>--tumorStandardDeviationsThreshold ==> active region determination</dd>
+ *     <dd>--af_of_alleles_not_in_resource ==> germline variant prior</dd>
+ *     <dd>--log_somatic_prior ==> somatic variant prior</dd>
+ *     <dd>--normal_lod ==> filter threshold for variants in tumor not being in the normal, i.e. germline-risk filter</dd>
+ *     <dd>--tumor_lod_to_emit ==> cutoff for tumor variants to appear in callset</dd>
+ * </dl>
+ *
+ * <p>
+ *     Additional parameters that factor towards filtering, including normal_artifact_lod (default threshold 0.0) and
+ *     tumor_lod (default threshold 5.3), are available in {@link FilterMutectCalls}. While the tool calculates
+ *     normal_lod with a fixed ploidy assumption given by the --sample_ploidy option (default is 2), it calculates
+ *     normal_artifact_lod with the same approach it uses for tumor_lod, i.e. with a variable ploidy assumption.
+ * </p>
+ *
+ * <p>
+ *     If the normal artifact log odds becomes large, then FilterMutectCalls applies the artifact-in-normal filter.
+ *     For matched normal samples with tumor contamination, consider increasing the normal_artifact_lod threshold.
+ * </p>
+ *
+ * <p>
+ *     The tumor log odds, which is calculated independently of any matched normal, determines whether to filter a tumor
+ *     variant. Variants with tumor LODs exceeding the threshold pass filtering.
+ * </p>
+ *
+ * <h3>Examples</h3>
+ *
+ * <p>Example commands show how to run Mutect2 for typical scenerios.</p>
+ *
+ * <h4>Tumor with matched normal</h4>
+ * <p>
+ *     Given a matched normal, Mutect2 is designed to call somatic variants only. The tool includes logic to skip
+ *     emitting variants that are clearly germline based on the evidence present in the matched normal. This is done at
+ *     an early stage to avoid spending computational resources on germline events. If the variant's germline status is
+ *     borderline, then Mutect2 will emit the variant to the callset with a germline-risk filter. Such filtered
+ *     emissions enable manual review.
+ * </p>
  * <pre>
- *   java
- *     -jar GenomeAnalysisTK.jar
- *     -T Mutect2
- *     -R reference.fasta
- *     -I:tumor normal1.bam \
- *     [--dbsnp dbSNP.vcf] \
- *     [--cosmic COSMIC.vcf] \
- *     --artifact_detection_mode \
- *     [-L targets.interval_list] \
- *     -o output.normal1.vcf
+ * java -Xmx4g -jar $gatk_jar Mutect2 \
+ *   -R ref_fasta.fa \
+ *   -I tumor.bam \
+ *   -tumor tumor_sample_name \
+ *   -I normal.bam \
+ *   -normal normal_sample_name \
+ *   --germline_resource af-only-gnomad.vcf.gz \
+ *   --normal_panel pon.vcf.gz \
+ *   -L intervals.list \
+ *   -O tumor_matched_m2_snvs_indels.vcf.gz
  * </pre>
- * <br />
- * For full PON creation, call each of your normals separately in artifact detection mode. Then use CombineVariants to
- * output only sites where a variant was seen in at least two samples:
+ *
+ * <h4>Single tumor sample</h4>
  * <pre>
- * java -jar GenomeAnalysisTK.jar
- *     -T CombineVariants
- *     -R reference.fasta
- *     -V output.normal1.vcf -V output.normal2.vcf [-V output.normal2.vcf ...] \
- *     -minN 2 \
- *     --setKey "null" \
- *     --filteredAreUncalled \
- *     --filteredrecordsmergetype KEEP_IF_ANY_UNFILTERED \
- *     [-L targets.interval_list] \
- *     -o Mutect2_PON.vcf
+ *  java -Xmx4g -jar $gatk_jar Mutect2 \
+ *   -R ref_fasta.fa \
+ *   -I tumor.bam \
+ *   -tumor tumor_sample_name \
+ *   --germline_resource af-only-gnomad.vcf.gz \
+ *   --normal_panel pon.vcf.gz \
+ *   -L intervals.list \
+ *   -O tumor_unmatched_m2_snvs_indels.vcf.gz
+ * </pre>
+ *
+ * <h4>Single normal sample for panel of normals (PoN) creation</h4>
+ * <p>
+ *    To create a panel of normals (PoN), call on each normal sample as if a tumor sample. Then use
+ *    {@link CreateSomaticPanelOfNormals} to output a PoN of germline and artifactual sites. This contrasts with the
+ *    GATK3 workflow, which uses CombineVariants to retain variant sites called in at least two samples and then uses
+ *    Picard MakeSitesOnlyVcf to simplify the callset for use as a PoN.
+ * </p>
+ * <pre>
+ * java -Xmx4g -jar $gatk_jar Mutect2 \
+ *   -R ref_fasta.fa \
+ *   -I normal1.bam \
+ *   -tumor normal1_sample_name \
+ *   --germline_resource af-only-gnomad.vcf.gz \
+ *   -L intervals.list \
+ *   -O normal1_for_pon.vcf.gz
  * </pre>
  *
  * <h3>Caveats</h3>
- * <ul>
- * <li>Mutect2 currently only supports the calling of a single tumor-normal pair at a time</li>
- * </ul>
- *
+ * <p>
+ *     Although GATK4 Mutect2 is optimized to accomodate varying coverage depths, further optimization of parameters
+ *     is necessary for extreme high depths, e.g. 1000X.
+ * </p>
  */
-@CommandLineProgramProperties(
-        summary = "Call somatic SNPs and indels via local re-assembly of haplotypes",
-        oneLineSummary = "Call somatic SNPs and indels via local re-assembly of haplotypes",
-        programGroup = VariantProgramGroup.class
-)
+ @CommandLineProgramProperties(
+         summary = "Call somatic SNVs and indels via local assembly of haplotypes",
+         oneLineSummary = "Call somatic SNVs and indels via local assembly of haplotypes",
+         programGroup = VariantProgramGroup.class
+ )
 @DocumentedFeature
 public final class Mutect2 extends AssemblyRegionWalker {
 


### PR DESCRIPTION
I've completely rewritten the documentation portion to be more helpful to users (and to reflect the new M2 rather than gatk3's M2), and I have updated the example commands.

---
### Questions for @davidbenjamin 
- `--af_of_alleles_not_in_resource`: is this allele frequency used only in certain contexts, e.g. with matched normal analyses, or towards tumor sample variant alleles, etc.? I need to add to the doc details how this argument factors into calculations.
- I need a sentence or two describing the new algorithmic improvement on the new Mutect2 integration over uncertainty. 
- The WDLs do not include use of a contamination.table and so I did not include it in the commands. Is this something we want to nudge users to use, i.e. should I put in a sentence in the documentation section about the new tool CalculateContamination?
