### PR TITLE
Upgrade htsjdk to 2.11.0-4-g958dc6e-SNAPSHOT.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.11.0')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.11.0-4-g958dc6e-SNAPSHOT')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.8.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.6.4-proto-3.0.0-beta-1')


### PR DESCRIPTION
Picks up VCF header performance fix.