### PR TITLE
Updated templates to fit current website logic

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
@@ -5,17 +5,17 @@
 
         -->
 
-    <#global siteRoot = "http://www.broadinstitute.org/gatk/" />
-    <#global guideIndex = "http://www.broadinstitute.org/gatk/guide/" />
-    <#global forum = "http://gatkforums.broadinstitute.org/" />
+    <#global siteRoot = "http://software.broadinstitute.org/gatk/" />
+    <#global guideIndex = "http://software.broadinstitute.org/gatk/documentation/" />
+    <#global forum = "http://gatkforums.broadinstitute.org/gatk/" />
 
     <#macro footerInfo>
         <hr>
         <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>
         <hr>
         <p class="see-also">See also 
-        	<a href="${guideIndex}">GATK Documentation Index</a> |
-        	<a href="index">Tool Docs Index</a> |
+        	<a href="${guideIndex}">General Documentation</a> |
+        	<a class="hide_me_php" href="index.html">Tool Docs Index</a> <a class="hide_me_html" href="index">Tool Docs Index</a> |
         	<a href="${forum}">Support Forum</a>
         </p>
 
@@ -29,6 +29,7 @@
     </#macro>
 
     <#macro getCategories groups>
+
         <style>
             #sidenav .accordion-body a {
                 color : gray;
@@ -38,6 +39,7 @@
                 list-style : none;
             }
         </style>
+
         <ul class="nav nav-pills nav-stacked" id="sidenav">
         	<#assign seq = ["engine", "tools", "other", "utilities"]>
         	<#list seq as supercat>
@@ -63,3 +65,4 @@
         	</#list>
         </ul>
     </#macro>
