### PR TITLE
Fix for randomly failing XHMM-related tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMEmissionProbabilityCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMEmissionProbabilityCalculator.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.tools.exome.germlinehmm.CopyNumberTriState;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import javax.annotation.Nonnull;
+import java.util.Random;
 
 /**
  * Implements the {@link TargetLikelihoodCalculator} interface for the original XHMM-based germline model.
@@ -17,23 +18,20 @@ import javax.annotation.Nonnull;
  * @author David Benjamin &lt;davidben@broadinstitute.org&gt;
  */
 public final class XHMMEmissionProbabilityCalculator implements TargetLikelihoodCalculator<XHMMEmissionData> {
-    private final RandomGenerator rng;
     private final double emissionStandardDeviation;
     private final double deletionMean;
     private final double duplicationMean;
     private static final double NEUTRAL_MEAN = 0.0;
 
-    public XHMMEmissionProbabilityCalculator(final double deletionMean, final double duplicationMean, final double emissionStdDev,
-                                             @Nullable final RandomGenerator rng) {
+    public XHMMEmissionProbabilityCalculator(final double deletionMean, final double duplicationMean, final double emissionStdDev) {
         this.deletionMean = ParamUtils.isNegativeOrZero(deletionMean, "Deletion coverage shift must be negative.");
         this.duplicationMean = ParamUtils.isPositiveOrZero(duplicationMean, "Duplication coverage shift must be positive");
         emissionStandardDeviation = ParamUtils.isPositive(emissionStdDev, "Emission standard deviation must be positive");
-        this.rng = rng;
     }
 
     @Override
     public double logLikelihood(@Nonnull final XHMMEmissionData emissionData, final double copyRatio, final Target target) {
-        return new NormalDistribution(rng, getEmissionMean(copyRatio), emissionStandardDeviation)
+        return new NormalDistribution(null, getEmissionMean(copyRatio), emissionStandardDeviation)
                 .logDensity(emissionData.getCoverageZScore());
     }
 
@@ -49,7 +47,7 @@ public final class XHMMEmissionProbabilityCalculator implements TargetLikelihood
         }
     }
 
