### PR TITLE
fixing problems with artifactory uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ after_success:
 - bash <(curl -s https://codecov.io/bash)
 - if [[ $TRAVIS_BRANCH == master && $UPLOAD == true ]]; then ./gradlew uploadArchives; fi
 # if this is actually a commit to master and not a pull request build into master, then publish master-snapshot
-- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && UPLOAD == true ]]; then
+- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && $UPLOAD == true ]]; then
     git tag master;
     ./gradlew uploadArchives; 
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ after_success:
 - bash <(curl -s https://codecov.io/bash)
 - if [[ $TRAVIS_BRANCH == master && $UPLOAD == true ]]; then ./gradlew uploadArchives; fi
 # if this is actually a commit to master and not a pull request build into master, then publish master-snapshot
-- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && UPLOAD == integration ]]; then
+- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && UPLOAD == true ]]; then
     git tag master;
     ./gradlew uploadArchives; 
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 env:
   matrix:
   - TEST_TYPE=cloud
-  - TEST_TYPE=integration TEST_VERBOSITY=minimal
+  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
   - TEST_TYPE=unit TEST_VERBOSITY=minimal
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
   - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
@@ -122,9 +122,9 @@ script:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- if [[ $TRAVIS_BRANCH == master && $TEST_TYPE == integration ]]; then ./gradlew uploadArchives; fi
+- if [[ $TRAVIS_BRANCH == master && $UPLOAD == true ]]; then ./gradlew uploadArchives; fi
 # if this is actually a commit to master and not a pull request build into master, then publish master-snapshot
-- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && $TEST_TYPE == integration ]]; then 
+- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false && UPLOAD == integration ]]; then
     git tag master;
     ./gradlew uploadArchives; 
   fi

--- a/build.gradle
+++ b/build.gradle
@@ -512,7 +512,7 @@ uploadArchives {
                 authentication(userName: project.findProperty("sonatypeUsername"), password: project.findProperty("sonatypePassword"))
             }
 
-            snapshotRepository(url: "https://artifactory.broadinstitute.org/artifactory/libs-snapshot-local/") {
+            snapshotRepository(url: "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/") {
                 authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
             }
 


### PR DESCRIPTION
update the artifactory url to point to the new artifactory
update the travis build with another environment variable called UPLOAD which determines if that build should upload a snapshot or not
fixes #3068 