### PR TITLE
Add default CharSet for retrieve bytes from String in GATKRead

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.util.*;
 
 /**
@@ -23,6 +24,8 @@ import java.util.*;
  */
 public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Serializable {
     private static final long serialVersionUID = 1L;
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
 
     private final Read genomicsRead;
 
@@ -544,7 +547,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead, Seri
         // Assume that byte array attributes are encoded as a single String in the first position of the List of values for an attribute,
         // and that the bytes of this String are directly convertible to byte array.
         final String rawValue = getRawAttributeValue(attributeName, "byte array");
-        return rawValue != null ? rawValue.getBytes() : null;
+        return rawValue != null ? rawValue.getBytes(DEFAULT_CHARSET) : null;
     }
 
     private void makeInfoMapIfNecessary() {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,8 @@ import java.util.Objects;
  */
 public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     private static final long serialVersionUID = 1L;
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
 
     private final SAMRecord samRecord;
 
@@ -523,7 +526,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
             return Arrays.copyOf(ret, ret.length);
         }
         else if ( attributeValue instanceof String ) {
-            return ((String)attributeValue).getBytes();
+            return ((String)attributeValue).getBytes(DEFAULT_CHARSET);
         }
         else {
             throw new GATKException.ReadAttributeTypeMismatch(attributeName, "byte array");


### PR DESCRIPTION
Currently, the GATKRead.getAttributeAsByteArray for a `String` attribute use the default CharSet, but it will be nice if the method sticks to a common representation by using a default charset. This PR adds a UTF-8 default encoding for this case in the GATKRead implementations to retrieve the bytes.