### PR TITLE
GVCFGQBands documentation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -48,12 +48,17 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      * sites are compressed into bands of similar genotype quality (GQ) that are emitted as a single VCF record. See
      * the FAQ documentation for more details about the GVCF format.
      *
-     * This argument allows you to set the GQ boundaries. HC expects a list of multiple GQ threshold values. To pass
-     * multiple values, you provide them one by one with the argument, as in `-GQB 10 -GQB 20 -GQB 30` and so on. Note
-     * that GQ values are capped at 99 in the GATK, so values must be integers in the range [1, 99].
+     * This argument allows you to set the GQ bands. HC expects a list of strictly increasing GQ values
+     * that will act as exclusive upper bounds for the GQ bands. To pass multiple values,
+     * you provide them one by one with the argument, as in `-GQB 10 -GQB 20 -GQB 30` and so on
+     * (this would set the GQ bands to be `[0, 10), [10, 20), [20, 30)` and so on, for example).
+     * Note that GQ values are capped at 99 in the GATK, so values must be integers in [1, 100].
+     * If the last value is strictly less than 100, the last GQ band will start at that value (inclusive)
+     * and end at 100 (exclusive).
      */
     @Advanced
-    @Argument(fullName = "GVCFGQBands", shortName = "GQB", doc= "GQ thresholds for reference confidence bands (must be in [1, 99] and specified in increasing order)", optional = true)
+    @Argument(fullName = "GVCFGQBands", shortName = "GQB", doc= "Exclusive upper bounds for reference confidence GQ bands " +
+            "(must be in [1, 100] and specified in increasing order)", optional = true)
     public List<Integer> GVCFGQBands = new ArrayList<>(70);
     {
             for (int i=1; i<=60; ++i) {


### PR DESCRIPTION
Implements the GVCFGQBands documentation for https://github.com/broadinstitute/gatk/issues/2981.
Port from https://github.com/broadinstitute/gsa-unstable/pull/1451.


