### PR TITLE
Fixing hash collision issue when adding filter value to the variant context

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFilterer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFilterer.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.engine.ProgressMeter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.picard.analysis.artifacts.Transition;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.UniqueIDWrapper;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
 import org.broadinstitute.hellbender.utils.genotyper.SampleList;
@@ -16,7 +17,6 @@ import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -385,22 +385,4 @@ public class OrientationBiasFilterer {
         return new VCFHeader(headerLines, sampleNameSet);
     }
 
-    static class UniqueIDWrapper<A>{
-        private static final AtomicLong counter = new AtomicLong();
-
-        private final long id;
-        private final A wrapped;
-        public UniqueIDWrapper(A toWrap){
-            id = counter.getAndIncrement();
-            wrapped = toWrap;
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public A getWrapped(){
-            return wrapped;
-        }
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/UniqueIDWrapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/UniqueIDWrapper.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.hellbender.utils;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Create a unique ID for an arbitrary object and wrap it.
+ *
+ * Warning:  This will not work as desired on a Spark cluster (local spark should be fine)
+ */
+public class UniqueIDWrapper<A> {
+    private static final AtomicLong counter = new AtomicLong();
+
+    private final long id;
+    private final A wrapped;
+
+    public UniqueIDWrapper(A toWrap) {
+        id = counter.getAndIncrement();
+        wrapped = toWrap;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public A getWrapped() {
+        return wrapped;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -9,9 +9,9 @@ import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFConstants;
-import org.apache.commons.io.FilenameUtils;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -1469,4 +1469,21 @@ public final class GATKVariantContextUtils {
         }
         return second - first;
     }
+
+    /**
+     *  Create a string with existing filters plus the one to append
+     * @param vc VariantContext to base initial filter values.  Not {@code null}
+     * @param filterToAppend the filter value to append to the strings Not {@code null}
+     * @return String of filter values.  Sorted alphabetically.
+     */
+    public static List<String> createFilterListWithAppend(VariantContext vc, String filterToAppend) {
+        Utils.nonNull(vc);
+        Utils.nonNull(filterToAppend);
+
+        final List<String> filtersAsList = new ArrayList<>(vc.getFilters());
+        filtersAsList.add(filterToAppend);
+        filtersAsList.sort(String::compareToIgnoreCase);
+        return filtersAsList;
+    }
 }
+

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFiltererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFiltererUnitTest.java
@@ -155,7 +155,7 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
         final List<String> sampleNames = updatedVariants.get(0).getSampleNamesOrderedByName();
 
         // Create a mapping from sample name to a genotype->variant context map
-        final Map<String, SortedMap<Genotype, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
+        final Map<String, SortedMap<OrientationBiasFilterer.UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
     }
 
 
@@ -194,7 +194,7 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
 
         // Do the test
         // Create a mapping from sample name to a genotype->variant context map with the second map sorted by p_artifact (i.e. OrientationBiasFilterConstants.P_ARTIFACT_FIELD_NAME)
-        final Map<String, SortedMap<Genotype, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
+        final Map<String, SortedMap<OrientationBiasFilterer.UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
         Assert.assertEquals(sampleNameToVariants.keySet().size(), 2);
         Assert.assertTrue(sampleNameToVariants.keySet().contains("TUMOR"));
         Assert.assertTrue(sampleNameToVariants.keySet().contains("NORMAL"));
@@ -206,7 +206,8 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
 
         // Check that the sorted map is getting smaller (or same) values of p_artifact and not staying put.
         double previousPArtifact = Double.POSITIVE_INFINITY;
-        for (final Genotype genotypeTumor : sampleNameToVariants.get("TUMOR").keySet()) {
+        for (final OrientationBiasFilterer.UniqueIDWrapper<Genotype> genotypeTumorWrapped : sampleNameToVariants.get("TUMOR").keySet()) {
+            final Genotype genotypeTumor = genotypeTumorWrapped.getWrapped();
             final Double pArtifact = OrientationBiasUtils.getGenotypeDouble(genotypeTumor, OrientationBiasFilterConstants.P_ARTIFACT_FIELD_NAME, Double.POSITIVE_INFINITY);
             Assert.assertNotNull(pArtifact);
             Assert.assertTrue(pArtifact <= previousPArtifact);

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFiltererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/orientationbiasvariantfilter/OrientationBiasFiltererUnitTest.java
@@ -6,6 +6,7 @@ import htsjdk.variant.vcf.VCFConstants;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.tools.picard.analysis.artifacts.Transition;
+import org.broadinstitute.hellbender.utils.UniqueIDWrapper;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -155,7 +156,7 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
         final List<String> sampleNames = updatedVariants.get(0).getSampleNamesOrderedByName();
 
         // Create a mapping from sample name to a genotype->variant context map
-        final Map<String, SortedMap<OrientationBiasFilterer.UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
+        final Map<String, SortedMap<UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
     }
 
 
@@ -194,7 +195,7 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
 
         // Do the test
         // Create a mapping from sample name to a genotype->variant context map with the second map sorted by p_artifact (i.e. OrientationBiasFilterConstants.P_ARTIFACT_FIELD_NAME)
-        final Map<String, SortedMap<OrientationBiasFilterer.UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
+        final Map<String, SortedMap<UniqueIDWrapper<Genotype>, VariantContext>> sampleNameToVariants = OrientationBiasFilterer.createSampleToGenotypeVariantContextSortedMap(sampleNames, updatedVariants);
         Assert.assertEquals(sampleNameToVariants.keySet().size(), 2);
         Assert.assertTrue(sampleNameToVariants.keySet().contains("TUMOR"));
         Assert.assertTrue(sampleNameToVariants.keySet().contains("NORMAL"));
@@ -206,7 +207,7 @@ public class OrientationBiasFiltererUnitTest extends BaseTest {
 
         // Check that the sorted map is getting smaller (or same) values of p_artifact and not staying put.
         double previousPArtifact = Double.POSITIVE_INFINITY;
-        for (final OrientationBiasFilterer.UniqueIDWrapper<Genotype> genotypeTumorWrapped : sampleNameToVariants.get("TUMOR").keySet()) {
+        for (final UniqueIDWrapper<Genotype> genotypeTumorWrapped : sampleNameToVariants.get("TUMOR").keySet()) {
             final Genotype genotypeTumor = genotypeTumorWrapped.getWrapped();
             final Double pArtifact = OrientationBiasUtils.getGenotypeDouble(genotypeTumor, OrientationBiasFilterConstants.P_ARTIFACT_FIELD_NAME, Double.POSITIVE_INFINITY);
             Assert.assertNotNull(pArtifact);

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -1918,8 +1918,9 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
         final VariantContextBuilder vcBuilder = new VariantContextBuilder("","chr1", 1, 1, alleles);
         final VariantContext vc = vcBuilder.make();
 
-        final List<String> filterResult = GATKVariantContextUtils.createFilterListWithAppend(vc, "TEST_FILTER");
+        final String testFilterString = "TEST_FILTER";
+        final List<String> filterResult = GATKVariantContextUtils.createFilterListWithAppend(vc, testFilterString);
         Assert.assertEquals(filterResult.size(), 1);
-        Assert.assertTrue(filterResult.contains("TEST_FILTER"));
+        Assert.assertTrue(filterResult.contains(testFilterString));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -70,7 +70,7 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
     }
 
     private VariantContext makeVC(String source, List<Allele> alleles, String filter) {
-        return makeVC(source, alleles, filter.equals(".") ? null : new LinkedHashSet<>(Collections.singletonList(filter)));
+        return makeVC(source, alleles, filter.equals(".") ? null : new LinkedHashSet<String>(Collections.singletonList(filter)));
     }
 
     private VariantContext makeVC(String source, List<Allele> alleles, Set<String> filters) {
@@ -1889,5 +1889,37 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
     public void testCalculateGQFromShortPLArray() {
         final int[] plValues = new int[]{0};
         GATKVariantContextUtils.calculateGQFromPLs(plValues);
+    }
+
+    @Test
+    public void testCreateFilterListWithAppend() {
+        final List<Allele> alleles = new ArrayList<>();
+        alleles.add(Cref);
+        alleles.add(Allele.create("A", false));
+        final VariantContextBuilder vcBuilder = new VariantContextBuilder("","chr1", 1, 1, alleles);
+        vcBuilder.filters("F1", "F2", "Y");
+        final VariantContext vc = vcBuilder.make();
+
+        final String testFilterString = "TEST_FILTER";
+        final List<String> filterResult = GATKVariantContextUtils.createFilterListWithAppend(vc, testFilterString);
+        Assert.assertEquals(filterResult.size(), 4);
+        Assert.assertTrue(vc.getFilters().stream().allMatch(f -> filterResult.contains(f)));
+        Assert.assertTrue(filterResult.contains(testFilterString));
+
+        // Check that it is in the proper position
+        Assert.assertEquals(filterResult.get(2), testFilterString);
+    }
+
+    @Test
+    public void testCreateFilterListWithAppendToEmpty() {
+        final List<Allele> alleles = new ArrayList<>();
+        alleles.add(Cref);
+        alleles.add(Allele.create("A", false));
+        final VariantContextBuilder vcBuilder = new VariantContextBuilder("","chr1", 1, 1, alleles);
+        final VariantContext vc = vcBuilder.make();
+
+        final List<String> filterResult = GATKVariantContextUtils.createFilterListWithAppend(vc, "TEST_FILTER");
+        Assert.assertEquals(filterResult.size(), 1);
+        Assert.assertTrue(filterResult.contains("TEST_FILTER"));
     }
 }


### PR DESCRIPTION
Closes #3291 

- Detects the issue earlier and fails with a better error message that is local (in code) to the problem.
- Removes the spew of warnings that are not useful except in debug.
- Fixes an issue where filter values were being replaced instead of appended.
- Implemented a wrapper to always guarantee sorting never collides.