### PR TITLE
prevent accidental toString call during validation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculator.java
@@ -26,7 +26,7 @@ public abstract class AFCalculator {
     public AFCalculationResult getLog10PNonRef(final VariantContext vc, final int defaultPloidy, final int maximumAlternativeAlleles, final double[] log10AlleleFrequencyPriors) {
         Utils.nonNull(vc, "VariantContext cannot be null");
         Utils.nonNull(log10AlleleFrequencyPriors, "priors vector cannot be null");
-        Utils.validateArg( vc.getNAlleles() > 1, "VariantContext has only a single reference allele, but getLog10PNonRef requires at least one alt allele " + vc);
+        Utils.validateArg( vc.getNAlleles() > 1, () -> "VariantContext has only a single reference allele, but getLog10PNonRef requires at least one alt allele " + vc);
 
         // reset the result, so we can store our new result there
         final StateTracker stateTracker = getStateTracker(true, maximumAlternativeAlleles);


### PR DESCRIPTION
profiling of GenotypeGVCFs showed a lot of wasted time in VariantContext.toString() which can be tracked to computing an error message we never display in `AFCalculator.getLog10PNonRef`
fixing it so we only compute the message when we the error occurs