-    public double generateRandomZScoreData(final double copyRatio) {
+    public double generateRandomZScoreData(final double copyRatio, final Random rng) {
         Utils.nonNull(rng, "Random z-score sampling is called by the random number generator is null. This" +
                 " instance of the class can not produce random samples.");
         return getEmissionMean(copyRatio) + rng.nextGaussian() * emissionStandardDeviation;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMModel.java
@@ -47,11 +47,6 @@ public final class XHMMModel extends CopyNumberTriStateHMM<XHMMEmissionData> {
     private static final double EMISSION_SD = 1.0;
 
     /**
-     * A random seed for instantiating a random number generator for {@link XHMMEmissionProbabilityCalculator}
-     */
-    private static final int RANDOM_SEED = 1767;
-
-    /**
      * Creates a new model instance.
      *
      * @param eventStartProbability the probability per base pair of a transition from neutral to a CNV
@@ -64,19 +59,15 @@ public final class XHMMModel extends CopyNumberTriStateHMM<XHMMEmissionData> {
                      final double meanEventSize,
                      final double deletionMeanShift,
                      final double duplicationMeaShift) {
-        super(new XHMMEmissionProbabilityCalculator(
-                deletionMeanShift,
-                duplicationMeaShift,
-                EMISSION_SD, RandomGeneratorFactory.createRandomGenerator(new Random(RANDOM_SEED))),
-                eventStartProbability,
-                meanEventSize);
+        super(new XHMMEmissionProbabilityCalculator(deletionMeanShift, duplicationMeaShift, EMISSION_SD),
+                eventStartProbability, meanEventSize);
     }
 
     @VisibleForTesting
     public Double randomDatum(final CopyNumberTriState state, final Random rdn) {
         Utils.nonNull(state);
         Utils.nonNull(rdn);
-        return ((XHMMEmissionProbabilityCalculator)targetLikelihoodCalculator).generateRandomZScoreData(state.copyRatio);
+        return ((XHMMEmissionProbabilityCalculator)targetLikelihoodCalculator).generateRandomZScoreData(state.copyRatio, rdn);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentGenotyper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentGenotyper.java
@@ -75,7 +75,7 @@ public final class XHMMSegmentGenotyper extends XHMMSegmentCallerBase {
         final HMMPostProcessor<XHMMEmissionData, CopyNumberTriState, Target> processor =
                 new HMMPostProcessor<>(inputCounts.columnNames(),
                         Collections.nCopies(inputCounts.columnNames().size(), targets),
-                        sampleForwardBackwardResults, sampleBestPaths,  CopyNumberTriState.NEUTRAL);
+                        sampleForwardBackwardResults, sampleBestPaths, CopyNumberTriState.NEUTRAL);
         processor.writeVariantsToVCFWriterOnGivenSegments(segmentsFile, CopyNumberTriState::fromCallString,
                 outputWriter, "CNV", this.getCommandLine());
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/hmm/segmentation/HMMPostProcessor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hmm/segmentation/HMMPostProcessor.java
@@ -548,9 +548,11 @@ public class HMMPostProcessor<D, S extends AlleleMetadataProducer & CallStringPr
             final Set<String> sampleNamesFromSegmentsFile = allRecords.stream()
                     .map(HiddenStateSegmentRecord::getSampleName)
                     .collect(Collectors.toSet());
-            if (!new HashSet<>(sampleNames).equals(sampleNamesFromSegmentsFile)) {
-                throw new UserException.BadInput("The sample names in the provided segments file does not match" +
-                        " those on which HMM output is given");
+            if (!new HashSet<>(sampleNames).containsAll(sampleNamesFromSegmentsFile)) {
+                throw new UserException.BadInput(String.format("Some samples in the genotyping segments file" +
+                                " do not have HMM results; queried samples: %s, samples with available HMM results: %s",
+                        sampleNamesFromSegmentsFile.stream().collect(Collectors.joining(", ", "[", "]")),
+                        sampleNames.stream().collect(Collectors.joining(", ", "[", "]"))));
             }
             final List<GenotypingSegment> result = new ArrayList<>();
             for (final HiddenStateSegmentRecord<S, T> record : nonRefAndSortedRecords) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerBaseIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerBaseIntegrationTest.java
@@ -30,11 +30,11 @@ public abstract class XHMMSegmentCallerBaseIntegrationTest extends CommandLinePr
 
     private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
 
-    public static final File REALISTIC_TARGETS_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "realistic-targets.tab");
+    public static final File TRUNCATED_REALISTIC_TARGETS_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "truncated-realistic-targets.tab");
     public static final TargetCollection<Target> REALISTIC_TARGETS;
 
     static {
-        try (final TargetTableReader reader = new TargetTableReader(REALISTIC_TARGETS_FILE)) {
+        try (final TargetTableReader reader = new TargetTableReader(TRUNCATED_REALISTIC_TARGETS_FILE)) {
             REALISTIC_TARGETS = new HashedListTargetCollection<>(reader.stream().collect(Collectors.toList()));
         } catch (final IOException ex) {
             throw new GATKException("could not read the realistic-targets file", ex);

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerIntegrationTest.java
@@ -73,7 +73,7 @@ public class XHMMSegmentCallerIntegrationTest extends XHMMSegmentCallerBaseInteg
         runCommandLine(chain, inputFile, outputFile);
 
         Assert.assertTrue(outputFile.exists());
-        final TargetCollection<Target> targets = TargetArgumentCollection.readTargetCollection(REALISTIC_TARGETS_FILE);
+        final TargetCollection<Target> targets = TargetArgumentCollection.readTargetCollection(TRUNCATED_REALISTIC_TARGETS_FILE);
         final List<HiddenStateSegmentRecord<CopyNumberTriState, Target>> outputRecords = readOutputRecords(outputFile);
         assertOutputIsInOrder(outputRecords, targets);
         assertOutputHasConsistentNumberOfTargets(outputRecords, targets);

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentGenotyperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentGenotyperIntegrationTest.java
@@ -52,7 +52,7 @@ public class XHMMSegmentGenotyperIntegrationTest extends XHMMSegmentCallerBaseIn
         arguments.add("-" + XHMMSegmentGenotyper.DISCOVERY_FILE_SHORT_NAME);
         arguments.add(segmentsFile.getAbsolutePath());
         arguments.add("-" + TargetArgumentCollection.TARGET_FILE_SHORT_NAME);
-        arguments.add(XHMMSegmentCallerBaseIntegrationTest.REALISTIC_TARGETS_FILE.getAbsolutePath());
+        arguments.add(XHMMSegmentCallerBaseIntegrationTest.TRUNCATED_REALISTIC_TARGETS_FILE.getAbsolutePath());
         arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
         arguments.add(outputFile.getAbsolutePath());
         loadModelArguments(chain, arguments);

--- a/src/test/resources/large/cnv/truncated-realistic-targets.tab
+++ b/src/test/resources/large/cnv/truncated-realistic-targets.tab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f63687a896fc192dc6e59f645dad77e8d59879c48a025ef03090a4a3bb7b8ca
+size 367666


### PR DESCRIPTION
Still not sure why the tests failed randomly! all XHMM-related tests use their own RNG with fixed seeds and there are no RNG calls in any parallel streams. Therefore, the randomly generated test data must be identical and fully deterministic across all runs. However, it did not appear to be the case! some test runs triggered a bug in HMMPostProcessor (see below) and some runs didn't. I removed a few unnecessary RNGs and the issue is not reproducible anymore. In particular, both XHMMModel and XHMMEmissionProbabilityCalculator had their own RNG but then again, if the tests are run in a deterministic order, it shouldn't matter. The good news is the bug in HMMPostProcessor is fixed; the bad news is, I still don't know why the tests were not deterministic. I bet the failing issue is (magically!) fixed as a result of pulling out the RNG from XHMMModel and XHMMEmissionProbabilityCalculator. If it occurs again, I'll investigate more.

- fixed a bug in HMMPostProcessor that required all samples to be queried in the given list of genotyping segments every time (origin of the failing tests: sometimes the randomly generated genotyping segments contained fewer samples than all samples available for genotyping)
- got rid of the unnecessary RNG in XHMMModel to make it stateless (sampling requires an external RNG)
- also made XHMMEmissionProbabilityCalculator stateless (sampling requires an external RNG)
- truncated the target list used in XHMM integration tests (cuts down the test time by a factor of 10)