### PR TITLE
Add scripts to manage SV spark jobs and copy result

### DIFF
--- a/scripts/sv/copy_sv_results.sh
+++ b/scripts/sv/copy_sv_results.sh
@@ -9,7 +9,7 @@ set -eu
 set -o pipefail
 
 if [[ "$#" -lt 3 ]]; then
-    echo -e
+    echo -e \
 "Please provide:
   [1] GCS project name (required)
   [2] GCS cluster name (required)
@@ -17,7 +17,11 @@ if [[ "$#" -lt 3 ]]; then
   [4] GCS user name (defaults to local user name)
   [5] path to local log file (default to empty, i.e. no log)
   [*] additional arguments that were passed to
-      StructuralVariationDiscoveryPipelineSpark"
+      StructuralVariationDiscoveryPipelineSpark
+To leave a value as default but specify a later value, use an empty
+  string. e.g. to use default user name but override log file:
+\$ copy_sv_results.sh my_project my_cluster_name /output/dir \\
+     \"\" /my/log/file.log"
   exit 1
 fi
 

--- a/scripts/sv/copy_sv_results.sh
+++ b/scripts/sv/copy_sv_results.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# This script copies SV analysis results from a Google Dataproc cluster
+# to an appropriate bucket/directory on GCS. It also uploads contents of
+# local output logs
+
+# terminate script on error or if a command fails before piping to another command
+set -eu
+set -o pipefail
+
+if [[ "$#" -lt 3 ]]; then
+    echo -e
+"Please provide:
+  [1] GCS project name (required)
+  [2] GCS cluster name (required)
+  [3] cluster output directory (required)
+  [4] GCS user name (defaults to local user name)
+  [5] path to local log file (default to empty, i.e. no log)
+  [*] additional arguments that were passed to
+      StructuralVariationDiscoveryPipelineSpark"
+  exit 1
+fi
+
+PROJECT_NAME=$1
+CLUSTER_NAME=$2
+OUTPUT_DIR=$3
+GCS_USER=${4:-${USER}}
+LOCAL_LOG_FILE=${5:-"/dev/null"}
+
+shift 5
+SV_ARGS=${*:-${SV_ARGS:-""}}
+
+# get appropriate ZONE for cluster
+echo "CLUSTER_INFO=\$(gcloud dataproc clusters list --project=${PROJECT_NAME} --filter='clusterName=${CLUSTER_NAME}')"
+CLUSTER_INFO=$(gcloud dataproc clusters list --project=${PROJECT_NAME} --filter="clusterName=${CLUSTER_NAME}" | tail -n 1 | tr -s ' ')
+ZONE=$(echo "${CLUSTER_INFO}" | cut -d' ' -f 4)
+if [ -z "${ZONE}" ]; then
+    # cluster is down.
+    echo "Cluster \"${CLUSTER_NAME}\" is down. Only log and command args will be uploaded"
+    RESULTS_DIR=""
+else
+    # get the latest time-stamped results directory from the cluster
+    # (may not be current date stamp if multiple jobs run on same cluster)
+    MASTER="${CLUSTER_NAME}-m"
+    RESULTS_DIR="$(dirname ${OUTPUT_DIR})"
+    RESULTS_DIR=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --command="hadoop fs -ls ${RESULTS_DIR} | tail -n 1")
+    RESULTS_DIR=$(echo "${RESULTS_DIR}" | awk '{print $NF}' | sed -e 's/^\///')
+fi
+
+if [ -z "${RESULTS_DIR}" ]; then
+    # directory is empty (presumably the job crashed). Use OUTPUT_DIR (without leading slash)
+    RESULTS_DIR=$(echo "${OUTPUT_DIR}" | sed -e 's/^\///')
+    echo "RESULTS_DIR=${RESULTS_DIR}" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    GCS_RESULTS_DIR="gs://${PROJECT_NAME}/${GCS_USER}/${RESULTS_DIR}"
+else
+    # copy the latest results to google cloud
+    echo "RESULTS_DIR=${RESULTS_DIR}" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    GCS_RESULTS_DIR="gs://${PROJECT_NAME}/${GCS_USER}/${RESULTS_DIR}"
+    # chose semi-optimal parallel args for distcp
+    # 1) count number of files to copy
+    COUNT_FILES_CMD="hadoop fs -count /${RESULTS_DIR}/ | tr -s ' ' | cut -d ' ' -f 3"
+    NUM_FILES=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --command="${COUNT_FILES_CMD}")
+    # 2) get the number of instances
+    NUM_INSTANCES=$(echo "${CLUSTER_INFO}" | cut -d' ' -f 2)
+    # 3) choose number of maps as min of NUM_FILES or NUM_INSTANCES * MAPS_PER_INSTANCE
+    MAPS_PER_INSTANCE=10
+    NUM_MAPS=$((${NUM_INSTANCES} * ${MAPS_PER_INSTANCE}))
+    NUM_MAPS=$((${NUM_FILES} < ${NUM_MAPS} ? ${NUM_FILES} : ${NUM_MAPS}))
+    # 4) set arguments to distcp to prevent it from erroring out due to too many maps
+    SPLIT_RATIO=$((${NUM_FILES}/${NUM_MAPS}))
+    SPLIT_RATIO=$((${SPLIT_RATIO} < 3 ? ${SPLIT_RATIO} : 3))
+    MAX_CHUNKS_IDEAL=$((${NUM_MAPS}*${SPLIT_RATIO}))
+    MAX_CHUNKS_TOL=$((${MAX_CHUNKS_IDEAL} + ${NUM_MAPS}))
+    DIST_CP_ARGS="-D distcp.dynamic.max.chunks.tolerable=${MAX_CHUNKS_TOL} -D distcp.dynamic.max.chunks.ideal=${MAX_CHUNKS_IDEAL} -D distcp.dynamic..min.records_per_chunk=0 -D distcp.dynamic.split.ratio=${SPLIT_RATIO}"
+    CPY_CMD="hadoop distcp ${DIST_CP_ARGS} -m ${NUM_MAPS} -strategy dynamic /${RESULTS_DIR}/* ${GCS_RESULTS_DIR}/"
+    echo "gcloud compute ssh ${MASTER} --zone ${ZONE} --command=\"${CPY_CMD}\" 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+    gcloud compute ssh ${MASTER} --zone ${ZONE} --command="${CPY_CMD}" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+fi
+
+# create file with command-line args. Always create (even if empty) so
+# that it's unambiguous if args were logged or not (file is present),
+# and if args were passed or not (file is non-empty)
+echo "gsutil cp >(echo \"${SV_ARGS}\") \"${GCS_RESULTS_DIR}/sv-command-line-args.txt\"" | tee -a ${LOCAL_LOG_FILE}
+gsutil cp <(echo "${SV_ARGS}") "${GCS_RESULTS_DIR}/sv-command-line-args.txt"
+
+if [ "${LOCAL_LOG_FILE}" != "/dev/null" ]; then
+    # copy log to google cloud
+    REMOTE_LOG_FILE="${GCS_RESULTS_DIR}/sv-discovery.log"
+    if gsutil -q stat ${REMOTE_LOG_FILE}; then
+        # remote log file exists, append local to remote
+        gsutil mv ${LOCAL_LOG_FILE} "${REMOTE_LOG_FILE}-append"
+        gsutil compose ${REMOTE_LOG_FILE} "${REMOTE_LOG_FILE}-append"
+        gsutil rm "${REMOTE_LOG_FILE}-append"
+    else
+        # mv log file from local to bucket
+        gsutil mv ${LOCAL_LOG_FILE} ${REMOTE_LOG_FILE}
+    fi
+fi

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -60,13 +60,30 @@ else
     fi
 fi
 
