### PR TITLE
Add out/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gsalib.tar.gz
 gradlew.bat
 tmp/
 src/main/java/local/
+out/
 
 #Please don't commit me
 client_secret.json


### PR DESCRIPTION
Building with Intellij 2017.2 generates an /out directory instead of using the build/ folder from gradle, that is show as untracked but can be committed by error.

This folder cannot be changed, even if the compiler output is changed (see CrazyCoder comment in https://stackoverflow.com/questions/45174989/building-with-intellij-2017-2-out-directory-duplicates-files-in-build-director).