### PR TITLE
travis PR builds now use the correct commit in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ script:
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
     if [ ${TRAVIS_PULL_REQUEST} ]; then
-      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+      sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
     else
       sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,9 +121,9 @@ script:
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
     if [ ${TRAVIS_PULL_REQUEST} ]; then
-      echo " pr "
+      echo " pr ";
     else
-      secho " non pr"
+      echo " non pr";
     fi
     sudo docker images;
     echo ${TEST_TYPE};

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ jdk:
 - openjdk8
 env:
   matrix:
-  - TEST_TYPE=cloud
-  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
-  - TEST_TYPE=unit TEST_VERBOSITY=minimal
+#  - TEST_TYPE=cloud
+#  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
+#  - TEST_TYPE=unit TEST_VERBOSITY=minimal
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
-  - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
-  - RUN_CNV_SOMATIC_WDL=true
+#  - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
+#  - RUN_CNV_SOMATIC_WDL=true
   - RUN_M2_WDL=true
-  - RUN_CNV_GERMLINE_WDL=true
+#  - RUN_CNV_GERMLINE_WDL=true
   global:
   #gradle needs this
   - TERM=dumb

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,14 +118,12 @@ script:
     echo "Running M2 WDL";
     sudo bash scripts/m2_cromwell_tests/run_m2_wdl.sh;
   elif [[ $TEST_DOCKER == true ]]; then
-    echo "Building docker image and running appropriate unit tests..." ;
-    echo "${TRAVIS_BRANCH}" ;
-    HASH=`git rev-parse ${TRAVIS_BRANCH}`;
-    echo ${HASH};
-    sudo bash build_docker.sh  -e ${HASH} -s -u -d $PWD/temp_staging/;
+    echo "Building docker image and running appropriate tests..." ;
+    echo ${TRAVIS_COMMIT};
+    sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
     sudo docker images;
     echo ${TEST_TYPE};
-    sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${HASH} bash /root/run_unit_tests.sh;
+    sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${TRAVIS_COMMIT} bash /root/run_unit_tests.sh;
   else
     ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     travis_wait 50 ./gradlew jacocoTestReport;

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,9 +121,9 @@ script:
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
     if [ ${TRAVIS_PULL_REQUEST} ]; then
-      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+      echo " pr "
     else
-      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
+      secho " non pr"
     fi
     sudo docker images;
     echo ${TEST_TYPE};

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,11 @@ script:
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
-    sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
+    if [ ${TRAVIS_PULL_REQUEST} ]; then
+      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+    else
+      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
+    fi
     sudo docker images;
     echo ${TEST_TYPE};
     sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${TRAVIS_COMMIT} bash /root/run_unit_tests.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,15 +119,17 @@ script:
     sudo bash scripts/m2_cromwell_tests/run_m2_wdl.sh;
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Building docker image and running appropriate tests..." ;
-    echo ${TRAVIS_COMMIT};
     if [ ${TRAVIS_PULL_REQUEST} != false ]; then
       sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+      DOCKER_TAG=FETCH_HEAD;
     else
+      echo ${TRAVIS_COMMIT};
       sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
+      DOCKER_TAG=$TRAVIS_COMMIT;
     fi;
     sudo docker images;
     echo ${TEST_TYPE};
-    sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${TRAVIS_COMMIT} bash /root/run_unit_tests.sh;
+    sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${DOCKER_TAG} bash /root/run_unit_tests.sh;
   else
     ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     travis_wait 50 ./gradlew jacocoTestReport;

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,18 +113,18 @@ script:
     echo "Running CNV germline workflows";
     bash scripts/cnv_cromwell_tests/germline/run_cnv_germline_workflows.sh;
   elif [[ $RUN_M2_WDL == true ]]; then
