### PR TITLE
updating AUTHORS to include gatk-protected authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,11 +14,11 @@ Cloudera Inc. <www.cloudera.com>
 Google Inc. <www.google.com>
 IBM Corp <www.ibm.com>
 Intel Corp. <www.intel.com>
-Anders Peterson
+Anders Peterson <apete@optimatika.se>
 Ayman Abdel Ghany <aymana.ghany@devfactory.com>
 Daniel Gómez-Sánchez <daniel.gomez.sanchez@hotmail.es>
 Eugene Wolfson <evulfson@gmail.com>
-Kenji Kaneda 
+Kenji Kaneda <kenji.kaneda@gmail.com>
 Mohammed Ezzat <mohamed.ezzat@devfactory.com>
-Nils Homer
 Nicholas Newell <nenewell@comcast.net>
+Nils Homer <nilshomer@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,7 +14,11 @@ Cloudera Inc. <www.cloudera.com>
 Google Inc. <www.google.com>
 IBM Corp <www.ibm.com>
 Intel Corp. <www.intel.com>
+Anders Peterson
+Ayman Abdel Ghany <aymana.ghany@devfactory.com>
 Daniel Gómez-Sánchez <daniel.gomez.sanchez@hotmail.es>
 Eugene Wolfson <evulfson@gmail.com>
+Kenji Kaneda 
 Mohammed Ezzat <mohamed.ezzat@devfactory.com>
+Nils Homer
 Nicholas Newell <nenewell@comcast.net>


### PR DESCRIPTION
Updating the AUTHORS file to include authors who contributed to gatk-protected who's work has been integrated into GATK by the merger.

I need to find out the preferred emails for the newly listed authors.

Anders Peterson
Ayman Abdel Ghany <aymana.ghany@devfactory.com>
Kenji Kaneda 
Nils Homer


@apete @AymanDF @kkaneda @nh13 Would you like to be included here and if so, what email address would you like listed?  Have I spelled your name correctly?

Resolves #3048 