### PR TITLE
Use a handmade TestReferenceMultiSource in tests instead of a mock.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceMultiSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceMultiSource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.datasources;
 
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.hellbender.utils.SerializableFunction;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
@@ -20,13 +21,16 @@ import java.io.Serializable;
 /**
  * Wrapper to load a reference sequence from the Google Genomics API, or a file stored on HDFS or locally.
  *
- * This class needs to be mocked, so it cannot be declared final.
+ * This class needs to subclassed by test code, so it cannot be declared final.
  */
 public class ReferenceMultiSource implements ReferenceSource, Serializable {
     private static final long serialVersionUID = 1L;
 
     private ReferenceSource referenceSource;
     private SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction;
+
+    @VisibleForTesting
+    protected ReferenceMultiSource() {};
 
     /**
      * @param pipelineOptions the pipeline options; must be GCSOptions if using the Google Genomics API


### PR DESCRIPTION
I've had ConcurrentModificationExceptions several times when mocked ReferenceMultiSource objects are both mocked and broadcast ([for example](https://travis-ci.org/broadinstitute/gatk/jobs/275982454)). Mocks appear to be mutated, even when the mocked object is immutable, so serialization can fail. This replaces the mock object with a faked one.