### PR TITLE
Upgrade to gkl-0.5.6, and added log4j-1.2-api bridge to dependencies,…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ configurations.all {
     }
     all*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
     all*.exclude group: 'com.google.guava', module: 'guava-jdk5'
-    all*.exclude group: 'log4j' //exclude log4j (1.x) and let log4j-1.2-api from log4j2 handle it
 }
 
 
@@ -133,7 +132,6 @@ dependencies {
     compile 'com.google.cloud.bigdataoss:gcs-connector:1.6.1-hadoop2'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
-    compile 'org.apache.logging.log4j:log4j-1.2-api:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.apache.commons:commons-math3:3.5'
     compile 'org.apache.commons:commons-collections4:4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ configurations.all {
     }
     all*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
     all*.exclude group: 'com.google.guava', module: 'guava-jdk5'
+    all*.exclude group: 'log4j' //exclude log4j (1.x) and let log4j-1.2-api from log4j2 handle it
 }
 
 
@@ -132,6 +133,7 @@ dependencies {
     compile 'com.google.cloud.bigdataoss:gcs-connector:1.6.1-hadoop2'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
+    compile 'org.apache.logging.log4j:log4j-1.2-api:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.apache.commons:commons-math3:3.5'
     compile 'org.apache.commons:commons-collections4:4.1'
@@ -195,7 +197,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.5.5') {
+    compile('com.intel.gkl:gkl:0.5.6') {
         exclude module: 'htsjdk'
     }
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -4,6 +4,6 @@ log4j.rootLogger=INFO, stdout
 # Direct log messages to stderr
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.Threshold=WARN
+log4j.appender.stdout.Threshold=INFO
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p %C{1} - %m%n


### PR DESCRIPTION
… as well as excluding log4j 1.x.

GKL 0.5.6 now uses the log4j 1.x API for logging, and we use the log4j-1.2-api bridge JAR to redirect to log4j2 implementation. See [here](https://logging.apache.org/log4j/2.0/faq.html#which_jars) for details. This change was made because GATK 3.x uses log4j 1.x, and users were reporting errors in the output. This release fixes those errors.

GATK 4 uses log4j2 and, in order to make the API compatible with the GKL, we need to add a dependency on the log4j-1.2-api bridge. Unfortunately, the log4j 1.X JAR is also brought in due to some transitive dependency from another package, which causes conflicts with the log4j-1.2-api bridge package. To solve that, we need to exclude log4j 1.X from the dependencies, and let log4j-1.2-api take care of any calls to the log4j 1.X API, redirecting them to the log4j2 implementation. See [here](https://logging.apache.org/log4j/2.0/faq.html#exclusions) for details.