### PR TITLE
Upgrade barclay, htsjdk, gatk-fermilite-jni and gatk-bwamem-jni

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.9.1-34-gd7bae17-SNAPSHOT')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.10.1')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.8.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.6.4-proto-3.0.0-beta-1')
@@ -111,7 +111,7 @@ dependencies {
     compileOnly(javadocJDKFiles)
     testCompile(javadocJDKFiles)
 
-    compile 'org.broadinstitute:barclay:1.0.0-32-g78b1711-SNAPSHOT'
+    compile 'org.broadinstitute:barclay:1.1.0'
     compile ('com.intel:genomicsdb:' + genomicsdbVersion)  {
         exclude module: 'spark-core_2.10'
         exclude module: 'htsjdk'
@@ -195,8 +195,8 @@ dependencies {
         exclude module: 'htsjdk'
     }
 
-    compile 'org.broadinstitute:gatk-bwamem-jni:1.0.0-rc2-SNAPSHOT'
-    compile 'org.broadinstitute:gatk-fermilite-jni:1.0.0.-rc5-SNAPSHOT'
+    compile 'org.broadinstitute:gatk-bwamem-jni:1.0.0'
+    compile 'org.broadinstitute:gatk-fermilite-jni:1.0.0'
 
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'


### PR DESCRIPTION
 from snapshots to released versions.