### PR TITLE
Enabled flush-to-zero by default and added option to disable. Address…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.5.2') {
+    compile('com.intel.gkl:gkl:0.5.3') {
         exclude module: 'htsjdk'
     }
 


### PR DESCRIPTION
…es #1572.

This commit also addresses #3069, by virtue of building against GKL 0.5.3, which pushes INFO and WARN messages to the Java logger.