### PR TITLE
Port VQSR model serialization and add data sampling

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSR.java
@@ -190,7 +190,7 @@ public class ApplyVQSR extends MultiVariantWalker {
     // Private Member Variables
     /////////////////////////////
     private VariantContextWriter vcfWriter;
-    final private List<Tranche> tranches = new ArrayList<>();
+    final private List<TruthSensitivityTranche> tranches = new ArrayList<>();
     final private Set<String> ignoreInputFilterSet = new TreeSet<>();
     final static private String listPrintSeparator = ",";
     final static private String trancheFilterString = "VQSRTranche";
@@ -209,7 +209,7 @@ public class ApplyVQSR extends MultiVariantWalker {
     public void onTraversalStart() {
         if( TS_FILTER_LEVEL != null ) {
             try {
-                for (final Tranche t : Tranche.readTranches(TRANCHES_FILE)) {
+                for (final TruthSensitivityTranche t : TruthSensitivityTranche.readTranches(TRANCHES_FILE)) {
                     if (t.targetTruthSensitivity >= TS_FILTER_LEVEL) {
                         tranches.add(t);
                     }
@@ -252,7 +252,7 @@ public class ApplyVQSR extends MultiVariantWalker {
 
             if( tranches.size() >= 2 ) {
                 for( int iii = 0; iii < tranches.size() - 1; iii++ ) {
-                    final Tranche t = tranches.get(iii);
+                    final TruthSensitivityTranche t = tranches.get(iii);
                     hInfo.add(new VCFFilterHeaderLine(t.name, String.format("Truth sensitivity tranche level for " + t.model.toString() + " model at VQS Lod: " + t.minVQSLod + " <= x < " + tranches.get(iii+1).minVQSLod)));
                 }
             }
@@ -444,7 +444,7 @@ public class ApplyVQSR extends MultiVariantWalker {
         String filterString = null;
         if( TS_FILTER_LEVEL != null ) {
             for( int i = tranches.size() - 1; i >= 0; i-- ) {
-                final Tranche tranche = tranches.get(i);
+                final TruthSensitivityTranche tranche = tranches.get(i);
                 if( lod >= tranche.minVQSLod ) {
                     if( i == tranches.size() - 1 ) {
                         filterString = VCFConstants.PASSES_FILTERS_v4;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranches.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranches.java
@@ -1,0 +1,85 @@
+package org.broadinstitute.hellbender.tools.walkers.vqsr;
+
+import htsjdk.samtools.util.IOUtil;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;
+
+@CommandLineProgramProperties(
+        summary = "Gathers scattered VQSLOD tranches into a single file. For use when running VariantRecalibrator on " +
+                "scattered input using the -scatterTranches mode.",
+        oneLineSummary = "Gathers scattered VQSLOD tranches into a single file",
+        programGroup = VariantProgramGroup.class
+)
+@DocumentedFeature
+public class GatherTranches extends CommandLineProgram {
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
+            shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc="List of scattered tranches files")
+    public final List<File> inputReports = new ArrayList<>();
+
+    /**
+     * Add truth sensitivity slices through the call set at the given values. The default values are 100.0, 99.9, 99.0, and 90.0
+     * which will result in 4 estimated tranches in the final call set: the full set of calls (100% sensitivity at the accessible
+     * sites in the truth set), a 99.9% truth sensitivity tranche, along with progressively smaller tranches at 99% and 90%.
+     */
+    @Argument(fullName="TStranche",
+            shortName="tranche",
+            doc="The levels of truth sensitivity at which to slice the data. (in percent, that is 1.0 for 1 percent)",
+            optional=true)
+    private List<Double> TS_TRANCHES = new ArrayList<>(Arrays.asList(100.0, 99.9, 99.0, 90.0));
+
+    /**
+     * Use either SNP for recalibrating only SNPs (emitting indels untouched in the output VCF) or INDEL for indels (emitting SNPs untouched in the output VCF). There is also a BOTH option for recalibrating both SNPs and indels simultaneously, but this is meant for testing purposes only and should not be used in actual analyses.
+     */
+    @Argument(fullName = "mode", shortName = "mode", doc = "Recalibration mode to employ", optional = false)
+    public VariantRecalibratorArgumentCollection.Mode MODE = VariantRecalibratorArgumentCollection.Mode.SNP;
+
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="File to output the gathered tranches file to")
+    public File outputReport;
+
+    private PrintStream tranchesStream;
+
+    @Override
+    protected Object doWork() {
+        inputReports.forEach(IOUtil::assertFileIsReadable);
+
+        try {
+            tranchesStream = new PrintStream(outputReport);
+        } catch (FileNotFoundException e) {
+            throw new UserException.CouldNotCreateOutputFile(outputReport, e);
+        }
+
+        //use a data structure to hold the tranches from each scatter shard in a format that's easy to merge
+        final Map<Double, List<VQSLODTranche>> scatteredTranches = new HashMap<>();
+        for (final File trancheFile : inputReports) {
+            try {
+                for (final VQSLODTranche currentTranche : VQSLODTranche.readTranches(trancheFile)) {
+                    if (scatteredTranches.containsKey(currentTranche.minVQSLod)) {
+                        scatteredTranches.get(currentTranche.minVQSLod).add(currentTranche);
+                    }
+                    else {
+                        scatteredTranches.put(currentTranche.minVQSLod, new ArrayList<>(Arrays.asList(currentTranche)));
+                    }
+                }
+            } catch (IOException e) {
+                throw new UserException.CouldNotReadInputFile(trancheFile, e);
+            }
+        }
+
+        tranchesStream.print(TruthSensitivityTranche.printHeader());
+        tranchesStream.print(Tranche.tranchesString(VQSLODTranche.mergeAndConvertTranches(scatteredTranches, TS_TRANCHES, MODE)));
+
+        return 0;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/Tranche.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/Tranche.java
@@ -1,33 +1,29 @@
 package org.broadinstitute.hellbender.tools.walkers.vqsr;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.text.XReadLines;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
-/*
- * Represents a truth sensitivity tranche in VQSR.
- * (Package-private because it's not usable outside.)
+/**
+ * Created by gauthier on 7/13/17.
  */
-final class Tranche {
-    private static final int CURRENT_VERSION = 5;
+public class Tranche {
 
-    private static final String DEFAULT_TRANCHE_NAME = "anonymous";
-    private static final String COMMENT_STRING = "#";
-    private static final String VALUE_SEPARATOR = ",";
-    private static final int EXPECTED_COLUMN_COUNT = 11;
+    protected static final String DEFAULT_TRANCHE_NAME = "anonymous";
+    protected static final String COMMENT_STRING = "#";
+    protected static final String VALUE_SEPARATOR = ",";
+    protected static final int EXPECTED_COLUMN_COUNT = 11;
 
-    static final Comparator<Tranche> TRUTH_SENSITIVITY_ORDER = (tranche1, tranche2) -> Double.compare(tranche1.targetTruthSensitivity, tranche2.targetTruthSensitivity);
-
-    private static final Logger logger = LogManager.getLogger(Tranche.class);
-
-    //Note: visibility is set to package-local for testing
-    final double targetTruthSensitivity;
+    protected final int accessibleTruthSites;
+    protected final int callsAtTruthSites;
     final double minVQSLod;  //minimum value of VQSLOD in this tranche
     final double knownTiTv;  //titv value of known sites in this tranche
     final double novelTiTv;  //titv value of novel sites in this tranche
@@ -36,37 +32,7 @@ final class Tranche {
     final VariantRecalibratorArgumentCollection.Mode model;
     final String name;       //Name of the tranche
 
-    private final int accessibleTruthSites;
-    private final int callsAtTruthSites;
-
-    public Tranche(
-            final double targetTruthSensitivity,
-            final double minVQSLod,
-            final int numKnown,
-            final double knownTiTv,
-            final int numNovel,
-            final double novelTiTv,
-            final int accessibleTruthSites,
-            final int callsAtTruthSites,
-            final VariantRecalibratorArgumentCollection.Mode model) {
-        this(targetTruthSensitivity, minVQSLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, callsAtTruthSites, model, "anonymous");
-    }
-
-    public Tranche(
-            final double targetTruthSensitivity,
-            final double minVQSLod,
-            final int numKnown,
-            final double knownTiTv,
-            final int numNovel,
-            final double novelTiTv,
-            final int accessibleTruthSites,
-            final int callsAtTruthSites,
-            final VariantRecalibratorArgumentCollection.Mode model,
-            final String name) {
-        if ( targetTruthSensitivity < 0.0 || targetTruthSensitivity > 100.0) {
-            throw new GATKException("Target FDR is unreasonable " + targetTruthSensitivity);
-        }
-
+    public Tranche(final String name, final double knownTiTv, final int numNovel, final double minVQSLod, final VariantRecalibratorArgumentCollection.Mode model, final double novelTiTv, final int accessibleTruthSites, final int numKnown, final int callsAtTruthSites) {
         if ( numKnown < 0 || numNovel < 0) {
             throw new GATKException("Invalid tranche - no. variants is < 0 : known " + numKnown + " novel " + numNovel);
         }
@@ -75,23 +41,30 @@ final class Tranche {
             throw new GATKException("BUG -- name cannot be null");
         }
 
-        this.targetTruthSensitivity = targetTruthSensitivity;
-        this.minVQSLod = minVQSLod;
-        this.novelTiTv = novelTiTv;
-        this.numNovel = numNovel;
-        this.knownTiTv = knownTiTv;
-        this.numKnown = numKnown;
-        this.model = model;
         this.name = name;
-
+        this.knownTiTv = knownTiTv;
+        this.numNovel = numNovel;
+        this.minVQSLod = minVQSLod;
+        this.model = model;
+        this.novelTiTv = novelTiTv;
         this.accessibleTruthSites = accessibleTruthSites;
+        this.numKnown = numKnown;
         this.callsAtTruthSites = callsAtTruthSites;
     }
 
-    @Override
-    public String toString() {
-        return String.format("Tranche targetTruthSensitivity=%.2f minVQSLod=%.4f known=(%d @ %.4f) novel=(%d @ %.4f) truthSites(%d accessible, %d called), name=%s]",
-                targetTruthSensitivity, minVQSLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, callsAtTruthSites, name);
+    public static class TrancheTruthSensitivityComparator implements Comparator<TruthSensitivityTranche> {
+        @Override
+        public int compare(final TruthSensitivityTranche tranche1, final TruthSensitivityTranche tranche2) {
+            return Double.compare(tranche1.targetTruthSensitivity, tranche2.targetTruthSensitivity);
+        }
+    }
+
+    public static class TrancheComparator<T extends Tranche> implements Comparator<T> {
+        @Override
+        public int compare(final T tranche1, final T tranche2) {
+            //no matter what type of tranche we have, we want the output in order of increasing sensitivity, as measured by calls at truth sites
+            return Double.compare(tranche1.callsAtTruthSites, tranche2.callsAtTruthSites);
+        }
     }
 
     /**
@@ -100,21 +73,15 @@ final class Tranche {
      * @param tranches
      * @return
      */
-    public static String tranchesString( final List<Tranche> tranches ) {
+    public static String tranchesString( final List<? extends Tranche> tranches ) {
         try (final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
              final PrintStream stream = new PrintStream(bytes)) {
             if( tranches.size() > 1 )
-                Collections.sort( tranches, new TrancheTruthSensitivityComparator() );
-
-            stream.println("# Variant quality score tranches file");
-            stream.println("# Version number " + CURRENT_VERSION);
-            stream.println("targetTruthSensitivity,numKnown,numNovel,knownTiTv,novelTiTv,minVQSLod,filterName,model,accessibleTruthSites,callsAtTruthSites,truthSensitivity");
+                Collections.sort( tranches, new TrancheComparator<>());
 
             Tranche prev = null;
             for ( Tranche t : tranches ) {
-                stream.printf("%.2f,%d,%d,%.4f,%.4f,%.4f,VQSRTranche%s%.2fto%.2f,%s,%d,%d,%.4f%n",
-                        t.targetTruthSensitivity, t.numKnown, t.numNovel, t.knownTiTv, t.novelTiTv, t.minVQSLod, t.model.toString(),
-                        (prev == null ? 0.0 : prev.targetTruthSensitivity), t.targetTruthSensitivity, t.model.toString(), t.accessibleTruthSites, t.callsAtTruthSites, t.getTruthSensitivity());
+                stream.printf(t.getTrancheString(prev));
                 prev = t;
             }
 
@@ -125,18 +92,56 @@ final class Tranche {
         }
     }
 
-    public static class TrancheTruthSensitivityComparator implements Comparator<Tranche> {
-        @Override
-        public int compare(final Tranche tranche1, final Tranche tranche2) {
-            return Double.compare(tranche1.targetTruthSensitivity, tranche2.targetTruthSensitivity);
+    public Double getTrancheIndex() {
+        return getTruthSensitivity();
+    }
+
+    public <T extends Tranche> String getTrancheString(final T prev) {
+            return String.format("%.2f,%d,%d,%.4f,%.4f,%.4f,VQSRTranche%s%.2fto%.2f,%s,%d,%d,%.4f%n",
+                    getTrancheIndex(), numKnown, numNovel, knownTiTv, novelTiTv, minVQSLod, model.toString(),
+                    (prev == null ? 0.0 : prev.getTrancheIndex()), getTrancheIndex(), model.toString(), accessibleTruthSites, callsAtTruthSites, getTruthSensitivity());
+
+    }
+
+    protected static Tranche trancheOfVariants(final List<VariantDatum> data, final int minI, final double ts, final VariantRecalibratorArgumentCollection.Mode model ) {
+        int numKnown = 0, numNovel = 0, knownTi = 0, knownTv = 0, novelTi = 0, novelTv = 0;
+
+        final double minLod = data.get(minI).lod;
+        for (final VariantDatum datum : data) {
+            if (datum.lod >= minLod) {
+                if (datum.isKnown) {
+                    numKnown++;
+                    if (datum.isSNP) {
+                        if (datum.isTransition) {
+                            knownTi++;
+                        } else {
+                            knownTv++;
+                        }
+                    }
+                } else {
+                    numNovel++;
+                    if (datum.isSNP) {
+                        if (datum.isTransition) {
+                            novelTi++;
+                        } else {
+                            novelTv++;
+                        }
+                    }
+                }
+            }
         }
+
+        final double knownTiTv = knownTi / Math.max(1.0 * knownTv, 1.0);
+        final double novelTiTv = novelTi / Math.max(1.0 * novelTv, 1.0);
+
+        final int accessibleTruthSites = VariantDatum.countCallsAtTruth(data, Double.NEGATIVE_INFINITY);
+        final int nCallsAtTruth = VariantDatum.countCallsAtTruth(data, minLod);
+
+        return new Tranche("unnamed", knownTiTv, numNovel, minLod, model, novelTiTv, accessibleTruthSites, numKnown, nCallsAtTruth);
     }
 
-    private double getTruthSensitivity() {
-        return accessibleTruthSites > 0 ? callsAtTruthSites / (1.0*accessibleTruthSites) : 0.0;
-    }
 
-    private static double getRequiredDouble(final Map<String,String> bindings, final String key ) {
+    protected static double getRequiredDouble(final Map<String, String> bindings, final String key) {
         if ( bindings.containsKey(key) ) {
             try {
                 return Double.valueOf(bindings.get(key));
@@ -148,7 +153,7 @@ final class Tranche {
         }
     }
 
-    private static double getOptionalDouble(final Map<String,String> bindings, String key, final double defaultValue ) {
+    protected static double getOptionalDouble(final Map<String, String> bindings, String key, final double defaultValue) {
         try{
             return Double.valueOf(bindings.getOrDefault(key, String.valueOf(defaultValue)));
         } catch (NumberFormatException e){
@@ -156,7 +161,7 @@ final class Tranche {
         }
     }
 
-    private static int getRequiredInteger(final Map<String,String> bindings, final String key) {
+    protected static int getRequiredInteger(final Map<String, String> bindings, final String key) {
         if ( bindings.containsKey(key) ) {
             try{
                 return Integer.valueOf(bindings.get(key));
@@ -168,7 +173,7 @@ final class Tranche {
         }
     }
 
-    private static int getOptionalInteger(final Map<String,String> bindings, final String key, final int defaultValue) {
+    protected static int getOptionalInteger(final Map<String, String> bindings, final String key, final int defaultValue) {
         try{
             return Integer.valueOf(bindings.getOrDefault(key, String.valueOf(defaultValue)));
         } catch (NumberFormatException e){
@@ -176,159 +181,7 @@ final class Tranche {
         }
     }
 
-    /**
-     * Returns a list of tranches, sorted from most to least specific, read in from file f.
-     * @throws IOException if there are problems reading the file.
-     */
-    public static List<Tranche> readTranches(final File f) throws IOException{
-        String[] header = null;
-        List<Tranche> tranches = new ArrayList<>();
-
-        try (XReadLines xrl = new XReadLines(f) ) {
-            for (final String line : xrl) {
-                if (line.startsWith(COMMENT_STRING)) {
-                    continue;
-                }
-
-                final String[] vals = line.split(VALUE_SEPARATOR);
-                if (header == null) {  //reading the header
-                    header = vals;
-                    if (header.length != EXPECTED_COLUMN_COUNT) {
-                        throw new UserException.MalformedFile(f, "Expected 11 elements in header line " + line);
-                    }
-                } else {
-                    if (header.length != vals.length) {
-                        throw new UserException.MalformedFile(f, "Line had too few/many fields.  Header = " + header.length + " vals " + vals.length + ". The line was: " + line);
-                    }
-
-                    Map<String, String> bindings = new LinkedHashMap<>();
-                    for (int i = 0; i < vals.length; i++) {
-                        bindings.put(header[i], vals[i]);
-                    }
-                    tranches.add(new Tranche(
-                            getRequiredDouble(bindings, "targetTruthSensitivity"),
-                            getRequiredDouble(bindings, "minVQSLod"),
-                            getOptionalInteger(bindings, "numKnown", -1),
-                            getOptionalDouble(bindings, "knownTiTv", -1.0),
-                            getRequiredInteger(bindings, "numNovel"),
-                            getRequiredDouble(bindings, "novelTiTv"),
-                            getOptionalInteger(bindings, "accessibleTruthSites", -1),
-                            getOptionalInteger(bindings, "callsAtTruthSites", -1),
-                            VariantRecalibratorArgumentCollection.Mode.valueOf(bindings.get("model")),
-                            bindings.get("filterName")));
-                }
-            }
-        }
-
-        tranches.sort(TRUTH_SENSITIVITY_ORDER);
-        return tranches;
+    protected double getTruthSensitivity() {
+        return accessibleTruthSites > 0 ? callsAtTruthSites / (1.0*accessibleTruthSites) : 0.0;
     }
-
-    @VisibleForTesting
-    static final class TruthSensitivityMetric {
-        private final String name;
-        private double[] runningSensitivity;
-        private final int nTrueSites;
-
-        public TruthSensitivityMetric(final int nTrueSites) {
-            this.name = "TruthSensitivity";
-            this.nTrueSites = nTrueSites;
-        }
-
-        public String getName(){
-            return name;
-        }
-
-        public double getThreshold(final double tranche) {
-            return 1.0 - tranche/100.0; // tranche of 1 => 99% sensitivity target
-        }
-
-        public void calculateRunningMetric(final List<VariantDatum> data) {
-            int nCalledAtTruth = 0;
-            runningSensitivity = new double[data.size()];
-
-            for ( int i = data.size() - 1; i >= 0; i-- ) {
-                VariantDatum datum = data.get(i);
-                nCalledAtTruth += datum.atTruthSite ? 1 : 0;
-                runningSensitivity[i] = 1 - nCalledAtTruth / (1.0 * nTrueSites);
-            }
-        }
-
-        public double getRunningMetric(final int i) {
-            return runningSensitivity[i];
-        }
-    }
-
-    public static List<Tranche> findTranches( final List<VariantDatum> data, final double[] trancheThresholds, final TruthSensitivityMetric metric, final VariantRecalibratorArgumentCollection.Mode model) {
-        logger.info(String.format("Finding %d tranches for %d variants", trancheThresholds.length, data.size()));
-
-        Collections.sort(data, VariantDatum.VariantDatumLODComparator);
-        metric.calculateRunningMetric(data);
-
-        List<Tranche> tranches = new ArrayList<>();
-        for ( double trancheThreshold : trancheThresholds ) {
-            Tranche t = findTranche(data, metric, trancheThreshold, model);
-
-            if ( t == null ) {
-                if (tranches.isEmpty()) {
-                    throw new UserException(String.format("Couldn't find any tranche containing variants with a %s > %.2f. Are you sure the truth files contain unfiltered variants which overlap the input data?", metric.getName(), metric.getThreshold(trancheThreshold)));
-                }
-                break;
-            }
-
-            tranches.add(t);
-        }
-
-        tranches.sort(Tranche.TRUTH_SENSITIVITY_ORDER);
-        return tranches;
-    }
-
-    private static Tranche findTranche( final List<VariantDatum> data, final TruthSensitivityMetric metric, final double trancheThreshold, final VariantRecalibratorArgumentCollection.Mode model ) {
-        logger.debug(String.format("  Tranche threshold %.2f => selection metric threshold %.3f", trancheThreshold, metric.getThreshold(trancheThreshold)));
-
-        double metricThreshold = metric.getThreshold(trancheThreshold);
-        int n = data.size();
-        for ( int i = 0; i < n; i++ ) {
-            if ( metric.getRunningMetric(i) >= metricThreshold ) {
-                // we've found the largest group of variants with sensitivity >= our target truth sensitivity
-                Tranche t = trancheOfVariants(data, i, trancheThreshold, model);
-                logger.debug(String.format("  Found tranche for %.3f: %.3f threshold starting with variant %d; running score is %.3f ",
-                        trancheThreshold, metricThreshold, i, metric.getRunningMetric(i)));
-                logger.debug(String.format("  Tranche is %s", t));
-                return t;
-            }
-        }
-
-        return null;
-    }
-
-    private static Tranche trancheOfVariants( final List<VariantDatum> data, int minI, double ts, final VariantRecalibratorArgumentCollection.Mode model ) {
-        int numKnown = 0, numNovel = 0, knownTi = 0, knownTv = 0, novelTi = 0, novelTv = 0;
-
-        double minLod = data.get(minI).lod;
-        for ( final VariantDatum datum : data ) {
-            if ( datum.lod >= minLod ) {
-                if ( datum.isKnown ) {
-                    numKnown++;
-                    if( datum.isSNP ) {
-                        if ( datum.isTransition ) { knownTi++; } else { knownTv++; }
-                    }
-                } else {
-                    numNovel++;
-                    if( datum.isSNP ) {
-                        if ( datum.isTransition ) { novelTi++; } else { novelTv++; }
-                    }
-                }
-            }
-        }
-
-        double knownTiTv = knownTi / Math.max(1.0 * knownTv, 1.0);
-        double novelTiTv = novelTi / Math.max(1.0 * novelTv, 1.0);
-
-        int accessibleTruthSites = VariantDatum.countCallsAtTruth(data, Double.NEGATIVE_INFINITY);
-        int nCallsAtTruth = VariantDatum.countCallsAtTruth(data, minLod);
-
-        return new Tranche(ts, minLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, nCallsAtTruth, model, DEFAULT_TRANCHE_NAME);
-    }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTranche.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTranche.java
@@ -1,0 +1,224 @@
+package org.broadinstitute.hellbender.tools.walkers.vqsr;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.text.XReadLines;
+
+import java.io.*;
+import java.util.*;
+
+/*
+ * Represents a truth sensitivity tranche in VQSR.
+ * (Package-private because it's not usable outside.)
+ */
+final class TruthSensitivityTranche extends Tranche {
+    private static final int CURRENT_VERSION = 5;
+
+    static final Comparator<TruthSensitivityTranche> TRUTH_SENSITIVITY_ORDER = (tranche1, tranche2) -> Double.compare(tranche1.targetTruthSensitivity, tranche2.targetTruthSensitivity);
+
+    private static final Logger logger = LogManager.getLogger(TruthSensitivityTranche.class);
+
+    //Note: visibility is set to package-local for testing
+    final double targetTruthSensitivity;
+
+    public TruthSensitivityTranche(
+            final double targetTruthSensitivity,
+            final double minVQSLod,
+            final int numKnown,
+            final double knownTiTv,
+            final int numNovel,
+            final double novelTiTv,
+            final int accessibleTruthSites,
+            final int callsAtTruthSites,
+            final VariantRecalibratorArgumentCollection.Mode model) {
+        this(targetTruthSensitivity, minVQSLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, callsAtTruthSites, model, "anonymous");
+    }
+
+    public TruthSensitivityTranche(
+            final double targetTruthSensitivity,
+            final double minVQSLod,
+            final int numKnown,
+            final double knownTiTv,
+            final int numNovel,
+            final double novelTiTv,
+            final int accessibleTruthSites,
+            final int callsAtTruthSites,
+            final VariantRecalibratorArgumentCollection.Mode model,
+            final String name) {
+        super(name, knownTiTv, numNovel, minVQSLod, model, novelTiTv, accessibleTruthSites, numKnown, callsAtTruthSites);
+        if ( targetTruthSensitivity < 0.0 || targetTruthSensitivity > 100.0) {
+            throw new GATKException("Target FDR is unreasonable " + targetTruthSensitivity);
+        }
+
+        if ( numKnown < 0 || numNovel < 0) {
+            throw new GATKException("Invalid tranche - no. variants is < 0 : known " + numKnown + " novel " + numNovel);
+        }
+
+        if ( name == null ) {
+            throw new GATKException("BUG -- name cannot be null");
+        }
+
+        this.targetTruthSensitivity = targetTruthSensitivity;
+
+    }
+
+    public Double getTrancheIndex() {
+        return targetTruthSensitivity;
+    }
+
+    public static String printHeader() {
+        try (final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+             final PrintStream stream = new PrintStream(bytes)) {
+
+            stream.println("# Variant quality score tranches file");
+            stream.println("# Version number " + CURRENT_VERSION);
+            stream.println("targetTruthSensitivity,numKnown,numNovel,knownTiTv,novelTiTv,minVQSLod,filterName,model,accessibleTruthSites,callsAtTruthSites,truthSensitivity");
+
+            return bytes.toString();
+        }
+        catch (IOException e) {
+            throw new GATKException("IOException while converting tranche to a string");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("TruthSensitivityTranche targetTruthSensitivity=%.2f minVQSLod=%.4f known=(%d @ %.4f) novel=(%d @ %.4f) truthSites(%d accessible, %d called), name=%s]",
+                targetTruthSensitivity, minVQSLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, callsAtTruthSites, name);
+    }
+
+    /**
+     * Returns a list of tranches, sorted from most to least specific, read in from file f.
+     * @throws IOException if there are problems reading the file.
+     */
+    public static List<TruthSensitivityTranche> readTranches(final File f) throws IOException{
+        String[] header = null;
+        List<TruthSensitivityTranche> tranches = new ArrayList<>();
+
+        try (XReadLines xrl = new XReadLines(f) ) {
+            for (final String line : xrl) {
+                if (line.startsWith(COMMENT_STRING)) {
+                    continue;
+                }
+
+                final String[] vals = line.split(VALUE_SEPARATOR);
+                if (header == null) {  //reading the header
+                    header = vals;
+                    if (header.length != EXPECTED_COLUMN_COUNT) {
+                        throw new UserException.MalformedFile(f, "Expected 11 elements in header line " + line);
+                    }
+                } else {
+                    if (header.length != vals.length) {
+                        throw new UserException.MalformedFile(f, "Line had too few/many fields.  Header = " + header.length + " vals " + vals.length + ". The line was: " + line);
+                    }
+
+                    Map<String, String> bindings = new LinkedHashMap<>();
+                    for (int i = 0; i < vals.length; i++) {
+                        bindings.put(header[i], vals[i]);
+                    }
+                    tranches.add(new TruthSensitivityTranche(
+                            getRequiredDouble(bindings, "targetTruthSensitivity"),
+                            getRequiredDouble(bindings, "minVQSLod"),
+                            getOptionalInteger(bindings, "numKnown", -1),
+                            getOptionalDouble(bindings, "knownTiTv", -1.0),
+                            getRequiredInteger(bindings, "numNovel"),
+                            getRequiredDouble(bindings, "novelTiTv"),
+                            getOptionalInteger(bindings, "accessibleTruthSites", -1),
+                            getOptionalInteger(bindings, "callsAtTruthSites", -1),
+                            VariantRecalibratorArgumentCollection.Mode.valueOf(bindings.get("model")),
+                            bindings.get("filterName")));
+                }
+            }
+        }
+
+        tranches.sort(TRUTH_SENSITIVITY_ORDER);
+        return tranches;
+    }
+
+    @VisibleForTesting
+    static final class TruthSensitivityMetric {
+        private final String name;
+        private double[] runningSensitivity;
+        private final int nTrueSites;
+
+        public TruthSensitivityMetric(final int nTrueSites) {
+            this.name = "TruthSensitivity";
+            this.nTrueSites = nTrueSites;
+        }
+
+        public String getName(){
+            return name;
+        }
+
+        public double getThreshold(final double tranche) {
+            return 1.0 - tranche/100.0; // tranche of 1 => 99% sensitivity target
+        }
+
+        public void calculateRunningMetric(final List<VariantDatum> data) {
+            int nCalledAtTruth = 0;
+            runningSensitivity = new double[data.size()];
+
+            for ( int i = data.size() - 1; i >= 0; i-- ) {
+                VariantDatum datum = data.get(i);
+                nCalledAtTruth += datum.atTruthSite ? 1 : 0;
+                runningSensitivity[i] = 1 - nCalledAtTruth / (1.0 * nTrueSites);
+            }
+        }
+
+        public double getRunningMetric(final int i) {
+            return runningSensitivity[i];
+        }
+    }
+
+    public static List<TruthSensitivityTranche> findTranches(final List<VariantDatum> data, final double[] trancheThresholds, final TruthSensitivityMetric metric, final VariantRecalibratorArgumentCollection.Mode model) {
+        logger.info(String.format("Finding %d tranches for %d variants", trancheThresholds.length, data.size()));
+
+        Collections.sort(data, VariantDatum.VariantDatumLODComparator);
+        metric.calculateRunningMetric(data);
+
+        List<TruthSensitivityTranche> tranches = new ArrayList<>();
+        for ( double trancheThreshold : trancheThresholds ) {
+            TruthSensitivityTranche t = findTranche(data, metric, trancheThreshold, model);
+
+            if ( t == null ) {
+                if (tranches.isEmpty()) {
+                    throw new UserException(String.format("Couldn't find any tranche containing variants with a %s > %.2f. Are you sure the truth files contain unfiltered variants which overlap the input data?", metric.getName(), metric.getThreshold(trancheThreshold)));
+                }
+                break;
+            }
+
+            tranches.add(t);
+        }
+
+        tranches.sort(TruthSensitivityTranche.TRUTH_SENSITIVITY_ORDER);
+        return tranches;
+    }
+
+    private static TruthSensitivityTranche findTranche(final List<VariantDatum> data, final TruthSensitivityMetric metric, final double trancheThreshold, final VariantRecalibratorArgumentCollection.Mode model ) {
+        logger.debug(String.format("  TruthSensitivityTranche threshold %.2f => selection metric threshold %.3f", trancheThreshold, metric.getThreshold(trancheThreshold)));
+
+        double metricThreshold = metric.getThreshold(trancheThreshold);
+        int n = data.size();
+        for ( int i = 0; i < n; i++ ) {
+            if ( metric.getRunningMetric(i) >= metricThreshold ) {
+                // we've found the largest group of variants with sensitivity >= our target truth sensitivity
+                TruthSensitivityTranche t = trancheOfVariants(data, i, trancheThreshold, model);
+                logger.debug(String.format("  Found tranche for %.3f: %.3f threshold starting with variant %d; running score is %.3f ",
+                        trancheThreshold, metricThreshold, i, metric.getRunningMetric(i)));
+                logger.debug(String.format("  TruthSensitivityTranche is %s", t));
+                return t;
+            }
+        }
+
+        return null;
+    }
+
+    protected static TruthSensitivityTranche trancheOfVariants(final List<VariantDatum> data, final int minI, final double ts, final VariantRecalibratorArgumentCollection.Mode model ) {
+        Tranche basicTranche = Tranche.trancheOfVariants(data, minI, ts, model);
+        return new TruthSensitivityTranche(ts, basicTranche.minVQSLod, basicTranche.numKnown, basicTranche.knownTiTv, basicTranche.numNovel, basicTranche.novelTiTv, basicTranche.accessibleTruthSites, basicTranche.callsAtTruthSites, model, DEFAULT_TRANCHE_NAME);
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VQSLODTranche.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VQSLODTranche.java
@@ -1,0 +1,200 @@
+package org.broadinstitute.hellbender.tools.walkers.vqsr;
+
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.text.XReadLines;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;
+
+import static java.lang.Math.abs;
+import static java.util.Collections.sort;
+
+/*
+ * Represents a VQSLOD tranche in VQSR for use in scattered VariantRecalibrator runs.
+ * (Package-private because it's not usable outside.)
+ */
+public class VQSLODTranche extends Tranche {
+    private static final int CURRENT_VERSION = 6;
+
+    public Double getTrancheIndex() {
+        return minVQSLod;
+    }
+
+    public VQSLODTranche(
+            final double minVQSLod,
+            final int numKnown,
+            final double knownTiTv,
+            final int numNovel,
+            final double novelTiTv,
+            final int accessibleTruthSites,
+            final int callsAtTruthSites,
+            final VariantRecalibratorArgumentCollection.Mode model,
+            final String name) {
+        super(name, knownTiTv, numNovel, minVQSLod, model, novelTiTv, accessibleTruthSites, numKnown, callsAtTruthSites);
+    }
+
+    public int compareTo(VQSLODTranche t) {
+        return (int)Math.round(t.minVQSLod - this.minVQSLod);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Tranche minVQSLod=%.4f known=(%d @ %.4f) novel=(%d @ %.4f) truthSites(%d accessible, %d called), name=%s]",
+                minVQSLod, numKnown, knownTiTv, numNovel, novelTiTv, accessibleTruthSites, callsAtTruthSites, name);
+    }
+
+    public static String printHeader() {
+        try (final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+             final PrintStream stream = new PrintStream(bytes)) {
+
+            stream.println("# Variant quality score tranches file");
+            stream.println("# Version number " + CURRENT_VERSION);
+            stream.println("requestedVQSLOD,numKnown,numNovel,knownTiTv,novelTiTv,minVQSLod,filterName,model,accessibleTruthSites,callsAtTruthSites,truthSensitivity");
+
+            return bytes.toString();
+        }
+        catch (IOException e) {
+            throw new GATKException("IOException while converting tranche to a string");
+        }
+    }
+
+    protected static VQSLODTranche trancheOfVariants(final List<VariantDatum> data, final int minI, final double trancheThreshold, final VariantRecalibratorArgumentCollection.Mode model ) {
+        Tranche basicTranche = Tranche.trancheOfVariants(data, minI, trancheThreshold, model);
+
+        //First column should be the requested threshold, not the value in the data closest to the threshold
+        return new VQSLODTranche(trancheThreshold, basicTranche.numKnown, basicTranche.knownTiTv, basicTranche.numNovel, basicTranche.novelTiTv, basicTranche.accessibleTruthSites, basicTranche.callsAtTruthSites, model, DEFAULT_TRANCHE_NAME);
+    }
+
+    /**
+     * Returns a list of tranches, sorted from most to least specific, read in from file f.
+     * @throws IOException if there are problems reading the file.
+     */
+    public static List<VQSLODTranche> readTranches(final File f) throws IOException{
+        String[] header = null;
+        List<VQSLODTranche> tranches = new ArrayList<>();
+
+        try (XReadLines xrl = new XReadLines(f) ) {
+            for (final String line : xrl) {
+                if (line.startsWith(COMMENT_STRING)) {
+                    if ( !line.contains("Version"))
+                        continue;
+                    else {
+                        String[] words = line.split("\\s+"); //split on whitespace
+                        if (Integer.parseInt(words[3]) != CURRENT_VERSION)
+                            throw new UserException.BadInput("The file " + " contains version " + words[3] + " tranches, but VQSLOD tranche parsing requires version " + CURRENT_VERSION);
+                        continue;
+                    }
+                }
+
+                final String[] vals = line.split(VALUE_SEPARATOR);
+                if (header == null) {  //reading the header
+                    header = vals;
+                    if (header.length != EXPECTED_COLUMN_COUNT) {
+                        throw new UserException.MalformedFile(f, "Expected " + EXPECTED_COLUMN_COUNT + " elements in header line " + line);
+                    }
+                } else {
+                    if (header.length != vals.length) {
+                        throw new UserException.MalformedFile(f, "Line had too few/many fields.  Header = " + header.length + " vals " + vals.length + ". The line was: " + line);
+                    }
+
+                    Map<String, String> bindings = new LinkedHashMap<>();
+                    for (int i = 0; i < vals.length; i++) {
+                        bindings.put(header[i], vals[i]);
+                    }
+                    tranches.add(new VQSLODTranche(
+                            getRequiredDouble(bindings, "minVQSLod"),
+                            getOptionalInteger(bindings, "numKnown", -1),
+                            getOptionalDouble(bindings, "knownTiTv", -1.0),
+                            getRequiredInteger(bindings, "numNovel"),
+                            getRequiredDouble(bindings, "novelTiTv"),
+                            getOptionalInteger(bindings, "accessibleTruthSites", -1),
+                            getOptionalInteger(bindings, "callsAtTruthSites", -1),
+                            VariantRecalibratorArgumentCollection.Mode.valueOf(bindings.get("model")),
+                            bindings.get("filterName")));
+                }
+            }
+        }
+
+        tranches.sort(new TrancheComparator<>());
+        return tranches;
+    }
+
+    public static List<TruthSensitivityTranche> mergeAndConvertTranches(final Map<Double, List<VQSLODTranche>> scatteredTranches, final List<Double> tsLevels, final VariantRecalibratorArgumentCollection.Mode mode) {
+        List<VQSLODTranche> mergedTranches = new ArrayList<>();
+        List<TruthSensitivityTranche> gatheredTranches = new ArrayList<>();
+
+        //make a list of merged tranches of the same length
+        for (final Double VQSLODlevel : scatteredTranches.keySet()) {
+            mergedTranches.add(mergeAndConvertTranches(scatteredTranches.get(VQSLODlevel),mode));
+        }
+
+        //go through the list of merged tranches to select those that match most closely the tsLevels
+        //don't assume tsLevels are sorted
+        sort(tsLevels);
+        //tranches should be sorted based on the file format and the fact that we read them into a list
+
+        ListIterator<Double> tsIter= tsLevels.listIterator();
+        double targetTS = tsIter.next();
+        double sensitivityDelta = 100.0; //initialize to 100%
+        double prevDelta;
+        ListIterator<VQSLODTranche> trancheIter = mergedTranches.listIterator();
+        VQSLODTranche currentTranche = trancheIter.next();
+        VQSLODTranche prevTranche;
+
+        //match the calculated tranches with the requested truth sensitivity outputs as best as possible
+        while (trancheIter.hasNext()) {  //we can only add tranches that we have and we should only add each at most once
+            prevDelta = sensitivityDelta;
+            prevTranche = currentTranche;
+            currentTranche = trancheIter.next();
+            sensitivityDelta = abs(targetTS - currentTranche.getTruthSensitivity()*100);
+            if (sensitivityDelta > prevDelta) {
+                gatheredTranches.add(new TruthSensitivityTranche(targetTS, prevTranche.minVQSLod, prevTranche.numKnown, prevTranche.knownTiTv, prevTranche.numNovel, prevTranche.novelTiTv, prevTranche.accessibleTruthSites, prevTranche.callsAtTruthSites, mode));
+                if (tsIter.hasNext()) {
+                    targetTS = tsIter.next();
+                    sensitivityDelta = abs(targetTS - currentTranche.getTruthSensitivity()*100);
+                }
+                else {
+                    break;
+                }
+            }
+            if ( !trancheIter.hasNext()) { //if we haven't seen the best match, but we ran out of tranches
+                gatheredTranches.add(new TruthSensitivityTranche(targetTS, currentTranche.minVQSLod, currentTranche.numKnown, currentTranche.knownTiTv, currentTranche.numNovel, currentTranche.novelTiTv, currentTranche.accessibleTruthSites, currentTranche.callsAtTruthSites, mode));
+            }
+        }
+
+        return gatheredTranches;
+    }
+
+    public static VQSLODTranche mergeAndConvertTranches(final List<VQSLODTranche> scatteredTranches, VariantRecalibratorArgumentCollection.Mode mode) {
+        double indexVQSLOD = scatteredTranches.get(0).minVQSLod;
+        int sumNumKnown = 0;
+        double sumKnownTransitions = 0;
+        double sumKnownTransversions = 0;
+        int sumNumNovel = 0;
+        double sumNovelTransitions = 0;
+        double sumNovelTransversions = 0;
+        int sumAccessibleTruthSites = 0;
+        int sumCallsAtTruthSites = 0;
+
+        for (final VQSLODTranche tranche : scatteredTranches) {
+            if (tranche.minVQSLod != indexVQSLOD)
+                throw new IllegalStateException("Scattered tranches do not contain the same VQSLODs");
+            sumNumKnown += tranche.numKnown;
+            double trancheKnownTransitions = (tranche.knownTiTv*tranche.numKnown) / (1+tranche.knownTiTv);
+            sumKnownTransitions += trancheKnownTransitions;
+            sumKnownTransversions += (tranche.numKnown - trancheKnownTransitions);
+            sumNumNovel += tranche.numNovel;
+            double trancheNovelTransitions = (tranche.novelTiTv*tranche.numNovel) / (1+tranche.novelTiTv);
+            sumNovelTransitions += trancheNovelTransitions;
+            sumNovelTransversions += (tranche.numNovel - trancheNovelTransitions);
+            sumAccessibleTruthSites += tranche.accessibleTruthSites;
+            sumCallsAtTruthSites += tranche.callsAtTruthSites;
+        }
+
+        return new VQSLODTranche(indexVQSLOD, sumNumKnown, sumKnownTransitions/sumKnownTransversions, sumNumNovel, sumNovelTransitions/sumNovelTransversions, sumAccessibleTruthSites, sumCallsAtTruthSites, mode, "gathered" + indexVQSLOD);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorEngine.java
@@ -53,7 +53,7 @@ public class VariantRecalibratorEngine {
             try {
                 model.precomputeDenominatorForEvaluation();
             } catch( Exception e ) {
-                //TODO: what is this catching ?????
+                logger.warn("Model could not pre-compute denominators.");  //this happened when we were reading in VQSR models that didn't have enough precision
                 model.failedToConverge = true;
                 return;
             }
@@ -63,6 +63,7 @@ public class VariantRecalibratorEngine {
         for( final VariantDatum datum : data ) {
             final double thisLod = evaluateDatum( datum, model );
             if( Double.isNaN(thisLod) ) {
+                logger.warn("Evaluate datum returned a NaN.");
                 model.failedToConverge = true;
                 return;
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportTable.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportTable.java
@@ -566,6 +566,10 @@ public final class GATKReportTable {
         return columnInfo.size();
     }
 
+    public List<GATKReportColumn> getColumnInfo() {
+        return columnInfo;
+    }
+
     public String getTableName() {
         return tableName;
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranchesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranchesIntegrationTest.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.hellbender.tools.walkers.vqsr;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/**
+ * Created by gauthier on 7/18/17.
+ */
+public class GatherTranchesIntegrationTest extends CommandLineProgramTest {
+
+    private static final String testDir = BaseTest.publicTestDir + "/large/VQSR/";
+
+    @Test
+    public void testCombine2Shards() throws Exception {
+        final File recal1 = new File(testDir + "snpTranches.scattered.txt");  //this is the output of VariantRecalibratorIntegrationTest.testVariantRecalibratorSNPscattered
+        final File recal2 = new File(testDir + "snpTranches.scattered.2.txt"); //this is the output of running the equivalent commandline as above outside of the integration test :-/
+
+        final File recal_original = new File(testDir + "expected/snpTranches.gathered.txt");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--input");
+        args.add(recal1.getAbsolutePath());
+        args.add("--input");
+        args.add(recal2.getAbsolutePath());
+
+        final File outFile = BaseTest.createTempFile("gatheredTranches", ".txt");
+        args.addOutput(outFile);
+        final Object res = this.runCommandLine(args.getArgsArray());
+        Assert.assertEquals(res, 0);
+        IntegrationTestSpec.assertEqualTextFiles(outFile, recal_original);
+    }
+
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTrancheUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTrancheUnitTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class TrancheUnitTest extends BaseTest {
+public final class TruthSensitivityTrancheUnitTest extends BaseTest {
     private final String testDir = CommandLineProgramTest.getTestDataDir() + "/walkers/VQSR/TrancheManagerUnitTest/";
     private final File QUAL_DATA = new File(testDir + "tranches.raw.dat");
     private final double[] TRUTH_SENSITIVITY_CUTS = new double[]{99.9, 99.0, 97.0, 95.0};
@@ -42,7 +42,7 @@ public final class TrancheUnitTest extends BaseTest {
 
     @Test(expectedExceptions = {UserException.MalformedFile.class})
     public final void readBadFormat() throws IOException{
-        Tranche.readTranches(QUAL_DATA);
+        TruthSensitivityTranche.readTranches(QUAL_DATA);
     }
 
     @Test
@@ -55,15 +55,15 @@ public final class TrancheUnitTest extends BaseTest {
         read(EXPECTED_TRANCHES_OLD);
     }
 
-    public final List<Tranche> read(File f) throws IOException{
-        return Tranche.readTranches(f);
+    public final List<TruthSensitivityTranche> read(File f) throws IOException{
+        return TruthSensitivityTranche.readTranches(f);
     }
 
-    private static void assertTranchesAreTheSame(List<Tranche> newFormat, List<Tranche> oldFormat) {
+    private static void assertTranchesAreTheSame(List<TruthSensitivityTranche> newFormat, List<TruthSensitivityTranche> oldFormat) {
         Assert.assertEquals(oldFormat.size(), newFormat.size());
         for ( int i = 0; i < newFormat.size(); i++ ) {
-            Tranche n = newFormat.get(i);
-            Tranche o = oldFormat.get(i);
+            TruthSensitivityTranche n = newFormat.get(i);
+            TruthSensitivityTranche o = oldFormat.get(i);
             Assert.assertEquals(n.targetTruthSensitivity, o.targetTruthSensitivity, 1e-3);
             Assert.assertEquals(n.numNovel, o.numNovel);
             Assert.assertEquals(n.novelTiTv, o.novelTiTv, 1e-3);
@@ -72,17 +72,17 @@ public final class TrancheUnitTest extends BaseTest {
         }
     }
 
-    private static List<Tranche> findMyTranches(ArrayList<VariantDatum> vd, double[] tranches) {
+    private static List<TruthSensitivityTranche> findMyTranches(ArrayList<VariantDatum> vd, double[] tranches) {
         final int nCallsAtTruth = VariantDatum.countCallsAtTruth( vd, Double.NEGATIVE_INFINITY );
-        final Tranche.TruthSensitivityMetric metric = new Tranche.TruthSensitivityMetric( nCallsAtTruth );
-        return Tranche.findTranches(vd, tranches, metric, VariantRecalibratorArgumentCollection.Mode.SNP);
+        final TruthSensitivityTranche.TruthSensitivityMetric metric = new TruthSensitivityTranche.TruthSensitivityMetric( nCallsAtTruth );
+        return TruthSensitivityTranche.findTranches(vd, tranches, metric, VariantRecalibratorArgumentCollection.Mode.SNP);
     }
 
     @Test
     public final void testFindTranches1() throws IOException {
         ArrayList<VariantDatum> vd = readData();
-        List<Tranche> tranches = findMyTranches(vd, TRUTH_SENSITIVITY_CUTS);
-        tranches.sort(Tranche.TRUTH_SENSITIVITY_ORDER);
+        List<TruthSensitivityTranche> tranches = findMyTranches(vd, TRUTH_SENSITIVITY_CUTS);
+        tranches.sort(TruthSensitivityTranche.TRUTH_SENSITIVITY_ORDER);
         assertTranchesAreTheSame(read(EXPECTED_TRANCHES_NEW), tranches);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantGaussianMixtureModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantGaussianMixtureModelUnitTest.java
@@ -42,7 +42,7 @@ public final class VariantGaussianMixtureModelUnitTest extends BaseTest {
 
     @Test(expectedExceptions = {UserException.MalformedFile.class})
     public final void readBadFormat() throws java.io.FileNotFoundException, java.io.IOException {
-        Tranche.readTranches(QUAL_DATA);
+        TruthSensitivityTranche.readTranches(QUAL_DATA);
     }
 
     @Test
@@ -55,17 +55,17 @@ public final class VariantGaussianMixtureModelUnitTest extends BaseTest {
         read(EXPECTED_TRANCHES_OLD);
     }
 
-    public final List<Tranche> read(File f) throws java.io.FileNotFoundException, java.io.IOException {
-        return Tranche.readTranches(f);
+    public final List<TruthSensitivityTranche> read(File f) throws java.io.FileNotFoundException, java.io.IOException {
+        return TruthSensitivityTranche.readTranches(f);
     }
 
-    private static void assertTranchesAreTheSame(List<Tranche> newFormat, List<Tranche> oldFormat, boolean completeP, boolean includeName) {
+    private static void assertTranchesAreTheSame(List<TruthSensitivityTranche> newFormat, List<TruthSensitivityTranche> oldFormat, boolean completeP, boolean includeName) {
         Assert.assertEquals(oldFormat.size(), newFormat.size());
         Collections.sort(oldFormat, new Tranche.TrancheTruthSensitivityComparator());
         Collections.sort(newFormat, new Tranche.TrancheTruthSensitivityComparator());
         for ( int i = 0; i < newFormat.size(); i++ ) {
-            Tranche n = newFormat.get(i);
-            Tranche o = oldFormat.get(i);
+            TruthSensitivityTranche n = newFormat.get(i);
+            TruthSensitivityTranche o = oldFormat.get(i);
             Assert.assertEquals(n.targetTruthSensitivity, o.targetTruthSensitivity, 1e-3);
             Assert.assertEquals(n.numNovel, o.numNovel);
             Assert.assertEquals(n.novelTiTv, o.novelTiTv, 1e-3);
@@ -78,7 +78,7 @@ public final class VariantGaussianMixtureModelUnitTest extends BaseTest {
         }
     }
 
-    private static List<Tranche> findMyTranches(ArrayList<VariantDatum> vd, List<Double> tranches) {
+    private static List<TruthSensitivityTranche> findMyTranches(ArrayList<VariantDatum> vd, List<Double> tranches) {
         final int nCallsAtTruth = TrancheManager.countCallsAtTruth( vd, Double.NEGATIVE_INFINITY );
         final TrancheManager.SelectionMetric metric = new TrancheManager.TruthSensitivityMetric( nCallsAtTruth );
         return TrancheManager.findTranches(vd, tranches, metric, VariantRecalibratorArgumentCollection.Mode.SNP);
@@ -87,7 +87,7 @@ public final class VariantGaussianMixtureModelUnitTest extends BaseTest {
     @Test
     public final void testFindTranches1() throws java.io.FileNotFoundException, java.io.IOException {
         ArrayList<VariantDatum> vd = readData();
-        List<Tranche> tranches = findMyTranches(vd, TRUTH_SENSITIVITY_CUTS);
+        List<TruthSensitivityTranche> tranches = findMyTranches(vd, TRUTH_SENSITIVITY_CUTS);
 
         assertTranchesAreTheSame(read(EXPECTED_TRANCHES_NEW), tranches, true, false);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorModelOutputUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorModelOutputUnitTest.java
@@ -5,116 +5,125 @@ import org.apache.log4j.Logger;
 import org.broadinstitute.hellbender.utils.report.GATKReport;
 import org.broadinstitute.hellbender.utils.report.GATKReportTable;
 
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-public class VariantRecalibratorModelOutputUnitTest {
+public class VariantRecalibratorModelOutputUnitTest extends BaseTest {
     protected final static Logger logger = Logger.getLogger(VariantRecalibratorModelOutputUnitTest.class);
-    private final boolean printTables = true;
+    private final boolean printTables = false;
+    private final int numAnnotations = 6;
+    private final double shrinkage = 1.0;
+    private final double dirichlet = 0.001;
+    private final double priorCounts = 20.0;
+    private final double epsilon = 1e-6;
+    private final String modelReportName = "vqsr_model.report";
+    private final int dataSize = 1000; //use this a placeholder so we can test model reading without data
 
     @Test
     public void testVQSRModelOutput() {
-        final int numAnnotations = 6;
-        final double shrinkage = 1.0;
-        final double dirichlet = 0.001;
-        final double priorCounts = 20.0;
-        final double epsilon = 1e-6;
-
-        Random rand = new Random(12878);
-        MultivariateGaussian goodGaussian1 = new MultivariateGaussian(1, numAnnotations);
-        goodGaussian1.initializeRandomMu(rand);
-        goodGaussian1.initializeRandomSigma(rand);
-
-        MultivariateGaussian goodGaussian2 = new MultivariateGaussian(1, numAnnotations);
-        goodGaussian2.initializeRandomMu(rand);
-        goodGaussian2.initializeRandomSigma(rand);
-
-        MultivariateGaussian badGaussian1 = new MultivariateGaussian(1, numAnnotations);
-        badGaussian1.initializeRandomMu(rand);
-        badGaussian1.initializeRandomSigma(rand);
-
-        List<MultivariateGaussian> goodGaussianList = new ArrayList<>();
-        goodGaussianList.add(goodGaussian1);
-        goodGaussianList.add(goodGaussian2);
-
-        List<MultivariateGaussian> badGaussianList = new ArrayList<>();
-        badGaussianList.add(badGaussian1);
-
-        GaussianMixtureModel goodModel = new GaussianMixtureModel(goodGaussianList, shrinkage, dirichlet, priorCounts);
-        GaussianMixtureModel badModel = new GaussianMixtureModel(badGaussianList, shrinkage, dirichlet, priorCounts);
+        GaussianMixtureModel goodModel = getGoodGMM();
+        GaussianMixtureModel badModel = getBadGMM();
 
         if (printTables) {
-            logger.info("Good model mean matrix:");
-            logger.info(vectorToString(goodGaussian1.mu));
-            logger.info(vectorToString(goodGaussian2.mu));
-            logger.info("\n\n");
+            System.out.println("Good model mean matrix:");
+            System.out.println(vectorToString(goodModel.getModelGaussians().get(0).mu));
+            System.out.println(vectorToString(goodModel.getModelGaussians().get(1).mu));
+            System.out.println("\n\n");
 
-            logger.info("Good model covariance matrices:");
-            goodGaussian1.sigma.print(10, 3);
-            goodGaussian2.sigma.print(10, 3);
-            logger.info("\n\n");
+            System.out.println("Good model covariance matrices:");
+            goodModel.getModelGaussians().get(0).sigma.print(10, 3);
+            goodModel.getModelGaussians().get(1).sigma.print(10, 3);
+            System.out.println("\n\n");
 
-            logger.info("Bad model mean matrix:\n");
-            logger.info(vectorToString(badGaussian1.mu));
-            logger.info("\n\n");
+            System.out.println("Bad model mean matrix:\n");
+            System.out.println(vectorToString(badModel.getModelGaussians().get(0).mu));
+            System.out.println("\n\n");
 
-            logger.info("Bad model covariance matrix:");
-            badGaussian1.sigma.print(10, 3);
+            System.out.println("Bad model covariance matrix:");
+            badModel.getModelGaussians().get(0).sigma.print(10, 3);
         }
 
         VariantRecalibrator vqsr = new VariantRecalibrator();
-        List<String> annotationList = new ArrayList<>();
-        annotationList.add("QD");
-        annotationList.add("MQ");
-        annotationList.add("FS");
-        annotationList.add("SOR");
-        annotationList.add("ReadPosRankSum");
-        annotationList.add("MQRankSum");
-
+        List<String> annotationList = getAnnotationList();
 
         GATKReport report = vqsr.writeModelReport(goodModel, badModel, annotationList);
-        if(printTables)
-            report.print(System.out);
+        //this generates input data for testVQSRModelInput
+        try {
+            PrintStream modelReporter = new PrintStream(publicTestDir+"/"+this.modelReportName);
+            report.print(modelReporter);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
 
         //Check values for Gaussian means
         GATKReportTable goodMus = report.getTable("PositiveModelMeans");
         for(int i = 0; i < annotationList.size(); i++) {
-            Assert.assertEquals(goodGaussian1.mu[i], (Double)goodMus.get(0,annotationList.get(i)), epsilon);
+            Assert.assertEquals(goodModel.getModelGaussians().get(0).mu[i], (Double)goodMus.get(0,annotationList.get(i)), epsilon);
         }
         for(int i = 0; i < annotationList.size(); i++) {
-            Assert.assertEquals(goodGaussian2.mu[i], (Double)goodMus.get(1,annotationList.get(i)), epsilon);
+            Assert.assertEquals(goodModel.getModelGaussians().get(1).mu[i], (Double)goodMus.get(1,annotationList.get(i)), epsilon);
         }
 
         GATKReportTable badMus = report.getTable("NegativeModelMeans");
         for(int i = 0; i < annotationList.size(); i++) {
-            Assert.assertEquals(badGaussian1.mu[i], (Double)badMus.get(0,annotationList.get(i)), epsilon);
+            Assert.assertEquals(badModel.getModelGaussians().get(0).mu[i], (Double)badMus.get(0,annotationList.get(i)), epsilon);
         }
 
         //Check values for Gaussian covariances
         GATKReportTable goodSigma = report.getTable("PositiveModelCovariances");
         for(int i = 0; i < annotationList.size(); i++) {
             for(int j = 0; j < annotationList.size(); j++) {
-                Assert.assertEquals(goodGaussian1.sigma.get(i,j), (Double)goodSigma.get(i,annotationList.get(j)), epsilon);
+                Assert.assertEquals(goodModel.getModelGaussians().get(0).sigma.get(i,j), (Double)goodSigma.get(i,annotationList.get(j)), epsilon);
             }
         }
 
         //add annotationList.size() to row indexes for second Gaussian because the matrices are concatenated by row in the report
         for(int i = 0; i < annotationList.size(); i++) {
             for(int j = 0; j < annotationList.size(); j++) {
-                Assert.assertEquals(goodGaussian2.sigma.get(i,j), (Double)goodSigma.get(annotationList.size()+i,annotationList.get(j)), epsilon);
+                Assert.assertEquals(goodModel.getModelGaussians().get(1).sigma.get(i,j), (Double)goodSigma.get(annotationList.size()+i,annotationList.get(j)), epsilon);
             }
         }
 
         GATKReportTable badSigma = report.getTable("NegativeModelCovariances");
         for(int i = 0; i < annotationList.size(); i++) {
             for(int j = 0; j < annotationList.size(); j++) {
-                Assert.assertEquals(badGaussian1.sigma.get(i,j), (Double)badSigma.get(i,annotationList.get(j)), epsilon);
+                Assert.assertEquals(badModel.getModelGaussians().get(0).sigma.get(i,j), (Double)badSigma.get(i,annotationList.get(j)), epsilon);
             }
         }
+    }
+
+
+    @Test (dependsOnMethods = {"testVQSRModelOutput"})
+    public void testVQSRModelInput(){
+        final File inputFile = new File(publicTestDir + "/" + this.modelReportName);
+        final GATKReport report = new GATKReport(inputFile);
+
+        // Now test model report reading
+        // Read all the tables
+        final GATKReportTable badMus = report.getTable("NegativeModelMeans");
+        final GATKReportTable badSigma = report.getTable("NegativeModelCovariances");
+        final GATKReportTable nPMixTable = report.getTable("BadGaussianPMix");
+
+        final GATKReportTable goodMus = report.getTable("PositiveModelMeans");
+        final GATKReportTable goodSigma = report.getTable("PositiveModelCovariances");
+        final GATKReportTable pPMixTable = report.getTable("GoodGaussianPMix");
+
+        List<String> annotationList = getAnnotationList();
+        VariantRecalibrator vqsr = new VariantRecalibrator();
+
+        GaussianMixtureModel goodModelFromFile = vqsr.GMMFromTables(goodMus, goodSigma, pPMixTable, annotationList.size(), dataSize);
+        GaussianMixtureModel badModelFromFile = vqsr.GMMFromTables(badMus, badSigma, nPMixTable, annotationList.size(), dataSize);
+
+        testGMMsForEquality(getGoodGMM(), goodModelFromFile, epsilon);
+        testGMMsForEquality(getBadGMM(), badModelFromFile, epsilon);
     }
 
     @Test
@@ -154,6 +163,68 @@ public class VariantRecalibratorModelOutputUnitTest {
                 returnString += ",";
         }
         return returnString;
+    }
+
+    private void testGMMsForEquality(GaussianMixtureModel gmm1, GaussianMixtureModel gmm2, double epsilon){
+        Assert.assertEquals(gmm1.getModelGaussians().size(), gmm2.getModelGaussians().size(), 0);
+
+        for(int k = 0; k < gmm1.getModelGaussians().size(); k++) {
+            final MultivariateGaussian g = gmm1.getModelGaussians().get(k);
+            final MultivariateGaussian gFile = gmm2.getModelGaussians().get(k);
+
+            Assert.assertEquals(g.pMixtureLog10, gFile.pMixtureLog10);
+
+            for(int i = 0; i < g.mu.length; i++){
+                Assert.assertEquals(g.mu[i], gFile.mu[i], epsilon);
+            }
+
+            for(int i = 0; i < g.sigma.getRowDimension(); i++) {
+                for (int j = 0; j < g.sigma.getColumnDimension(); j++) {
+                    Assert.assertEquals(g.sigma.get(i, j), gFile.sigma.get(i, j), epsilon);
+                }
+            }
+        }
+    }
+
+    private List<String> getAnnotationList(){
+        List<String> annotationList = new ArrayList<>();
+        annotationList.add("QD");
+        annotationList.add("MQ");
+        annotationList.add("FS");
+        annotationList.add("SOR");
+        annotationList.add("ReadPosRankSum");
+        annotationList.add("MQRankSum");
+        return annotationList;
+    }
+
+    private GaussianMixtureModel getGoodGMM(){
+        Random rand = new Random(12878);
+        MultivariateGaussian goodGaussian1 = new MultivariateGaussian(dataSize, numAnnotations);
+        goodGaussian1.initializeRandomMu(rand);
+        goodGaussian1.initializeRandomSigma(rand);
+
+        MultivariateGaussian goodGaussian2 = new MultivariateGaussian(dataSize, numAnnotations);
+        goodGaussian2.initializeRandomMu(rand);
+        goodGaussian2.initializeRandomSigma(rand);
+
+        List<MultivariateGaussian> goodGaussianList = new ArrayList<>();
+        goodGaussianList.add(goodGaussian1);
+        goodGaussianList.add(goodGaussian2);
+
+        return new GaussianMixtureModel(goodGaussianList, shrinkage, dirichlet, priorCounts);
+    }
+
+    private GaussianMixtureModel getBadGMM(){
+        Random rand = new Random(12878);
+        MultivariateGaussian badGaussian1 = new MultivariateGaussian(dataSize, numAnnotations);
+
+        badGaussian1.initializeRandomMu(rand);
+        badGaussian1.initializeRandomSigma(rand);
+
+        List<MultivariateGaussian> badGaussianList = new ArrayList<>();
+        badGaussianList.add(badGaussian1);
+
+        return new GaussianMixtureModel(badGaussianList, shrinkage, dirichlet, priorCounts);
     }
 
 }

--- a/src/test/resources/large/VQSR/expected/snpRecal.scattered.vcf
+++ b/src/test/resources/large/VQSR/expected/snpRecal.scattered.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f73c42b1458fc30149018ad448adcccf15c2ecf58c1247711e228fe4d0e87f
+size 9021341

--- a/src/test/resources/large/VQSR/expected/snpRecal.scattered.vcf.idx
+++ b/src/test/resources/large/VQSR/expected/snpRecal.scattered.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bfd74e682fad4d053d6292bb89fd5d4f1927c001229d957eb2ce2b398508a7a
+size 42021

--- a/src/test/resources/large/VQSR/expected/snpSampledRecal.vcf
+++ b/src/test/resources/large/VQSR/expected/snpSampledRecal.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:247617da2b3e9a03e4fc9c309622fe69f4e17a06b044ae04f0195c011b93ac09
+size 4512693

--- a/src/test/resources/large/VQSR/expected/snpSampledRecal.vcf.idx
+++ b/src/test/resources/large/VQSR/expected/snpSampledRecal.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e525cc233b47b13bf8b736016c4fdca71224086587ee555db429d8f90a4a92de
+size 22017

--- a/src/test/resources/large/VQSR/expected/snpSampledTranches.txt
+++ b/src/test/resources/large/VQSR/expected/snpSampledTranches.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:740facdf15d6532e8f31821da5b1b973a342b22400e3ba700c51b6b4d0425fd7
+size 554

--- a/src/test/resources/large/VQSR/expected/snpTranches.gathered.txt
+++ b/src/test/resources/large/VQSR/expected/snpTranches.gathered.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84435fbcadecb6904210371229fb373dd76092ccb91cec3255a189df48b423f7
+size 568

--- a/src/test/resources/large/VQSR/snpTranches.scattered.2.txt
+++ b/src/test/resources/large/VQSR/snpTranches.scattered.2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b67b4a8bdf273328ddd0fa9a5a456d597f7c545a7d784be6d49b2be17de8db8b
+size 1260

--- a/src/test/resources/large/VQSR/snpTranches.scattered.txt
+++ b/src/test/resources/large/VQSR/snpTranches.scattered.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23550b7de65186c0f15572e5597ac7c915829653b3b21816eb03f06eff4e96b3
+size 1260


### PR DESCRIPTION
New functionality to limit the amount of memory needed to read in all the data, intended for use with large WGS callsets.  (VQSR downsamples training data if there are more than 2.5M variants anyway.)

Also contains port of broadinstitute/gsa-unstable#1608 and broadinstitute/gsa-unstable#1575

Addresses #3230 