-    echo "Deleting some unused files before running M2 WDL..."
-    rm -Rf src/test/resources/large/VQSR
+    echo "Deleting some unused files before running M2 WDL...";
+    rm -Rf src/test/resources/large/VQSR;
     echo "Running M2 WDL";
     sudo bash scripts/m2_cromwell_tests/run_m2_wdl.sh;
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
     if [ ${TRAVIS_PULL_REQUEST} ]; then
-      echo " pr ";
+      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
     else
-      echo " non pr";
-    fi
+      sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;
+    fi;
     sudo docker images;
     echo ${TEST_TYPE};
     sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${TRAVIS_COMMIT} bash /root/run_unit_tests.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ jdk:
 - openjdk8
 env:
   matrix:
-#  - TEST_TYPE=cloud
-#  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
-#  - TEST_TYPE=unit TEST_VERBOSITY=minimal
+  - TEST_TYPE=cloud
+  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
+  - TEST_TYPE=unit TEST_VERBOSITY=minimal
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
-#  - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
-#  - RUN_CNV_SOMATIC_WDL=true
+  - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
+  - RUN_CNV_SOMATIC_WDL=true
   - RUN_M2_WDL=true
-#  - RUN_CNV_GERMLINE_WDL=true
+  - RUN_CNV_GERMLINE_WDL=true
   global:
   #gradle needs this
   - TERM=dumb
@@ -120,7 +120,7 @@ script:
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Building docker image and running appropriate tests..." ;
     echo ${TRAVIS_COMMIT};
-    if [ ${TRAVIS_PULL_REQUEST} ]; then
+    if [ ${TRAVIS_PULL_REQUEST} != false ]; then
       sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
     else
       sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u -d $PWD/temp_staging/;

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -88,7 +88,7 @@ if [ -n "$STAGING_DIR" ]; then
     rm -Rf ${STAGING_DIR}/${STAGING_CLONE_DIR}
     set -e
     GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/${REPO}/${PROJECT}.git ${STAGING_DIR}/${STAGING_CLONE_DIR}
-    if [ -n ${PULL_REQUEST_NUMBER} ]; then
+    if [ ${PULL_REQUEST_NUMBER} ]; then
         GIT_FETCH_COMMAND="git fetch origin +refs/pull/${PULL_REQUEST_NUMBER}/merge"
         echo "${GIT_FETCH_COMMAND}"
         ${GIT_FETCH_COMMAND}

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -11,7 +11,7 @@ STAGING_CLONE_DIR=${PROJECT}_staging_temp
 #################################################
 # Parsing arguments
 #################################################
-while getopts "e:pslrud:" option; do
+while getopts "e:pslrud:t:" option; do
 	case "$option" in
 		e) GITHUB_TAG="$OPTARG" ;;
 		p) IS_PUSH=true ;;
@@ -20,6 +20,7 @@ while getopts "e:pslrud:" option; do
 		r) IS_NOT_REMOVE_UNIT_TEST_CONTAINER=true ;;
 		u) IS_NOT_RUN_UNIT_TESTS=true ;;
 		d) STAGING_DIR="$OPTARG" ;;
+		t) PULL_REQUEST_NUMBER="$OPTARG" ;;
 	esac
 done
 
@@ -35,7 +36,8 @@ Optional arguments:  \n \
 -d <STAGING_DIR> \t staging directory to grab code from repo and build the docker iamge.  If unspecified, then use whatever is in current dir (do not go to the repo).  NEVER SPECIFY YOUR WORKING DIR \n \
 -p \t (GATK4 developers only) push image to docker hub once complete.  This will use the GITHUB_TAG in dockerhub as well. \n \
 \t\t Unless -l is specified, this will also push this image to the 'latest' tag. \n \
--r \t (GATK4 developers only) Do not remove the unit test docker container.  This is useful for debugging failing unit tests. \n" $0
+-r \t (GATK4 developers only) Do not remove the unit test docker container.  This is useful for debugging failing unit tests. \n \
+-t <PULL_REQUEST_NUMBER>\t (Travis CI only) The pull request number.  This is only used during pull request builds on Travis CI. \n" $0
 	exit 1
 fi
 