+ZONE=${CLOUDSDK_COMPUTE_ZONE:-"us-central1-a"}
+if [ "${CLOUDSDK_COMPUTE_ZONE:-""}" == "" ]; then
+    echo "Using zone=${ZONE} because CLOUDSDK_COMPUTE_ZONE is not set"
+else
+    # note: not a typo, letting user know that CLOUDSDK_COMPUTE_ZONE
+    # is the environmental variable being used
+    echo "Using zone=CLOUDSDK_COMPUTE_ZONE=${ZONE}"
+fi
+
+# experimental feature: allow setting number of workers
+# make 10 worker by default, but allow overload by setting env variable
+NUM_SV_WORKERS=${NUM_SV_WORKERS:-10}
+# make *no* preemptible workers by default, but allow overload by
+# setting env variable
+NUM_SV_PREEMPTIBLE_WORKERS=${NUM_SV_PREEMPTIBLE_WORKERS:-0}
+
 gcloud dataproc clusters create ${CLUSTER_NAME} \
-    --zone us-central1-a \
+    --zone ${ZONE} \
     --master-machine-type n1-highmem-8 \
     --worker-machine-type n1-highmem-16 \
     --master-boot-disk-size 500 \
     --worker-boot-disk-size 500 \
-    --num-workers 10 \
+    --num-workers ${NUM_SV_WORKERS} \
+    --num-preemptible-workers ${NUM_SV_PREEMPTIBLE_WORKERS} \
     --num-worker-local-ssds 1 \
     --metadata "reference=$REF_DIR" \
     --metadata "sample=$SAMP_DIR" \

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -21,10 +21,15 @@ if [[ "$#" -lt 4 ]]; then
   [4] GCS path to reference fasta (required)
       OPTIONAL arguments:
   [5] path to initialization script (local or GCS, defaults to
-      ${GATK_DIR}/scripts/sv/default_init.sh if omitted or empty)
+      \${GATK_DIR}/scripts/sv/default_init.sh if omitted or empty)
   [6] GCS username (defaults to local username if omitted or empty)
   [*] additional arguments to pass to
