### PR TITLE
Update to GKL 0.5.8, which fixes bug in AVX detection, which was beha…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     // Dependency change for including MLLib
     compile('com.esotericsoftware:reflectasm:1.10.0:shaded')
 
-    compile('com.intel.gkl:gkl:0.5.5') {
+    compile('com.intel.gkl:gkl:0.5.8') {
         exclude module: 'htsjdk'
     }
 


### PR DESCRIPTION
…ving incorrectly on some AMD systems. . See [this issue](https://github.com/broadinstitute/gsa-unstable/issues/1627) (link in private GitHub repo). GKL 0.5.8 fixes this issue. There is no other change between GKL 0.5.5 and GKL 0.5.8.