### PR TITLE
Fix stack trace error message.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -195,7 +195,9 @@ public class Main {
         if(printStackTraceOnUserExceptions()) {
             e.printStackTrace();
         } else {
-            System.err.println("Use -D" + STACK_TRACE_ON_USER_EXCEPTION_PROPERTY + "to print the stack trace.");
+            System.err.println("Use the system property "
+                            + STACK_TRACE_ON_USER_EXCEPTION_PROPERTY
+                            + " (--javaOptions '-DGATK_STACKTRACE_ON_USER_EXCEPTION=true') to print the stack trace.");
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -195,9 +195,10 @@ public class Main {
         if(printStackTraceOnUserExceptions()) {
             e.printStackTrace();
         } else {
-            System.err.println("Use the system property "
-                            + STACK_TRACE_ON_USER_EXCEPTION_PROPERTY
-                            + " (--javaOptions '-DGATK_STACKTRACE_ON_USER_EXCEPTION=true') to print the stack trace.");
+            System.err.println(String.format(
+                    "Set the system property %s (--javaOptions '-D%s=true') to print the stack trace.",
+                    STACK_TRACE_ON_USER_EXCEPTION_PROPERTY,
+                    STACK_TRACE_ON_USER_EXCEPTION_PROPERTY));
         }
     }
 


### PR DESCRIPTION
When an error occurs, we currently print this:

> Use -DGATK_STACKTRACE_ON_USER_EXCEPTIONto print the stack trace.

In addition to missing a space, this doesn't work with gatk-launch. Replace this with:

> Use the system property GATK_STACKTRACE_ON_USER_EXCEPTION (--javaOptions '-DGATK_STACKTRACE_ON_USER_EXCEPTION=true') to print the stack trace.

