### PR TITLE
Repackage ReadFilter plugin tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -37,7 +37,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
     // the purpose of this argument collection is to allow the caller to control the exposure of the command line arguments
     @VisibleForTesting
     @ArgumentCollection
-    public final GATKReadFilterArgumentCollection userArgs;
+    final GATKReadFilterArgumentCollection userArgs;
 
     // Map of read filter (simple) class names to the corresponding discovered plugin instance
     private final Map<String, ReadFilter> allDiscoveredReadFilters = new HashMap<>();

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorTest.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.engine.filters;
+package org.broadinstitute.hellbender.cmdline.GATKPlugin;
 
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;
@@ -7,9 +7,10 @@ import org.apache.commons.io.output.NullOutputStream;
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineParser;
-import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
+import org.broadinstitute.hellbender.engine.filters.*;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,7 +24,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 
-public class ReadFilterPluginUnitTest {
+public class GATKReadFilterPluginDescriptorTest extends BaseTest {
 
     // null print stream for the tests
     private static final PrintStream nullMessageStream = new PrintStream(new NullOutputStream());


### PR DESCRIPTION
* Repackage and rename `org.broadinstitute.hellbender.engine.filters.ReadFilterPluginUnitTest` to `org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptorTest`.
* Add `BaseTest` to `GATKReadFilterPluginDescriptorTest`.
* Make the filed `GATKReadFilterPluginDescriptor.userArgs` package-private now that it is possible. 

Closes #2532