### PR TITLE
use correct logger class in MathUtils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
@@ -4,8 +4,8 @@ import org.apache.commons.math3.exception.NotStrictlyPositiveException;
 import org.apache.commons.math3.exception.NumberIsTooLargeException;
 import org.apache.commons.math3.special.Gamma;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
MathUtils was using the log4j1 logger, fixed to use the log4j 2 logger
