### PR TITLE
Update to Intel GKL version 0.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.5.3') {
+    compile('com.intel.gkl:gkl:0.5.5') {
         exclude module: 'htsjdk'
     }
 


### PR DESCRIPTION
GKL 0.5.5 fixes a critical bug in the FPGA PairHMM implementation. The bug produces a segmentation fault when FPGA PairHMM is invoked in 'private' mode. GKL 0.5.5 is otherwise identical to 0.5.3.