### PR TITLE
Remove extra .gitattributes file that got checked into large via an SV PR

### DIFF
--- a/src/test/resources/large/.gitattributes
+++ b/src/test/resources/large/.gitattributes
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f142cb74a26cdc08ae560290902c3e18377ba8b058f2b889c9249c12d72ab7c
-size 120


### PR DESCRIPTION
Only the top-level .gitattributes is needed these days, as it includes
all of large recursively via a wildcard.