### PR TITLE
sv/create_cluster.sh uses Dataproc image 1.1

### DIFF
--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -70,7 +70,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --num-worker-local-ssds 1 \
     --metadata "reference=$REF_DIR" \
     --metadata "sample=$SAMP_DIR" \
-    --image-version preview \
+    --image-version 1.1 \
     --project ${PROJECT} \
     --initialization-actions ${INIT_ACTION} \
     --initialization-action-timeout 10m


### PR DESCRIPTION
Avoid spark crash by switching from preview to latest supported Dataproc image.