### PR TITLE
Create TestResources for GATK-specific file constants and GenomeLocParser

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -1,24 +1,18 @@
 package org.broadinstitute.hellbender.utils.test;
 
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.GenomeLoc;
-import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
-import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.Reporter;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeSuite;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.*;
@@ -44,76 +38,6 @@ public abstract class BaseTest {
     }
 
     public static final Logger logger = LogManager.getLogger("org.broadinstitute.gatk");
-
-    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
-    public static final String gatkDirectory = System.getProperty("gatkdir", CURRENT_DIRECTORY) + "/";
-
-    private static final String publicTestDirRelative = "src/test/resources/";
-    public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + "/";
-    public static final String publicTestDirRoot = publicTestDir.replace(publicTestDirRelative, "");
-
-    public static final String packageRootTestDir = publicTestDir + "org/broadinstitute/hellbender/";
-    public static final String toolsTestDir = packageRootTestDir + "tools/";
-
-    public static final String GCS_GATK_TEST_RESOURCES = "gs://hellbender/test/resources/";
-
-    public static final String GCS_b37_REFERENCE_2BIT = GCS_GATK_TEST_RESOURCES + "benchmark/human_g1k_v37.2bit";
-    public static final String GCS_b37_CHR20_21_REFERENCE_2BIT = GCS_GATK_TEST_RESOURCES + "human_g1k_v37.20.21.2bit";
-
-    /**
-     * LARGE FILES FOR TESTING (MANAGED BY GIT LFS)
-     */
-    public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + "/";
-
-    // All of chromosomes 20 and 21 from the b37 reference
-    public static final String b37_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.fasta";
-
-    public static final String b37_2bit_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.2bit";
-
-    // All of chromosomes 20 and 21 from the b38 reference
-    public static final String b38_reference_20_21 = largeFileTestDir + "Homo_sapiens_assembly38.20.21.fasta";
-
-    // ~600,000 reads from chromosomes 20 and 21 of an NA12878 WGS bam aligned to b37, plus ~50,000 unmapped reads
-    public static final String NA12878_20_21_WGS_bam = largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam";
-
-    // Variants from a DBSNP 138 VCF overlapping the reads in NA12878_20_21_WGS_bam
-    public static final String dbsnp_138_b37_20_21_vcf = largeFileTestDir + "dbsnp_138.b37.20.21.vcf";
-
-    // Variants from a DBSNP 138 VCF form the first 65Mb of chr1
-    public static final String dbsnp_138_b37_1_65M_vcf = largeFileTestDir + "dbsnp_138.b37.1.1-65M.vcf";
-
-    public static final String WGS_B37_CH20_1M_1M1K_BAM = "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
-    public static final String DBSNP_138_B37_CH20_1M_1M1K_VCF = "dbsnp_138.b37.excluding_sites_after_129.ch20.1m-1m1k.vcf";
-
-    /**
-     * END OF LARGE FILES FOR TESTING
-     */
-
-    public static final String NA12878_chr17_1k_BAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.bam";
-    public static final String NA12878_chr17_1k_CRAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.cram";
-    public static final String v37_chr17_1Mb_Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
-
-    public static final String hg19_chr1_1M_Reference = publicTestDir + "Homo_sapiens_assembly19_chr1_1M.fasta";
-    public static final String hg19_chr1_1M_dbSNP = publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
-
-    // the following file has been modified such that the first chromosome length is 1M; this is sometimes
-    // required due to sequence dictionary validation, since a reference FASTA with only 1M bases is used
-    public static final String hg19_chr1_1M_dbSNP_modified = publicTestDir + "HSA19.dbsnp135.chr1_1M.exome_intervals.modified.vcf";
-
-    public static final String hg19_chr1_1M_exampleVCF = publicTestDir + "joint_calling.chr1_1M.1kg_samples.10samples.noINFO.vcf";
-    public static final String hg19MiniReference = publicTestDir + "hg19mini.fasta";
-    // Micro reference is the same as hg19mini, but contains only chromosomes 1 and 2
-    public static final String hg19MicroReference = publicTestDir + "hg19micro.fasta";
-
-    public static final String exampleFASTA = publicTestDir + "exampleFASTA.fasta";
-    public static final String exampleReference = hg19MiniReference;
-    public static final String hg19MiniIntervalFile = publicTestDir + "hg19mini.interval_list";
-
-    public CachingIndexedFastaSequenceFile hg19ReferenceReader;
-    public GenomeLocParser hg19GenomeLocParser;
-
-    // used to seed the genome loc parser with a sequence dictionary
-    protected SAMFileHeader hg19Header;
 
     /**
      * name of the google cloud project that stores the data and will run the code
@@ -164,25 +88,6 @@ public abstract class BaseTest {
             throw new UserException("For this test, please define environment variable \""+envVarName+"\"");
         }
         return value;
-    }
-
-    @BeforeClass
-    public void initGenomeLocParser() throws FileNotFoundException {
-        hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));
-        hg19Header = new SAMFileHeader();
-        hg19Header.setSequenceDictionary(hg19ReferenceReader.getSequenceDictionary());
-        hg19GenomeLocParser = new GenomeLocParser(hg19ReferenceReader);
-    }
-
-    protected List<GenomeLoc> intervalStringsToGenomeLocs( String... intervals) {
-        return intervalStringsToGenomeLocs(Arrays.asList(intervals));
-    }
-
-    protected List<GenomeLoc> intervalStringsToGenomeLocs( List<String> intervals ) {
-        List<GenomeLoc> locs = new ArrayList<>();
-        for (String interval: intervals)
-            locs.add(hg19GenomeLocParser.parseGenomeLoc(interval));
-        return Collections.unmodifiableList(locs);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/TestResources.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/TestResources.java
@@ -1,0 +1,131 @@
+package org.broadinstitute.hellbender.utils.test;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.GenomeLoc;
+import org.broadinstitute.hellbender.utils.GenomeLocParser;
+import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.testng.Assert;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class containing helper methods and resolved directories for test resources.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class TestResources {
+
+    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
+    public static final String gatkDirectory = System.getProperty("gatkdir", CURRENT_DIRECTORY) + "/";
+
+    private static final String publicTestDirRelative = "src/test/resources/";
+    public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + "/";
+    public static final String publicTestDirRoot = publicTestDir.replace(publicTestDirRelative, "");
+
+    public static final String packageRootTestDir = publicTestDir + "org/broadinstitute/hellbender/";
+    public static final String toolsTestDir = packageRootTestDir + "tools/";
+
+    public static final String GCS_GATK_TEST_RESOURCES = "gs://hellbender/test/resources/";
+
+    public static final String GCS_b37_REFERENCE_2BIT = GCS_GATK_TEST_RESOURCES + "benchmark/human_g1k_v37.2bit";
+    public static final String GCS_b37_CHR20_21_REFERENCE_2BIT = GCS_GATK_TEST_RESOURCES + "human_g1k_v37.20.21.2bit";
+
+    /**
+     * LARGE FILES FOR TESTING (MANAGED BY GIT LFS)
+     */
+    public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + "/";
+
+    // All of chromosomes 20 and 21 from the b37 reference
+    public static final String b37_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.fasta";
+
+    public static final String b37_2bit_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.2bit";
+
+    // All of chromosomes 20 and 21 from the b38 reference
+    public static final String b38_reference_20_21 = largeFileTestDir + "Homo_sapiens_assembly38.20.21.fasta";
+
+    // ~600,000 reads from chromosomes 20 and 21 of an NA12878 WGS bam aligned to b37, plus ~50,000 unmapped reads
+    public static final String NA12878_20_21_WGS_bam = largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam";
+
+    // Variants from a DBSNP 138 VCF overlapping the reads in NA12878_20_21_WGS_bam
+    public static final String dbsnp_138_b37_20_21_vcf = largeFileTestDir + "dbsnp_138.b37.20.21.vcf";
+
+    // Variants from a DBSNP 138 VCF form the first 65Mb of chr1
+    public static final String dbsnp_138_b37_1_65M_vcf = largeFileTestDir + "dbsnp_138.b37.1.1-65M.vcf";
+
+    public static final String WGS_B37_CH20_1M_1M1K_BAM = "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
+    public static final String DBSNP_138_B37_CH20_1M_1M1K_VCF = "dbsnp_138.b37.excluding_sites_after_129.ch20.1m-1m1k.vcf";
+
+    /**
+     * END OF LARGE FILES FOR TESTING
+     */
+
+    public static final String NA12878_chr17_1k_BAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.bam";
+    public static final String NA12878_chr17_1k_CRAM = publicTestDir + "NA12878.chr17_69k_70k.dictFix.cram";
+    public static final String v37_chr17_1Mb_Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+
+    public static final String hg19_chr1_1M_Reference = publicTestDir + "Homo_sapiens_assembly19_chr1_1M.fasta";
+    public static final String hg19_chr1_1M_dbSNP = publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
+
+    // the following file has been modified such that the first chromosome length is 1M; this is sometimes
+    // required due to sequence dictionary validation, since a reference FASTA with only 1M bases is used
+    public static final String hg19_chr1_1M_dbSNP_modified = publicTestDir + "HSA19.dbsnp135.chr1_1M.exome_intervals.modified.vcf";
+
+    public static final String hg19_chr1_1M_exampleVCF = publicTestDir + "joint_calling.chr1_1M.1kg_samples.10samples.noINFO.vcf";
+    public static final String hg19MiniReference = publicTestDir + "hg19mini.fasta";
+    // Micro reference is the same as hg19mini, but contains only chromosomes 1 and 2
+    public static final String hg19MicroReference = publicTestDir + "hg19micro.fasta";
+
+    public static final String exampleFASTA = publicTestDir + "exampleFASTA.fasta";
+    public static final String exampleReference = hg19MiniReference;
+    public static final String hg19MiniIntervalFile = publicTestDir + "hg19mini.interval_list";
+
+
+    private static CachingIndexedFastaSequenceFile hg19ReferenceReader;
+    private static GenomeLocParser hg19GenomeLocParser;
+    // used to seed the genome loc parser with a sequence dictionary
+    public static SAMFileHeader hg19Header;
+
+
+    /** Gets the genome location parser, initialized only once. */
+    public static synchronized GenomeLocParser getGenomeLocParser() {
+        if (hg19GenomeLocParser == null) {
+            try {
+                hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));
+                hg19Header = new SAMFileHeader();
+                hg19Header.setSequenceDictionary(hg19ReferenceReader.getSequenceDictionary());
+                hg19GenomeLocParser = new GenomeLocParser(hg19ReferenceReader);
+            } catch (FileNotFoundException e) {
+                Assert.fail("Required file for test not found: " + hg19MiniReference);
+            }
+        }
+        return hg19GenomeLocParser;
+    }
+
+    /** Used to seed the genome loc parser with a sequence dictionary. */
+    public static synchronized SAMFileHeader getHg19Header() {
+        getGenomeLocParser();
+        return hg19Header;
+    }
+
+    /** Gets the HG19 reference reader, initialized only once. */
+    public static synchronized CachingIndexedFastaSequenceFile getHg19ReferenceReader() {
+        getGenomeLocParser();
+        return hg19ReferenceReader;
+    }
+
+    public static List<GenomeLoc> intervalStringsToGenomeLocs(String... intervals) {
+        return intervalStringsToGenomeLocs(Arrays.asList(intervals));
+    }
+
+    public static List<GenomeLoc> intervalStringsToGenomeLocs( List<String> intervals ) {
+        List<GenomeLoc> locs = new ArrayList<>();
+        for (String interval: intervals)
+            locs.add(getGenomeLocParser().parseGenomeLoc(interval));
+        return Collections.unmodifiableList(locs);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender;
 
 import org.broadinstitute.hellbender.utils.bwa.BwaMemIndex;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -12,8 +13,8 @@ public class BwaMemIntegrationTest extends BaseTest {
 
     @BeforeSuite
     public void loadIndex() {
-        final String imageFile = createTempFile(b37_reference_20_21, ".img").toString();
-        BwaMemIndex.createIndexImage(b37_reference_20_21, imageFile);
+        final String imageFile = createTempFile(TestResources.b37_reference_20_21, ".img").toString();
+        BwaMemIndex.createIndexImage(TestResources.b37_reference_20_21, imageFile);
         index = new BwaMemIndex(imageFile);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/GitLfsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/GitLfsTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -15,7 +16,7 @@ public class GitLfsTest extends BaseTest{
 
     @Test(groups = "large")
     public void testLargeFilesAreDownloaded() throws IOException {
-        File exampleLargeFile = new File(publicTestDir, "large/exampleLargeFile.txt");
+        File exampleLargeFile = new File(TestResources.publicTestDir, "large/exampleLargeFile.txt");
         Assert.assertTrue(exampleLargeFile.exists(), "Expected file:" + exampleLargeFile.getAbsoluteFile() + " to exist but it didn't");
         try( XReadLines lines = new XReadLines(exampleLargeFile)){
             Assert.assertEquals(lines.next(), "This is a file to test if git-lfs is working.  Please don't change this text.");

--- a/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.utils.NativeUtils;
 import org.broadinstitute.hellbender.utils.RandomDNA;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -87,7 +88,7 @@ public class IntelInflaterDeflaterIntegrationTest extends CommandLineProgramTest
             throw new SkipException("IntelInflater/IntelDeflater not available on this platform");
         }
 
-        final File ORIG_BAM = new File(largeFileTestDir, INPUT_FILE);
+        final File ORIG_BAM = new File(TestResources.largeFileTestDir, INPUT_FILE);
         final File outFile = BaseTest.createTempFile(INPUT_FILE, ".bam");
 
         final ArrayList<String> args = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.IntervalSetRule;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -56,15 +57,15 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
     @Test(dataProvider = "optionalOrNot",expectedExceptions = GATKException.class)
     public void emptyIntervalsTest(IntervalArgumentCollection iac){
         Assert.assertFalse(iac.intervalsSpecified());
-        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());  //should throw an exception
+        iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary());  //should throw an exception
     }
 
     @Test(dataProvider = "optionalOrNot")
     public void testExcludeWithNoIncludes(IntervalArgumentCollection iac){
         iac.excludeIntervalStrings.addAll(Arrays.asList("1", "2", "3"));
         Assert.assertTrue(iac.intervalsSpecified());
-        GenomeLoc chr4GenomeLoc = hg19GenomeLocParser.createOverEntireContig("4");
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval(chr4GenomeLoc)));
+        GenomeLoc chr4GenomeLoc = TestResources.getGenomeLocParser().createOverEntireContig("4");
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval(chr4GenomeLoc)));
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -73,7 +74,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:1-100");
         iac.excludeIntervalStrings.add("1:90-100");
         Assert.assertTrue(iac.intervalsSpecified());
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 79)));
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 79)));
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -81,14 +82,14 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:1-100");
         iac.excludeIntervalStrings.add("1:90-200");
         Assert.assertTrue(iac.intervalsSpecified());
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 89)));
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 89)));
     }
 
     @Test(dataProvider = "optionalOrNot")
     public void testIncludeWithPadding(IntervalArgumentCollection iac){
         iac.addToIntervalStrings("1:20-30");
         iac.intervalPadding = 10;
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 10, 40)));
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 10, 40)));
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -96,7 +97,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:1-100");
         iac.addToIntervalStrings("1:90-200");
         iac.intervalSetRule = IntervalSetRule.INTERSECTION;
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 90, 100)));
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 90, 100)));
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -104,7 +105,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:1-100");
         iac.addToIntervalStrings("1:90-200");
         iac.intervalSetRule = IntervalSetRule.UNION;
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 200)));
+        Assert.assertEquals(iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary()), Arrays.asList(new SimpleInterval("1", 1, 200)));
     }
 
 
@@ -112,7 +113,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
     public void testAllExcluded(IntervalArgumentCollection iac){
         iac.addToIntervalStrings("1:10-20");
         iac.excludeIntervalStrings.add("1:1-200");
-        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
+        iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary());
     }
 
     @Test(dataProvider = "optionalOrNot", expectedExceptions= CommandLineException.BadArgumentValue.class)
@@ -120,13 +121,13 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:10-20");
         iac.addToIntervalStrings("1:50-200");
         iac.intervalSetRule = IntervalSetRule.INTERSECTION;
-        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
+        iac.getIntervals(TestResources.getGenomeLocParser().getSequenceDictionary());
     }
 
     @Test(dataProvider = "optionalOrNot")
     public void testUnmappedInclusion(IntervalArgumentCollection iac) {
         iac.addToIntervalStrings("unmapped");
-        final TraversalParameters traversalParameters = iac.getTraversalParameters(hg19GenomeLocParser.getSequenceDictionary());
+        final TraversalParameters traversalParameters = iac.getTraversalParameters(TestResources.getGenomeLocParser().getSequenceDictionary());
         Assert.assertTrue(traversalParameters.traverseUnmappedReads());
         Assert.assertTrue(traversalParameters.getIntervalsForTraversal().isEmpty());
     }
@@ -136,7 +137,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:10-20");
         iac.addToIntervalStrings("2:1-5");
         iac.addToIntervalStrings("unmapped");
-        final TraversalParameters traversalParameters = iac.getTraversalParameters(hg19GenomeLocParser.getSequenceDictionary());
+        final TraversalParameters traversalParameters = iac.getTraversalParameters(TestResources.getGenomeLocParser().getSequenceDictionary());
         Assert.assertTrue(traversalParameters.traverseUnmappedReads());
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().size(), 2);
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().get(0), new SimpleInterval("1", 10, 20));
@@ -149,7 +150,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("2:1-5");
         iac.addToIntervalStrings("unmapped");
         iac.excludeIntervalStrings.addAll(Arrays.asList("1"));
-        final TraversalParameters traversalParameters = iac.getTraversalParameters(hg19GenomeLocParser.getSequenceDictionary());
+        final TraversalParameters traversalParameters = iac.getTraversalParameters(TestResources.getGenomeLocParser().getSequenceDictionary());
         Assert.assertTrue(traversalParameters.traverseUnmappedReads());
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().size(), 1);
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().get(0), new SimpleInterval("2", 1, 5));
@@ -158,7 +159,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
     @Test(dataProvider = "optionalOrNot", expectedExceptions = UserException.class)
     public void testThrowOnUnmappedExclusion(IntervalArgumentCollection iac) {
         iac.excludeIntervalStrings.addAll(Arrays.asList("unmapped"));
-        iac.getTraversalParameters(hg19GenomeLocParser.getSequenceDictionary());
+        iac.getTraversalParameters(TestResources.getGenomeLocParser().getSequenceDictionary());
     }
 
     @Test(dataProvider = "optionalOrNot")
@@ -167,7 +168,7 @@ public final class IntervalArgumentCollectionTest extends BaseTest{
         iac.addToIntervalStrings("1:10-20");
         iac.addToIntervalStrings("unmapped");
         iac.addToIntervalStrings("unmapped");
-        final TraversalParameters traversalParameters = iac.getTraversalParameters(hg19GenomeLocParser.getSequenceDictionary());
+        final TraversalParameters traversalParameters = iac.getTraversalParameters(TestResources.getGenomeLocParser().getSequenceDictionary());
         Assert.assertTrue(traversalParameters.traverseUnmappedReads());
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().size(), 1);
         Assert.assertEquals(traversalParameters.getIntervalsForTraversal().get(0), new SimpleInterval("1", 10, 20));

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
@@ -11,11 +11,11 @@ import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.activityprofile.ActivityProfileState;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
-import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -37,7 +36,7 @@ public final class AssemblyRegionUnitTest extends BaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        seq = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));
+        seq = new CachingIndexedFastaSequenceFile(new File(TestResources.hg19MiniReference));
         contig = "1";
         contigLength = seq.getSequence(contig).length();
         header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