-      StructuralVariationDiscoveryPipelineSpark"
+      StructuralVariationDiscoveryPipelineSpark
+To leave a value as default but specify a later value, use an empty
+  string. e.g. to use default initialization script but override
+  GCS user name:
+\$ manage_sv_pipeline.sh /my/gatk/dir my_project gs://mybam.bam \\
+     gs://myfasta.fasta \"\" my_gcs_user"
     exit 1
 fi
 
@@ -45,7 +50,7 @@ SV_ARGS=${*:-${SV_ARGS:-""}} && SV_ARGS=${SV_ARGS:+" ${SV_ARGS}"}
 PATH="${GATK_DIR}/scripts/sv:${PATH}"
 
 # configure caching .jar files
-export GATK_GCS_STAGING="gs://${PROJECT_NAME}/${GCS_USER}/staging/"
+export GATK_GCS_STAGING=${GATK_GCS_STAGING:-"gs://${PROJECT_NAME}/${GCS_USER}/staging/"}
 
 # set cluster name based on user and target bam file
 # (NOTE: can override by defining SV_CLUSTER_NAME)

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# This script manages the SV discovery pipeline by calling other scripts
+# a) it creates a Google Dataproc cluster used for running the GATK-SV
+#    pipeline (call create_cluster.sh)
+# b) it runs the analysis (call runWholePipeline.sh)
+# c) it copies results to a datetime and git-version stamped directory
+#    on GCS, along with logged console output (call copy_sv_results.sh)
+# d) it shuts down the cluster
+
+# terminate script on error or if a command fails before piping to another command
+set -eu
+set -o pipefail
+
+if [[ "$#" -lt 4 ]]; then
+    echo -e \
+"Please provide:
+  [1] local directory of GATK build (required)
+  [2] project name (required)
+  [3] GCS path to indexed BAM (required)
+  [4] GCS path to reference fasta (required)
+      OPTIONAL arguments:
+  [5] path to initialization script (local or GCS, defaults to
+      ${GATK_DIR}/scripts/sv/default_init.sh if omitted or empty)
+  [6] GCS username (defaults to local username if omitted or empty)
+  [*] additional arguments to pass to
+      StructuralVariationDiscoveryPipelineSpark"
+    exit 1
+fi
+
+# init variables that MUST be defined
+GATK_DIR="$1"
+PROJECT_NAME="$2"
+GCS_BAM="$3"
+GCS_REFERENCE_FASTA="$4"
+
+# init variables with optional overrides / defaults
+# passed value -> overrides system value -> overrides default value
+INIT_SCRIPT=${5:-${INIT_SCRIPT:-"${GATK_DIR}/scripts/sv/default_init.sh"}}
+GCS_USER=${6:-${GCS_USER:-${USER}}}
+shift 6
+SV_ARGS=${*:-${SV_ARGS:-""}} && SV_ARGS=${SV_ARGS:+" ${SV_ARGS}"}
+
+# add GATK SV scripts to PATH
+PATH="${GATK_DIR}/scripts/sv:${PATH}"
+
+# configure caching .jar files
+export GATK_GCS_STAGING="gs://${PROJECT_NAME}/${GCS_USER}/staging/"
+
+# set cluster name based on user and target bam file
+# (NOTE: can override by defining SV_CLUSTER_NAME)
+SANITIZED_BAM=$(basename "${GCS_BAM}" | awk '{print tolower($0)}' | sed 's/[^a-z0-9]/-/g')
+CLUSTER_NAME=${SV_CLUSTER_NAME:-"${GCS_USER}-${SANITIZED_BAM}"}
+
+# update gcloud
+gcloud components update
+
+# for now assume the reference image is just the reference fasta + ".img"
+GCS_REFERENCE_IMAGE="${GCS_REFERENCE_FASTA}.img"
+# monkey around with variables to put them in form used by gatk/sv/scripts
+GCS_BAM_DIR="$(dirname ${GCS_BAM})"
+GCS_BAM="/data/$(basename ${GCS_BAM})"
+GCS_REFERENCE_DIR="$(dirname ${GCS_REFERENCE_FASTA})"
+if [ "$(dirname ${GCS_REFERENCE_IMAGE})" != "$(dirname ${GCS_REFERENCE_IMAGE})" ]; then
+    echo "Reference fasta and reference image must be in same folder"
+    exit -1
+fi
+GCS_REFERENCE_FASTA="/reference/$(basename ${GCS_REFERENCE_FASTA})"
+GCS_REFERENCE_IMAGE="/mnt/1/reference/$(basename ${GCS_REFERENCE_IMAGE})"
+
+# store run log in this file
+# (NOTE: can override by defining SV_LOCAL_LOG_FILE)
+LOCAL_LOG_FILE=${SV_LOCAL_LOG_FILE:-"${TMPDIR}sv-discovery-${SANITIZED_BAM}.log"}
+
+# check if GATK jar was compiled from the current .git hash
+GATK_GIT_HASH=$(readlink ${GATK_DIR}/build/libs/gatk-spark.jar | cut -d- -f5 | cut -c2-)
+CURRENT_GIT_HASH=$(git -C ${GATK_DIR} rev-parse --short HEAD | cut -c1-7)
+if [ "${GATK_GIT_HASH}" != "${CURRENT_GIT_HASH}" ]; then
+        while true; do
+                read -p "Current git hash does not match GATK git hash. Run anyway?" yn
+                case $yn in
+                        [Yy]*)  break
+                                ;;
+                        [Nn]*)  exit
+                                ;;
+                        *)      echo "Please answer yes or no"
+                        
+                esac
+        done
+fi
+GIT_BRANCH=$(git -C ${GATK_DIR} branch --contains ${GATK_GIT_HASH} | rev | cut -d" " -f 1 | rev)
+# set output directory to datetime-git branch-git hash stamped folder
+OUTPUT_DIR="/results/$(date "+%Y-%m-%d_%H.%M.%S")-${GIT_BRANCH}-${GATK_GIT_HASH}"
+
+# call create_cluster, using default_init
+while true; do
+    echo "#############################################################" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    read -p "Create cluster? (yes/no/cancel)" yn
+    case $yn in
+        [Yy]*)  if [[ ${INIT_SCRIPT} == gs://* ]]; then
+                        INIT_ARGS=${INIT_SCRIPT}
+                else
+                        INIT_ARGS="${INIT_SCRIPT} gs://${PROJECT_NAME}/${GCS_USER}/init/$(basename INIT_SCRIPT)"
+                fi
+
+                echo "create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${GCS_REFERENCE_DIR} ${GCS_BAM_DIR} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+                create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${GCS_REFERENCE_DIR} ${GCS_BAM_DIR} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
+                break
+                ;;
+        [Nn]*)  break
+                ;;
+        [Cc]*)  exit
+                ;;
+        *)      echo "Please answer yes, no, or cancel."
+                ;;
+    esac
+done
+
+# call runWholePipeline
+while true; do
+    echo "#############################################################" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    read -p "Run whole pipeline? (yes/no/cancel)" yn
+    case $yn in
+        [Yy]*)  SECONDS=0
+                echo "runWholePipeline.sh ${GATK_DIR} ${CLUSTER_NAME} ${OUTPUT_DIR} ${GCS_BAM} ${GCS_REFERENCE_FASTA} ${GCS_REFERENCE_IMAGE}${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+                runWholePipeline.sh ${GATK_DIR} ${CLUSTER_NAME} ${OUTPUT_DIR} ${GCS_BAM} ${GCS_REFERENCE_FASTA} ${GCS_REFERENCE_IMAGE}${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
+                printf 'Pipeline completed in %02dh:%02dm:%02ds\n' $((${SECONDS}/3600)) $((${SECONDS}%3600/60)) $((${SECONDS}%60))
+                break
+                ;;
+        [Nn]*)  break
+                ;;
+        [Cc]*)  exit
+                ;;
+        *)      echo "Please answer yes, no, or cancel."
+                ;;
+    esac
+done
+
+# copy results into gcloud
+while true; do
+    echo "#############################################################" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    read -p "Copy results? (yes/no/cancel)" yn
+    case $yn in
+        [Yy]*)  echo "copy_sv_results.sh ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${GCS_USER} ${LOCAL_LOG_FILE} 2>&1" | tee -a ${LOCAL_LOG_FILE}
+                copy_sv_results.sh ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${GCS_USER} ${LOCAL_LOG_FILE}${SV_ARGS}
+                break
+                ;;
+        [Nn]*)  break
+                ;;
+        [Cc]*)  exit
+                ;;
+        *)      echo "Please answer yes, no, or cancel."
+                ;;
+    esac
+done
+
+# delete cluster
+while true; do
+    echo "#############################################################"
+    read -p "Delete cluster? (yes/no/cancel)" yn
+    case $yn in
+        [Yy]*)  echo "gcloud dataproc clusters delete ${CLUSTER_NAME} --project=${PROJECT_NAME} --async --quiet"
+                gcloud dataproc clusters delete ${CLUSTER_NAME} --project=${PROJECT_NAME} --async --quiet
+                echo
+                break
+                ;;
+        [Nn]*)  break
+                ;;
+        [Cc]*)  exit
+                ;;
+        *)      echo "Please answer yes, no, or cancel."
+                ;;
+    esac
+done

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -56,6 +56,7 @@ export GATK_GCS_STAGING=${GATK_GCS_STAGING:-"gs://${PROJECT_NAME}/${GCS_USER}/st
 # (NOTE: can override by defining SV_CLUSTER_NAME)
 SANITIZED_BAM=$(basename "${GCS_BAM}" | awk '{print tolower($0)}' | sed 's/[^a-z0-9]/-/g')
 CLUSTER_NAME=${SV_CLUSTER_NAME:-"${GCS_USER}-${SANITIZED_BAM}"}
+echo "Using cluster name \"${CLUSTER_NAME}\""
 
 # update gcloud
 gcloud components update

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-
-
 # terminate script on error or if a command fails before piping to another command
 set -eu
 set -o pipefail

--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -36,7 +36,7 @@ ALTS_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.alts/')
 REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
 
 # extract any extra arguments to StructuralVariationDiscoveryPipelineSpark
-shift 6
+shift $(($# < 6 ? $# : 6))
 SV_ARGS=${*:-${SV_ARGS:-""}}
 # expand any local variables passed as strings (e.g. PROJECT_OUTPUT_DIR)
 eval "SV_ARGS=\"${SV_ARGS}\""

--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -10,6 +10,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "  [4] absolute path to the BAM on the cluster (index assumed accompanying the bam) (HDFS,required)"
     echo -e "  [5] absolute path to the reference fasta on the cluster (2bit is assumed accompanying with same basename and extension \".2bit\", skiplist with extension \".kill.intervals\") (HDFS,required)"
     echo -e "  [6] absolute path to the reference index image on each worker node's local file system (required)"
+    echo -e "  [*] extra command-line arguments to StructuralVariationDiscoveryPipelineSpark"
     echo -e "Example:"
     echo -e " bash svDiscover.sh \\"
     echo -e "      ~/GATK/gatk \\"
@@ -34,6 +35,16 @@ KMER_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.kmers/')
 ALTS_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.alts/')
 REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
 
+# extract any extra arguments to StructuralVariationDiscoveryPipelineSpark
+shift 6
+SV_ARGS=${*:-${SV_ARGS:-""}}
+# expand any local variables passed as strings (e.g. PROJECT_OUTPUT_DIR)
+eval "SV_ARGS=\"${SV_ARGS}\""
+
+# Choose NUM_EXECUTORS = 2 * NUM_WORKERS
+NUM_WORKERS=$(gcloud compute instances list --filter="name ~ ${CLUSTER_NAME}-[sw].*" | grep RUNNING | wc -l)
+NUM_EXECUTORS=$((2 * ${NUM_WORKERS}))
+
 "${GATK_DIR}/gatk-launch" StructuralVariationDiscoveryPipelineSpark \
     -I "${INPUT_BAM}" \
     -O "${PROJECT_OUTPUT_DIR}/variants/inv_del_ins.vcf" \
@@ -46,10 +57,11 @@ REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
     --breakpointIntervals "${PROJECT_OUTPUT_DIR}/intervals" \
     --fastqDir "${PROJECT_OUTPUT_DIR}/fastq" \
     --contigSAMFile "${PROJECT_OUTPUT_DIR}/assemblies.sam" \
+    ${SV_ARGS} \
     -- \
     --sparkRunner GCS \
     --cluster "${CLUSTER_NAME}" \
-    --num-executors 20 \
+    --num-executors ${NUM_EXECUTORS} \
     --driver-memory 30G \
     --executor-memory 30G \
     --conf spark.yarn.executor.memoryOverhead=5000 \


### PR DESCRIPTION
Add new scripts to gatk/scripts/sv/ folder, and alter action (but not
passed parameters) of older scripts to make running sv spark jobs
more convenient.
Added:
  -copy_sv_results.sh: copy files to time and git-stamped folder on
   google cloud storage
     -> results folder on cluster
     -> command line arguments to SV discover pipeline
     -> console log file (if present)

  -manage_sv_pipeline.sh: create cluster, run job, copy results, and
   delete cluster. Manage cluster naming, time and git-stamping,
   and log file production.

Altered:
  -create_cluster.sh: control GCS zone and numbers of workers via
   environmental variables. Defaults to previous hard-coded values.

  -runWholePipeline.sh: accept command-line arguments for sv
   discovery pipeline, work with clusters having NUM_WORKERS != 10