### PR TITLE
Add support for running tools with omitFromCommandLine=true

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -258,7 +258,16 @@ public class Main {
                 if (null == property) {
                     if (missingAnnotationClasses.isEmpty()) missingAnnotationClasses += clazz.getSimpleName();
                     else missingAnnotationClasses += ", " + clazz.getSimpleName();
-                } else if (!property.omitFromCommandLine()) { /** We should check for missing annotations later **/
+                } else if (property.omitFromCommandLine()) {
+                    // for classes that should be removed from the command line, run directly if is it called in the command line
+                    if (args.length > 1 && clazz.getSimpleName().equals(args[0])) {
+                        try {
+                            return (CommandLineProgram) clazz.newInstance();
+                        } catch (final InstantiationException | IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                } else { /** We should check for missing annotations later **/
                     if (simpleNameToClass.containsKey(clazz.getSimpleName())) {
                         throw new RuntimeException("Simple class name collision: " + clazz.getSimpleName());
                     }

--- a/src/test/java/org/broadinstitute/hellbender/MainTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/MainTest.java
@@ -1,13 +1,65 @@
 package org.broadinstitute.hellbender;
 
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.junit.Assert;
 import org.testng.annotations.Test;
 
-public final class MainTest extends CommandLineProgramTest{
+import java.util.Collections;
+import java.util.List;
+
+public final class MainTest extends CommandLineProgramTest {
 
     @Test(expectedExceptions = UserException.class)
     public void testCommandNotFoundThrows(){
         this.runCommandLine(new String[]{"Brain"});
     }
+
+
+    /** Main class for testing a single CLP */
+    private static final class SingleClpMain extends Main {
+
+        private Class<? extends CommandLineProgram> clazz;
+
+        private SingleClpMain(final Class<? extends CommandLineProgram> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        protected List<String> getPackageList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected List<Class<? extends CommandLineProgram>> getClassList() {
+            return Collections.singletonList(clazz);
+        }
+    }
+
+    @CommandLineProgramProperties(
+            programGroup = TestProgramGroup.class,
+            summary = "OmitFromCommanLine test",
+            oneLineSummary = "OmitFromCommanLine test",
+            omitFromCommandLine = true)
+    public static final class OmitFromCommanLineCLP extends CommandLineProgram {
+
+        @Override
+        protected Object doWork() {
+            return 1;
+        }
+    }
+
+    @Test
+    public void testClpOmitFromCommandLine() {
+        final SingleClpMain main = new SingleClpMain(OmitFromCommanLineCLP.class);
+        // test that the tool can be run from main correctly (returns non-null)
+        Assert.assertNotNull(main.instanceMain(new String[]{"OmitFromCommanLineCLP"}));
+        // test that the usage is not shown if help is printed
+        final String usage = captureStderr(() -> main.instanceMain(new String[]{"-h"}));
+        Assert.assertFalse(usage.contains("OmitFromCommanLineCLP"));
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/MainTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/MainTest.java
@@ -19,8 +19,8 @@ public final class MainTest extends CommandLineProgramTest {
 
     @CommandLineProgramProperties(
             programGroup = TestProgramGroup.class,
-            summary = "OmitFromCommanLine test",
-            oneLineSummary = "OmitFromCommanLine test",
+            summary = "OmitFromCommandLine test",
+            oneLineSummary = "OmitFromCommandLine test",
             omitFromCommandLine = true)
     public static final class OmitFromCommandLineCLP extends CommandLineProgram {
 

--- a/src/test/java/org/broadinstitute/hellbender/MainTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/MainTest.java
@@ -44,22 +44,25 @@ public final class MainTest extends CommandLineProgramTest {
             summary = "OmitFromCommanLine test",
             oneLineSummary = "OmitFromCommanLine test",
             omitFromCommandLine = true)
-    public static final class OmitFromCommanLineCLP extends CommandLineProgram {
+    public static final class OmitFromCommandLineCLP extends CommandLineProgram {
+
+        public static final int RETURN_VALUE = 1;
 
         @Override
         protected Object doWork() {
-            return 1;
+            return RETURN_VALUE;
         }
     }
 
     @Test
     public void testClpOmitFromCommandLine() {
-        final SingleClpMain main = new SingleClpMain(OmitFromCommanLineCLP.class);
+        final SingleClpMain main = new SingleClpMain(OmitFromCommandLineCLP.class);
+        final String clpName = "OmitFromCommandLineCLP";
         // test that the tool can be run from main correctly (returns non-null)
-        Assert.assertNotNull(main.instanceMain(new String[]{"OmitFromCommanLineCLP"}));
+        Assert.assertEquals(main.instanceMain(new String[]{clpName}), OmitFromCommandLineCLP.RETURN_VALUE);
         // test that the usage is not shown if help is printed
         final String usage = captureStderr(() -> main.instanceMain(new String[]{"-h"}));
-        Assert.assertFalse(usage.contains("OmitFromCommanLineCLP"));
+        Assert.assertFalse(usage.contains(clpName));
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/MainTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/MainTest.java
@@ -4,7 +4,6 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
@@ -16,27 +15,6 @@ public final class MainTest extends CommandLineProgramTest {
     @Test(expectedExceptions = UserException.class)
     public void testCommandNotFoundThrows(){
         this.runCommandLine(new String[]{"Brain"});
-    }
-
-
-    /** Main class for testing a single CLP */
-    private static final class SingleClpMain extends Main {
-
-        private Class<? extends CommandLineProgram> clazz;
-
-        private SingleClpMain(final Class<? extends CommandLineProgram> clazz) {
-            this.clazz = clazz;
-        }
-
-        @Override
-        protected List<String> getPackageList() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        protected List<Class<? extends CommandLineProgram>> getClassList() {
-            return Collections.singletonList(clazz);
-        }
     }
 
     @CommandLineProgramProperties(
@@ -54,9 +32,16 @@ public final class MainTest extends CommandLineProgramTest {
         }
     }
 
+    private static final class OmitFromCommandLineMain extends Main {
+        @Override
+        protected List<Class<? extends CommandLineProgram>> getClassList() {
+            return Collections.singletonList(OmitFromCommandLineCLP.class);
+        }
+    }
+
     @Test
     public void testClpOmitFromCommandLine() {
-        final SingleClpMain main = new SingleClpMain(OmitFromCommandLineCLP.class);
+        final OmitFromCommandLineMain main = new OmitFromCommandLineMain();
         final String clpName = "OmitFromCommandLineCLP";
         // test that the tool can be run from main correctly (returns non-null)
         Assert.assertEquals(main.instanceMain(new String[]{clpName}), OmitFromCommandLineCLP.RETURN_VALUE);


### PR DESCRIPTION
Tools with omitFromCommandLine=true can be run after this commit, but
they do not appear in the CLI help (they are hidden).

Related with https://github.com/broadinstitute/barclay/issues/92