### PR TITLE
Upgrade Mockito from 1.10.19 -> 2.10.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
-    testCompile "org.mockito:mockito-core:1.10.19"
+    testCompile "org.mockito:mockito-core:2.10.0"
 }
 
 //add gatk-launch to the jar as a resource

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 import com.google.api.services.genomics.model.Read;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.common.collect.Lists;
 import htsjdk.samtools.SAMRecord;
@@ -32,7 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class AddContextDataToReadSparkUnitTest extends BaseTest {
@@ -65,7 +63,7 @@ public class AddContextDataToReadSparkUnitTest extends BaseTest {
         JavaRDD<GATKVariant> rddVariants = ctx.parallelize(variantList);
 
         ReferenceMultiSource mockSource = mock(ReferenceMultiSource.class, withSettings().serializable());
-        when(mockSource.getReferenceBases(any(PipelineOptions.class), any())).then(new ReferenceBasesAnswer());
+        when(mockSource.getReferenceBases(isNull(), any(SimpleInterval.class))).then(new ReferenceBasesAnswer());
         when(mockSource.getReferenceWindowFunction()).thenReturn(ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SAMSequenceDictionary sd = new SAMSequenceDictionary(Lists.newArrayList(new SAMSequenceRecord("1", 100000), new SAMSequenceRecord("2", 100000)));
         when(mockSource.getReferenceSequenceDictionary(null)).thenReturn(sd);
@@ -90,7 +88,7 @@ public class AddContextDataToReadSparkUnitTest extends BaseTest {
         private static final long serialVersionUID = 1L;
         @Override
         public ReferenceBases answer(InvocationOnMock invocation) throws Throwable {
-            return FakeReferenceSource.bases(invocation.getArgumentAt(1, SimpleInterval.class));
+            return FakeReferenceSource.bases(invocation.getArgument(1));
         }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public class JoinReadsWithRefBasesSparkUnitTest extends BaseTest {
@@ -53,7 +51,7 @@ public class JoinReadsWithRefBasesSparkUnitTest extends BaseTest {
 
         ReferenceMultiSource mockSource = mock(ReferenceMultiSource.class, withSettings().serializable());
         for (SimpleInterval i : intervals) {
-            when(mockSource.getReferenceBases(any(PipelineOptions.class), eq(i))).thenReturn(FakeReferenceSource.bases(i));
+            when(mockSource.getReferenceBases(isNull(), eq(i))).thenReturn(FakeReferenceSource.bases(i));
         }
         when(mockSource.getReferenceWindowFunction()).thenReturn(ReferenceWindowFunctions.IDENTITY_FUNCTION);
 
@@ -76,7 +74,7 @@ public class JoinReadsWithRefBasesSparkUnitTest extends BaseTest {
 
         ReferenceMultiSource mockSource = mock(ReferenceMultiSource.class, withSettings().serializable());
         for (SimpleInterval i : intervals) {
-            when(mockSource.getReferenceBases(any(PipelineOptions.class), eq(i))).thenReturn(FakeReferenceSource.bases(i));
+            when(mockSource.getReferenceBases(isNull(), eq(i))).thenReturn(FakeReferenceSource.bases(i));
         }
         when(mockSource.getReferenceWindowFunction()).thenReturn(ReferenceWindowFunctions.IDENTITY_FUNCTION);
 


### PR DESCRIPTION
I've had several Travis test failures (on my picard removal branch) that appear to be failures during kryo serialization of a mocked ReferenceMultiSource object (based on the failing class name, (org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource$$EnhancerByMockitoWithCGLIB$$b0dc631f, which looks like the CGLIB names mentioned [here](https://github.com/mockito/mockito/issues/319)).

We're on an ancient version of mockito anyway, and newer versions no longer use cglib, so it seemed like a good time to upgrade. To do so I also had to replace usage of the method getArgumentAt, which has been [deprecated](https://github.com/mockito/mockito/pull/373) in favor of getArgument.
