### PR TITLE
Move to google-cloud-java snapshot with more robust retries, and set number of retries/reopens globally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.19.0-alpha:shaded'
+    compile 'com.google.cloud:google-cloud-nio:0.20.2-alpha-20170717.214602-1:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.20.2-alpha-20170717.214602-1:shaded'
+    compile 'com.google.cloud:google-cloud-nio:0.20.2-alpha-20170718.213753-11:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -301,7 +301,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
 
         logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration().maxChannelReopens());
-        logger.info("Using google-cloud-java patch 92d6ed9eb9e8bc52eb094222ad4849d329956d8c");
+        logger.info("Using google-cloud-java patch 317951be3c2e898e3916a4b1abf5a9c220d84df8");
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -23,6 +23,7 @@ import org.broadinstitute.barclay.argparser.CommandLinePluginProvider;
 import org.broadinstitute.barclay.argparser.SpecialArgumentsCollection;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -147,6 +148,8 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         if (! useJdkInflater) {
             BlockGunzipper.setDefaultInflaterFactory(new IntelInflaterFactory());
         }
+
+        BucketUtils.setGlobalNIODefaultOptions();
 
         if (!QUIET) {
             System.err.println("[" + Utils.getDateTimeForDisplay(startDateTime) + "] " + commandLine);
@@ -296,6 +299,9 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Deflater: " + (usingIntelDeflater ? "IntelDeflater": "JdkDeflater"));
         final boolean usingIntelInflater = (BlockGunzipper.getDefaultInflaterFactory() instanceof IntelInflaterFactory && ((IntelInflaterFactory)BlockGunzipper.getDefaultInflaterFactory()).usingIntelInflater());
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
+
+        logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration().maxChannelReopens());
+        logger.info("Using google-cloud-java patch 92d6ed9eb9e8bc52eb094222ad4849d329956d8c");
     }
 
     /**


### PR DESCRIPTION
This moves us to a snapshot of google-cloud-java based off of a branch in my fork here: https://github.com/droazen/google-cloud-java/tree/dr_retry_CloudStorageReadChannel_fetchSize. This patch wraps many more operations within retries, and in our tests resolves the intermittent 503/SSL errors completely when running at scale.

This PR also migrates us from setting retry settings per-Path to setting it globally, using a new API from that google-cloud-java branch. This fixes an issue where the number of reopens was getting set to 0 deep in the google-cloud-java library.

Resolves #2749
Resolves #2685
Resolves #3118
Resolves #3120
Resolves #3253