### PR TITLE
fixed contamination calculation, added error bars to output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
@@ -83,15 +83,15 @@ public class CalculateContamination extends CommandLineProgram {
         // if eg ref is A, alt is C, then # of ref reads due to error is roughly (# of G read + # of T reads)/2
         final long errorRefCount = homAltSites.stream().mapToLong(PileupSummary::getOtherAltCount).sum() / 2;
         final long contaminationRefCount = Math.max(totalRefCount - errorRefCount, 0);
-        final double totalDepthWeightedByRefFraction = homAltSites.stream()
+        final double totalDepthWeightedByRefFrequency = homAltSites.stream()
                 .mapToDouble(ps -> ps.getTotalCount() * (1 - ps.getAlleleFrequency()))
                 .sum();
-        final double contamination = contaminationRefCount / totalDepthWeightedByRefFraction;
-        final double standardError = Math.sqrt(contamination / totalDepthWeightedByRefFraction);
+        final double contamination = contaminationRefCount / totalDepthWeightedByRefFrequency;
+        final double standardError = Math.sqrt(contamination / totalDepthWeightedByRefFrequency);
 
         logger.info(String.format("In %d homozygous variant sites we find %d reference reads due to contamination and %d" +
                         " due to to sequencing error out of a total %d reads.", homAltSites.size(), contaminationRefCount, errorRefCount, totalReadCount));
-        logger.info(String.format("Based on population data, we would expect %d reference reads in a contaminant with the same depths at these sites.", (long) totalDepthWeightedByRefFraction));
+        logger.info(String.format("Based on population data, we would expect %d reference reads in a contaminant with equal depths at these sites.", (long) totalDepthWeightedByRefFrequency));
         logger.info(String.format("Therefore, we estimate a contamination of %.3f.", contamination));
         logger.info(String.format("The error bars on this estimate are %.5f.", standardError));
         return Pair.of(contamination, standardError);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/ContaminationRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/ContaminationRecord.java
@@ -17,18 +17,22 @@ import java.util.List;
 public class ContaminationRecord {
     private String level;
     private double contamination;
+    private double error;
 
-    public ContaminationRecord(final String level, final double contamination) {
+    public ContaminationRecord(final String level, final double contamination, final double error) {
         this.level = level;
         this.contamination = contamination;
+        this.error = error;
     }
 
-    public String getLevel() {
-        return level;
-    }
+    public String getLevel() { return level; }
 
     public double getContamination() {
         return contamination;
+    }
+
+    public double getError() {
+        return error;
     }
 
     //----- The following two public static methods read and write contamination files
@@ -57,7 +61,8 @@ public class ContaminationRecord {
         @Override
         protected void composeLine(final ContaminationRecord record, final DataLine dataLine) {
             dataLine.set(ContaminationTableColumn.LEVEL.toString(), record.getLevel())
-                    .set(ContaminationTableColumn.CONTAMINATION.toString(), record.getContamination());
+                    .set(ContaminationTableColumn.CONTAMINATION.toString(), record.getContamination())
+                    .set(ContaminationTableColumn.ERROR.toString(), record.getError());
         }
     }
 
@@ -70,13 +75,15 @@ public class ContaminationRecord {
         protected ContaminationRecord createRecord(final DataLine dataLine) {
             final String sample = dataLine.get(ContaminationTableColumn.LEVEL);
             final double contamination = dataLine.getDouble(ContaminationTableColumn.CONTAMINATION);
-            return new ContaminationRecord(sample, contamination);
+            final double error = dataLine.getDouble(ContaminationTableColumn.ERROR);
+            return new ContaminationRecord(sample, contamination, error);
         }
     }
 
     private enum ContaminationTableColumn {
         LEVEL("level"),
-        CONTAMINATION("contamination");
+        CONTAMINATION("contamination"),
+        ERROR("error");
 
         private final String columnName;
 
@@ -89,7 +96,7 @@ public class ContaminationRecord {
             return columnName;
         }
 
-        public static final TableColumnCollection COLUMNS = new TableColumnCollection(LEVEL, CONTAMINATION);
+        public static final TableColumnCollection COLUMNS = new TableColumnCollection(LEVEL, CONTAMINATION, ERROR);
     }
 
     public enum Level {


### PR DESCRIPTION
@takutosato This corrects the math error you pointed out in your code review of the docs.  While we're at it, it also outputs the error bars according to the formula given in the docs.  I have tested it on an in silico contamination series and it improves results slightly.