### PR TITLE
Use ReadClipper in BaseQualityClipReadTransformer

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/transformers/BaseQualityClipReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/BaseQualityClipReadTransformer.java
@@ -8,8 +8,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 /**
  * Clips reads on both ends using base quality scores
  */
-public class BaseQualityClipReadTransformer implements ReadTransformer {
-    public static final long serialVersionUID = 1L;
+public final class BaseQualityClipReadTransformer implements ReadTransformer {
+    private static final long serialVersionUID = 1L;
     private int qTrimmingThreshold = 15;
 
     public BaseQualityClipReadTransformer(final int trim_thresh) {
@@ -35,6 +35,9 @@ public class BaseQualityClipReadTransformer implements ReadTransformer {
         return clipReadLeftEnd(readClippedRightEnd);
     }
 
+    /**
+     * Returns right clip point or -1 if no clip
+     */
     public int getRightClipPoint( final byte[] quals ) {
         int clipSum = 0, lastMax = -1, clipPoint = -1; // -1 means no clip
         final int readLength = quals.length;
@@ -48,6 +51,9 @@ public class BaseQualityClipReadTransformer implements ReadTransformer {
         return clipPoint;
     }
 
+    /**
+     * Returns left clip point or -1 if no clip
+     */
     public int getLeftClipPoint( final byte[] quals ) {
         int clipSum = 0, lastMax = -1, clipPoint = -1; // -1 means no clip
         final int readLength = quals.length;

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
@@ -377,7 +377,7 @@ public final class ClippingOp {
         hardClippedRead.setBaseQualities(newQuals);
         hardClippedRead.setBases(newBases);
         hardClippedRead.setCigar(cigarShift.cigar);
-        if (start == 0) {
+        if (start == 0 && !read.isUnmapped()) {
             hardClippedRead.setPosition(read.getContig(), read.getStart() + calculateAlignmentStartShift(cigar, cigarShift.cigar));
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/transformers/BaseQualityClipReadTransformerTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/BaseQualityClipReadTransformerTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.hellbender.transformers;
 
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -14,30 +17,37 @@ public class BaseQualityClipReadTransformerTest {
         return new Object[][] {
             {"IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
             "CTCAAGTACAAGCTGATCCAGACCTACAGGGTGATGTCATTAGAGGCACTGATAACACACACACTATGGGGTGGGGGTGGACAGTTCCCCACTGCAATCC",
-            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"},
+            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+            "100M"},
 
             {"####################################################################################################",
             "",
-            ""},
+            "",
+            "*"},
 
             {"############################IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
             "GGGTGATGTCATTAGAGGCACTGATAACACACACACTATGGGGTGGGGGTGGACAGTTCCCCACTGCAATCC",
-            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"},
+            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+            "28H72M"},
 
             {"IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII######",
             "CTCAAGTACAAGCTGATCCAGACCTACAGGGTGATGTCATTAGAGGCACTGATAACACACACACTATGGGGTGGGGGTGGACAGTTCCCCACTG",
-            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"}
+            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+            "94M6H"}
         };
     }
 
     @Test(dataProvider = "sequenceStrings")
-    public void testApply(final String quals_in, final String bases_out, final String quals_out) throws Exception {
-        final String bases_in = "CTCAAGTACAAGCTGATCCAGACCTACAGGGTGATGTCATTAGAGGCACTGATAACACACACACTATGGGGTGGGGGTGGACAGTTCCCCACTGCAATCC";
+    public void testApply(final String quals_in, final String basesOut, final String qualsOut, final String cigarOut) throws Exception {
+        final String basesIn = "CTCAAGTACAAGCTGATCCAGACCTACAGGGTGATGTCATTAGAGGCACTGATAACACACACACTATGGGGTGGGGGTGGACAGTTCCCCACTGCAATCC";
         final BaseQualityClipReadTransformer trans = new BaseQualityClipReadTransformer(15);
-        final GATKRead read_in = ArtificialReadUtils.createArtificialRead(bases_in.getBytes(),SAMUtils.fastqToPhred(quals_in),"*");
-        final GATKRead read_out = trans.apply(read_in);
-        Assert.assertEquals(read_out.getBases(),bases_out.getBytes());
-        Assert.assertEquals(read_out.getBaseQualities(),SAMUtils.fastqToPhred(quals_out));
+        final Cigar cigar = new Cigar();
+        cigar.add(new CigarElement(basesIn.length(), CigarOperator.MATCH_OR_MISMATCH));
+        final GATKRead readIn = ArtificialReadUtils.createArtificialRead(basesIn.getBytes(),SAMUtils.fastqToPhred(quals_in), cigar.toString());
+        final GATKRead readOut = trans.apply(readIn);
+        Assert.assertEquals(readOut.getBases(),basesOut.getBytes());
+        Assert.assertEquals(readOut.getBaseQualities(),SAMUtils.fastqToPhred(qualsOut));
+        Assert.assertEquals(readOut.getCigar().toString(), cigarOut);
     }
 
 }


### PR DESCRIPTION
The earlier version of BaseQualityClipReadTransformer clipped bases by just removing them from the bases and base qualities arrays, but did not adjust the cigar, coordinate, etc. (thanks to @SHuang-Broad for catching this in #3354).

This commit fixes this behavior by invoking the ReadClipper class and adds cigar checking to the unit test. It also makes some minor style changes to the transformer and test code.