### PR TITLE
Increased maximum copy-ratio variance slice-sampling bound.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/copyratio/CopyRatioModeller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/copyratio/CopyRatioModeller.java
@@ -53,7 +53,7 @@ public final class CopyRatioModeller {
         final double coverageMax = data.getCoverageMax();
         final double varianceEstimate = data.estimateVariance();
         final double varianceSliceSamplingWidth = Math.sqrt(2. * varianceEstimate / data.getNumTargets()) / 10.;    //take the width down an order of magnitude to account for inflation by outliers
-        final double varianceMax = Math.abs(coverageMax - coverageMin);
+        final double varianceMax = Math.abs(coverageMax - coverageMin) * Math.abs(coverageMax - coverageMin);
         final double meanSliceSamplingWidth = Math.sqrt(varianceEstimate * data.getNumSegments() / data.getNumTargets());
 
         //the uniform log-likelihood for outliers is determined by the minimum and maximum coverages in the dataset;


### PR DESCRIPTION
Just a patch to make the change suggested in the review of broadinstitute/gatk-protected#1001.  @asmirnov239 your comment was correct, not sure what I was thinking back then!

Closes #3372.