### PR TITLE
Shl Correct and expand the M2ArgumentCollection documentation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -34,13 +34,13 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     /**
      * A panel of normals can be a useful (optional) input to help filter out commonly seen sequencing noise that may appear as low allele-fraction somatic variants.
      */
-    @Argument(fullName="normal_panel", shortName = "PON", doc="VCF file of sites observed in normal", optional = true)
+    @Argument(fullName="normal_panel", shortName = "PON", doc="VCF file of sites observed in normal.", optional = true)
     public FeatureInput<VariantContext> pon;
 
     /**
      * A resource, such as gnomAD, containing population allele frequencies of common and rare variants.
      */
-    @Argument(fullName="germline_resource", doc="Population vcf of germline sequencing containing allele fractions", optional = true)
+    @Argument(fullName="germline_resource", doc="Population vcf of germline sequencing containing allele fractions.", optional = true)
     public FeatureInput<VariantContext> germlineResource;
 
     /**
@@ -91,41 +91,46 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public double minNormalVariantFraction = 0.1;
 
     /**
-     * Only variants with tumor LODs exceeding this threshold will be written to the VCF, irregardless of filter status.
-     * Set to less than or equal to tumor_lod. Increase argument value to reduce false positive calls in the callset.
-     * Default setting of 3 is permissive and will emit some amount of false-positive calls that
-     * filtering should filter and that allows for downstream training outside of the current workflow, e.g. akin to germline VQSR.
+     * Only variants with tumor LODs exceeding this threshold will be written to the VCF, regardless of filter status.
+     * Set to less than or equal to tumor_lod. Increase argument value to reduce false positives in the callset.
+     * Default setting of 3 is permissive and will emit some amount of false-positives that
+     * filtering should filter and that allows for downstream training outside of the current workflow.
      */
-    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold to emit tumor variant to results")
+    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold to emit tumor variant to results.")
     public double emissionLodThreshold = 3.0;
 
     /**
      * This is a measure of the minimum evidence to support that a variant observed in the tumor is not also present in the normal.
-     * Applies to normal data in a tumor with matched normal analysis.
+     * Applies to normal data in a tumor with matched normal analysis. The default has been tuned for diploid somatic analyses.
+     * It is unlikely such analyses will require changing the default value. Increasing the parameter may increase the sensitivity of somatic calling,
+     * but may also increase calling false positive, i.e. germline, variants.
      */
-    @Argument(fullName = "normal_lod", optional = true, doc = "LOD threshold for calling normal variant non-germline")
+    @Argument(fullName = "normal_lod", optional = true, doc = "LOD threshold for calling normal variant non-germline.")
     public double NORMAL_LOD_THRESHOLD = 2.2;
 
     /**
-     * This argument is used for the M1-style strand bias filter
+     * @deprecated This argument is obsolete as of June 2017. It was previously used for the M1-style strand bias filter.
      */
-    @Argument(fullName="power_constant_qscore", doc="Phred scale quality score constant to use in power calculations", optional = true)
+    @Deprecated
+    @Argument(fullName="power_constant_qscore", doc="Phred scale quality score constant to use in power calculations.", optional = true)
     public int POWER_CONSTANT_QSCORE = 30;
 
     /**
-     * Which annotations to add to the output VCF file. See the VariantAnnotator -list argument to view available annotations.
+     * Which annotations to add to the output VCF file. By default the tool adds all annotations.
+     * If an annotation that a filter depends upon is absent, then the particular filtering will not occur and no warning will be given.
      */
     @Advanced
