### PR TITLE
Fix a minor comment mistake in AlignmentContext

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AlignmentContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AlignmentContext.java
@@ -19,7 +19,7 @@ public final class AlignmentContext implements Locatable, HasGenomeLocation {
     // Definitions:
     //   COMPLETE = full alignment context
     //   FORWARD  = reads on forward strand
-    //   REVERSE  = reads on forward strand
+    //   REVERSE  = reads on reverse strand
     //
     public enum ReadOrientation { COMPLETE, FORWARD, REVERSE }
 


### PR DESCRIPTION
Hi, I found the following minor comment bug while looking into code.

   REVERSE  = reads on forward strand
-> REVERSE  = reads on reverse strand

Thanks!