### PR TITLE
Add gcs-connector for Spark unit tests running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ source("scripts/install_R_packages.R")
 #### <a name="cnv_workflows">Running the CNV workflows</a>
 
 * A walkthrough and examples for the CNV workflows can be found [here](http://gatkforums.broadinstitute.org/gatk/discussion/9143)
-      
+
 ## <a name="developers">For GATK Developers</a>
 
 #### <a name="dev_guidelines">General guidelines for GATK4 developers</a>
@@ -321,6 +321,7 @@ source("scripts/install_R_packages.R")
        * `all`                            : run the entire test suite
     * Cloud tests require being logged into `gcloud` and authenticated with a project that has access
       to the cloud test data.  They also require setting several certain environment variables.
+      * `HELLBENDER_JSON_SERVICE_ACCOUNT_KEY` : path to a local JSON file with [service account credentials](https://cloud.google.com/storage/docs/authentication#service_accounts) 
       * `HELLBENDER_TEST_PROJECT` : your google cloud project 
       * `HELLBENDER_TEST_APIKEY` : your google cloud API key
       * `HELLBENDER_TEST_STAGING` : a gs:// path to a writable location

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,10 @@ dependencies {
     compile 'com.google.cloud:google-cloud-nio:0.19.0-alpha:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
+    // this comes built-in when running on Google Dataproc, but the library
+    // allows us to reads from GCS also when testing locally (or on non-Dataproc clusters,
+    // should we want to)
+    compile group: 'com.google.cloud.bigdataoss', name: 'gcs-connector', version: '1.6.0-hadoop2'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     // this comes built-in when running on Google Dataproc, but the library
     // allows us to reads from GCS also when testing locally (or on non-Dataproc clusters,
     // should we want to)
-    compile group: 'com.google.cloud.bigdataoss', name: 'gcs-connector', version: '1.6.0-hadoop2'
+    compile group: 'com.google.cloud.bigdataoss', name: 'gcs-connector', version: '1.6.1-hadoop2'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -22,6 +22,8 @@ public final class SparkContextFactory {
     public static final String DEFAULT_SPARK_MASTER = determineDefaultSparkMaster();
     private static final boolean SPARK_DEBUG_ENABLED = Boolean.getBoolean("gatk.spark.debug");
     private static final String SPARK_CORES_ENV_VARIABLE = "GATK_TEST_SPARK_CORES";
+    private static final String TEST_PROJECT_ENV_VARIABLE = "HELLBENDER_TEST_PROJECT";
+    private static final String TEST_JSON_KEYFILE_ENV_VARIABLE = "HELLBENDER_JSON_SERVICE_ACCOUNT_KEY";
 
     /**
      * GATK will not run without these properties
@@ -51,6 +53,13 @@ public final class SparkContextFactory {
             .put("spark.ui.enabled", Boolean.toString(SPARK_DEBUG_ENABLED))
             .put("spark.kryoserializer.buffer.max", "256m")
             .put("spark.hadoop.fs.file.impl.disable.cache", "true") // so NonChecksumLocalFileSystem is not cached between tests
+            // configure the gcs-connector
+            .put("spark.hadoop.fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
+            .put("spark.hadoop.fs.AbstractFileSystem.gs.impl",
+                "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
+            .put("spark.hadoop.fs.gs.project.id", System.getenv(TEST_PROJECT_ENV_VARIABLE))
+            .put("spark.hadoop.google.cloud.auth.service.account.json.keyfile",
+                System.getenv(TEST_JSON_KEYFILE_ENV_VARIABLE))
             .build();
 
     private static boolean testContextEnabled;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
@@ -226,7 +226,7 @@ public final class ReadsSparkSink {
             final SAMFileHeader header, final int numReducers) throws IOException {
 
         final JavaRDD<SAMRecord> sortedReads = SparkUtils.sortReads(reads, header, numReducers);
-        final String outputPartsDirectory = outputFile + ".parts";
+        final String outputPartsDirectory = outputFile + ".parts/";
         saveAsShardedHadoopFiles(ctx, outputPartsDirectory, referenceFile, samOutputFormat, sortedReads,  header, false);
         SAMFileMerger.mergeParts(outputPartsDirectory, outputFile, samOutputFormat, header);
     }


### PR DESCRIPTION
For the tests to work we must define:
HELLBENDER_TEST_PROJECT : Google Project to use
HELLBENDER_JSON_SERVICE_ACCOUNT_KEY : path to a JSON file with service
account credentials

(I've updated the README accordingly)

(We've used both before so they should already be configured)

This fixes issue #3125