### PR TITLE
Added functionality for travis tests to upload reports from a docker image 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ jdk:
 - openjdk8
 env:
   matrix:
-  - TEST_TYPE=cloud
-  - TEST_TYPE=integration TEST_VERBOSITY=minimal UPLOAD=true
-  - TEST_TYPE=unit TEST_VERBOSITY=minimal
+  - TEST_TYPE=cloud UPLOAD=true
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
   - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
   - RUN_CNV_SOMATIC_WDL=true
@@ -133,7 +131,9 @@ script:
     fi;
     sudo docker images;
     echo ${TEST_TYPE};
-    sudo docker run -v $(pwd)/src/test/resources:/testdata --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${DOCKER_TAG} bash /root/run_unit_tests.sh;
+    sudo mkdir -p build/reports/;
+    sudo chmod -R a+w build/reports/;
+    sudo docker run -v $(pwd)/src/test/resources:/testdata -v $(pwd)/build/reports/:/gatk/build/reports/ --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${DOCKER_TAG} bash /root/run_unit_tests.sh;
   else
     ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     travis_wait 50 ./gradlew jacocoTestReport;

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN ln -s /testdata src/test/resources
 
 # Create a simple unit test runner
 ENV CI true
-RUN echo "cd /gatk/ && ./gradlew test" >/root/run_unit_tests.sh
+RUN echo "cd /gatk/ && ./gradlew jacocoTestReport" >/root/run_unit_tests.sh
 
 WORKDIR /root


### PR DESCRIPTION
Also reduced the overall number of tests to execute by eliminating non-docker unit and integration tests from the travis.yml.

I would suggest checking that the docker tests in this travis execution actually uploaded to where it says they do on gcloud. 