### PR TITLE
Fix writing variants to GCS buckets

### DIFF
--- a/scripts/spark_eval/exome_pipeline_single_gcs.sh
+++ b/scripts/spark_eval/exome_pipeline_single_gcs.sh
@@ -2,8 +2,6 @@
 
 # Run the pipeline (ReadsPipelineSpark) on exome data on a GCS Dataproc cluster. Data is in GCS.
 
-# TODO: change output to a GCS bucket when writing works again
-
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I gs://gatk-tom-testdata-exome/NA12878.ga2.exome.maq.raw.bam -O hdfs://${GCS_CLUSTER}-m:8020/user/$USER/exome_spark_eval/out/NA12878.ga2.exome.maq.raw.vcf -R gs://gatk-tom-testdata-exome/Homo_sapiens_assembly18.2bit --knownSites gs://gatk-tom-testdata-exome/dbsnp_138.hg18.vcf -pairHMM AVX_LOGLESS_CACHING -maxReadsPerAlignmentStart 10" 4 8 32g 4g
+time_gatk "ReadsPipelineSpark -I gs://gatk-tom-testdata-exome/NA12878.ga2.exome.maq.raw.bam -O gs://gatk-tom-testdata-exome/NA12878.ga2.exome.maq.raw.vcf -R gs://gatk-tom-testdata-exome/Homo_sapiens_assembly18.2bit --knownSites gs://gatk-tom-testdata-exome/dbsnp_138.hg18.vcf -pairHMM AVX_LOGLESS_CACHING -maxReadsPerAlignmentStart 10" 4 8 32g 4g

--- a/scripts/spark_eval/small_pipeline_single_gcs.sh
+++ b/scripts/spark_eval/small_pipeline_single_gcs.sh
@@ -2,8 +2,6 @@
 
 # Run the pipeline (ReadsPipelineSpark) on small data on a GCS Dataproc cluster. Data is in GCS.
 
-# TODO: change output to a GCS bucket when writing works again
-
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I gs://hellbender/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -O hdfs://${GCS_CLUSTER}-m:8020/user/$USER/small_spark_eval/out/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf -R gs://hellbender/test/resources/large/human_g1k_v37.20.21.2bit --knownSites gs://hellbender/test/resources/large/dbsnp_138.b37.20.21.vcf -pairHMM AVX_LOGLESS_CACHING -maxReadsPerAlignmentStart 10" 1 8 32g 4g
+time_gatk "ReadsPipelineSpark -I gs://hellbender/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -O gs://gatk-tom-testdata-small/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf -R gs://hellbender/test/resources/large/human_g1k_v37.20.21.2bit --knownSites gs://hellbender/test/resources/large/dbsnp_138.b37.20.21.vcf -pairHMM AVX_LOGLESS_CACHING -maxReadsPerAlignmentStart 10" 1 8 32g 4g

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSink.java
@@ -118,7 +118,7 @@ public final class VariantsSparkSink {
         }
 
         final JavaRDD<VariantContext> sortedVariants = sortVariants(variants, header, numReducers);
-        final String outputPartsDirectory = outputFile + ".parts";
+        final String outputPartsDirectory = outputFile + ".parts/";
         saveAsShardedHadoopFiles(ctx, conf, outputPartsDirectory, sortedVariants,  header, false);
         VCFFileMerger.mergeParts(outputPartsDirectory, outputFile, header);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
@@ -1,0 +1,38 @@
+package org.broadinstitute.hellbender.tools.spark.pipelines;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.VariantWalkerContext;
+import org.broadinstitute.hellbender.engine.spark.VariantWalkerSpark;
+import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSink;
+import org.broadinstitute.hellbender.exceptions.UserException;
+
+import java.io.IOException;
+
+@CommandLineProgramProperties(summary = "Print variants from the input VCF", oneLineSummary = "Print variants from the input VCF", programGroup = SparkProgramGroup.class)
+@DocumentedFeature
+@BetaFeature
+public final class PrintVariantsSpark extends VariantWalkerSpark {
+
+    private static final long serialVersionUID = 1L;
+
+    @Argument(doc = "uri for the output file: a local file path",
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+            optional = false)
+    public String output;
+
+    @Override
+    protected void processVariants(JavaRDD<VariantWalkerContext> rdd, JavaSparkContext ctx) {
+        try {
+            VariantsSparkSink.writeVariants(ctx, output, rdd.map(VariantWalkerContext::getVariant), getHeaderForVariants());
+        } catch (IOException e) {
+            throw new UserException.CouldNotCreateOutputFile(output, "writing failed", e);
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSparkIntegrationTest.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.hellbender.tools.spark.pipelines;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public final class PrintVariantsSparkIntegrationTest extends CommandLineProgramTest {
+
+    @Override
+    public String getTestedClassName() {
+        return PrintVariantsSpark.class.getSimpleName();
+    }
+
+    @DataProvider
+    public Object[][] gcsTestingData() {
+        return new Object[][]{
+            {"org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf", ".vcf", false},
+            {"org/broadinstitute/hellbender/engine/dbsnp_138.b37.20.10000000-10010000.vcf", ".vcf", true},
+        };
+    }
+
+    /**
+     * Test the Spark code locally, including GCS access.
+     *
+     * For this to work, the settings in src/main/resources/core-site.xml must be correct,
+     * and the project name and credential file it points to must be present.
+     */
+    @Test(dataProvider = "gcsTestingData", groups = "bucket")
+    public void testGCSInputsAndOutputs(final String gcsInput, final String outputExtension,
+        final boolean outputToGCS) {
+        final String gcsInputPath = getGCPTestInputPath() + gcsInput;
+        final String outputPrefix = outputToGCS ? getGCPTestStaging() : "testGCSInputsAndOutputs";
+        final String outputPath = BucketUtils.getTempFilePath(outputPrefix, outputExtension);
+
+        final ArgumentsBuilder argBuilder = new ArgumentsBuilder();
+        argBuilder.addArgument("variant", gcsInputPath)
+            .addArgument("output", outputPath);
+        runCommandLine(argBuilder);
+    }
+}


### PR DESCRIPTION
Writing reads was fixed in https://github.com/broadinstitute/gatk/commit/73f2a62bee52518b57a985717770ed3a64d83243, but unfortunately the same problem occurs with variants.

This commit (https://github.com/broadinstitute/gatk/commit/a861a23b544012fb8f69358a3999dd587d343547) fixes the problem for variants, when deployed with a Hadoop-BAM fix (https://github.com/HadoopGenomics/Hadoop-BAM/pull/143).