### PR TITLE
Re-enable openPrivateFileWithExplicitCredentials test

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -150,11 +150,13 @@ public abstract class BaseTest {
     }
 
     /**
-     * A local path where the service account credentials are stored
-     * @return GOOGLE_APPLICATION_CREDENTIALS env. var if defined, throws otherwise.
+     * A local path where the non-default service account credentials are stored.
+     * GOOGLE_APPLICATION_CREDENTIALS contains the default credentials, but this is
+     * to test the code path for explicit credentials.
+     * @return HELLBENDER_JSON_SERVICE_ACCOUNT_KEY env. var if defined, throws otherwise.
      */
     public static String getGoogleServiceAccountKeyPath() {
-      return getNonNullEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+      return getNonNullEnvironmentVariable("HELLBENDER_JSON_SERVICE_ACCOUNT_KEY");
     }
 
     protected static String getNonNullEnvironmentVariable(String envVarName) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/nio/GcsNioIntegrationTest.java
@@ -57,11 +57,20 @@ public final class GcsNioIntegrationTest extends BaseTest {
         }
     }
 
-    // TODO(jpmartin):uncomment once getAuthenticatedGcs is back
     /**
      * Opening the private file even when the user is not logged in on gcloud should work
      * when we provide explicit credentials.
      *
+     * How to run this test properly:
+     * - `gcloud auth revoke`
+     * - `gcloud beta auth application-default revoke`
+     * - unset GOOGLE_APPLICATION_CREDENTIALS
+     * - make sure HELLBENDER_JSON_SERVICE_ACCOUNT_KEY is set. It should
+     *   be the name of a file that holds your explicit credentials.
+     *
+     * The test "openPrivateFileUsingDefaultCredentials" should fail in those
+     * circumstances, but this test should pass.
+     **/
     @Test(groups = {"cloud"})
     public void openPrivateFileWithExplicitCredentials() throws IOException {
         // this file, potentially unlike the others in the set, is not marked as "Public link".


### PR DESCRIPTION
Also updated code and documentation to indicate how to properly run this
test. Sadly it has to be done manually because I don't know of a
reasonable way to disable default credentials.

Nevertheless it's good that the test is there even for automated runs,
so we can check that loading the explicit credentials does not break
anything.