### PR TITLE
allowing variant walkers to configure their caching behavior

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
@@ -68,16 +68,17 @@ public abstract class MultiVariantWalker extends VariantWalkerBase {
                     }
                     drivingVariantsFeatureInputs.add(featureInput);
 
-                    //Add the driving datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.
-                    //Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
+                    //Add each driving variants FeatureInput to the feature manager so that it can be queried, using a lookahead value
+                    //of 0 to avoid caching because of windowed queries that need to "look behind" as well.
                     features.addToFeatureSources(0, featureInput, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                  referenceArguments.getReferencePath());
                 }
         );
-        drivingVariants = new MultiVariantDataSource(drivingVariantsFeatureInputs, getVariantCacheLookAheadBases(), cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        // Create a (MultiVariantDataSource) FeatureDataSource for the driving variants inputs, but use a lookahead value from getDrivingVariantCacheLookAheadBases()
+        drivingVariants = new MultiVariantDataSource(drivingVariantsFeatureInputs, getDrivingVariantCacheLookAheadBases(), cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                      referenceArguments.getReferencePath());
 
-        //Note: the intervals for the driving variants are set in onStartup
+        // Note: the intervals for the driving variants are set in onStartup
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
@@ -74,7 +74,7 @@ public abstract class MultiVariantWalker extends VariantWalkerBase {
                                                  referenceArguments.getReferencePath());
                 }
         );
-        drivingVariants = new MultiVariantDataSource(drivingVariantsFeatureInputs, VariantWalkerBase.FEATURE_CACHE_LOOKAHEAD, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        drivingVariants = new MultiVariantDataSource(drivingVariantsFeatureInputs, getVariantCacheLookAheadBases(), cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                      referenceArguments.getReferencePath());
 
         //Note: the intervals for the driving variants are set in onStartup

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
@@ -68,17 +68,19 @@ public abstract class MultiVariantWalker extends VariantWalkerBase {
                     }
                     drivingVariantsFeatureInputs.add(featureInput);
 
-                    //Add each driving variants FeatureInput to the feature manager so that it can be queried, using a lookahead value
-                    //of 0 to avoid caching because of windowed queries that need to "look behind" as well.
+                    // Add each driving variants FeatureInput to the feature manager so that it can be queried, using a lookahead value
+                    // of 0 to avoid caching because of windowed queries that need to "look behind" as well.
                     features.addToFeatureSources(0, featureInput, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                  referenceArguments.getReferencePath());
                 }
         );
-        // Create a (MultiVariantDataSource) FeatureDataSource for the driving variants inputs, but use a lookahead value from getDrivingVariantCacheLookAheadBases()
+
+        // Create a (MultiVariantDataSource) FeatureDataSource for the driving variants inputs using the
+        // cache lookahead value from getDrivingVariantCacheLookAheadBases()
         drivingVariants = new MultiVariantDataSource(drivingVariantsFeatureInputs, getDrivingVariantCacheLookAheadBases(), cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                      referenceArguments.getReferencePath());
 
