### PR TITLE
multithreaded vcf header loading for GenomicsDBImport

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -162,12 +162,12 @@ public final class GenomicsDBImport extends GATKTool {
     @Argument(fullName = VCF_INITIALIZER_THREADS_LONG_NAME,
             shortName = VCF_INITIALIZER_THREADS_LONG_NAME,
             doc = "how many simultaneous threads to use when opening VCFs in batches, higher values may improve performance " +
-                    "if accessing files over a network latency",
+                    "when network latency is an issue",
             optional = true,
             minValue = 1)
     private int vcfInitializerThreads = 1;
 
-    //executor service used when vcfInitializerThreads != 1
+    //executor service used when vcfInitializerThreads > 1
     private ExecutorService headerLoadingExecutorService;
 
     @Override
@@ -669,7 +669,7 @@ public final class GenomicsDBImport extends GATKTool {
     /**
      * This class is a hack to force parallel loading of the headers and indexes of remote gvcf files.
      * It initializes a feature reader and starts a query.  This causes the header and index to be read, and also causes any
-     * pre-fetching to begin if enabled.  It is very narrowly crafted and likely brittle.
+     * pre-fetching to begin if enabled.  It is very narrowly crafted and should not be used for other purposes.
      */
     private static class InitializedQueryWrapper implements FeatureReader<VariantContext> {
         private final FeatureReader<VariantContext> reader;
@@ -691,13 +691,13 @@ public final class GenomicsDBImport extends GATKTool {
             if( query != null){
                 return query;
             } else {
-                throw new IllegalStateException("Cannot call query twice on this");
+                throw new GATKException("Cannot call query twice on this wrapper.");
             }
         }
 
         @Override
         public CloseableTribbleIterator<VariantContext> iterator() throws IOException {
-            throw new UnsupportedOperationException("get SequenceNames not supported");
+            throw new UnsupportedOperationException("iterator() not supported, this should not have been called and indicates an issue with GenomicsDB integration");
         }
 
         @Override
@@ -707,7 +707,7 @@ public final class GenomicsDBImport extends GATKTool {
 
         @Override
         public List<String> getSequenceNames() {
-            throw new UnsupportedOperationException("get SequenceNames not supported");
+            throw new UnsupportedOperationException("getSequenceNames() not supported, this should not have been called and indicates an issue with GenomicsDB integration");
         }
 
         @Override

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -10,7 +10,6 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
-import htsjdk.variant.vcf.VCFHeaderLine;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -77,7 +76,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
      *
      * The cloud bucket must be organized the same way as the local test files in order to resolve correctly.
      */
-    private List<String> resolveLargeFilesAsCloudURIs(final List<String> filenames){
+    private static List<String> resolveLargeFilesAsCloudURIs(final List<String> filenames){
         return filenames.stream()
                 .map( filename -> filename.replace(publicTestDir, getGCPTestInputPath()))
                 .peek( filename -> Assert.assertTrue(BucketUtils.isCloudStorageUrl(filename)))

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -12,6 +12,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -50,18 +52,18 @@ public class GenomicsDBImportUnitTest extends BaseTest{
                 "Sample2\tfile2\n" +
                 "Sample3\tfile3";
         final File sampleFile = IOUtils.writeTempFile(content, "sampleMapping", ".txt");
-        final Map<String, String> expected = new LinkedHashMap<>();
-        expected.put("Sample1", "file1");
-        expected.put("Sample2", "file2");
-        expected.put("Sample3", "file3");
-        final LinkedHashMap<String, String> actual = GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath());
+        final Map<String, Path> expected = new LinkedHashMap<>();
+        expected.put("Sample1", Paths.get("file1"));
+        expected.put("Sample2", Paths.get("file2"));
+        expected.put("Sample3", Paths.get("file3"));
+        final LinkedHashMap<String, Path> actual = GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath());
         Assert.assertEquals(actual, expected);
         Assert.assertEquals(actual.keySet().iterator().next(), "Sample1");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNullFeatureReadersToFail() {
-        Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
+        final Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
         sampleToReaderMap.put("Sample1", null);
         GenomicsDBImporter.generateSortedCallSetMap(sampleToReaderMap, true, true, 0L);
     }


### PR DESCRIPTION
This adds the option to use multithreading to load multiple headers at the same time when initializing FeatureReaders.  

Empirically this speeds up large runs of GenomicsDBImport over GCS by 20-30%.