### PR TITLE
PR series for complex SV, part 5

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -175,8 +175,6 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
 
         public static final int GAPPED_ALIGNMENT_BREAK_DEFAULT_SENSITIVITY = 50; // alignment with gap of size >= 50 will be broken apart.
         public static final int CHIMERIC_ALIGNMENTS_HIGHMQ_THRESHOLD = 60;
-        public static final int MISSING_NM = Integer.MIN_VALUE;
-        public static final int ARTIFICIAL_MISMATCH = MISSING_NM;
         public static final int DEFAULT_MIN_ALIGNMENT_LENGTH = 50; // Minimum flanking alignment length filters used when going through contig alignments.
         public static final int DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY = 100;
         public static final int DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD = 7;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -95,13 +95,11 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
         DiscoverVariantsFromContigAlignmentsSAMSpark
                 .discoverVariantsAndWriteVCF(
                         parsedAlignments,
-                        discoverStageArgs,
+                        evidenceLinkTree, assembledEvidenceResults.getReadMetadata(), discoverStageArgs,
                         ctx.broadcast(getReference()),
-                        vcfOutputFileName,
-                        localLogger,
-                        evidenceLinkTree,
-                        assembledEvidenceResults.getReadMetadata(),
-                        header.getSequenceDictionary());
+                        header.getSequenceDictionary(), vcfOutputFileName,
+                        localLogger
+                );
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AlignedContig.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AlignedContig.java
@@ -5,6 +5,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +61,17 @@ public final class AlignedContig {
         Comparator<AlignmentInterval> compareRefSpanStart = (AlignmentInterval a1, AlignmentInterval a2) -> a1.referenceSpan.getStart() - a2.referenceSpan.getStart();
         return comparePos.thenComparing(compareRefTig).thenComparing(compareRefSpanStart);
     }
