### PR TITLE
No more prepareReadLikelihoodsForAnnotation in Mutect

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerGenotypingEngine.java
@@ -201,7 +201,7 @@ public abstract class AssemblyBasedCallerGenotypingEngine extends GenotypingEngi
         }
 
         // Skim the filtered map based on the location so that we do not add filtered read that are going to be removed
-        // right after a few lines of code bellow.
+        // right after a few lines of code below.
         final Map<String, List<GATKRead>> overlappingFilteredReads = overlappingFilteredReads(perSampleFilteredReadList, loc);
 
         readAlleleLikelihoodsForAnnotations.addReads(overlappingFilteredReads,0);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -154,9 +154,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
 
             addGenotypes(subsettedLog10TumorMatrix, subsettedLog10NormalMatrix, callVcb);
             final VariantContext call = callVcb.make();
-            final ReadLikelihoods<Allele> log10LikelihoodsForAnotations = prepareReadAlleleLikelihoodsForAnnotation(log10ReadLikelihoods, Collections.emptyMap(),
-                    false, alleleMapper, log10Likelihoods, call);
-            final VariantContext annotatedCall =  annotationEngine.annotateContext(call, featureContext, referenceContext, log10LikelihoodsForAnotations, a -> true);
+            final VariantContext annotatedCall =  annotationEngine.annotateContext(call, featureContext, referenceContext, log10Likelihoods, a -> true);
 
             call.getAlleles().stream().map(alleleMapper::get).filter(Objects::nonNull).forEach(calledHaplotypes::addAll);
             returnCalls.add( annotatedCall );


### PR DESCRIPTION
This simplifies the code and didn't affect specificity in our validations.  @takutosato can you review this?