### PR TITLE
Filter Mutect2 artifacts that arise from apparent-duplicate reads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/UniqueAltReadCount.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/UniqueAltReadCount.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator;
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFFormatHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This annotation counts, at each variant locus, the number of ALT reads with unique start positions and fragment lengths.
+ * i.e. multiple reads with the same start position and fragment length are grouped and counted only once as they are
+ * likely duplicates. We have seen that the majority of false positives in low allele fraction, cell-free DNA samples
+ * have the profile where the evidence for alternate allele comes solely from one, two, or three sets of apparent PCR-duplicates.
+ * Reads in such a set have the same read-start and mate-end position i.e. they come from the same original insert.
+ * Normally, they are marked as duplicates by Picard MarkDuplicates. But when we use unique molecular identifiers (UMIs),
+ * these apparent PCR-duplicate reads may get different UMIs, and hence to Mutect these reads appear as
+ * independent evidence for ALT allele.
+ *
+ * Although these reads have different UMIs, we suspect that they really are PCR-duplicates, for two reasons:
+ * 1) these sites are false positives, and
+ * 2) with hybrid selection, it's highly unlikely that we sequence multiple fragments with identical start and end positions.
+ *
+ * We now believe that these duplicates are the result of a false-priming event that occurs during PCR amplification.
+ * We suspect that during amplification excess adapter remains after the ligation step and fails to be completely
+ * cleaned up during SPRI. This excess adapter is thought to act as a PCR primer during amplification, which leads to
+ * the synthesis of a molecule with the wrong UMI.
+ *
+ * We filter the variant if the count is lower than a user-specified threshold.
+ * Mutect2FilteringEngine::applyDuplicatedAltReadFilter is the accompanying filter.
+ */
+public class UniqueAltReadCount extends GenotypeAnnotation implements StandardSomaticAnnotation {
+    public static final String UNIQUE_ALT_READ_SET_COUNT_KEY = "UNIQ_ALT_READ_COUNT";
+
+    @Override
+    public List<String> getKeyNames() {
+        return Collections.singletonList(UNIQUE_ALT_READ_SET_COUNT_KEY);
+    }
+
+    @Override
+    public List<VCFFormatHeaderLine> getDescriptions() {
+        return Arrays.asList(new VCFFormatHeaderLine(UNIQUE_ALT_READ_SET_COUNT_KEY, 1, VCFHeaderLineType.Integer,
+                "Number of ALT reads with unique start and mate end positions at a variant site"));
+    }
+
+    @Override
+    public void annotate(final ReferenceContext ref,
+                         final VariantContext vc,
+                         final Genotype g,
+                         final GenotypeBuilder gb,
+                         final ReadLikelihoods<Allele> likelihoods) {
+        if (g.isHomRef()) {
+            // skip the normal sample
+            return;
+        }
+
+        final Allele altAllele = vc.getAlternateAllele(0); // assume single-allelic
+        final String tumorSampleName = g.getSampleName();
+        Collection<ReadLikelihoods<Allele>.BestAllele> tumorBestAlleles = likelihoods.bestAlleles(tumorSampleName);
+
+        // Build a map from the (Start Position, Fragment Size) tuple to the count of reads with that
+        // start position and fragment size
+        Map<ImmutablePair<Integer, Integer>, Long> duplicateReadMap = tumorBestAlleles.stream()
+                .filter(ba -> ba.allele.equals(altAllele) && ba.isInformative())
+                .map(ba -> new ImmutablePair<>(ba.read.getStart(), ba.read.getFragmentLength()))
+                .collect(Collectors.groupingBy(x -> x, Collectors.counting()));
+
+        gb.attribute(UNIQUE_ALT_READ_SET_COUNT_KEY, duplicateReadMap.size());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
@@ -88,6 +88,7 @@ public final class FilterMutectCalls extends VariantWalker {
         GATKVCFConstants.MUTECT_FILTER_NAMES.stream().map(GATKVCFHeaderLines::getFilterLine).forEach(headerLines::add);
 
         headerLines.addAll(getDefaultToolVCFHeaderLines());
+
         final VCFHeader vcfHeader = new VCFHeader(headerLines, inputHeader.getGenotypeSamples());
         vcfWriter = createVCFWriter(new File(outputVcf));
         vcfWriter.writeHeader(vcfHeader);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
@@ -30,25 +30,25 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
     @Argument(fullName = "max_germline_posterior", optional = true, doc = "Maximum posterior probability that an allele is a germline variant")
     public double maxGermlinePosterior = 0.025;
 
-    @Argument(fullName = "maxAltAllelesThreshold", optional = true, doc="filter variants with too many alt alleles")
+    @Argument(fullName = "maxAltAllelesThreshold", optional = true, doc = "filter variants with too many alt alleles")
     public int numAltAllelesThreshold = 1;
 
-    @Argument(fullName = "maxMedianMappingQualityDifference", optional = true, doc="filter variants for which alt reads' median mapping quality is much lower than ref reads' median mapping quality.")
+    @Argument(fullName = "maxMedianMappingQualityDifference", optional = true, doc = "filter variants for which alt reads' median mapping quality is much lower than ref reads' median mapping quality.")
     public int maxMedianMappingQualityDifference = 30;
 
-    @Argument(fullName = "maxMedianBaseQualityDifference", optional = true, doc="filter variants for which alt reads' median base quality is much lower than ref reads' median base quality.")
+    @Argument(fullName = "maxMedianBaseQualityDifference", optional = true, doc = "filter variants for which alt reads' median base quality is much lower than ref reads' median base quality.")
     public int maxMedianBaseQualityDifference = 10;
 
-    @Argument(fullName = "maxMedianClippingDifference", optional = true, doc="filter variants for which alt reads' median number of clipped bases is too high compared to the median for ref reads.")
+    @Argument(fullName = "maxMedianClippingDifference", optional = true, doc = "filter variants for which alt reads' median number of clipped bases is too high compared to the median for ref reads.")
     public int maxMedianClippingDifference = 1;
 
-    @Argument(fullName = "maxMedianFragmentLengthDifference", optional = true, doc="filter variants for which alt reads' median fragment length is very different from the median for ref reads.")
+    @Argument(fullName = "maxMedianFragmentLengthDifference", optional = true, doc = "filter variants for which alt reads' median fragment length is very different from the median for ref reads.")
     public int maxMedianFragmentLengthDifference = 10000;
 
-    @Argument(fullName = "minMedianReadPosition", optional = true, doc="filter variants for which the median position of alt alleles within reads is too near the end of reads.")
+    @Argument(fullName = "minMedianReadPosition", optional = true, doc = "filter variants for which the median position of alt alleles within reads is too near the end of reads.")
     public int minMedianReadPosition = 5;
 
-    @Argument(fullName = "maxEventsInHaplotype", optional = true, doc="Variants coming from a haplotype with more than this many events are filtered")
+    @Argument(fullName = "maxEventsInHaplotype", optional = true, doc = "Variants coming from a haplotype with more than this many events are filtered")
     public int maxEventsInHaplotype = 2;
 
     @Argument(shortName = "strand_prob", fullName = "strandArtifactPosteriorProbability", optional = true, doc = "Filter a variant if the probability of strand artifact exceeds this number")
@@ -57,7 +57,10 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
     @Argument(shortName = "strand_af", fullName = "strandArtifactAlleleFraction", optional = true, doc = "Only filter a variant if the MAP estimate of allele fraction given artifact is below this number")
     public double STRAND_ARTIFACT_ALLELE_FRACTION_THRESHOLD = 0.01;
 
-    @Argument(shortName = "contaminationTable", fullName = "contaminationTable", optional = true, doc="Table containing contamination information.")
+    @Argument(shortName = "contaminationTable", fullName = "contaminationTable", optional = true, doc = "Table containing contamination information.")
     public File contaminationTable = null;
+
+    @Argument(shortName = "unique", fullName = "uniqueAltReadCount", optional = true, doc = "Filter a variant if a site contains fewer than this many unique (i.e. deduplicated) reads supporting the alternate allele")
+    public int uniqueAltReadCount = 0;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -14,7 +14,6 @@ import java.util.*;
  * Created by David Benjamin on 9/15/16.
  */
 public class Mutect2FilteringEngine {
-
     private M2FiltersArgumentCollection MTFAC;
     private final double contamination;
     private final String tumorSample;
@@ -192,11 +191,28 @@ public class Mutect2FilteringEngine {
         }
     }
 
+    // This filter checks for the case in which PCR-duplicates with unique UMIs (which we assume is caused by false adapter priming)
+    // amplify the erroneous signal for an alternate allele.
+    private void applyDuplicatedAltReadFilter(final M2FiltersArgumentCollection MTFAC, final VariantContext vc, final Collection<String> filters) {
+        Genotype tumorGenotype = vc.getGenotype(tumorSample);
+
+        if (!tumorGenotype.hasExtendedAttribute(UniqueAltReadCount.UNIQUE_ALT_READ_SET_COUNT_KEY)) {
+            return;
+        }
+
+        final int uniqueReadSetCount = GATKProtectedVariantContextUtils.getAttributeAsInt(tumorGenotype, UniqueAltReadCount.UNIQUE_ALT_READ_SET_COUNT_KEY, -1);
+
+        if (uniqueReadSetCount <= MTFAC.uniqueAltReadCount) {
+            filters.add(GATKVCFConstants.DUPLICATED_EVIDENCE_FILTER_NAME);
+        }
+    }
+
     //TODO: building a list via repeated side effects is ugly
     public Set<String> calculateFilters(final M2FiltersArgumentCollection MTFAC, final VariantContext vc) {
         final Set<String> filters = new HashSet<>();
         applyInsufficientEvidenceFilter(MTFAC, vc, filters);
         applyClusteredEventFilter(vc, filters);
+        applyDuplicatedAltReadFilter(MTFAC, vc, filters);
         applyTriallelicFilter(vc, filters);
         applyPanelOfNormalsFilter(MTFAC, vc, filters);
         applyGermlineVariantFilter(MTFAC, vc, filters);

--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
@@ -121,7 +121,7 @@ public class GATKProtectedVariantContextUtils {
             if (o == null) {
                 return missingValue;
             } else {
-                final String s = String.valueOf(o);
+                final String s = String.valueOf(o).trim();
                 if (s.equals(VCFConstants.MISSING_VALUE_v4)) {
                     return missingValue;
                 } else {

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -142,6 +142,7 @@ public final class GATKVCFConstants {
     public static final String TUMOR_LOD_FILTER_NAME =                        "t_lod"; //M2
     public static final String MULTIALLELIC_FILTER_NAME =                     "multiallelic"; //M2
     public static final String STRAND_ARTIFACT_FILTER_NAME =                  "strand_artifact"; // M2
+    public static final String DUPLICATED_EVIDENCE_FILTER_NAME =              "duplicate_evidence";
     public final static String ARTIFACT_IN_NORMAL_FILTER_NAME =                "artifact_in_normal";
     public final static String MEDIAN_BASE_QUALITY_DIFFERENCE_FILTER_NAME =     "base_quality";
     public final static String MEDIAN_MAPPING_QUALITY_DIFFERENCE_FILTER_NAME = "mapping_quality";
@@ -155,7 +156,7 @@ public final class GATKVCFConstants {
             MULTIALLELIC_FILTER_NAME, STRAND_ARTIFACT_FILTER_NAME, ARTIFACT_IN_NORMAL_FILTER_NAME,
             MEDIAN_BASE_QUALITY_DIFFERENCE_FILTER_NAME, MEDIAN_MAPPING_QUALITY_DIFFERENCE_FILTER_NAME,
             MEDIAN_CLIPPING_DIFFERENCE_FILTER_NAME, MEDIAN_FRAGMENT_LENGTH_DIFFERENCE_FILTER_NAME,
-            READ_POSITION_FILTER_NAME, CONTAMINATION_FILTER_NAME);
+            READ_POSITION_FILTER_NAME, CONTAMINATION_FILTER_NAME, DUPLICATED_EVIDENCE_FILTER_NAME);
 
     // Symbolic alleles
     public final static String SYMBOLIC_ALLELE_DEFINITION_HEADER_TAG = "ALT";

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -61,6 +61,7 @@ public class GATKVCFHeaderLines {
         addFilterLine(new VCFFilterHeaderLine(MEDIAN_FRAGMENT_LENGTH_DIFFERENCE_FILTER_NAME, "abs(ref - alt) median fragment length"));
         addFilterLine(new VCFFilterHeaderLine(READ_POSITION_FILTER_NAME, "median distance of alt variants from end of reads"));
         addFilterLine(new VCFFilterHeaderLine(CONTAMINATION_FILTER_NAME, "contamination"));
+        addFilterLine(new VCFFilterHeaderLine(DUPLICATED_EVIDENCE_FILTER_NAME, "evidence for alt allele is overrepresented by apparent duplicates"));
 
         addFormatLine(new VCFFormatHeaderLine(ALLELE_BALANCE_KEY, 1, VCFHeaderLineType.Float, "Allele balance for each het genotype"));
         addFormatLine(new VCFFormatHeaderLine(MAPPING_QUALITY_ZERO_BY_SAMPLE_KEY, 1, VCFHeaderLineType.Integer, "Number of Mapping Quality Zero Reads per sample"));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/UniqueAltReadCountUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/UniqueAltReadCountUnitTest.java
@@ -1,0 +1,126 @@
+package org.broadinstitute.hellbender.tools.walkers.mutect;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.variant.variantcontext.*;
+import org.broadinstitute.hellbender.tools.walkers.annotator.UniqueAltReadCount;
+import org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils;
+import org.broadinstitute.hellbender.utils.genotyper.*;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+public class UniqueAltReadCountUnitTest {
+    final String sampleName = "Mark";
+    final int chromosomeIndex = 1;
+    final long variantSite = 105;
+    final int numAltReads = 12;
+
+    final SampleList sampleList = new IndexedSampleList(sampleName);
+
+    final List<Allele> alleles = Arrays.asList(Allele.create((byte) 'C', true), Allele.create((byte) 'A', false));
+    final AlleleList<Allele> alleleList = new IndexedAlleleList<>(alleles);
+    final VariantContext vc = new VariantContextBuilder("source", Integer.toString(chromosomeIndex), variantSite, variantSite, alleles).make();
+
+    @Test
+    public void testSingleDuplicate() throws IOException {
+        final ReadLikelihoods<Allele> likelihoods = createTestLikelihoods(Optional.empty());
+        final UniqueAltReadCount uniqueAltReadCountAnnotation = new UniqueAltReadCount();
+        final GenotypeBuilder genotypeBuilder = new GenotypeBuilder(sampleName);
+        uniqueAltReadCountAnnotation.annotate(null, vc, genotypeBuilder.make(), genotypeBuilder, likelihoods);
+
+        final Genotype genotype = genotypeBuilder.make();
+
+        final int uniqueReadSetCount = GATKProtectedVariantContextUtils.getAttributeAsInt(genotype, UniqueAltReadCount.UNIQUE_ALT_READ_SET_COUNT_KEY, -1);
+        Assert.assertEquals(uniqueReadSetCount, 1);
+    }
+
+    @Test
+    public void testMultipleDuplicateSets() throws IOException {
+        final UniqueAltReadCount duplicateReadCountsAnnotation = new UniqueAltReadCount();
+
+        // should get three unique sets of ALT reads
+        final int numUniqueStarts1 = 3;
+        final ReadLikelihoods<Allele> likelihoods1 = createTestLikelihoods(Optional.of(numUniqueStarts1));
+        final GenotypeBuilder genotypeBuilder1 = new GenotypeBuilder(sampleName);
+        duplicateReadCountsAnnotation.annotate(null, vc, genotypeBuilder1.make(), genotypeBuilder1, likelihoods1);
+
+        final Genotype genotype1 = genotypeBuilder1.make();
+
+        final int uniqueReadSetCount1 = GATKProtectedVariantContextUtils.getAttributeAsInt(genotype1, UniqueAltReadCount.UNIQUE_ALT_READ_SET_COUNT_KEY, -1);
+
+        Assert.assertEquals(uniqueReadSetCount1, numUniqueStarts1);
+
+        // here ALT reads are all distinct
+        final int numUniqueStarts2 = numAltReads;
+        final ReadLikelihoods<Allele> likelihoods2 = createTestLikelihoods(Optional.of(numUniqueStarts2));
+        final GenotypeBuilder genotypeBuilder2 = new GenotypeBuilder(sampleName);
+        duplicateReadCountsAnnotation.annotate(null, vc, genotypeBuilder2.make(), genotypeBuilder2, likelihoods2);
+
+        final Genotype genotype2 = genotypeBuilder2.make();
+
+        final int uniqueReadSetCount2 = GATKProtectedVariantContextUtils.getAttributeAsInt(genotype2, UniqueAltReadCount.UNIQUE_ALT_READ_SET_COUNT_KEY, -1);
+
+        Assert.assertEquals(uniqueReadSetCount2, numUniqueStarts2);
+    }
+
+    private ReadLikelihoods<Allele> createTestLikelihoods(final Optional<Integer> shiftModulus) {
+        final int numChromosomes = 2;
+        final int startingChromosome = 1;
+        final int chromosomeSize = 1000;
+        final SAMFileHeader SAM_HEADER = ArtificialReadUtils.createArtificialSamHeader(numChromosomes, startingChromosome, chromosomeSize);
+
+        final int alignmentStart = 100;
+        final int readLength = 11;
+        final byte baseq = 30;
+
+        final int numRefReads = 10;
+        final int numReads = numAltReads + numRefReads;
+
+        final Map<String, List<GATKRead>> readMap = new LinkedHashMap<>();
+        final List<GATKRead> reads = new ArrayList<>(numReads);
+        final byte[] quals = new byte[readLength];
+        Arrays.fill(quals, baseq);
+
+        // add alt reads, with the start position shifted by i mod shiftModulus
+        for (int i = 0; i < numAltReads; i++) {
+            final int startPosition = shiftModulus.isPresent() ? alignmentStart + (i % shiftModulus.get()) : alignmentStart;
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(SAM_HEADER, "Read" + i, chromosomeIndex, startPosition,
+                    "CCCCCACCCCC".getBytes(), quals, "11M");
+            reads.add(read);
+        }
+
+        // add ref reads
+        for (int j = numAltReads; j < numReads; j++) {
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(SAM_HEADER, "Read" + j, chromosomeIndex, alignmentStart,
+                    "CCCCCCCCCCC".getBytes(), quals, "11M");
+            reads.add(read);
+        }
+
+        readMap.put(sampleName, reads);
+
+        final ReadLikelihoods<Allele> likelihoods = new ReadLikelihoods<>(sampleList, alleleList, readMap);
+        final int sampleIndex = 0;
+        final LikelihoodMatrix<Allele> matrix = likelihoods.sampleMatrix(sampleIndex);
+
+        final double logLikelihoodOfBestAllele = 10.0;
+        final int refAlleleIndex = 0;
+        final int altAlleleIndex = 1;
+
+        // Log likelihoods are initialized to 0 for all alleles. For each read_i, set its log likelihood for ALT allele to a positive value.
+        // This makes read_i an ALT read
+        for (int i = 0; i < numAltReads; i++) {
+            matrix.set(altAlleleIndex, i, logLikelihoodOfBestAllele);
+        }
+
+        // Analogously, make read_j a REF read
+        for (int j = numAltReads; j < numReads; j++) {
+            matrix.set(refAlleleIndex, j, logLikelihoodOfBestAllele);
+        }
+
+        return likelihoods;
+    }
+}


### PR DESCRIPTION
Migrated from broadinstitute/gatk-protected#1109