### PR TITLE
VCF header fixes (A -> R); all allele annotations

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQuality.java
@@ -34,6 +34,9 @@ public class BaseQuality extends PerAlleleAnnotation {
     protected String getDescription() { return "median base quality"; }
 
     @Override
+    protected boolean includeRefAllele() { return true; }
+
+    @Override
     protected OptionalInt getValueForRead(final GATKRead read, final VariantContext vc) {
         Utils.nonNull(read);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQuality.java
@@ -34,6 +34,9 @@ public class MappingQuality extends PerAlleleAnnotation {
     protected String getDescription() { return "median mapping quality"; }
 
     @Override
+    protected boolean includeRefAllele() { return true; }
+
+    @Override
     protected OptionalInt getValueForRead(final GATKRead read, final VariantContext vc) {
         Utils.nonNull(read);
         return OptionalInt.of(read.getMappingQuality());

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosition.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPosition.java
@@ -31,6 +31,9 @@ public class ReadPosition extends PerAlleleAnnotation {
     protected String getDescription() { return "median distance from end of read"; }
 
     @Override
+    protected boolean includeRefAllele() { return true; }
+
+    @Override
     protected OptionalInt getValueForRead(final GATKRead read, final VariantContext vc) {
         Utils.nonNull(read);
         final int offset = ReadUtils.getReadCoordinateForReferenceCoordinate(ReadUtils.getSoftStart(read), read.getCigar(), vc.getStart(), ReadUtils.ClippingTail.RIGHT_TAIL, true);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityUnitTest.java
@@ -68,6 +68,6 @@ public class BaseQualityUnitTest {
 
         final int[] medianAltQuals = (int[]) g.getExtendedAttribute(BaseQuality.KEY);
 
-        Assert.assertEquals(medianAltQuals[0], 25);
+        Assert.assertEquals(medianAltQuals[0], 30);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPositionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadPositionUnitTest.java
@@ -70,7 +70,7 @@ public class ReadPositionUnitTest extends BaseTest {
 
         final int[] medianAltPositions = (int[]) g.getExtendedAttribute(ReadPosition.KEY);
 
-        Assert.assertEquals(medianAltPositions[0], 1);
+        Assert.assertEquals(medianAltPositions[0], 2);
     }
 
 }


### PR DESCRIPTION
Fixes issue identified by @kgururaj when investigating GenomicsDB
dropping calls (https://github.com/broadinstitute/gatk/issues/3429#issuecomment-324188028)
which is due to incorrect VCF header length descriptions.

It looks like this mismatch was reported early by @LeeTL1220
in #3296 when validating VCFs.

@davidbenjamin provided a partial fix in #3351, generalizing the output
to include the option of specifying R instead of A using
`includeRefAllele`, fixing MFRL and removing MCL.

This fixes the 3 remaining cases, MMQ (which breaks the GenomicsDB
example), MPOS and MBQ.

Fixes #3296
Fixes #3429