@@ -64,7 +66,8 @@ echo "This is a git hash: ${IS_HASH}"
 echo "Push to dockerhub: ${IS_PUSH}"
 echo "Do NOT remove the unit test container: ${IS_NOT_REMOVE_UNIT_TEST_CONTAINER}"
 echo "Staging directory: ${STAGING_DIR}"
-echo -e "Do NOT make this the default docker image: ${IS_NOT_LATEST}\n\n\n"
+echo -e "Do NOT make this the default docker image: ${IS_NOT_LATEST}"
+echo -e "Fetch from this remote path: ${PULL_REQUEST_NUMBER}\n\n\n"
 
 # Login to dockerhub
 if [ -n "${IS_PUSH}" ]; then
@@ -85,6 +88,11 @@ if [ -n "$STAGING_DIR" ]; then
     rm -Rf ${STAGING_DIR}/${STAGING_CLONE_DIR}
     set -e
     GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/${REPO}/${PROJECT}.git ${STAGING_DIR}/${STAGING_CLONE_DIR}
+    if [ -n ${PULL_REQUEST_NUMBER} ]; then
+        GIT_FETCH_COMMAND="git fetch origin +refs/pull/${PULL_REQUEST_NUMBER}/merge"
+        echo "${GIT_FETCH_COMMAND}"
+        ${GIT_FETCH_COMMAND}
+    fi
     cd ${STAGING_DIR}/${STAGING_CLONE_DIR}
     echo "Now in ${PWD}"
     GIT_CHECKOUT_COMMAND="git checkout ${GITHUB_DIR}${GITHUB_TAG}"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -33,7 +33,7 @@ Optional arguments:  \n \
 -s \t The GITHUB_TAG (-e parameter) is actually a github hash, not tag.  git hashes cannot be pushed as latest, so -l is implied.  \n \
 -l \t Do not also push the image to the 'latest' tag. \n \
 -u \t Do not run the unit tests. \n \
--d <STAGING_DIR> \t staging directory to grab code from repo and build the docker iamge.  If unspecified, then use whatever is in current dir (do not go to the repo).  NEVER SPECIFY YOUR WORKING DIR \n \
+-d <STAGING_DIR> \t staging directory to grab code from repo and build the docker image.  If unspecified, then use whatever is in current dir (do not go to the repo).  NEVER SPECIFY YOUR WORKING DIR \n \
 -p \t (GATK4 developers only) push image to docker hub once complete.  This will use the GITHUB_TAG in dockerhub as well. \n \
 \t\t Unless -l is specified, this will also push this image to the 'latest' tag. \n \
 -r \t (GATK4 developers only) Do not remove the unit test docker container.  This is useful for debugging failing unit tests. \n \

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -88,13 +88,13 @@ if [ -n "$STAGING_DIR" ]; then
     rm -Rf ${STAGING_DIR}/${STAGING_CLONE_DIR}
     set -e
     GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/${REPO}/${PROJECT}.git ${STAGING_DIR}/${STAGING_CLONE_DIR}
-    if [ ${PULL_REQUEST_NUMBER} ]; then
-        GIT_FETCH_COMMAND="git fetch origin +refs/pull/${PULL_REQUEST_NUMBER}/merge"
-        echo "${GIT_FETCH_COMMAND}"
-        ${GIT_FETCH_COMMAND}
-    fi
     cd ${STAGING_DIR}/${STAGING_CLONE_DIR}
     echo "Now in ${PWD}"
