### PR TITLE
[SV] Fix cross-contig exclusion issues

### DIFF
--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -31,6 +31,7 @@ REF_FASTA="${MASTER_NODE}$5"
 REF_INDEX_IMAGE="$6"
 INTERVAL_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.intervals/')
 KMER_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.kmers/')
+ALTS_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.alts/')
 REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
 
 "${GATK_DIR}/gatk-launch" StructuralVariationDiscoveryPipelineSpark \
@@ -41,6 +42,7 @@ REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
     --alignerIndexImage "${REF_INDEX_IMAGE}" \
     --exclusionIntervals "${INTERVAL_KILL_LIST}" \
     --kmersToIgnore "${KMER_KILL_LIST}" \
+    --crossContigsToIgnore "${ALTS_KILL_LIST}" \
     --breakpointIntervals "${PROJECT_OUTPUT_DIR}/intervals" \
     --fastqDir "${PROJECT_OUTPUT_DIR}/fastq" \
     --contigSAMFile "${PROJECT_OUTPUT_DIR}/assemblies.sam" \
@@ -51,5 +53,5 @@ REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
     --driver-memory 30G \
     --executor-memory 30G \
     --conf spark.yarn.executor.memoryOverhead=5000 \
-    --conf spark.network.timeout=300 \
-    --conf spark.executor.heartbeatInterval=60
+    --conf spark.network.timeout=600 \
+    --conf spark.executor.heartbeatInterval=120

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ReadClassifierTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/ReadClassifierTest.java
@@ -70,6 +70,14 @@ public class ReadClassifierTest extends BaseTest {
 
         read.setMatePosition(header.getSequenceDictionary().getSequence(2).getSequenceName(), rightStart);
         checkClassification(classifier, read, Collections.emptyList());
+
+        read.setMateIsReverseStrand(false);
+        checkClassification(classifier, read, Collections.emptyList());
+
+        read.setMateIsReverseStrand(true);
+        read.setMatePosition(header.getSequenceDictionary().getSequence(2).getSequenceName(), read.getStart() - fragmentLen);
+        checkClassification(classifier, read, Collections.emptyList());
+
     }
 
     private void checkClassification( final ReadClassifier classifier, final GATKRead read, final List<BreakpointEvidence> expectedEvidence ) {


### PR DESCRIPTION
This PR fixes two problems I noticed relative to how we are treating cross-contig evidence that comes from the alt contigs:

- The cross-contig exclusion rule in `ReadClassifier` was incorrect. Due to the structure of the `if`-`else if` logic in `checkDiscordantPair()`, `SameStrandPair` or `OutiesPair` evidence was still being created for cross-contig pairs based on the strand configuration of the two reads (even though they were aligned to different contigs).
- The `runWholePipeline` script we've been using was not actually setting the cross-contig kill list parameter, meaning no cross-contig evidence was being filtered out.

The change makes the number of intervals for CMHMIX WGS1 drop from 31962 to 27645.