### PR TITLE
Implement PathSeq taxon hit scoring in Spark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPathogenTaxonScore.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSPathogenTaxonScore.java
@@ -1,20 +1,37 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq;
 
+import org.broadinstitute.hellbender.exceptions.GATKException;
+
 /**
- * Pathogen abundance scores assigned to a taxonomic node and reported by the ClassifyReads tool.
- * See the ClassifyReads tool for scoring documentation.
+ * Pathogen abundance scores assigned to a taxonomic node and reported by the PathSeqScoreSpark tool.
+ * See the PathSeqScoreSpark tool for scoring documentation.
  */
 public final class PSPathogenTaxonScore {
-    public double score = 0; //PathSeq abundance score calculated in the ClassifyReads tool
-    public double scoreNormalized = 0; //Score normalized to percent of total
-    public int reads = 0; //Number of total reads mapped
-    public int unambiguous = 0; //Number of reads mapped unamibuously to this node
-    public long refLength = 0; //Length of reference in bp
 
     public final static String outputHeader = "score\tscore_normalized\treads\tunambiguous\treference_length";
 
+    public double selfScore = 0; //Total abundance score assigned directly to this taxon
+    public double descendentScore = 0; //Sum of descendents' scores
+    public double scoreNormalized = 0; //selfScore + descendentScore, normalized to percent of total selfScores
+    public int totalReads = 0; //Number of total reads mapped
+    public int unambiguousReads = 0; //Number of reads mapped unamibuously to this node
+    public long referenceLength = 0; //Length of reference in bp
+
     @Override
     public String toString() {
-        return score + "\t" + scoreNormalized + "\t" + reads + "\t" + unambiguous + "\t" + refLength;
+        return (selfScore + descendentScore) + "\t" + scoreNormalized + "\t" + totalReads + "\t" + unambiguousReads + "\t" + referenceLength;
+    }
+
+    public PSPathogenTaxonScore add(final PSPathogenTaxonScore other) {
+        final PSPathogenTaxonScore result = new PSPathogenTaxonScore();
+        result.selfScore = this.selfScore + other.selfScore;
+        result.descendentScore = this.descendentScore + other.descendentScore;
+        result.totalReads = this.totalReads + other.totalReads;
+        result.unambiguousReads = this.unambiguousReads + other.unambiguousReads;
+        if (this.referenceLength != other.referenceLength) {
+            throw new GATKException("Cannot add PSPathogenTaxonScores with different reference lengths.");
+        }
+        result.referenceLength = this.referenceLength;
+        return result;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSScorer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSScorer.java
@@ -317,7 +317,7 @@ public final class PSScorer {
                     continue;
                 }
                 final Double score = SCORE_GENOME_LENGTH_UNITS * hit.numMates / (numHits * tree.getLengthOf(taxId));
-                //Git list containing this node and its ancestors
+                //Get list containing this node and its ancestors
                 final List<String> path = tree.getPathOf(taxId);
                 hitPathNodes.addAll(path);
                 for (final String pathTaxId : path) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
@@ -5,7 +5,6 @@ import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -49,8 +48,8 @@ public class PathSeqPipelineSparkIntegrationTest extends CommandLineProgramTest 
         SamAssertionUtils.assertEqualBamFiles(outputBam, expectedBam, true, ValidationStringency.STRICT);
 
         final File expectedScores = getTestFile("pipeline_output.txt");
-        final byte[] expectedScoresBytes = FileUtils.readFileToByteArray(expectedScores);
-        final byte[] actualScoresBytes = FileUtils.readFileToByteArray(outputScores);
-        Assert.assertArrayEquals(expectedScoresBytes, actualScoresBytes);
+        final String expectedScoreString = FileUtils.readFileToString(expectedScores);
+        final String actualScoresString = FileUtils.readFileToString(outputScores);
+        PathSeqScoreIntegrationTest.compareScoreTables(expectedScoreString, actualScoresString);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreIntegrationTest.java
@@ -8,12 +8,60 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class PathSeqScoreIntegrationTest extends CommandLineProgramTest {
+
+    final static int SCORE_TABLE_COLUMNS = 9;
+    final static double SCORE_ABSOLUTE_ERROR_TOLERANCE = 1e-6;
 
     @Override
     public String getTestedClassName() {
         return PathSeqScoreSpark.class.getSimpleName();
+    }
+
+    private static boolean testPathogenTaxonScores(final PSPathogenTaxonScore a, final PSPathogenTaxonScore b) {
+        if (!PathSeqTestUtils.equalWithinTolerance(a.descendentScore,b.descendentScore, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        if (!PathSeqTestUtils.equalWithinTolerance(a.totalReads,b.totalReads, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        if (!PathSeqTestUtils.equalWithinTolerance(a.referenceLength,b.referenceLength, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        if (!PathSeqTestUtils.equalWithinTolerance(a.selfScore,b.selfScore, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        if (!PathSeqTestUtils.equalWithinTolerance(a.scoreNormalized,b.scoreNormalized, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        if (!PathSeqTestUtils.equalWithinTolerance(a.unambiguousReads,b.unambiguousReads, SCORE_ABSOLUTE_ERROR_TOLERANCE)) return false;
+        return true;
+    }
+
+    private static Map<String, PSPathogenTaxonScore> getScores(final String[] lines) {
+        final Map<String, PSPathogenTaxonScore> scores = new HashMap<>(lines.length);
+        for (int i = 1; i < lines.length; i++) {
+            String[] tok = lines[i].split("\t");
+            Assert.assertTrue(tok.length == SCORE_TABLE_COLUMNS, "Expected " + SCORE_TABLE_COLUMNS + " columns, but found " + tok.length);
+            final PSPathogenTaxonScore score = new PSPathogenTaxonScore();
+            final String taxonId = tok[0];
+            score.selfScore = new Double(tok[4]);
+            score.scoreNormalized = new Double(tok[5]);
+            score.totalReads = new Integer(tok[6]);
+            score.unambiguousReads = new Integer(tok[7]);
+            score.referenceLength = new Long(tok[8]);
+            Assert.assertFalse(scores.containsKey(taxonId), "Found more than one entry for taxon ID " + taxonId);
+            scores.put(taxonId, score);
+        }
+        return scores;
+    }
+
+    public static void compareScoreTables(final String expected, final String test) {
+        final String[] expectedLines = expected.split("\n");
+        final String[] testLines = test.split("\n");
+        if (expectedLines.length == 0 && testLines.length == 0) return;
+        Assert.assertEquals(expectedLines[0], testLines[0], "Headers did not match");
+
+        final Map<String, PSPathogenTaxonScore> expectedScores = getScores(expectedLines);
+        final Map<String, PSPathogenTaxonScore> testScores = getScores(testLines);
+
+        for (final String taxonId : expectedScores.keySet()) {
+            Assert.assertTrue(testScores.containsKey(taxonId), "Did not find taxon ID: " + taxonId);
+            Assert.assertTrue(testPathogenTaxonScores(testScores.get(taxonId), expectedScores.get(taxonId)), "Scores for taxon ID " + taxonId + " did not match.");
+        }
     }
 
     @Test(groups = "spark")
@@ -33,10 +81,9 @@ public class PathSeqScoreIntegrationTest extends CommandLineProgramTest {
         args.addFileArgument("scoresOutputPath", output);
         this.runCommandLine(args.getArgsArray());
 
-        final byte[] input_expected = FileUtils.readFileToByteArray(expectedFile);
-        final byte[] input_test = FileUtils.readFileToByteArray(output);
-
-        Assert.assertEquals(input_test, input_expected);
+        final String input_expected = FileUtils.readFileToString(expectedFile);
+        final String input_test = FileUtils.readFileToString(output);
+        compareScoreTables(input_expected, input_test);
     }
 
     @Test(groups = "spark")
@@ -56,10 +103,9 @@ public class PathSeqScoreIntegrationTest extends CommandLineProgramTest {
         args.addFileArgument("scoreWarningsFile",warnings);
         this.runCommandLine(args.getArgsArray());
 
-        final byte[] input_expected = FileUtils.readFileToByteArray(expectedFile);
-        final byte[] input_test = FileUtils.readFileToByteArray(output);
-
-        Assert.assertEquals(input_test, input_expected);
+        final String input_expected = FileUtils.readFileToString(expectedFile);
+        final String input_test = FileUtils.readFileToString(output);
+        compareScoreTables(input_expected, input_test);
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqTestUtils.java
@@ -1,0 +1,11 @@
+package org.broadinstitute.hellbender.tools.spark.pathseq;
+
+public final class PathSeqTestUtils {
+
+    /**
+     * Returns true if a and b are within absoluteTolerance of each other.
+     */
+    public static boolean equalWithinTolerance(final double a, final double b, final double absoluteTolerance) {
+        return Math.abs(a - b) < absoluteTolerance;
+    }
+}


### PR DESCRIPTION
Upgrades PathSeqScoreSpark to perform abundance score calculations on the executors rather than the driver. This was crashing on inputs with a lot of pathogen reads. 

This also required some minor changes to the `PSPathogenTaxonScore` class to be able to keep track of abundance score contributions that come directly from hits to that taxon and those that are from the taxon's descendents.

As a result, some of the test output changed when using bitwise, exact checks on the output. So the tests now check for output equivalence, meaning parsing the scores table, checking that all the taxa are the same, and that the scores are equal to within some defined epsilon.