+        if [ ${PULL_REQUEST_NUMBER} ]; then
+            GIT_FETCH_COMMAND="git fetch origin +refs/pull/${PULL_REQUEST_NUMBER}/merge"
+            echo "${GIT_FETCH_COMMAND}"
+            ${GIT_FETCH_COMMAND}
+        fi
     GIT_CHECKOUT_COMMAND="git checkout ${GITHUB_DIR}${GITHUB_TAG}"
     echo "${GIT_CHECKOUT_COMMAND}"
     ${GIT_CHECKOUT_COMMAND}

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -15,7 +15,7 @@ echo "Building docker without running unit tests... ========="
 cd $WORKING_DIR/gatk
 
 if [ ${TRAVIS_PULL_REQUEST} ]; then
-  sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+  sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
 else
   sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/;
 fi

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -8,15 +8,17 @@ WORKING_DIR=/home/travis/build/broadinstitute
 
 set -e
 echo "Building docker image for M2 WDL tests (skipping unit tests)..."
-HASH_TO_USE=$TRAVIS_COMMIT
+
 #cd $WORKING_DIR/gatk/scripts/docker/
 #assume Dockerfile is in root
 echo "Building docker without running unit tests... ========="
 cd $WORKING_DIR/gatk
 
 if [ ${TRAVIS_PULL_REQUEST} != false ]; then
+  HASH_TO_USE=FETCH_HEAD
   sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
 else
+  HASH_TO_USE=${TRAVIS_COMMIT}
   sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/;
 fi
 echo "Docker build done =========="

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -13,6 +13,13 @@ HASH_TO_USE=$TRAVIS_COMMIT
 #assume Dockerfile is in root
 echo "Building docker without running unit tests... ========="
 cd $WORKING_DIR/gatk
+
+if [ ${TRAVIS_PULL_REQUEST} ]; then
+  sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
+else
+  sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/;
+fi
+
 sudo bash build_docker.sh  -e $HASH_TO_USE -s -u -d $PWD/temp_staging/
 echo "Docker build done =========="
 echo "Putting the newly built docker image into the json parameters"

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -8,7 +8,7 @@ WORKING_DIR=/home/travis/build/broadinstitute
 
 set -e
 echo "Building docker image for M2 WDL tests (skipping unit tests)..."
-HASH_TO_USE=`git rev-parse ${TRAVIS_BRANCH}`
+HASH_TO_USE=$TRAVIS_COMMIT
 #cd $WORKING_DIR/gatk/scripts/docker/
 #assume Dockerfile is in root
 echo "Building docker without running unit tests... ========="

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -14,7 +14,7 @@ HASH_TO_USE=$TRAVIS_COMMIT
 echo "Building docker without running unit tests... ========="
 cd $WORKING_DIR/gatk
 
-if [ ${TRAVIS_PULL_REQUEST} ]; then
+if [ ${TRAVIS_PULL_REQUEST} != false ]; then
   sudo bash build_docker.sh  -e FETCH_HEAD -s -u -d $PWD/temp_staging/ -t ${TRAVIS_PULL_REQUEST};
 else
   sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/;

--- a/scripts/m2_cromwell_tests/run_m2_wdl.sh
+++ b/scripts/m2_cromwell_tests/run_m2_wdl.sh
@@ -19,8 +19,6 @@ if [ ${TRAVIS_PULL_REQUEST} != false ]; then
 else
   sudo bash build_docker.sh  -e ${HASH_TO_USE} -s -u -d $PWD/temp_staging/;
 fi
-
-sudo bash build_docker.sh  -e $HASH_TO_USE -s -u -d $PWD/temp_staging/
 echo "Docker build done =========="
 echo "Putting the newly built docker image into the json parameters"
 cd $WORKING_DIR/gatk/scripts/


### PR DESCRIPTION
Previously we had an issue where our travis builds would use the wrong
commit for the docker builds in the travis pull-request builds but not for the push
builds.

This caused the tests from master to run and usually pass.  However,
since we are mounting the test data from the correct commit into the
docker, this would result in confusing mismatches where old tests would
try to run on new test data.

Fixing the problem by using the $TRAVIS_COMMIT environment variable
instead of the TRAVIS_BRANCH.

fixes #3216