### PR TITLE
Fix @BeforeSuite usages to prevent excessive code execution

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
@@ -2,22 +2,20 @@ package org.broadinstitute.hellbender;
 
 import org.broadinstitute.hellbender.utils.bwa.BwaMemIndex;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 public class BwaMemIntegrationTest extends BaseTest {
 
     private BwaMemIndex index;
 
-    @BeforeSuite
+    @BeforeClass
     public void loadIndex() {
         final String imageFile = createTempFile(b37_reference_20_21, ".img").toString();
         BwaMemIndex.createIndexImageFromFastaFile(b37_reference_20_21, imageFile);
         index = new BwaMemIndex(imageFile);
     }
 
-    @AfterSuite
+    @AfterClass
     public void unloadIndex() {
         index.close();
         index = null;

--- a/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/germline/GermlineCNVCallerIntegrationTest.java
@@ -21,7 +21,7 @@ import org.broadinstitute.hellbender.tools.exome.sexgenotyper.SexGenotypeDataCol
 import org.broadinstitute.hellbender.utils.SparkToggleCommandLineProgram;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
@@ -105,7 +105,7 @@ public class GermlineCNVCallerIntegrationTest extends CommandLineProgramTest {
     private static SexGenotypeDataCollection LEARNING_SEX_GENOTYPES_DATA;
     private static SexGenotypeDataCollection CALLING_SEX_GENOTYPES_DATA;
 
-    @BeforeSuite
+    @BeforeClass
     public void init() throws IOException {
         LEARNING_SEX_GENOTYPES_DATA = new SexGenotypeDataCollection(TEST_LEARNING_SAMPLE_SEX_GENOTYPES_FILE);
         CALLING_SEX_GENOTYPES_DATA = new SexGenotypeDataCollection(TEST_CALLING_SAMPLE_SEX_GENOTYPES_FILE);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorsUnitTest.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -14,7 +14,7 @@ public final class GenotypeLikelihoodCalculatorsUnitTest extends BaseTest {
 
     GenotypeLikelihoodCalculators calcs;
 
-    @BeforeSuite
+    @BeforeClass
     public void init(){
         calcs = new GenotypeLikelihoodCalculators();
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/AFCalculationUnitTest.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -44,7 +44,7 @@ public final class AFCalculationUnitTest extends BaseTest {
         return AFCalculators;
     }
 
-    @BeforeSuite
+    @BeforeClass
     public void before() {
         AA1 = makePL(Arrays.asList(A, A), 0, 20, 20);
         AB1 = makePL(Arrays.asList(A, C), 20, 0, 20);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/GeneralPloidyAFCalculationModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/afcalc/GeneralPloidyAFCalculationModelUnitTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.genotyper.afcalc;
 import htsjdk.variant.variantcontext.*;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -18,7 +18,7 @@ public final class GeneralPloidyAFCalculationModelUnitTest extends BaseTest {
     static final int numSamples = 4;
     static final int samplePloidy = 4;   // = 2*samplesPerPool
 
-    @BeforeSuite
+    @BeforeClass
     public void before() {
         // legacy diploid cases
         AA1 = new double[]{-5.0, -20.0, -20.0};

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
@@ -17,7 +17,7 @@ import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -31,7 +31,7 @@ public final class PairHMMLikelihoodCalculationEngineUnitTest extends BaseTest {
 
     Allele Aref, T, C, G, Cref, ATC, ATCATC;
 
-    @BeforeSuite
+    @BeforeClass
     public void setup() {
         // alleles
         Aref = Allele.create("A", true);

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/QualQuantizerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/QualQuantizerUnitTest.java
@@ -6,7 +6,7 @@ import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -16,10 +16,6 @@ import java.util.List;
 
 
 public final class QualQuantizerUnitTest extends BaseTest {
-    @BeforeSuite
-    public void before() {
-
-    }
 
     // --------------------------------------------------------------------------------
     //

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -19,7 +19,7 @@ import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -36,7 +36,7 @@ public final class GATKVariantContextUtilsUnitTest extends BaseTest {
     Allele Anoref;
     Allele GT;
 
-    @BeforeSuite
+    @BeforeClass
     public void setup() throws IOException {
         // alleles
         Aref = Allele.create("A", true);


### PR DESCRIPTION
There is quite a bit of code annotated with @BeforeSuite that should probably just be @BeforeClass. @BeforeSuite code can run even when no methods in the class are selected in the current suite. Most of it is harmless, but some of it is painfully slow, i.e., using gradle to run a single test method always causes the BwaMemIntegrationTest code to create an index image for the large test reference, which takes 1-2 minutes, before the selected test even starts.

We should probably reserve @BeforeSuite for test-infrastructure setup code; most test classes should use @BeforeClass instead.

