### PR TITLE
shl add BETA tag to 19 tools; missing doc tags are resolved in se…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -18,6 +18,7 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
@@ -58,6 +59,8 @@ import java.util.stream.StreamSupport;
  *
  */
 @CommandLineProgramProperties(summary = "HaplotypeCaller on Spark", oneLineSummary = "HaplotypeCaller on Spark", programGroup = SparkProgramGroup.class)
+@DocumentedFeature
+@BetaFeature
 public final class HaplotypeCallerSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCaller.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -113,6 +114,7 @@ import java.util.Map;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public final class GermlineCNVCaller extends SparkToggleCommandLineProgram {
 
     private static final long serialVersionUID = -1149969750485027900L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
@@ -46,6 +47,7 @@ import java.util.List;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public class ConvertACNVResults extends SparkCommandLineProgram {
 
     static final long serialVersionUID = 42123132L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormals.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.exome;
 
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hdf5.HDF5File;
 import org.broadinstitute.hdf5.HDF5Library;
@@ -32,6 +33,7 @@ import java.util.List;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public final class CreateAllelicPanelOfNormals extends CommandLineProgram {
     protected static final String SITE_FREQUENCY_THRESHOLD_SHORT_NAME = "f";
     protected static final String SITE_FREQUENCY_THRESHOLD_LONG_NAME = "siteFrequencyThreshold";

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformAlleleFractionSegmentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformAlleleFractionSegmentation.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.exome.segmentation;
 
 import org.apache.commons.io.FilenameUtils;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
@@ -48,6 +49,7 @@ import java.util.List;
         oneLineSummary = "(Experimental) Segment genomic data into regions of constant minor allele fraction",
         programGroup = CopyNumberProgramGroup.class
 )
+@BetaFeature
 @DocumentedFeature
 public final class PerformAlleleFractionSegmentation extends CommandLineProgram {
     protected static final String INITIAL_NUM_STATES_LONG_NAME = "initialNumberOfStates";

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformCopyRatioSegmentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformCopyRatioSegmentation.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.exome.segmentation;
 
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
@@ -27,6 +28,7 @@ import java.util.List;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public final class PerformCopyRatioSegmentation extends CommandLineProgram {
     protected static final String INITIAL_NUM_STATES_LONG_NAME = "initialNumberOfStates";
     protected static final String INITIAL_NUM_STATES_SHORT_NAME = "initialNumStates";

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformJointSegmentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformJointSegmentation.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.exome.segmentation;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public class PerformJointSegmentation extends CommandLineProgram {
     protected static final String INITIAL_NUM_COPY_RATIO_STATES_LONG_NAME = "initialNumberOfCopyRatioStates";
     protected static final String INITIAL_NUM_COPY_RATIO_STATES_SHORT_NAME = "initialNumCRStates";

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotyper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotyper.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.exome.sexgenotyper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
@@ -99,6 +100,7 @@ import java.util.List;
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public class TargetCoverageSexGenotyper extends CommandLineProgram {
 
     private final Logger logger = LogManager.getLogger(TargetCoverageSexGenotyper.class);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignAssembledContigsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/AlignAssembledContigsSpark.java
@@ -7,6 +7,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 @CommandLineProgramProperties(summary="Align assembled contigs to the reference",
         oneLineSummary="Align assembled contigs to the reference",
         programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class AlignAssembledContigsSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromContigAlignmentsSAMSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromContigAlignmentsSAMSpark.java
@@ -14,9 +14,11 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
@@ -39,7 +41,8 @@ import java.util.stream.Collectors;
  */
 @CommandLineProgramProperties(summary="Parse a SAM file containing contigs or long reads aligned to the reference, and call SVs",
         oneLineSummary="Parse a SAM file containing contigs or long reads aligned to the reference, and call SVs",
-        programGroup = SparkProgramGroup.class)
+        programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class DiscoverVariantsFromContigAlignmentsSAMSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
     private final Logger localLogger = LogManager.getLogger(DiscoverVariantsFromContigAlignmentsSAMSpark.class);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromContigAlignmentsSGASpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromContigAlignmentsSGASpark.java
@@ -8,6 +8,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
@@ -23,6 +24,7 @@ import java.util.stream.StreamSupport;
 @CommandLineProgramProperties(summary="Filter breakpoint alignments and call variants.",
         oneLineSummary="Filter breakpoint alignments and call variants",
         programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class DiscoverVariantsFromContigAlignmentsSGASpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
     private static final Logger localLogger = LogManager.getLogger(DiscoverVariantsFromContigAlignmentsSGASpark.class);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSpark.java
@@ -12,6 +12,7 @@ import org.apache.spark.HashPartitioner;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
@@ -34,6 +35,7 @@ import java.util.*;
 @CommandLineProgramProperties(summary="Find the set of high copy number kmers in a reference.",
         oneLineSummary="find ref kmers with high copy number",
         programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class FindBadGenomicKmersSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
     @VisibleForTesting static final int MAX_KMER_FREQ = 3;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/FindBreakpointEvidenceSpark.java
@@ -10,6 +10,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
@@ -48,6 +49,7 @@ import static org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDi
         "  Assemble breakpoint regions with FermiLite, and align assembled contigs to reference.",
         oneLineSummary="Prepare local assemblies of putative genomic breakpoints for structural variant discovery.",
         programGroup=StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/RunSGAViaProcessBuilderOnSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/RunSGAViaProcessBuilderOnSpark.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
@@ -34,6 +35,7 @@ import java.util.stream.Stream;
                          "or runtime error messages if the process erred for some breakpoints.",
         oneLineSummary = "Perform SGA-based local assembly on fasta files on Spark.",
         programGroup   = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public final class RunSGAViaProcessBuilderOnSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -10,6 +10,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
@@ -30,6 +31,7 @@ import java.util.stream.IntStream;
 @CommandLineProgramProperties(summary="Master tool to run the structural variation discovery pipeline",
         oneLineSummary="Master tool to run the structural variation discovery pipeline",
         programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
 public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
     private final Logger localLogger = LogManager.getLogger(StructuralVariationDiscoveryPipelineSpark.class);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.contamination;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFConstants;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -22,7 +23,7 @@ import java.util.List;
  * Given a sites VCF of common population SNPs and a BAM file, summarizes alt and ref counts along with population allele frequency.
  *
  * <p>
- *     The resulting table is the input for {@link CalculateContamination}. 
+ *     The resulting table is the input for {@link CalculateContamination}.
  *     The sites VCF, e.g. gnomAD resource file, contains population allele frequencies (AF) in the INFO field.
  *     Note the default maximum population allele frequency (--maximumPopulationAlleleFrequency or -maxAF) is set to 0.2,
  *     which limits sites the tool considers to those in the variants resource file that have allele frequencies (AF) of 0.2 or less.
@@ -38,12 +39,13 @@ import java.util.List;
  *   -O pileups.table
  * </pre>
  *
- * @author David Benjamin &lt;davidben@brgoadinstitute.org&gt;
+ * @author David Benjamin &lt;davidben@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
         summary = "Calculate pileup statistics for inferring contamination",
         oneLineSummary = "Calculate pileup statistics for inferring contamination",
         programGroup = VariantProgramGroup.class)
+@BetaFeature
 @DocumentedFeature
 public class GetPileupSummaries extends MultiVariantWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -155,6 +156,7 @@ import java.util.List;
         programGroup = VariantProgramGroup.class
 )
 @DocumentedFeature
+@BetaFeature
 public final class HaplotypeCaller extends AssemblyRegionWalker {
 
     public static final int DEFAULT_READSHARD_SIZE = 5000;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
@@ -10,7 +10,9 @@ import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang.mutable.MutableLong;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.AbstractConcordanceWalker;
 import org.broadinstitute.hellbender.engine.ReadsContext;
@@ -48,6 +50,8 @@ import java.util.Set;
         oneLineSummary = "Evaluate a vcf against a vcf of validated (true) variants",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
+@BetaFeature
 public class Concordance extends AbstractConcordanceWalker {
     public static final String SUMMARY_LONG_NAME = "summary";
     public static final String SUMMARY_SHORT_NAME = "S";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/CountFalsePositives.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/CountFalsePositives.java
@@ -3,7 +3,9 @@ package org.broadinstitute.hellbender.tools.walkers.validation;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.commons.io.FilenameUtils;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
@@ -26,6 +28,8 @@ import java.util.List;
 /**
  * Created by Takuto Sato on 12/28/16.
  */
+@DocumentedFeature
+@BetaFeature
 public class CountFalsePositives extends VariantWalker {
     @Argument(
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,


### PR DESCRIPTION
…parate PRs

### Here are the twelve tools with the BETA tag:
```
CountFalsePositives
HaplotypeCaller
Concordance
GetPileupSummaries
PerformAlleleFractionSegmentation
PerformCopyRatioSegmentation
PerformJointSegmentation
TargetCoverageSexGenotyper
GermlineCNVCaller
CreateAllelicPanelOfNormals
HaplotypeCallerSpark
ConvertACNVResults
```

These include true BETA tools as well as experimental tools. The tag show up as:

![screenshot 2017-06-05 17 58 09](https://cloud.githubusercontent.com/assets/11543866/26805139/a346eff8-4a18-11e7-873b-4964dbf00aaa.png)