-    @Argument(fullName="annotation", shortName="A", doc="One or more specific annotations to apply to variant calls", optional = true)
+    @Argument(fullName="annotation", shortName="A", doc="One or more specific annotations to apply to variant calls.", optional = true)
     protected List<String> annotationsToUse = new ArrayList<>(Arrays.asList(new String[]{"Coverage", "DepthPerAlleleBySample",
             "TandemRepeat", "OxoGReadCounts", "ClippedBases", "ReadPosition", "BaseQuality", "MappingQuality",
             "FragmentLength", "StrandArtifact"}));
 
     /**
-     * Which groups of annotations to add to the output VCF file. The single value 'none' removes the default group. See
-     * the VariantAnnotator -list argument to view available groups. Note that this usage is not recommended because
-     * it obscures the specific requirements of individual annotations. Any requirements that are not met (e.g. failing
-     * to provide a pedigree file for a pedigree-based annotation) may cause the run to fail.
+     * Which groups of annotations to add to the output VCF file. The single value 'none' removes the default group.
+     * Note that this usage is not recommended because it obscures the specific requirements of individual annotations.
+     * Any requirements that are not met, e.g. failing to provide a pedigree file for a pedigree-based annotation, may cause the run to fail.
+     * For somatic analyses, the StandardSomaticAnnotation group currently contains two annotations: BaseQualitySumPerAlleleBySample and StrandArtifact.
+     * Note the latter is redundant to an annotation given by the --annotation argument default.
      */
     @Argument(fullName = "group", shortName = "G", doc = "One or more classes/groups of annotations to apply to variant calls", optional = true)
     public List<String> annotationGroupsToUse = new ArrayList<>(Arrays.asList(new String[]{}));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -53,7 +53,8 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public double afOfAllelesNotInGermlineResource = 0.001;
 
     /**
-     * Prior probability that any given site has a somatic allele. Impacts germline probability calculation.
+     * Prior log-10 probability that any given site has a somatic allele. Impacts germline probability calculation.
+     * The workflow uses this parameter only towards the germline event filter. It does NOT relate to the LOD threshold.
      * For example, -6 translates to one in a million or ~3000 somatic mutations per human genome.
      * Depending on tumor type, mutation rate ranges vary (Lawrence et al. Nature 2013), and so adjust parameter accordingly.
      * For higher expected rate of mutation, adjust number up, e.g. -5. For lower expected rate of mutation, adjust number down, e.g. -7.
@@ -84,19 +85,19 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
 
     /**
      * Minimum fraction of variant reads in normal for a pileup to be considered inactive. Applies to normal data in a tumor with matched normal analysis.
-     * For value of 0.1, at least one tenth of pileup must be variant for tool to consider it a germline variant site and therefore not a region of interest
+     * For value of 0.1, at least one tenth of pileup must be variant for tool to consider it a germline variant site and therefore not a locus of interest 
      * in the somatic analysis.
      */
-    @Argument(fullName = "minNormalVariantFraction", optional = true, doc = "Minimum fraction of variant reads in normal pileup to be considered germline.")
+    @Argument(fullName = "minNormalVariantFraction", optional = true, doc = "Minimum fraction of variant reads in normal pileup to be considered a germline variant site and thus not of further interest.")
     public double minNormalVariantFraction = 0.1;
 
     /**
      * Only variants with tumor LODs exceeding this threshold will be written to the VCF, regardless of filter status.
      * Set to less than or equal to tumor_lod. Increase argument value to reduce false positives in the callset.
-     * Default setting of 3 is permissive and will emit some amount of false-positives that
-     * filtering should filter and that allows for downstream training outside of the current workflow.
+     * Default setting of 3 is permissive and will emit some amount of negative training data that 
+     * {@link FilterMutectCalls} should then filter.
      */
-    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold to emit tumor variant to results.")
+    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold to emit tumor variant to VCF.")
     public double emissionLodThreshold = 3.0;
 
     /**
@@ -116,7 +117,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public int POWER_CONSTANT_QSCORE = 30;
 
     /**
-     * Which annotations to add to the output VCF file. By default the tool adds all annotations.
+     * Which annotations to add to the output VCF file. By default the tool adds all of the following annotations.
      * If an annotation that a filter depends upon is absent, then the particular filtering will not occur and no warning will be given.
      */
     @Advanced

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -46,14 +46,17 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     /**
      * Population allele fraction assigned to alleles not found in germline resource.
      */
