### PR TITLE
updating to newer htsjdk snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.11.0-4-g958dc6e-SNAPSHOT')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.11.0-18-ga35b420-SNAPSHOT')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.7.0-proto-3.0.0-beta-1')

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriter.java
@@ -252,4 +252,9 @@ public final class GVCFWriter implements VariantContextWriter {
         }
 
     }
+
+    @Override
+    public void setHeader(VCFHeader header) {
+        underlyingWriter.setHeader(header);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriterUnitTest.java
@@ -40,9 +40,11 @@ public class GVCFWriterUnitTest extends BaseTest {
         boolean headerWritten = false;
         boolean closed = false;
         boolean error = false;
+        boolean headerSet = false;
 
         @Override
         public void writeHeader(VCFHeader header) {
+            headerSet = true;
             headerWritten = true;
         }
 
@@ -60,6 +62,11 @@ public class GVCFWriterUnitTest extends BaseTest {
         public void add(VariantContext vc) {
             emitted.add(vc);
         }
+
+        @Override
+        public void setHeader(VCFHeader header) {
+            headerSet = true;
+        }
     }
 
     private static final List<Integer> standardPartition = ImmutableList.of(1, 10, 20);
@@ -74,7 +81,17 @@ public class GVCFWriterUnitTest extends BaseTest {
         final MockWriter mockWriter = new MockWriter();
         final GVCFWriter writer = new GVCFWriter(mockWriter, standardPartition, HomoSapiensConstants.DEFAULT_PLOIDY);
         writer.writeHeader(new VCFHeader());
+        Assert.assertTrue(mockWriter.headerSet);
         Assert.assertTrue(mockWriter.headerWritten);
+    }
+
+    @Test
+    public void testHeaderSetting(){
+        final MockWriter mockWriter = new MockWriter();
+        final GVCFWriter writer = new GVCFWriter(mockWriter, standardPartition, HomoSapiensConstants.DEFAULT_PLOIDY);
+        writer.setHeader(new VCFHeader());
+        Assert.assertTrue(mockWriter.headerSet);
+        Assert.assertFalse(mockWriter.headerWritten);
     }
 
     @Test


### PR DESCRIPTION
updating to a new htsjdk snapshot and updating our VariantContextWriters to compile

test may fail on this....