### PR TITLE
Update google-cloud-nio dependency to 0.20.4-alpha-20170727.190814-1:shaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.20.2-alpha-20170718.213753-11:shaded'
+    compile 'com.google.cloud:google-cloud-nio:0.20.4-alpha-20170727.190814-1:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     compile 'org.apache.logging.log4j:log4j-api:2.3'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -301,7 +301,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
 
         logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration().maxChannelReopens());
-        logger.info("Using google-cloud-java patch 317951be3c2e898e3916a4b1abf5a9c220d84df8");
+        logger.info("Using google-cloud-java patch c035098b5e62cb4fe9155eff07ce88449a361f5d from https://github.com/droazen/google-cloud-java/tree/dr_all_nio_fixes");
     }
 
     /**


### PR DESCRIPTION
This includes the fix for the position overflowing in CloudStorageReadChannel
(https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2283), as well
as the fix for the intermittent 503 errors we've already been depending on
(https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2281)