### PR TITLE
Addresses #3242.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.sv;
 
+import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.barclay.argparser.Argument;
 
 import java.io.Serializable;
@@ -140,6 +141,14 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
                 fullName = "crossContigsToIgnore", optional = true)
         public String crossContigsToIgnoreFile;
 
+        private static final String OUTPUT_ORDER_SHORT_NAME = "sort";
+        private static final String OUTPUT_ORDER_FULL_NAME = "assembliesSortOrder";
+
+        @Argument(doc = "sorting order to be used for the output assembly alignments SAM/BAM file",
+                shortName = OUTPUT_ORDER_SHORT_NAME,
+                fullName = OUTPUT_ORDER_FULL_NAME,
+                optional = true)
+        public SAMFileHeader.SortOrder assembliesSortOrder = SAMFileHeader.SortOrder.coordinate;
     }
 
     public static class DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection implements Serializable {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -52,7 +52,6 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
     private StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection discoverStageArgs
             = new StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection();
 
-
     @Override
     public boolean requiresReads()
     {
@@ -72,7 +71,7 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
         final List<AlignedAssemblyOrExcuse> alignedAssemblyOrExcuseList =
                 FindBreakpointEvidenceSpark
                         .gatherEvidenceAndWriteContigSamFile(ctx, evidenceAndAssemblyArgs, header, getUnfilteredReads(),
-                                outputSAM, localLogger);
+                                outputSAM, this.evidenceAndAssemblyArgs.assembliesSortOrder, localLogger);
         if (alignedAssemblyOrExcuseList.isEmpty()) return;
 
         // parse the contig alignments and extract necessary information


### PR DESCRIPTION
Now the assemblies file will be sorted by coordinates by default.... one can indicate the sorting order using an additional option (-sort coordinate|queryname|...). The assemblies sam/bam output format will depend on the file name extension: .bam -> binary BAM, .sam -> text SAM and anything else will result in an exception.