### PR TITLE
Added a .dockerignore file to the gatk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# These are files that for whatever reason we don't want to include in our distribution docker images
+src/test/resources
+src/test/resources/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,7 @@ RUN java -jar gatk.jar -h
 
 #Setup test data
 WORKDIR /gatk
-# remove existing test data
-RUN rm -rf src/test/resources
-# Create link to where test data is expeced
+# Create link to where test data is expected
 RUN ln -s /testdata src/test/resources
 
 # Create a simple unit test runner

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -91,7 +91,7 @@ if [ -n "$STAGING_DIR" ]; then
     set -e
     GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/${REPO}/${PROJECT}.git ${STAGING_DIR}/${STAGING_CLONE_DIR}
     cd ${STAGING_DIR}/${STAGING_CLONE_DIR}
-   STAGING_ABSOLUTE_PATH=$(pwd)
+    STAGING_ABSOLUTE_PATH=$(pwd)
 
     echo "Now in $(pwd)"
     if [ ${PULL_REQUEST_NUMBER} ]; then
@@ -102,11 +102,6 @@ if [ -n "$STAGING_DIR" ]; then
     GIT_CHECKOUT_COMMAND="git checkout ${GITHUB_DIR}${GITHUB_TAG}"
     echo "${GIT_CHECKOUT_COMMAND}"
     ${GIT_CHECKOUT_COMMAND}
-    if [ -z "${IS_NOT_RUN_UNIT_TESTS}" ] ; then
-        git lfs pull
-        chmod -R a+w ${STAGING_ABSOLUTE_PATH}/*
-        chmod a+w ${STAGING_ABSOLUTE_PATH}/
-    fi
 fi
 
 # Build
@@ -121,6 +116,10 @@ if [ -z "${IS_NOT_RUN_UNIT_TESTS}" ] ; then
 	if [ -n "${IS_NOT_REMOVE_UNIT_TEST_CONTAINER}" ] ; then
 		REMOVE_CONTAINER_STRING=" "
 	fi
+
+	git lfs pull
+    chmod -R a+w ${STAGING_ABSOLUTE_PATH}/*
+    chmod a+w ${STAGING_ABSOLUTE_PATH}/
 
 	echo docker run ${REMOVE_CONTAINER_STRING} -v ${STAGING_ABSOLUTE_PATH}/src/test/resources:/testdata -t ${REPO_PRJ}:${GITHUB_TAG} bash /root/run_unit_tests.sh
 	docker run ${REMOVE_CONTAINER_STRING} -v ${STAGING_ABSOLUTE_PATH}/src/test/resources:/testdata -t ${REPO_PRJ}:${GITHUB_TAG} bash /root/run_unit_tests.sh


### PR DESCRIPTION
This reduces the size of the docker image from ~9GB when LFS tests were being run to 2.74GB

fixes #3414