### PR TITLE
Update to Intel GKL version 0.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.5.2') {
+    compile('com.intel.gkl:gkl:0.5.3') {
         exclude module: 'htsjdk'
     }
 


### PR DESCRIPTION
This release fixes (among other issues) a bug that could cause the
AVX compatibility check to hang on CentOS machines.