-        // Note: the intervals for the driving variants are set in onStartup
+        // Note: the intervals for the driving variants are set in onStartup()
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantLocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantLocusWalker.java
@@ -72,16 +72,17 @@ public abstract class VariantLocusWalker extends VariantWalkerBase {
     protected void initializeDrivingVariants() {
         drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
 
-        //This is the data source for the driving source of variants, which uses a cache lookahead of FEATURE_CACHE_LOOKAHEAD
-        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, FEATURE_CACHE_LOOKAHEAD, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        // This is the data source for the driving source of variants,
+        // which uses a cache lookahead of getDrivingVariantCacheLookAheadBases()
+        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getDrivingVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                 referenceArguments.getReferencePath());
 
-        //Add the driving datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.
-        //Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
+        // Also add the driving datasource to the feature manager so that it can be queried. Setting cache lookahead
+        // to 0 to avoid caching. Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
         features.addToFeatureSources(0, drivingVariantsFeatureInput, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                 referenceArguments.getReferencePath());
 
-        //Note: the intervals for the driving variants are set in onStartup
+        // Note: the intervals for the driving variants are set in onStartup()
     }
 
     /**
@@ -139,7 +140,7 @@ public abstract class VariantLocusWalker extends VariantWalkerBase {
             // Traverse loci in shards. For any shard with overlapping variants, drop down to per-locus iteration,
             // calling apply for a single locus, only if there are overlapping variants, passing all such variants
             // as a group.
-            Utils.stream(new ShardedIntervalIterator(getTraversalIntervals().iterator(), FEATURE_CACHE_LOOKAHEAD))
+            Utils.stream(new ShardedIntervalIterator(getTraversalIntervals().iterator(), getDrivingVariantCacheLookAheadBases()))
                     .forEachOrdered (shard -> {
                         if (drivingVariants.query(shard).hasNext()) {
                             getLocusStream(Collections.singletonList(new SimpleInterval(shard.getContig(), shard.getStart(), shard.getEnd())))

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -27,7 +27,7 @@ public abstract class VariantWalker extends VariantWalkerBase {
     public String drivingVariantFile;
 
     // NOTE: keeping the driving source of variants separate from other, supplementary FeatureInputs in our FeatureManager in GATKTool
-    //we do add the driving source to the Feature manager but we do need to treat it differently and thus this field.
+    // we do add the driving source to the Feature manager but we do need to treat it differently and thus this field.
     private FeatureDataSource<VariantContext> drivingVariants;
     private FeatureInput<VariantContext> drivingVariantsFeatureInput;
 
@@ -52,12 +52,12 @@ public abstract class VariantWalker extends VariantWalkerBase {
     protected void initializeDrivingVariants() {
         drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
 
-        //This is the data source for the driving source of variants, which uses a cache lookahead value from getVariantCacheLookAheadBases()
-        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        // Create a FeatureDataSource for the driving variants FeatureInput, using a lookahead value from getDrivingVariantCacheLookAheadBases()
+        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getDrivingVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                   referenceArguments.getReferencePath());
 
-        //Add the driving datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.
-        //Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
+        // Also add the driving variants FeatureInput to FeatureManager so it can be queried, but use a lookahead value of 0
+        // to avoid caching because of windowed queries that need to "look behind" as well.
         features.addToFeatureSources(0, drivingVariantsFeatureInput, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                      referenceArguments.getReferencePath());
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -52,8 +52,8 @@ public abstract class VariantWalker extends VariantWalkerBase {
     protected void initializeDrivingVariants() {
         drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
 
-        //This is the data source for the driving source of variants, which uses a cache lookahead of FEATURE_CACHE_LOOKAHEAD
-        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, FEATURE_CACHE_LOOKAHEAD, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        //This is the data source for the driving source of variants, which uses a cache lookahead of DEFAULT_FEATURE_CACHE_LOOKAHEAD
+        drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                   referenceArguments.getReferencePath());
 
         //Add the driving datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -52,7 +52,7 @@ public abstract class VariantWalker extends VariantWalkerBase {
     protected void initializeDrivingVariants() {
         drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
 
-        //This is the data source for the driving source of variants, which uses a cache lookahead of DEFAULT_FEATURE_CACHE_LOOKAHEAD
+        //This is the data source for the driving source of variants, which uses a cache lookahead value from getVariantCacheLookAheadBases()
         drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                   referenceArguments.getReferencePath());
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -52,16 +52,17 @@ public abstract class VariantWalker extends VariantWalkerBase {
     protected void initializeDrivingVariants() {
         drivingVariantsFeatureInput = new FeatureInput<>(drivingVariantFile, "drivingVariantFile");
 
-        // Create a FeatureDataSource for the driving variants FeatureInput, using a lookahead value from getDrivingVariantCacheLookAheadBases()
+        // Create a FeatureDataSource for the driving variants FeatureInput, using the
+        // cache lookahead value from getDrivingVariantCacheLookAheadBases()
         drivingVariants = new FeatureDataSource<>(drivingVariantsFeatureInput, getDrivingVariantCacheLookAheadBases(), VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                                   referenceArguments.getReferencePath());
 
-        // Also add the driving variants FeatureInput to FeatureManager so it can be queried, but use a lookahead value of 0
-        // to avoid caching because of windowed queries that need to "look behind" as well.
+        // Also add the driving variants FeatureInput to FeatureManager as well so that it can be queried,
+        // but use a lookahead value of 0 to avoid caching because of windowed queries that need to "look behind" as well.
         features.addToFeatureSources(0, drivingVariantsFeatureInput, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                      referenceArguments.getReferencePath());
 
-        //Note: the intervals for the driving variants are set in onStartup
+        // Note: the intervals for the driving variants are set in onStartup()
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
@@ -29,10 +29,10 @@ import java.util.stream.StreamSupport;
 public abstract class VariantWalkerBase extends GATKTool {
 
     /**
-     * Default value to control the size of the cache for our primary FeatureInputs
-     * (specifically, the number of additional bases worth of overlapping records to cache when querying feature sources).
+     * Default value to control the size of the cache for our driving variants input(s)
+     * (specifically, the number of additional bases worth of overlapping records to cache for driving variants).
      */
