### PR TITLE
removing the explicit System.exit(0) from Main

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -151,7 +151,6 @@ public class Main {
         try {
             final Object result = runCommandLineProgram(program, args);
             handleResult(result);
-            System.exit(0);
         } catch (final CommandLineException e){
             System.err.println(program.getUsage());
             handleUserException(e);

--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -151,6 +151,7 @@ public class Main {
         try {
             final Object result = runCommandLineProgram(program, args);
             handleResult(result);
+            //no explicit System.exit(0) since that causes issues when running in Yarn containers
         } catch (final CommandLineException e){
             System.err.println(program.getUsage());
             handleUserException(e);


### PR DESCRIPTION
this fixes the yarn early termination bug reported in #2666 and #3166