@@ -398,8 +397,8 @@ public final class AssemblyRegionUnitTest extends BaseTest {
 
     @Test
     public void testCreateFromReadShard() {
-        final Path testBam = IOUtils.getPath(NA12878_20_21_WGS_bam);
-        final File reference = new File(b37_reference_20_21);
+        final Path testBam = IOUtils.getPath(TestResources.NA12878_20_21_WGS_bam);
+        final File reference = new File(TestResources.b37_reference_20_21);
         final SimpleInterval shardInterval = new SimpleInterval("20", 10000000, 10001000);
         final SimpleInterval paddedShardInterval = new SimpleInterval(shardInterval.getContig(), shardInterval.getStart() - 100, shardInterval.getEnd() + 100);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/CRAMSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/CRAMSupportIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.PrintReads;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,7 +32,7 @@ public final class CRAMSupportIntegrationTest extends CommandLineProgramTest{
 
     @DataProvider(name = "ReadEntireCramTestData")
     public Object[][] readEntireCramTestData() {
-        final File ref = new File(hg19MiniReference);
+        final File ref = new File(TestResources.hg19MiniReference);
         final List<Object[]> testCases = new ArrayList<>();
         for ( final String outputExtension : Arrays.asList(".sam", ".bam", ".cram") ) {
             // cram, reference, output file extension, expected read names
@@ -57,7 +58,7 @@ public final class CRAMSupportIntegrationTest extends CommandLineProgramTest{
 
     @DataProvider(name = "ReadCramWithIntervalsIndexTestData")
     public Object[][] readCramWithIntervalsBAIIndexTestData() {
-        final File ref = new File(hg19MiniReference);
+        final File ref = new File(TestResources.hg19MiniReference);
         final List<Object[]> testCases = new ArrayList<>();
         for ( final String outputExtension : Arrays.asList(".sam", ".bam", ".cram") ) {
             // cram, reference, output file extension, intervals, expected read names

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureContextUnitTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -22,7 +23,7 @@ public final class FeatureContextUnitTest extends BaseTest {
         FeatureInput<Feature> featureArgument;
 
         public ArtificialFeatureContainingCommandLineProgram() {
-            featureArgument = new FeatureInput<>(publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test.vcf");
+            featureArgument = new FeatureInput<>(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test.vcf");
         }
 
         @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -17,7 +18,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public final class FeatureDataSourceUnitTest extends BaseTest {
-    private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
     private static final File QUERY_TEST_VCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "feature_data_source_test.vcf");
     private static final File QUERY_TEST_GVCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "feature_data_source_test_gvcf.vcf");
     private static final File UNINDEXED_VCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "unindexed.vcf");

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
@@ -20,6 +20,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.codecs.table.TableCodec;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -27,10 +28,9 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public final class FeatureManagerUnitTest extends BaseTest {
-    private static final String FEATURE_MANAGER_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String FEATURE_MANAGER_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
 
     @DataProvider(name = "DetectCorrectFileFormatTestData")
     public Object[][] getDetectCorrectFileFormatTestData() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureSupportIntegrationTest.java
@@ -4,13 +4,14 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.tools.examples.ExampleReadWalkerWithVariants;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 public final class FeatureSupportIntegrationTest extends CommandLineProgramTest {
-    private static final String FEATURE_INTEGRATION_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String FEATURE_INTEGRATION_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
 
     @Override
     public String getTestedClassName() {
@@ -20,7 +21,7 @@ public final class FeatureSupportIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testFeatureSupportUsingVCF() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + FEATURE_INTEGRATION_TEST_DIRECTORY + "reads_data_source_test1.bam" +
                 " -V " + "TestFeatures:" + FEATURE_INTEGRATION_TEST_DIRECTORY + "feature_data_source_test.vcf" +
                 " --groupVariantsBySource" +
@@ -33,9 +34,9 @@ public final class FeatureSupportIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testFeaturesAsIntervals() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + FEATURE_INTEGRATION_TEST_DIRECTORY + "reads_data_source_test1.bam" +
-                " -L " + publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test.vcf" +
+                " -L " + TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test.vcf" +
                 " -O %s",
                 Arrays.asList(FEATURE_INTEGRATION_TEST_DIRECTORY + "expected_testFeaturesAsIntervals_output.txt")
         );
@@ -45,10 +46,10 @@ public final class FeatureSupportIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testFeaturesAsIntervalsWithExclusion() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + FEATURE_INTEGRATION_TEST_DIRECTORY + "reads_data_source_test1.bam" +
-                " -L " + publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test.vcf" +
-                " -XL " + publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test_exclude.vcf" +
+                " -L " + TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test.vcf" +
+                " -XL " + TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/interval/intervals_from_features_test_exclude.vcf" +
                 " -O %s",
                 Arrays.asList(FEATURE_INTEGRATION_TEST_DIRECTORY + "expected_testFeaturesAsIntervalsWithExclusion_output.txt")
         );
@@ -59,9 +60,9 @@ public final class FeatureSupportIntegrationTest extends CommandLineProgramTest 
     public void testFeaturesAsIntervalsNonExistentFile() throws IOException {
         // Non-existent files should be interpreted as interval strings and fail interval parsing
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + FEATURE_INTEGRATION_TEST_DIRECTORY + "reads_data_source_test1.bam" +
-                " -L " + publicTestDir + "non_existent_file.vcf" +
+                " -L " + TestResources.publicTestDir + "non_existent_file.vcf" +
                 " -O %s",
                 1,
                 UserException.MalformedGenomeLoc.class
@@ -72,9 +73,9 @@ public final class FeatureSupportIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testFeaturesAsIntervalsUnrecognizedFormatFile() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + FEATURE_INTEGRATION_TEST_DIRECTORY + "reads_data_source_test1.bam" +
-                " -L " + publicTestDir + "org/broadinstitute/hellbender/utils/interval/unrecognized_format_file.xyz" +
+                " -L " + TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/interval/unrecognized_format_file.xyz" +
                 " -O %s",
                 1,
                 UserException.CouldNotReadInputFile.class

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
@@ -27,6 +27,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -39,15 +40,15 @@ import java.util.Set;
 
 public final class GATKToolUnitTest extends BaseTest{
 
-    public static final String bqsrTestDir = toolsTestDir + "BQSR/";
+    public static final String bqsrTestDir = TestResources.toolsTestDir + "BQSR/";
 
     public static final String BQSR_WGS_B37_CH20_21_10M_100_CRAM = bqsrTestDir +
             "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram";
 
-    public static final String hg19MicroDictFileName = ReferenceUtils.getFastaDictionaryFileName(hg19MicroReference);
-    public static final String hg19MiniDictFileName  = ReferenceUtils.getFastaDictionaryFileName(hg19MiniReference);
-    public static final String v37_chr17DictFileName = ReferenceUtils.getFastaDictionaryFileName(v37_chr17_1Mb_Reference);
-    public static final String b37_20_21DictFile     = ReferenceUtils.getFastaDictionaryFileName(b37_reference_20_21);
+    public static final String hg19MicroDictFileName = ReferenceUtils.getFastaDictionaryFileName(TestResources.hg19MicroReference);
+    public static final String hg19MiniDictFileName  = ReferenceUtils.getFastaDictionaryFileName(TestResources.hg19MiniReference);
+    public static final String v37_chr17DictFileName = ReferenceUtils.getFastaDictionaryFileName(TestResources.v37_chr17_1Mb_Reference);
+    public static final String b37_20_21DictFile     = ReferenceUtils.getFastaDictionaryFileName(TestResources.b37_reference_20_21);
 
     @CommandLineProgramProperties(
             summary = "TestGATKToolWithSequenceDictionary",
@@ -169,11 +170,11 @@ public final class GATKToolUnitTest extends BaseTest{
     public Object[][] sequenceDictionaryTestValuesCompatible() {
 
         return new Object[][] {
-                { v37_chr17DictFileName, "--input", NA12878_chr17_1k_BAM, null, null },
-                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", b37_reference_20_21 },
-                { hg19MiniDictFileName, "--reference", hg19MicroReference, null, null },
-                { hg19MicroDictFileName, "--reference", hg19MiniReference, null, null },
-                { v37_chr17DictFileName, "--reference", v37_chr17_1Mb_Reference, null, null },
+                { v37_chr17DictFileName, "--input", TestResources.NA12878_chr17_1k_BAM, null, null },
+                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", TestResources.b37_reference_20_21 },
+                { hg19MiniDictFileName, "--reference", TestResources.hg19MicroReference, null, null },
+                { hg19MicroDictFileName, "--reference", TestResources.hg19MiniReference, null, null },
+                { v37_chr17DictFileName, "--reference", TestResources.v37_chr17_1Mb_Reference, null, null },
         };
     }
 
@@ -181,10 +182,10 @@ public final class GATKToolUnitTest extends BaseTest{
     public Object[][] sequenceDictionaryTestValuesIncompatible() {
 
         return new Object[][] {
-                { v37_chr17DictFileName, "--input", NA12878_20_21_WGS_bam, null, null },
-                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", v37_chr17_1Mb_Reference },
-                { b37_20_21DictFile, "--reference", hg19MiniReference, null, null },
-                { v37_chr17DictFileName, "--reference", hg19_chr1_1M_Reference, null, null },
+                { v37_chr17DictFileName, "--input", TestResources.NA12878_20_21_WGS_bam, null, null },
+                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", TestResources.v37_chr17_1Mb_Reference },
+                { b37_20_21DictFile, "--reference", TestResources.hg19MiniReference, null, null },
+                { v37_chr17DictFileName, "--reference", TestResources.hg19_chr1_1M_Reference, null, null },
         };
     }
 
@@ -235,12 +236,12 @@ public final class GATKToolUnitTest extends BaseTest{
     @DataProvider
     public Object[][] provideForGetMasterSequenceTest() {
 
-        final String dictFileName = ReferenceUtils.getFastaDictionaryFileName(v37_chr17_1Mb_Reference);
+        final String dictFileName = ReferenceUtils.getFastaDictionaryFileName(TestResources.v37_chr17_1Mb_Reference);
         final SAMSequenceDictionary dict = ReferenceUtils.loadFastaDictionary(new File(dictFileName));
 
         return new Object[][] {
-                { null, NA12878_chr17_1k_BAM, null },
-                { dictFileName, NA12878_chr17_1k_BAM, dict },
+                { null, TestResources.NA12878_chr17_1k_BAM, null },
+                { dictFileName, TestResources.NA12878_chr17_1k_BAM, dict },
         };
     }
 
@@ -271,10 +272,10 @@ public final class GATKToolUnitTest extends BaseTest{
         final SAMSequenceDictionary hg19MicroDict = ReferenceUtils.loadFastaDictionary(new File(hg19MicroDictFileName));
 
         return new Object[][] {
-                { v37_chr17DictFileName, "--input", NA12878_chr17_1k_BAM, null, null, v37_chr17Dict },
-                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", b37_reference_20_21, b37_20_21Dict },
-                { hg19MiniDictFileName, "--reference", hg19MicroReference, null, null, hg19MiniDict },
-                { hg19MicroDictFileName, "--reference", hg19MiniReference, null, null, hg19MicroDict },
+                { v37_chr17DictFileName, "--input", TestResources.NA12878_chr17_1k_BAM, null, null, v37_chr17Dict },
+                { b37_20_21DictFile, "--input", BQSR_WGS_B37_CH20_21_10M_100_CRAM, "--reference", TestResources.b37_reference_20_21, b37_20_21Dict },
+                { hg19MiniDictFileName, "--reference", TestResources.hg19MicroReference, null, null, hg19MiniDict },
+                { hg19MicroDictFileName, "--reference", TestResources.hg19MiniReference, null, null, hg19MicroDict },
         };
     }
 
@@ -304,7 +305,7 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testReadsHeader() throws Exception {
         final GATKTool tool = new TestGATKToolWithReads();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File bamFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File bamFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
         final String[] args = {"-I", bamFile.getCanonicalPath()};
         clp.parseArguments(System.out, args);
         tool.onStartup();
@@ -324,7 +325,7 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testFeaturesHeader() throws Exception {
         final TestGATKToolWithFeatures tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_with_bigHeader.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_with_bigHeader.vcf");
         final String[] args = {"--mask", vcfFile.getCanonicalPath()};
         clp.parseArguments(System.out, args);
         tool.onStartup();
@@ -349,7 +350,7 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testAllowLexicographicallySortedVariantHeader() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/lexicographically_sorted_dict.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/lexicographically_sorted_dict.vcf");
         final String[] args = {"--mask", vcfFile.getCanonicalPath() };
         clp.parseArguments(System.out, args);
 
@@ -371,9 +372,9 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testDisallowLexicographicallySortedVariantHeader_ifClashWithReference() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/lexicographically_sorted_dict.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/lexicographically_sorted_dict.vcf");
         final String[] args = {"--mask", vcfFile.getCanonicalPath(),
-                "--reference", hg19MiniReference};
+                "--reference", TestResources.hg19MiniReference};
         clp.parseArguments(System.out, args);
 
         // This method throws despite the lexicographically-sorted sequence dictionary in the vcf.
@@ -384,7 +385,7 @@ public final class GATKToolUnitTest extends BaseTest{
     @DataProvider(name="validationStringency")
     public Object[][] validationStringency() {
         return new Object[][]{
-                {NA12878_chr17_1k_CRAM, v37_chr17_1Mb_Reference, 493}
+                {TestResources.NA12878_chr17_1k_CRAM, TestResources.v37_chr17_1Mb_Reference, 493}
         };
     }
 
@@ -395,8 +396,8 @@ public final class GATKToolUnitTest extends BaseTest{
     {
         final TestGATKToolValidationStringency tool = new TestGATKToolValidationStringency();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File bamFile = new File(NA12878_chr17_1k_CRAM);
-        final File refFile = new File(v37_chr17_1Mb_Reference);
+        final File bamFile = new File(TestResources.NA12878_chr17_1k_CRAM);
+        final File refFile = new File(TestResources.v37_chr17_1Mb_Reference);
         final String[] args = {
                 "-I", bamFileName,
                 "-R", referenceFileName,
@@ -430,7 +431,7 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testBestSequenceDictionary_fromReads() throws Exception {
         final GATKTool tool = new TestGATKToolWithReads();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File bamFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File bamFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
         final String[] args = {"-I", bamFile.getCanonicalPath()};
         clp.parseArguments(System.out, args);
         tool.onStartup();
@@ -448,8 +449,8 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testBestSequenceDictionary_fromReadsAndReference() throws Exception {
         final GATKTool tool = new TestGATKToolWithReads();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File bamFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
-        final String fastaFile =   hg19MiniReference;
+        final File bamFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final String fastaFile =   TestResources.hg19MiniReference;
         final String[] args = {"-I", bamFile.getCanonicalPath(),
                                "-R", fastaFile};
         clp.parseArguments(System.out, args);
@@ -467,7 +468,7 @@ public final class GATKToolUnitTest extends BaseTest{
     public void testBestSequenceDictionary_fromVariants() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_withSequenceDict.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_withSequenceDict.vcf");
         final String[] args = {"--mask", vcfFile.getCanonicalPath()};
         clp.parseArguments(System.out, args);
         tool.onStartup();
@@ -496,15 +497,15 @@ public final class GATKToolUnitTest extends BaseTest{
     @DataProvider(name="createVCFWriterData")
     public Object[][] createVCFWriterData() {
         return new Object[][]{
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", false, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, false},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", true, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", false, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", true, false},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.bgz", ".tbi", true, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.gz", ".tbi", false, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.bgz", ".tbi", true, false}
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", false, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, false},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", true, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", false, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".bcf", ".idx", true, false},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.bgz", ".tbi", true, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.gz", ".tbi", false, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf.bgz", ".tbi", true, false}
         };
     }
 
@@ -570,9 +571,9 @@ public final class GATKToolUnitTest extends BaseTest{
     @DataProvider(name="createVCFWriterLenientData")
     public Object[][] createVCFWriterLenientData() {
         return new Object[][]{
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", false, true},
-                {new File(publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, false}
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", false, true},
+                {new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/engine/example_variants.vcf"), ".vcf", ".idx", true, false}
         };
     }
 
@@ -689,7 +690,7 @@ public final class GATKToolUnitTest extends BaseTest{
     @Test
     public void testGetDefaultToolVCFHeaderLines() throws IOException {
         final TestGATKToolWithFeatures tool = new TestGATKToolWithFeatures();
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_with_bigHeader.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/feature_data_source_test_with_bigHeader.vcf");
         final String[] args = {"--mask", vcfFile.getCanonicalPath(), "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "true"};
         tool.instanceMain(args);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -5,10 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.GenomicsDBTestUtils;
-import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
+import org.broadinstitute.hellbender.utils.test.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -18,7 +15,7 @@ import java.util.Collections;
 
 
 public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
-    public static final String TEST_DATA_PATH =  publicTestDir + "/org/broadinstitute/hellbender/engine/GenomicsDBIntegration/";
+    public static final String TEST_DATA_PATH =  TestResources.publicTestDir + "/org/broadinstitute/hellbender/engine/GenomicsDBIntegration/";
     private static final File TINY_GVCF = new File(TEST_DATA_PATH, "tiny.g.vcf");
     private static final SimpleInterval INTERVAL = new SimpleInterval("20", 1, 63025520);
 
@@ -38,7 +35,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
         final File workspace = GenomicsDBTestUtils.createTempGenomicsDB(TINY_GVCF, INTERVAL);
         testExpectedVariantsFromGenomicsDB(TINY_GVCF, new ArgumentsBuilder()
                 .addArgument("V", GenomicsDBTestUtils.makeGenomicsDBUri(workspace))
-                .addReference(new File(BaseTest.b37_reference_20_21)));
+                .addReference(new File(TestResources.b37_reference_20_21)));
     }
 
     @Test
@@ -49,7 +46,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
                 .addArgument("V", TINY_GVCF.getAbsolutePath())
             .addArgument("concordance", GenomicsDBTestUtils.makeGenomicsDBUri(workspace))
             .addArgument("L", "20")
-            .addReference(new File(BaseTest.b37_reference_20_21)));
+            .addReference(new File(TestResources.b37_reference_20_21)));
     }
 
     @Test
@@ -57,7 +54,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
         final File workspace = GenomicsDBTestUtils.createTempGenomicsDB(TINY_GVCF, INTERVAL);
         testExpectedVariantsFromGenomicsDB(TINY_GVCF, new ArgumentsBuilder()
                 .addArgument("L", "20")
-                .addReference(new File(BaseTest.b37_reference_20_21))
+                .addReference(new File(TestResources.b37_reference_20_21))
                 .addArgument("V", GenomicsDBTestUtils.makeGenomicsDBUri(workspace))
         );
     }
@@ -67,7 +64,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
     public void testRestrictingIntervals() throws IOException {
         final File workspace = GenomicsDBTestUtils.createTempGenomicsDB(TINY_GVCF, INTERVAL);
         testExpectedVariantsFromGenomicsDB(new File(TEST_DATA_PATH, "intervalsRestrictedExpected.g.vcf"), new ArgumentsBuilder()
-                .addReference(new File(BaseTest.b37_reference_20_21))
+                .addReference(new File(TestResources.b37_reference_20_21))
                 .addArgument("L", "20:69491-69521")
                 .addArgument("V", GenomicsDBTestUtils.makeGenomicsDBUri(workspace)));
     }
@@ -92,6 +89,6 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
         testExpectedVariantsFromGenomicsDB(TINY_GVCF, new ArgumentsBuilder()
                     .addArgument("V", TINY_GVCF.getAbsolutePath())
                     .addArgument("concordance", GenomicsDBTestUtils.makeGenomicsDBUri(workspace))
-                    .addReference(new File(BaseTest.b37_reference_20_21)));
+                    .addReference(new File(TestResources.b37_reference_20_21)));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/LocalReadShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/LocalReadShardUnitTest.java
@@ -6,10 +6,10 @@ import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
-import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,7 +23,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "InvalidConstructionTestData")
     public Object[][] invalidConstructionTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 { new SimpleInterval("1", 200, 250), new SimpleInterval("1", 200, 250), null },
@@ -44,7 +44,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardBoundsTestData")
     public Object[][] shardBoundsTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 {new LocalReadShard(new SimpleInterval("1", 200, 250), readsSource), new SimpleInterval("1", 200, 250), new SimpleInterval("1", 200, 250), "1", 200, 250, 0, 0 },
@@ -68,7 +68,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardContainsTestData")
     public Object[][] shardContainsTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 // Tests with no padding
@@ -91,7 +91,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "ShardIterationTestData")
     public Object[][] shardIterationTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         final ReadFilter keepReadBOnly = new ReadFilter() {
             private static final long serialVersionUID = 1l;
@@ -144,7 +144,7 @@ public class LocalReadShardUnitTest extends BaseTest {
     @DataProvider(name = "DivideIntervalIntoShardsTestData")
     public Object[][] divideIntervalIntoShardsTestData() {
         // Doesn't matter which bam we use to back the reads source for the purposes of these tests.
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Arrays.asList(new SAMSequenceRecord("1", 16000)));
 
         return new Object[][] {
@@ -290,7 +290,7 @@ public class LocalReadShardUnitTest extends BaseTest {
 
     @DataProvider(name = "DivideIntervalIntoShardsInvalidTestData")
     public Object[][] divideIntervalIntoShardsInvalidTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Arrays.asList(new SAMSequenceRecord("1", 16000)));
 
         return new Object[][] {

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
@@ -5,6 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -13,8 +14,8 @@ import java.io.File;
 import java.util.*;
 
 public final class MultiVariantDataSourceUnitTest extends BaseTest {
-    private static final String ENGINE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String MULTI_VARIANT_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/MultiVariantDataSource/";
+    private static final String ENGINE_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String MULTI_VARIANT_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/MultiVariantDataSource/";
 
     private static final File QUERY_TEST_VCF = new File(ENGINE_TEST_DIRECTORY + "feature_data_source_test.vcf");
     private static final File QUERY_TEST_GVCF = new File(ENGINE_TEST_DIRECTORY + "feature_data_source_test_gvcf.vcf");

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,7 +26,7 @@ public final class MultiVariantWalkerIntegrationTest extends CommandLineProgramT
     }
 
     public static File getTestDataDir() {
-        return new File(publicTestDir + "org/broadinstitute/hellbender/engine/MultiVariantDataSource/");
+        return new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/MultiVariantDataSource/");
     }
 
     @CommandLineProgramProperties(

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerGCSSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerGCSSupportIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.PrintReads;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -18,7 +19,7 @@ import java.util.List;
 public class ReadWalkerGCSSupportIntegrationTest extends CommandLineProgramTest {
 
     private static final String TEST_BAM_ON_GCS = "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10000000-10000020.with.unmapped.bam";
-    private static final String EXPECTED_OUTPUT_DIR = publicTestDir + "org/broadinstitute/hellbender/engine/GCSTests/";
+    private static final String EXPECTED_OUTPUT_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/GCSTests/";
 
     @Override
     public String getTestedToolName() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.examples.ExampleReadWalkerWithReference;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -18,10 +19,10 @@ public class ReadWalkerIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void testManuallySpecifiedIndices() throws IOException {
-        final String BAM_PATH = publicTestDir + "org/broadinstitute/hellbender/engine/readIndexTest/";
+        final String BAM_PATH = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/readIndexTest/";
         final String INDEX_PATH = BAM_PATH + "indices/";
         final File outFile = createTempFile("testManuallySpecifiedIndices", ".txt");
-        final File expectedFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/expected_ReadWalkerIntegrationTest_testManuallySpecifiedIndices.txt");
+        final File expectedFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/expected_ReadWalkerIntegrationTest_testManuallySpecifiedIndices.txt");
 
         final String[] args = new String[] {
             "-I", BAM_PATH + "reads_data_source_test1.bam",
@@ -37,7 +38,7 @@ public class ReadWalkerIntegrationTest extends CommandLineProgramTest {
 
     @Test(expectedExceptions = UserException.class)
     public void testManuallySpecifiedIndicesWrongNumberOfIndices() throws IOException {
-        final String BAM_PATH = publicTestDir + "org/broadinstitute/hellbender/engine/readIndexTest/";
+        final String BAM_PATH = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/readIndexTest/";
         final String INDEX_PATH = BAM_PATH + "indices/";
 
         final String[] args = new String[] {

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
@@ -1,12 +1,12 @@
 package org.broadinstitute.hellbender.engine;
 
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.ReadNameReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -24,7 +24,7 @@ public final class ReadsContextUnitTest extends BaseTest {
                 { new ReadsContext() },
                 { new ReadsContext(null, null) },
                 { new ReadsContext(null, new SimpleInterval("1", 1, 1) ) },
-                { new ReadsContext(new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
+                { new ReadsContext(new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
         };
     }
 
@@ -43,12 +43,12 @@ public final class ReadsContextUnitTest extends BaseTest {
         readNameFilter.readName = "d";
         return new Object[][]{
                 {new ReadsContext(
-                        new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
+                        new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
                         new SimpleInterval("1", 200, 210), // query over small interval, with no read filter
                         ReadFilterLibrary.ALLOW_ALL_READS), new String[] { "a", "b", "c" },
                 },
                 {new ReadsContext(
-                        new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
+                        new ReadsDataSource(IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
                         new SimpleInterval("1", 200, 1000), // query over larger interval with readNameFilter on "d"
                         readNameFilter), new String[] { "d" }
                 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsDataSourceUnitTest.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.XorWrapper;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -21,7 +22,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 public final class ReadsDataSourceUnitTest extends BaseTest {
-    private static final String READS_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String READS_DATA_SOURCE_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
     private final Path FIRST_TEST_BAM = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "reads_data_source_test1.bam");
     private final Path SECOND_TEST_BAM = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "reads_data_source_test2.bam");
     private final Path THIRD_TEST_BAM = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "reads_data_source_test3.bam");
@@ -354,15 +355,15 @@ public final class ReadsDataSourceUnitTest extends BaseTest {
     @DataProvider(name = "TraversalWithUnmappedReadsTestData")
     public Object[][] traversalWithUnmappedReadsTestData() {
         // This bam has only mapped reads
-        final Path mappedBam = IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final Path mappedBam = IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
 
         // This bam has mapped reads from various contigs, plus a few unmapped reads with no mapped mate
-        final Path unmappedBam = IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
+        final Path unmappedBam = IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
 
         // This is a snippet of the CEUTrio.HiSeq.WGS.b37.NA12878 bam from large, with mapped reads
         // from chromosome 20 (with one mapped read having an unmapped mate), plus several unmapped
         // reads with no mapped mate.
-        final Path ceuSnippet = IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
+        final Path ceuSnippet = IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
 
         return new Object[][] {
                 // One interval, no unmapped
@@ -434,8 +435,8 @@ public final class ReadsDataSourceUnitTest extends BaseTest {
     @DataProvider(name = "QueryUnmappedTestData")
     public Object[][] queryUnmappedTestData() {
         return new Object[][] {
-                { IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam"), Arrays.asList("u1", "u2", "u3", "u4", "u5") },
-                { IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam"), Arrays.asList("g", "h", "h", "i", "i") }
+                { IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam"), Arrays.asList("u1", "u2", "u3", "u4", "u5") },
+                { IOUtils.getPath(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam"), Arrays.asList("g", "h", "h", "i", "i") }
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.engine;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -14,7 +15,7 @@ import java.util.List;
 
 public final class ReferenceContextUnitTest extends BaseTest {
 
-    private static final File TEST_REFERENCE = new File(hg19MiniReference);
+    private static final File TEST_REFERENCE = new File(TestResources.hg19MiniReference);
 
     @DataProvider(name = "EmptyReferenceContextDataProvider")
     public Object[][] getEmptyReferenceContextData() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -17,7 +18,7 @@ import java.util.List;
 
 public final class ReferenceDataSourceUnitTest extends BaseTest {
 
-    private static final File TEST_REFERENCE = new File(hg19MiniReference);
+    private static final File TEST_REFERENCE = new File(TestResources.hg19MiniReference);
 
     @Test(expectedExceptions = UserException.class)
     public void testNonExistentReference() {
@@ -26,12 +27,12 @@ public final class ReferenceDataSourceUnitTest extends BaseTest {
 
     @Test(expectedExceptions = UserException.MissingReferenceFaiFile.class)
     public void testReferenceWithMissingFaiFile() {
-        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(publicTestDir + "fastaWithoutFai.fasta"));
+        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(TestResources.publicTestDir + "fastaWithoutFai.fasta"));
     }
 
     @Test(expectedExceptions = UserException.MissingReferenceDictFile.class)
     public void testReferenceWithMissingDictFile() {
-        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(publicTestDir + "fastaWithoutDict.fasta"));
+        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(TestResources.publicTestDir + "fastaWithoutDict.fasta"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceMultiSourceUnitTest.java
@@ -7,12 +7,13 @@ import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.SparkTestUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ReferenceMultiSourceUnitTest extends BaseTest {
 
-    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+    private static String twoBitRefURL = TestResources.publicTestDir + "large/human_g1k_v37.20.21.2bit";
 
     @Test
     public void testSerializeRoundTrip2Bit() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerGCSSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerGCSSupportIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -19,7 +20,7 @@ public class VariantWalkerGCSSupportIntegrationTest extends CommandLineProgramTe
 
     private static final String TEST_VCF_ON_GCS = "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf";
     private static final String TEST_BGZIPPED_VCF_ON_GCS = "org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf.block.gz";
-    private static final String EXPECTED_OUTPUT_DIR = publicTestDir + "org/broadinstitute/hellbender/engine/GCSTests/";
+    private static final String EXPECTED_OUTPUT_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/GCSTests/";
 
     @Override
     public String getTestedToolName() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.examples.ExampleVariantWalker;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -91,8 +92,8 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
     public void testBestSequenceDictionary_FromVariantReference() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/example_variants_noSequenceDict.vcf");
-        final String[] args = {"-V", vcfFile.getCanonicalPath(), "-R", hg19MiniReference};
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/example_variants_noSequenceDict.vcf");
+        final String[] args = {"-V", vcfFile.getCanonicalPath(), "-R", TestResources.hg19MiniReference};
         clp.parseArguments(System.out, args);
         tool.onStartup();
         // make sure we DON'T get the seq dictionary from the VCF index, and instead get the one from
@@ -100,7 +101,7 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
         final SAMSequenceDictionary toolDict = tool.getBestAvailableSequenceDictionary();
         Assert.assertFalse(toolDict.getSequences().stream().allMatch(seqRec -> seqRec.getSequenceLength() == 0));
 
-        SAMSequenceDictionary refDict = new ReferenceFileSource(new File(hg19MiniReference)).getSequenceDictionary();
+        SAMSequenceDictionary refDict = new ReferenceFileSource(new File(TestResources.hg19MiniReference)).getSequenceDictionary();
         toolDict.assertSameDictionary(refDict);
         refDict.assertSameDictionary(toolDict);
         Assert.assertEquals(toolDict, refDict);
@@ -110,7 +111,7 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
     public void testBestSequenceDictionary_FromVariantIndex() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
         final CommandLineParser clp = new CommandLineArgumentParser(tool);
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/example_variants_noSequenceDict.vcf");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/example_variants_noSequenceDict.vcf");
         final String[] args = {"--variant", vcfFile.getCanonicalPath()};
         clp.parseArguments(System.out, args);
         tool.onStartup();
@@ -122,8 +123,8 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
     @Test
     public void testReadFilterOff() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.vcf");
-        final File bamFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.bam");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.vcf");
+        final File bamFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.bam");
 
         final String[] args = {
                 "--variant", vcfFile.getCanonicalPath(),
@@ -139,8 +140,8 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
     @Test
     public void testReadFilterOn() throws Exception {
         final GATKTool tool = new TestGATKToolWithFeatures();
-        final File vcfFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.vcf");
-        final File bamFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.bam");
+        final File vcfFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.vcf");
+        final File bamFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/VariantWalkerTest_VariantsWithReads.bam");
         final String[] args = {
                 "--variant", vcfFile.getCanonicalPath(),
                 "--input", bamFile.getCanonicalPath(),

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadGroupBlackListReadFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadGroupBlackListReadFilterUnitTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -176,7 +177,7 @@ public final class ReadGroupBlackListReadFilterUnitTest extends BaseTest {
         }
 
         List<String> filterList = new ArrayList<>();
-        filterList.add(publicTestDir + "readgroupblacklisttest.txt");
+        filterList.add(TestResources.publicTestDir + "readgroupblacklisttest.txt");
 
         ReadGroupBlackListReadFilter filter = new ReadGroupBlackListReadFilter(filterList, header);
         int filtered = 0;
@@ -215,7 +216,7 @@ public final class ReadGroupBlackListReadFilterUnitTest extends BaseTest {
         }
 
         List<String> filterList = new ArrayList<>();
-        filterList.add(publicTestDir + "readgroupblacklisttestlist.txt");
+        filterList.add(TestResources.publicTestDir + "readgroupblacklisttestlist.txt");
 
         ReadGroupBlackListReadFilter filter = new ReadGroupBlackListReadFilter(filterList, header);
         int filtered = 0;

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/VariantFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/VariantFilterUnitTest.java
@@ -9,6 +9,7 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ public class VariantFilterUnitTest extends BaseTest {
     VariantContext mnpVC;
 
     public VariantFilterUnitTest() throws FileNotFoundException {
-        initGenomeLocParser();
+        TestResources.getGenomeLocParser();
         snpVC = createArtificialVC(
                 "id1",
                 new SimpleInterval("1", 42, 42),

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -5,14 +5,12 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordCoordinateComparator;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -20,6 +18,7 @@ import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.seqdoop.hadoop_bam.SplittingBAMIndexer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -31,14 +30,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
 public class ReadsSparkSinkUnitTest extends BaseTest {
     private MiniDFSCluster cluster;
 
-    private static String testDataDir = publicTestDir + "org/broadinstitute/hellbender/";
+    private static String testDataDir = TestResources.publicTestDir + "org/broadinstitute/hellbender/";
 
     @BeforeClass(alwaysRun = true)
     private void setupMiniCluster() throws IOException {
@@ -62,7 +60,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
                 // htsjdk.samtools.SAMRecordCoordinateComparator
                 {testDataDir + "tools/BQSR/CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam", "ReadsSparkSinkUnitTest3", null, ".bam"},
                 {testDataDir + "tools/BQSR/NA12878.chr17_69k_70k.dictFix.cram", "ReadsSparkSinkUnitTest5",
-                                                publicTestDir + "human_g1k_v37.chr17_1Mb.fasta", ".cram"},
+                                                TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta", ".cram"},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSourceUnitTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.engine.datasources.ReferenceSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -12,8 +13,8 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 public class ReferenceTwoBitSourceUnitTest extends BaseTest {
-    private static String fastaRefURL = publicTestDir + "large/human_g1k_v37.20.21.fasta";
-    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+    private static String fastaRefURL = TestResources.publicTestDir + "large/human_g1k_v37.20.21.fasta";
+    private static String twoBitRefURL = TestResources.publicTestDir + "large/human_g1k_v37.20.21.2bit";
 
     @DataProvider(name = "goodIntervals")
     public Object[][] goodIntervals() throws IOException {
@@ -37,7 +38,7 @@ public class ReferenceTwoBitSourceUnitTest extends BaseTest {
 
     @DataProvider(name = "outOfBoundsIntervals")
     public Object[][] getOutOfBoundsIntervals() throws IOException {
-        final ReferenceTwoBitSource twoBitRef = new ReferenceTwoBitSource(null, publicTestDir + "large/human_g1k_v37.20.21.2bit");
+        final ReferenceTwoBitSource twoBitRef = new ReferenceTwoBitSource(null, TestResources.publicTestDir + "large/human_g1k_v37.20.21.2bit");
         final int chr20End = 63025520;
 
         return new Object[][] {

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.seqdoop.hadoop_bam.util.VCFHeaderReader;
 import org.testng.Assert;
@@ -49,9 +50,9 @@ public final class VariantsSparkSinkUnitTest extends BaseTest {
     @DataProvider(name = "loadVariants")
     public Object[][] loadVariants() {
         return new Object[][]{
-                {hg19_chr1_1M_dbSNP, ".vcf"},
-                {hg19_chr1_1M_dbSNP, ".vcf.bgz"},
-                {hg19_chr1_1M_dbSNP_modified, ".vcf"},
+                {TestResources.hg19_chr1_1M_dbSNP, ".vcf"},
+                {TestResources.hg19_chr1_1M_dbSNP, ".vcf.bgz"},
+                {TestResources.hg19_chr1_1M_dbSNP_modified, ".vcf"},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.engine.datasources.VariantsSource;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVariant;
 import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
@@ -26,8 +27,8 @@ public final class VariantsSparkSourceUnitTest extends BaseTest {
     @DataProvider(name = "loadVariants")
     public Object[][] loadVariants() {
         return new Object[][]{
-                {hg19_chr1_1M_dbSNP},
-                {hg19_chr1_1M_dbSNP_modified},
+                {TestResources.hg19_chr1_1M_dbSNP},
+                {TestResources.hg19_chr1_1M_dbSNP_modified},
         };
     }
 
@@ -58,7 +59,7 @@ public final class VariantsSparkSourceUnitTest extends BaseTest {
     @DataProvider(name = "loadMultipleVCFs")
     public Object[][] loadMultipleVCFs() {
         return new Object[][]{
-                {Arrays.asList(hg19_chr1_1M_dbSNP, hg19_chr1_1M_dbSNP_modified)},
+                {Arrays.asList(TestResources.hg19_chr1_1M_dbSNP, TestResources.hg19_chr1_1M_dbSNP_modified)},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/ClipReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/ClipReadsIntegrationTest.java
@@ -1,9 +1,9 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -82,8 +82,8 @@ public final class ClipReadsIntegrationTest extends CommandLineProgramTest {
                 {b1, null, ".bam", "-QT 10 -CR WRITE_NS", "QT_10_CR_WRITE_NS", true},
                 {b1, null, ".bam", "-QT 10 -CR WRITE_Q0S", "QT_10_CR_WRITE_Q0S", true},
                 {b1, null, ".bam", "-QT 10 -CR SOFTCLIP_BASES","QT_10_CR_SOFTCLIP_BASES", true} ,
-                {b1, null, ".bam", "-XF " + BaseTest.publicTestDir + "seqsToClip.fasta", "XF", true},
-                {b1, null, ".bam", "-QT 10 -CT 1-5 -X CCCCC -XF " + BaseTest.publicTestDir + "seqsToClip.fasta", "QT_10_CT_15_X_CCCCC_XF", true},
+                {b1, null, ".bam", "-XF " + TestResources.publicTestDir + "seqsToClip.fasta", "XF", true},
+                {b1, null, ".bam", "-QT 10 -CT 1-5 -X CCCCC -XF " + TestResources.publicTestDir + "seqsToClip.fasta", "QT_10_CT_15_X_CCCCC_XF", true},
                 {cramFile, referenceFile, ".cram", "-QT 10", "QT_10", true},
                 {cramFile, referenceFile, ".cram", "-QT 10", "QT_10", false},
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -14,9 +15,9 @@ public class ConvertHeaderlessHadoopBamShardToBamIntegrationTest extends Command
 
     @Test
     public void testConvertHeaderlessHadoopBamShardToBam() {
-        final File bamShard = new File(publicTestDir + "org/broadinstitute/hellbender/utils/spark/reads_data_source_test1.bam.headerless.part-r-00000");
+        final File bamShard = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/spark/reads_data_source_test1.bam.headerless.part-r-00000");
         final File output = createTempFile("testConvertHeaderlessHadoopBamShardToBam", ".bam");
-        final File headerSource = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File headerSource = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
         final int expectedReadCount = 11;
 
         List<String> args = Arrays.asList(

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountVariantsIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.CountVariants;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ public final class CountVariantsIntegrationTest extends CommandLineProgramTest {
                 {new File(getTestDataDir(), "count_variants.blockgz.gz"), "", 26L},
                 {new File(getTestDataDir(), "count_variants_withSequenceDict.vcf"), "", 26L},
                 {new File(getTestDataDir(), "count_variants_withSequenceDict.vcf"), "-L 1", 14L},
-                {new File(dbsnp_138_b37_1_65M_vcf), "", 1375319L},
+                {new File(TestResources.dbsnp_138_b37_1_65M_vcf), "", 1375319L},
         };
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -14,8 +14,8 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeCalculationArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerArgumentCollection;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SparkTestUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,7 +27,7 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCall
 
 public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest {
 
-    private  static final String TEST_FILES_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/haplotypecaller/";
+    private  static final String TEST_FILES_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/haplotypecaller/";
 
     /*
     * Test that in VCF mode we're >= 99% concordant with GATK3.5 results
@@ -46,8 +46,8 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk3.5.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_2bit_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
@@ -81,8 +81,8 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk3.5.alleleSpecific.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_2bit_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -114,8 +114,8 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testGVCFMode.gatk3.5.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_2bit_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
@@ -144,8 +144,8 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testGVCFMode.gatk3.5.alleleSpecific.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_2bit_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -164,7 +164,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testReferenceAdapterIsSerializable() throws IOException {
         final AuthHolder auth = new AuthHolder("name", "somestring");
-        final ReferenceMultiSource referenceMultiSource = new ReferenceMultiSource(auth, b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        final ReferenceMultiSource referenceMultiSource = new ReferenceMultiSource(auth, TestResources.b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SparkTestUtils.roundTripInKryo(referenceMultiSource, ReferenceMultiSource.class, SparkContextFactory.getTestSparkContext().getConf());
         final HaplotypeCallerSpark.ReferenceMultiSourceAdapter adapter = new HaplotypeCallerSpark.ReferenceMultiSourceAdapter(referenceMultiSource, auth);
         SparkTestUtils.roundTripInKryo(adapter, HaplotypeCallerSpark.ReferenceMultiSourceAdapter.class, SparkContextFactory.getTestSparkContext().getConf());
@@ -187,7 +187,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
     @Test
     public void testReferenceMultiSourceIsSerializable() {
-        final ReferenceMultiSource args = new ReferenceMultiSource((PipelineOptions) null, BaseTest.b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        final ReferenceMultiSource args = new ReferenceMultiSource((PipelineOptions) null, TestResources.b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SparkTestUtils.roundTripInKryo(args, ReferenceMultiSource.class, SparkContextFactory.getTestSparkContext().getConf());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -165,28 +166,28 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
     @DataProvider(name = "UnmappedReadInclusionTestData")
     public Object[][] unmappedReadInclusionTestData() {
         // This bam has mapped reads from various contigs, plus a few unmapped reads with no mapped mate
-        final File unmappedBam = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
+        final File unmappedBam = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
 
         // This is a snippet of the CEUTrio.HiSeq.WGS.b37.NA12878 bam from large, with mapped reads
         // from chromosome 20 (with one mapped read having an unmapped mate), plus several unmapped
         // reads with no mapped mate.
-        final File ceuSnippet = new File(publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
-        final File ceuSnippetCram = new File(publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.cram");
+        final File ceuSnippet = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
+        final File ceuSnippetCram = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.cram");
 
         return new Object[][] {
                 { unmappedBam, null, Arrays.asList("unmapped"), Arrays.asList("u1", "u2", "u3", "u4", "u5") },
                 // The same interval as above in an intervals file
-                { unmappedBam, null, Arrays.asList(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped.intervals"), Arrays.asList("u1", "u2", "u3", "u4", "u5") },
+                { unmappedBam, null, Arrays.asList(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped.intervals"), Arrays.asList("u1", "u2", "u3", "u4", "u5") },
                 { unmappedBam, null, Arrays.asList("1:200-300", "unmapped"), Arrays.asList("a", "b", "c", "u1", "u2", "u3", "u4", "u5") },
                 { unmappedBam, null, Arrays.asList("1:200-300", "4:700-701", "unmapped"), Arrays.asList("a", "b", "c", "k", "u1", "u2", "u3", "u4", "u5") },
                 // The same intervals as above in an intervals file
-                { unmappedBam, null, Arrays.asList(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped2.intervals"), Arrays.asList("a", "b", "c", "k", "u1", "u2", "u3", "u4", "u5") },
+                { unmappedBam, null, Arrays.asList(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped2.intervals"), Arrays.asList("a", "b", "c", "k", "u1", "u2", "u3", "u4", "u5") },
                 { ceuSnippet, null, Arrays.asList("unmapped"), Arrays.asList("g", "h", "h", "i", "i") },
                 { ceuSnippet, null, Arrays.asList("20:10000009-10000011", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "g", "h", "h", "i", "i") },
                 { ceuSnippet, null, Arrays.asList("20:10000009-10000013", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "f", "f", "g", "h", "h", "i", "i") },
-                { ceuSnippetCram, b37_reference_20_21, Arrays.asList("unmapped"), Arrays.asList("g", "h", "h", "i", "i") },
-                { ceuSnippetCram, b37_reference_20_21, Arrays.asList("20:10000009-10000011", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "g", "h", "h", "i", "i") },
-                { ceuSnippetCram, b37_reference_20_21, Arrays.asList("20:10000009-10000013", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "f", "f", "g", "h", "h", "i", "i") }
+                { ceuSnippetCram, TestResources.b37_reference_20_21, Arrays.asList("unmapped"), Arrays.asList("g", "h", "h", "i", "i") },
+                { ceuSnippetCram, TestResources.b37_reference_20_21, Arrays.asList("20:10000009-10000011", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "g", "h", "h", "i", "i") },
+                { ceuSnippetCram, TestResources.b37_reference_20_21, Arrays.asList("20:10000009-10000013", "unmapped"), Arrays.asList("a", "b", "c", "d", "e", "f", "f", "g", "h", "h", "i", "i") }
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCountsIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.copynumber.allelic.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.tools.copynumber.allelic.alleliccount.AllelicCountCollection;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -22,12 +23,12 @@ import java.io.IOException;
  */
 public final class CollectAllelicCountsIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/copynumber/allelic";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/copynumber/allelic";
     private static final File NORMAL_BAM_FILE = new File(TEST_SUB_DIR, "collect-allelic-counts-normal.bam");
     private static final File TUMOR_BAM_FILE = new File(TEST_SUB_DIR, "collect-allelic-counts-tumor.bam");
     private static final File NON_STRICT_BAM_FILE = new File(TEST_SUB_DIR, "collect-allelic-counts-simple-overhang.sam");
     private static final File SITES_FILE = new File(TEST_SUB_DIR, "collect-allelic-counts-sites.interval_list");
-    private static final File REF_FILE = new File(hg19MiniReference);
+    private static final File REF_FILE = new File(TestResources.hg19MiniReference);
 
     @DataProvider(name = "testData")
     public Object[][] testData() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/allelic/alleliccount/AllelicCountCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/allelic/alleliccount/AllelicCountCollectionUnitTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,7 +18,7 @@ import java.io.IOException;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class AllelicCountCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/copynumber/allelic";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/copynumber/allelic";
     private static final File ALLELIC_COUNTS_FILE = new File(TEST_SUB_DIR, "allelic-count-collection-normal.tsv");
     private static final File ALLELIC_COUNTS_MISSING_NUCLEOTIDES_FILE = new File(TEST_SUB_DIR, "allelic-count-collection-normal-missing-nucleotides.tsv");
     private static final AllelicCountCollection ALLELIC_COUNTS_EXPECTED = new AllelicCountCollection();

--- a/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCallerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.broadinstitute.hellbender.tools.exome.sexgenotyper.SexGenotypeDataCol
 import org.broadinstitute.hellbender.utils.SparkToggleCommandLineProgram;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
@@ -46,7 +47,7 @@ import java.util.stream.IntStream;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class GermlineCNVCallerIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/coveragemodel";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/coveragemodel";
     private static final File TEST_CONTIG_PLOIDY_ANNOTATIONS_FILE = new File(TEST_SUB_DIR,
             "sim_contig_anots.tsv");
     private static final File TEST_HMM_PRIORS_TABLE_FILE = new File(TEST_SUB_DIR,

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerIntegrationTest.java
@@ -2,19 +2,20 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
 public class ExampleAssemblyRegionWalkerIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleAssemblyRegionWalker() throws Exception {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + b37_reference_20_21 +
-                " -I " + NA12878_20_21_WGS_bam +
-                " -knownVariants " + dbsnp_138_b37_20_21_vcf +
+                " -R " + TestResources.b37_reference_20_21 +
+                " -I " + TestResources.NA12878_20_21_WGS_bam +
+                " -knownVariants " + TestResources.dbsnp_138_b37_20_21_vcf +
                 " -L 20:10000000-10050000 " +
                 " -O %s",
                 Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleAssemblyRegionWalkerIntegrationTest_output.txt")

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSparkIntegrationTest.java
@@ -3,12 +3,13 @@ package org.broadinstitute.hellbender.tools.examples;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
 
 public class ExampleAssemblyRegionWalkerSparkIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     // DISABLED until https://github.com/broadinstitute/gatk/issues/2349 is resolved
     @Test(enabled = false)
@@ -18,12 +19,12 @@ public class ExampleAssemblyRegionWalkerSparkIntegrationTest extends CommandLine
         out.deleteOnExit();
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input");
-        args.add(NA12878_20_21_WGS_bam);
+        args.add(TestResources.NA12878_20_21_WGS_bam);
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(b37_reference_20_21);
-        args.add("-knownVariants " + dbsnp_138_b37_20_21_vcf);
+        args.add(TestResources.b37_reference_20_21);
+        args.add("-knownVariants " + TestResources.dbsnp_138_b37_20_21_vcf);
         args.add("-L 20:10000000-10050000");
         this.runCommandLine(args.getArgsArray());
         File expected = new File(TEST_OUTPUT_DIRECTORY, "expected_ExampleAssemblyRegionWalkerIntegrationTest_output.txt");

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleFeatureWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleFeatureWalkerIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -9,13 +10,13 @@ import java.util.Arrays;
 
 public final class ExampleFeatureWalkerIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleFeatureWalker() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                 " -F " + TEST_DATA_DIRECTORY + "example_features.bed" +
                 " -auxiliaryVariants " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
@@ -28,7 +29,7 @@ public final class ExampleFeatureWalkerIntegrationTest extends CommandLineProgra
     @Test
     public void testExampleFeatureWalkerWithIntervals() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                         " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                         " -F " + TEST_DATA_DIRECTORY + "example_features.bed" +
                         " -L 1 " +

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerIntegrationTest.java
@@ -2,20 +2,21 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 public final class ExampleIntervalWalkerIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleIntervalWalker() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
                 " -L 1:100-200 -L 2:500-600" +
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                 " -V " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
                 " -O %s",

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerSparkIntegrationTest.java
@@ -3,14 +3,15 @@ package org.broadinstitute.hellbender.tools.examples;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 
 public final class ExampleIntervalWalkerSparkIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleIntervalWalker() throws IOException {
@@ -26,7 +27,7 @@ public final class ExampleIntervalWalkerSparkIntegrationTest extends CommandLine
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(hg19MiniReference);
+        args.add(TestResources.hg19MiniReference);
         this.runCommandLine(args.getArgsArray());
         File expected = new File(TEST_OUTPUT_DIRECTORY, "expected_ExampleIntervalWalkerIntegrationTest_output.txt");
         IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalkerIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -11,14 +12,14 @@ import java.util.Arrays;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class ExampleLocusWalkerIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleVariantWalker() throws IOException {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
             " -L 1" +
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                 " -V " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +
                 " -O %s",

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -9,13 +10,13 @@ import java.util.Arrays;
 
 public final class ExampleReadWalkerWithReferenceIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleVariantWalker() throws IOException {
         final IntegrationTestSpec testSpec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                 " -O %s",
                 Arrays.asList(TEST_OUTPUT_DIRECTORY + "expected_ExampleReadWalkerWithReferenceIntegrationTest_output.txt")

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceSparkIntegrationTest.java
@@ -3,14 +3,15 @@ package org.broadinstitute.hellbender.tools.examples;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 
 public final class ExampleReadWalkerWithReferenceSparkIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleIntervalWalker() throws IOException {
@@ -23,7 +24,7 @@ public final class ExampleReadWalkerWithReferenceSparkIntegrationTest extends Co
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(hg19MiniReference);
+        args.add(TestResources.hg19MiniReference);
         this.runCommandLine(args.getArgsArray());
         File expected = new File(TEST_OUTPUT_DIRECTORY, "expected_ExampleReadWalkerWithReferenceIntegrationTest_output.txt");
         IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.examples;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -9,14 +10,14 @@ import java.util.Arrays;
 
 public final class ExampleVariantWalkerIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleVariantWalker() throws IOException {
         final IntegrationTestSpec testSpec = new IntegrationTestSpec(
                 " -L 1:100-200" +
-                        " -R " + hg19MiniReference +
+                        " -R " + TestResources.hg19MiniReference +
                         " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                         " -V " + TEST_DATA_DIRECTORY + "example_variants_withSequenceDict.vcf" +
                         " -auxiliaryVariants " + TEST_DATA_DIRECTORY + "feature_data_source_test.vcf" +

--- a/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerSparkIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.examples;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -10,8 +11,8 @@ import java.io.IOException;
 
 public final class ExampleVariantWalkerSparkIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/examples/";
 
     @Test
     public void testExampleVariantWalker() throws IOException {
@@ -28,7 +29,7 @@ public final class ExampleVariantWalkerSparkIntegrationTest extends CommandLineP
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(hg19MiniReference);
+        args.add(TestResources.hg19MiniReference);
         this.runCommandLine(args.getArgsArray());
         File expected = new File(TEST_OUTPUT_DIRECTORY, "expected_ExampleVariantWalkerSparkIntegrationTest_output.txt");
         IntegrationTestSpec.assertEqualTextFiles(new File(out, "part-00000"), expected);

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/ACNVModellerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/ACNVModellerUnitTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -26,7 +27,7 @@ import static org.broadinstitute.hellbender.tools.exome.AllelicCNV.*;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class ACNVModellerUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     private static final File COVERAGES_FILE = new File(TEST_SUB_DIR, "coverages-for-acnv-modeller.tsv");
     private static final File TUMOR_ALLELIC_COUNTS_FILE = new File(TEST_SUB_DIR, "snps-for-acnv-modeller.tsv");
@@ -60,7 +61,7 @@ public final class ACNVModellerUnitTest extends BaseTest {
     public void testMergeSimilarSegmentsCopyRatio() throws IOException {
         final boolean doRefit = true;
 
-        final String tempDir = publicTestDir + "similar-segment-copy-ratio-test";
+        final String tempDir = TestResources.publicTestDir + "similar-segment-copy-ratio-test";
         final File tempDirFile = createTempDir(tempDir);
 
         //load data (coverages and segments)
@@ -101,7 +102,7 @@ public final class ACNVModellerUnitTest extends BaseTest {
     public void testMergeSimilarSegmentsWithRefitting() {
         final boolean doRefit = true;
 
-        final String tempDir = publicTestDir + "similar-segment-test";
+        final String tempDir = TestResources.publicTestDir + "similar-segment-test";
         final File tempDirFile = createTempDir(tempDir);
 
         //load data (coverages, SNP counts, and segments)
@@ -139,7 +140,7 @@ public final class ACNVModellerUnitTest extends BaseTest {
     public void testMergeSimilarSegmentsWithoutRefitting() {
         final boolean doRefit = false;
 
-        final String tempDir = publicTestDir + "similar-segment-test-without-refitting";
+        final String tempDir = TestResources.publicTestDir + "similar-segment-test-without-refitting";
         final File tempDirFile = createTempDir(tempDir);
 
         //load data (coverages, SNP counts, and segments)
@@ -178,7 +179,7 @@ public final class ACNVModellerUnitTest extends BaseTest {
      */
     @Test
     public void testSegmentAndParameterFileOutput() {
-        final String tempDir = publicTestDir + "acnv-modeller-file-output";
+        final String tempDir = TestResources.publicTestDir + "acnv-modeller-file-output";
         final File tempDirFile = createTempDir(tempDir);
 
         //load data (coverages, SNP counts, and segments)

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/AllelicCNVIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/AllelicCNVIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.exome.samplenamefinder.SampleNameFinder;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -24,7 +25,7 @@ import static org.broadinstitute.hellbender.tools.exome.AllelicCNV.*;
  */
 public class AllelicCNVIntegrationTest extends CommandLineProgramTest {
     private static final String DUMMY_OUTPUT_PREFIX = "dummyOutputPrefix";
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
     private static final File COVERAGES_FILE = new File(TEST_SUB_DIR, "coverages-for-allelic-integration.tsv");
     private static final File TUMOR_ALLELIC_COUNTS_FILE = new File(TEST_SUB_DIR, "snps-for-allelic-integration.tsv");
     private static final File SEGMENT_FILE = new File(TEST_SUB_DIR, "segments-for-allelic-integration.seg");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargetsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargetsIntegrationTest.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.tribble.Tribble;
-import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.util.LittleEndianOutputStream;
@@ -12,10 +11,9 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.IndexRange;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.codecs.TargetCodec;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -32,7 +30,7 @@ import java.util.stream.Collectors;
  */
 public class AnnotateTargetsIntegrationTest extends CommandLineProgramTest {
 
-    private static final File REFERENCE = new File(BaseTest.hg19MiniReference);
+    private static final File REFERENCE = new File(TestResources.hg19MiniReference);
 
     // Test meta-parameters:
     private static final int MIN_TARGET_SIZE = 10;

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResultsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResultsIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.exome.conversion.acsconversion.ACSModeledSegment;
 import org.broadinstitute.hellbender.tools.exome.conversion.acsconversion.ACSModeledSegmentUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -17,8 +18,8 @@ import java.util.List;
 
 
 public class ConvertACNVResultsIntegrationTest extends CommandLineProgramTest {
-    private static final String ACNV_TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/conversion/allelicbalancecaller";
+    private static final String ACNV_TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/conversion/allelicbalancecaller";
 
     // Typically, this next file would be the output of a tangent normalization run.
     private static final File COVERAGES_FILE = new File(ACNV_TEST_SUB_DIR, "coverages-for-allelic-integration.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormalsIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.pon.allelic.AllelicPanelOfNormals;
 import org.broadinstitute.hellbender.tools.pon.allelic.AllelicPoNTestUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -24,7 +25,7 @@ import static org.broadinstitute.hellbender.tools.exome.CreateAllelicPanelOfNorm
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public class CreateAllelicPanelOfNormalsIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     private static final FileFilter PULLDOWN_FILTER = new WildcardFileFilter("allelic-pon-test-pulldown-*tsv");
     private static final File[] PULLDOWN_FILES = new File(TEST_SUB_DIR).listFiles(PULLDOWN_FILTER);

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormalsIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.tools.pon.PoNTestUtils;
 import org.broadinstitute.hellbender.tools.pon.coverage.pca.HDF5PCACoveragePoN;
 import org.broadinstitute.hellbender.tools.pon.coverage.pca.PCACoveragePoN;
 import org.broadinstitute.hellbender.tools.pon.coverage.pca.RamPCACoveragePoN;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -28,7 +29,7 @@ public class CreatePanelOfNormalsIntegrationTest extends CommandLineProgramTest 
 
     private static final File TEST_FILE_DIR = new File("src/test/resources/org/broadinstitute/hellbender/tools/exome");
 
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
 
     private static final File CONTROL_PCOV_FULL_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-control-full.pcov");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverageIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverageIntegrationTest.java
@@ -7,11 +7,11 @@ import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.tools.exome.pulldown.Pulldown;
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -25,12 +25,12 @@ import java.io.IOException;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public final class GetBayesianHetCoverageIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File NORMAL_BAM_FILE = new File(TEST_SUB_DIR, "normal.sorted.bam");
     private static final File TUMOR_BAM_FILE = new File(TEST_SUB_DIR, "tumor.sorted.bam");
     private static final File SNP_FILE = new File(TEST_SUB_DIR, "common_SNP.interval_list");
-    private static final File REF_FILE = new File(hg19MiniReference);
+    private static final File REF_FILE = new File(TestResources.hg19MiniReference);
 
     private static SAMFileHeader normalHeader;
     private static SAMFileHeader tumorHeader;

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/GetHetCoverageIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/GetHetCoverageIntegrationTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.tools.exome.pulldown.Pulldown;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -25,13 +26,13 @@ import java.io.IOException;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class GetHetCoverageIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File NORMAL_BAM_FILE = new File(TEST_SUB_DIR, "normal.sorted.bam");
     private static final File TUMOR_BAM_FILE = new File(TEST_SUB_DIR, "tumor.sorted.bam");
     private static final File NON_STRICT_BAM_FILE = new File(TEST_SUB_DIR, "simple_overhang.sam");
     private static final File SNP_FILE = new File(TEST_SUB_DIR, "common_SNP.interval_list");
-    private static final File REF_FILE = new File(hg19MiniReference);
+    private static final File REF_FILE = new File(TestResources.hg19MiniReference);
 
     private static SAMFileHeader normalHeader;
     private static SAMFileHeader tumorHeader;

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenterUnitTest.java
@@ -4,11 +4,11 @@ import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCountCollection;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -18,7 +18,7 @@ import java.util.List;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class SNPSegmenterUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     /**
      * Tests that segments are correctly determined using allelic counts from SNP sites.

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/SegmentedGenomeUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/SegmentedGenomeUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.exome;
 
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +17,7 @@ import java.util.List;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class SegmentedGenomeUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     private static final File TARGET_FILE_SMALL_SEGMENT_MERGING
             = new File(TEST_SUB_DIR, "targets-for-small-segment-merging-base.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionModellerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionModellerUnitTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.mcmc.PosteriorSummary;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class AlleleFractionModellerUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     // test data is a "normal" PoN with counts generated from 50 normals simulated from the allele-fraction model with alpha = 65 and beta = 60
     // and a PoN with "bad SNPs" described below

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/alleliccount/AllelicCountCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/alleliccount/AllelicCountCollectionUnitTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +17,7 @@ import java.io.File;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class AllelicCountCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File BASIC_SNPS_FILE = new File(TEST_SUB_DIR, "snps-basic.tsv");
     private static final File INTERMEDIATE_SNPS_FILE = new File(TEST_SUB_DIR, "snps-intermediate.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/alleliccount/AllelicCountWithPhasePosteriorsCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/alleliccount/AllelicCountWithPhasePosteriorsCollectionUnitTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,7 +16,7 @@ import java.io.File;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public class AllelicCountWithPhasePosteriorsCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File BASIC_SNPS_FILE = new File(TEST_SUB_DIR, "snps-basic-with-phase-posteriors.tsv");
     private static final File INTERMEDIATE_SNPS_FILE = new File(TEST_SUB_DIR, "snps-intermediate-with-phase-posteriors.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/conversion/titanconversion/TitanFileConverterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/conversion/titanconversion/TitanFileConverterUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.exome.conversion.titanconversion;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -13,7 +14,7 @@ import java.util.List;
 
 
 public class TitanFileConverterUnitTest extends BaseTest {
-    private static final String ACNV_TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String ACNV_TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     // Typically, this next file would be the output of a tangent normalization run.
     private static final File COVERAGES_FILE = new File(ACNV_TEST_SUB_DIR, "coverages-for-allelic-integration.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/copyratio/CopyRatioModellerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/copyratio/CopyRatioModellerUnitTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.tools.exome.SegmentedGenome;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.mcmc.PosteriorSummary;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -37,7 +38,7 @@ import java.util.stream.Collectors;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class CopyRatioModellerUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File COVERAGES_FILE = new File(TEST_SUB_DIR, "coverages-for-copy-ratio-modeller.tsv");
     private static final File SEGMENT_FILE = new File(TEST_SUB_DIR, "segments-for-copy-ratio-modeller.seg");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegmentsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegmentsIntegrationTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.utils.hmm.segmentation.HiddenStateSegmentRe
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.tools.exome.germlinehmm.CopyNumberTriState;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,7 +29,7 @@ import java.util.stream.Stream;
  */
 public class ConvertGSVariantsToSegmentsIntegrationTest extends CommandLineProgramTest {
 
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
 
     private static final File TEST_INPUT_FILE =
             new File("src/test/resources/org/broadinstitute/hellbender/tools/exome/eval", "gs-calls.vcf.gz");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionMatrixCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionMatrixCollectionUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.exome.germlinehmm;
 
 import org.broadinstitute.hellbender.utils.MathObjectAsserts;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -10,7 +11,7 @@ import java.io.File;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class IntegerCopyNumberTransitionMatrixCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
     private static final File HOMO_SAPIENS_COPY_NUMBER_TRANSITION_PRIOR_TABLE_FILE = new File(TEST_SUB_DIR,
             "homo_sapiens_germline_HMM_priors.tsv");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionMatrixUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionMatrixUnitTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.MathObjectAsserts;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +17,7 @@ import java.util.Arrays;
  */
 public class IntegerCopyNumberTransitionMatrixUnitTest extends BaseTest {
 
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
     private static final File HOMO_SAPIENS_COPY_NUMBER_TRANSITION_AUTOSOMAL_TABLE_FILE = new File(TEST_SUB_DIR,
             "TCGA_T_matrix_autosomal.tsv");
     private static final File HOMO_SAPIENS_COPY_NUMBER_TRANSITION_BAD_AUTOSOMAL_TABLE_FILE = new File(TEST_SUB_DIR,

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionProbabilityCacheCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/IntegerCopyNumberTransitionProbabilityCacheCollectionUnitTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.util.FastMath;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -19,7 +20,7 @@ import java.util.stream.IntStream;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class IntegerCopyNumberTransitionProbabilityCacheCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/germlinehmm";
     private static final File HOMO_SAPIENS_COPY_NUMBER_TRANSITION_PRIOR_TABLE_FILE = new File(TEST_SUB_DIR,
             "homo_sapiens_germline_HMM_priors.tsv");
     public static final Set<String> HOMO_SAPIENS_SEX_GENOTYPES = Arrays.stream(new String[] {"SEX_XX", "SEX_XY"})

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerBaseIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/germlinehmm/xhmm/XHMMSegmentCallerBaseIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.exome.*;
 import org.broadinstitute.hellbender.tools.exome.germlinehmm.CopyNumberTriState;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.tsv.DataLine;
 import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
 import org.broadinstitute.hellbender.utils.tsv.TableWriter;
@@ -28,7 +29,7 @@ import java.util.stream.Stream;
  */
 public abstract class XHMMSegmentCallerBaseIntegrationTest extends CommandLineProgramTest {
 
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
 
     public static final File TRUNCATED_REALISTIC_TARGETS_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "truncated-realistic-targets.tab");
     public static final TargetCollection<Target> REALISTIC_TARGETS;

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/PreAdapterOrientationScorerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/PreAdapterOrientationScorerUnitTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.broadinstitute.hellbender.tools.picard.analysis.artifacts.SequencingArtifactMetrics;
 import org.broadinstitute.hellbender.tools.picard.analysis.artifacts.Transition;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class PreAdapterOrientationScorerUnitTest extends BaseTest {
 
-    public static final String testPreAdapterDetailsMetrics = publicTestDir + "picard_metrics_test.pre_adapter_detail_metrics";
+    public static final String testPreAdapterDetailsMetrics = TestResources.publicTestDir + "picard_metrics_test.pre_adapter_detail_metrics";
 
     /**
      * Note that (due to raw data), this test includes collapsing over libraries (not just the contexts).

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotACNVResultsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotACNVResultsIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -11,7 +12,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class PlotACNVResultsIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     //test files
     private static final File SNP_COUNTS_FILE = new File(TEST_SUB_DIR, "snps-for-plotting.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/pulldown/BayesianHetPulldownCalculatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/pulldown/BayesianHetPulldownCalculatorUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCountTableC
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -33,12 +34,12 @@ import java.util.stream.IntStream;
  */
 public final class BayesianHetPulldownCalculatorUnitTest extends BaseTest {
 
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     /*****************************************************************************************************************/
 
     private static final File SNP_FILE = new File(TEST_SUB_DIR, "common_SNP.interval_list");
-    private static final File REF_FILE = new File(hg19MiniReference);
+    private static final File REF_FILE = new File(TestResources.hg19MiniReference);
     private static final File NORMAL_BAM_FILE = new File(TEST_SUB_DIR, "normal.sorted.bam");
     private static final File TUMOR_BAM_FILE = new File(TEST_SUB_DIR, "tumor.sorted.bam");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/pulldown/HetPulldownCalculatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/pulldown/HetPulldownCalculatorUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCount;
 import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -24,13 +25,13 @@ import java.util.stream.IntStream;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class HetPulldownCalculatorUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome";
 
     private static final File NORMAL_BAM_FILE = new File(TEST_SUB_DIR, "normal.sorted.bam");
     private static final File NORMAL_UNSORTED_BAM_FILE = new File(TEST_SUB_DIR, "normal.unsorted.bam");
     private static final File TUMOR_BAM_FILE = new File(TEST_SUB_DIR, "tumor.sorted.bam");
     private static final File SNP_FILE = new File(TEST_SUB_DIR, "common_SNP.interval_list");
-    private static final File REF_FILE = new File(hg19MiniReference);
+    private static final File REF_FILE = new File(TestResources.hg19MiniReference);
 
     private static final int MINIMUM_MAPPING_QUALITY = 30;
     private static final int MINIMUM_BASE_QUALITY = 20;

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformAlleleFractionSegmentationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformAlleleFractionSegmentationIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.exome.ModeledSegment;
 import org.broadinstitute.hellbender.tools.exome.SegmentUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -13,7 +14,7 @@ import java.util.List;
  * Created by davidben on 5/23/16.
  */
 public final class PerformAlleleFractionSegmentationIntegrationTest extends CommandLineProgramTest {
-    private static final String TOOLS_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TOOLS_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
     private static final File ALLELIC_COUNTS_FILE = new File(TOOLS_TEST_DIRECTORY, "snps-for-allelic-integration.tsv");
 
     // checks that segmentation output is created -- only the unit test checks correctness of results

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformCopyRatioSegmentationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformCopyRatioSegmentationIntegrationTest.java
@@ -4,19 +4,18 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.exome.ModeledSegment;
 import org.broadinstitute.hellbender.tools.exome.SegmentUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.testng.Assert.*;
-
 /**
  * Created by davidben on 7/25/16.
  */
 public class PerformCopyRatioSegmentationIntegrationTest extends CommandLineProgramTest {
-    private static final String TOOLS_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TOOLS_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
     private static final File LOG2_TN_COVERAGE_FILE = new File(TOOLS_TEST_DIRECTORY, "coverages-for-copy-ratio-modeller.tsv" );
 
     // checks that segmentation output is created -- only the unit test checks correctness of results

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformJointSegmentationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/segmentation/PerformJointSegmentationIntegrationTest.java
@@ -3,21 +3,19 @@ package org.broadinstitute.hellbender.tools.exome.segmentation;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.exome.ACNVModeledSegment;
-import org.broadinstitute.hellbender.tools.exome.ModeledSegment;
 import org.broadinstitute.hellbender.tools.exome.SegmentUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.testng.Assert.*;
-
 /**
  * Created by davidben on 10/21/16.
  */
 public class PerformJointSegmentationIntegrationTest extends CommandLineProgramTest {
-    private static final String TOOLS_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TOOLS_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
     private static final File ALLELIC_COUNTS_FILE = new File(TOOLS_TEST_DIRECTORY, "snps-for-acnv-modeller.tsv");
     private static final File LOG2_TN_COVERAGE_FILE = new File(TOOLS_TEST_DIRECTORY, "coverages-for-acnv-modeller.tsv" );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/ContigGermlinePloidyAnnotationTableReaderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/ContigGermlinePloidyAnnotationTableReaderUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.exome.sexgenotyper;
 
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -14,7 +15,7 @@ import java.io.IOException;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class ContigGermlinePloidyAnnotationTableReaderUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
     private static final File BAD_CONTIG_PLOIDY_ANNOTS_FILE_1 = new File(TEST_SUB_DIR, "contig_annots_bad_autosomal_annot.tsv");
     private static final File BAD_CONTIG_PLOIDY_ANNOTS_FILE_2 = new File(TEST_SUB_DIR, "contig_annots_bad_class.tsv");
     private static final File BAD_CONTIG_PLOIDY_ANNOTS_FILE_3 = new File(TEST_SUB_DIR, "contig_annots_bad_missing_some_annots.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/GermlinePloidyAnnotatedTargetCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/GermlinePloidyAnnotatedTargetCollectionUnitTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.tools.exome.Target;
 import org.broadinstitute.hellbender.tools.exome.TargetTableReader;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class GermlinePloidyAnnotatedTargetCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
     private static final File CONTIG_PLOIDY_ANNOTS_FILE = new File(TEST_SUB_DIR, "contig_annots.tsv");
     private static final File TARGET_FILE = new File(TEST_SUB_DIR, "sex_genotyper_agilent_targets_trunc.tsv");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/SexGenotypeDataCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/SexGenotypeDataCollectionUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.exome.sexgenotyper;
 import com.google.cloud.dataflow.sdk.repackaged.com.google.common.collect.ImmutableMap;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -22,7 +23,7 @@ import java.util.stream.IntStream;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class SexGenotypeDataCollectionUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
     private static final File TEST_SEX_GENOTYPE_BASIC_FILE = new File(TEST_SUB_DIR, "sex_genotypes_broadies_basic.tsv");
     private static final File TEST_SEX_GENOTYPE_EXTENDED_FILE = new File(TEST_SUB_DIR, "sex_genotypes_broadies_extended.tsv");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotypeCalculatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotypeCalculatorUnitTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.tools.exome.ReadCountCollectionUtils;
 import org.broadinstitute.hellbender.tools.exome.Target;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeSuite;
@@ -28,7 +29,7 @@ import java.util.stream.IntStream;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class TargetCoverageSexGenotypeCalculatorUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
     private static final File TEST_CONTIG_PLOIDY_ANNOTS_FILE = new File(TEST_SUB_DIR, "contig_annots.tsv");
     private static final File TEST_RCC_FILE = new File(TEST_SUB_DIR, "sex_genotyper_rcc_trunc.tsv");
     private static final File TEST_SEX_GENOTYPE_FILE = new File(TEST_SUB_DIR, "sex_genotypes_agilent_trunc.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotyperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/sexgenotyper/TargetCoverageSexGenotyperIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -16,7 +17,7 @@ import java.io.IOException;
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class TargetCoverageSexGenotyperIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/sexgenotyper/";
     private static final File TEST_CONTIG_PLOIDY_ANNOTS_FILE = new File(TEST_SUB_DIR, "contig_annots.tsv");
     private static final File TEST_RCC_FILE = new File(TEST_SUB_DIR, "sex_genotyper_rcc_trunc.tsv");
     private static final File TEST_SEX_GENOTYPE_FILE = new File(TEST_SUB_DIR, "sex_genotypes_agilent_trunc.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -10,7 +10,6 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
-import htsjdk.variant.vcf.VCFHeaderLine;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -20,6 +19,7 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -34,13 +34,13 @@ import java.util.stream.Collectors;
 
 public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTest {
 
-    private static final String HG_00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
-    private static final String HG_00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
-    private static final String NA_19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
+    private static final String HG_00096 = TestResources.largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
+    private static final String HG_00268 = TestResources.largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
+    private static final String NA_19625 = TestResources.largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
     private static final List<String> LOCAL_GVCFS = Arrays.asList(HG_00096, HG_00268, NA_19625);
-    private static final String GENOMICSDB_TEST_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/GenomicsDBImport/";
+    private static final String GENOMICSDB_TEST_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/GenomicsDBImport/";
 
-    private static final String COMBINED = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+    private static final String COMBINED = TestResources.largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
     private static final SimpleInterval INTERVAL = new SimpleInterval("chr20", 17960187, 17981445);
 
     @Override
@@ -79,7 +79,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
      */
     private List<String> resolveLargeFilesAsCloudURIs(final List<String> filenames){
         return filenames.stream()
-                .map( filename -> filename.replace(publicTestDir, getGCPTestInputPath()))
+                .map( filename -> filename.replace(TestResources.publicTestDir, getGCPTestInputPath()))
                 .peek( filename -> Assert.assertTrue(BucketUtils.isCloudStorageUrl(filename)))
                 .collect(Collectors.toList());
     }
@@ -155,7 +155,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
                         new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).getAbsolutePath(),
                         workspace,
                         GenomicsDBConstants.DEFAULT_ARRAY_NAME,
-                        b38_reference_20_21, null, new BCF2Codec());
+                        TestResources.b38_reference_20_21, null, new BCF2Codec());
 
         final AbstractFeatureReader<VariantContext, LineIterator> combinedVCFReader =
                 AbstractFeatureReader.getFeatureReader(expectedCombinedVCF, new VCFCodec(), true);
@@ -229,15 +229,15 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         writeToGenomicsDB(Arrays.asList(GENOMICSDB_TEST_DIR + "testHeaderContigLineSorting1.g.vcf", GENOMICSDB_TEST_DIR + "testHeaderContigLineSorting2.g.vcf"),
                 new SimpleInterval("chr20", 17959479, 17959479), workspace, 0, false, 0);
 
-        try ( final GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
+        try (final GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
                 new GenomicsDBFeatureReader<>(
                         new File(workspace, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME).getAbsolutePath(),
                         new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).getAbsolutePath(),
                         workspace,
                         GenomicsDBConstants.DEFAULT_ARRAY_NAME,
-                        b38_reference_20_21, null, new BCF2Codec());
+                        TestResources.b38_reference_20_21, null, new BCF2Codec());
 
-              final AbstractFeatureReader<VariantContext, LineIterator> inputGVCFReader =
+             final AbstractFeatureReader<VariantContext, LineIterator> inputGVCFReader =
                       AbstractFeatureReader.getFeatureReader(GENOMICSDB_TEST_DIR + "testHeaderContigLineSorting1.g.vcf", new VCFCodec(), true);
         ) {
             final SAMSequenceDictionary dictionaryFromGenomicsDB = ((VCFHeader)genomicsDBFeatureReader.getHeader()).getSequenceDictionary();

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycleIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycleIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -28,7 +29,7 @@ public final class CollectBaseDistributionByCycleIntegrationTest extends Command
         list.add(new Object[]{"valid.cram", "valid.CollectBaseDistributionByCycle.txt", getTestDataDir() + "/picard/analysis/CollectBaseDistributionByCycle/" + "valid.fasta", true, false, false});
 
         list.add(new Object[]{"first5000a.bam", "CollectBaseDistributionByCycle.txt", null, true, false, false});
-        list.add(new Object[]{"first5000a.cram", "CollectBaseDistributionByCycle.txt", b37_reference_20_21, true, false, false});
+        list.add(new Object[]{"first5000a.cram", "CollectBaseDistributionByCycle.txt", TestResources.b37_reference_20_21, true, false, false});
         list.add(new Object[]{"originalQuals.chr1.1-1K.bam", "CollectBaseDistributionByCycle.origQuals.txt", null, true, false, false});
 
         list.add(new Object[]{"example_pfFail_reads.bam", "CollectBaseDistributionByCycle.pfReads.txt", null, true, false, false});

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsIntegrationTest.java
@@ -1,18 +1,15 @@
 package org.broadinstitute.hellbender.tools.picard.analysis;
 
-import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.metrics.InsertSizeMetrics;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
-import org.testng.Assert;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 
 /**
@@ -31,11 +28,11 @@ public final class CollectInsertSizeMetricsIntegrationTest extends CommandLinePr
         return new Object[][] {
                 {"insert_size_metrics_test.sam", null, false, "expectedInsertSizeMetricsL1.txt"},
                 {"insert_size_metrics_test.bam", null, false, "expectedInsertSizeMetricsL1.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
 
                 {"insert_size_metrics_test.sam", null, true, "expectedInsertSizeMetricsL3.txt"},
                 {"insert_size_metrics_test.bam", null, true, "expectedInsertSizeMetricsL3.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectMultipleMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectMultipleMetricsIntegrationTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.metrics.MetricsArgumentCollection;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -21,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public final class CollectMultipleMetricsIntegrationTest extends CommandLineProgramTest {
     private static final File TEST_DATA_DIR = new File(getTestDataDir(), "picard/analysis/CollectInsertSizeMetrics");
@@ -37,7 +37,7 @@ public final class CollectMultipleMetricsIntegrationTest extends CommandLineProg
                 // single level collection
                 {"insert_size_metrics_test.sam", null, "expectedInsertSizeMetricsL1.txt"},
                 {"insert_size_metrics_test.bam", null, "expectedInsertSizeMetricsL1.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, "expectedInsertSizeMetricsL1.txt"},
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, "expectedInsertSizeMetricsL1.txt"},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectQualityYieldMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectQualityYieldMetricsIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -30,8 +31,8 @@ public final class CollectQualityYieldMetricsIntegrationTest extends CommandLine
         list.add(new Object[]{"collect_quality_yield_metrics.sam", "collect_quality_yield_metrics.quals.txt", null, false});
         list.add(new Object[]{"collect_quality_yield_metrics.bam", "collect_quality_yield_metrics.originalquals.txt", null, true});
         list.add(new Object[]{"collect_quality_yield_metrics.bam", "collect_quality_yield_metrics.quals.txt", null, false});
-        list.add(new Object[]{"collect_quality_yield_metrics.cram", "collect_quality_yield_metrics.originalquals.txt", hg19_chr1_1M_Reference, true});
-        list.add(new Object[]{"collect_quality_yield_metrics.cram", "collect_quality_yield_metrics.quals.txt", hg19_chr1_1M_Reference, false});
+        list.add(new Object[]{"collect_quality_yield_metrics.cram", "collect_quality_yield_metrics.originalquals.txt", TestResources.hg19_chr1_1M_Reference, true});
+        list.add(new Object[]{"collect_quality_yield_metrics.cram", "collect_quality_yield_metrics.quals.txt", TestResources.hg19_chr1_1M_Reference, false});
         return list.iterator();
     }
     @Test(dataProvider = "CollectQualityYieldMetrics")

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycleIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycleIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -20,7 +21,7 @@ public final class MeanQualityByCycleIntegrationTest extends CommandLineProgramT
     public Object[][] filenames() {
         return new String[][]{
                 {"first5000a.bam", null},
-                {"first5000a.cram", b37_reference_20_21}
+                {"first5000a.cram", TestResources.b37_reference_20_21}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistributionIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistributionIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -24,7 +25,7 @@ public class QualityScoreDistributionIntegrationTest extends CommandLineProgramT
     private Iterator<Object[]> makeQualityScoreDistributionData(){
         final List<Object[]> list= new ArrayList<>();
         list.add(new Object[]{"first5000a.bam", "qualscoredist.txt", null, true, false, false});
-        list.add(new Object[]{"first5000a.cram", "qualscoredist.txt", b37_reference_20_21, true, false, false});
+        list.add(new Object[]{"first5000a.cram", "qualscoredist.txt", TestResources.b37_reference_20_21, true, false, false});
         list.add(new Object[]{"originalQuals.chr1.1-1K.bam", "originalQuals.chr1.1-1K.QualityScoreDistribution.txt", null, true, false, false});
 
         list.add(new Object[]{"example_pfFail_reads.bam", "pfFailBam.pf.txt", null, true, false, false});

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectTargetedPcrMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectTargetedPcrMetricsIntegrationTest.java
@@ -4,6 +4,7 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -20,7 +21,7 @@ public final class CollectTargetedPcrMetricsIntegrationTest extends CommandLineP
         final File target_intervals = new File(TEST_DATA_PATH, "lifted_Chr20test_regions_t.interval_list");
         final File expectedFile = new File(TEST_DATA_PATH, "PCR_new_Metrics.txt");
         final File outfile = BaseTest.createTempFile("PCRMetrics", ".txt");
-        final File reference = new File(largeFileTestDir, "human_g1k_v37.20.21.fasta");
+        final File reference = new File(TestResources.largeFileTestDir, "human_g1k_v37.20.21.fasta");
         final File pertargetcoverage = new File(TEST_DATA_PATH, "pcr_metrics_pertarg_new.txt");
         final File pertargetcoverageout = BaseTest.createTempFile("pcr_metrics_pertarg_new_out", ".txt");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectWgsMetricsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectWgsMetricsIntegrationTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -14,8 +15,8 @@ public final class CollectWgsMetricsIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void test() throws IOException {
-        final File input = new File(NA12878_20_21_WGS_bam);
-        final File refFile = new File(b37_reference_20_21);
+        final File input = new File(TestResources.NA12878_20_21_WGS_bam);
+        final File refFile = new File(TestResources.b37_reference_20_21);
         final File expectedFile = new File(TEST_DATA_DIR, "CollectWgsMetrics.txt");
         final File outfile = BaseTest.createTempFile("testCollectWgsMetrics", ".metrics");
         final String[] args = {

--- a/src/test/java/org/broadinstitute/hellbender/tools/pon/allelic/AllelicPanelOfNormalsCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/pon/allelic/AllelicPanelOfNormalsCreatorUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.util.Log;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -19,7 +20,7 @@ import java.util.List;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class AllelicPanelOfNormalsCreatorUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     private static final FileFilter PULLDOWN_FILTER = new WildcardFileFilter("allelic-pon-test-pulldown-*tsv");
     private static final List<File> PULLDOWN_FILES = Arrays.asList(new File(TEST_SUB_DIR).listFiles(PULLDOWN_FILTER));

--- a/src/test/java/org/broadinstitute/hellbender/tools/pon/allelic/AllelicPanelOfNormalsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/pon/allelic/AllelicPanelOfNormalsUnitTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.tools.exome.alleliccount.AllelicCountCollec
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,7 +18,7 @@ import java.io.File;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class AllelicPanelOfNormalsUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/";
 
     // test data is a PoN with counts generated from 50 normals simulated from the allele-fraction model with alpha = 65 and beta = 60
     private static final File ALLELIC_PON_NORMAL_COUNTS_FILE = new File(TEST_SUB_DIR, "allelic-pon-test-pon-counts-normal.tsv");

--- a/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/HDF5PCACoveragePoNCreationUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/HDF5PCACoveragePoNCreationUtilsUnitTest.java
@@ -26,6 +26,7 @@ import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.svd.SVD;
 import org.broadinstitute.hellbender.utils.svd.SVDFactory;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,7 +45,7 @@ import java.util.stream.Stream;
  */
 public final class HDF5PCACoveragePoNCreationUtilsUnitTest extends BaseTest {
     private static final String TEST_DIR = "src/test/resources/org/broadinstitute/hellbender/tools/exome/";
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
     private static final File TEST_PCOV_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-control-full.pcov");
     private static final File GT_TARGET_VAR_FILE = new File(TEST_DIR, "dummy_pon_target_variances_matlab.txt");
     private static final File TEST_FULL_PON_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-all-targets.pon");

--- a/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/PCATangentNormalizationUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/PCATangentNormalizationUtilsUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.tools.exome.ReadCountCollection;
 import org.broadinstitute.hellbender.tools.exome.Target;
 import org.broadinstitute.hellbender.tools.pon.PoNTestUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -18,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class PCATangentNormalizationUtilsUnitTest extends BaseTest {
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
     private static final File TEST_PCOV_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-control-full.pcov");
     private static final File TEST_FULL_NORMALS_TN_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-all-targets.pon.normal_projection");
     private static final File TEST_SOME_NORMALS_TN_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-some-targets.pon.normal_projection");

--- a/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/RamPCACoveragePoNUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/pon/coverage/pca/RamPCACoveragePoNUnitTest.java
@@ -5,13 +5,14 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.broadinstitute.hdf5.HDF5File;
 import org.broadinstitute.hellbender.tools.pon.PoNTestUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 
 public final class RamPCACoveragePoNUnitTest extends BaseTest {
-    private static final File LARGE_CNV_TEST_FILE_DIR = new File(largeFileTestDir, "cnv");
+    private static final File LARGE_CNV_TEST_FILE_DIR = new File(TestResources.largeFileTestDir, "cnv");
 
     private static final File TEST_PCOV_FILE = new File(LARGE_CNV_TEST_FILE_DIR, "create-pon-control-full.pcov");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSparkIntegrationTest.java
@@ -2,10 +2,7 @@ package org.broadinstitute.hellbender.tools.spark;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
-import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
-import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.*;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -42,7 +39,7 @@ public final class ApplyBQSRSparkIntegrationTest extends CommandLineProgramTest 
 
     final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
     final String hiSeqBam = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate_allaligned.bam";
-    final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+    final String hg18Reference = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
     final String hiSeqCram = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.cram";
 
     @DataProvider(name = "ApplyBQSRTest")

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -67,15 +68,15 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     public Object[][] createBQSRTestData() {
         final String localResources =  getResourceDir();
 
-        final String GRCh37Ref2bit_chr2021 = b37_2bit_reference_20_21;
-        final String GRCh37Ref_chr2021 = b37_reference_20_21;
-        final String hiSeqBam_chr20 = localResources + WGS_B37_CH20_1M_1M1K_BAM;
+        final String GRCh37Ref2bit_chr2021 = TestResources.b37_2bit_reference_20_21;
+        final String GRCh37Ref_chr2021 = TestResources.b37_reference_20_21;
+        final String hiSeqBam_chr20 = localResources + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
         final String hiSeqBam_1read = localResources + "overlappingRead.bam";
-        final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-        final String dbSNPb37_chr2021 = dbsnp_138_b37_20_21_vcf;
+        final String dbSNPb37_chr20 = localResources + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String dbSNPb37_chr2021 = TestResources.dbsnp_138_b37_20_21_vcf;
 
-        final String hg19Chr171Mb = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
-        final String hg19Chr171Mb_2bit = publicTestDir + "human_g1k_v37.chr17_1Mb.2bit";
+        final String hg19Chr171Mb = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String hg19Chr171Mb_2bit = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.2bit";
         final String HiSeqBam_chr17 = localResources + "NA12878.chr17_69k_70k.dictFix.bam";
         final String dbSNPb37_chr17 =  localResources + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
         final String more17Sites = localResources + "bqsr.fakeSitesForTesting.b37.chr17.vcf";
@@ -154,11 +155,11 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String localResources =  getResourceDir();
 
         final String GRCh37RefCloud = ReferenceAPISource.URL_PREFIX + ReferenceAPISource.GRCH37_REF_ID;
-        final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
-        final String hiSeqBam_chr20 = localResources + WGS_B37_CH20_1M_1M1K_BAM;
+        final String chr2021Reference2bit = TestResources.GCS_b37_CHR20_21_REFERENCE_2BIT;
+        final String hiSeqBam_chr20 = localResources + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
         final String hiSeqBam_1read = localResources + "overlappingRead.bam";
-        final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-        final String dbSNPb37_chr2021 = dbsnp_138_b37_20_21_vcf;
+        final String dbSNPb37_chr20 = localResources + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String dbSNPb37_chr2021 = TestResources.dbsnp_138_b37_20_21_vcf;
 
         return new Object[][]{
                 //Note: recal tables were created using GATK3.4 with one change from 2.87 to 2.88 in expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recal.txt
@@ -198,10 +199,10 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     @Test(groups = "spark")
     public void testBlowUpOnBroadcastIncompatibleReference() throws IOException {
         //this should blow up because broadcast requires a 2bit reference
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String hiSeqBam_chr20 = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_chr20 = getResourceDir() + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
-        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
+        BQSRTest params = new BQSRTest(TestResources.b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
 
         ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLineNoApiKey());
         IntegrationTestSpec spec = new IntegrationTestSpec(
@@ -215,10 +216,10 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     @DataProvider(name = "BQSRTestBucket")
     public Object[][] createBQSRTestDataBucket() {
         final String GRCh37RefCloud = ReferenceAPISource.URL_PREFIX + ReferenceAPISource.GRCH37_REF_ID;
-        final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
+        final String chr2021Reference2bit = TestResources.GCS_b37_CHR20_21_REFERENCE_2BIT;
         final String localResources = getResourceDir();
-        final String HiSeqBamCloud_chr20 = getCloudInputs() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String HiSeqBamCloud_chr20 = getCloudInputs() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_chr20 = localResources + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
         return new Object[][]{
                 // input in cloud, computation local.
@@ -243,9 +244,9 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322", groups = {"cloud", "spark"}, enabled = false)
     public void testPlottingWorkflow() throws IOException {
         final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
-        final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
-        final String dbSNPb37_chr2021 = resourceDir + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-        final String HiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
+        final String chr2021Reference2bit = TestResources.GCS_b37_CHR20_21_REFERENCE_2BIT;
+        final String dbSNPb37_chr2021 = resourceDir + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String HiSeqBam_chr20 = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
 
         final File actualHiSeqBam_recalibrated = createTempFile("actual.recalibrated", ".bam");
 
@@ -275,7 +276,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
         final String localResources =  getResourceDir();
 
-        final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
+        final String chr2021Reference2bit = TestResources.GCS_b37_CHR20_21_REFERENCE_2BIT;
         final String HiSeqBam_chr17 = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";
 
         final String  NO_DBSNP = "";
@@ -295,7 +296,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String hg19Ref = ReferenceAPISource.URL_PREFIX + ReferenceAPISource.HG19_REF_ID;
         final String HiSeqBam_chr17 = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";
 
-        final String dbSNPb37_chr2021 = resourceDir + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String dbSNPb37_chr2021 = resourceDir + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
         final BQSRTest params = new BQSRTest(hg19Ref, HiSeqBam_chr17, dbSNPb37_chr2021, "", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkShardedIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkShardedIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -68,9 +69,9 @@ public class BaseRecalibratorSparkShardedIntegrationTest extends CommandLineProg
         final String localResources =  getResourceDir();
         final String hg19Ref = ReferenceAPISource.HG19_REF_ID;
         final String GRCh37Ref = ReferenceAPISource.URL_PREFIX + ReferenceAPISource.GRCH37_REF_ID;
-        final String HiSeqBam_chr20 = localResources + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-        final String GRCh37RefLocal = b37_reference_20_21;
+        final String HiSeqBam_chr20 = localResources + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_chr20 = localResources + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String GRCh37RefLocal = TestResources.b37_reference_20_21;
         final String more20Sites = getResourceDir() + "bqsr.fakeSitesForTesting.b37.chr20.vcf"; //for testing 2 input files
 
         return new Object[][]{
@@ -97,8 +98,8 @@ public class BaseRecalibratorSparkShardedIntegrationTest extends CommandLineProg
     public Object[][] createBQSRTestDataBucket() {
         final String GRCh37Ref = ReferenceAPISource.URL_PREFIX + ReferenceAPISource.GRCH37_REF_ID;
         final String localResources =  getResourceDir();
-        final String HiSeqBamCloud_chr20 = getCloudInputs() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String HiSeqBamCloud_chr20 = getCloudInputs() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_chr20 = localResources + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
         return new Object[][]{
                 // input in cloud, computation local.
@@ -134,7 +135,7 @@ public class BaseRecalibratorSparkShardedIntegrationTest extends CommandLineProg
         final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
         final String GRCh37Ref = ReferenceAPISource.GRCH37_REF_ID; // that's the "full" version
         final String dbSNPb37 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
-        final String HiSeqBam = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
+        final String HiSeqBam = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
 
         final File actualHiSeqBam_recalibrated = createTempFile("actual.NA12878.chr17_69k_70k.dictFix.recalibrated", ".bam");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/PileupSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/PileupSparkIntegrationTest.java
@@ -1,22 +1,16 @@
 package org.broadinstitute.hellbender.tools.spark;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
-import org.testng.Assert;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -39,11 +33,11 @@ public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
         final File out = createTempFile();
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input");
-        args.add(NA12878_20_21_WGS_bam);
+        args.add(TestResources.NA12878_20_21_WGS_bam);
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-L 20:9999900-10000000");
         if (useShuffle) {
             args.add("--shuffle");
@@ -58,11 +52,11 @@ public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
         final File out = createTempFile();
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input");
-        args.add(NA12878_20_21_WGS_bam);
+        args.add(TestResources.NA12878_20_21_WGS_bam);
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-L 20:9999990-10000000");
         args.add("-verbose");
         if (useShuffle) {
@@ -78,13 +72,13 @@ public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
         final File out = createTempFile();
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input");
-        args.add(NA12878_20_21_WGS_bam);
+        args.add(TestResources.NA12878_20_21_WGS_bam);
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-L 20:10000092-10000112");
-        args.add("-metadata " + dbsnp_138_b37_20_21_vcf);
+        args.add("-metadata " + TestResources.dbsnp_138_b37_20_21_vcf);
         if (useShuffle) {
             args.add("--shuffle");
         }
@@ -98,11 +92,11 @@ public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
         final File out = createTempFile();
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("--input");
-        args.add(NA12878_20_21_WGS_bam);
+        args.add(TestResources.NA12878_20_21_WGS_bam);
         args.add("--output");
         args.add(out.getAbsolutePath());
         args.add("--reference");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-L 20:10000092-10000112");
         args.add("-outputInsertLength");
         if (useShuffle) {
@@ -120,17 +114,17 @@ public final class PileupSparkIntegrationTest extends CommandLineProgramTest {
             final Path workingDirectory = MiniClusterUtils.getWorkingDir(cluster);
             final Path vcfPath = new Path(workingDirectory, "dbsnp_138.b37.20.21.vcf");
             final Path idxPath = new Path(workingDirectory, "dbsnp_138.b37.20.21.vcf.idx");
-            cluster.getFileSystem().copyFromLocalFile(new Path(dbsnp_138_b37_20_21_vcf), vcfPath);
-            cluster.getFileSystem().copyFromLocalFile(new Path(dbsnp_138_b37_20_21_vcf + ".idx"), idxPath);
+            cluster.getFileSystem().copyFromLocalFile(new Path(TestResources.dbsnp_138_b37_20_21_vcf), vcfPath);
+            cluster.getFileSystem().copyFromLocalFile(new Path(TestResources.dbsnp_138_b37_20_21_vcf + ".idx"), idxPath);
 
             final File out = createTempFile();
             final ArgumentsBuilder args = new ArgumentsBuilder();
             args.add("--input");
-            args.add(NA12878_20_21_WGS_bam);
+            args.add(TestResources.NA12878_20_21_WGS_bam);
             args.add("--output");
             args.add(out.getAbsolutePath());
             args.add("--reference");
-            args.add(b37_reference_20_21);
+            args.add(TestResources.b37_reference_20_21);
             args.add("-L 20:10000092-10000112");
             args.add("-metadata " + vcfPath.toString());
             if (useShuffle) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.spark.pipelines.BwaAndMarkDuplicatesPipelineSpark;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -19,10 +20,10 @@ public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends Comm
     @Test
     public void test() throws Exception {
         //This file was created by 1) running bwaspark on the input and 2) running picard MarkDuplicates on the result
-        final File expectedSam = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.md.bam");
+        final File expectedSam = new File(TestResources.largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.md.bam");
 
-        final File ref = new File(b37_reference_20_21);
-        final File input = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.unaligned.bam");
+        final File ref = new File(TestResources.b37_reference_20_21);
+        final File input = new File(TestResources.largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.unaligned.bam");
         final File output = createTempFile("bwa", ".bam");
         if (!output.delete()) {
             Assert.fail();
@@ -32,7 +33,7 @@ public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends Comm
         args.addReference(ref);
         args.addInput(input);
         args.addOutput(output);
-        args.addArgument("bwamemIndexImage", b37_reference_20_21+".img");
+        args.addArgument("bwamemIndexImage", TestResources.b37_reference_20_21+".img");
         args.addBooleanArgument("disableSequenceDictionaryValidation", true);
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBuildReferenceTaxonomyUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBuildReferenceTaxonomyUtilsTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import htsjdk.samtools.SAMSequenceRecord;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.TestException;
 import org.testng.annotations.Test;
@@ -302,7 +303,7 @@ public final class PSBuildReferenceTaxonomyUtilsTest extends BaseTest {
     public void testCloseReader() {
         final BufferedReader r;
         try {
-            r = new BufferedReader(new FileReader(hg19MiniReference));
+            r = new BufferedReader(new FileReader(TestResources.hg19MiniReference));
         } catch (IOException e) {
             throw new TestException(e);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
@@ -5,10 +5,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.bqsr.BQSRTestData;
-import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
-import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.*;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -61,10 +58,10 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
 
     @DataProvider(name = "BQSRLocalRefTest")
     public Object[][] createBQSRLocalRefTestData() {
-        final String GRCh37Ref_2021 = b37_reference_20_21;
-        final String GRCh37Ref2bit_chr2021 = b37_2bit_reference_20_21;
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String GRCh37Ref_2021 = TestResources.b37_reference_20_21;
+        final String GRCh37Ref2bit_chr2021 = TestResources.b37_2bit_reference_20_21;
+        final String hiSeqBam_chr20 = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_20 = getResourceDir() + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
         final String hiSeqBam_20_21_100000 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.bam";
         final String hiSeqCram_20_21_100000 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram";
@@ -80,10 +77,10 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
                 {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
 
                 //Output generated with GATK4 (resulting BAM has 4 differences with GATK3)
-                {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
-                {new BQSRTest(b37_reference_20_21 , hiSeqCram_20_21_100000, more20Sites, ".cram", "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.cram")},
-                {new BQSRTest(b37_2bit_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
-                {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
+                {new BQSRTest(TestResources.b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
+                {new BQSRTest(TestResources.b37_reference_20_21 , hiSeqCram_20_21_100000, more20Sites, ".cram", "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.cram")},
+                {new BQSRTest(TestResources.b37_2bit_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
+                {new BQSRTest(TestResources.b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER -knownSites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
        };
     }
 
@@ -122,10 +119,10 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
     @Test(groups = "spark")
     public void testBlowUpOnBroadcastIncompatibleReference() throws IOException {
         //this should blow up because broadcast requires a 2bit reference
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String hiSeqBam_chr20 = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
+        final String dbSNPb37_chr20 = getResourceDir() + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
-        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
+        BQSRTest params = new BQSRTest(TestResources.b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, ".bam", "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
 
         ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLineNoApiKey());
         IntegrationTestSpec spec = new IntegrationTestSpec(

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,14 +38,14 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
         return new Object[][]{
                 {COUNT_VARIANTS_VCF, 26L},
                 {new File(getTestDataDir(), "count_variants.blockgz.gz"), 26L},
-                {new File(dbsnp_138_b37_1_65M_vcf), 1375319L},
+                {new File(TestResources.dbsnp_138_b37_1_65M_vcf), 1375319L},
         };
     }
 
     @DataProvider(name="intervals")
     public Object[][] intervals(){
-        File vcf = new File(largeFileTestDir, "dbsnp_138.b37.20.21.vcf");
-        File vcf_gz = new File(largeFileTestDir, "dbsnp_138.b37.20.21.vcf.blockgz.gz");
+        File vcf = new File(TestResources.largeFileTestDir, "dbsnp_138.b37.20.21.vcf");
+        File vcf_gz = new File(TestResources.largeFileTestDir, "dbsnp_138.b37.20.21.vcf.blockgz.gz");
         return new Object[][]{
                 new Object[]{vcf, "", 9594L}, // no intervals specified
                 new Object[]{vcf, "-L 20", 5657L},
@@ -67,7 +68,7 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
         ArgumentsBuilder args = new ArgumentsBuilder();
         args.addVCF(fileIn);
         args.add(intervalArgs);
-        args.addReference(new File(largeFileTestDir, "human_g1k_v37.20.21.fasta"));
+        args.addReference(new File(TestResources.largeFileTestDir, "human_g1k_v37.20.21.fasta"));
         args.addOutput(outputTxt);
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSource;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -57,12 +58,12 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
 
     @DataProvider(name = "ReadsPipeline")
     public Object[][] createReadsPipelineSparkTestData() {
-        final String GRCh37Ref_2021 = b37_reference_20_21;
-        final String GRCh37Ref2bit_chr2021 = b37_2bit_reference_20_21;
+        final String GRCh37Ref_2021 = TestResources.b37_reference_20_21;
+        final String GRCh37Ref2bit_chr2021 = TestResources.b37_2bit_reference_20_21;
         final String hiSeqBam_chr20 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.bam";
         final String hiSeqBam_chr20_queryNameSorted = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.queryNameSorted.bam";
         final String hiSeqCram_chr20 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.cram";
-        final String dbSNPb37_20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String dbSNPb37_20 = getResourceDir() + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
         final String more20Sites = getResourceDir() + "dbsnp_138.b37.20.10m-10m100.vcf"; //for testing 2 input files
 
         final String expectedSingleKnownSites = "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.md.bqsr.bam";

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectBaseDistributionByCycleSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectBaseDistributionByCycleSparkIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -28,7 +29,7 @@ public final class CollectBaseDistributionByCycleSparkIntegrationTest extends Co
         list.add(new Object[]{"valid.cram", new File(TEST_DATA_DIR, "valid.fasta").getAbsolutePath(), "valid.CollectBaseDistributionByCycle.txt", true, false, false});
 
         list.add(new Object[]{"first5000a.bam", null, "CollectBaseDistributionByCycle.txt", true, false, false});
-        list.add(new Object[]{"first5000a.cram", b37_reference_20_21, "CollectBaseDistributionByCycle.txt", true, false, false});
+        list.add(new Object[]{"first5000a.cram", TestResources.b37_reference_20_21, "CollectBaseDistributionByCycle.txt", true, false, false});
 
         list.add(new Object[]{"originalQuals.chr1.1-1K.bam", null, "CollectBaseDistributionByCycle.origQuals.txt", true, false, false});
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectInsertSizeMetricsSparkIntegrationTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -26,12 +27,12 @@ public final class CollectInsertSizeMetricsSparkIntegrationTest extends CommandL
                 // single level collection
                 {"insert_size_metrics_test.sam", null, false, "expectedInsertSizeMetricsL1.txt"},
                 {"insert_size_metrics_test.bam", null, false, "expectedInsertSizeMetricsL1.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
 
                 // collect for all levels
                 {"insert_size_metrics_test.sam", null, true, "expectedInsertSizeMetricsL3.txt"},
                 {"insert_size_metrics_test.bam", null, true, "expectedInsertSizeMetricsL3.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectMultipleMetricsSparkIntegrationTest.java
@@ -13,12 +13,12 @@ import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.metrics.InsertSizeMetrics;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +38,7 @@ public final class CollectMultipleMetricsSparkIntegrationTest extends CommandLin
                 // single level collection
                 {"insert_size_metrics_test.sam", null, "expectedInsertSizeMetricsL1.txt", "expectedQualityYieldOnInsertSizeMetrics.txt"},
                 {"insert_size_metrics_test.bam", null, "expectedInsertSizeMetricsL1.txt", "expectedQualityYieldOnInsertSizeMetrics.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, "expectedInsertSizeMetricsL1.txt", "expectedQualityYieldOnInsertSizeMetrics.txt"},
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, "expectedInsertSizeMetricsL1.txt", "expectedQualityYieldOnInsertSizeMetrics.txt"},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/CollectQualityYieldMetricsSparkIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -33,8 +34,8 @@ public final class CollectQualityYieldMetricsSparkIntegrationTest extends Comman
         list.add(new Object[]{"collect_quality_yield_metrics.dictFix.sam", "collect_quality_yield_metrics.originalquals.txt", null, true});
         list.add(new Object[]{"collect_quality_yield_metrics.dictFix.sam", "collect_quality_yield_metrics.quals.txt", null, false});
 
-        list.add(new Object[]{"collect_quality_yield_metrics.dictFix.cram", "collect_quality_yield_metrics.originalquals.txt", hg19_chr1_1M_Reference, true});
-        list.add(new Object[]{"collect_quality_yield_metrics.dictFix.cram", "collect_quality_yield_metrics.quals.txt", hg19_chr1_1M_Reference, false});
+        list.add(new Object[]{"collect_quality_yield_metrics.dictFix.cram", "collect_quality_yield_metrics.originalquals.txt", TestResources.hg19_chr1_1M_Reference, true});
+        list.add(new Object[]{"collect_quality_yield_metrics.dictFix.cram", "collect_quality_yield_metrics.quals.txt", TestResources.hg19_chr1_1M_Reference, false});
 
         return list.iterator();
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -41,11 +42,11 @@ public class InsertSizeMetricsCollectorSparkUnitTest extends CommandLineProgramT
         return new Object[][] {
                 {"insert_size_metrics_test.sam", null, false, "expectedInsertSizeMetricsL1.txt"},
                 {"insert_size_metrics_test.bam", null, false, "expectedInsertSizeMetricsL1.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, false, "expectedInsertSizeMetricsL1.txt"},
 
                 {"insert_size_metrics_test.sam", null, true, "expectedInsertSizeMetricsL3.txt"},
                 {"insert_size_metrics_test.bam", null, true, "expectedInsertSizeMetricsL3.txt"},
-                {"insert_size_metrics_test.cram", hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
+                {"insert_size_metrics_test.cram", TestResources.hg19_chr1_1M_Reference, true, "expectedInsertSizeMetricsL3.txt"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/MeanQualityByCycleSparkIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ public final class MeanQualityByCycleSparkIntegrationTest extends CommandLinePro
     public Object[][] filenames() {
         return new String[][]{
                 {"first5000a.bam", null},
-                {"first5000a.cram", b37_reference_20_21}
+                {"first5000a.cram", TestResources.b37_reference_20_21}
         };
     }
     @Test(dataProvider="filenames", groups = {"R", "spark"})

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/QualityScoreDistributionSparkIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -77,7 +78,7 @@ public class QualityScoreDistributionSparkIntegrationTest  extends CommandLinePr
     private Iterator<Object[]> makeQualityScoreDistributionData(){
         final List<Object[]> list= new ArrayList<>();
         list.add(new Object[]{"first5000a.bam", "qualscoredist.txt", null, true, false, false});
-        list.add(new Object[]{"first5000a.cram", "qualscoredist.txt", b37_reference_20_21, true, false, false});
+        list.add(new Object[]{"first5000a.cram", "qualscoredist.txt", TestResources.b37_reference_20_21, true, false, false});
         list.add(new Object[]{"originalQuals.chr1.1-1K.bam", "originalQuals.chr1.1-1K.QualityScoreDistribution.txt", null, true, false, false});
 
         list.add(new Object[]{"example_pfFail_reads.bam", "pfFailBam.pf.txt", null, true, false, false});

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedAssemblyUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedAssemblyUnitTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
 import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignmentUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -107,7 +108,7 @@ public class AlignedAssemblyUnitTest extends BaseTest{
                                               final boolean expectedIsPositiveStrand, final int expectedStartOnContig_1BasedInclusive, final int expectedEndOnContig_1BasedInclusive,
                                               final int expectedContigLength, final int expectedMapQualInBwaMemAlignment, final AlignedAssembly.AlignmentInterval expectedAlignmentInterval) {
 
-        final SAMRecord samRecord = BwaMemAlignmentUtils.applyAlignment("whatever", SVDiscoveryTestDataProvider.makeDummySequence(expectedContigLength, (byte)'A'), null, null, bwaMemAlignment, refNames, hg19Header, false, false);
+        final SAMRecord samRecord = BwaMemAlignmentUtils.applyAlignment("whatever", SVDiscoveryTestDataProvider.makeDummySequence(expectedContigLength, (byte)'A'), null, null, bwaMemAlignment, refNames, TestResources.getHg19Header(), false, false);
         final AlignedAssembly.AlignmentInterval alignmentInterval = new AlignedAssembly.AlignmentInterval(samRecord);
         Assert.assertEquals(alignmentInterval.referenceInterval, expectedReferenceInterval);
         Assert.assertEquals(alignmentInterval.cigarAlong5to3DirectionOfContig, expectedCigar);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedContigGeneratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/AlignedContigGeneratorUnitTest.java
@@ -20,6 +20,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -326,7 +327,7 @@ public class AlignedContigGeneratorUnitTest extends BaseTest {
 
         // concordance test with results obtained via SAM route
         final List<AlignedContig> parsedContigsViaSAMRoute
-                = StructuralVariationDiscoveryPipelineSpark.InMemoryAlignmentParser.filterAndConvertToAlignedContigViaSAM(Collections.singletonList(alignedAssembly), hg19Header, SparkContextFactory.getTestSparkContext(), null).collect();
+                = StructuralVariationDiscoveryPipelineSpark.InMemoryAlignmentParser.filterAndConvertToAlignedContigViaSAM(Collections.singletonList(alignedAssembly), TestResources.getHg19Header(), SparkContextFactory.getTestSparkContext(), null).collect();
         Assert.assertEquals(parsedContigsViaDirectRoute, parsedContigsViaSAMRoute);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ContigAlignerTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ContigAlignerTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.spark.sv;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.bwa.BwaMemIndexSingleton;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -17,7 +18,7 @@ public class ContigAlignerTest extends BaseTest {
 
     @BeforeClass
     public void setup() throws Exception {
-        contigAligner = new ContigAligner(b37_reference_20_21+".img");
+        contigAligner = new ContigAligner(TestResources.b37_reference_20_21+".img");
     }
 
     @Test(groups = "sv")

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/FindBadGenomicKmersSparkUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -20,7 +21,7 @@ import java.util.*;
 public class FindBadGenomicKmersSparkUnitTest extends BaseTest {
 
     private static final int KMER_SIZE = SVConstants.KMER_SIZE;
-    private static final String REFERENCE_FILE_NAME = hg19MiniReference;
+    private static final String REFERENCE_FILE_NAME = TestResources.hg19MiniReference;
 
     @Test(groups = "spark")
     public void badKmersTest() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVDiscoveryTestDataProvider.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVDiscoveryTestDataProvider.java
@@ -8,7 +8,7 @@ import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import scala.Tuple4;
 
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public final class SVDiscoveryTestDataProvider {
 
-    public static final ReferenceMultiSource reference = new ReferenceMultiSource((PipelineOptions)null, BaseTest.b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+    public static final ReferenceMultiSource reference = new ReferenceMultiSource((PipelineOptions)null, TestResources.b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
     public static final SAMSequenceDictionary seqDict = reference.getReferenceSequenceDictionary(null);
 
     public static byte[] getReverseComplimentCopy(final byte[] sequence) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVIntegrationTestDataProvider.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVIntegrationTestDataProvider.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.sv;
 
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -10,16 +11,16 @@ import java.util.List;
 
 class SVIntegrationTestDataProvider extends CommandLineProgramTest {
 
-    static final File reference = new File(b37_reference_20_21);
-    static final File reference_2bit = new File(b37_2bit_reference_20_21);
-    static final File reference_fai = new File(b37_reference_20_21+".fai");
-    static final File reference_dict = new File(b37_reference_20_21.replace(".fasta", ".dict"));
+    static final File reference = new File(TestResources.b37_reference_20_21);
+    static final File reference_2bit = new File(TestResources.b37_2bit_reference_20_21);
+    static final File reference_fai = new File(TestResources.b37_reference_20_21+".fai");
+    static final File reference_dict = new File(TestResources.b37_reference_20_21.replace(".fasta", ".dict"));
 
     private static final String THIS_TEST_FOLDER = getTestDataDir() + "/spark/sv/integration";
     static final String TEST_BAM_LEFT = THIS_TEST_FOLDER + "/hg19_DEL_leftReads.bam";
     static final String TEST_BAM_RIGHT = THIS_TEST_FOLDER + "/hg19_DEL_rightReads.bam";
     static final String KMER_KILL_LIST = THIS_TEST_FOLDER + "/dummy.kill.kmers";
-    static final String ALIGNER_INDEX_IMG = largeFileTestDir + "human_g1k_v37.20.21.fasta.img";
+    static final String ALIGNER_INDEX_IMG = TestResources.largeFileTestDir + "human_g1k_v37.20.21.fasta.img";
     static final String TEST_CONTIG_SAM = THIS_TEST_FOLDER + "/hg19_DEL_contigAssemblies.sam";
 
     static final String EXPECTED_SIMPLE_DEL_VCF = THIS_TEST_FOLDER + "/hg19_DEL.vcf";

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/SVVCFWriterUnitTest.java
@@ -5,6 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -48,7 +49,7 @@ public class SVVCFWriterUnitTest extends BaseTest{
                 .attribute(GATKSVVCFHeaderLines.INSERTED_SEQUENCE, insOne)
                 .make();
 
-        final File referenceDictionaryFile = new File(ReferenceUtils.getFastaDictionaryFileName(b37_reference_20_21));
+        final File referenceDictionaryFile = new File(ReferenceUtils.getFastaDictionaryFileName(TestResources.b37_reference_20_21));
         final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryFile);
 
         final List<VariantContext> sortedVariants = SVVCFWriter.sortVariantsByCoordinate(Arrays.asList(downstreamVariant, inversionTwo, inversionOne, upstreamVariant), dictionary);

--- a/src/test/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualitiesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualitiesIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -39,7 +40,7 @@ public class CompareBaseQualitiesIntegrationTest extends CommandLineProgramTest 
         final File secondBam = new File(resourceDir, "another.single.read.bam");
         final File firstCram = new File(resourceDir, "single.read.cram");
         final File secondCram = new File(resourceDir, "another.single.read.cram");
-        final File referenceFile = new File(b37_reference_20_21);
+        final File referenceFile = new File(TestResources.b37_reference_20_21);
 
         final List<Integer> sq = Arrays.asList(10, 20, 30, 40);
         return new Object[][]{

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.utils.runtime.ProcessOutput;
 import org.broadinstitute.hellbender.utils.runtime.ProcessSettings;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.GenomicsDBTestUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -41,10 +42,10 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
 
     private static final List<String> NO_EXTRA_ARGS = Collections.emptyList();
      private static final String BASE_PAIR_EXPECTED = "gvcf.basepairResolution.gatk3.7_30_ga4f720357.output.vcf";
-    private static final String b38_reference_20_21 = largeFileTestDir + "Homo_sapiens_assembly38.20.21.fasta";
+    private static final String b38_reference_20_21 = TestResources.largeFileTestDir + "Homo_sapiens_assembly38.20.21.fasta";
     private static final String BASE_PAIR_GVCF = "gvcf.basepairResolution.gvcf";
 
-    private static final File CEUTRIO_20_21_GATK3_4_G_VCF = new File(largeFileTestDir, "gvcfs/CEUTrio.20.21.gatk3.4.g.vcf");
+    private static final File CEUTRIO_20_21_GATK3_4_G_VCF = new File(TestResources.largeFileTestDir, "gvcfs/CEUTrio.20.21.gatk3.4.g.vcf");
     private static final String CEUTRIO_20_21_EXPECTED_VCF = "CEUTrio.20.21.gatk3.7_30_ga4f720357.expected.vcf";
     private static final List<String> ATTRIBUTES_TO_IGNORE = Arrays.asList(
             "QD",//TODO QD has a cap value and anything that reaches that is randomized.  It's difficult to reproduce the same random numbers across gatk3 -> 4
@@ -65,26 +66,26 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
         return new Object[][]{
                 //combine not supported yet, see https://github.com/broadinstitute/gatk/issues/2429 and https://github.com/broadinstitute/gatk/issues/2584
                 //{"combine.single.sample.pipeline.1.vcf", null, Arrays.asList("-V", getTestFile("combine.single.sample.pipeline.2.vcf").toString() , "-V", getTestFile("combine.single.sample.pipeline.3.vcf").toString()), b37_reference_20_21},
-                {getTestFile("leadingDeletion.g.vcf"), getTestFile("leadingDeletionRestrictToStartExpected.vcf"), Arrays.asList("-L", "20:69512-69513", "--"+GenotypeGVCFs.ONLY_OUTPUT_CALLS_STARTING_IN_INTERVALS_FULL_NAME), b37_reference_20_21},
-                {getTestFile("leadingDeletion.g.vcf"), getTestFile("leadingDeletionExpected.vcf"), Arrays.asList("-L", "20:69512-69513"), b37_reference_20_21},
-                {getTestFile(BASE_PAIR_GVCF), getTestFile( BASE_PAIR_EXPECTED), NO_EXTRA_ARGS, b37_reference_20_21}, //base pair level gvcf
-                {getTestFile("testUpdatePGT.gvcf"), getTestFile( "testUpdatePGT.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},   //testUpdatePGT
-                {getTestFile("gvcfExample1.vcf"), getTestFile( "gvcfExample1.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, b37_reference_20_21}, //single sample vcf
-                {getTestFile("gvcfExample1.vcf"), getTestFile( "gvcfExample1.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-L", "20"), b37_reference_20_21}, //single sample vcf with -L
-                {getTestFile("combined_genotype_gvcf_exception.original.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21}, //test that an input vcf with 0/0 already in GT field is overwritten
-                {getTestFile("combined_genotype_gvcf_exception.nocall.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},  //same test as above but with ./.
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("ndaTest.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("-nda"), b37_reference_20_21},  //annotating with the number of alleles discovered option
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("maxAltAllelesTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-maxAltAlleles", "1"), b37_reference_20_21 }, //restricting the max number of alt alleles
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("standardConfTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-stand_call_conf", "300"),b37_reference_20_21}, //set minimum calling threshold
-                {getTestFile("spanningDel.combined.g.vcf"), getTestFile( "spanningDel.combined.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},
-                {getTestFile("spanningDel.delOnly.g.vcf"), getTestFile( "spanningDel.delOnly.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},
-                {getTestFile("spanningDel.depr.delOnly.g.vcf"), getTestFile( "spanningDel.depr.delOnly.gatk3.7_30_ga4f720357.expected.vcf" ), NO_EXTRA_ARGS, b37_reference_20_21},
-                {getTestFile("ad-bug-input.vcf"), getTestFile( "ad-bug-gatk3.7_30_ga4f720357-output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21}, //Bad AD Propagation Haploid Bug
-                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile(CEUTRIO_20_21_EXPECTED_VCF), Arrays.asList("--dbsnp", largeFileTestDir + "dbsnp_138.b37.20.21.vcf"), b37_reference_20_21},
-                {getTestFile("CEUTrio.20.21.missingIndel.g.vcf"), getTestFile( "CEUTrio.20.21.missingIndel.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("--dbsnp", "src/test/resources/large/dbsnp_138.b37.20.21.vcf"), b37_reference_20_21},
-                {new File(largeFileTestDir + "gvcfs/gatk3.7_30_ga4f720357.24_sample.21.g.vcf"), new File( largeFileTestDir + "gvcfs/gatk3.7_30_ga4f720357.24_sample.21.expected.vcf"), NO_EXTRA_ARGS, b38_reference_20_21},
+                {getTestFile("leadingDeletion.g.vcf"), getTestFile("leadingDeletionRestrictToStartExpected.vcf"), Arrays.asList("-L", "20:69512-69513", "--"+GenotypeGVCFs.ONLY_OUTPUT_CALLS_STARTING_IN_INTERVALS_FULL_NAME), TestResources.b37_reference_20_21},
+                {getTestFile("leadingDeletion.g.vcf"), getTestFile("leadingDeletionExpected.vcf"), Arrays.asList("-L", "20:69512-69513"), TestResources.b37_reference_20_21},
+                {getTestFile(BASE_PAIR_GVCF), getTestFile( BASE_PAIR_EXPECTED), NO_EXTRA_ARGS, TestResources.b37_reference_20_21}, //base pair level gvcf
+                {getTestFile("testUpdatePGT.gvcf"), getTestFile( "testUpdatePGT.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21},   //testUpdatePGT
+                {getTestFile("gvcfExample1.vcf"), getTestFile( "gvcfExample1.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21}, //single sample vcf
+                {getTestFile("gvcfExample1.vcf"), getTestFile( "gvcfExample1.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-L", "20"), TestResources.b37_reference_20_21}, //single sample vcf with -L
+                {getTestFile("combined_genotype_gvcf_exception.original.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21}, //test that an input vcf with 0/0 already in GT field is overwritten
+                {getTestFile("combined_genotype_gvcf_exception.nocall.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21},  //same test as above but with ./.
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("ndaTest.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("-nda"), TestResources.b37_reference_20_21},  //annotating with the number of alleles discovered option
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("maxAltAllelesTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-maxAltAlleles", "1"), TestResources.b37_reference_20_21 }, //restricting the max number of alt alleles
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("standardConfTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-stand_call_conf", "300"), TestResources.b37_reference_20_21}, //set minimum calling threshold
+                {getTestFile("spanningDel.combined.g.vcf"), getTestFile( "spanningDel.combined.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21},
+                {getTestFile("spanningDel.delOnly.g.vcf"), getTestFile( "spanningDel.delOnly.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21},
+                {getTestFile("spanningDel.depr.delOnly.g.vcf"), getTestFile( "spanningDel.depr.delOnly.gatk3.7_30_ga4f720357.expected.vcf" ), NO_EXTRA_ARGS, TestResources.b37_reference_20_21},
+                {getTestFile("ad-bug-input.vcf"), getTestFile( "ad-bug-gatk3.7_30_ga4f720357-output.vcf"), NO_EXTRA_ARGS, TestResources.b37_reference_20_21}, //Bad AD Propagation Haploid Bug
+                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile(CEUTRIO_20_21_EXPECTED_VCF), Arrays.asList("--dbsnp", TestResources.largeFileTestDir + "dbsnp_138.b37.20.21.vcf"), TestResources.b37_reference_20_21},
+                {getTestFile("CEUTrio.20.21.missingIndel.g.vcf"), getTestFile( "CEUTrio.20.21.missingIndel.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("--dbsnp", "src/test/resources/large/dbsnp_138.b37.20.21.vcf"), TestResources.b37_reference_20_21},
+                {new File(TestResources.largeFileTestDir + "gvcfs/gatk3.7_30_ga4f720357.24_sample.21.g.vcf"), new File( TestResources.largeFileTestDir + "gvcfs/gatk3.7_30_ga4f720357.24_sample.21.expected.vcf"), NO_EXTRA_ARGS, b38_reference_20_21},
                 {getTestFile("chr21.bad.pl.g.vcf"), getTestFile( "chr21.bad.pl.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-L", "chr21:28341770-28341790"), b38_reference_20_21},
-                {new File(largeFileTestDir + "gvcfs/combined.gatk3.7_30_ga4f720357.g.vcf.gz"),  new File(largeFileTestDir + "gvcfs/combined.gatk3.7_30_ga4f720357.expected.vcf.gz"), NO_EXTRA_ARGS, b38_reference_20_21}
+                {new File(TestResources.largeFileTestDir + "gvcfs/combined.gatk3.7_30_ga4f720357.g.vcf.gz"),  new File(TestResources.largeFileTestDir + "gvcfs/combined.gatk3.7_30_ga4f720357.expected.vcf.gz"), NO_EXTRA_ARGS, b38_reference_20_21}
                 //all sites not supported yet see https://github.com/broadinstitute/gatk-protected/issues/580 and  https://github.com/broadinstitute/gatk/issues/2429
                 //{getTestFile(basePairGVCF), getTestFile( "gvcf.basepairResolution.includeNonVariantSites.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("--includeNonVariantSites") //allsites not supported yet
         };
@@ -158,9 +159,9 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
     //so we need to provide a list of intervals and then look at each one
     public Object[][] getGVCFsForGenomicsDB(){
         return new Object[][]{
-                {getTestFile(BASE_PAIR_GVCF), getTestFile(BASE_PAIR_EXPECTED), new SimpleInterval("20", 1, 11_000_000), b37_reference_20_21},
-                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile("CEUTrio.20.gatk3.7_30_ga4f720357.expected.vcf"), new SimpleInterval("20", 1, 11_000_000), b37_reference_20_21},
-                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile("CEUTrio.21.gatk3.7_30_ga4f720357.expected.vcf"), new SimpleInterval("21", 1, 11_000_000), b37_reference_20_21}
+                {getTestFile(BASE_PAIR_GVCF), getTestFile(BASE_PAIR_EXPECTED), new SimpleInterval("20", 1, 11_000_000), TestResources.b37_reference_20_21},
+                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile("CEUTrio.20.gatk3.7_30_ga4f720357.expected.vcf"), new SimpleInterval("20", 1, 11_000_000), TestResources.b37_reference_20_21},
+                {CEUTRIO_20_21_GATK3_4_G_VCF, getTestFile("CEUTrio.21.gatk3.7_30_ga4f720357.expected.vcf"), new SimpleInterval("21", 1, 11_000_000), TestResources.b37_reference_20_21}
         };
     }
 
@@ -240,7 +241,7 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .addVCF(getTestFile(BASE_PAIR_GVCF))
                 .addOutput(output)
-                .addReference(new File(b37_reference_20_21))
+                .addReference(new File(TestResources.b37_reference_20_21))
                 .addArgument(StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME, "true");
 
         runCommandLine(args);
@@ -251,7 +252,7 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
     public void testIntervalsAndOnlyOutputCallsStartingInIntervalsAreMutuallyRequired(){
         ArgumentsBuilder args =   new ArgumentsBuilder()
                 .addVCF(getTestFile("leadingDeletion.g.vcf"))
-                .addReference(new File(b37_reference_20_21))
+                .addReference(new File(TestResources.b37_reference_20_21))
                 .addOutput( createTempFile("tmp",".vcf"))
                 .addBooleanArgument(GenotypeGVCFs.ONLY_OUTPUT_CALLS_STARTING_IN_INTERVALS_FULL_NAME, true);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +22,7 @@ import java.util.stream.Stream;
  */
 public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
 
-    private static final File REFERENCE = new File(b37_reference_20_21);
+    private static final File REFERENCE = new File(TestResources.b37_reference_20_21);
     private static final GenomeLocParser GLP = new GenomeLocParser(ReferenceDataSource.of(REFERENCE).getSequenceDictionary());
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.ValidateVariants;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -16,7 +17,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     public String baseTestString(final boolean sharedFile, final String file, final boolean exclude, final ValidateVariants.ValidationType type) {
         final String defaultRegion = "1:1-1000000";
 
-        return baseTestString(sharedFile, file, exclude, type, defaultRegion, hg19_chr1_1M_Reference);
+        return baseTestString(sharedFile, file, exclude, type, defaultRegion, TestResources.hg19_chr1_1M_Reference);
     }
 
     public String baseTestString(boolean sharedFile, String file, boolean exclude, ValidateVariants.ValidationType type, String region, String reference) {
@@ -59,7 +60,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testGoodFile2() throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(true, hg19_chr1_1M_exampleVCF, false, ALL),
+                baseTestString(true, TestResources.hg19_chr1_1M_exampleVCF, false, ALL),
                 Collections.emptyList()
         );
 
@@ -124,7 +125,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testBadID() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(false, "validationExampleBadRSID.vcf", false, IDS) + " --dbsnp " + hg19_chr1_1M_dbSNP_modified,
+                baseTestString(false, "validationExampleBadRSID.vcf", false, IDS) + " --dbsnp " + TestResources.hg19_chr1_1M_dbSNP_modified,
                 0,
                 UserException.FailsStrictValidation.class
         );
@@ -143,7 +144,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testBadID2_OKif_notInDBSNP() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(false, "validationExampleRSIDonPositionNotInDBSNP.vcf", false, IDS) + " --dbsnp " + hg19_chr1_1M_dbSNP_modified,
+                baseTestString(false, "validationExampleRSIDonPositionNotInDBSNP.vcf", false, IDS) + " --dbsnp " + TestResources.hg19_chr1_1M_dbSNP_modified,
                 Collections.emptyList()
         );
         spec.executeTest("test bad RS ID is OK when not in dbSNP even with dbsnp arg", this);
@@ -216,7 +217,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     @Test(description = "Fixes '''bug''' reported in story https://www.pivotaltracker.com/story/show/68725164")
     public void testUnusedAlleleFix() throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(false, "validationUnusedAllelesBugFix.vcf", true, ALLELES,"1:1-739000",hg19_chr1_1M_Reference), Collections.emptyList());
+                baseTestString(false, "validationUnusedAllelesBugFix.vcf", true, ALLELES,"1:1-739000", TestResources.hg19_chr1_1M_Reference), Collections.emptyList());
         spec.executeTest("test unused allele bug fix", this);
     }
 
@@ -225,7 +226,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     @Test(description = "Checks '''bug''' reported in story https://www.pivotaltracker.com/story/show/68725164")
     public void testUnusedAlleleError() throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(false, "validationUnusedAllelesBugFix.vcf", false, ALLELES,"1:1-739000",hg19_chr1_1M_Reference),0, UserException.FailsStrictValidation.class);
+                baseTestString(false, "validationUnusedAllelesBugFix.vcf", false, ALLELES,"1:1-739000", TestResources.hg19_chr1_1M_Reference),0, UserException.FailsStrictValidation.class);
         spec.executeTest("test unused allele bug fix", this);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +22,7 @@ public class ReferenceBasesUnitTest extends BaseTest {
 
     @Test
     public void test() {
-        final File refFasta = new File(b37_reference_20_21);
+        final File refFasta = new File(TestResources.b37_reference_20_21);
 
         final ReferenceDataSource refDataSource = new ReferenceFileSource(refFasta);
         final ReferenceContext ref = new ReferenceContext(refDataSource, new SimpleInterval("20", 10_000_000, 10_000_200));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngineUnitTest.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.genotyper.*;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -272,7 +273,7 @@ public final class VariantAnnotatorEngineUnitTest extends BaseTest {
         final List<String> annotationGroupsToUse= Collections.emptyList();
         final List<String> annotationsToUse = Arrays.asList(Coverage.class.getSimpleName());//good one
         final List<String> annotationsToExclude= Collections.emptyList();
-        final String path = publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
+        final String path = TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
         final FeatureInput<VariantContext> dbSNPBinding = new FeatureInput<>(path, "dbsnp", Collections.emptyMap());
 
         final List<FeatureInput<VariantContext>> features = Collections.emptyList();
@@ -304,7 +305,7 @@ public final class VariantAnnotatorEngineUnitTest extends BaseTest {
         final List<String> annotationGroupsToUse= Collections.emptyList();
         final List<String> annotationsToUse = Arrays.asList(Coverage.class.getSimpleName());//good one
         final List<String> annotationsToExclude= Collections.emptyList();
-        final String path = publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
+        final String path = TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
         final FeatureInput<VariantContext> dbSNPBinding = null;
 
         final String featureSourceName = "fred";
@@ -345,7 +346,7 @@ public final class VariantAnnotatorEngineUnitTest extends BaseTest {
         final List<String> annotationGroupsToUse= Collections.emptyList();
         final List<String> annotationsToUse = Arrays.asList(Coverage.class.getSimpleName());//good one
         final List<String> annotationsToExclude= Collections.emptyList();
-        final String dbSNPPath= publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
+        final String dbSNPPath= TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
         final FeatureInput<VariantContext> dbSNPBinding = new FeatureInput<>(dbSNPPath, "dbsnp", Collections.emptyMap());
 
         final File fredFile = getTestFile("one_entry_source.vcf");
@@ -393,7 +394,7 @@ public final class VariantAnnotatorEngineUnitTest extends BaseTest {
         final List<String> annotationGroupsToUse = Collections.emptyList();
         final List<String> annotationsToUse = Arrays.asList(Coverage.class.getSimpleName());//good one
         final List<String> annotationsToExclude = Collections.emptyList();
-        final File dbSNPFile = new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File dbSNPFile = new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureInput<VariantContext> dbSNPBinding = new FeatureInput<>(dbSNPFile.getAbsolutePath(), VCFConstants.DBSNP_KEY, Collections.emptyMap());
 
         final File fredFile = getTestFile("one_entry_source.vcf");
@@ -405,7 +406,7 @@ public final class VariantAnnotatorEngineUnitTest extends BaseTest {
 
     @Test
     public void testCoverageAnnotationViaEngine() throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureInput<VariantContext> dbSNPBinding = new FeatureInput<>(file.getAbsolutePath(), "dbsnp", Collections.emptyMap());
 
         final List<String> annotationGroupsToUse= Collections.emptyList();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantOverlapAnnotatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantOverlapAnnotatorUnitTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.FeatureManager;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -152,7 +153,7 @@ public final class VariantOverlapAnnotatorUnitTest extends BaseTest {
 
     @Test(dataProvider = "AnnotateRsIDData")
     public void testRsIDFeatureContext(final VariantContext toAnnotate, final List<VariantContext> dbSNPRecords, final String expectedID, final boolean expectOverlap) throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureContext ctx = new FeatureContext(new FeatureManager(new ArtificialFeatureContainingCommandLineProgram_ForVariantOverlap(file)), new SimpleInterval(toAnnotate));
         final VariantOverlapAnnotator annotator = makeAnnotator(file, "dbsnp");
         final VariantContext annotated = annotator.annotateRsID(ctx, toAnnotate);
@@ -162,7 +163,7 @@ public final class VariantOverlapAnnotatorUnitTest extends BaseTest {
 
     @Test(dataProvider = "AnnotateRsIDData")
     public void testRsIDFeatureContextWith2Sets(final VariantContext toAnnotate, final List<VariantContext> dbSNPRecords, final String expectedID, final boolean expectOverlap) throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureContext ctx = new FeatureContext(new FeatureManager(new ArtificialFeatureContainingCommandLineProgram_ForVariantOverlap(file)), new SimpleInterval(toAnnotate));
         final VariantOverlapAnnotator annotator = makeAnnotator(file, "dbsnp", "binding");
         final VariantContext annotated = annotator.annotateRsID(ctx, toAnnotate);
@@ -172,7 +173,7 @@ public final class VariantOverlapAnnotatorUnitTest extends BaseTest {
 
     @Test(dataProvider = "AnnotateRsIDData")
     public void testRsIDFeatureContextWithNoDBSnP(final VariantContext toAnnotate, final List<VariantContext> dbSNPRecords, final String expectedID, final boolean expectOverlap) throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureContext ctx = new FeatureContext(new FeatureManager(new ArtificialFeatureContainingCommandLineProgram_ForVariantOverlap(file)), new SimpleInterval(toAnnotate));
         final VariantOverlapAnnotator annotator = makeAnnotator(file, null, "binding");
         final VariantContext annotated = annotator.annotateRsID(ctx, toAnnotate);
@@ -182,7 +183,7 @@ public final class VariantOverlapAnnotatorUnitTest extends BaseTest {
 
     @Test(dataProvider = "AnnotateRsIDData")
     public void testAnnotateOverlapsFeatureContext(final VariantContext toAnnotate, final List<VariantContext> records, final String expectedID, final boolean expectOverlap) throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureContext ctx = new FeatureContext(new FeatureManager(new ArtificialFeatureContainingCommandLineProgram_ForVariantOverlap(file)), new SimpleInterval(toAnnotate));
         final VariantOverlapAnnotator annotator = makeAnnotator(file, "dbsnp");
         final VariantContext annotated = annotator.annotateOverlaps(ctx, toAnnotate);
@@ -191,7 +192,7 @@ public final class VariantOverlapAnnotatorUnitTest extends BaseTest {
 
     @Test(dataProvider = "AnnotateRsIDData")
     public void testAnnotateOverlapsFeatureContextWith2Sets(final VariantContext toAnnotate, final List<VariantContext> records, final String expectedID, final boolean expectOverlap) throws Exception {
-        final File file= new File(publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
+        final File file= new File(TestResources.publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf");
         final FeatureContext ctx = new FeatureContext(new FeatureManager(new ArtificialFeatureContainingCommandLineProgram_ForVariantOverlap(file)), new SimpleInterval(toAnnotate));
         final VariantOverlapAnnotator annotator = makeAnnotator(file, "dbsnp", "binding");
         final VariantContext annotated = annotator.annotateOverlaps(ctx, toAnnotate);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -47,7 +48,7 @@ public final class ApplyBQSRIntegrationTest extends CommandLineProgramTest {
     }
 
     final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
-    final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+    final String hg18Reference = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
     final String hiSeqBam = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.bam";
     final String hiSeqCram = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.cram";
     final String hiSeqBamAligned = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate_allaligned.bam";

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -52,16 +53,16 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
     @DataProvider(name = "BQSRTest")
     public Object[][] createBQSRTestData() {
-        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String hg18Reference = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
         final String b36Reference = getResourceDir() + "human_b36_both.chr1_1k.fasta";
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
+        final String hiSeqBam_chr20 = getResourceDir() + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
         final String hiSeqBam_1read = getResourceDir() + "overlappingRead.bam";
         final String hiSeqBam_readNithNoRefBases = getResourceDir() + "NA12878.oq.read_consumes_zero_ref_bases.chr20.bam";
         final String HiSeqBam_chr17 = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.bam";
         final String HiSeqCram_chr17 = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.cram";
         final String trickyBam_chr20 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.4379150-4379157.bam";
         final String dbSNPb37_chr17 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
-        final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
+        final String dbSNPb37_chr20 = getResourceDir() + TestResources.DBSNP_138_B37_CH20_1M_1M1K_VCF;
         final String origQualsBam_chr1 = getResourceDir() + "originalQuals.1kg.chr1.1-1K.1RG.dictFix.bam";
         final String dbSNPb36_chr1 = getResourceDir() + "dbsnp_132.b36.excluding_sites_after_129.chr1_1k.vcf";
         final String GRCh37Ref_chr2021 = "src/test/resources/large/human_g1k_v37.20.21.fasta";
@@ -78,8 +79,8 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
                 {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
                 {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, dbsnp_138_b37_20_21_vcf, "-indelBQSR -enableBAQ", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_readNithNoRefBases, dbsnp_138_b37_20_21_vcf, "-indelBQSR -enableBAQ", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_NOREFBASES_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, TestResources.dbsnp_138_b37_20_21_vcf, "-indelBQSR -enableBAQ", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_readNithNoRefBases, TestResources.dbsnp_138_b37_20_21_vcf, "-indelBQSR -enableBAQ", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_NOREFBASES_RECAL)},
 
                 {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " + "--indels_context_size 4",  getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
                 {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " + "--low_quality_tail 5",     getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
@@ -108,7 +109,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
     @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322")
     public void testPlottingWorkflow() throws IOException {
         final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
-        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String hg18Reference = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
         final String dbSNPb37_chr17 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
         final String HiSeqBam_chr17 = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.bam";
 
@@ -137,7 +138,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
     public void testBQSRFailWithoutDBSNP() throws IOException {
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
 
-        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String hg18Reference = TestResources.publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
         final String HiSeqBam_chr17 = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";
 
         final String  NO_DBSNP = "";
@@ -157,7 +158,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
         final String HiSeqBam_Hg18 = resourceDir + "HiSeq.1mb.1RG.2k_lines.bam";
 
         final String  NO_ARGS = "";
-        final BQSRTest params = new BQSRTest(hg19MiniReference, HiSeqBam_Hg18, hg19_chr1_1M_dbSNP, NO_ARGS, resourceDir + "expected.txt");
+        final BQSRTest params = new BQSRTest(TestResources.hg19MiniReference, HiSeqBam_Hg18, TestResources.hg19_chr1_1M_dbSNP, NO_ARGS, resourceDir + "expected.txt");
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),
                 1,
@@ -169,11 +170,11 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
     public void testBQSRFailWithIncompatibleSequenceDictionaries() throws IOException {
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
 
-        final String bam_chr20 = resourceDir + WGS_B37_CH20_1M_1M1K_BAM;
+        final String bam_chr20 = resourceDir + TestResources.WGS_B37_CH20_1M_1M1K_BAM;
         final String dbSNPb37_chr17 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
 
         final String  NO_ARGS = "";
-        final BQSRTest params = new BQSRTest(b37_reference_20_21, bam_chr20, dbSNPb37_chr17, NO_ARGS, resourceDir + "expected.txt");
+        final BQSRTest params = new BQSRTest(TestResources.b37_reference_20_21, bam_chr20, dbSNPb37_chr17, NO_ARGS, resourceDir + "expected.txt");
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),
                 1,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BothStepsOfBQSRIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BothStepsOfBQSRIntegrationTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.tools.validation.CompareBaseQualities;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,7 +18,7 @@ public final class BothStepsOfBQSRIntegrationTest extends CommandLineProgramTest
     @Test //Tests that BQSR with and without indel recalibration produces the same bam file
     public void testIndelRemoval() throws Exception {
         //Note; using a small 27M file for speed
-        final File bamIn = new File(NA12878_20_21_WGS_bam);
+        final File bamIn = new File(TestResources.NA12878_20_21_WGS_bam);
         final String interval = "20";
 
         final File recalOutWithIndels = baseRecalibrator(bamIn, interval, false);
@@ -52,8 +53,8 @@ public final class BothStepsOfBQSRIntegrationTest extends CommandLineProgramTest
         args1.addInput(bamIn);
         args1.addOutput(recalOut);
         args1.addArgument("L", interval);
-        args1.addFileArgument("knownSites", new File(dbsnp_138_b37_20_21_vcf));
-        args1.addReference(new File(b37_reference_20_21));
+        args1.addFileArgument("knownSites", new File(TestResources.dbsnp_138_b37_20_21_vcf));
+        args1.addReference(new File(TestResources.b37_reference_20_21));
         args1.addBooleanArgument("indelBQSR", !skipIndels);
         new Main().instanceMain(makeCommandLineArgs(args1.getArgsList(), BaseRecalibrator.class.getSimpleName()));
         return recalOut;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/GatherBQSRReportsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/GatherBQSRReportsIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,7 +13,7 @@ import java.io.File;
 
 public final class GatherBQSRReportsIntegrationTest extends CommandLineProgramTest {
 
-    private static final String testDir = BaseTest.publicTestDir + "/org/broadinstitute/hellbender/utils/recalibration/";
+    private static final String testDir = TestResources.publicTestDir + "/org/broadinstitute/hellbender/utils/recalibration/";
 
     @Test
     public void testCombine5Reports() throws Exception {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
@@ -1,13 +1,12 @@
 package org.broadinstitute.hellbender.tools.walkers.contamination;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.List;
-
-import static org.testng.Assert.*;
 
 /**
  * Created by David Benjamin on 2/16/17.
@@ -16,8 +15,8 @@ public class GetPileupSummariesIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void test() {
-        final File NA12878 = new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam");
-        final File thousandGenomes = new File(largeFileTestDir, "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf");
+        final File NA12878 = new File(TestResources.largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam");
+        final File thousandGenomes = new File(TestResources.largeFileTestDir, "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf");
 
         final File output = createTempFile("output", ".table");
         final String[] args = {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltrationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltrationIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.filters;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -13,7 +14,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
 
     public String baseTestString(final String vcf, final String options) {
         final String file = getToolTestDataDir() + vcf;
-        return "--variant " + file + " " + options + " -O %s" + " -R" + hg19_chr1_1M_Reference + " --addOutputVCFCommandLine false ";
+        return "--variant " + file + " " + options + " -O %s" + " -R" + TestResources.hg19_chr1_1M_Reference + " --addOutputVCFCommandLine false ";
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.utils.locusiterator.LocusIteratorByState;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -24,8 +25,8 @@ public class HaplotypeCallerEngineUnitTest extends BaseTest {
 
     @Test
     public void testIsActive() throws IOException {
-        final File testBam = new File(NA12878_20_21_WGS_bam);
-        final File reference = new File(b37_reference_20_21);
+        final File testBam = new File(TestResources.NA12878_20_21_WGS_bam);
+        final File reference = new File(TestResources.b37_reference_20_21);
         final SimpleInterval shardInterval = new SimpleInterval("20", 10000000, 10001000);
         final SimpleInterval paddedShardInterval = new SimpleInterval(shardInterval.getContig(), shardInterval.getStart() - 100, shardInterval.getEnd() + 100);
         final HaplotypeCallerArgumentCollection hcArgs = new HaplotypeCallerArgumentCollection();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -18,7 +19,7 @@ import java.util.Set;
 
 public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
 
-    public static final String TEST_FILES_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/haplotypecaller/";
+    public static final String TEST_FILES_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/haplotypecaller/";
 
     /*
      * Test that in VCF mode we're consistent with past GATK4 results
@@ -31,8 +32,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File expected = new File(TEST_FILES_DIR, "expected.testVCFMode.gatk4.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
@@ -60,8 +61,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File expected = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk4.alleleSpecific.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -94,8 +95,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk3.5.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
@@ -126,8 +127,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk3.5.alleleSpecific.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -154,8 +155,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File expected = new File(TEST_FILES_DIR, "expected.testGVCFMode.gatk4.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
@@ -181,8 +182,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File expected = new File(TEST_FILES_DIR + "expected.testGVCFMode.gatk4.alleleSpecific.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -217,8 +218,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testGVCFMode.gatk3.5.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
@@ -246,8 +247,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File gatk3Output = new File(TEST_FILES_DIR + "expected.testGVCFMode.gatk3.5.alleleSpecific.g.vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -281,8 +282,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         final File bamOutput = createTempFile("testBamoutProducesReasonablySizedOutput", ".bam");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_reference_20_21,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", testInterval,
                 "-O", vcfOutput.getAbsolutePath(),
                 "-bamout", bamOutput.getAbsolutePath(),
@@ -312,7 +313,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
 
         final String[] args = {
                 "-I", testBAM.getAbsolutePath(),
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:11363580-11363600",
                 "-O", output.getAbsolutePath(),
                 "-ploidy", "4",
@@ -329,11 +330,11 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
     // e.g. read name HAVCYADXX150109:1:2102:20528:2129 with cigar 23S53I
     @Test
     public void testReadsThatConsumeZeroReferenceReads() throws Exception {
-        final String CONSUMES_ZERO_REFERENCE_BASES = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/na12878-chr20-consumes-zero-reference-bases.bam";
+        final String CONSUMES_ZERO_REFERENCE_BASES = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/na12878-chr20-consumes-zero-reference-bases.bam";
         final File outputVcf = createTempFile("output", ".vcf");
         final String[] args = {
                 "-I", CONSUMES_ZERO_REFERENCE_BASES,
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-O", outputVcf.getAbsolutePath()
         };
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -21,6 +21,7 @@ import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -39,7 +40,7 @@ public final class ReadThreadingAssemblerUnitTest extends BaseTest {
 
     @BeforeClass
     public void setup() throws FileNotFoundException {
-        seq = new CachingIndexedFastaSequenceFile(new File(hg19_chr1_1M_Reference));
+        seq = new CachingIndexedFastaSequenceFile(new File(TestResources.hg19_chr1_1M_Reference));
         header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormalsIntegrationTest.java
@@ -3,8 +3,8 @@ package org.broadinstitute.hellbender.tools.walkers.mutect;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,14 +15,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.testng.Assert.*;
-
 /**
  * Created by David Benjamin on 2/17/17.
  */
 public class CreateSomaticPanelOfNormalsIntegrationTest extends CommandLineProgramTest {
 
-    private static final File PON_VCFS_DIR = new File(publicTestDir, "org/broadinstitute/hellbender/tools/mutect/createpon/");
+    private static final File PON_VCFS_DIR = new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/tools/mutect/createpon/");
 
     /**
      * In the following test, we have sample1.vcf:

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceSummaryRecord;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -24,10 +25,10 @@ import java.util.stream.StreamSupport;
  */
 public class Mutect2IntegrationTest extends CommandLineProgramTest {
     // positions 10,000,000 - 11,000,000 of chr 20 and with most annotations removed
-    private static final File GNOMAD = new File(largeFileTestDir, "very-small-gnomad.vcf");
-    private static final String DREAM_BAMS_DIR = largeFileTestDir + "mutect/dream_synthetic_bams/";
-    private static final String DREAM_VCFS_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs/";
-    private static final String DREAM_MASKS_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/masks/";
+    private static final File GNOMAD = new File(TestResources.largeFileTestDir, "very-small-gnomad.vcf");
+    private static final String DREAM_BAMS_DIR = TestResources.largeFileTestDir + "mutect/dream_synthetic_bams/";
+    private static final String DREAM_VCFS_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs/";
+    private static final String DREAM_MASKS_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/masks/";
 
     /**
      * Several DREAM challenge bams with synthetic truth data.  In order to keep file sizes manageable, bams are restricted
@@ -58,7 +59,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-tumor", tumorSample,
                 "-I", normalBam.getAbsolutePath(),
                 "-normal", normalSample,
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20",
                 "-germline_resource", GNOMAD.getAbsolutePath(),
                 "-XL", mask.getAbsolutePath(),
@@ -96,7 +97,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-tumor", tumorSample,
                 "-I", normalBam.getAbsolutePath(),
                 "-normal", normalSample,
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20",
                 "-O", ponVcf.getAbsolutePath()
         };
@@ -111,7 +112,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-I", normalBam.getAbsolutePath(),
                 "-normal", normalSample,
                 "-normal_panel", ponVcf.getAbsolutePath(),
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20",
                 "-O", unfilteredVcf.getAbsolutePath()
         };
@@ -146,7 +147,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-tumor", tumorName,
                 "-I", normalBam.getAbsolutePath(),
                 "-normal", normalName,
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10100000", // this is 1/3 of the chr 20 interval of our mini-dbSNP
                 "-O", outputVcf.getAbsolutePath()
         };
@@ -165,9 +166,9 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final File filteredVcf = createTempFile("filtered", ".vcf");
 
         final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
+                "-I", TestResources.NA12878_20_21_WGS_bam,
                 "-tumor", "NA12878",
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10000000-10010000",
                 "-germline_resource", GNOMAD.getAbsolutePath(),
                 "-O", unfilteredVcf.getAbsolutePath()
@@ -195,12 +196,12 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
     // e.g. read name HAVCYADXX150109:1:2102:20528:2129 with cigar 23S53I
     @Test
     public void testReadsThatConsumeZeroReferenceReads() throws Exception {
-        final String CONSUMES_ZERO_REFERENCE_BASES = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/na12878-chr20-consumes-zero-reference-bases.bam";
+        final String CONSUMES_ZERO_REFERENCE_BASES = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/na12878-chr20-consumes-zero-reference-bases.bam";
         final File outputVcf = createTempFile("output", ".vcf");
         final String[] args = {
                 "-I", CONSUMES_ZERO_REFERENCE_BASES,
                 "-tumor", "SM-612V3",
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-O", outputVcf.getAbsolutePath()
         };
         runCommandLine(args);
@@ -213,13 +214,13 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
     // per megabase).
     @Test
     public void testBamWithRepeatedReads() {
-        final String repeatedReadsBam = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/repeated_reads.bam";
+        final String repeatedReadsBam = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/repeated_reads.bam";
         final File outputVcf = createTempFile("output", ".vcf");
 
         final String[] args = {
                 "-I", repeatedReadsBam,
                 "-tumor", "SM-612V3",
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", "20:10018000-10020000",
                 "-O", outputVcf.getAbsolutePath()
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/CheckPileupIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/CheckPileupIntegrationTest.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.hellbender.tools.walkers.qc;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -17,8 +17,8 @@ import java.util.Arrays;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class CheckPileupIntegrationTest extends CommandLineProgramTest {
-    private static final String TEST_DATA_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
-    private static final String TEST_OUTPUT_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/walkers/qc/pileup/";
+    private static final String TEST_DATA_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String TEST_OUTPUT_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/walkers/qc/pileup/";
 
     /**
      * This test runs on a basic pileup obtained with samtools (version 1.3.1) and options -B --min-BQ 0
@@ -29,7 +29,7 @@ public class CheckPileupIntegrationTest extends CommandLineProgramTest {
         emptyTemp.createNewFile();
         // pileup was generated with "samtools -f hg19MiniReference -B --min-BQ 0 reads_data_source_test1.bam"
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
-            " -R " + hg19MiniReference +
+            " -R " + TestResources.hg19MiniReference +
             " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
             " -pileup " +  TEST_OUTPUT_DIRECTORY + "reads_data_source_test1.samtools.pileup" +
             " -O %s", Arrays.asList(emptyTemp.toString()));
@@ -46,7 +46,7 @@ public class CheckPileupIntegrationTest extends CommandLineProgramTest {
         // pileup was generated with "samtools -f hg19MiniReference --min-BQ 0 reads_data_source_test1.bam"
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
                 " --continue_after_error " +
-                " -R " + hg19MiniReference +
+                " -R " + TestResources.hg19MiniReference +
                 " -I " + TEST_DATA_DIRECTORY + "reads_data_source_test1.bam" +
                 " -pileup " +  TEST_OUTPUT_DIRECTORY + "reads_data_source_test1.samtools.baq.pileup" +
                 " -O %s", Arrays.asList(TEST_OUTPUT_DIRECTORY + "reads_data_source_test1.samtools.baq.pileup.diff"));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/PileupIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/PileupIntegrationTest.java
@@ -3,12 +3,11 @@ package org.broadinstitute.hellbender.tools.walkers.qc;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -22,8 +21,8 @@ public class PileupIntegrationTest extends CommandLineProgramTest {
         // GATK 3.5 code have a the last line with a REDUCE RESULT that was removed in this implementation
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
             " -L 20:9999900-10000000" +
-                " -R " + b37_reference_20_21 +
-                " -I " + NA12878_20_21_WGS_bam +
+                " -R " + TestResources.b37_reference_20_21 +
+                " -I " + TestResources.NA12878_20_21_WGS_bam +
                 " -O %s",
             Arrays.asList(TEST_OUTPUT_DIRECTORY + "expectedSimplePileup.txt")
         );
@@ -36,8 +35,8 @@ public class PileupIntegrationTest extends CommandLineProgramTest {
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
             " -L 20:9999990-10000000" +
                 " -verbose " +
-                " -R " + b37_reference_20_21 +
-                " -I " + NA12878_20_21_WGS_bam +
+                " -R " + TestResources.b37_reference_20_21 +
+                " -I " + TestResources.NA12878_20_21_WGS_bam +
                 " -O %s",
             Arrays.asList(TEST_OUTPUT_DIRECTORY + "expectedVerbosePileup.txt")
         );
@@ -51,9 +50,9 @@ public class PileupIntegrationTest extends CommandLineProgramTest {
         // awk '{gsub("metadata", "Unknown", $0); gsub("\\[ROD: ", "\[Feature(s): ", $0); print $0}'
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
             " -L 20:10000092-10000112" +
-                " -R " + b37_reference_20_21 +
-                " -I " + NA12878_20_21_WGS_bam +
-                " -metadata " + dbsnp_138_b37_20_21_vcf +
+                " -R " + TestResources.b37_reference_20_21 +
+                " -I " + TestResources.NA12878_20_21_WGS_bam +
+                " -metadata " + TestResources.dbsnp_138_b37_20_21_vcf +
                 " -O %s",
             Arrays.asList(TEST_OUTPUT_DIRECTORY + "expectedFeaturesPileup.txt")
         );
@@ -65,8 +64,8 @@ public class PileupIntegrationTest extends CommandLineProgramTest {
         // GATK 3.5 code have a the last line with a REDUCE RESULT that was removed in this implementation
         IntegrationTestSpec testSpec = new IntegrationTestSpec(
                 " -L 20:10000092-10000112" +
-                        " -R " + b37_reference_20_21 +
-                        " -I " + NA12878_20_21_WGS_bam +
+                        " -R " + TestResources.b37_reference_20_21 +
+                        " -I " + TestResources.NA12878_20_21_WGS_bam +
                         " -outputInsertLength " +
                         " -O %s",
                 Arrays.asList(TEST_OUTPUT_DIRECTORY + "expectedInsertLengthPileup.txt")
@@ -79,8 +78,8 @@ public class PileupIntegrationTest extends CommandLineProgramTest {
         // GATK 3.5 code have a the last line with a REDUCE RESULT that was removed in this implementation
         final String[] args = new String[] {
                 "-L" , "20:9999900-10000000",
-                "-R" , b37_reference_20_21,
-                "-I" , NA12878_20_21_WGS_bam,
+                "-R" , TestResources.b37_reference_20_21,
+                "-I" , TestResources.NA12878_20_21_WGS_bam,
                 "-O" , "/foobar/foobar"
         };
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounterIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -12,12 +13,12 @@ import java.util.Arrays;
 
 public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest {
     private static final String aseDirRelative = "src/test/resources/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounter";
-    public static final String aseTestDir = new File(gatkDirectory, aseDirRelative).getAbsolutePath() + "/";
+    public static final String aseTestDir = new File(TestResources.gatkDirectory, aseDirRelative).getAbsolutePath() + "/";
 
     @Test
     public void testASEReadCounterWithHighMQ() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -O %s -mmq 60 ",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -O %s -mmq 60 ",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithHighMQ.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -25,7 +26,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterWithLowMQ() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 1 -O %s ",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 1 -O %s ",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithLowMQ.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -33,7 +34,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterWithLowMQNoDedup() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 10 -O %s -DF NotDuplicateReadFilter",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 10 -O %s -DF NotDuplicateReadFilter",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithLowMQNoDedup.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -41,7 +42,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterWithHighMQLowBQ() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s ",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s ",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithHighMQLowBQ.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -49,7 +50,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterWithCountOverlaps() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -overlap COUNT_FRAGMENTS",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -overlap COUNT_FRAGMENTS",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithCountOverlaps.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -57,7 +58,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterWithCountReads() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -overlap COUNT_READS",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -overlap COUNT_READS",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.WithCountReads.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -65,7 +66,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterMinDepth70() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -minDepth 70",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -minDepth 70",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.MinDepth70.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -73,7 +74,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterFileFormat() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.FileFormat.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -83,9 +84,9 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
         ArgumentsBuilder args = new ArgumentsBuilder();
 
         args.add("-R");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-I");
-        args.add(largeFileTestDir + "NA12878.RNAseq.bam");
+        args.add(TestResources.largeFileTestDir + "NA12878.RNAseq.bam");
         args.add("-V");
         args.add(aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.MultiContext.vcf");
         args.add("-O");
@@ -99,9 +100,9 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
         ArgumentsBuilder args = new ArgumentsBuilder();
 
         args.add("-R");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-I");
-        args.add(largeFileTestDir + "NA12878.RNAseq.bam");
+        args.add(TestResources.largeFileTestDir + "NA12878.RNAseq.bam");
         args.add("-V");
         args.add(aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.NON_REF.vcf");
         args.add("-O");
@@ -115,9 +116,9 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
         ArgumentsBuilder args = new ArgumentsBuilder();
 
         args.add("-R");
-        args.add(b37_reference_20_21);
+        args.add(TestResources.b37_reference_20_21);
         args.add("-I");
-        args.add(largeFileTestDir + "NA12878.RNAseq.bam");
+        args.add(TestResources.largeFileTestDir + "NA12878.RNAseq.bam");
         args.add("-V");
         args.add(aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.warnings.vcf");
         args.add("-O");
@@ -129,7 +130,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterImproperPairs() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.IMPROPER_PAIR.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.IMPROPER_PAIR.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.ImproperPair.table"));
         spec.executeTest("test improper pairs", this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.rnaseq;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -19,39 +20,39 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.bam"));
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.bam"));
         spec.executeTest("test splits with overhangs", this);
     }
 
     @Test
     public void testSplitsWithOverhangsNotClipping() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--doNotFixOverhangs -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.doNotFixOverhangs.bam"));
+                "--doNotFixOverhangs -R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.doNotFixOverhangs.bam"));
         spec.executeTest("test splits with overhangs not clipping", this);
     }
 
     @Test
     public void testSplitsWithOverhangs0Mismatches() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--maxMismatchesInOverhang 0 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxMismatchesInOverhang0.bam"));
+                "--maxMismatchesInOverhang 0 -R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxMismatchesInOverhang0.bam"));
         spec.executeTest("test splits with overhangs 0 mismatches", this);
     }
 
     @Test
     public void testSplitsWithOverhangs5BasesInOverhang()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--maxBasesInOverhang 5 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxBasesInOverhang5.bam"));
+                "--maxBasesInOverhang 5 -R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxBasesInOverhang5.bam"));
         spec.executeTest("test splits with overhangs 5 bases in overhang", this);
     }
 
     @Test
     public void testSplitsFixNDN() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN --processSecondaryAlignments",
+                "-R " + TestResources.b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN --processSecondaryAlignments",
                 Arrays.asList(getTestDataDir() +"/" + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
         spec.executeTest("test fix NDN", this);
     }
@@ -59,16 +60,16 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test //regression test for https://github.com/broadinstitute/gatk/pull/1853
     public void testSplitsOfUnpairedAndUnmappedReads() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "K-562.duplicateMarked.chr20.bam -O %s --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.K-562.splitNCigarReads.chr20.bam"));
+                "-R" + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "K-562.duplicateMarked.chr20.bam -O %s --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.K-562.splitNCigarReads.chr20.bam"));
         spec.executeTest("regression test for unmapped and unpaired reads", this);
     }
 
     @Test //regression test for https://github.com/broadinstitute/gatk/pull/1864
     public void testSplitsTargetRegionFunctionality() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s -L 20:2444518-2454410 --processSecondaryAlignments",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.subSequenceTest.bam"));
+                "-R" + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s -L 20:2444518-2454410 --processSecondaryAlignments",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.subSequenceTest.bam"));
         spec.executeTest("regression test for unmapped and unpaired reads", this);
     }
 
@@ -76,8 +77,8 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test //regression test for https://github.com/broadinstitute/gatk/issues/2026
     public void testLargeFileThatForcesSnappyUsage(){
         final ArgumentsBuilder args = new ArgumentsBuilder()
-                .addReference(new File(b37_reference_20_21))
-                .addInput(new File(largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam"))
+                .addReference(new File(TestResources.b37_reference_20_21))
+                .addInput(new File(TestResources.largeFileTestDir, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam"))
                 .addOutput(createTempFile("largeSplitNCigarReadsTest",".bam"));
         //Just make sure this doesn't fail with NoClassDefFoundError
         runCommandLine(args);
@@ -86,8 +87,8 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithoutSecondaryAlignments()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
-                Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.noSecondaryAlignments.bam"));
+                "-R " + TestResources.b37_reference_20_21 + " -I " + TestResources.largeFileTestDir + "NA12878.RNAseq.bam -O %s ",
+                Arrays.asList(TestResources.largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.noSecondaryAlignments.bam"));
         spec.executeTest("test splits with overhangs", this);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
@@ -5,11 +5,15 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.GenomeLocParser;
+import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.ReadClipperTestUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -35,14 +39,14 @@ public final class SplitNCigarReadsUnitTest extends BaseTest {
 
     private final class TestManager extends OverhangFixingManager {
         public TestManager( final SAMFileHeader header , DummyTestWriter writer) {
-            super(header, writer, hg19GenomeLocParser, hg19ReferenceReader, 10000, 1, 40, false, true);
+            super(header, writer, TestResources.getGenomeLocParser(), TestResources.getHg19ReferenceReader(), 10000, 1, 40, false, true);
         }
     }
 
     @Test
     public void testBogusNSplits() {
         DummyTestWriter writer = new DummyTestWriter();
-        header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+        header.setSequenceDictionary(TestResources.getGenomeLocParser().getSequenceDictionary());
         TestManager manager = new TestManager(header, writer);
         manager.activateWriting();
 
@@ -58,7 +62,7 @@ public final class SplitNCigarReadsUnitTest extends BaseTest {
     public void testBogusMidNSection() {
         //Testing that bogus subsections dont end up clipped
         DummyTestWriter writer = new DummyTestWriter();
-        header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+        header.setSequenceDictionary(TestResources.getGenomeLocParser().getSequenceDictionary());
         TestManager manager = new TestManager(header, writer);
         manager.activateWriting();
 
@@ -76,7 +80,7 @@ public final class SplitNCigarReadsUnitTest extends BaseTest {
     public void testSplitNComplexCase() {
         //Complex Case involving insertions & deletions
         DummyTestWriter writer = new DummyTestWriter();
-        header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+        header.setSequenceDictionary(TestResources.getGenomeLocParser().getSequenceDictionary());
         TestManager manager = new TestManager(header, writer);
 
         manager.activateWriting();
@@ -117,7 +121,7 @@ public final class SplitNCigarReadsUnitTest extends BaseTest {
 
             if(numOfSplits != 0 && isCigarDoesNotHaveEmptyRegionsBetweenNs(cigar)){
                 final SAMFileHeader header = new SAMFileHeader();
-                header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+                header.setSequenceDictionary(TestResources.getGenomeLocParser().getSequenceDictionary());
                 final TestManager manager = new TestManager(header, new DummyTestWriter());
                 manager.activateWriting();
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithBamDepthIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithBamDepthIntegrationTest.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,8 +18,8 @@ import java.util.stream.StreamSupport;
  * Created by davidben on 1/31/17.
  */
 public class AnnotateVcfWithBamDepthIntegrationTest extends CommandLineProgramTest {
-    private static final String DREAM_BAMS_DIR = largeFileTestDir + "mutect/dream_synthetic_bams/";
-    private static final String DREAM_VCFS_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs/";
+    private static final String DREAM_BAMS_DIR = TestResources.largeFileTestDir + "mutect/dream_synthetic_bams/";
+    private static final String DREAM_VCFS_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs/";
 
     // test on the DREAM bam 1 and accompanying variants
     // depths verified manually in IGV

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithExpectedAlleleFractionIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithExpectedAlleleFractionIntegrationTest.java
@@ -4,8 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
-import org.broadinstitute.hellbender.tools.walkers.validation.AnnotateVcfWithExpectedAlleleFraction;
-import org.broadinstitute.hellbender.tools.walkers.validation.MixingFraction;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -20,7 +19,7 @@ import java.util.stream.StreamSupport;
  */
 public class AnnotateVcfWithExpectedAlleleFractionIntegrationTest extends CommandLineProgramTest {
 
-    private static final String VCF_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
+    private static final String VCF_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
     private static final File INPUT_VCF = new File(VCF_DIRECTORY, "dream_4_mixing.vcf");
 
     // run with made-up mixing fractions and the doctored 2-sample version of DREAM challenge sample 4

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/CalculateMixingFractionsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/CalculateMixingFractionsIntegrationTest.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.validation;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.tools.walkers.validation.MixingFraction;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
  * Created by David Benjamin on 1/31/17.
  */
 public class CalculateMixingFractionsIntegrationTest extends CommandLineProgramTest {
-    private static final String VCF_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
+    private static final String VCF_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
     private static final File INPUT_VCF = new File(VCF_DIRECTORY, "dream_4_mixing.vcf");
-    private static final String DREAM_BAMS_DIR = largeFileTestDir + "mutect/dream_synthetic_bams/";
+    private static final String DREAM_BAMS_DIR = TestResources.largeFileTestDir + "mutect/dream_synthetic_bams/";
     private static final File INPUT_BAM = new File(DREAM_BAMS_DIR, "tumor_4.bam");
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/ConcordanceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/ConcordanceIntegrationTest.java
@@ -2,9 +2,9 @@ package org.broadinstitute.hellbender.tools.walkers.validation;
 
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.AbstractConcordanceWalker;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +21,7 @@ public class ConcordanceIntegrationTest extends CommandLineProgramTest{
 
     @Test
     public void testSimple() throws Exception {
-        final String testDir =  publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
+        final String testDir =  TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
         final File evalVcf = new File(testDir, "gatk4-dream3-mini.vcf");
         final File truthVcf = new File(testDir, "gatk3-dream3-mini.vcf");
         final File summary = createTempFile("summary", ".txt");
@@ -55,7 +55,7 @@ public class ConcordanceIntegrationTest extends CommandLineProgramTest{
     // Test going from an integer chromosome (22) to a character chromosome (X)
     @Test
     public void testt22X() throws Exception {
-        final String testDir = publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
+        final String testDir = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
         final File truthVcf = new File(testDir, "gatk3-dream3-x.vcf");
         final File evalVcf = new File(testDir, "gatk4-dream3-x.vcf");
         final File tpfp = createTempFile("tpfp", ".vcf");
@@ -109,7 +109,7 @@ public class ConcordanceIntegrationTest extends CommandLineProgramTest{
     // The truth file only contains the PASS sites; should get 100% sensitivity and specificity.
     @Test
     public void testPerfectMatchVcf() throws Exception {
-        final String testDir = publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
+        final String testDir = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
         final File truthVcf = new File(testDir, "same-truth.vcf");
         final File evalVcf = new File(testDir, "same-eval.vcf");
         final File summary = createTempFile("summary", ".txt");
@@ -138,7 +138,7 @@ public class ConcordanceIntegrationTest extends CommandLineProgramTest{
 
     @Test
     public void testDreamSensitivity() throws Exception {
-        final String testDir = publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
+        final String testDir = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/concordance/";
         final File evalVcf = new File(testDir, "dream3-chr21.vcf");
         final File truthVcf = new File(testDir, "dream3-truth-minus-SV-chr21.vcf");
         final File summary = createTempFile("summary", ".txt");

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/CountFalsePositivesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/CountFalsePositivesIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.validation;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.tools.walkers.validation.FalsePositiveRecord;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.tsv.DataLine;
 import org.broadinstitute.hellbender.utils.tsv.TableReader;
 import org.testng.Assert;
@@ -17,11 +17,11 @@ import static org.broadinstitute.hellbender.tools.walkers.validation.FalsePositi
 public class CountFalsePositivesIntegrationTest extends CommandLineProgramTest {
     @Test
     public void testSimple() throws Exception {
-        final File dreamDir =  new File(publicTestDir, "org/broadinstitute/hellbender/tools/mutect/dream");
+        final File dreamDir =  new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/tools/mutect/dream");
         final File output = createTempFile("output", ".txt");
         final String[] args = {
                 "-V", dreamDir + "/vcfs/dream3-chr20.vcf",
-                "-R", b37_reference_20_21,
+                "-R", TestResources.b37_reference_20_21,
                 "-L", dreamDir + "/dream-chr20.interval_list",
                 "-O", output.toString()
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/RemoveNearbyIndelsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/RemoveNearbyIndelsIntegrationTest.java
@@ -4,7 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
-import org.broadinstitute.hellbender.tools.walkers.validation.RemoveNearbyIndels;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -19,7 +19,7 @@ import java.util.stream.StreamSupport;
  */
 public class RemoveNearbyIndelsIntegrationTest extends CommandLineProgramTest {
 
-    private static final String TOOLS_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
+    private static final String TOOLS_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/mutect/validation/";
     private static final File INPUT_VCF = new File(TOOLS_TEST_DIRECTORY, "nearby_indels.vcf");
     /**
      * nearby_indels.vcf looks like this:

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriorsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriorsIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.variantutils;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -9,7 +10,7 @@ import java.util.Collections;
 
 public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLineProgramTest {
 
-    private final String largeDir = largeFileTestDir;
+    private final String largeDir = TestResources.largeFileTestDir;
     private final String dir= getToolTestDataDir();
 
     private String CEUtrioFamilyFile = dir + "CEUtrio.ped";
@@ -24,7 +25,7 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
     public void testUsingDiscoveredAF() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                         " -O %s" +
-                        " -R " + b37_reference_20_21 +    //NOTE: we need a reference for -L
+                        " -R " + TestResources.b37_reference_20_21 +    //NOTE: we need a reference for -L
                         " -L 20:10,000,000-10,001,432" +
                         " -V " + largeDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf" +
                         " -addOutputVCFCommandLine false",
@@ -40,7 +41,7 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
         IntegrationTestSpec spec = new IntegrationTestSpec(
                         "-useACoff" +
                         " -O %s" +
-                        " -R " + b37_reference_20_21 +    //NOTE: we need a reference for -L
+                        " -R " + TestResources.b37_reference_20_21 +    //NOTE: we need a reference for -L
                         " -L 20:10,000,000-10,001,432" +
                         " -V " + largeDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf" +
                         " -addOutputVCFCommandLine false",
@@ -54,7 +55,7 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
         IntegrationTestSpec spec = new IntegrationTestSpec(
                         "-useACoff" +
                         " -O %s" +
-                        " -R " + b37_reference_20_21 +    //NOTE: we need a reference for -L
+                        " -R " + TestResources.b37_reference_20_21 +    //NOTE: we need a reference for -L
                         " -L 20:10,000,000-10,100,000" +
                         " -V " + dir + "NA12878.Jan2013.haplotypeCaller.subset.indels.vcf" +
                         " -supporting " + largeDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf" +

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.variantutils;
 
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -27,7 +28,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample2.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference
+                " -R " + TestResources.hg19MiniReference
                         + " --variant " + testFile
                         + " -sn NA11918 "
                         + " -sr " // suppress reference file path in output for test differencing
@@ -44,7 +45,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "filteringDepthInFormat.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                " -R " + hg19MiniReference
+                " -R " + TestResources.hg19MiniReference
                         + " --variant " + testFile
                         + " -select 'DP < 7' "
                         + " -sr " // suppress reference file path in output for test differencing

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSRIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSRIntegrationTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,11 +31,11 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
 
     @Override
     public String getToolTestDataDir(){
-        return publicTestDir + "org/broadinstitute/hellbender/tools/VQSR/";
+        return TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/VQSR/";
     }
 
     private String getLargeVQSRTestDataDir(){
-        return largeFileTestDir + "VQSR/";
+        return TestResources.largeFileTestDir + "VQSR/";
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.vqsr;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -27,11 +28,11 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
 
     @Override
     public String getToolTestDataDir(){
-        return publicTestDir + "org/broadinstitute/hellbender/tools/walkers/VQSR/";
+        return TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/walkers/VQSR/";
     }
 
     private String getLargeVQSRTestDataDir(){
-        return largeFileTestDir + "VQSR/";
+        return TestResources.largeFileTestDir + "VQSR/";
     }
 
     @BeforeMethod

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocParserUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocParserUnitTest.java
@@ -16,6 +16,7 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -435,7 +436,7 @@ public final class GenomeLocParserUnitTest extends BaseTest {
 
     @Test
     public void testcreateGenomeLocOnContig() throws FileNotFoundException {
-        final CachingIndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final CachingIndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleReference));
         final SAMSequenceDictionary dict = seq.getSequenceDictionary();
         final GenomeLocParser genomeLocParser = new GenomeLocParser(dict);
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSetUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -299,7 +300,7 @@ public final class GenomeLocSortedSetUnitTest extends BaseTest {
 
     @DataProvider(name = "GetOverlapping")
     public Object[][] makeGetOverlappingTest() throws Exception {
-        final GenomeLocParser genomeLocParser = new GenomeLocParser(new CachingIndexedFastaSequenceFile(new File(exampleReference)));
+        final GenomeLocParser genomeLocParser = new GenomeLocParser(new CachingIndexedFastaSequenceFile(new File(TestResources.exampleReference)));
 
         List<Object[]> tests = new ArrayList<>();
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -20,10 +21,10 @@ public final class GenomeLocUnitTest extends BaseTest {
      */
     @Test
     public void testIsBetween() {
-        GenomeLoc locMiddle = hg19GenomeLocParser.createGenomeLoc("1", 3, 3);
+        GenomeLoc locMiddle = TestResources.getGenomeLocParser().createGenomeLoc("1", 3, 3);
 
-        GenomeLoc locLeft = hg19GenomeLocParser.createGenomeLoc("1", 1, 1);
-        GenomeLoc locRight = hg19GenomeLocParser.createGenomeLoc("1", 5, 5);
+        GenomeLoc locLeft = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 1);
+        GenomeLoc locRight = TestResources.getGenomeLocParser().createGenomeLoc("1", 5, 5);
 
         Assert.assertTrue(locMiddle.isBetween(locLeft, locRight));
         Assert.assertFalse(locLeft.isBetween(locMiddle, locRight));
@@ -32,15 +33,15 @@ public final class GenomeLocUnitTest extends BaseTest {
     }
     @Test
     public void testContigIndex() {
-        GenomeLoc locOne = hg19GenomeLocParser.createGenomeLoc("1",1,1);
+        GenomeLoc locOne = TestResources.getGenomeLocParser().createGenomeLoc("1",1,1);
         Assert.assertEquals(0, locOne.getContigIndex());
         Assert.assertEquals("1", locOne.getContig());
 
-        GenomeLoc locFour = hg19GenomeLocParser.createGenomeLoc("4",1,1);
+        GenomeLoc locFour = TestResources.getGenomeLocParser().createGenomeLoc("4",1,1);
         Assert.assertEquals(3, locFour.getContigIndex());
         Assert.assertEquals("4", locFour.contigName);
 
-        GenomeLoc locNumber = hg19GenomeLocParser.createGenomeLoc(hg19Header.getSequenceDictionary().getSequence(0).getSequenceName(), 1, 1);
+        GenomeLoc locNumber = TestResources.getGenomeLocParser().createGenomeLoc(TestResources.getHg19Header().getSequenceDictionary().getSequence(0).getSequenceName(), 1, 1);
         Assert.assertEquals(0, locNumber.getContigIndex());
         Assert.assertEquals("1", locNumber.getContig());
         Assert.assertEquals(0, locOne.compareTo(locNumber));
@@ -49,49 +50,49 @@ public final class GenomeLocUnitTest extends BaseTest {
 
     @Test
     public void testCompareTo() {
-        GenomeLoc twoOne = hg19GenomeLocParser.createGenomeLoc("2", 1);
-        GenomeLoc twoFive = hg19GenomeLocParser.createGenomeLoc("2", 5);
-        GenomeLoc twoOtherFive = hg19GenomeLocParser.createGenomeLoc("2", 5);
+        GenomeLoc twoOne = TestResources.getGenomeLocParser().createGenomeLoc("2", 1);
+        GenomeLoc twoFive = TestResources.getGenomeLocParser().createGenomeLoc("2", 5);
+        GenomeLoc twoOtherFive = TestResources.getGenomeLocParser().createGenomeLoc("2", 5);
         Assert.assertEquals(twoFive.compareTo(twoOtherFive), 0);
 
         Assert.assertEquals(twoOne.compareTo(twoFive), -1);
         Assert.assertEquals(twoFive.compareTo(twoOne), 1);
 
-        GenomeLoc oneOne = hg19GenomeLocParser.createGenomeLoc("1", 5);
+        GenomeLoc oneOne = TestResources.getGenomeLocParser().createGenomeLoc("1", 5);
         Assert.assertEquals(oneOne.compareTo(twoOne), -1);
         Assert.assertEquals(twoOne.compareTo(oneOne), 1);
     }
 
     @Test
     public void testEndpointSpan() throws Exception {
-        GenomeLoc twoOne = hg19GenomeLocParser.createGenomeLoc("2", 1);
-        GenomeLoc twoFive = hg19GenomeLocParser.createGenomeLoc("2", 5);
+        GenomeLoc twoOne = TestResources.getGenomeLocParser().createGenomeLoc("2", 1);
+        GenomeLoc twoFive = TestResources.getGenomeLocParser().createGenomeLoc("2", 5);
         final GenomeLoc twoOne_twoFive = twoOne.endpointSpan(twoFive);
         final GenomeLoc twoFive_twoOne = twoFive.endpointSpan(twoOne);
 
-        final GenomeLoc expectedSpan =  hg19GenomeLocParser.createGenomeLoc("2", 1, 5);
+        final GenomeLoc expectedSpan =  TestResources.getGenomeLocParser().createGenomeLoc("2", 1, 5);
         Assert.assertEquals(twoOne_twoFive, expectedSpan);
         Assert.assertEquals(twoFive_twoOne, expectedSpan);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testEndpointSpanUnmapped() throws Exception {
-        GenomeLoc twoOne = hg19GenomeLocParser.createGenomeLoc("2", 1);
+        GenomeLoc twoOne = TestResources.getGenomeLocParser().createGenomeLoc("2", 1);
         GenomeLoc unmapped = GenomeLoc.UNMAPPED;
         twoOne.endpointSpan(unmapped);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testEndpointWrongContig() throws Exception {
-        GenomeLoc twoOne = hg19GenomeLocParser.createGenomeLoc("2", 1);
-        GenomeLoc threeFive = hg19GenomeLocParser.createGenomeLoc("3", 5);
+        GenomeLoc twoOne = TestResources.getGenomeLocParser().createGenomeLoc("2", 1);
+        GenomeLoc threeFive = TestResources.getGenomeLocParser().createGenomeLoc("3", 5);
         twoOne.endpointSpan(threeFive);
     }
 
     @Test
     public void testUnmappedSort() {
-        GenomeLoc chr1 = hg19GenomeLocParser.createGenomeLoc("1",1,10000000);
-        GenomeLoc chr2 = hg19GenomeLocParser.createGenomeLoc("2",1,10000000);
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().createGenomeLoc("1",1,10000000);
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().createGenomeLoc("2",1,10000000);
         GenomeLoc unmapped = GenomeLoc.UNMAPPED;
 
         List<GenomeLoc> unmappedOnly = Arrays.asList(unmapped);
@@ -127,26 +128,26 @@ public final class GenomeLocUnitTest extends BaseTest {
 
     @Test
     public void testUnmappedMerge() {
-        GenomeLoc chr1 = hg19GenomeLocParser.createGenomeLoc("1",1,10000000);
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().createGenomeLoc("1",1,10000000);
         GenomeLoc unmapped = GenomeLoc.UNMAPPED;
 
         List<GenomeLoc> oneUnmappedOnly = Arrays.asList(unmapped);
-        oneUnmappedOnly = IntervalUtils.sortAndMergeIntervals(hg19GenomeLocParser,oneUnmappedOnly, IntervalMergingRule.OVERLAPPING_ONLY).toList();
+        oneUnmappedOnly = IntervalUtils.sortAndMergeIntervals(TestResources.getGenomeLocParser(),oneUnmappedOnly, IntervalMergingRule.OVERLAPPING_ONLY).toList();
         Assert.assertEquals(oneUnmappedOnly.size(),1,"Wrong number of elements in list.");
         Assert.assertEquals(oneUnmappedOnly.get(0),unmapped,"List sorted in wrong order");
 
         List<GenomeLoc> twoUnmapped = Arrays.asList(unmapped,unmapped);
-        twoUnmapped = IntervalUtils.sortAndMergeIntervals(hg19GenomeLocParser,twoUnmapped,IntervalMergingRule.OVERLAPPING_ONLY).toList();
+        twoUnmapped = IntervalUtils.sortAndMergeIntervals(TestResources.getGenomeLocParser(),twoUnmapped,IntervalMergingRule.OVERLAPPING_ONLY).toList();
         Assert.assertEquals(twoUnmapped.size(),1,"Wrong number of elements in list.");
         Assert.assertEquals(twoUnmapped.get(0),unmapped,"List sorted in wrong order");
 
         List<GenomeLoc> twoUnmappedAtEnd = Arrays.asList(chr1,unmapped,unmapped);
-        twoUnmappedAtEnd = IntervalUtils.sortAndMergeIntervals(hg19GenomeLocParser,twoUnmappedAtEnd,IntervalMergingRule.OVERLAPPING_ONLY).toList();
+        twoUnmappedAtEnd = IntervalUtils.sortAndMergeIntervals(TestResources.getGenomeLocParser(),twoUnmappedAtEnd,IntervalMergingRule.OVERLAPPING_ONLY).toList();
         Assert.assertEquals(twoUnmappedAtEnd.size(),2,"Wrong number of elements in list.");
         Assert.assertEquals(twoUnmappedAtEnd,Arrays.asList(chr1,unmapped),"List sorted in wrong order");
 
         List<GenomeLoc> twoUnmappedMixed = Arrays.asList(unmapped,chr1,unmapped);
-        twoUnmappedMixed = IntervalUtils.sortAndMergeIntervals(hg19GenomeLocParser,twoUnmappedMixed,IntervalMergingRule.OVERLAPPING_ONLY).toList();
+        twoUnmappedMixed = IntervalUtils.sortAndMergeIntervals(TestResources.getGenomeLocParser(),twoUnmappedMixed,IntervalMergingRule.OVERLAPPING_ONLY).toList();
         Assert.assertEquals(twoUnmappedMixed.size(),2,"Wrong number of elements in list.");
         Assert.assertEquals(twoUnmappedMixed,Arrays.asList(chr1,unmapped),"List sorted in wrong order");
     }
@@ -164,8 +165,8 @@ public final class GenomeLocUnitTest extends BaseTest {
 
         private ReciprocalOverlapProvider(int start1, int stop1, int start2, int stop2) {
             super(ReciprocalOverlapProvider.class);
-            gl1 = hg19GenomeLocParser.createGenomeLoc("1", start1, stop1);
-            gl2 = hg19GenomeLocParser.createGenomeLoc("1", start2, stop2);
+            gl1 = TestResources.getGenomeLocParser().createGenomeLoc("1", start1, stop1);
+            gl2 = TestResources.getGenomeLocParser().createGenomeLoc("1", start2, stop2);
 
             int shared = 0;
             for ( int i = start1; i <= stop1; i++ ) {
@@ -223,11 +224,11 @@ public final class GenomeLocUnitTest extends BaseTest {
 
         final int start = 10;
         for ( int stop = start; stop < start + 3; stop++ ) {
-            final GenomeLoc g1 = hg19GenomeLocParser.createGenomeLoc("2", start, stop);
+            final GenomeLoc g1 = TestResources.getGenomeLocParser().createGenomeLoc("2", start, stop);
             for ( final String contig : Arrays.asList("1", "2", "3")) {
                 for ( int start2 = start - 1; start2 <= stop + 1; start2++ ) {
                     for ( int stop2 = start2; stop2 < stop + 2; stop2++ ) {
-                        final GenomeLoc g2 = hg19GenomeLocParser.createGenomeLoc(contig, start2, stop2);
+                        final GenomeLoc g2 = TestResources.getGenomeLocParser().createGenomeLoc(contig, start2, stop2);
 
                         ComparisonResult cmp = ComparisonResult.EQUALS;
                         if ( contig.equals("3") ) cmp = ComparisonResult.LESS_THAN;

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -16,6 +16,7 @@ import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -31,16 +32,16 @@ import java.util.stream.Stream;
  * test out the interval utility methods
  */
 public final class IntervalUtilsUnitTest extends BaseTest {
-    public static final String INTERVAL_TEST_DATA = publicTestDir + "org/broadinstitute/hellbender/utils/interval/";
-    public static final String emptyIntervals = BaseTest.publicTestDir + "empty_intervals.list";
+    public static final String INTERVAL_TEST_DATA = TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/interval/";
+    public static final String emptyIntervals = TestResources.publicTestDir + "empty_intervals.list";
     private List<GenomeLoc> hg19ReferenceLocs;
     private List<GenomeLoc> hg19exomeIntervals;
 
 
     @BeforeClass
     public void init() {
-        hg19ReferenceLocs = Collections.unmodifiableList(GenomeLocSortedSet.createSetFromSequenceDictionary(hg19Header.getSequenceDictionary()).toList()) ;
-        hg19exomeIntervals = Collections.unmodifiableList(IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(hg19MiniIntervalFile)));
+        hg19ReferenceLocs = Collections.unmodifiableList(GenomeLocSortedSet.createSetFromSequenceDictionary(TestResources.getHg19Header().getSequenceDictionary()).toList()) ;
+        hg19exomeIntervals = Collections.unmodifiableList(IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(TestResources.hg19MiniIntervalFile)));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -249,25 +250,25 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @DataProvider(name = "SplitLocusIntervalsSmallTest")
     public Object[][] createSplitLocusIntervalsSmallTest() {
-        GenomeLoc bp01_10 = hg19GenomeLocParser.createGenomeLoc("1", 1, 10);
+        GenomeLoc bp01_10 = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 10);
 
-        GenomeLoc bp1_5 = hg19GenomeLocParser.createGenomeLoc("1", 1, 5);
-        GenomeLoc bp6_10 = hg19GenomeLocParser.createGenomeLoc("1", 6, 10);
+        GenomeLoc bp1_5 = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 5);
+        GenomeLoc bp6_10 = TestResources.getGenomeLocParser().createGenomeLoc("1", 6, 10);
         new SplitLocusIntervalsSmallTest("cut into two", Arrays.asList(bp01_10), 2, Arrays.asList(bp1_5, bp6_10));
 
-        GenomeLoc bp20_30 = hg19GenomeLocParser.createGenomeLoc("1", 20, 30);
+        GenomeLoc bp20_30 = TestResources.getGenomeLocParser().createGenomeLoc("1", 20, 30);
         new SplitLocusIntervalsSmallTest("two in two", Arrays.asList(bp01_10, bp20_30), 2, Arrays.asList(bp01_10, bp20_30));
 
-        GenomeLoc bp1_7 = hg19GenomeLocParser.createGenomeLoc("1", 1, 7);
-        GenomeLoc bp8_10 = hg19GenomeLocParser.createGenomeLoc("1", 8, 10);
-        GenomeLoc bp20_23 = hg19GenomeLocParser.createGenomeLoc("1", 20, 23);
-        GenomeLoc bp24_30 = hg19GenomeLocParser.createGenomeLoc("1", 24, 30);
+        GenomeLoc bp1_7 = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 7);
+        GenomeLoc bp8_10 = TestResources.getGenomeLocParser().createGenomeLoc("1", 8, 10);
+        GenomeLoc bp20_23 = TestResources.getGenomeLocParser().createGenomeLoc("1", 20, 23);
+        GenomeLoc bp24_30 = TestResources.getGenomeLocParser().createGenomeLoc("1", 24, 30);
         new SplitLocusIntervalsSmallTest("two in three", Arrays.asList(bp01_10, bp20_30), 3,
                 Arrays.asList(bp1_7, bp8_10, bp20_23, bp24_30));
 
-        GenomeLoc bp1_2 = hg19GenomeLocParser.createGenomeLoc("1", 1, 2);
-        GenomeLoc bp1_1 = hg19GenomeLocParser.createGenomeLoc("1", 1, 1);
-        GenomeLoc bp2_2 = hg19GenomeLocParser.createGenomeLoc("1", 2, 2);
+        GenomeLoc bp1_2 = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 2);
+        GenomeLoc bp1_1 = TestResources.getGenomeLocParser().createGenomeLoc("1", 1, 1);
+        GenomeLoc bp2_2 = TestResources.getGenomeLocParser().createGenomeLoc("1", 2, 2);
         new SplitLocusIntervalsSmallTest("too many pieces", Arrays.asList(bp1_2), 5, Arrays.asList(bp1_1, bp2_2), 2);
 
         new SplitLocusIntervalsSmallTest("emptyList", Collections.<GenomeLoc>emptyList(), 5, Collections.<GenomeLoc>emptyList(), 0);
@@ -302,9 +303,9 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         // create the two lists we'll use
         for (int x = 1; x < 101; x++) {
             if (x % 2 == 0)
-                listEveryTwoFromTwo.add(hg19GenomeLocParser.createGenomeLoc("chr1",x,x));
+                listEveryTwoFromTwo.add(TestResources.getGenomeLocParser().createGenomeLoc("chr1",x,x));
             else
-                listEveryTwoFromOne.add(hg19GenomeLocParser.createGenomeLoc("chr1",x,x));
+                listEveryTwoFromOne.add(TestResources.getGenomeLocParser().createGenomeLoc("chr1",x,x));
         }
 
         List<GenomeLoc> ret;
@@ -325,8 +326,8 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         // create the two lists we'll use
         for (int x = 1; x < 101; x++) {
             if (x % 2 == 0)
-                listEveryTwoFromTwo.add(hg19GenomeLocParser.createGenomeLoc("1",x,x));
-            allSites.add(hg19GenomeLocParser.createGenomeLoc("1",x,x));
+                listEveryTwoFromTwo.add(TestResources.getGenomeLocParser().createGenomeLoc("1",x,x));
+            allSites.add(TestResources.getGenomeLocParser().createGenomeLoc("1",x,x));
         }
 
         List<GenomeLoc> ret;
@@ -347,8 +348,8 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         // create the two lists we'll use
         for (int x = 1; x < 101; x++) {
             if (x % 5 == 0) {
-                listEveryTwoFromTwo.add(hg19GenomeLocParser.createGenomeLoc("1",x,x));
-                allSites.add(hg19GenomeLocParser.createGenomeLoc("1",x,x));
+                listEveryTwoFromTwo.add(TestResources.getGenomeLocParser().createGenomeLoc("1",x,x));
+                allSites.add(TestResources.getGenomeLocParser().createGenomeLoc("1",x,x));
             }
         }
 
@@ -367,11 +368,11 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         List<GenomeLoc> source1 = new ArrayList<>();
         List<GenomeLoc> source2 = new ArrayList<>();
 
-        source1.add(hg19GenomeLocParser.createGenomeLoc("1", 10, 20));
-        source1.add(hg19GenomeLocParser.createGenomeLoc("1", 15, 25));
+        source1.add(TestResources.getGenomeLocParser().createGenomeLoc("1", 10, 20));
+        source1.add(TestResources.getGenomeLocParser().createGenomeLoc("1", 15, 25));
 
-        source2.add(hg19GenomeLocParser.createGenomeLoc("1", 16, 18));
-        source2.add(hg19GenomeLocParser.createGenomeLoc("1", 22, 24));
+        source2.add(TestResources.getGenomeLocParser().createGenomeLoc("1", 16, 18));
+        source2.add(TestResources.getGenomeLocParser().createGenomeLoc("1", 22, 24));
 
         List<GenomeLoc> ret = IntervalUtils.mergeListsBySetOperator(source1, source2, IntervalSetRule.INTERSECTION);
         Assert.assertEquals(ret.size(), 2);
@@ -379,7 +380,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test
     public void testGetContigLengths() {
-        Map<String, Integer> lengths = IntervalUtils.getContigSizes(new File(BaseTest.exampleReference));
+        Map<String, Integer> lengths = IntervalUtils.getContigSizes(new File(TestResources.exampleReference));
         Assert.assertEquals((long)lengths.get("1"), 16000);
         Assert.assertEquals((long)lengths.get("2"), 16000);
         Assert.assertEquals((long) lengths.get("3"), 16000);
@@ -389,8 +390,8 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testParseIntervalArguments() {
         Assert.assertEquals(hg19ReferenceLocs.size(), 4);
-        Assert.assertEquals(intervalStringsToGenomeLocs("1", "2", "3").size(), 3);
-        Assert.assertEquals(intervalStringsToGenomeLocs("1:1-2", "1:4-5", "2:1-1", "3:2-2").size(), 4);
+        Assert.assertEquals(TestResources.intervalStringsToGenomeLocs("1", "2", "3").size(), 3);
+        Assert.assertEquals(TestResources.intervalStringsToGenomeLocs("1:1-2", "1:4-5", "2:1-1", "3:2-2").size(), 4);
     }
 
     @Test
@@ -410,7 +411,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Arrays.asList(contigRecord));
         final GenomeLocParser parser = new GenomeLocParser(dictionary);
 
-        List<GenomeLoc> unmappedLoc = IntervalUtils.parseIntervalArguments(parser, publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped.intervals");
+        List<GenomeLoc> unmappedLoc = IntervalUtils.parseIntervalArguments(parser, TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_unmapped.intervals");
         Assert.assertTrue(unmappedLoc.size() == 1);
         Assert.assertTrue(unmappedLoc.get(0).isUnmapped());
     }
@@ -431,7 +432,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)
     public void testMissingIntervalFile() {
-        IntervalUtils.isIntervalFile(BaseTest.publicTestDir + "no_such_intervals.list");
+        IntervalUtils.isIntervalFile(TestResources.publicTestDir + "no_such_intervals.list");
     }
 
     @Test
@@ -451,19 +452,19 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test
     public void testFixedScatterIntervalsBasic() {
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3");
 
         List<File> files = testFiles("basic.", 3, ".intervals");
 
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs("1", "2", "3");
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs("1", "2", "3");
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -476,20 +477,20 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test
     public void testScatterFixedIntervalsLessFiles() {
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3");
-        GenomeLoc chr4 = hg19GenomeLocParser.parseGenomeLoc("4");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3");
+        GenomeLoc chr4 = TestResources.getGenomeLocParser().parseGenomeLoc("4");
 
         List<File> files = testFiles("less.", 3, ".intervals");
 
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs("1", "2", "3", "4");
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs("1", "2", "3", "4");
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -504,34 +505,34 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test(expectedExceptions=CommandLineException.BadArgumentValue.class)
     public void testSplitFixedIntervalsMoreFiles() {
         List<File> files = testFiles("more.", 3, ".intervals");
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs("1", "2");
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs("1", "2");
         IntervalUtils.splitFixedIntervals(locs, files.size());
     }
 
     @Test(expectedExceptions=CommandLineException.BadArgumentValue.class)
     public void testScatterFixedIntervalsMoreFiles() {
         List<File> files = testFiles("more.", 3, ".intervals");
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs("1", "2");
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs("1", "2");
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, locs.size()); // locs.size() instead of files.size()
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
     }
     @Test
     public void testScatterFixedIntervalsStart() {
         List<String> intervals = Arrays.asList("1:1-2", "1:4-5", "2:1-1", "3:2-2");
-        GenomeLoc chr1a = hg19GenomeLocParser.parseGenomeLoc("1:1-2");
-        GenomeLoc chr1b = hg19GenomeLocParser.parseGenomeLoc("1:4-5");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2:1-1");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3:2-2");
+        GenomeLoc chr1a = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-2");
+        GenomeLoc chr1b = TestResources.getGenomeLocParser().parseGenomeLoc("1:4-5");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2:1-1");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3:2-2");
 
         List<File> files = testFiles("split.", 3, ".intervals");
 
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs(intervals);
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs(intervals);
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -546,20 +547,20 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterFixedIntervalsMiddle() {
         List<String> intervals = Arrays.asList("1:1-1", "2:1-2", "2:4-5", "3:2-2");
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1:1-1");
-        GenomeLoc chr2a = hg19GenomeLocParser.parseGenomeLoc("2:1-2");
-        GenomeLoc chr2b = hg19GenomeLocParser.parseGenomeLoc("2:4-5");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3:2-2");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-1");
+        GenomeLoc chr2a = TestResources.getGenomeLocParser().parseGenomeLoc("2:1-2");
+        GenomeLoc chr2b = TestResources.getGenomeLocParser().parseGenomeLoc("2:4-5");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3:2-2");
 
         List<File> files = testFiles("split.", 3, ".intervals");
 
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs(intervals);
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs(intervals);
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -574,20 +575,20 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterFixedIntervalsEnd() {
         List<String> intervals = Arrays.asList("1:1-1", "2:2-2", "3:1-2", "3:4-5");
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1:1-1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2:2-2");
-        GenomeLoc chr3a = hg19GenomeLocParser.parseGenomeLoc("3:1-2");
-        GenomeLoc chr3b = hg19GenomeLocParser.parseGenomeLoc("3:4-5");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2:2-2");
+        GenomeLoc chr3a = TestResources.getGenomeLocParser().parseGenomeLoc("3:1-2");
+        GenomeLoc chr3b = TestResources.getGenomeLocParser().parseGenomeLoc("3:4-5");
 
         List<File> files = testFiles("split.", 3, ".intervals");
 
-        List<GenomeLoc> locs = intervalStringsToGenomeLocs(intervals);
+        List<GenomeLoc> locs = TestResources.intervalStringsToGenomeLocs(intervals);
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 2);
         Assert.assertEquals(locs2.size(), 1);
@@ -602,7 +603,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterFixedIntervalsFile() {
         List<File> files = testFiles("sg.", 10, ".intervals");
-        List<GenomeLoc> locs = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(hg19MiniIntervalFile));
+        List<GenomeLoc> locs = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(TestResources.hg19MiniIntervalFile));
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(locs, files.size());
 
         int[] counts = {
@@ -617,12 +618,12 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         }
         //System.out.println(splitCounts.substring(2));
 
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
         int locIndex = 0;
         for (int i = 0; i < files.size(); i++) {
             String file = files.get(i).toString();
-            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(file));
+            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(file));
             Assert.assertEquals(parsedLocs.size(), counts[i], "Intervals in " + file);
             for (GenomeLoc parsedLoc: parsedLocs)
                 Assert.assertEquals(parsedLoc, locs.get(locIndex), String.format("Genome loc %d from file %d", locIndex++, i));
@@ -634,11 +635,11 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     public void testScatterFixedIntervalsMax() {
         List<File> files = testFiles("sg.", 4, ".intervals");
         List<List<GenomeLoc>> splits = IntervalUtils.splitFixedIntervals(hg19ReferenceLocs, files.size());
-        IntervalUtils.scatterFixedIntervals(hg19Header, splits, files);
+        IntervalUtils.scatterFixedIntervals(TestResources.getHg19Header(), splits, files);
 
         for (int i = 0; i < files.size(); i++) {
             String file = files.get(i).toString();
-            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(file));
+            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(file));
             Assert.assertEquals(parsedLocs.size(), 1, "parsedLocs[" + i + "].size()");
             Assert.assertEquals(parsedLocs.get(0), hg19ReferenceLocs.get(i), "parsedLocs[" + i + "].get()");
         }
@@ -647,17 +648,17 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterContigIntervalsOrder() {
         List<String> intervals = Arrays.asList("2:1-1", "1:1-1", "3:2-2");
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1:1-1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2:1-1");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3:2-2");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2:1-1");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3:2-2");
 
         List<File> files = testFiles("split.", 3, ".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs(intervals), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs(intervals), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -670,17 +671,17 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test
     public void testScatterContigIntervalsBasic() {
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3");
 
         List<File> files = testFiles("contig_basic.", 3, ".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs("1", "2", "3"), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs("1", "2", "3"), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -693,18 +694,18 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test
     public void testScatterContigIntervalsLessFiles() {
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3");
-        GenomeLoc chr4 = hg19GenomeLocParser.parseGenomeLoc("4");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3");
+        GenomeLoc chr4 = TestResources.getGenomeLocParser().parseGenomeLoc("4");
 
         List<File> files = testFiles("contig_less.", 3, ".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs("1", "2", "3", "4"), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs("1", "2", "3", "4"), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 2);
         Assert.assertEquals(locs2.size(), 1);
@@ -719,24 +720,24 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test(expectedExceptions=UserException.BadInput.class)
     public void testScatterContigIntervalsMoreFiles() {
         List<File> files = testFiles("contig_more.", 3, ".intervals");
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs("1", "2"), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs("1", "2"), files);
     }
 
     @Test
     public void testScatterContigIntervalsStart() {
         List<String> intervals = Arrays.asList("1:1-2", "1:4-5", "2:1-1", "3:2-2");
-        GenomeLoc chr1a = hg19GenomeLocParser.parseGenomeLoc("1:1-2");
-        GenomeLoc chr1b = hg19GenomeLocParser.parseGenomeLoc("1:4-5");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2:1-1");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3:2-2");
+        GenomeLoc chr1a = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-2");
+        GenomeLoc chr1b = TestResources.getGenomeLocParser().parseGenomeLoc("1:4-5");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2:1-1");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3:2-2");
 
         List<File> files = testFiles("contig_split_start.", 3, ".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs(intervals), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs(intervals), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 2);
         Assert.assertEquals(locs2.size(), 1);
@@ -751,18 +752,18 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterContigIntervalsMiddle() {
         List<String> intervals = Arrays.asList("1:1-1", "2:1-2", "2:4-5", "3:2-2");
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1:1-1");
-        GenomeLoc chr2a = hg19GenomeLocParser.parseGenomeLoc("2:1-2");
-        GenomeLoc chr2b = hg19GenomeLocParser.parseGenomeLoc("2:4-5");
-        GenomeLoc chr3 = hg19GenomeLocParser.parseGenomeLoc("3:2-2");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-1");
+        GenomeLoc chr2a = TestResources.getGenomeLocParser().parseGenomeLoc("2:1-2");
+        GenomeLoc chr2b = TestResources.getGenomeLocParser().parseGenomeLoc("2:4-5");
+        GenomeLoc chr3 = TestResources.getGenomeLocParser().parseGenomeLoc("3:2-2");
 
         List<File> files = testFiles("contig_split_middle.", 3, ".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs(intervals), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs(intervals), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 2);
@@ -777,18 +778,18 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterContigIntervalsEnd() {
         List<String> intervals = Arrays.asList("1:1-1", "2:2-2", "3:1-2", "3:4-5");
-        GenomeLoc chr1 = hg19GenomeLocParser.parseGenomeLoc("1:1-1");
-        GenomeLoc chr2 = hg19GenomeLocParser.parseGenomeLoc("2:2-2");
-        GenomeLoc chr3a = hg19GenomeLocParser.parseGenomeLoc("3:1-2");
-        GenomeLoc chr3b = hg19GenomeLocParser.parseGenomeLoc("3:4-5");
+        GenomeLoc chr1 = TestResources.getGenomeLocParser().parseGenomeLoc("1:1-1");
+        GenomeLoc chr2 = TestResources.getGenomeLocParser().parseGenomeLoc("2:2-2");
+        GenomeLoc chr3a = TestResources.getGenomeLocParser().parseGenomeLoc("3:1-2");
+        GenomeLoc chr3b = TestResources.getGenomeLocParser().parseGenomeLoc("3:4-5");
 
         List<File> files = testFiles("contig_split_end.", 3 ,".intervals");
 
-        IntervalUtils.scatterContigIntervals(hg19Header, intervalStringsToGenomeLocs(intervals), files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), TestResources.intervalStringsToGenomeLocs(intervals), files);
 
-        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(0).toString()));
-        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(1).toString()));
-        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(files.get(2).toString()));
+        List<GenomeLoc> locs1 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(0).toString()));
+        List<GenomeLoc> locs2 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(1).toString()));
+        List<GenomeLoc> locs3 = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(files.get(2).toString()));
 
         Assert.assertEquals(locs1.size(), 1);
         Assert.assertEquals(locs2.size(), 1);
@@ -803,11 +804,11 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @Test
     public void testScatterContigIntervalsMax() {
         List<File> files = testFiles("sg.", 4, ".intervals");
-        IntervalUtils.scatterContigIntervals(hg19Header, hg19ReferenceLocs, files);
+        IntervalUtils.scatterContigIntervals(TestResources.getHg19Header(), hg19ReferenceLocs, files);
 
         for (int i = 0; i < files.size(); i++) {
             String file = files.get(i).toString();
-            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Arrays.asList(file));
+            List<GenomeLoc> parsedLocs = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Arrays.asList(file));
             Assert.assertEquals(parsedLocs.size(), 1, "parsedLocs[" + i + "].size()");
             Assert.assertEquals(parsedLocs.get(0), hg19ReferenceLocs.get(i), "parsedLocs[" + i + "].get()");
         }
@@ -831,7 +832,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test(dataProvider="unmergedIntervals")
     public void testUnmergedIntervals(String unmergedIntervals) {
-        List<GenomeLoc> locs = IntervalUtils.parseIntervalArguments(hg19GenomeLocParser, Collections.singletonList(publicTestDir + unmergedIntervals));
+        List<GenomeLoc> locs = IntervalUtils.parseIntervalArguments(TestResources.getGenomeLocParser(), Collections.singletonList(TestResources.publicTestDir + unmergedIntervals));
         Assert.assertEquals(locs.size(), 2);
 
         List<GenomeLoc> merged;
@@ -921,7 +922,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @DataProvider(name="invalidIntervalTestData")
     public Object[][] invalidIntervalDataProvider() throws Exception {
-        File fastaFile = new File(publicTestDir + "exampleFASTA.fasta");
+        File fastaFile = new File(TestResources.publicTestDir + "exampleFASTA.fasta");
         GenomeLocParser genomeLocParser = new GenomeLocParser(new IndexedFastaSequenceFile(fastaFile));
 
         return new Object[][] {
@@ -934,7 +935,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     // TODO - remove once a corrected version of the exome interval list is released.
     @DataProvider(name="negativeOneLengthIntervalTestData")
     public Object[][] negativeOneLengthIntervalDataProvider() throws Exception {
-        File fastaFile = new File(publicTestDir + "exampleFASTA.fasta");
+        File fastaFile = new File(TestResources.publicTestDir + "exampleFASTA.fasta");
         GenomeLocParser genomeLocParser = new GenomeLocParser(new IndexedFastaSequenceFile(fastaFile));
 
         return new Object[][] {
@@ -953,18 +954,18 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     @DataProvider(name = "sortAndMergeIntervals")
     public Object[][] getSortAndMergeIntervals() {
         return new Object[][] {
-                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, intervalStringsToGenomeLocs("1:1", "1:3", "1:2"), intervalStringsToGenomeLocs("1:1", "1:2", "1:3") },
-                new Object[] { IntervalMergingRule.ALL, intervalStringsToGenomeLocs("1:1", "1:3", "1:2"), intervalStringsToGenomeLocs("1:1-3") },
-                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, intervalStringsToGenomeLocs("1:1", "1:3", "2:2"), intervalStringsToGenomeLocs("1:1", "1:3", "2:2") },
-                new Object[] { IntervalMergingRule.ALL, intervalStringsToGenomeLocs("1:1", "1:3", "2:2"), intervalStringsToGenomeLocs("1:1", "1:3", "2:2") },
-                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, intervalStringsToGenomeLocs("1:1", "1"), intervalStringsToGenomeLocs("1") },
-                new Object[] { IntervalMergingRule.ALL, intervalStringsToGenomeLocs("1:1", "1"), intervalStringsToGenomeLocs("1") }
+                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "1:2"), TestResources.intervalStringsToGenomeLocs("1:1", "1:2", "1:3") },
+                new Object[] { IntervalMergingRule.ALL, TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "1:2"), TestResources.intervalStringsToGenomeLocs("1:1-3") },
+                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "2:2"), TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "2:2") },
+                new Object[] { IntervalMergingRule.ALL, TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "2:2"), TestResources.intervalStringsToGenomeLocs("1:1", "1:3", "2:2") },
+                new Object[] { IntervalMergingRule.OVERLAPPING_ONLY, TestResources.intervalStringsToGenomeLocs("1:1", "1"), TestResources.intervalStringsToGenomeLocs("1") },
+                new Object[] { IntervalMergingRule.ALL, TestResources.intervalStringsToGenomeLocs("1:1", "1"), TestResources.intervalStringsToGenomeLocs("1") }
         };
     }
 
     @Test(dataProvider = "sortAndMergeIntervals")
     public void testSortAndMergeIntervals(IntervalMergingRule merge, List<GenomeLoc> unsorted, List<GenomeLoc> expected) {
-        List<GenomeLoc> sorted = IntervalUtils.sortAndMergeIntervals(hg19GenomeLocParser, unsorted, merge).toList();
+        List<GenomeLoc> sorted = IntervalUtils.sortAndMergeIntervals(TestResources.getGenomeLocParser(), unsorted, merge).toList();
         Assert.assertEquals(sorted, expected);
     }
 
@@ -973,24 +974,24 @@ public final class IntervalUtilsUnitTest extends BaseTest {
         final String severalIntervals = "src/test/resources/org/broadinstitute/hellbender/utils/interval/example_intervals.list";
 
         return new Object[][]{
-                new Object[]{Arrays.asList("1:1-2"), IntervalSetRule.UNION, 0, intervalStringsToGenomeLocs("1:1-2")},
-                new Object[]{Arrays.asList("1:1-2", "2:1-2"), IntervalSetRule.UNION, 0, intervalStringsToGenomeLocs("1:1-2", "2:1-2")},
-                new Object[]{Arrays.asList("1:1-10", "1:5-15"), IntervalSetRule.UNION, 0, intervalStringsToGenomeLocs("1:1-15")},
-                new Object[]{Arrays.asList("1:1-10", "1:5-15"), IntervalSetRule.INTERSECTION, 0, intervalStringsToGenomeLocs("1:5-10")},
-                new Object[]{Arrays.asList("1:5-5"), IntervalSetRule.UNION, 5, intervalStringsToGenomeLocs("1:1-10")},
-                new Object[]{Arrays.asList(severalIntervals), IntervalSetRule.UNION, 0, intervalStringsToGenomeLocs("1:100-200", "2:20-30", "4:50")}
+                new Object[]{Arrays.asList("1:1-2"), IntervalSetRule.UNION, 0, TestResources.intervalStringsToGenomeLocs("1:1-2")},
+                new Object[]{Arrays.asList("1:1-2", "2:1-2"), IntervalSetRule.UNION, 0, TestResources.intervalStringsToGenomeLocs("1:1-2", "2:1-2")},
+                new Object[]{Arrays.asList("1:1-10", "1:5-15"), IntervalSetRule.UNION, 0, TestResources.intervalStringsToGenomeLocs("1:1-15")},
+                new Object[]{Arrays.asList("1:1-10", "1:5-15"), IntervalSetRule.INTERSECTION, 0, TestResources.intervalStringsToGenomeLocs("1:5-10")},
+                new Object[]{Arrays.asList("1:5-5"), IntervalSetRule.UNION, 5, TestResources.intervalStringsToGenomeLocs("1:1-10")},
+                new Object[]{Arrays.asList(severalIntervals), IntervalSetRule.UNION, 0, TestResources.intervalStringsToGenomeLocs("1:100-200", "2:20-30", "4:50")}
         };
     }
 
     @Test( dataProvider = "loadintervals")
     public void loadIntervalsTest(List<String> intervals, IntervalSetRule setRule, int padding, List<GenomeLoc> results){
-        GenomeLocSortedSet loadedIntervals = IntervalUtils.loadIntervals(intervals, setRule, IntervalMergingRule.ALL, padding, hg19GenomeLocParser);
+        GenomeLocSortedSet loadedIntervals = IntervalUtils.loadIntervals(intervals, setRule, IntervalMergingRule.ALL, padding, TestResources.getGenomeLocParser());
         Assert.assertEquals(loadedIntervals, results);
     }
 
     @DataProvider(name = "loadIntervalsFromFeatureFileData")
     public Object[][] loadIntervalsFromFeatureFileData() {
-        final List<GenomeLoc> expectedIntervals = intervalStringsToGenomeLocs("1:100-100", "1:203-206", "1:1000-1003", "2:200-200", "2:548-550", "4:776-779");
+        final List<GenomeLoc> expectedIntervals = TestResources.intervalStringsToGenomeLocs("1:100-100", "1:203-206", "1:1000-1003", "2:200-200", "2:548-550", "4:776-779");
 
         return new Object[][] {
                 { new File(INTERVAL_TEST_DATA + "intervals_from_features_test.vcf"), expectedIntervals },
@@ -1000,7 +1001,7 @@ public final class IntervalUtilsUnitTest extends BaseTest {
 
     @Test(dataProvider = "loadIntervalsFromFeatureFileData")
     public void testLoadIntervalsFromFeatureFile( final File featureFile, final List<GenomeLoc> expectedIntervals ) {
-        final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Arrays.asList(featureFile.getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Arrays.asList(featureFile.getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, TestResources.getGenomeLocParser());
         Assert.assertEquals(actualIntervals, expectedIntervals, "Wrong intervals loaded from Feature file " + featureFile.getAbsolutePath());
     }
 
@@ -1009,17 +1010,17 @@ public final class IntervalUtilsUnitTest extends BaseTest {
     // So we'll blow up with MalformedGenomeLoc and not anything related to files
     @Test(expectedExceptions = UserException.MalformedGenomeLoc.class)
     public void testLoadIntervalsFromNonExistentFile() {
-        IntervalUtils.loadIntervals(Arrays.asList(BaseTest.getSafeNonExistentFile("non_existent_file.vcf").getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(BaseTest.getSafeNonExistentFile("non_existent_file.vcf").getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, TestResources.getGenomeLocParser());
     }
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)
     public void testLoadIntervalsFromUnrecognizedFormatFile() {
-        IntervalUtils.loadIntervals(Arrays.asList(INTERVAL_TEST_DATA + "unrecognized_format_file.xyz"), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(INTERVAL_TEST_DATA + "unrecognized_format_file.xyz"), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, TestResources.getGenomeLocParser());
     }
 
     @Test(expectedExceptions = UserException.MalformedFile.class)
     public void loadIntervalsEmptyFile(){
-        IntervalUtils.loadIntervals(Arrays.asList(emptyIntervals), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(emptyIntervals), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, TestResources.getGenomeLocParser());
     }
 
     @Test(dataProvider = "genomeLocsFromLocatablesData",expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/org/broadinstitute/hellbender/utils/NGSPlatformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/NGSPlatformUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -31,7 +32,7 @@ public final class NGSPlatformUnitTest extends BaseTest {
     @BeforeClass
     public void setup() throws FileNotFoundException {
         // sequence
-        seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        seq = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleReference));
     }
 
     @DataProvider(name = "TestPrimary")

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -8,11 +8,10 @@ import com.google.common.primitives.Ints;
 import htsjdk.samtools.util.Log.LogLevel;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -345,7 +344,7 @@ public final class UtilsUnitTest extends BaseTest {
 
     @Test
     public void testCalcMD5() throws Exception {
-        final File source = new File(publicTestDir + "exampleFASTA.fasta");
+        final File source = new File(TestResources.publicTestDir + "exampleFASTA.fasta");
         final String sourceMD5 = "d0d4cbffece546c231fabd0103f54592";
 
         final byte[] sourceBytes = IOUtils.readFileIntoByteArray(source);

--- a/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileUnitTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -26,7 +27,7 @@ public class ActivityProfileUnitTest extends BaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(b37_reference_20_21));
+        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(TestResources.b37_reference_20_21));
         genomeLocParser = new GenomeLocParser(seq);
         startLoc = genomeLocParser.createGenomeLoc("20", 0, 1, 100);
         header = new SAMFileHeader();

--- a/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/BandPassActivityProfileUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/BandPassActivityProfileUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -30,7 +31,7 @@ public class BandPassActivityProfileUnitTest extends BaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(b37_reference_20_21));
+        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(TestResources.b37_reference_20_21));
         genomeLocParser = new GenomeLocParser(seq);
         header = new SAMFileHeader();
         seq.getSequenceDictionary().getSequences().forEach(sequence -> header.addSequence(sequence));

--- a/src/test/java/org/broadinstitute/hellbender/utils/baq/BAQUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/baq/BAQUnitTest.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -174,7 +175,7 @@ public final class BAQUnitTest extends BaseTest {
 
     @Test
     public void testBAQOverwritesExistingTagWithNull() {
-        final File referenceFile = new File(hg19_chr1_1M_Reference);
+        final File referenceFile = new File(TestResources.hg19_chr1_1M_Reference);
         final ReferenceDataSource rds = new ReferenceFileSource(referenceFile);
 
         // create a read with a single base off the end of the contig, which cannot be BAQed

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -4,13 +4,11 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileHeader;
-import org.broadinstitute.hellbender.tools.walkers.rnaseq.OverhangFixingManager;
-import org.broadinstitute.hellbender.tools.walkers.rnaseq.SplitNCigarReads;
-import org.broadinstitute.hellbender.tools.walkers.rnaseq.SplitNCigarReadsUnitTest;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.ReadClipperTestUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -412,7 +410,7 @@ public final class ReadClipperUnitTest extends BaseTest {
     @Test
     public void testSoftClippingOpEdgeCase() {
         final SAMFileHeader header = new SAMFileHeader();
-        header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+        header.setSequenceDictionary(TestResources.getGenomeLocParser().getSequenceDictionary());
 
         GATKRead read = ReadClipperTestUtils.makeReadFromCigar("8M");
         ReadClipper clipper = new ReadClipper(read);

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/TargetCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/TargetCodecUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.codecs;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,7 +13,7 @@ public class TargetCodecUnitTest extends BaseTest {
     @Test
     public void testTargetCodecCanDecodeFileURIs() {
         final TargetCodec codec = new TargetCodec();
-        final String tsvURI = new File(publicTestDir + "org/broadinstitute/hellbender/tools/exome/targets.tsv").toURI().toString();
+        final String tsvURI = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/targets.tsv").toURI().toString();
         Assert.assertTrue(tsvURI.startsWith("file:"));
         Assert.assertTrue(codec.canDecode(tsvURI), "TargetCodec should be able to decode file URIs");
     }
@@ -20,7 +21,7 @@ public class TargetCodecUnitTest extends BaseTest {
     @Test
     public void testTargetCodecCanDecodeAbsoluteFilePath() {
         final TargetCodec codec = new TargetCodec();
-        final String tsvPath = new File(publicTestDir + "org/broadinstitute/hellbender/tools/exome/targets.tsv").getAbsolutePath();
+        final String tsvPath = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/exome/targets.tsv").getAbsolutePath();
         Assert.assertTrue(codec.canDecode(tsvPath), "TargetCodec should be able to decode absolute file paths");
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFileUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFileUnitTest.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,7 +26,7 @@ import java.util.List;
  * Basic unit test for CachingIndexedFastaSequenceFile
  */
 public final class CachingIndexedFastaSequenceFileUnitTest extends BaseTest {
-    private File simpleFasta = new File(publicTestDir + "/exampleFASTA.fasta");
+    private File simpleFasta = new File(TestResources.publicTestDir + "/exampleFASTA.fasta");
     private static final int STEP_SIZE = 1;
     private final static boolean DEBUG = false;
 
@@ -140,9 +141,9 @@ public final class CachingIndexedFastaSequenceFileUnitTest extends BaseTest {
     // make sure some bases are lower case and some are upper case
     @Test
     public void testMixedCasesInExample() throws FileNotFoundException, InterruptedException {
-        final IndexedFastaSequenceFile original = new IndexedFastaSequenceFile(new File(exampleFASTA));
-        final CachingIndexedFastaSequenceFile casePreserving = new CachingIndexedFastaSequenceFile(new File(exampleFASTA), true);
-        final CachingIndexedFastaSequenceFile allUpper = new CachingIndexedFastaSequenceFile(new File(exampleFASTA));
+        final IndexedFastaSequenceFile original = new IndexedFastaSequenceFile(new File(TestResources.exampleFASTA));
+        final CachingIndexedFastaSequenceFile casePreserving = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleFASTA), true);
+        final CachingIndexedFastaSequenceFile allUpper = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleFASTA));
 
         int nMixedCase = 0;
         for ( SAMSequenceRecord contig : original.getSequenceDictionary().getSequences() ) {
@@ -184,7 +185,7 @@ public final class CachingIndexedFastaSequenceFileUnitTest extends BaseTest {
 
     @Test
     public void testIupacChanges() throws FileNotFoundException, InterruptedException {
-        final String testFasta = publicTestDir + "iupacFASTA.fasta";
+        final String testFasta = TestResources.publicTestDir + "iupacFASTA.fasta";
         final CachingIndexedFastaSequenceFile iupacPreserving = new CachingIndexedFastaSequenceFile(new File(testFasta), CachingIndexedFastaSequenceFile.DEFAULT_CACHE_SIZE, false, true);
         final CachingIndexedFastaSequenceFile makeNs = new CachingIndexedFastaSequenceFile(new File(testFasta));
 
@@ -203,7 +204,7 @@ public final class CachingIndexedFastaSequenceFileUnitTest extends BaseTest {
 
     @Test(expectedExceptions = {UserException.class})
     public void testFailOnBadBase() throws FileNotFoundException, InterruptedException {
-        final String testFasta = publicTestDir + "problematicFASTA.fasta";
+        final String testFasta = TestResources.publicTestDir + "problematicFASTA.fasta";
         final CachingIndexedFastaSequenceFile fasta = new CachingIndexedFastaSequenceFile(new File(testFasta));
 
         for ( SAMSequenceRecord contig : fasta.getSequenceDictionary().getSequences() ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gcs/BucketUtilsTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -55,7 +56,7 @@ public final class BucketUtilsTest extends BaseTest {
 
     @Test
     public void testCopyLocal() throws IOException {
-        final String src = publicTestDir+"empty.vcf";
+        final String src = TestResources.publicTestDir+"empty.vcf";
         File dest = createTempFile("copy-empty",".vcf");
 
         BucketUtils.copyFile(src, dest.getPath());
@@ -74,7 +75,7 @@ public final class BucketUtilsTest extends BaseTest {
 
     @Test(groups={"bucket"})
     public void testCopyAndDeleteGCS() throws IOException, GeneralSecurityException {
-        final String src = publicTestDir + "empty.vcf";
+        final String src = TestResources.publicTestDir + "empty.vcf";
         File dest = createTempFile("copy-empty", ".vcf");
         final String intermediate = BucketUtils.randomRemotePath(getGCPTestStaging(), "test-copy-empty", ".vcf");
         Assert.assertTrue(BucketUtils.isCloudStorageUrl(intermediate), "!BucketUtils.isCloudStorageUrl(intermediate)");
@@ -95,7 +96,7 @@ public final class BucketUtilsTest extends BaseTest {
 
     @Test
     public void testCopyAndDeleteHDFS() throws Exception {
-        final String src = publicTestDir + "empty.vcf";
+        final String src = TestResources.publicTestDir + "empty.vcf";
         File dest = createTempFile("copy-empty", ".vcf");
 
         MiniClusterUtils.runOnIsolatedMiniCluster( cluster -> {

--- a/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.core.util.FileUtils;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -142,7 +143,7 @@ public final class IOUtilsUnitTest extends BaseTest {
         //It runs at jvm shutdown so there isn't a good way to test it properly.
         //If you see a directory in the hellbender main folder called
 
-        final File dir = new File(BaseTest.publicTestDir + "I_SHOULD_HAVE_BEEN_DELETED");
+        final File dir = new File(TestResources.publicTestDir + "I_SHOULD_HAVE_BEEN_DELETED");
         IOUtils.deleteRecursivelyOnExit(dir);
 
         FileUtils.mkdir(dir, true);
@@ -174,8 +175,8 @@ public final class IOUtilsUnitTest extends BaseTest {
     @Test(groups={"bucket"})
     public void testGetPath() throws IOException {
         innerTestGetPath(getGCPTestInputPath() + "large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam");
-        innerTestGetPath("file://" + NA12878_20_21_WGS_bam);
-        innerTestGetPath(NA12878_20_21_WGS_bam);
+        innerTestGetPath("file://" + TestResources.NA12878_20_21_WGS_bam);
+        innerTestGetPath(TestResources.NA12878_20_21_WGS_bam);
     }
 
     private void innerTestGetPath(String s) throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/SamReaderQueryingIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/SamReaderQueryingIteratorUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.utils.iterators;
 import htsjdk.samtools.*;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -12,22 +13,21 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SamReaderQueryingIteratorUnitTest extends BaseTest {
 
     @DataProvider(name = "SamReaderQueryingIteratorTestData")
     public Object[][] samReaderQueryingIteratorTestData() {
         // This bam has only mapped reads
-        final File mappedBam = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File mappedBam = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
 
         // This bam has mapped reads from various contigs, plus a few unmapped reads with no mapped mate
-        final File unmappedBam = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
+        final File unmappedBam = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1_with_unmapped.bam");
 
         // This is a snippet of the CEUTrio.HiSeq.WGS.b37.NA12878 bam from large, with mapped reads
         // from chromosome 20 (with one mapped read having an unmapped mate), plus several unmapped
         // reads with no mapped mate.
-        final File ceuSnippet = new File(publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
+        final File ceuSnippet = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/CEUTrio.HiSeq.WGS.b37.NA12878.snippet_with_unmapped.bam");
 
         return new Object[][] {
                 // One interval, no unmapped

--- a/src/test/java/org/broadinstitute/hellbender/utils/mcmc/GibbsSamplerCopyRatioUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/mcmc/GibbsSamplerCopyRatioUnitTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class GibbsSamplerCopyRatioUnitTest extends BaseTest {
-    private static final String TEST_SUB_DIR = publicTestDir + "org/broadinstitute/hellbender/utils/mcmc/";
+    private static final String TEST_SUB_DIR = TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/mcmc/";
 
     private static final File COVERAGES_FILE =
             new File(TEST_SUB_DIR, "coverages-for-gibbs-sampler-copy-ratio-test.txt");

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
@@ -8,23 +8,22 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.text.parsers.BasicInputParser;
 import org.testng.Assert;
 import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.*;
 
 public final class VectorPairHMMUnitTest extends BaseTest {
 
-    private static final String pairHMMTestData = publicTestDir + "pairhmm-testdata.txt";
+    private static final String pairHMMTestData = TestResources.publicTestDir + "pairhmm-testdata.txt";
 
     // Return a list of supported VectorLoglessPairHMM implementations, skip the test if none are supported
     private List<Pair<PairHMM, Boolean> > getHMMs() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/HeaderlessSAMRecordCoordinateComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/HeaderlessSAMRecordCoordinateComparatorUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -23,7 +24,7 @@ public class HeaderlessSAMRecordCoordinateComparatorUnitTest extends BaseTest {
         // in the test below will fail if our ordering of these reads relative to the mapped reads
         // is not consistent with the definition of coordinate sorting as defined in
         // htsjdk.samtools.SAMRecordCoordinateComparator
-        final String inputBam = publicTestDir + "org/broadinstitute/hellbender/tools/BQSR/CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
+        final String inputBam = TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/BQSR/CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
         final List<SAMRecord> originalReads = new ArrayList<>();
         final List<SAMRecord> headerlessReads = new ArrayList<>();
         SAMFileHeader header = null;

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
@@ -2,13 +2,12 @@ package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
-import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,7 +27,7 @@ public final class ReadCoordinateComparatorUnitTest extends BaseTest{
         // unmapped reads with no position -- the ordering check in the test below will fail if
         // our ordering of these reads relative to the mapped reads is not consistent with the
         // definition of coordinate sorting as defined in htsjdk.samtools.SAMRecordCoordinateComparator
-        final String inputBam = publicTestDir + "org/broadinstitute/hellbender/utils/read/comparator_test_with_unmapped.bam";
+        final String inputBam = TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/read/comparator_test_with_unmapped.bam";
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header = null;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -16,6 +16,7 @@ import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -205,7 +206,7 @@ public final class ReadUtilsUnitTest extends BaseTest {
     @Test
     public void testReadWithNsRefIndexInDeletion() throws FileNotFoundException {
 
-        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleReference));
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
         final int readLength = 76;
 
@@ -221,7 +222,7 @@ public final class ReadUtilsUnitTest extends BaseTest {
     @Test
     public void testReadWithNsRefAfterDeletion() throws FileNotFoundException {
 
-        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(TestResources.exampleReference));
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
         final int readLength = 76;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationReportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationReportUnitTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.utils.recalibration.covariates.*;
 import org.broadinstitute.hellbender.utils.report.GATKReport;
 import org.broadinstitute.hellbender.utils.report.GATKReportTable;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,7 +24,7 @@ import java.util.*;
 
 public final class RecalibrationReportUnitTest extends BaseTest {
 
-    private static final String testDir = BaseTest.publicTestDir + "/org/broadinstitute/hellbender/utils/recalibration/";
+    private static final String testDir = TestResources.publicTestDir + "/org/broadinstitute/hellbender/utils/recalibration/";
     private static final File recal1 = new File(testDir + "HiSeq.1mb.1RG.sg1.table");
     private static final File recal2 = new File(testDir + "HiSeq.1mb.1RG.sg2.table");
     private static final File recal3 = new File(testDir + "HiSeq.1mb.1RG.sg3.table");
@@ -144,7 +145,7 @@ public final class RecalibrationReportUnitTest extends BaseTest {
 
     @Test(expectedExceptions = UserException.class)
     public void testUnsupportedCovariates(){
-        File file = new File(publicTestDir + "org/broadinstitute/hellbender/tools/" + "unsupported-covariates.table.gz");
+        File file = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/tools/" + "unsupported-covariates.table.gz");
         new RecalibrationReport(file);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -4,12 +4,10 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.annotations.DataProvider;
-
-import java.lang.reflect.Method;
-import java.util.*;
 
 import java.io.*;
 
@@ -18,7 +16,7 @@ public class ReferenceUtilsUnitTest extends BaseTest {
 
     @Test
     public void testLoadFastaDictionaryFromFile() {
-        final File referenceDictionaryFile = new File(ReferenceUtils.getFastaDictionaryFileName(hg19MiniReference));
+        final File referenceDictionaryFile = new File(ReferenceUtils.getFastaDictionaryFileName(TestResources.hg19MiniReference));
         final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryFile);
 
         Assert.assertNotNull(dictionary, "Sequence dictionary null after loading");
@@ -46,7 +44,7 @@ public class ReferenceUtilsUnitTest extends BaseTest {
 
     @Test
     public void testLoadFastaDictionaryFromStream() throws IOException {
-        try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(new File(ReferenceUtils.getFastaDictionaryFileName(hg19MiniReference))) ) {
+        try ( final ClosingAwareFileInputStream referenceDictionaryStream = new ClosingAwareFileInputStream(new File(ReferenceUtils.getFastaDictionaryFileName(TestResources.hg19MiniReference))) ) {
             final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);
 
             Assert.assertNotNull(dictionary, "Sequence dictionary null after loading");
@@ -61,8 +59,8 @@ public class ReferenceUtilsUnitTest extends BaseTest {
 
         // Trying to ingest a fasta file as a dict file to induce a MalformedFile Exception.
         return new Object[][] {
-                {hg19MiniReference, true},
-                {hg19MiniReference, false}
+                {TestResources.hg19MiniReference, true},
+                {TestResources.hg19MiniReference, false}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/report/GATKReportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/report/GATKReportUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.report;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -18,7 +19,7 @@ public final class GATKReportUnitTest extends BaseTest {
 
     @Test
     public void testParse() throws Exception {
-        String reportPath = publicTestDir + "exampleGATKReportv2.tbl";
+        String reportPath = TestResources.publicTestDir + "exampleGATKReportv2.tbl";
         GATKReport report = new GATKReport(reportPath);
         Assert.assertEquals(report.getVersion(), GATKReportVersion.V1_1);
         Assert.assertEquals(report.getTables().size(), 5);

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,9 +22,9 @@ public class SparkUtilsUnitTest extends BaseTest {
 
     @Test
     public void testConvertHeaderlessHadoopBamShardToBam() throws Exception {
-        final File bamShard = new File(publicTestDir + "org/broadinstitute/hellbender/utils/spark/reads_data_source_test1.bam.headerless.part-r-00000");
+        final File bamShard = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/spark/reads_data_source_test1.bam.headerless.part-r-00000");
         final File output = createTempFile("testConvertHadoopBamShardToBam", ".bam");
-        final File headerSource = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
+        final File headerSource = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
         final int expectedReadCount = 11;
 
         boolean shardIsNotValidBam = false;

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/IntegrationTestSpecUnitTest.java
@@ -42,13 +42,13 @@ public final class IntegrationTestSpecUnitTest extends BaseTest {
 
     @Test(expectedExceptions = AssertionError.class, dataProvider = "differentFilesButSameContent")
     public void compareFilesWithAndWithoutComments(final String f1, final String f2) throws IOException {
-        final String dir = publicTestDir + "org/broadinstitute/hellbender/utils/testing/";
+        final String dir = TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/testing/";
         IntegrationTestSpec.assertEqualTextFiles(new File(dir + f1), new File(dir + f2));
     }
 
     @Test(dataProvider = "differentFilesButSameContent")
     public void compareFilesWithAndWithoutComments_ignoreComments(final String f1, final String f2) throws IOException {
-        final String dir = publicTestDir + "org/broadinstitute/hellbender/utils/testing/";
+        final String dir = TestResources.publicTestDir + "org/broadinstitute/hellbender/utils/testing/";
         IntegrationTestSpec.assertEqualTextFiles(new File(dir + f1), new File(dir + f2), "#");
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/SamAssertionUtilsUnitTest.java
@@ -33,7 +33,7 @@ public final class SamAssertionUtilsUnitTest extends BaseTest{
         };
     }
 
-    private static final File TEST_DATA_DIR = new File(publicTestDir, "org/broadinstitute/hellbender/utils/test/SamAssertionUtilsUnitTest");
+    private static final File TEST_DATA_DIR = new File(TestResources.publicTestDir, "org/broadinstitute/hellbender/utils/test/SamAssertionUtilsUnitTest");
 
     @Test(dataProvider = "bamPairs")
     public void testCompareStringent(final String expectedFile, final String actualFile, boolean expectedEqual) throws Exception {

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.engine.FeatureManager;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAssignmentMethod;
 import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
@@ -1540,7 +1541,7 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
         for (final String chr : chrs )
             for (final int size : eventSizes )
                 for (final int starts : eventStarts ) {
-                    locs[nextIndex] = hg19GenomeLocParser.createGenomeLoc(chr,starts,starts + Math.max(0,size));
+                    locs[nextIndex] = TestResources.getGenomeLocParser().createGenomeLoc(chr,starts,starts + Math.max(0,size));
                     events[nextIndex++] = new VariantContextBuilder().source("test").loc(chr,starts,starts + Math.max(0,size)).alleles(Arrays.asList(
                             Allele.create(randomBases(size <= 0 ? 1 : size + 1, true), true), Allele.create(randomBases(size < 0 ? -size + 1 : 1, false), false))).make();
                 }
@@ -1757,7 +1758,7 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
     // https://github.com/broadinstitute/gatk/issues/2801.
     @Test
     public void testOnTheFlyTabixCreation() throws IOException {
-        final File inputGZIPFile = new File(publicTestDir + "org/broadinstitute/hellbender/engine/8_mutect2_sorted.vcf.gz");
+        final File inputGZIPFile = new File(TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/8_mutect2_sorted.vcf.gz");
         final File outputGZIPFile = createTempFile("testOnTheFlyTabixCreation", ".vcf.gz");
 
         long recordCount = 0;

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -14,7 +15,7 @@ import java.util.List;
 
 public class VariantContextVariantAdapterTest extends BaseTest {
 
-    private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = TestResources.publicTestDir + "org/broadinstitute/hellbender/engine/";
     private static final File QUERY_TEST_VCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "feature_data_source_test.vcf");
 
     @Test(dataProvider = "VariantDataProvider")

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/VcfUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/VcfUtilsUnitTest.java
@@ -6,6 +6,7 @@ import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderVersion;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.TestResources;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -20,10 +21,10 @@ public class VcfUtilsUnitTest extends BaseTest {
     @DataProvider(name = "testData")
     public Object[][] getInitialData() {
     return new Object[][] {
-            { createHeaderLines(), createSequenceDictonary(), new File(b37_reference_20_21), true,  "human_g1k_v37.20.21"},
+            { createHeaderLines(), createSequenceDictonary(), new File(TestResources.b37_reference_20_21), true,  "human_g1k_v37.20.21"},
             { createHeaderLines(), createSequenceDictonary(), null, true,  "human_g1k_v37.20.21"},
-            { createHeaderLines(), createSequenceDictonary(), new File(b37_reference_20_21), false,
-                    "file://" + new File(b37_reference_20_21).getAbsolutePath() }
+            { createHeaderLines(), createSequenceDictonary(), new File(TestResources.b37_reference_20_21), false,
+                    "file://" + new File(TestResources.b37_reference_20_21).getAbsolutePath() }
         };
     }
 


### PR DESCRIPTION
* Remove repo-specific files from `BaseTest` in favor of `TestResources` constants
* Remove `GenomeLocParser`initialization in `BaseTest` in favor of on-demand initialization in `TestResources` and getters for related objects.

Closes #3029 
Closes #2125