### PR TITLE
Minor doc fixes - addresses issue 3173

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
@@ -39,9 +39,9 @@ import java.util.List;
  * </p>
  *
  * <pre>
- *     .@HD	VN:1.4	SO:unsorted
- *     .@SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
- *     .@SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
+ *     {@literal @}HD	VN:1.4	SO:unsorted
+ *     {@literal @}SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
+ *     {@literal @}SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
  *      1	10736	10736	+	normal
  *      1	11522	11522	+	normal
  *      1	12098	12098	+	normal

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
@@ -39,9 +39,9 @@ import java.util.List;
  * </p>
  *
  * <pre>
- *     @HD	VN:1.4	SO:unsorted
- *     @SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
- *     @SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
+ *     .@HD	VN:1.4	SO:unsorted
+ *     .@SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274
+ *     .@SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89
  *      1	10736	10736	+	normal
  *      1	11522	11522	+	normal
  *      1	12098	12098	+	normal
@@ -54,6 +54,8 @@ import java.util.List;
  *      2	15110	15110	+	normal
  *      2	15629	15629	+	normal
  * </pre>
+ *
+ * <p><em>Note that the periods (.) at the start of the header lines above were added as a workaround for a problem with our documentation system.</em></p>
  *
  * <p>
  *     The resulting table counts the reference versus alternate allele and indicates the alleles. For example:

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
@@ -55,8 +55,6 @@ import java.util.List;
  *      2	15629	15629	+	normal
  * </pre>
  *
- * <p><em>Note that the periods (.) at the start of the header lines above were added as a workaround for a problem with our documentation system.</em></p>
- *
  * <p>
  *     The resulting table counts the reference versus alternate allele and indicates the alleles. For example:
  * </p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
@@ -38,12 +38,13 @@ import java.util.stream.IntStream;
  * gatk-launch --javaOptions "-Xmx4g" CalculateContamination \
  *   -I pileups.table \
  *   -O contamination.table
+ * </pre>
  *
  * @author David Benjamin &lt;davidben@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
-        summary = "Calculate contamination",
-        oneLineSummary = "Calculate contamination",
+        summary = "Calculate the fraction of reads coming from cross-sample contamination",
+        oneLineSummary = "Calculate the fraction of reads coming from cross-sample contamination",
         programGroup = VariantProgramGroup.class
 )
 @DocumentedFeature

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -37,27 +37,27 @@ import java.util.List;
  * <h3>How HaplotypeCaller works</h3>
  *
  * <br />
- * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4147'>1. Define active regions </h4>
+ * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4147'>1. Define active regions </a></h4>
  *
  * <p>The program determines which regions of the genome it needs to operate on (active regions), based on the presence of
  * evidence for variation.
  *
  * <br />
- * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4146'>2. Determine haplotypes by assembly of the active region </h4>
+ * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4146'>2. Determine haplotypes by assembly of the active region </a></h4>
  *
  * <p>For each active region, the program builds a De Bruijn-like graph to reassemble the active region and identifies
  * what are the possible haplotypes present in the data. The program then realigns each haplotype against the reference
  * haplotype using the Smith-Waterman algorithm in order to identify potentially variant sites. </p>
  *
  * <br />
- * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4441'>3. Determine likelihoods of the haplotypes given the read data </h4>
+ * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4441'>3. Determine likelihoods of the haplotypes given the read data </a></h4>
  *
  * <p>For each active region, the program performs a pairwise alignment of each read against each haplotype using the
  * PairHMM algorithm. This produces a matrix of likelihoods of haplotypes given the read data. These likelihoods are
  * then marginalized to obtain the likelihoods of alleles for each potentially variant site given the read data.   </p>
  *
  * <br />
- * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4442'>4. Assign sample genotypes </h4>
+ * <h4><a href='https://software.broadinstitute.org/gatk/documentation/article?id=4442'>4. Assign sample genotypes </a></h4>
  *
  * <p>For each potentially variant site, the program applies Bayes' rule, using the likelihoods of alleles given the
  * read data to calculate the likelihoods of each genotype per sample given the read data observed for that


### PR DESCRIPTION
Addresses issue #3173 

I'd welcome advice from @cmnbroad on how to deal with the issue in CalculateContamination where the `@` starting the header lines in the example of Picard interval list breaks the docgen.  My hacky workaround is to add a dot before the @ but it's icky. 