-    
+
+    @Override
+    public String toString() {
+        return formatContigInfo(
+                new Tuple2<>(contigName, alignmentIntervals.stream().map(AlignmentInterval::toPackedString).collect(Collectors.toList())));
+    }
+
+    public static String formatContigInfo(final Tuple2<String, List<String>> pair) {
+        return "(" + pair._1 + ",[" + pair._2 + "])";
+    }
+
     void serialize(final Kryo kryo, final Output output) {
 
         output.writeString(contigName);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/BreakEndVariantType.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/BreakEndVariantType.java
@@ -1,28 +1,56 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery;
 
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.variant.variantcontext.Allele;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import scala.Tuple2;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.*;
+
 public abstract class BreakEndVariantType extends SvType {
 
+    /**
+     * Technically, a BND-formatted variant should have two VCF records, for mates, hence we also have this field.
+     */
     protected final boolean isTheUpstreamMate;
 
     public final boolean isTheUpstreamMate() {
         return isTheUpstreamMate;
     }
 
+    protected static SimpleInterval getMateRefLoc(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc) {
+        return forUpstreamLoc ? narl.leftJustifiedRightRefLoc : narl.leftJustifiedLeftRefLoc;
+    }
+
+    protected static String getIDString(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc) {
+        return BREAKEND_STR + INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
+                narl.leftJustifiedLeftRefLoc.getContig() + INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
+                narl.leftJustifiedLeftRefLoc.getEnd() + INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
+                narl.leftJustifiedRightRefLoc.getContig() + INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
+                narl.leftJustifiedRightRefLoc.getStart() + INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
+                (forUpstreamLoc ? "1" : "2");
+    }
+
+
     @Override
     public final String toString() {
-        return GATKSVVCFConstants.BREAKEND_STR;
+        return BREAKEND_STR;
+    }
+
+    private static Allele constructAltAllele(final byte[] bases, final boolean bracketPointsLeft, final SimpleInterval novelAdjRefLoc,
+                                             final boolean basesFirst) {
+        final String s = bracketPointsLeft ? "]" + novelAdjRefLoc.getContig() + ":" + novelAdjRefLoc.getStart() + "]"
+                : "[" + novelAdjRefLoc.getContig() + ":" + novelAdjRefLoc.getStart() + "[";
+        return Allele.create( basesFirst ? new String(bases) + s  : s + new String(bases) );
     }
 
     // see VCF spec 4.2 or 4.3 for BND format ALT allele field for SV
@@ -33,28 +61,59 @@ public abstract class BreakEndVariantType extends SvType {
         this.isTheUpstreamMate = isTheUpstreamMate;
     }
 
-    private static Allele constructAltAllele(final byte[] bases, final boolean bracketPointsLeft, final SimpleInterval novelAdjRefLoc,
-                                             final boolean basesFirst) {
-        final String s = bracketPointsLeft ? "]" + novelAdjRefLoc.getContig() + ":" + novelAdjRefLoc.getStart() + "]"
-                                           : "[" + novelAdjRefLoc.getContig() + ":" + novelAdjRefLoc.getStart() + "[";
-        return Allele.create( basesFirst ? new String(bases) + s  : s + new String(bases) );
-    }
+    //==================================================================================================================
 
-    static abstract class StrandSwitchBND extends BreakEndVariantType {
+    /**
+     * Breakend variant type for inversion suspects: those with novel adjacency between two reference locations
+     * on the same chromosome but the novel adjacency brings them together in a strand-switch fashion.
+     * This is to be distinguished from the more general "translocation" breakends, which are novel adjacency between
+     * reference locations without strand switch if the reference bases are from the same chromosome.
+     */
+    public static final class InvSuspectBND extends BreakEndVariantType {
+        /**
+         * for breakends, there's a concept of partner (see VCF spec) relationship between two reference bases.
+         * This indicates if the breakpoint, for an inversion suspect specifically, represents (one of the two) bases
+         * that is the left of the pair.
+         */
+        private static final Map<String, String> INV55_FLAG = Collections.singletonMap(INV55, "");
+        private static final Map<String, String> INV33_FLAG = Collections.singletonMap(INV33, "");
 
-        StrandSwitchBND(final String id, final Map<String, String> typeSpecificExtraAttributes,
-                        final byte[] bases, final boolean bracketPointsLeft, final SimpleInterval novelAdjRefLoc,
-                        final boolean basesFirst, boolean isTheUpstreamMate){
-            super(id, typeSpecificExtraAttributes, bases, bracketPointsLeft, novelAdjRefLoc, basesFirst, isTheUpstreamMate);
+        private InvSuspectBND(final String id, final byte[] bases, final SimpleInterval novelAdjRefLoc,
+                              final boolean bracketPointsLeft, final boolean basesFirst, boolean isTheUpstreamMate) {
+            super(id, (bracketPointsLeft && basesFirst) ? INV55_FLAG: INV33_FLAG,
+                    bases, bracketPointsLeft, novelAdjRefLoc, basesFirst, isTheUpstreamMate);
         }
 
+        public static Tuple2<BreakEndVariantType, BreakEndVariantType> getOrderedMates(final NovelAdjacencyReferenceLocations narl,
+                                                                                       final ReferenceMultiSource reference) {
+
+            // inversion breakend formatted records have "bracketPointsLeft" "basesFirst" taking the same value (see spec)
+            final boolean isInv55Suspect;
+            if (narl.strandSwitch == StrandSwitch.FORWARD_TO_REVERSE) { // INV55, leftHalfInPartnerPair
+                isInv55Suspect = true;
+            } else if (narl.strandSwitch == StrandSwitch.REVERSE_TO_FORWARD){
+                isInv55Suspect = false;
+            } else {
+                throw new GATKException("Wrong type of novel adjacency sent to wrong analysis pathway: " +
+                        "no strand-switch being sent to strand-switch path. \n" + narl.toString());
+            }
+            final BreakEndVariantType upstreamBreakpoint = new BreakEndVariantType.InvSuspectBND(getIDString(narl, true),
+                    extractBasesForAltAllele(narl, true, reference),
+                    getMateRefLoc(narl, true),
+                    isInv55Suspect, isInv55Suspect, true);
+            final BreakEndVariantType downstreamBreakpoint = new BreakEndVariantType.InvSuspectBND(getIDString(narl, false),
+                    extractBasesForAltAllele(narl, false, reference),
+                    getMateRefLoc(narl, false),
+                    isInv55Suspect, isInv55Suspect, false);
+            return new Tuple2<>(upstreamBreakpoint, downstreamBreakpoint);
+        }
 
         static byte[] extractBasesForAltAllele(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc,
                                                final ReferenceMultiSource reference) {
             try {
                 final byte[] ref = reference
                         .getReferenceBases(null, forUpstreamLoc ? narl.leftJustifiedLeftRefLoc :
-                                narl.leftJustifiedRightRefLoc)
+                                                                                narl.leftJustifiedRightRefLoc)
                         .getBases();
                 final String ins = narl.complication.getInsertedSequenceForwardStrandRep();
                 if (ins.isEmpty()) {
@@ -67,57 +126,70 @@ public abstract class BreakEndVariantType extends SvType {
                 throw new GATKException("Could not read reference for extracting reference bases.", ioex);
             }
         }
-
-        static SimpleInterval getTheOtherRefLoc(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc) {
-            return forUpstreamLoc ? narl.leftJustifiedRightRefLoc : narl.leftJustifiedLeftRefLoc;
-        }
     }
 
-    public static final class INV55BND extends StrandSwitchBND {
+    //==================================================================================================================
+    /**
+     * Generic variant type for suspected "translocations", including what could be a breakpoint for
+     * a dispersed duplication or an inter-chromosome novel adjacency.
+     */
+    public static final class TransLocBND extends BreakEndVariantType {
+        private static Map<String, String> emptyMap = Collections.emptyMap();
 
-        /**
-         * Technically, a strand switch breakpoint should have two VCF records, hence we also have {@code forUpstreamLoc}.
-         */
-        public INV55BND(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc,
-                        final ReferenceMultiSource reference) {
-            super(getIDString(narl, forUpstreamLoc),
-                    Collections.singletonMap(GATKSVVCFConstants.INV55, ""),
-                    extractBasesForAltAllele(narl, forUpstreamLoc, reference), true,
-                    getTheOtherRefLoc(narl, forUpstreamLoc), true, forUpstreamLoc);
+        private TransLocBND(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc,
+                            final ReferenceMultiSource reference, final SAMSequenceDictionary referenceDictionary,
+                            final boolean basesFirst, final boolean bracketPointsLeft) {
+            super(getIDString(narl, forUpstreamLoc), emptyMap,
+                    extractBasesForAltAllele(narl, forUpstreamLoc, reference, referenceDictionary), bracketPointsLeft,
+                    getMateRefLoc(narl, forUpstreamLoc), basesFirst, forUpstreamLoc);
         }
 
-        private static String getIDString(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc) {
-
-            return GATKSVVCFConstants.BREAKEND_STR + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    GATKSVVCFConstants.INV55 + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedLeftRefLoc.getContig() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedLeftRefLoc.getEnd() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedRightRefLoc.getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    (forUpstreamLoc ? "1" : "2") ;
+        public static Tuple2<BreakEndVariantType, BreakEndVariantType> getOrderedMates(final NovelAdjacencyReferenceLocations narl,
+                                                                                       final ReferenceMultiSource reference,
+                                                                                       final SAMSequenceDictionary referenceDictionary) {
+            final boolean isSameChr = narl.leftJustifiedLeftRefLoc.getContig().equals(narl.leftJustifiedRightRefLoc.getContig());
+            final BreakEndVariantType bkpt_1, bkpt_2;
+            if (isSameChr) {
+                bkpt_1 = new BreakEndVariantType.TransLocBND(narl, true, reference, referenceDictionary, false, true);
+                bkpt_2 = new BreakEndVariantType.TransLocBND(narl, false, reference, referenceDictionary, true, false);
+            } else {
+                if (narl.strandSwitch == StrandSwitch.NO_SWITCH) {
+                    final boolean isFirstOfPartner = IntervalUtils.compareContigs(narl.leftJustifiedLeftRefLoc,
+                                                                                  narl.leftJustifiedRightRefLoc, referenceDictionary) < 0;
+                    bkpt_1 = new BreakEndVariantType.TransLocBND(narl, true, reference, referenceDictionary,
+                            isFirstOfPartner, !isFirstOfPartner);
+                    bkpt_2 = new BreakEndVariantType.TransLocBND(narl, false, reference, referenceDictionary,
+                            !isFirstOfPartner, isFirstOfPartner);
+                } else {
+                    bkpt_1 = new BreakEndVariantType.TransLocBND(narl, true, reference, referenceDictionary,
+                            narl.strandSwitch == StrandSwitch.FORWARD_TO_REVERSE, narl.strandSwitch == StrandSwitch.FORWARD_TO_REVERSE);
+                    bkpt_2 = new BreakEndVariantType.TransLocBND(narl, false, reference, referenceDictionary,
+                            narl.strandSwitch != StrandSwitch.FORWARD_TO_REVERSE, narl.strandSwitch != StrandSwitch.FORWARD_TO_REVERSE);
+                }
+            }
+            return new Tuple2<>(bkpt_1, bkpt_2);
         }
-    }
 
-    public static final class INV33BND extends StrandSwitchBND {
-
-        /**
-         * Technically, a strand switch breakpoint should have two VCF records, hence we also have {@code forUpstreamLoc}.
-         */
-        public INV33BND(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc,
-                        final ReferenceMultiSource reference) {
-            super(getIDString(narl, forUpstreamLoc),
-                    Collections.singletonMap(GATKSVVCFConstants.INV33, ""),
-                    extractBasesForAltAllele(narl, forUpstreamLoc, reference), false,
-                    getTheOtherRefLoc(narl, forUpstreamLoc), false, forUpstreamLoc);
-        }
-
-        private static String getIDString(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc) {
-
-            return GATKSVVCFConstants.BREAKEND_STR + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    GATKSVVCFConstants.INV33 + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedLeftRefLoc.getContig() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedLeftRefLoc.getEnd() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    narl.leftJustifiedRightRefLoc.getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR +
-                    (forUpstreamLoc ? "1" : "2") ;
+        static byte[] extractBasesForAltAllele(final NovelAdjacencyReferenceLocations narl, final boolean forUpstreamLoc,
+                                               final ReferenceMultiSource reference, final SAMSequenceDictionary referenceDictionary) {
+            try {
+                final SimpleInterval refLoc = forUpstreamLoc ? narl.leftJustifiedLeftRefLoc : narl.leftJustifiedRightRefLoc;
+                final byte[] ref = reference.getReferenceBases(null, refLoc).getBases();
+                final String ins = narl.complication.getInsertedSequenceForwardStrandRep();
+                if (ins.isEmpty()) {
+                    return ref;
+                } else {
+                    if (narl.leftJustifiedLeftRefLoc.getContig().equals(narl.leftJustifiedRightRefLoc.getContig())
+                            || (narl.strandSwitch == StrandSwitch.NO_SWITCH && IntervalUtils.compareContigs(narl.leftJustifiedLeftRefLoc, narl.leftJustifiedRightRefLoc, referenceDictionary) > 0)
+                            || narl.strandSwitch == StrandSwitch.REVERSE_TO_FORWARD) {
+                        return forUpstreamLoc ? ArrayUtils.addAll(ins.getBytes(), ref) : ArrayUtils.addAll(ref, ins.getBytes());
+                    } else {
+                        return forUpstreamLoc ? ArrayUtils.addAll(ref, ins.getBytes()) : ArrayUtils.addAll(ins.getBytes(), ref);
+                    }
+                }
+            } catch (final IOException ioex) {
+                throw new GATKException("Could not read reference for extracting reference bases.", ioex);
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/BreakpointComplications.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/BreakpointComplications.java
@@ -5,10 +5,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.google.common.annotations.VisibleForTesting;
-import htsjdk.samtools.Cigar;
-import htsjdk.samtools.CigarElement;
-import htsjdk.samtools.CigarOperator;
-import htsjdk.samtools.TextCigarCodec;
+import htsjdk.samtools.*;
 import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
@@ -93,7 +90,7 @@ public final class BreakpointComplications {
         return homologyForwardStrandRep;
     }
 
-    public String getInsertedSequenceForwardStrandRep() {
+    String getInsertedSequenceForwardStrandRep() {
         return insertedSequenceForwardStrandRep;
     }
 
@@ -135,6 +132,7 @@ public final class BreakpointComplications {
         return hasDuplicationAnnotation && dupSeqStrandOnCtg.stream().noneMatch(s -> s.equals(Strand.NEGATIVE));
     }
 
+    // =================================================================================================================
     @VisibleForTesting
     BreakpointComplications() {
 
@@ -168,34 +166,45 @@ public final class BreakpointComplications {
      * identify potential complications such as homology and duplication on the reference and/or on the contig.
      */
     BreakpointComplications(final ChimericAlignment chimericAlignment, final byte[] contigSeq) {
-        // TODO: 12/5/16 simple translocation, don't tackle yet
-        // a segment with lower coordinate on the locally-assembled contig could map to a higher reference coordinate region
-        // under two basic types of SV's: inversion (strand switch necessary) and translocation (no strand switch necessary)
-        final boolean isNotSimpleTranslocation = chimericAlignment.isNotSimpleTranslocation();
 
-        if (chimericAlignment.strandSwitch!= StrandSwitch.NO_SWITCH) {
+        // if-else testing order matters here:
+        // if the two segments in the input chimeric alignment suggests simple translocation {@see ChimericAlignment#isNotSimpleTranslocation()}, then
+        //  we need other types of evidence to fully resolve type of event, until then we can only say a novel adjacency (BND) is detected;
+        // if the two segments in the input chimeric alignment map to the same chromosome, then
+        //  the segment with lower coordinate on the locally-assembled contig could map to a higher reference coordinate region
+        //  under two basic types of SV's: inversion (strand switch necessary) and "translocation" (no strand switch necessary)
+        final boolean suggestsSimpleTranslocation = !chimericAlignment.isNotSimpleTranslocation();
+        if (suggestsSimpleTranslocation) {
+            initForSuspectedTranslocation(chimericAlignment, contigSeq);
+        } else if (chimericAlignment.strandSwitch != StrandSwitch.NO_SWITCH) { // TODO: 9/9/17 the case involves an inversion, could be retired once same chr strand-switch BND calls are evaluated.
             if (isLikelyInvertedDuplication(chimericAlignment.regionWithLowerCoordOnContig, chimericAlignment.regionWithHigherCoordOnContig))
                 initForInvDup(chimericAlignment, contigSeq);
             else
                 initForInversion(chimericAlignment, contigSeq);
-        } else if (isNotSimpleTranslocation) {
+        } else {
             initForInsDel(chimericAlignment, contigSeq);
         }
     }
 
-    private void initForInversion(final ChimericAlignment chimericAlignment, final byte[] contigSeq) {
+    // =================================================================================================================
 
-        final AlignmentInterval firstAlignmentInterval  = chimericAlignment.regionWithLowerCoordOnContig;
-        final AlignmentInterval secondAlignmentInterval = chimericAlignment.regionWithHigherCoordOnContig;
+    private void initForSuspectedTranslocation(final ChimericAlignment chimericAlignment, final byte[] contigSeq) {
+        homologyForwardStrandRep = getHomology(chimericAlignment.regionWithLowerCoordOnContig,
+                chimericAlignment.regionWithHigherCoordOnContig, contigSeq);
+        insertedSequenceForwardStrandRep = getInsertedSequence(chimericAlignment.regionWithLowerCoordOnContig,
+                chimericAlignment.regionWithHigherCoordOnContig, contigSeq);
+    }
 
-        homologyForwardStrandRep = getHomology(firstAlignmentInterval, secondAlignmentInterval, contigSeq);
-        insertedSequenceForwardStrandRep = getInsertedSequence(firstAlignmentInterval, secondAlignmentInterval, contigSeq);
-        dupSeqRepeatUnitRefSpan = null;
-        dupSeqRepeatNumOnRef = dupSeqRepeatNumOnCtg = 0;
-        dupSeqStrandOnRef = dupSeqStrandOnCtg = null;
-        cigarStringsForDupSeqOnCtg = null;
-        dupAnnotIsFromOptimization = false;
-        hasDuplicationAnnotation = false;
+    // =================================================================================================================
+    /**
+     * todo : see ticket #3529
+     * @return true iff the two AI of the {@code longRead} overlaps on reference is more than half of the two AI's minimal read span.
+     */
+    @VisibleForTesting
+    public static boolean isLikelyInvertedDuplication(final AlignmentInterval one, final AlignmentInterval two) {
+        return 2 * AlignmentInterval.overlapOnRefSpan(one, two) >
+                Math.min(one.endInAssembledContig - one.startInAssembledContig,
+                         two.endInAssembledContig - two.startInAssembledContig) + 1;
     }
 
     /**
@@ -218,15 +227,15 @@ public final class BreakpointComplications {
 
         // jump start and jump landing locations
         final int jumpStartRefLoc = firstAlignmentInterval.forwardStrand ? firstAlignmentInterval.referenceSpan.getEnd()
-                                                                         : firstAlignmentInterval.referenceSpan.getStart();
+                : firstAlignmentInterval.referenceSpan.getStart();
         final int jumpLandingRefLoc = secondAlignmentInterval.forwardStrand ? secondAlignmentInterval.referenceSpan.getStart()
-                                                                            : secondAlignmentInterval.referenceSpan.getEnd();
+                : secondAlignmentInterval.referenceSpan.getEnd();
 
         if (firstAlignmentInterval.forwardStrand) {
             final int alpha = firstAlignmentInterval.referenceSpan.getStart(),
-                      omega = secondAlignmentInterval.referenceSpan.getStart();
+                    omega = secondAlignmentInterval.referenceSpan.getStart();
             dupSeqRepeatUnitRefSpan = new SimpleInterval(firstAlignmentInterval.referenceSpan.getContig(),
-                                                         Math.max(alpha, omega), Math.min(jumpStartRefLoc, jumpLandingRefLoc));
+                    Math.max(alpha, omega), Math.min(jumpStartRefLoc, jumpLandingRefLoc));
             if ( (alpha <= omega && jumpStartRefLoc < jumpLandingRefLoc) || (alpha > omega && jumpLandingRefLoc < jumpStartRefLoc) ) {
                 invertedTransInsertionRefSpan = new SimpleInterval(firstAlignmentInterval.referenceSpan.getContig(),
                         Math.min(jumpStartRefLoc, jumpLandingRefLoc) + 1, Math.max(jumpStartRefLoc, jumpLandingRefLoc));
@@ -234,7 +243,7 @@ public final class BreakpointComplications {
             dupSeqStrandOnCtg = DEFAULT_INV_DUP_CTG_ORIENTATIONS_FR;
         } else {
             final int alpha = firstAlignmentInterval.referenceSpan.getEnd(),
-                      omega = secondAlignmentInterval.referenceSpan.getEnd();
+                    omega = secondAlignmentInterval.referenceSpan.getEnd();
             dupSeqRepeatUnitRefSpan = new SimpleInterval(firstAlignmentInterval.referenceSpan.getContig(),
                     Math.max(jumpStartRefLoc, jumpLandingRefLoc), Math.min(alpha, omega));
             if ( (alpha >= omega && jumpLandingRefLoc < jumpStartRefLoc) || (alpha < omega && jumpStartRefLoc < jumpLandingRefLoc) ) {
@@ -260,7 +269,7 @@ public final class BreakpointComplications {
         final boolean needRC;
         if (firstAlignmentInterval.forwardStrand) {
             final int alpha = firstAlignmentInterval.referenceSpan.getStart(),
-                      omega = secondAlignmentInterval.referenceSpan.getStart();
+                    omega = secondAlignmentInterval.referenceSpan.getStart();
             if (alpha <= omega) {
                 final int walkOnRead = SvCigarUtils.computeAssociatedDistOnRead(firstAlignmentInterval.cigarAlong5to3DirectionOfContig,
                         firstAlignmentInterval.startInAssembledContig, omega - alpha, false);
@@ -276,7 +285,7 @@ public final class BreakpointComplications {
             }
         } else {
             final int alpha = firstAlignmentInterval.referenceSpan.getEnd(),
-                      omega = secondAlignmentInterval.referenceSpan.getEnd();
+                    omega = secondAlignmentInterval.referenceSpan.getEnd();
             if (alpha >= omega) {
                 final int walkOnRead = SvCigarUtils.computeAssociatedDistOnRead(firstAlignmentInterval.cigarAlong5to3DirectionOfContig,
                         firstAlignmentInterval.startInAssembledContig, alpha - omega, false);
@@ -297,18 +306,22 @@ public final class BreakpointComplications {
         return seq;
     }
 
-    /**
-     * todo : see ticket #3529
-     * @return true iff the two AI of the {@code longRead} overlaps on reference is more than half of the two AI's minimal read span.
-     */
-    @VisibleForTesting
-    public static boolean isLikelyInvertedDuplication(final AlignmentInterval one, final AlignmentInterval two) {
-        return 2 * AlignmentInterval.overlapOnRefSpan(one, two) >
-                Math.min(one.endInAssembledContig - one.startInAssembledContig,
-                         two.endInAssembledContig - two.startInAssembledContig) + 1;
-    }
-
     //==================================================================================================================
+    //////////// BELOW ARE CODE PATH USED FOR INSERTION, DELETION, AND DUPLICATION (INV OR NOT) AND INVERSION, AND ARE TESTED FOR THAT PURPOSE
+    private void initForInversion(final ChimericAlignment chimericAlignment, final byte[] contigSeq) {
+
+        final AlignmentInterval firstAlignmentInterval  = chimericAlignment.regionWithLowerCoordOnContig;
+        final AlignmentInterval secondAlignmentInterval = chimericAlignment.regionWithHigherCoordOnContig;
+
+        homologyForwardStrandRep = getHomology(firstAlignmentInterval, secondAlignmentInterval, contigSeq);
+        insertedSequenceForwardStrandRep = getInsertedSequence(firstAlignmentInterval, secondAlignmentInterval, contigSeq);
+        dupSeqRepeatUnitRefSpan = null;
+        dupSeqRepeatNumOnRef = dupSeqRepeatNumOnCtg = 0;
+        dupSeqStrandOnRef = dupSeqStrandOnCtg = null;
+        cigarStringsForDupSeqOnCtg = null;
+        dupAnnotIsFromOptimization = false;
+        hasDuplicationAnnotation = false;
+    }
 
     private void initForInsDel(final ChimericAlignment chimericAlignment, final byte[] contigSeq) {
 
@@ -349,8 +362,6 @@ public final class BreakpointComplications {
                 throw new GATKException("An identified breakpoint pair seem to suggest insertion but the inserted sequence is empty: " + chimericAlignment.onErrStringRep());
         }
     }
-
-    //==================================================================================================================
 
     private void resolveComplicationForSimpleTandupExpansion(final SimpleInterval leftReferenceInterval,
                                                              final AlignmentInterval firstContigRegion,

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/GappedAlignmentSplitter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/GappedAlignmentSplitter.java
@@ -13,8 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection;
-
 public final class GappedAlignmentSplitter {
 
     /**
@@ -114,8 +112,7 @@ public final class GappedAlignmentSplitter {
 
                     final AlignmentInterval split = new AlignmentInterval(referenceInterval, contigIntervalStart, contigIntervalEnd,
                             cigarForNewAlignmentInterval, oneRegion.forwardStrand, originalMapQ,
-                            DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.ARTIFICIAL_MISMATCH,
-                            oneRegion.alnScore, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT);
+                            AlignmentInterval.NO_NM, oneRegion.alnScore, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT);
 
                     result.add(split);
 
@@ -158,8 +155,7 @@ public final class GappedAlignmentSplitter {
         result.add(new AlignmentInterval(lastReferenceInterval,
                 contigIntervalStart, unclippedContigLen-clippedNBasesFromEnd, lastForwardStrandCigar,
                 oneRegion.forwardStrand, originalMapQ,
-                DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.ARTIFICIAL_MISMATCH,
-                oneRegion.alnScore, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                AlignmentInterval.NO_NM, oneRegion.alnScore, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
 
 
         return result;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
@@ -1,11 +1,9 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery;
 
-import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
 import org.broadinstitute.hellbender.tools.spark.sv.evidence.ReadMetadata;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
-import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/ContigAlignmentsModifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/ContigAlignmentsModifier.java
@@ -1,0 +1,212 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.*;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SvCigarUtils;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
+import scala.Tuple3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class ContigAlignmentsModifier {
+
+    /**
+     * Removes overlap between input {@code contig}'s two alignments.
+     * If the two alignment intervals are NOT overlapping, return the original aligned contig.
+     */
+    public static List<AlignmentInterval> removeOverlap(final AlignmentInterval one, final AlignmentInterval two,
+                                                        final SAMSequenceDictionary dictionary) {
+
+        final AlignmentInterval reconstructedOne, reconstructedTwo;
+        final int overlapOnRead = AlignmentInterval.overlapOnContig(one, two);
+        if (overlapOnRead == 0) {
+            reconstructedOne = one;
+            reconstructedTwo = two;
+        } else {
+            final boolean oneYieldToTwo;
+            if (one.referenceSpan.getContig().equals(two.referenceSpan.getContig())) {
+                if (one.forwardStrand != two.forwardStrand) { // so that the inverted duplicated reference span is minimal.
+                    // jumpStart is for "the starting reference location of a jump that linked two alignment intervals", and
+                    // jumpLandingRefLoc is for "that jump's landing reference location"
+                    final int jumpStartRefLoc = one.referenceSpan.getEnd(),
+                            jumpLandingRefLoc = two.referenceSpan.getStart();
+                    oneYieldToTwo = jumpStartRefLoc <= jumpLandingRefLoc == one.forwardStrand;
+                } else {
+                    oneYieldToTwo = one.forwardStrand;
+                }
+            } else {
+                oneYieldToTwo = IntervalUtils.compareContigs(one.referenceSpan, two.referenceSpan, dictionary) > 0;
+            }
+
+            if (oneYieldToTwo) {
+                reconstructedOne = clipAlignmentInterval(one, overlapOnRead, true);
+                reconstructedTwo = two;
+            } else {
+                reconstructedOne = one;
+                reconstructedTwo = clipAlignmentInterval(two, overlapOnRead, false);
+            }
+
+        }
+        return Arrays.asList(reconstructedOne, reconstructedTwo);
+    }
+
+    /**
+     * Given {@code clipLengthOnRead} to be clipped from an aligned contig's {@link AlignmentInterval} {@code input},
+     * return a modified {@link AlignmentInterval} with the requested number of bases clipped away and ref span recomputed.
+     * <p>
+     *     Note that the returned AlignmentInterval will have its {@code NM} set to {@link AlignmentInterval#NO_NM}
+     *     whereas its {@code AS} and mapping quality are simply copied from the input alignment
+     *     (recalculating them doesn't payoff at this stage, and makes the alignment filtering step more complicated since they are used there)
+     * </p>
+     * @param input                 alignment to be modified (record not modified in place)
+     * @param clipLengthOnRead      number of read bases to be clipped away
+     * @param clipFrom3PrimeEnd     to clip from the 3' end of the read or not
+     */
+    private static AlignmentInterval clipAlignmentInterval(final AlignmentInterval input, final int clipLengthOnRead,
+                                                           final boolean clipFrom3PrimeEnd) {
+        Utils.validateArg(clipLengthOnRead < input.endInAssembledContig - input.startInAssembledContig + 1,
+                            "input alignment to be clipped away: " + input.toPackedString() + "\twith clip length: " + clipLengthOnRead);
+
+        final Tuple2<SimpleInterval, Cigar> result = computeNewRefSpanAndCigar(input, clipLengthOnRead, clipFrom3PrimeEnd);
+        final int newTigStart, newTigEnd;
+        if (clipFrom3PrimeEnd) {
+            newTigStart = input.startInAssembledContig;
+            newTigEnd   = input.endInAssembledContig - clipLengthOnRead;
+        } else {
+            newTigStart = input.startInAssembledContig + clipLengthOnRead;
+            newTigEnd   = input.endInAssembledContig;
+        }
+        return new AlignmentInterval(result._1, newTigStart, newTigEnd, result._2, input.forwardStrand, input.mapQual,
+                AlignmentInterval.NO_NM, input.alnScore, input.alnModType);
+    }
+
+    /**
+     * Given {@code clipLengthOnRead} to be clipped from an aligned contig's {@link AlignmentInterval} {@code input},
+     * return a modified reference span with the requested number of bases clipped away and new cigar.
+     * @param input                 alignment to be modified (record not modified in place)
+     * @param clipLengthOnRead      number of read bases to be clipped away
+     * @param clipFrom3PrimeEnd     to clip from the 3' end of the read or not
+     * @throws IllegalArgumentException if the {@code input} alignment contains {@link CigarOperator#P} or {@link CigarOperator#N} operations
+     */
+    @VisibleForTesting
+    static Tuple2<SimpleInterval, Cigar> computeNewRefSpanAndCigar(final AlignmentInterval input, final int clipLengthOnRead,
+                                                                   final boolean clipFrom3PrimeEnd) {
+        Utils.validateArg(input.cigarAlong5to3DirectionOfContig.getCigarElements().stream().map(CigarElement::getOperator)
+                        .noneMatch(op -> op.equals(CigarOperator.N) || op.isPadding()),
+                "Input alignment contains padding or skip operations, which is currently unsupported: " + input.toPackedString());
+
+        final Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> threeSections = splitCigarByLeftAndRightClipping(input);
+        final List<CigarElement> leftClippings = threeSections._1();
+        final List<CigarElement> unclippedCigarElementsForThisAlignment = threeSections._2();
+        final List<CigarElement> rightClippings = threeSections._3();
+
+        int readBasesConsumed = 0, refBasesConsumed = 0;
+        final List<CigarElement> cigarElements = new ArrayList<>(unclippedCigarElementsForThisAlignment);
+        if (clipFrom3PrimeEnd) Collections.reverse(cigarElements);
+        final List<CigarElement> newMiddleSection = new ArrayList<>(unclippedCigarElementsForThisAlignment.size());
+        for (int idx = 0; idx < cigarElements.size(); ++idx) {
+            final CigarElement ce = cigarElements.get(idx);
+            if (ce.getOperator().consumesReadBases()) {
+                if (readBasesConsumed + ce.getLength() < clipLengthOnRead) {
+                    readBasesConsumed += ce.getLength();
+                } else { // enough read bases would be clipped, note that here we can have only either 'M' or 'I'
+
+                    if (!ce.getOperator().isAlignment() && !ce.getOperator().equals(CigarOperator.I))
+                        throw new GATKException.ShouldNeverReachHereException("Logic error, should not reach here: operation consumes read bases but is neither alignment nor insertion.\n " +
+                                "Original cigar(" + TextCigarCodec.encode(input.cigarAlong5to3DirectionOfContig) + ")\tclipLengthOnRead(" + clipLengthOnRead + ")\t" + (clipFrom3PrimeEnd ? "clipFrom3PrimeEnd" : "clipFrom5PrimeEnd"));
+
+                    // deal with cigar first
+                    newMiddleSection.add( new CigarElement(clipLengthOnRead, CigarOperator.S) );
+                    // # of bases left, for the current operation, after requested clipping is done,
+                    // may be 0 because we probably don't need the entire current operation to have the requested
+                    // number of read bases clipped, e.g. we only 15 more bases from the current operation,
+                    // but its length is 20, then 5 bases should be "left over"
+                    final int leftOverBasesForCurrOp = readBasesConsumed + ce.getLength() - clipLengthOnRead;
+                    if (leftOverBasesForCurrOp!=0) {
+                        newMiddleSection.add(// again note that here we can have only either 'M' or 'I'
+                                new CigarElement(leftOverBasesForCurrOp, ce.getOperator().isAlignment() ? CigarOperator.M
+                                                                                                        : CigarOperator.S) );
+                    }
+                    newMiddleSection.addAll( cigarElements.subList(idx+1, cigarElements.size()) );
+
+                    // then deal with ref span
+                    refBasesConsumed += ce.getOperator().isAlignment() ? (clipLengthOnRead - readBasesConsumed)
+                                                                       : ce.getLength();
+
+                    break;
+                }
+            }
+            if ( ce.getOperator().consumesReferenceBases() ) { // if reaches here, not enough read bases have been consumed
+                refBasesConsumed += ce.getLength();
+            }
+        }
+        if (clipFrom3PrimeEnd) Collections.reverse(newMiddleSection);
+        final Cigar newCigar = constructNewCigar(leftClippings, newMiddleSection, rightClippings);
+        if (newCigar.getCigarElements().isEmpty())
+            throw new GATKException("Logic error: new cigar is empty.\t" + input.toPackedString() + "\tclip length " +
+                    clipLengthOnRead + "\tclip from end " + (clipFrom3PrimeEnd? "3":"5"));
+
+        final SimpleInterval newRefSpan;
+        if (clipFrom3PrimeEnd == input.forwardStrand) {
+            newRefSpan = new SimpleInterval(input.referenceSpan.getContig(), input.referenceSpan.getStart(),
+                    input.referenceSpan.getEnd() - refBasesConsumed);
+        } else {
+            newRefSpan = new SimpleInterval(input.referenceSpan.getContig(), input.referenceSpan.getStart() + refBasesConsumed,
+                    input.referenceSpan.getEnd());
+        }
+
+        return new Tuple2<>(newRefSpan, newCigar);
+    }
+
+    /**
+     * Extract, from provided {@code input} alignment, three parts of cigar elements:
+     * <ul>
+     *     <li> a list of cigar elements leading to the start position of the input alignment on the read</li>
+     *     <li> </li>
+     *     <li> a list of cigar elements after the end position of the input alignment on the read</li>
+     * </ul>
+     * For example, an alignment with cigar "10H20S5M15I25M35D45M30S40H" with start pos 31 and end pos 120,
+     * the result would be ([10H, 20S], [5M, 15I, 25M, 35D, 45M], [30S, 40H]).
+     */
+    @VisibleForTesting
+    static Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> splitCigarByLeftAndRightClipping(final AlignmentInterval input) {
+        final List<CigarElement> cigarElements = input.cigarAlong5to3DirectionOfContig.getCigarElements();
+        final List<CigarElement> left = new ArrayList<>(cigarElements.size()),
+                                 middle = new ArrayList<>(cigarElements.size()),
+                                 right = new ArrayList<>(cigarElements.size());
+        // using input's startInAssembledContig and endInAssembledContig in testing conditions because they must be the boundaries of alignment operations
+        int readBasesConsumed = 0;
+        for(final CigarElement ce : cigarElements) {
+            if (readBasesConsumed < input.startInAssembledContig-1) {
+                left.add(ce);
+            } else if (readBasesConsumed < input.endInAssembledContig) {
+                middle.add(ce);
+            } else {
+                right.add(ce);
+            }
+            readBasesConsumed += ce.getOperator().consumesReadBases() || ce.getOperator().equals(CigarOperator.H)? ce.getLength() : 0;
+        }
+
+        if (middle.isEmpty())
+            throw new GATKException("Logic error: cigar elements corresponding to alignment block is empty. " + input.toPackedString());
+
+        return new Tuple3<>(left, middle, right);
+    }
+
+    private static Cigar constructNewCigar(final List<CigarElement> left, final List<CigarElement> middle, final List<CigarElement> right) {
+        final Cigar cigar = new Cigar(left);
+        middle.forEach(cigar::add);
+        right.forEach(cigar::add);
+        return new Cigar(SvCigarUtils.compactifyNeighboringSoftClippings(cigar.getCigarElements()));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SimpleStrandSwitchVariantDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SimpleStrandSwitchVariantDetector.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
 
-import com.google.common.annotations.VisibleForTesting;
-import htsjdk.samtools.*;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -9,17 +8,17 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.*;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.RDDUtils;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVVCFWriter;
-import org.broadinstitute.hellbender.tools.spark.sv.utils.SvCigarUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import scala.Tuple2;
 import scala.Tuple3;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -36,207 +35,34 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
                                    final Broadcast<ReferenceMultiSource> broadcastReference, final SAMSequenceDictionary refSequenceDictionary,
                                    final Logger toolLogger) {
 
-        contigs.cache();
         toolLogger.info(contigs.count() + " chimeras indicating either 1) simple strand-switch breakpoints, or 2) inverted duplication.");
 
         // split between suspected inv dup VS strand-switch breakpoints
         // logic flow: first modify alignments (heuristically) if there are overlaps on read between the alignments,
         //             then split the input reads into two classes--those judged by IsLikelyInvertedDuplication are likely invdup and those aren't
-        //             finally send the two split reads down different path, one for invdup and one for BND records
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> split =
-                RDDUtils.split(contigs.map(SimpleStrandSwitchVariantDetector::removeOverlap),
+        //             finally send the two split reads down different path, one for inv dup and one for BND records
+        final JavaRDD<AlignedContig> deOverlappedContigs = contigs.map(tig -> {
+            final AlignmentInterval one = tig.alignmentIntervals.get(0),
+                                    two = tig.alignmentIntervals.get(1);
+            return new AlignedContig(tig.contigName, tig.contigSequence,
+                    ContigAlignmentsModifier.removeOverlap(one, two, refSequenceDictionary), false);
+        });
+        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> invDupAndStrandSwitchBreakpoints =
+                RDDUtils.split(deOverlappedContigs,
                         contig -> BreakpointComplications.isLikelyInvertedDuplication(contig.alignmentIntervals.get(0),
-                                contig.alignmentIntervals.get(1)), true);
+                                contig.alignmentIntervals.get(1)), false);
 
         final JavaRDD<VariantContext> simpleStrandSwitchBkpts =
-                dealWithSimpleStrandSwitchBkpts(split._2, broadcastReference, toolLogger);
+                dealWithSimpleStrandSwitchBkpts(invDupAndStrandSwitchBreakpoints._2, broadcastReference, refSequenceDictionary, toolLogger);
 
         SVVCFWriter.writeVCF(simpleStrandSwitchBkpts.collect(), vcfOutputFileName.replace(".vcf", "_simpleSS.vcf"),
                 refSequenceDictionary, toolLogger);
         simpleStrandSwitchBkpts.unpersist();
 
         final JavaRDD<VariantContext> invDups =
-                dealWithSuspectedInvDup(split._1, broadcastReference, toolLogger);
+                dealWithSuspectedInvDup(invDupAndStrandSwitchBreakpoints._1, broadcastReference, refSequenceDictionary, toolLogger);
         SVVCFWriter.writeVCF(invDups.collect(), vcfOutputFileName.replace(".vcf", "_invDup.vcf"),
                 refSequenceDictionary, toolLogger);
-    }
-
-    // =================================================================================================================
-
-    /**
-     * Removes overlap from a designated alignment interval, so that the inverted duplicated reference span is minimal.
-     * If the two alignment intervals are NOT overlapping, return the original aligned contig.
-     */
-    private static AlignedContig removeOverlap(final AlignedContig contig) {
-        final int overlapOnRead = AlignmentInterval.overlapOnContig(contig.alignmentIntervals.get(0),
-                                                                    contig.alignmentIntervals.get(1));
-        if (overlapOnRead==0) {
-            return contig;
-        } else {
-            final AlignmentInterval one = contig.alignmentIntervals.get(0),
-                                    two = contig.alignmentIntervals.get(1);
-            // jumpStart is for "the starting reference location of a jump that linked two alignment intervals", and
-            // jumpLandingRefLoc is for "that jump's landing reference location"
-            final int jumpStartRefLoc   = one.referenceSpan.getEnd(),
-                      jumpLandingRefLoc = two.referenceSpan.getStart();
-            final AlignmentInterval reconstructedOne, reconstructedTwo;
-            if (jumpStartRefLoc <= jumpLandingRefLoc ^ one.forwardStrand) {
-                reconstructedOne = one;
-                reconstructedTwo = clipAlignmentInterval(two, overlapOnRead, false);
-            } else {
-                reconstructedOne = clipAlignmentInterval(one, overlapOnRead, true);
-                reconstructedTwo = two;
-            }
-            return new AlignedContig(contig.contigName, contig.contigSequence,
-                                     Arrays.asList(reconstructedOne, reconstructedTwo),
-                                     contig.hasEquallyGoodAlnConfigurations);
-        }
-    }
-
-    /**
-     * Given {@code clipLengthOnRead} to be clipped from an aligned contig's {@link AlignmentInterval} {@code input},
-     * return a modified {@link AlignmentInterval} with the requested number of bases clipped away and ref span recomputed.
-     * @param input                 alignment to be modified (record not modified in place)
-     * @param clipLengthOnRead      number of read bases to be clipped away
-     * @param clipFrom3PrimeEnd     to clip from the 3' end of the read or not
-     */
-    private static AlignmentInterval clipAlignmentInterval(final AlignmentInterval input, final int clipLengthOnRead,
-                                                           final boolean clipFrom3PrimeEnd) {
-        Utils.validateArg(clipLengthOnRead < input.endInAssembledContig - input.startInAssembledContig + 1,
-                            "input alignment to be clipped away: " + input.toPackedString() + "\twith clip length: " + clipLengthOnRead);
-
-        final Tuple2<SimpleInterval, Cigar> result = computeNewRefSpanAndCigar(input, clipLengthOnRead, clipFrom3PrimeEnd);
-        final int newTigStart, newTigEnd;
-        if (clipFrom3PrimeEnd) {
-            newTigStart = input.startInAssembledContig;
-            newTigEnd   = input.endInAssembledContig - clipLengthOnRead;
-        } else {
-            newTigStart = input.startInAssembledContig + clipLengthOnRead;
-            newTigEnd   = input.endInAssembledContig;
-        }
-        return new AlignmentInterval(result._1, newTigStart, newTigEnd, result._2, input.forwardStrand, input.mapQual,
-                StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.MISSING_NM,
-                input.alnScore, input.alnModType);
-    }
-
-    /**
-     * Given {@code clipLengthOnRead} to be clipped from an aligned contig's {@link AlignmentInterval} {@code input},
-     * return a modified reference span with the requested number of bases clipped away and new cigar.
-     * @param input                 alignment to be modified (record not modified in place)
-     * @param clipLengthOnRead      number of read bases to be clipped away
-     * @param clipFrom3PrimeEnd     to clip from the 3' end of the read or not
-     * @throws IllegalArgumentException if the {@code input} alignment contains {@link CigarOperator#P} or {@link CigarOperator#N} operations
-     */
-    @VisibleForTesting
-    static Tuple2<SimpleInterval, Cigar> computeNewRefSpanAndCigar(final AlignmentInterval input, final int clipLengthOnRead,
-                                                                   final boolean clipFrom3PrimeEnd) {
-        Utils.validateArg(input.cigarAlong5to3DirectionOfContig.getCigarElements().stream().map(CigarElement::getOperator)
-                        .noneMatch(op -> op.equals(CigarOperator.N) || op.isPadding()),
-                "Input alignment contains padding or skip operations, which is currently unsupported: " + input.toPackedString());
-
-        final Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> threeSections = splitCigarByLeftAndRightClipping(input);
-        final List<CigarElement> leftClippings = threeSections._1();
-        final List<CigarElement> unclippedCigarElementsForThisAlignment = threeSections._2();
-        final List<CigarElement> rightClippings = threeSections._3();
-
-        int readBasesConsumed = 0, refBasesConsumed = 0;
-        final List<CigarElement> cigarElements = new ArrayList<>(unclippedCigarElementsForThisAlignment);
-        if (clipFrom3PrimeEnd) Collections.reverse(cigarElements);
-        final List<CigarElement> newMiddleSection = new ArrayList<>(unclippedCigarElementsForThisAlignment.size());
-        for (int idx = 0; idx < cigarElements.size(); ++idx) {
-            final CigarElement ce = cigarElements.get(idx);
-            if (ce.getOperator().consumesReadBases()) {
-                if (readBasesConsumed + ce.getLength() < clipLengthOnRead) {
-                    readBasesConsumed += ce.getLength();
-                } else { // enough read bases would be clipped, note that here we can have only either 'M' or 'I'
-
-                    if (!ce.getOperator().isAlignment() && !ce.getOperator().equals(CigarOperator.I))
-                        throw new GATKException.ShouldNeverReachHereException("Logic error, should not reach here: operation consumes read bases but is neither alignment nor insertion.\n " +
-                                "Original cigar(" + TextCigarCodec.encode(input.cigarAlong5to3DirectionOfContig) + ")\tclipLengthOnRead(" + clipLengthOnRead + ")\t" + (clipFrom3PrimeEnd ? "clipFrom3PrimeEnd" : "clipFrom5PrimeEnd"));
-
-                    // deal with cigar first
-                    newMiddleSection.add( new CigarElement(clipLengthOnRead, CigarOperator.S) );
-                    // # of bases left, for the current operation, after requested clipping is done,
-                    // may be 0 because we probably don't need the entire current operation to have the requested
-                    // number of read bases clipped, e.g. we only 15 more bases from the current operation,
-                    // but its length is 20, then 5 bases should be "left over"
-                    final int leftOverBasesForCurrOp = readBasesConsumed + ce.getLength() - clipLengthOnRead;
-                    if (leftOverBasesForCurrOp!=0) {
-                        newMiddleSection.add(// again note that here we can have only either 'M' or 'I'
-                                new CigarElement(leftOverBasesForCurrOp, ce.getOperator().isAlignment() ? CigarOperator.M
-                                                                                                        : CigarOperator.S) );
-                    }
-                    newMiddleSection.addAll( cigarElements.subList(idx+1, cigarElements.size()) );
-
-                    // then deal with ref span
-                    refBasesConsumed += ce.getOperator().isAlignment() ? (clipLengthOnRead - readBasesConsumed)
-                                                                       : ce.getLength();
-
-                    break;
-                }
-            }
-            if ( ce.getOperator().consumesReferenceBases() ) { // if reaches here, not enough read bases have been consumed
-                refBasesConsumed += ce.getLength();
-            }
-        }
-        if (clipFrom3PrimeEnd) Collections.reverse(newMiddleSection);
-        final Cigar newCigar = constructNewCigar(leftClippings, newMiddleSection, rightClippings);
-        if (newCigar.getCigarElements().isEmpty())
-            throw new GATKException("Logic error: new cigar is empty.\t" + input.toPackedString() + "\tclip length " +
-                    clipLengthOnRead + "\tclip from end " + (clipFrom3PrimeEnd? "3":"5"));
-
-        final SimpleInterval newRefSpan;
-        if (clipFrom3PrimeEnd == input.forwardStrand) {
-            newRefSpan = new SimpleInterval(input.referenceSpan.getContig(), input.referenceSpan.getStart(),
-                    input.referenceSpan.getEnd() - refBasesConsumed);
-        } else {
-            newRefSpan = new SimpleInterval(input.referenceSpan.getContig(), input.referenceSpan.getStart() + refBasesConsumed,
-                    input.referenceSpan.getEnd());
-        }
-
-        return new Tuple2<>(newRefSpan, newCigar);
-    }
-
-    /**
-     * Extract, from provided {@code input} alignment, three parts of cigar elements:
-     * <ul>
-     *     <li> a list of cigar elements leading to the start position of the input alignment on the read</li>
-     *     <li> </li>
-     *     <li> a list of cigar elements after the end position of the input alignment on the read</li>
-     * </ul>
-     * For example, an alignment with cigar "10H20S5M15I25M35D45M30S40H" with start pos 31 and end pos 120,
-     * the result would be ([10H, 20S], [5M, 15I, 25M, 35D, 45M], [30S, 40H]).
-     */
-    @VisibleForTesting
-    static Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> splitCigarByLeftAndRightClipping(final AlignmentInterval input) {
-        final List<CigarElement> cigarElements = input.cigarAlong5to3DirectionOfContig.getCigarElements();
-        final List<CigarElement> left = new ArrayList<>(cigarElements.size()),
-                                 middle = new ArrayList<>(cigarElements.size()),
-                                 right = new ArrayList<>(cigarElements.size());
-        // using input's startInAssembledContig and endInAssembledContig in testing conditions because they must be the boundaries of alignment operations
-        int readBasesConsumed = 0;
-        for(final CigarElement ce : cigarElements) {
-            if (readBasesConsumed < input.startInAssembledContig-1) {
-                left.add(ce);
-            } else if (readBasesConsumed < input.endInAssembledContig) {
-                middle.add(ce);
-            } else {
-                right.add(ce);
-            }
-            readBasesConsumed += ce.getOperator().consumesReadBases() || ce.getOperator().equals(CigarOperator.H)? ce.getLength() : 0;
-        }
-
-        if (middle.isEmpty())
-            throw new GATKException("Logic error: cigar elements corresponding to alignment block is empty. " + input.toPackedString());
-
-        return new Tuple3<>(left, middle, right);
-    }
-
-    private static Cigar constructNewCigar(final List<CigarElement> left, final List<CigarElement> middle, final List<CigarElement> right) {
-        final Cigar cigar = new Cigar(left);
-        middle.forEach(cigar::add);
-        right.forEach(cigar::add);
-        return new Cigar(SvCigarUtils.compactifyNeighboringSoftClippings(cigar.getCigarElements()));
     }
 
     // =================================================================================================================
@@ -246,17 +72,16 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
      *                                  mapped to the same chr with strand switch is invalid
      */
     private static Tuple2<ChimericAlignment, byte[]> convertAlignmentIntervalsToChimericAlignment
-    (final AlignedContig contigWith2AIMappedToSameChrAndStrandSwitch) {
+    (final AlignedContig contigWith2AIMappedToSameChrAndStrandSwitch, final SAMSequenceDictionary referenceDictionary) {
         Utils.validateArg(SvDiscoverFromLocalAssemblyContigAlignmentsSpark.isLikelyInvBreakpointOrInsInv(contigWith2AIMappedToSameChrAndStrandSwitch),
                 "assumption that input aligned assembly contig has 2 alignments mapped to the same chr with strand switch is invalid.\n" +
-                        SvDiscoverFromLocalAssemblyContigAlignmentsSpark.onErrorStringRepForAlignedContig(contigWith2AIMappedToSameChrAndStrandSwitch));
+                        contigWith2AIMappedToSameChrAndStrandSwitch.toString());
 
         final AlignmentInterval intervalOne = contigWith2AIMappedToSameChrAndStrandSwitch.alignmentIntervals.get(0),
                                 intervalTwo = contigWith2AIMappedToSameChrAndStrandSwitch.alignmentIntervals.get(1);
 
-        // TODO: 8/28/17 this default empty insertion mapping treatment is temporary and should be fixed later
         return new Tuple2<>(new ChimericAlignment(intervalOne, intervalTwo, EMPTY_INSERTION_MAPPINGS,
-                contigWith2AIMappedToSameChrAndStrandSwitch.contigName), contigWith2AIMappedToSameChrAndStrandSwitch.contigSequence);
+                contigWith2AIMappedToSameChrAndStrandSwitch.contigName, referenceDictionary), contigWith2AIMappedToSameChrAndStrandSwitch.contigSequence);
     }
 
     /**
@@ -265,10 +90,10 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
      *  2) either alignment may consume only a "short" part of the contig, or if assuming that the alignment consumes
      *     roughly the same amount of ref bases and read bases, has isAlignment that is too short
      */
-    private static boolean splitPairStrongEnoughEvidenceForCA(final AlignmentInterval intervalOne,
-                                                              final AlignmentInterval intervalTwo,
-                                                              final int mapQThresholdInclusive,
-                                                              final int alignmentLengthThresholdInclusive) {
+    static boolean splitPairStrongEnoughEvidenceForCA(final AlignmentInterval intervalOne,
+                                                      final AlignmentInterval intervalTwo,
+                                                      final int mapQThresholdInclusive,
+                                                      final int alignmentLengthThresholdInclusive) {
 
         if (intervalOne.mapQual < mapQThresholdInclusive || intervalTwo.mapQual < mapQThresholdInclusive)
             return false;
@@ -286,6 +111,7 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
     // workflow manager for simple strand-switch alignment contigs
     private JavaRDD<VariantContext> dealWithSimpleStrandSwitchBkpts(final JavaRDD<AlignedContig> contigs,
                                                                     final Broadcast<ReferenceMultiSource> broadcastReference,
+                                                                    final SAMSequenceDictionary refSequenceDictionary,
                                                                     final Logger toolLogger) {
 
         final JavaPairRDD<ChimericAlignment, byte[]> simpleStrandSwitchBkpts =
@@ -293,12 +119,12 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
                         .filter(tig ->
                                 splitPairStrongEnoughEvidenceForCA(tig.alignmentIntervals.get(0), tig.alignmentIntervals.get(1),
                                         MORE_RELAXED_ALIGNMENT_MIN_MQ,  MORE_RELAXED_ALIGNMENT_MIN_LENGTH))
-                        .mapToPair(SimpleStrandSwitchVariantDetector::convertAlignmentIntervalsToChimericAlignment).cache();
+                        .mapToPair(tig -> convertAlignmentIntervalsToChimericAlignment(tig, refSequenceDictionary)).cache();
 
         toolLogger.info(simpleStrandSwitchBkpts.count() + " chimeras indicating simple strand-switch breakpoints.");
 
         return simpleStrandSwitchBkpts
-                .mapToPair(pair -> new Tuple2<>(new NovelAdjacencyReferenceLocations(pair._1, pair._2), pair._1))
+                .mapToPair(pair -> new Tuple2<>(new NovelAdjacencyReferenceLocations(pair._1, pair._2, refSequenceDictionary), pair._1))
                 .groupByKey()
                 .mapToPair(noveltyAndEvidence -> inferBNDType(noveltyAndEvidence, broadcastReference.getValue()))
                 .flatMap(noveltyTypeAndEvidence ->
@@ -307,31 +133,21 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
                                         noveltyTypeAndEvidence._2._1, noveltyTypeAndEvidence._2._2, broadcastReference).iterator());
     }
 
-    private static Tuple2<NovelAdjacencyReferenceLocations, Tuple2<List<SvType>, Iterable<ChimericAlignment>>>
+    private static Tuple2<NovelAdjacencyReferenceLocations, Tuple2<Tuple2<BreakEndVariantType, BreakEndVariantType>, Iterable<ChimericAlignment>>>
     inferBNDType(final Tuple2<NovelAdjacencyReferenceLocations, Iterable<ChimericAlignment>> noveltyAndEvidence,
                  final ReferenceMultiSource reference) {
 
         final NovelAdjacencyReferenceLocations novelAdjacency = noveltyAndEvidence._1;
         final Iterable<ChimericAlignment> chimericAlignments = noveltyAndEvidence._2;
-        final BreakEndVariantType bkpt_1, bkpt_2;
-        if (novelAdjacency.strandSwitch == StrandSwitch.FORWARD_TO_REVERSE) {
-            bkpt_1 = new BreakEndVariantType.INV55BND(novelAdjacency, true, reference);
-            bkpt_2 = new BreakEndVariantType.INV55BND(novelAdjacency, false, reference);
-        } else if (novelAdjacency.strandSwitch == StrandSwitch.REVERSE_TO_FORWARD) {
-            bkpt_1 = new BreakEndVariantType.INV33BND(novelAdjacency, true, reference);
-            bkpt_2 = new BreakEndVariantType.INV33BND(novelAdjacency, false, reference);
-        } else {
-            throw new GATKException("Wrong type of novel adjacency sent to wrong analysis pathway: no strand-switch being sent to strand-switch path. \n" +
-                    Utils.stream(chimericAlignments).map(ChimericAlignment::onErrStringRep).collect(Collectors.toList()));
-        }
-
-        return new Tuple2<>(novelAdjacency, new Tuple2<>(Arrays.asList(bkpt_1, bkpt_2), chimericAlignments));
+        return new Tuple2<>(novelAdjacency,
+                new Tuple2<>(BreakEndVariantType.InvSuspectBND.getOrderedMates(novelAdjacency, reference), chimericAlignments));
     }
 
     // =================================================================================================================
 
     private JavaRDD<VariantContext> dealWithSuspectedInvDup(final JavaRDD<AlignedContig> contigs,
                                                             final Broadcast<ReferenceMultiSource> broadcastReference,
+                                                            final SAMSequenceDictionary refSequenceDictionary,
                                                             final Logger toolLogger) {
 
         final JavaPairRDD<ChimericAlignment, byte[]> invDupSuspects =
@@ -339,12 +155,12 @@ final class SimpleStrandSwitchVariantDetector implements VariantDetectorFromLoca
                         .filter(tig ->
                                 splitPairStrongEnoughEvidenceForCA(tig.alignmentIntervals.get(0), tig.alignmentIntervals.get(1),
                                         MORE_RELAXED_ALIGNMENT_MIN_MQ,  MORE_RELAXED_ALIGNMENT_MIN_LENGTH))
-                        .mapToPair(SimpleStrandSwitchVariantDetector::convertAlignmentIntervalsToChimericAlignment).cache();
+                        .mapToPair(tig -> convertAlignmentIntervalsToChimericAlignment(tig, refSequenceDictionary)).cache();
 
         toolLogger.info(invDupSuspects.count() + " chimera indicating inverted duplication");
 
         return invDupSuspects
-                .mapToPair(pair -> new Tuple2<>(new NovelAdjacencyReferenceLocations(pair._1, pair._2), new Tuple2<>(pair._1, pair._2)))
+                .mapToPair(pair -> new Tuple2<>(new NovelAdjacencyReferenceLocations(pair._1, pair._2, refSequenceDictionary), new Tuple2<>(pair._1, pair._2)))
                 .groupByKey()
                 .flatMapToPair(SimpleStrandSwitchVariantDetector::inferInvDupRange)
                 .map(noveltyTypeAndAltSeqAndEvidence ->

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SuspectedTransLocDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SuspectedTransLocDetector.java
@@ -1,0 +1,68 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.logging.log4j.Logger;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.broadcast.Broadcast;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.*;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVVCFWriter;
+import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+final class SuspectedTransLocDetector implements VariantDetectorFromLocalAssemblyContigAlignments {
+
+    @SuppressWarnings("unchecked")
+    private static final List<String> EMPTY_INSERTION_MAPPINGS = Collections.EMPTY_LIST;
+
+    @Override
+    public void inferSvAndWriteVCF(final JavaRDD<AlignedContig> localAssemblyContigs, final String vcfOutputFileName,
+                                   final Broadcast<ReferenceMultiSource> broadcastReference, final SAMSequenceDictionary refSequenceDictionary,
+                                   final Logger toolLogger) {
+        toolLogger.info(localAssemblyContigs.count() + " chimeras indicating strand-switch-less breakpoints");
+
+        final JavaPairRDD<ChimericAlignment, byte[]> chimeraAndSequence =
+                localAssemblyContigs
+                        .filter(tig ->
+                                SimpleStrandSwitchVariantDetector.splitPairStrongEnoughEvidenceForCA(tig.alignmentIntervals.get(0),
+                                        tig.alignmentIntervals.get(1), SimpleStrandSwitchVariantDetector.MORE_RELAXED_ALIGNMENT_MIN_MQ,
+                                        0))
+                        .mapToPair(tig -> convertAlignmentIntervalsToChimericAlignment(tig, refSequenceDictionary)).cache();
+
+        final JavaRDD<VariantContext> annotatedBNDs =
+                chimeraAndSequence
+                        .mapToPair(pair -> new Tuple2<>(new NovelAdjacencyReferenceLocations(pair._1, pair._2, refSequenceDictionary), pair._1))
+                        .groupByKey()
+                        .mapToPair(noveltyAndEvidence -> inferBNDType(noveltyAndEvidence, broadcastReference.getValue(), refSequenceDictionary))
+                        .flatMap(noveltyTypeAndEvidence ->
+                                AnnotatedVariantProducer
+                                        .produceAnnotatedBNDmatesVcFromNovelAdjacency(noveltyTypeAndEvidence._1,
+                                                noveltyTypeAndEvidence._2._1, noveltyTypeAndEvidence._2._2, broadcastReference).iterator());
+
+        SVVCFWriter.writeVCF(annotatedBNDs.collect(), vcfOutputFileName.replace(".vcf", "_transBND.vcf"),
+                refSequenceDictionary, toolLogger);
+    }
+
+    private static Tuple2<ChimericAlignment, byte[]> convertAlignmentIntervalsToChimericAlignment(final AlignedContig contig,
+                                                                                                  final SAMSequenceDictionary referenceDictionary) {
+        return new Tuple2<>(new ChimericAlignment(contig.alignmentIntervals.get(0), contig.alignmentIntervals.get(1),
+                EMPTY_INSERTION_MAPPINGS, contig.contigName, referenceDictionary), contig.contigSequence);
+    }
+
+    private static Tuple2<NovelAdjacencyReferenceLocations, Tuple2<Tuple2<BreakEndVariantType, BreakEndVariantType>, Iterable<ChimericAlignment>>>
+    inferBNDType(final Tuple2<NovelAdjacencyReferenceLocations, Iterable<ChimericAlignment>> noveltyAndEvidence,
+                 final ReferenceMultiSource reference, final SAMSequenceDictionary referenceDictionary) {
+
+        final NovelAdjacencyReferenceLocations novelAdjacency = noveltyAndEvidence._1;
+        final Iterable<ChimericAlignment> chimericAlignments = noveltyAndEvidence._2;
+        return new Tuple2<>(novelAdjacency,
+                new Tuple2<>(BreakEndVariantType.TransLocBND.getOrderedMates(novelAdjacency, reference, referenceDictionary),
+                        chimericAlignments));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
@@ -23,14 +23,15 @@ import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscovery
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.FileUtils;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.RDDUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import scala.Tuple2;
 
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 
 /**
@@ -95,7 +96,7 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
 
         // filter alignments and split the gaps
         final JavaRDD<AlignedContig> contigsWithAlignmentsReconstructed =
-                FilterLongReadAlignmentsSAMSpark.filterByScore(reads, headerForReads, nonCanonicalChromosomeNamesFile, localLogger)
+                FilterLongReadAlignmentsSAMSpark.filterByScore(reads, headerForReads, nonCanonicalChromosomeNamesFile, localLogger, 0.0)
                         .filter(lr -> lr.alignmentIntervals.size()>1).cache();
 
         // divert the long reads by their possible type of SV
@@ -111,6 +112,12 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
         }
 
         final Broadcast<ReferenceMultiSource> referenceMultiSourceBroadcast = ctx.broadcast(getReference());
+        dispatchJobs( contigsByPossibleRawTypes, referenceMultiSourceBroadcast, refSequenceDictionary);
+    }
+
+    private void dispatchJobs(final EnumMap<RawTypes, JavaRDD<AlignedContig>> contigsByPossibleRawTypes,
+                              final Broadcast<ReferenceMultiSource> referenceMultiSourceBroadcast,
+                              final SAMSequenceDictionary refSequenceDictionary) {
 
         new InsDelVariantDetector()
                 .inferSvAndWriteVCF(contigsByPossibleRawTypes.get(RawTypes.InsDel), outputDir+"/"+RawTypes.InsDel.name()+".vcf",
@@ -118,6 +125,14 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
 
         new SimpleStrandSwitchVariantDetector()
                 .inferSvAndWriteVCF(contigsByPossibleRawTypes.get(RawTypes.Inv), outputDir+"/"+RawTypes.Inv.name()+".vcf",
+                        referenceMultiSourceBroadcast, refSequenceDictionary, localLogger);
+
+        // here contigs supporting cpx having only 2 alignments could be handled easily together with ref block order switch ones
+        final JavaRDD<AlignedContig> diffChrTrans =
+                contigsByPossibleRawTypes.get(RawTypes.Cpx).filter(tig -> tig.alignmentIntervals.size() == 2);
+        new SuspectedTransLocDetector()
+                .inferSvAndWriteVCF(contigsByPossibleRawTypes.get(RawTypes.DispersedDupOrMEI).union(diffChrTrans),
+                        outputDir+"/"+ RawTypes.DispersedDupOrMEI.name()+".vcf",
                         referenceMultiSourceBroadcast, refSequenceDictionary, localLogger);
     }
 
@@ -132,7 +147,7 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
     private static boolean isSameChromosomeMapping(final AlignedContig contigWithOnlyOneConfigAnd2Aln) {
         Utils.validateArg(hasOnly2Alignments(contigWithOnlyOneConfigAnd2Aln),
                 "assumption that input contig has only 2 alignments is violated. \n" +
-                        onErrorStringRepForAlignedContig(contigWithOnlyOneConfigAnd2Aln));
+                        contigWithOnlyOneConfigAnd2Aln.toString());
         return contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(0).referenceSpan.getContig()
                 .equals(contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(1).referenceSpan.getContig());
     }
@@ -140,7 +155,7 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
     static boolean isLikelyInvBreakpointOrInsInv(final AlignedContig contigWithOnlyOneConfigAnd2AlnToSameChr) {
         Utils.validateArg(isSameChromosomeMapping(contigWithOnlyOneConfigAnd2AlnToSameChr),
                 "assumption that input contig's 2 alignments map to the same chr is violated. \n" +
-                        onErrorStringRepForAlignedContig(contigWithOnlyOneConfigAnd2AlnToSameChr));
+                        contigWithOnlyOneConfigAnd2AlnToSameChr.toString());
         return contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(0).forwardStrand
                 ^
                 contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(1).forwardStrand;
@@ -149,21 +164,26 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
     private static boolean isSuggestingRefBlockOrderSwitch(final AlignedContig contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch) {
         Utils.validateArg(isSameChromosomeMapping(contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch),
                 "assumption that input contig's 2 alignments map to the same chr is violated. \n" +
-                        onErrorStringRepForAlignedContig(contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch));
+                        contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.toString());
         Utils.validateArg( !isLikelyInvBreakpointOrInsInv(contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch),
                 "assumption that input contig's 2 alignments map to the same chr is violated. \n" +
-                        onErrorStringRepForAlignedContig(contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch));
+                        contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.toString());
 
-        final AlignmentInterval intervalOne = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(0),
-                                intervalTwo = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(1);
+        final AlignmentInterval one = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(0),
+                                two = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(1);
+        if (one.referenceSpan.contains(two.referenceSpan) || two.referenceSpan.contains(one.referenceSpan))
+            return false;
+        final List<AlignmentInterval> deOverlappedTempAlignments =
+                ContigAlignmentsModifier.removeOverlap(one, two, null);
 
-        return intervalOne.referenceSpan.getStart() > intervalTwo.referenceSpan.getStart() == intervalOne.forwardStrand;
+        return deOverlappedTempAlignments.get(0).referenceSpan.getStart() > deOverlappedTempAlignments.get(1).referenceSpan.getStart()
+                == deOverlappedTempAlignments.get(0).forwardStrand;
     }
 
     private static boolean isLikelyCpx(final AlignedContig contigWithOnlyOneConfig) {
         Utils.validateArg(!contigWithOnlyOneConfig.hasEquallyGoodAlnConfigurations,
                 "assumption that input contig has one unique best alignment configuration is violated: " +
-                        onErrorStringRepForAlignedContig(contigWithOnlyOneConfig));
+                        contigWithOnlyOneConfig.toString());
 
         return !hasOnly2Alignments(contigWithOnlyOneConfig) || !isSameChromosomeMapping(contigWithOnlyOneConfig);
     }
@@ -182,34 +202,30 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
                 contigsWithAlignmentsReconstructed.filter(lr -> !lr.hasEquallyGoodAlnConfigurations).cache();
 
         // divert away those likely suggesting cpx sv (more than 2 alignments after gap split, or 2 alignments to diff chr)
-        contigsByRawTypes.put(RawTypes.Cpx,
-                contigsWithOnlyOneBestConfig.filter(SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isLikelyCpx));
+        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> cpxAndNot =
+                RDDUtils.split(contigsWithOnlyOneBestConfig, SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isLikelyCpx, true);
+
+        contigsByRawTypes.put(RawTypes.Cpx, cpxAndNot._1);
 
         // long reads with only 1 best configuration and having only 2 alignments mapped to the same chromosome
-        final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfigAnd2AIToSameChr =
-                contigsWithOnlyOneBestConfig
-                        .filter(SvDiscoverFromLocalAssemblyContigAlignmentsSpark::hasOnly2Alignments)
-                        .filter(SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isSameChromosomeMapping).cache();
+        final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfigAnd2AIToSameChr = cpxAndNot._2;
 
         // divert away those with strand switch
-        contigsByRawTypes.put(RawTypes.Inv,
-                contigsWithOnlyOneBestConfigAnd2AIToSameChr.filter(SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isLikelyInvBreakpointOrInsInv));
+        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> strandSwitchAndNot =
+                RDDUtils.split(contigsWithOnlyOneBestConfigAnd2AIToSameChr, SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isLikelyInvBreakpointOrInsInv, true);
+
+        contigsByRawTypes.put(RawTypes.Inv, strandSwitchAndNot._1);
 
         // 2 AI, same chr, no strand switch, then only 2 cases left
-        final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch =
-                contigsWithOnlyOneBestConfigAnd2AIToSameChr.filter(tig -> !isLikelyInvBreakpointOrInsInv(tig)).cache();
+        final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch = strandSwitchAndNot._2;
 
         // case 1: dispersed duplication, or MEI (that is, reference blocks seemingly switched their orders)
-        contigsByRawTypes.put(RawTypes.DispersedDupOrMEI,
-                contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch.filter(SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isSuggestingRefBlockOrderSwitch));
+        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> x =
+                RDDUtils.split(contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch, SvDiscoverFromLocalAssemblyContigAlignmentsSpark::isSuggestingRefBlockOrderSwitch, true);
+        contigsByRawTypes.put(RawTypes.DispersedDupOrMEI, x._1);
 
         // case 2: no order switch: ins, del, or tandem dup
-        contigsByRawTypes.put(RawTypes.InsDel,
-                contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch.filter(tig -> !isSuggestingRefBlockOrderSwitch(tig)));
-
-        contigsWithOnlyOneBestConfigAnd2AIToSameChrWithoutStrandSwitch.unpersist();
-        contigsWithOnlyOneBestConfigAnd2AIToSameChr.unpersist();
-        contigsWithOnlyOneBestConfig.unpersist();
+        contigsByRawTypes.put(RawTypes.InsDel, x._2);
 
         return contigsByRawTypes;
     }
@@ -226,9 +242,4 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
                 outputDir+"/"+rawTypeString+".sam", false);
     }
 
-    static String onErrorStringRepForAlignedContig(final AlignedContig contig) {
-        return FilterLongReadAlignmentsSAMSpark.formatContigInfo(
-                new Tuple2<>(contig.contigName ,
-                        contig.alignmentIntervals.stream().map(AlignmentInterval::toPackedString).collect(Collectors.toList())));
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/RDDUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/RDDUtils.java
@@ -15,7 +15,7 @@ public final class RDDUtils implements Serializable{
      * @param predicate          filtering criteria
      * @param unpersistInputRDD  option to unpersist the input RDD or not.
      * @return a pair of RDD that where the first has all its elements evaluate to "true" given the predicate,
-     *         and the second is the compliment; both are cached.
+     *         and the second is the compliment
      */
     public static <T> Tuple2<JavaRDD<T>, JavaRDD<T>> split(final JavaRDD<T> input, final Function<T, Boolean> predicate,
                                                            final boolean unpersistInputRDD) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
@@ -29,6 +29,10 @@ import java.util.stream.Collectors;
  */
 public class SVVCFWriter {
 
+    /**
+     * {@code referenceSequenceDictionary} is required because 2bit Broadcast references currently order their
+     * sequence dictionaries in a scrambled order, see https://github.com/broadinstitute/gatk/issues/2037.
+     */
     public static void writeVCF(final List<VariantContext> localVariants, final String vcfFileName,
                                 final SAMSequenceDictionary referenceSequenceDictionary, final Logger logger) {
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AnnotatedVariantProducerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AnnotatedVariantProducerUnitTest.java
@@ -44,14 +44,14 @@ public class AnnotatedVariantProducerUnitTest extends BaseTest {
      */
     private static void seeIfItWorks_evidenceAnnotation(final Tuple4<AlignmentInterval, AlignmentInterval, NovelAdjacencyReferenceLocations, String> testData,
                                                         final String[] expectedMappingQualitiesAsStrings,
-                                                        final String[] expectedAlignmentLengthsAsStrings) throws IOException {
+                                                        final String[] expectedAlignmentLengthsAsStrings) {
 
         final AlignmentInterval region1 = testData._1();
         final AlignmentInterval region2 = testData._2();
         final byte[] contigSeq = null; // hack, as the contig sequence is really not necessary for this test purpose
 
         final Map<String, Object> attributeMap =
-                AnnotatedVariantProducer.getEvidenceRelatedAnnotations(Collections.singletonList(new ChimericAlignment(region1, region2, Collections.emptyList(), testData._4())));
+                AnnotatedVariantProducer.getEvidenceRelatedAnnotations(Collections.singletonList(new ChimericAlignment(region1, region2, Collections.emptyList(), testData._4(), SVDiscoveryTestDataProvider.seqDict)));
 
         Assert.assertEquals(((String)attributeMap.get(GATKSVVCFConstants.MAPPING_QUALITIES)).split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR),
                 expectedMappingQualitiesAsStrings);
@@ -60,7 +60,7 @@ public class AnnotatedVariantProducerUnitTest extends BaseTest {
     }
 
     @Test(groups = "sv")
-    public void testGetEvidenceRelatedAnnotations() throws IOException {
+    public void testGetEvidenceRelatedAnnotations() {
 
         // inversion
         Tuple4<AlignmentInterval, AlignmentInterval, NovelAdjacencyReferenceLocations, String> testData = SVDiscoveryTestDataProvider.forSimpleInversionFromLongCtg1WithStrangeLeftBreakpoint;
@@ -132,7 +132,7 @@ public class AnnotatedVariantProducerUnitTest extends BaseTest {
         final AlignmentInterval region1 = testData._1();
         final AlignmentInterval region2 = testData._2();
 
-        final Iterable<ChimericAlignment> evidence = Collections.singletonList(new ChimericAlignment(region1, region2, Collections.emptyList(), testData._4()));
+        final Iterable<ChimericAlignment> evidence = Collections.singletonList(new ChimericAlignment(region1, region2, Collections.emptyList(), testData._4(), SVDiscoveryTestDataProvider.seqDict));
 
         final NovelAdjacencyReferenceLocations breakpoints = testData._3();
 
@@ -246,7 +246,7 @@ public class AnnotatedVariantProducerUnitTest extends BaseTest {
     }
 
     @Test(dataProvider = "CIIntervals")
-    public void testProduceCIInterval(final int point, final SVInterval interval, final String expected, final Exception expectedException) throws Exception {
+    public void testProduceCIInterval(final int point, final SVInterval interval, final String expected, final Exception expectedException) {
         if (expectedException == null) {
             Assert.assertEquals(AnnotatedVariantProducer.produceCIInterval(point, interval), expected);
         } else {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/ChimericAlignmentUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/ChimericAlignmentUnitTest.java
@@ -177,7 +177,7 @@ public class ChimericAlignmentUnitTest extends BaseTest {
 
     private static void testSerialization(final AlignmentInterval region1, final AlignmentInterval region2) {
 
-        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "dummyName");
+        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "dummyName", SVDiscoveryTestDataProvider.seqDict);
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final Output out = new Output(bos);
         final Kryo kryo = new Kryo();

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
@@ -18,7 +18,6 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.StrandedInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -132,8 +131,8 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest extends BaseTe
         etls.forEach(e -> evidenceTree.put(e.getPairedStrandedIntervals(), e));
 
         final List<VariantContext> processedVariantContexts =
-                DiscoverVariantsFromContigAlignmentsSAMSpark.processEvidenceTargetLinks(params, localLogger, evidenceTree,
-                        metadata, inputVariants, referenceMultiSource);
+                DiscoverVariantsFromContigAlignmentsSAMSpark.processEvidenceTargetLinks(inputVariants, evidenceTree, metadata, referenceMultiSource, params, localLogger
+                );
 
         VariantContextTestUtils.assertEqualVariants(processedVariantContexts, expectedVariants);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/GappedAlignmentSplitterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/GappedAlignmentSplitterUnitTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.MISSING_NM;
+import static org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval.NO_NM;
 
 public class GappedAlignmentSplitterUnitTest {
 
@@ -37,10 +37,10 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.size(), 2);
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(new SimpleInterval("1", 100, 126),
                 57, 83, TextCigarCodec.decode("56S27M68S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(new SimpleInterval("1", 127, 158),
                 99, 130, TextCigarCodec.decode("98S32M21S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
 
     }
 
@@ -55,10 +55,10 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.size(), 2);
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(new SimpleInterval("1", 100, 304),
                 3, 207, TextCigarCodec.decode("2S205M346S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(new SimpleInterval("1", 307, 575),
                 208, 476, TextCigarCodec.decode("207S269M77S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -75,23 +75,22 @@ public class GappedAlignmentSplitterUnitTest {
 
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(new SimpleInterval("1", 100, 217),
                 398, 515, TextCigarCodec.decode("397S118M594S"),
-                true, 60, MISSING_NM,
-                100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(new SimpleInterval("1", 220, 245),
                 516, 541, TextCigarCodec.decode("515S26M568S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(2), new AlignmentInterval(new SimpleInterval("1", 246, 295),
                 548, 597, TextCigarCodec.decode("547S50M512S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(3), new AlignmentInterval(new SimpleInterval("1", 296, 321),
                 605, 630, TextCigarCodec.decode("604S26M479S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(4), new AlignmentInterval(new SimpleInterval("1", 322, 329),
                 632, 639, TextCigarCodec.decode("631S8M470S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(5), new AlignmentInterval(new SimpleInterval("1", 343, 414),
                 640, 711, TextCigarCodec.decode("639S72M398S"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -108,13 +107,13 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.size(), 3);
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(new SimpleInterval("1", 100, 129),
                 1, 20, TextCigarCodec.decode("10M10D10M100S"),
-                true, 60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(new SimpleInterval("1", 130, 149),
                 81, 110, TextCigarCodec.decode("80S10M10I10M10S"),
-                true, 60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(2), new AlignmentInterval(new SimpleInterval("1", 200, 209),
                 111, 120, TextCigarCodec.decode("110S10M"),
-                true, 60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -130,13 +129,13 @@ public class GappedAlignmentSplitterUnitTest {
 
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(new SimpleInterval("1", 100, 102),
                 4, 6, TextCigarCodec.decode("1H2S3M28S8H"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(new SimpleInterval("1", 103, 112),
                 12, 21, TextCigarCodec.decode("1H10S10M13S8H"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(2), new AlignmentInterval(new SimpleInterval("1", 133, 138),
                 22, 27, TextCigarCodec.decode("1H20S6M7S8H"), true,
-                60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -155,11 +154,11 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(
                 new SimpleInterval("1", 101, 110), 11, 20,
                 TextCigarCodec.decode("10S10M15S"),
-                true, 60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(
                 new SimpleInterval("1", 111, 120), 26, 35,
                 TextCigarCodec.decode("25S10M"),
-                true, 60, MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                true, 60, NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
 
         // ending with 'I'
         cigar = TextCigarCodec.decode("10M5I10M10I");
@@ -172,11 +171,11 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(
                 new SimpleInterval("1", 101, 110), 1, 10,
                 TextCigarCodec.decode("10M25S"), true, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(
                 new SimpleInterval("1", 111, 120), 16, 25,
                 TextCigarCodec.decode("15S10M10S"), true, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -202,11 +201,11 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(
                 new SimpleInterval("1", 101, 140), 61, 100,
                 TextCigarCodec.decode("10H50S40M125S70H"), true, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(
                 new SimpleInterval("1", 146, 160), 101, 115,
                 TextCigarCodec.decode("10H90S15M110S70H"), true, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")
@@ -222,11 +221,11 @@ public class GappedAlignmentSplitterUnitTest {
         Assert.assertEquals(generatedARList.get(0), new AlignmentInterval(
                 new SimpleInterval("chrUn_JTFH01000557v1_decoy", 416, 1459), 11,
                 1054, TextCigarCodec.decode("10S1044M592S"), false, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
         Assert.assertEquals(generatedARList.get(1), new AlignmentInterval(
                 new SimpleInterval("chrUn_JTFH01000557v1_decoy", 21, 415), 1177,
                 1571, TextCigarCodec.decode("1176S395M75S"), false, 60,
-                MISSING_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
+                NO_NM, 100, AlnModType.FROM_SPLIT_GAPPED_ALIGNMENT));
     }
 
     @Test(groups = "sv")

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/NovelAdjacencyReferenceLocationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/NovelAdjacencyReferenceLocationsUnitTest.java
@@ -99,24 +99,24 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
         Assert.assertEquals(roundTrip, novelAdjacencyReferenceLocations1);
     }
 
-    private static NovelAdjacencyReferenceLocations getBreakpoints(final String contigName, final String insertionMapping) throws IOException{
+    private static NovelAdjacencyReferenceLocations getBreakpoints(final String contigName, final String insertionMapping) {
         final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 10000, 10100), 1, 100, TextCigarCodec.decode("100M"), true, 60, 0, 100, AlnModType.NONE);
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 20100, 20200), 101, 200, TextCigarCodec.decode("100M"), false, 60, 0, 100, AlnModType.NONE);
         final ArrayList<String> insertionMappings = new ArrayList<>();
         insertionMappings.add(insertionMapping);
-        final ChimericAlignment breakpoint = new ChimericAlignment(region1, region2, insertionMappings, contigName);
-        return new NovelAdjacencyReferenceLocations(breakpoint, SVDiscoveryTestDataProvider.makeDummySequence(200, (byte)'A'));
+        final ChimericAlignment breakpoint = new ChimericAlignment(region1, region2, insertionMappings, contigName, SVDiscoveryTestDataProvider.seqDict);
+        return new NovelAdjacencyReferenceLocations(breakpoint, SVDiscoveryTestDataProvider.makeDummySequence(200, (byte)'A'), SVDiscoveryTestDataProvider.seqDict);
     }
 
     // -----------------------------------------------------------------------------------------------
     // Tests for inversion
     // -----------------------------------------------------------------------------------------------
     @Test(groups = "sv")
-    public void testGetBreakpoints_5to3Inversion_withSimpleInsertion() throws IOException {
+    public void testGetBreakpoints_5to3Inversion_withSimpleInsertion() {
 
         final NovelAdjacencyReferenceLocations breakpoints = SVDiscoveryTestDataProvider.forSimpleInversionWithNovelInsertion._3();
         seeIfItWorks(breakpoints, StrandSwitch.FORWARD_TO_REVERSE,
-                new SimpleInterval("21", 108569294, 108569294), new SimpleInterval("21", 108569364, 108569364),
+                new SimpleInterval("21", 69294, 69294), new SimpleInterval("21", 69364, 69364),
                 null, "", "T", 0, 0, null);
     }
 
@@ -135,7 +135,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
      *  @see SVDiscoveryTestDataProvider#forSimpleInversionWithHomology(ByteArrayOutputStream)
      */
     @Test(groups = "sv")
-    public void testSimpleInversionWithHomologyBreakpointsIdentification_allFourRepresentations() throws IOException {
+    public void testSimpleInversionWithHomologyBreakpointsIdentification_allFourRepresentations() {
 
         final byte[] homology = "ACACA".getBytes();
 
@@ -169,7 +169,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
         final AlignmentInterval region3 = new AlignmentInterval(new SimpleInterval("20", 23103633, 23104603), 524, 1493, TextCigarCodec.decode("523S970M"), true, 60, 3, 100, AlnModType.NONE);
 
         final AlignedContig alignedContig = new AlignedContig("asm00001:tig0001", contigSequence, Arrays.asList(region1, region2, region3), false);
-        final List<ChimericAlignment> assembledBreakpointsFromAlignmentIntervals = ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH);
+        final List<ChimericAlignment> assembledBreakpointsFromAlignmentIntervals = ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertEquals(assembledBreakpointsFromAlignmentIntervals.size(), 1);
         final ChimericAlignment chimericAlignment = assembledBreakpointsFromAlignmentIntervals.get(0);
         Assert.assertEquals(chimericAlignment.sourceContigName, "asm00001:tig0001");
@@ -178,7 +178,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
         Assert.assertEquals(chimericAlignment.insertionMappings.size(), 1);
         final String expectedInsertionMappingsString = String.join(AlignmentInterval.PACKED_STRING_REP_SEPARATOR, "484", "525", "20:23103196-23103238", "-", "483S42M968S", "60", "2", "100", "O");
         Assert.assertEquals(chimericAlignment.insertionMappings.get(0), expectedInsertionMappingsString);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment, contigSequence);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment, contigSequence, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertTrue(breakpoints.complication.getHomologyForwardStrandRep().isEmpty());
         Assert.assertEquals(breakpoints.complication.getInsertedSequenceForwardStrandRep(), "TGAGAGTTGGCCCGAACACTGCTGGATTCCACTTCA");
     }
@@ -188,8 +188,8 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
     public void testGetBreakpoints_5to3Inversion_simple() throws IOException {
         final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 101, 200), 1, 100, TextCigarCodec.decode("100M100S"), true, 60, 0, 100, AlnModType.NONE);
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 501, 600), 101, 200, TextCigarCodec.decode("100S100M"), false, 60, 0, 100, AlnModType.NONE);
-        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1");
-        final Tuple2<SimpleInterval, SimpleInterval> breakpoints = NovelAdjacencyReferenceLocations.leftJustifyBreakpoints(chimericAlignment, DEFAULT_BREAKPOINT_COMPLICATIONS);
+        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1", SVDiscoveryTestDataProvider.seqDict);
+        final Tuple2<SimpleInterval, SimpleInterval> breakpoints = NovelAdjacencyReferenceLocations.leftJustifyBreakpoints(chimericAlignment, DEFAULT_BREAKPOINT_COMPLICATIONS, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertEquals(breakpoints._1(), new SimpleInterval("20", 200, 200));
         Assert.assertEquals(breakpoints._2(), new SimpleInterval("20", 600, 600));
     }
@@ -198,10 +198,10 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
     public void testGetBreakpoints_5to3Inversion_withSimpleHomology() throws IOException {
         final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 101, 205), 1, 105, TextCigarCodec.decode("105M100S"), true, 60, 0, 100, AlnModType.NONE);
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 501, 605), 96, 200, TextCigarCodec.decode("105M100S"), false, 60, 0, 100, AlnModType.NONE);
-        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1");
+        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1", SVDiscoveryTestDataProvider.seqDict);
         final BreakpointComplications homologyComplications = new BreakpointComplications("ACACA", "",
                 DEFAULT_BREAKPOINT_COMPLICATIONS.hasDuplicationAnnotation(), DEFAULT_BREAKPOINT_COMPLICATIONS.getDupSeqRepeatUnitRefSpan(), DEFAULT_BREAKPOINT_COMPLICATIONS.getDupSeqRepeatNumOnRef(), DEFAULT_BREAKPOINT_COMPLICATIONS.getDupSeqRepeatNumOnCtg(), null, null, DEFAULT_BREAKPOINT_COMPLICATIONS.getCigarStringsForDupSeqOnCtg(), DEFAULT_BREAKPOINT_COMPLICATIONS.isDupAnnotIsFromOptimization(), null);
-        final Tuple2<SimpleInterval, SimpleInterval> breakpoints = NovelAdjacencyReferenceLocations.leftJustifyBreakpoints(chimericAlignment, homologyComplications);
+        final Tuple2<SimpleInterval, SimpleInterval> breakpoints = NovelAdjacencyReferenceLocations.leftJustifyBreakpoints(chimericAlignment, homologyComplications, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertEquals(breakpoints._1(), new SimpleInterval("20", 200, 200));
         Assert.assertEquals(breakpoints._2(), new SimpleInterval("20", 605, 605));
     }
@@ -213,7 +213,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
     public void testGetBreakpoints_ExpectException() throws IOException {
         final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100100), 1 ,100, TextCigarCodec.decode("100M"), true, 60, 0, 100, AlnModType.NONE);
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100101, 100200), 101 ,200, TextCigarCodec.decode("100M"), true, 60, 0, 100, AlnModType.NONE);
-        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1");
+        final ChimericAlignment chimericAlignment = new ChimericAlignment(region1, region2, Collections.emptyList(), "1", SVDiscoveryTestDataProvider.seqDict);
         new BreakpointComplications(chimericAlignment, SVDiscoveryTestDataProvider.makeDummySequence(200, (byte)'A'));
     }
 
@@ -333,7 +333,7 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
      * @see SVDiscoveryTestDataProvider#forComplexTandemDuplication()
      */
     @Test(groups = "sv")
-    public void testGetBreakpoints_tandemDuplication_complex() throws IOException {
+    public void testGetBreakpoints_tandemDuplication_complex() {
 
         final String leftRefFlank       = "TGCCAGGTTACATGGCAAAGAGGGTAGATAT";                                                                    // 31
         final String rightRefFlank      = "TGGTGCAAATGCCATTTATGCTCCTCTCCACCCATATCC";                                                            // 39
@@ -434,19 +434,19 @@ public class NovelAdjacencyReferenceLocationsUnitTest extends BaseTest{
      * @throws Exception
      */
     @Test(enabled = false)
-    public void testGetAssembledBreakpointsFromAlignmentIntervals() throws Exception {
+    public void testGetAssembledBreakpointsFromAlignmentIntervals() {
         final byte[] contigSequence = "GACGAACGATTTGACTTTAATATGAAATGTTTTATGTGGGCTATAAAATTATCCAAACTCGACACAGGACATTTTGAGCTTATTTCCAAATCATCTGGCCTTCATCTACCCACTGGAACTATTACTCTGCTGGGTCCTCATGGAAACATATCTTTCAGCCCTAACAATGAGACTACAGACATCTACGTCCCCAACACAACAGCTAAAAAGCAGTAGAATGTCAGAAAGGCTATCCACTTAGCCCTTGGCTGACAGGCCCCACTGAGCATCCTTTGCGAAGTCCATTTACTAGCTAATTCATAATTTACACAAGGCATTCAGACATAGCAGCTAAGATATAAAACATTTATCAACACAGGGACTAGTTTGTCATTTTAAAATAATTATGTTTAAGTAAGCCAATAAAGTCTATCTTCTCCAATTTACTTATTGAGCTTTATGAGGCAATTTAAGTCCCGATTTTGGGGGGTATGTATGAAAGGAGAGCATGGAAATGCCATTTGCTCCCTGAAGTTTTTATCTTTTTTTTTTTGAGATAGAGTCTTGTGTTTTCTGTGGAGTACATGAGTATGCATCAAAGCTAACAACGCCCACTGCCCTGTTAGTCAAATACCTTTGA".getBytes();
         final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 118873207, 118873739), 1, 532, TextCigarCodec.decode("532M87S"), true, 60, 0, 100, AlnModType.NONE);
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 175705642, 175705671), 519, 547, TextCigarCodec.decode("518S29M72S"), false, 3, 0, 100, AlnModType.NONE);
         final AlignmentInterval region3 = new AlignmentInterval(new SimpleInterval("20", 118875262, 118875338), 544, 619, TextCigarCodec.decode("543S76M"), false, 60, 0, 100, AlnModType.NONE);
         final AlignedContig alignedContig = new AlignedContig("asm00001:tig0001", contigSequence, Arrays.asList(region1, region2, region3), false);
-        final List<ChimericAlignment> assembledBreakpointsFromAlignmentIntervals = ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH);
+        final List<ChimericAlignment> assembledBreakpointsFromAlignmentIntervals = ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertEquals(assembledBreakpointsFromAlignmentIntervals.size(), 1);
         final ChimericAlignment chimericAlignment = assembledBreakpointsFromAlignmentIntervals.get(0);
         Assert.assertEquals(chimericAlignment.sourceContigName, "asm00001:tig0001");
         Assert.assertEquals(chimericAlignment.regionWithLowerCoordOnContig, region1);
         Assert.assertEquals(chimericAlignment.regionWithHigherCoordOnContig, region3);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment, contigSequence);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(chimericAlignment, contigSequence, SVDiscoveryTestDataProvider.seqDict);
         Assert.assertTrue(breakpoints.complication.getHomologyForwardStrandRep().isEmpty());
         Assert.assertEquals(breakpoints.complication.getInsertedSequenceForwardStrandRep(), "GAGATAGAGTC");
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVDiscoveryTestDataProvider.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVDiscoveryTestDataProvider.java
@@ -184,11 +184,11 @@ public final class SVDiscoveryTestDataProvider {
         contigSeq[leftFlank.length] = (byte) 'T';
         System.arraycopy(rightFlankRC, 0, contigSeq, leftFlank.length+1, rightFlankRC.length);
 
-
-        final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 108569149, 108569294), 1, 146, TextCigarCodec.decode("146M51S"), true, 60, 0, 100, AlnModType.NONE);
-        final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 108569315, 108569364), 148, 197, TextCigarCodec.decode("147S50M"), false, 60, 0, 100, AlnModType.NONE);
+        // reference intervals are changed from real values, which were generated on a different chromosome, to a fake but valid value.
+        final AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 69149, 69294), 1, 146, TextCigarCodec.decode("146M51S"), true, 60, 0, 100, AlnModType.NONE);
+        final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 69315, 69364), 148, 197, TextCigarCodec.decode("147S50M"), false, 60, 0, 100, AlnModType.NONE);
         final AlignedContig alignedContig = new AlignedContig("asm000001:tig00001", contigSeq, Arrays.asList(region1, region2), false);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), alignedContig.contigName), alignedContig.contigSequence);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), alignedContig.contigName, seqDict), alignedContig.contigSequence, seqDict);
         return new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001");
     }
 
@@ -200,7 +200,7 @@ public final class SVDiscoveryTestDataProvider {
         final AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval(chrForLongContig1, 20152030, 20154634), 3604, contigSequence.length, TextCigarCodec.decode("3603H24M1I611M1I1970M"), true, 60, 36, 100, AlnModType.NONE);
 
         final AlignedContig alignedContig = new AlignedContig("asm702700:tig00001", contigSequence, Arrays.asList(region1, region2), false);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH).get(0), contigSequence);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(ChimericAlignment.parseOneContig(alignedContig, StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection.DEFAULT_MIN_ALIGNMENT_LENGTH, seqDict).get(0), contigSequence, seqDict);
         return new Tuple4<>(region1, region2, breakpoints, "asm702700:tig00001");
     }
 
@@ -239,7 +239,7 @@ public final class SVDiscoveryTestDataProvider {
 
             AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 101, 205), 1, 105, TextCigarCodec.decode("105M100S"), true, 60, 0, 100, AlnModType.NONE);
             AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 501, 605), 101, 205, TextCigarCodec.decode("100S105M"), false, 60, 0, 100, AlnModType.NONE);
-            final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001"), contigSeq);
+            final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
             result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
             outputStream.reset();
@@ -247,7 +247,7 @@ public final class SVDiscoveryTestDataProvider {
             contigSeq = outputStream.toByteArray();
             region1 = new AlignmentInterval(new SimpleInterval("20", 501, 605), 1, 105, TextCigarCodec.decode("105M100S"), true, 60, 0, 100, AlnModType.NONE);
             region2 = new AlignmentInterval(new SimpleInterval("20", 101, 205), 101, 205, TextCigarCodec.decode("100S105M"), false, 60, 0, 100, AlnModType.NONE);
-            final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001"), contigSeq);
+            final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
             result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
         }
         {// right flanking evidence '+'/'-' strand representation
@@ -257,7 +257,7 @@ public final class SVDiscoveryTestDataProvider {
 
             AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 201, 305), 1, 105, TextCigarCodec.decode("105M100S"), false, 60, 0, 100, AlnModType.NONE);
             AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 601, 705), 101, 205, TextCigarCodec.decode("100S105M"), true, 60, 0, 100, AlnModType.NONE);
-            final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001"), contigSeq);
+            final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
             result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
             outputStream.reset();
@@ -266,7 +266,7 @@ public final class SVDiscoveryTestDataProvider {
 
             region1 = new AlignmentInterval(new SimpleInterval("20", 601, 705), 1, 105, TextCigarCodec.decode("105M100S"), false, 60, 0, 100, AlnModType.NONE);
             region2 = new AlignmentInterval(new SimpleInterval("20", 201, 305), 101, 205, TextCigarCodec.decode("100S105M"), true, 60, 0, 100, AlnModType.NONE);
-            final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001"), contigSeq);
+            final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, new ArrayList<>(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
             result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
         }
         return result;
@@ -289,7 +289,7 @@ public final class SVDiscoveryTestDataProvider {
         byte[] contigSeq = outputStream.toByteArray();
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100040), 1 ,40, TextCigarCodec.decode("40M40S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100061, 100100), 41 ,80, TextCigarCodec.decode("40S40M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple deletion '-' strand representation
@@ -300,7 +300,7 @@ public final class SVDiscoveryTestDataProvider {
         contigSeq = outputStream.toByteArray();
         region1 = new AlignmentInterval(new SimpleInterval("21", 100061, 100100), 1 ,40, TextCigarCodec.decode("40M40S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100040), 41 ,80, TextCigarCodec.decode("40S40M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -323,7 +323,7 @@ public final class SVDiscoveryTestDataProvider {
         byte[] contigSeq = outputStream.toByteArray();
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100100), 1 ,100, TextCigarCodec.decode("100M100S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100101, 100200), 151 ,250, TextCigarCodec.decode("100S100M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple insertion '-' strand representation
@@ -335,7 +335,7 @@ public final class SVDiscoveryTestDataProvider {
         contigSeq = outputStream.toByteArray();
         region1 = new AlignmentInterval(new SimpleInterval("21", 100101, 100200), 1 ,100, TextCigarCodec.decode("100M100S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100100), 151 ,250, TextCigarCodec.decode("100S100M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -359,7 +359,7 @@ public final class SVDiscoveryTestDataProvider {
         System.arraycopy(rightRefFlank, 0, contigSeq, 50, 40);
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100040), 1 ,40, TextCigarCodec.decode("40M50S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100061, 100100), 51 ,90, TextCigarCodec.decode("50S40M"), true, 60, 0, 100, AlnModType.NONE);
-        NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // long range substitution '-' strand representation
@@ -371,7 +371,7 @@ public final class SVDiscoveryTestDataProvider {
         System.arraycopy(leftRefFlank, 0, contigSeq, 40 + substitution.length, 40);
         region1 = new AlignmentInterval(new SimpleInterval("21", 100061, 100100), 1 ,40, TextCigarCodec.decode("40M50S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100040), 51 ,90, TextCigarCodec.decode("50S40M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -395,7 +395,7 @@ public final class SVDiscoveryTestDataProvider {
         byte[] contigSeq = outputStream.toByteArray();
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100044), 1 ,44, TextCigarCodec.decode("44M40S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100079, 100122), 41 ,84, TextCigarCodec.decode("40S44M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple deletion with homology '-' strand representation
@@ -407,7 +407,7 @@ public final class SVDiscoveryTestDataProvider {
         contigSeq = outputStream.toByteArray();
         region1 = new AlignmentInterval(new SimpleInterval("21", 100079, 100122), 1 ,44, TextCigarCodec.decode("44M40S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100044), 41 ,84, TextCigarCodec.decode("40S44M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -433,7 +433,7 @@ public final class SVDiscoveryTestDataProvider {
 
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100050), 1 ,50, TextCigarCodec.decode("50M40S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100051, 100100), 41 ,100, TextCigarCodec.decode("40S50M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple tandem duplication contraction '-' strand representation
@@ -445,7 +445,7 @@ public final class SVDiscoveryTestDataProvider {
         System.arraycopy(leftRefFlank, 0, contigSeq, 50, 40);
         region1 = new AlignmentInterval(new SimpleInterval("21", 100051, 100100), 1 ,50, TextCigarCodec.decode("50M40S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100050), 41 ,100, TextCigarCodec.decode("40S50M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -470,7 +470,7 @@ public final class SVDiscoveryTestDataProvider {
 
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 100001, 100050), 1 ,50, TextCigarCodec.decode("50M50S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 100041, 100090), 51 ,100, TextCigarCodec.decode("50S50M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple tandem duplication expansion '-' strand representation
@@ -482,7 +482,7 @@ public final class SVDiscoveryTestDataProvider {
         contigSeq = outputStream.toByteArray();
         region1 = new AlignmentInterval(new SimpleInterval("21", 100041, 100090), 1 ,50, TextCigarCodec.decode("50M50S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 100001, 100050), 51 ,100, TextCigarCodec.decode("50S50M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -516,7 +516,7 @@ public final class SVDiscoveryTestDataProvider {
 
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("21", 25297101, 25297252), 1 ,152, TextCigarCodec.decode("152M147S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("21", 25297164, 25297300), 163 ,299, TextCigarCodec.decode("162S137M"), true, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // simple tandem duplication expansion with novel insertion '-' strand representation
@@ -530,7 +530,7 @@ public final class SVDiscoveryTestDataProvider {
 
         region1 = new AlignmentInterval(new SimpleInterval("21", 25297164, 25297300), 1 ,137, TextCigarCodec.decode("137M162S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("21", 25297101, 25297252), 148 ,299, TextCigarCodec.decode("147S152M"), false, 60, 0, 100, AlnModType.NONE);
-        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeq);
+        final NovelAdjacencyReferenceLocations breakpointsDetectedFromReverseStrand = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeq, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpointsDetectedFromReverseStrand, "asm000001:tig00001"));
 
         return result;
@@ -565,7 +565,7 @@ public final class SVDiscoveryTestDataProvider {
         final byte[] contigSeqForComplexExpansionWithPseudoHomology = String.format("%s%s%s%s%s", leftRefFlank, firstRepeat, secondRepeat, pseudoHomology, rightRefFlank).getBytes();
         AlignmentInterval region1 = new AlignmentInterval(new SimpleInterval("20", 312579, 312718), 1 ,140, TextCigarCodec.decode("140M135S"), true, 60, 0, 100, AlnModType.NONE);
         AlignmentInterval region2 = new AlignmentInterval(new SimpleInterval("20", 312610, 312757), 128 ,275, TextCigarCodec.decode("127S148M"), true, 60, 0, 100, AlnModType.NONE);
-        NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexExpansionWithPseudoHomology);
+        NovelAdjacencyReferenceLocations breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexExpansionWithPseudoHomology, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         final byte[] fakeRefSeqForComplexExpansionWithPseudoHomology_reverseStrand = Arrays.copyOf(fakeRefSeqForComplexExpansionWithPseudoHomology, fakeRefSeqForComplexExpansionWithPseudoHomology.length);
@@ -575,7 +575,7 @@ public final class SVDiscoveryTestDataProvider {
 
         region1 = new AlignmentInterval(new SimpleInterval("20", 312610, 312757), 1 ,148, TextCigarCodec.decode("148M127S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312579, 312718), 136 ,275, TextCigarCodec.decode("135S140M"), false, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexExpansionWithPseudoHomology_reverseStrand);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexExpansionWithPseudoHomology_reverseStrand, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // second test: contraction from 2 units to 1 unit with pseudo-homology
@@ -583,7 +583,7 @@ public final class SVDiscoveryTestDataProvider {
         final byte[] contigSeqForComplexContractionWithPseudoHomology = fakeRefSeqForComplexExpansionWithPseudoHomology;
         region1 = new AlignmentInterval(new SimpleInterval("20", 312579, 312718), 1, 140, TextCigarCodec.decode("140M39S"), true, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312706, 312853), 32, 179, TextCigarCodec.decode("31S148M"), true, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexContractionWithPseudoHomology);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexContractionWithPseudoHomology, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         final byte[] fakeRefSeqForComplexContractionWithPseudoHomology_reverseStrand = Arrays.copyOf(fakeRefSeqForComplexContractionWithPseudoHomology, fakeRefSeqForComplexContractionWithPseudoHomology.length);
@@ -592,7 +592,7 @@ public final class SVDiscoveryTestDataProvider {
         SequenceUtil.reverseComplement(contigSeqForComplexContractionWithPseudoHomology_reverseStrand);
         region1 = new AlignmentInterval(new SimpleInterval("20", 312706, 312853), 1, 148, TextCigarCodec.decode("148M31S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312579, 312718), 40, 179, TextCigarCodec.decode("39S140M"), false, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexContractionWithPseudoHomology_reverseStrand);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexContractionWithPseudoHomology_reverseStrand, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // third test: contraction from 3 units to 2 units without pseudo-homology
@@ -601,7 +601,7 @@ public final class SVDiscoveryTestDataProvider {
 
         region1 = new AlignmentInterval(new SimpleInterval("20", 312579, 312801), 1, 223, TextCigarCodec.decode("223M39S"), true, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312706, 312936), 32, 262, TextCigarCodec.decode("31S231M"), true, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexContractionNoPseudoHomology);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexContractionNoPseudoHomology, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         final byte[] fakeRefSeqForComplexContractionNoPseudoHomology_reverseStrand = Arrays.copyOf(fakeRefSeqForComplexContractionNoPseudoHomology, fakeRefSeqForComplexContractionNoPseudoHomology.length);
@@ -610,7 +610,7 @@ public final class SVDiscoveryTestDataProvider {
         SequenceUtil.reverseComplement(contigSeqForComplexContractionNoPseudoHomology_reverseStrand);
         region1 = new AlignmentInterval(new SimpleInterval("20", 312706, 312936), 1, 231, TextCigarCodec.decode("231M31S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312579, 312801), 40, 262, TextCigarCodec.decode("39S223M"), false, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexContractionNoPseudoHomology_reverseStrand);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexContractionNoPseudoHomology_reverseStrand, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         // fourth test: expansion from 2 units to 3 units without pseudo-homology
@@ -618,7 +618,7 @@ public final class SVDiscoveryTestDataProvider {
         final byte[] contigSeqForComplexExpansionNoPseudoHomology = fakeRefSeqForComplexContractionNoPseudoHomology;
         region1 = new AlignmentInterval(new SimpleInterval("20", 312579, 312801), 1, 223, TextCigarCodec.decode("223M135S"), true, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312610, 312840), 128, 358, TextCigarCodec.decode("127S231M"), true, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexExpansionNoPseudoHomology);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexExpansionNoPseudoHomology, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         final byte[] fakeRefSeqForComplexExpansionNoPseudoHomology_reverseStrand = Arrays.copyOf(fakeRefSeqForComplexExpansionNoPseudoHomology, fakeRefSeqForComplexExpansionNoPseudoHomology.length);
@@ -627,7 +627,7 @@ public final class SVDiscoveryTestDataProvider {
         SequenceUtil.reverseComplement(contigSeqForComplexExpansionNoPseudoHomology_reverseStrand);
         region1 = new AlignmentInterval(new SimpleInterval("20", 312610, 312840), 1, 231, TextCigarCodec.decode("231M127S"), false, 60, 0, 100, AlnModType.NONE);
         region2 = new AlignmentInterval(new SimpleInterval("20", 312579, 312801), 136, 358, TextCigarCodec.decode("135S223M"), false, 60, 0, 100, AlnModType.NONE);
-        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001"), contigSeqForComplexExpansionNoPseudoHomology_reverseStrand);
+        breakpoints = new NovelAdjacencyReferenceLocations(new ChimericAlignment(region1, region2, Collections.emptyList(), "asm000001:tig00001", seqDict), contigSeqForComplexExpansionNoPseudoHomology_reverseStrand, seqDict);
         result.add(new Tuple4<>(region1, region2, breakpoints, "asm000001:tig00001"));
 
         return result;

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVTypeUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVTypeUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.sv.discovery;
 
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -11,7 +12,7 @@ import java.util.List;
 
 import static  org.broadinstitute.hellbender.tools.spark.sv.discovery.SimpleSVType.createBracketedSymbAlleleString;
 
-public class SVTypeUnitTest {
+public class SVTypeUnitTest extends BaseTest {
 
     /**
      * Hack to force trigger test data generation.

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/ContigAlignmentsModifierUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/ContigAlignmentsModifierUnitTest.java
@@ -19,10 +19,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class VariantDetectorFromLongReadAlignmentsForSimpleStrandSwitchUnitTest extends BaseTest {
+public class ContigAlignmentsModifierUnitTest extends BaseTest {
 
     @DataProvider(name = "forComputeNewRefSpanAndCigar")
-    private Object[][] createTestDataForComputeNewRefSpanAndCigar() throws IOException {
+    private Object[][] createTestDataForComputeNewRefSpanAndCigar() {
 
         final List<Object[]> data = new ArrayList<>(20);
 
@@ -57,13 +57,13 @@ public class VariantDetectorFromLongReadAlignmentsForSimpleStrandSwitchUnitTest 
     public void testComputeNewRefSpanAndCigar(final AlignmentInterval interval, final int clipLength, final boolean clipFrom3PrimeEnd,
                                               final SimpleInterval expectedRefSpan, final Cigar expectedCigar) {
 
-        final Tuple2<SimpleInterval, Cigar> x = SimpleStrandSwitchVariantDetector.computeNewRefSpanAndCigar(interval, clipLength, clipFrom3PrimeEnd);
+        final Tuple2<SimpleInterval, Cigar> x = ContigAlignmentsModifier.computeNewRefSpanAndCigar(interval, clipLength, clipFrom3PrimeEnd);
         Assert.assertEquals(x._1, expectedRefSpan);
         Assert.assertEquals(x._2, expectedCigar);
     }
 
     @DataProvider(name = "forCigarExtraction")
-    private Object[][] createTestDataForCigarExtraction() throws IOException {
+    private Object[][] createTestDataForCigarExtraction() {
 
         final List<Object[]> data = new ArrayList<>(20);
 
@@ -101,7 +101,8 @@ public class VariantDetectorFromLongReadAlignmentsForSimpleStrandSwitchUnitTest 
     public void testExtractCigar(final AlignmentInterval interval, final List<CigarElement> expectedLeft,
                                  final List<CigarElement> expectedMiddle, final List<CigarElement> expectedRight) {
 
-        final Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> x = SimpleStrandSwitchVariantDetector.splitCigarByLeftAndRightClipping(interval);
+        final Tuple3<List<CigarElement>, List<CigarElement>, List<CigarElement>> x =
+                ContigAlignmentsModifier.splitCigarByLeftAndRightClipping(interval);
         Assert.assertEquals(x._1(), expectedLeft);
         Assert.assertEquals(x._2(), expectedMiddle);
         Assert.assertEquals(x._3(), expectedRight);


### PR DESCRIPTION
This PR deals with long reads with exactly two alignments (no other equally good alignment configuration), mapped to 
* the same chromosome with reference order switch but without strand switch, or
* different chromosomes

This brings us (unfiltered) ~6000 mated BND records, half of which are on canonical chromosomes.