### PR TITLE
SplitIntervals output argument made required, as it should be.  Closes #3409

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
@@ -71,7 +71,7 @@ public class SplitIntervals extends GATKTool {
 
     @Argument(doc = "The directory into which to write the scattered interval sub-directories.",
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
-            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, optional = true)
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME)
     public File outputDir;
 
     @Override


### PR DESCRIPTION
@lbergelson 