### PR TITLE
Fix mention of STACK_TRACE_ON_USEREXCEPTION

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -195,7 +195,7 @@ public class Main {
         if(printStackTraceOnUserExceptions()) {
             e.printStackTrace();
         } else {
-            System.err.println("Use -DSTACK_TRACE_ON_USEREXCEPTION to print the stack trace.");
+            System.err.println("Use -D" + STACK_TRACE_ON_USER_EXCEPTION_PROPERTY + "to print the stack trace.");
         }
     }
 


### PR DESCRIPTION
(The variable was renamed to GATK_STACKTRACE_ON_USER_EXCEPTION)

There are no mentions left of STACK_TRACE_ON_USEREXCEPTION.

Thanks to David who reported this bug on gatk-dev-public.