### PR TITLE
Clarify two uses of "Raw" in CNV workflow

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -57,9 +57,8 @@ import java.util.stream.IntStream;
  * </pre>
  *
  * <p>
- *     To collect raw coverage, omit the --transform PCOV option.
- *     "Raw" in the context of the workflow can refer to either (i) raw coverage counts from this step or 
- *     (ii) non-normalized raw proportional coverage counts.
+ *     To collect raw coverage in terms of integer count, i.e. not normalized by the total number of targets,
+ *     use the --transform RAW option.
  * </p>
  * <p>
  *     The interval targets are exome target intervals padded, e.g. with 250 bases on either side.

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -57,8 +57,9 @@ import java.util.stream.IntStream;
  * </pre>
  *
  * <p>
- *     Panel of Normal (PoN) creation uses the --transform PCOV parameter as shown.
- *     To collect raw coverage for tumor sample copy number analysis, omit this option.
+ *     To collect raw coverage, omit the --transform PCOV option.
+ *     "Raw" in the context of the workflow can refer to either (i) raw coverage counts from this step or 
+ *     (ii) non-normalized raw proportional coverage counts.
  * </p>
  * <p>
  *     The interval targets are exome target intervals padded, e.g. with 250 bases on either side.


### PR DESCRIPTION
I'd mistaken the two meanings of RAW in the CNV workflow and have clarified with @samuelklee and on behalf of our users.