+

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/gatkDoc.css
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/gatkDoc.css
@@ -1,0 +1,160 @@
+body {
+    margin: 40px;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 18px;
+    color: #333333;
+    background-color: #ffffff;
+}
+a {
+    color: #269abc;
+    text-decoration: none;
+}
+a:hover {
+    color: #004d8b;
+    text-decoration: underline;
+}
+.label,
+.badge {
+    font-size: 11px;
+    font-weight: bold;
+    line-height: 14px;
+    color: #ffffff;
+    vertical-align: baseline;
+    white-space: nowrap;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+    background-color: #999999;
+}
+.label {
+    padding: 1px 4px 2px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+}
+.badge {
+    padding: 1px 9px 2px;
+    -webkit-border-radius: 9px;
+    -moz-border-radius: 9px;
+    border-radius: 9px;
+}
+a.label:hover,
+a.badge:hover {
+    color: #ffffff;
+    text-decoration: none;
+    cursor: pointer;
+}
+.label-important,
+.badge-important {
+    background-color: #b94a48;
+}
+.label-important[href],
+.badge-important[href] {
+    background-color: #953b39;
+}
+.label-warning,
+.badge-warning {
+    background-color: #e44a00;
+}
+.label-warning[href],
+.badge-warning[href] {
+    background-color: #b13900;
+}
+.label-success,
+.badge-success {
+    background-color: #468847;
+}
+.label-success[href],
+.badge-success[href] {
+    background-color: #356635;
+}
+.label-info,
+.badge-info {
+    background-color: #3a87ad;
+}
+.label-info[href],
+.badge-info[href] {
+    background-color: #2d6987;
+}
+.label-inverse,
+.badge-inverse {
+    background-color: #333333;
+}
+.label-inverse[href],
+.badge-inverse[href] {
+    background-color: #1a1a1a;
+}
+table {
+    max-width: 100%;
+    background-color: transparent;
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+.table {
+    width: 100%;
+    margin-bottom: 40px;
+}
+.table th,
+.table td {
+    padding: 8px;
+    line-height: 18px;
+    text-align: left;
+    vertical-align: top;
+    border-top: 1px solid #dddddd;
+}
+.table th {
+    font-weight: bold;
+}
+.table thead th {
+    vertical-align: bottom;
+}
+.table tbody + tbody {
+    border-top: 2px solid #dddddd;
+}
+.table-condensed th,
+.table-condensed td {
+    padding: 4px 5px;
+}
+.table-bordered {
+    border: 1px solid #dddddd;
+    border-collapse: separate;
+    *border-collapse: collapsed;
+    border-left: 0;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+.table-bordered th,
+.table-bordered td {
+    border-left: 1px solid #dddddd;
+}
+.table-striped tbody tr:nth-child(odd) td,
+.table-striped tbody tr:nth-child(odd) th {
+    background-color: #f9f9f9;
+}
+.table tbody tr:hover td,
+.table tbody tr:hover th {
+    background-color: #f5f5f5;
+}
+pre code {
+    padding: 0;
+    color: #F5F5F5;
+    background-color: transparent;
+    border: 0;
+}
+.accordion-heading {
+    font-size: 24px;
+    line-height: 30px;
+}
+.lead {
+    font-size: 18px;
+}
+.hide_me_html {
+    display: none;
+}
+.well {
+    font-size: 14px;
+    padding-bottom: 20px;
+}
+.cozy {
+    font-size: 12px;
+}

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
@@ -1,66 +1,96 @@
 <?php
 
-    include '../../../common/include/common.php';
-    include_once '../../config.php';
+    include '../../../../common/include/common.php';
+    include_once '../../../config.php';
     $module = modules::GATK;
-    printHeader($module, "GATK | Tool Documentation Index", "Guide");
+    $name = docSN::toolDocs;
+
+    printHeader($module, $name, "Documentation");
+
+    $dirs = array_diff(scandir("../", SCANDIR_SORT_DESCENDING), array('..', '.'));
+    $curr_version = file_get_contents(engConst::versions_dir.versionFiles::gatk);
 ?>
+
+<link type='text/css' rel='stylesheet' href='gatkDoc.css'>
 
 <div class='row-fluid'>
 
-<?php printGATKDocsNav($module); ?>
+    <aside class="span3">
 
-<div class='span9'>
+        <?php echo produceGuideNav($module, $name) . makeTwitterFeed(); ?>
+
+    </aside>
+
+    <div class='span9'>
 
 <#include "common.html"/>
 
 <#macro emitGroup group>
-    <div class="accordion-group">
-        <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#${group.id}">
-                <h4>${group.name}</h4>
-            </a>
-        </div>
-        <div class="accordion-body collapse" id="${group.id}">
-            <div class="accordion-inner">
-                <p class="lead">${group.summary}</p>
-                <table class="table table-striped table-bordered table-condensed">
-                    <tr>
-                        <th>Name</th>
-                        <th>Summary</th>
-                    </tr>
-                    <#list data as datum>
-                        <#if datum.group == group.name>
-                            <tr>
-                                <td><a href="${datum.filename}">${datum.name}</a></td>
-                                <#if datum.beta?? && datum.beta == "true">
-                                    <td>**BETA** ${datum.summary}</td>
-                                    <#else>
-                                        <td>${datum.summary}</td>
-                                </#if>
-                            </tr>
-                        </#if>
-                    </#list>
-                </table>
+        <div class="accordion-group">
+            <div class="accordion-heading">
+                <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#${group.id}">
+                    <h4>${group.name}</h4>
+                </a>
+            </div>
+            <div class="accordion-body collapse" id="${group.id}">
+                <div class="accordion-inner">
+                    <p class="lead">${group.summary}</p>
+                    <table class="table table-striped table-bordered table-condensed cozy">
+                        <tr>
+                            <th>Name</th>
+                            <th>Summary</th>
+                        </tr>
+                        <#list data as datum>
+                            <#if datum.group == group.name>
+                                <tr>
+                                    <td><a href="${datum.filename}">${datum.name}</a></td>
+                                    <#if datum.beta?? && datum.beta == "true">
+                                        <td>**BETA** ${datum.summary}</td>
+                                        <#else>
+                                            <td>${datum.summary}</td>
+                                    </#if>
+                                </tr>
+                            </#if>
+                        </#list>
+                    </table>
+                </div>
             </div>
         </div>
-    </div>
 </#macro>
 
-<h1 id="top">GATK Tool Documentation Index
-    <small>${version}</small>
-</h1>
-<div class="accordion" id="index">
-    <#assign seq = ["engine", "tools", "other", "utilities"]>
-	<#list seq as supercat>
-		<br />
-		<#list groups?sort_by("name") as group>
-			<#if group.supercat == supercat>
-				<@emitGroup group=group/>
-			</#if>
-		</#list>
-	</#list>
-</div>
+        <div class="row-fluid">
+            <div class="span6">
+                <h1 id="top"><i class='<?php print ico::toolDocsIcon; ?>'></i> Tool Documentation Index</h1>
+            </div>
+            <div class="span6">
+                <div class="btn-group pull-right">
+                    <a class="btn btn-warning dropdown-toggle" data-toggle="dropdown" href="#">
+                        Version ${version}
+                        <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu">
+                        <?php foreach($dirs as $dir) { ?>
+                            <li class="hide_me_html"><a tabindex='-1' href='../<?=$dir?>' ><?=$dir?></a></li>
+                        <?php } ?>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <h1 class="hide_me_html"><small>Showing docs for version ${version} | The latest version is <?=$curr_version?></small></h1>
+        <hr />
+
+        <div class="accordion" id="index">
+            <#assign seq = ["engine", "tools", "other", "utilities"]>
+            <#list seq as supercat>
+                <br />
+                <#list groups?sort_by("name") as group>
+                    <#if group.supercat == supercat>
+                        <@emitGroup group=group/>
+                    </#if>
+                </#list>
+            </#list>
+        </div>
 
 <@footerInfo />
 <@footerClose />

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -1,10 +1,16 @@
 <?php
 
-    include '../../../common/include/common.php';
-    include_once '../../config.php';
+	define('noTWITTER', TRUE);
+    include '../../../../common/include/common.php';
+    include_once '../../../config.php';
     $module = modules::GATK;
-    printHeader($module, "GATK | Tool Documentation Index", "Guide");
+    printHeader($module, "Tool Documentation Index", "Documentation");
+
+    $curr_version = file_get_contents(engConst::versions_dir.versionFiles::gatk);
+    $dirs = array_diff(scandir("../", SCANDIR_SORT_DESCENDING), array('..', '.'));
 ?>
+
+<link type='text/css' rel='stylesheet' href='gatkDoc.css'>
 
 <div class='row-fluid' id="top">
 
@@ -86,13 +92,13 @@
 
 	<section class="span4">
 		<aside class="well">
-			<a href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+			<a class="hide_me_php" href="index.html"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+			<a class="hide_me_html" href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
 		</aside>
-		<aside class="well">
+		<aside class="well hide_me_html">
 			<h2>Categories</h2>
 			<@getCategories groups=groups />
 		</aside>
-		<?php getForumPosts( '${name}' ) ?>
 
 	</section>
 
@@ -154,7 +160,7 @@
 			<#if arguments.all?size != 0>
 				<h3>${name} specific arguments</h3>
 				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
-				<table class="table table-striped table-bordered table-condensed">
+				<table class="table table-striped table-bordered table-condensed cozy">
 					<thead>
 					<tr>
 						<th>Argument name(s)</th>
@@ -187,6 +193,6 @@
 			<@footerInfo />
 			<@footerClose />
 
-	</div>
+</div></div>
 
 	<?php printFooter($module); ?>


### PR DESCRIPTION
This PR updates the Freemarker templates so that the resulting pages will work with the current state of the website code. Most of the changes have to do with functionality I put in to enable hosting multiple doc versions and easy switching between them via a dropdown menu. 

I had already done some retrofitting on older tooldocs so the versioned tool docs go back to 3.5, and we can add beta versions of 4 without changing the "latest supported version". 

The only remaining problem is that I couldn't figure out how to output php instead of html. To test the web integration, I just renamed all *.html to *.php with `for f in *.html; do mv -- "$f" "${f%.html}.php"; done` but that doesn't take care of internal links, which are of course broken as a result. @cmnbroad please let me know if I missed something obvious on this front ^^. 

That being said this PR is fully functional as far as I'm concerned.