### PR TITLE
Upgrade to htsjdk 2.11.0. Make TargetCodec indexable.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.10.1-26-g9c6c364-20170731.190658-1')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.11.0')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.8.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.6.4-proto-3.0.0-beta-1')

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/TargetCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/TargetCodec.java
@@ -1,16 +1,20 @@
 package org.broadinstitute.hellbender.utils.codecs;
 
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
-import htsjdk.tribble.readers.LineIterator;
+import htsjdk.tribble.readers.*;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.exome.Target;
 import org.broadinstitute.hellbender.tools.exome.TargetTableReader;
-
+import org.broadinstitute.hellbender.utils.tsv.TableUtils;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static htsjdk.tribble.bed.BEDCodec.BED_EXTENSION;
 
@@ -34,9 +38,52 @@ public class TargetCodec extends AsciiFeatureCodec<Target> {
         return sourceTargetTableReader.readRecord(line);
     }
 
+    /**
+     * TargetCodec uses a com.opencsv.CSVReader, which uses a buffered reader. Since just initializing the
+     * CSVReader causes it to buffer a large portion of the underlying input stream, it can't be used directly
+     * on an input stream that is being indexed.
+     *
+     * To avoid this, we override makeIndexableSourceFromStream and instantiate and return a marker class that is a
+     * subclass of AsciiLineReaderIterator, and which is recognized by the readActualHeader method (where the actual
+     * TargetTableReader/CSVReader state is established). The marker class signals the codec to manually extract
+     * everything up to the end of the header from the stream, and instantiate the CSVReader on a separate stream
+     * containing only the (header) portion of the input. This allows the CSV reader to correctly establish it's
+     * internal state based on the header, without consuming the rest of the stream.
+     *
+     * The rest of the indexing process is driven by the indexer, which pulls from the input directly and passes
+     * candidate features to the codec's decode metho), so the features are then consumed and indexed with the correct
+     * stream offsets.
+     *
+     * @param inputStream stream to be indexed
+     * @return An AsciiLineReaderIterator implementation.
+     */
+    @Override
+    public LocationAware makeIndexableSourceFromStream(final InputStream inputStream) {
+        return new IndexableAsciiLineReaderIterator(AsciiLineReader.from(inputStream));
+    }
+
+    // Marker class to indicate to readActualHeader that we're being indexed
+    private class IndexableAsciiLineReaderIterator extends AsciiLineReaderIterator {
+        public IndexableAsciiLineReaderIterator(final AsciiLineReader asciiLineReader) {
+            super(asciiLineReader);
+        }
+    }
+
+    /**
+     * Read the actual header. This method instantiates the underlying TargetTableReader on either the entirety
+     * of the passed in LineIterator (in the case where we're not indexing) or on the subset of the input lines
+     * representing the header lines (in the case that were indexing).
+     * @param reader
+     * @return column header object
+     */
     @Override
     public Object readActualHeader(final LineIterator reader) {
-        sourceReader = new LineIteratorReader(reader);
+        // If we're being indexed, create a shim Reader that consumes only the header portion of the input
+        // stream, leaving the rest of the stream underlying the LineIterator available for the indexer
+        sourceReader = reader instanceof IndexableAsciiLineReaderIterator ?
+                makeIndexableReaderShim(reader) :
+                new LineIteratorReader(reader);
+
         try {
             sourceTargetTableReader = new TargetTableReader(sourceReader);
         } catch (final IOException ex) {
@@ -44,6 +91,44 @@ public class TargetCodec extends AsciiFeatureCodec<Target> {
         }
         return sourceTargetTableReader.columns();
     }
+
+    // Return a LineIteratorReader backed by only the header line from the underlying reader.
+    // This method needs to be certain not to consume any input from the stream beyond the headerline
+    // (that is, it shoud consume no features).
+    //
+    // NOTE: This implementation discards leading comments, which is based on the assumption
+    // that TableReader.processComment is a no-op.
+    private LineIteratorReader makeIndexableReaderShim(final LineIterator reader) {
+        // find the first non-comment line (which must be the header)
+        String line = null;
+        while (reader.hasNext()) {
+            line = reader.peek();
+            if (line != null && line.startsWith(TableUtils.COMMENT_PREFIX)) {
+                reader.next();
+            } else {
+                break;
+            }
+        }
+
+        // return a line reader iterator backed by the single string representing the header line
+        final String sourceLine = line;
+        return new LineIteratorReader(
+                new LineIteratorImpl(
+                    new LineReader() {
+                        private Iterator<String> iterator = Collections.singletonList(sourceLine).iterator();
+
+                        @Override
+                        public String readLine() throws IOException {
+                            return iterator.hasNext() ? iterator.next() : null;
+                        }
+
+                        @Override
+                        public void close() {
+                        }
+                    }
+                )
+        );
+}
 
     @Override
     public boolean canDecode(final String path) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/TargetCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/TargetCodecUnitTest.java
@@ -1,10 +1,16 @@
 package org.broadinstitute.hellbender.utils.codecs;
 
+import htsjdk.tribble.readers.LineIterator;
+import htsjdk.tribble.readers.PositionalBufferedStream;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
+import org.broadinstitute.hellbender.utils.tsv.TableUtils;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 
 public class TargetCodecUnitTest extends BaseTest {
@@ -30,4 +36,77 @@ public class TargetCodecUnitTest extends BaseTest {
         final String tsvPath = "src/test/resources/org/broadinstitute/hellbender/tools/exome/targets.tsv";
         Assert.assertTrue(codec.canDecode(tsvPath), "TargetCodec should be able to decode relative file paths");
     }
+
+    @DataProvider(name = "targetCodecMissingHeaders")
+    public Object[][] targetCodecMissingHeaders() {
+        return new Object[][] {
+                { "" },
+                { "# a comment only" },
+                { "# a comment\n" +
+                        "1" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "389" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "455" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "target_1_389_455\n" },
+
+        };
+    }
+
+    @Test(dataProvider = "targetCodecMissingHeaders", expectedExceptions = UserException.BadInput.class)
+    public void testIndexableMissingHeaderFails(final String featureTableContents) {
+        final TargetCodec codec = new TargetCodec();
+        LineIterator lit = (LineIterator) codec.makeIndexableSourceFromStream(new ByteArrayInputStream(featureTableContents.getBytes()));
+        codec.readActualHeader(lit);  // no header to be found
+    }
+
+    @DataProvider(name = "targetCodecFeatureOffsets")
+    public Object[][] goodTargetCodecHeaders() {
+        return new Object[][] {
+                new Object[] {
+                        "contig" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "start" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "stop" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "name\n" +
+                        "1" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "389" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "455" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "target_1_389_455\n",
+                        23L
+                },
+                new Object[] {
+                        "# a comment\n" +
+                        "contig" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "start" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "stop" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "name\n" +
+                        "1" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "389" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "455" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "target_1_389_455\n",
+                        35L
+                },
+                new Object[] {
+                        "# one comment\n" +
+                        "# two comments\n" +
+                        "contig" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "start" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "stop" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "name\n" +
+                        "1" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "389" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "455" + TableUtils.COLUMN_SEPARATOR_STRING +
+                        "target_1_389_455\n",
+                        52L
+                }
+        };
+    }
+
+    @Test(dataProvider = "targetCodecFeatureOffsets")
+    public void testIndexableFeatureOffset(final String featureTableContents, final long firstFeatureOffset) {
+        final TargetCodec codec = new TargetCodec();
+        final PositionalBufferedStream pbs = new PositionalBufferedStream(new ByteArrayInputStream(featureTableContents.getBytes()));
+        final LineIterator lit = (LineIterator) codec.makeIndexableSourceFromStream(pbs);
+        codec.readActualHeader(lit);
+        Assert.assertEquals(pbs.getPosition(), firstFeatureOffset);
+    }
+
 }


### PR DESCRIPTION
TargetCodec is dependent on the old htsjdk indexing scheme whereby the indexer called readActualHeader on the codec first (for the side effect of initializing the codec header state), and then manually processed the feature file contents by:

- re-creating the input SOURCE/stream a second time
- NOT calling readActualHeader
- extracting and passing the features one at a time to the codec's decode method, using the stream position to find the feature file offsets

Although this scheme worked with TargetCodec, it had several other failure modes (see https://github.com/samtools/htsjdk/pull/906). With https://github.com/samtools/htsjdk/pull/906, the SOURCE/stream is only opened once for indexing. However, TargetCodec uses an underlying CSVReader that automatically buffers input, which confounds the indexer. This PR works around that issue for indexing.

Note: this won't compile until there is an htsjdk snapshot available with https://github.com/samtools/htsjdk/pull/906.