### PR TITLE
Fix javadoc HTML in ReadLengthReadFilter and WellformedReadFilter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadLengthReadFilter.java
@@ -8,7 +8,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import java.io.Serializable;
 
 /**
- * Keep only reads whose length is >= min value and <= max value.
+ * Keep only reads whose length is &ge; min value and &le; max value.
  */
 @DocumentedFeature(groupName= HelpConstants.DOC_CAT_READFILTERS, groupSummary=HelpConstants.DOC_CAT_READFILTERS_SUMMARY)
 public final class ReadLengthReadFilter extends ReadFilter implements Serializable{

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/WellformedReadFilter.java
@@ -6,7 +6,7 @@ import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * Tests whether a read is "well-formed" -- that is, is free of major internal inconsistencies and issues that could lead
+ * Tests whether a read is &quot;well-formed&quot; -- that is, is free of major internal inconsistencies and issues that could lead
  * to errors downstream. If a read passes this filter, the rest of the hellbender engine should be able to process it without
  * blowing up.
  */


### PR DESCRIPTION
Using character entities in javadoc to correct HTML formatting.