### PR TITLE
Fix GATKSAMRecordToGATKReadAdapter.getAttributeAsString for byte[]

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -507,7 +507,13 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     public String getAttributeAsString( final String attributeName ) {
         ReadUtils.assertAttributeNameIsLegal(attributeName);
         final Object attributeValue = samRecord.getAttribute(attributeName);
-
+        if ( attributeValue instanceof byte[]) {
+            // in case that the attribute is a byte[] array, the toString method will format it as name@hashCode
+            // for a good representation of the byte[] as String, it encodes the bytes with the default charset (UTF-8)
+            final byte[] val = (byte[]) attributeValue;
+            return (val.length == 0) ? "" : new String(val, DEFAULT_CHARSET);
+        }
+        // otherwise, just use the toString() method unless it is null
         return attributeValue != null ? attributeValue.toString() : null;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/GATKReadAdaptersUnitTest.java
@@ -1069,6 +1069,9 @@ public class GATKReadAdaptersUnitTest extends BaseTest {
         read.setAttribute("DR", "bar");
         Assert.assertEquals(read.getAttributeAsString("DR"), "bar", "Wrong value for attribute DR");
 
+        read.setAttribute("DR", new byte[] {'A', 'C', 'T', 'G'});
+        Assert.assertEquals(read.getAttributeAsString("DR"), "ACTG", "Wrong value for attribute DR");
+
         read.clearAttribute("DR");
         Assert.assertNull(read.getAttributeAsString("DR"), "Attribute DR should be null");
     }


### PR DESCRIPTION
For `byte[]` attributes, the `GATKSAMRecordToGATKReadAdapter.getAttributesAsString()` uses the default `Object.toString()` (className@hashCode). This is something unexpected for my point of view, because the following code may fail:

```java
public void testGATKReadGetAttributeAsString(final GATKRead read) {
    read.setAttribute("BC", new byte[]{'A', 'C', 'T', 'G'});
    // this will fail with the current implementation
    Assert.assertEquals(read.getAttributesAsString("BC").getBytes(Charset.forName("UTF-8")),
                        read.getAttributeAsByteArray("BC"));
}
```

This PR fixes the issue by identifying `byte[]` attributes and converting them to Strings by using the default GATKRead charset (UTF-8).