-    @Argument(fullName="af_of_alleles_not_in_resurce", shortName = "default_af",
+    @Argument(fullName="af_of_alleles_not_in_resource", shortName = "default_af",
             doc="Population allele fraction assigned to alleles not found in germline resource.  A reasonable value is" +
                     "1/(2* number of samples in resource) if a germline resource is available; otherwise an average " +
                     "heterozygosity rate such as 0.001 is reasonable.", optional = true)
     public double afOfAllelesNotInGermlineResource = 0.001;
 
     /**
-     * Prior probability that any given site has a somatic allele
+     * Prior probability that any given site has a somatic allele. Impacts germline probability calculation.
+     * For example, -6 translates to one in a million or ~3000 somatic mutations per human genome.
+     * Depending on tumor type, mutation rate ranges vary (Lawrence et al. Nature 2013), and so adjust parameter accordingly.
+     * For higher expected rate of mutation, adjust number up, e.g. -5. For lower expected rate of mutation, adjust number down, e.g. -7.
      */
     @Argument(fullName="log_somatic_prior",
             doc="Prior probability that a given site has a somatic allele.", optional = true)
@@ -62,32 +65,45 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
 
     /**
      * Minimum number of variant reads in pileup to be considered an active region.
+     * In the hypothetical case of extreme high quality alignments, consider adjusting parameter down to 1.
+     * In the rare case of extreme deep coverage and where low fraction alleles are not of interest, adjust up to 3.
+     * Providing genomic intervals of interest with -L, setting the tumor standard deviation to zero and
+     * setting minimum variants in pileup to zero forces the tool to consider all provided regions as active.
      */
-    @Argument(fullName = "min_variants_in_pileup", optional = true, doc = "Minimum number of reads in pileup to be considered active region.")
+    @Argument(fullName = "min_variants_in_pileup", optional = true, doc = "Minimum number of variant reads in pileup to be considered active region.")
     public int minVariantsInPileup = 2;
 
     /**
-     * How many standard deviations above the expected number of variant reads due to error we require for a tumor pielup to be considered active
+     * How many standard deviations above the expected number of variant reads due to error we require for tool to consider a tumor pileup active.
+     * Argument sets the z-score. Here, base qualities inform expected error rate.
+     * Providing genomic intervals of interest with -L, setting the tumor standard deviation to zero and
+     * setting minimum variants in pileup to zero forces the tool to consider all provided regions as active.
      */
-    @Argument(fullName = "tumorStandardDeviationsThreshold", optional = true, doc = "How many standard deviations above the expected number of variant reads due to error we require for a tumor pielup to be considered active.")
+    @Argument(fullName = "tumorStandardDeviationsThreshold", optional = true, doc = "How many standard deviations above the expected number of variant reads due to error we require for a tumor pileup to be considered active.")
     public int tumorStandardDeviationsThreshold = 2;
 
     /**
-     * Minimum allele fraction of variant reads in normal for a pileup to be considered inactive
+     * Minimum fraction of variant reads in normal for a pileup to be considered inactive. Applies to normal data in a tumor with matched normal analysis.
+     * For value of 0.1, at least one tenth of pileup must be variant for tool to consider it a germline variant site and therefore not a region of interest
+     * in the somatic analysis.
      */
-    @Argument(fullName = "minNormalVariantFraction", optional = true, doc = "Minimum number of reads in pileup to be considered active region.")
+    @Argument(fullName = "minNormalVariantFraction", optional = true, doc = "Minimum fraction of variant reads in normal pileup to be considered germline.")
     public double minNormalVariantFraction = 0.1;
 
     /**
-     * Only variants with tumor LODs exceeding this threshold can pass filtering.
+     * Only variants with tumor LODs exceeding this threshold will be written to the VCF, irregardless of filter status.
+     * Set to less than or equal to tumor_lod. Increase argument value to reduce false positive calls in the callset.
+     * Default setting of 3 is permissive and will emit some amount of false-positive calls that
+     * filtering should filter and that allows for downstream training outside of the current workflow, e.g. akin to germline VQSR.
      */
-    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold for emit tumor variant")
+    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold to emit tumor variant to results")
     public double emissionLodThreshold = 3.0;
 
     /**
      * This is a measure of the minimum evidence to support that a variant observed in the tumor is not also present in the normal.
+     * Applies to normal data in a tumor with matched normal analysis.
      */
-    @Argument(fullName = "normal_lod", optional = true, doc = "LOD threshold for calling normal non-germline")
+    @Argument(fullName = "normal_lod", optional = true, doc = "LOD threshold for calling normal variant non-germline")
     public double NORMAL_LOD_THRESHOLD = 2.2;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -71,8 +71,6 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
         this.tumorSampleName = tumorSampleName;
         this.matchedNormalSampleName = matchedNormalSampleName;
         hasNormal = matchedNormalSampleName != null;
-
-        final double errorProbability = QualityUtils.qualToErrorProb(MTAC.POWER_CONSTANT_QSCORE);
     }
 
     /**


### PR DESCRIPTION
I also removed the obsolete errorProbability variable line of code in the SomaticGenotypingEngine.java and noted this argument is deprecated in the M2ArgumentCollection.

Somewhat relatedly, see request in #3123.
