### PR TITLE
Adding in the necessary hooks to make the nightly builds automatic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ after_success:
   fi
 
 # This creates and uploads the gatk zip file to the nightly build bucket, only keeping the 10 newest entries
+# This also pokes the Dockerhub web api which is securely stored in the travis API with the variable "DOCKERHUB_URL"
 - if [[ $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == cron && $UPLOAD == true ]]; then
     $GCLOUD/gcloud components -q update gsutil;
     gsutil ls -l gs://gatk-nightly-builds | grep gatk | sort -r -k 2 | grep -o '\S\+$' | tail -n +11 | xargs -I {} gsutil rm {};
@@ -158,6 +159,8 @@ after_success:
     ZIP_FILE="$(ls build/ | grep .zip)";
     echo "Uploading zip to gs://gatk-nightly-builds/";
     $GCLOUD/gsutil -m cp build/$ZIP_FILE gs://gatk-nightly-builds/"$(date +%Y-%m-%d)"-$ZIP_FILE;
+    echo "Triggering an automatic build on dockerhub";
+    curl -H "Content-Type:application/json" --data '{"build":true}' -X POST ${DOCKERHUB_URL};
   fi
 after_failure:
 - dmesg | tail -100

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can download and run pre-built versions of GATK4 from the following places:
 
 * Starting with the beta release, a zip archive with everything you need to run GATK4 can be downloaded for each release from the [github releases page](https://github.com/broadinstitute/gatk/releases).
 
-* Starting with the beta release, you can download a GATK4 docker image from [our dockerhub repository](https://hub.docker.com/r/broadinstitute/gatk/)
+* Starting with the beta release, you can download a GATK4 docker image from [our dockerhub repository](https://hub.docker.com/r/broadinstitute/gatk/). We also host unstable nightly development builds on [this dockerhub repository](https://hub.docker.com/r/broadinstitute/gatk-nightly/).
     * Within the docker image, run gatk-launch commands as usual from the default startup directory (/gatk).
 
 ## <a name="building">Building GATK4</a>

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,4 @@
+## NOTE
+This directory holds webhooks for the automatic build feature of DockerHub and does not affect git hooks. 
+
+Nightly docker builds of the current version of master can be found at https://hub.docker.com/r/broadinstitute/gatk-nightly/.

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,19 @@
+#!/bin/bash
+## This is a dockerhub hook and is separate from a .git hook, which lives elsewhere.
+## This file ensures that dockerhub builds of the GATK are tagged with an appropriate name after they are built.
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)  
+repoName=${IMAGE_NAME:0:tagStart-1}
+DATE=`date +%Y-%m-%d`
+# Grabbing the commit tag for master
+git clone https://github.com/broadinstitute/gatk.git tmp
+cd tmp
+git checkout $SOURCE_COMMIT
+NAME=$(git describe)"-SNAPSHOT"
+cd ..
+
+# Tag and push image for each additional tag
+docker tag $IMAGE_NAME ${repoName}:${DATE}-${NAME}
+docker push ${repoName}:${DATE}-${NAME}


### PR DESCRIPTION
These changes are needed for dockerhub automatic builds so that they will be triggered when we do our nightly builds.