-    public static final int DEFAULT_FEATURE_CACHE_LOOKAHEAD = 100_000;
+    public static final int DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES = 100_000;
 
     @Override
     public boolean requiresFeatures() { return true; }
@@ -43,9 +43,15 @@ public abstract class VariantWalkerBase extends GATKTool {
     @Override
     void initializeFeatures() {
 
-        //Note: we override this method because we don't want to set feature manager to null if there are no FeatureInputs.
-        //This is because we have at least 1 source of features (namely the driving dataset).
-        features = new FeatureManager(this, FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        // We override this method to prevent our FeatureManager from being set to null when no side feature inputs
+        // are specified, since VariantWalkers always have at least one (driving) variants input. Note that the query
+        // lookahead size used here for side inputs is not necessarily the same as for driving variants, which is
+        // determined by {@link #getDrivingVariantCacheLookAheadBases}.
+        //
+        // TODO: I think reducing the lookahead for side inputs from DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES to
+        // FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES will likely hurt performance for tools like VQSR, but lets
+        // test it
+        features = new FeatureManager(this, DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                       referenceArguments.getReferencePath());
         initializeDrivingVariants();
     }
@@ -98,12 +104,13 @@ public abstract class VariantWalkerBase extends GATKTool {
     protected abstract Spliterator<VariantContext> getSpliteratorForDrivingVariants();
 
     /**
-     * When performing a query on the primary variant input how many overlapping records should be cached when querying.
+     * When performing a query on the driving variants input(s), the number of lookahead bases for which overlapping
+     * variants should be pre-fetched and cached.
      * Subclasses can set this value by overriding this method.
      * @return the number of bases ahead of a query to prefetch
      */
-    protected int getVariantCacheLookAheadBases(){
-        return DEFAULT_FEATURE_CACHE_LOOKAHEAD;
+    protected int getDrivingVariantCacheLookAheadBases(){
+        return DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
@@ -29,10 +29,10 @@ import java.util.stream.StreamSupport;
 public abstract class VariantWalkerBase extends GATKTool {
 
     /**
-     * This number controls the size of the cache for our primary and auxiliary FeatureInputs
+     * Default value to control the size of the cache for our primary FeatureInputs
      * (specifically, the number of additional bases worth of overlapping records to cache when querying feature sources).
      */
-    public static final int FEATURE_CACHE_LOOKAHEAD = 100_000;
+    public static final int DEFAULT_FEATURE_CACHE_LOOKAHEAD = 100_000;
 
     @Override
     public boolean requiresFeatures() { return true; }
@@ -45,7 +45,7 @@ public abstract class VariantWalkerBase extends GATKTool {
 
         //Note: we override this method because we don't want to set feature manager to null if there are no FeatureInputs.
         //This is because we have at least 1 source of features (namely the driving dataset).
-        features = new FeatureManager(this, FEATURE_CACHE_LOOKAHEAD, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+        features = new FeatureManager(this, FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                       referenceArguments.getReferencePath());
         initializeDrivingVariants();
     }
@@ -96,6 +96,15 @@ public abstract class VariantWalkerBase extends GATKTool {
      * Return a spliterator to be used to iterate over the elements of the driving variants.
      */
     protected abstract Spliterator<VariantContext> getSpliteratorForDrivingVariants();
+
+    /**
+     * When performing a query on the primary variant input how many overlapping records should be cached when querying.
+     * Subclasses can set this value by overriding this method.
+     * @return the number of bases ahead of a query to prefetch
+     */
+    protected int getVariantCacheLookAheadBases(){
+        return DEFAULT_FEATURE_CACHE_LOOKAHEAD;
+    }
 
     /**
      * Returns the pre-filter variant transformer (simple or composite) that will be applied to the variants before filtering.

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalkerBase.java
@@ -30,7 +30,8 @@ public abstract class VariantWalkerBase extends GATKTool {
 
     /**
      * Default value to control the size of the cache for our driving variants input(s)
-     * (specifically, the number of additional bases worth of overlapping records to cache for driving variants).
+     * (specifically, the number of additional bases worth of overlapping records to cache for
+     * queries on the driving variants).
      */
     public static final int DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES = 100_000;
 
@@ -49,8 +50,8 @@ public abstract class VariantWalkerBase extends GATKTool {
         // determined by {@link #getDrivingVariantCacheLookAheadBases}.
         //
         // TODO: I think reducing the lookahead for side inputs from DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES to
-        // FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES will likely hurt performance for tools like VQSR, but lets
-        // test it
+        // TODO: FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES will likely hurt performance for tools like VQSR,
+        // TODO: but let's test it
         features = new FeatureManager(this, DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
                                       referenceArguments.getReferencePath());
         initializeDrivingVariants();
@@ -104,10 +105,14 @@ public abstract class VariantWalkerBase extends GATKTool {
     protected abstract Spliterator<VariantContext> getSpliteratorForDrivingVariants();
 
     /**
-     * When performing a query on the driving variants input(s), the number of lookahead bases for which overlapping
-     * variants should be pre-fetched and cached.
-     * Subclasses can set this value by overriding this method.
-     * @return the number of bases ahead of a query to prefetch
+     * When performing a query on the driving variants input(s), the number of additional bases beyond the end
+     * of the query for which overlapping variants should be pre-fetched and cached.
+     *
+     * Defaults to {@link #DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES}
+     *
+     * Subclasses can customize this value by overriding this method.
+     *
+     * @return the number of additional bases to prefetch and cache beyond a query on the driving variants
      */
     protected int getDrivingVariantCacheLookAheadBases(){
         return DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -62,7 +62,7 @@ public class FuncotatorArgumentDefinitions {
     public static final int THREE_PRIME_FLANK_SIZE_DEFAULT_VALUE = 0;
 
     public static final String LOOKAHEAD_CACHE_IN_BP_NAME = "lookahead-cache-bp";
-    public static final int LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE = VariantWalkerBase.FEATURE_CACHE_LOOKAHEAD;
+    public static final int LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE = VariantWalkerBase.DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES;
 
     public static final String FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION = "force-b37-to-hg19-reference-contig-conversion";
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -150,12 +150,6 @@ public final class GenotypeGVCFs extends VariantLocusWalker {
         return Arrays.asList(StandardAnnotation.class);
     }
 
-
-    @Override
-    protected int getVariantCacheLookAheadBases() {
-        return 1000;
-    }
-
     @Override
     public void onTraversalStart() {
         if (!includeNonVariants) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -150,6 +150,12 @@ public final class GenotypeGVCFs extends VariantLocusWalker {
         return Arrays.asList(StandardAnnotation.class);
     }
 
+
+    @Override
+    protected int getVariantCacheLookAheadBases() {
+        return 1000;
+    }
+
     @Override
     public void onTraversalStart() {
         if (!includeNonVariants) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -2467,7 +2467,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         final FeatureInput<GencodeGtfFeature> gencodeFeatureInput = new FeatureInput<>(transcriptGtfFile, GencodeFuncotationFactory.DEFAULT_NAME, Collections.emptyMap());
         final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputMap = new HashMap<>();
         featureInputMap.put(gencodeFeatureInput, GencodeGtfFeature.class);
-        final FeatureContext featureContext = FeatureContext.createFeatureContextForTesting(featureInputMap, "dummyName", variantInterval, VariantWalker.FEATURE_CACHE_LOOKAHEAD, 0, 0, null);
+        final FeatureContext featureContext = FeatureContext.createFeatureContextForTesting(featureInputMap, "dummyName", variantInterval, VariantWalker.DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES, 0, 0, null);
 
         // Create a factory for our funcotations:
         try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(


### PR DESCRIPTION
Adding a new method `getVariantCacheLookAheadBases` to `VariantWalkerBase` which allows subclasses to set how far to look ahead when caching variants.  This may help reduce memory use in GenotypeGVCFs.

This also changes the side inputs to use FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES which is `1000`, this is the value used by the other tools.  I'm not sure if that's the right thing to do, but it makes variant walkers more consistent with other tools.  Alternatively we could add a separate configuration method that lets tools change the side input value.  We could also expose an optional parameter in the feature input that lets you set that on a per input basis if we need it.  

This doesn't seem to have any negative effect on performance for genotypegvcfs, but it's hard to tell from short runs.  It's also hard to tell if it's improving memory usage.  It doesn't seem to make an appreciable difference at random places in the genome, but I'm hoping it will make a difference in very bad locations that have a lot of variation.  Ideally our caches would be based on size rather than number of variants, but that's a more complicated change.

fixes #3471 