### PR TITLE
trivial spark tool for extracting original SAM records based on a file …

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/ExtractOriginalAlignmentRecordsByNameSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/ExtractOriginalAlignmentRecordsByNameSpark.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariationSparkProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Created by shuang on 3/3/17.
+ */
+@CommandLineProgramProperties(summary="Find original alignment records that have the requested read names and outputs them.",
+        oneLineSummary="Dump original alignment records that have the requested read names.",
+        usageExample = "ExtractOriginalAlignmentRecordsByNameSpark \\" +
+                "-I /path/to/my/dir/allAlignments.sam \\" +
+                "-O /path/to/my/dir/extractedOriginalAlignments.bam \\" +
+                "--readNameFile /path/to/my/dir/readNames.txt",
+        omitFromCommandLine = true,
+        programGroup = StructuralVariationSparkProgramGroup.class)
+@BetaFeature
+public final class ExtractOriginalAlignmentRecordsByNameSpark extends GATKSparkTool {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(doc = "file containing list of read names", shortName = "rF",
+            fullName = "readNameFile")
+    private String readNameFile;
+
+    @Argument(doc = "file to write reads to", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
+    private String outputSAM;
+
+    @Override
+    public boolean requiresReads() {
+        return true;
+    }
+
+    @Override
+    protected void runTool( final JavaSparkContext ctx ) {
+
+        final Broadcast<Set<String>> namesToLookForBroadcast = ctx.broadcast(parseReadNames());
+
+        final JavaRDD<GATKRead> reads =
+                getUnfilteredReads().filter(read -> namesToLookForBroadcast.getValue().contains(read.getName())).cache();
+        writeReads(ctx, outputSAM, reads);
+
+        logger.info("Found " + reads.count() + " alignment records for " +
+                    namesToLookForBroadcast.getValue().size() + " unique read names.");
+    }
+
+    private Set<String> parseReadNames() {
+
+        try ( final BufferedReader rdr =
+                      new BufferedReader(new InputStreamReader(BucketUtils.openFile(readNameFile))) ) {
+            return rdr.lines().map(s -> s.replace("^@", "")
+                                         .replace("/1$", "")
+                                         .replace("/2$", ""))
+                    .collect(Collectors.toCollection(HashSet::new));
+        } catch ( final IOException ioe ) {
+            throw new GATKException("Unable to read names file from " + readNameFile, ioe);
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
@@ -1,0 +1,51 @@
+package org.broadinstitute.hellbender.tools.spark.sv.integration;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.FileUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest extends CommandLineProgramTest {
+
+    @Test(groups = "sv")
+    public void testExtractOriginalAlignmentRecordsByNameSparkRunnableLocal() throws IOException {
+
+        final File tempWorkingDir = BaseTest.createTempDir("extractOriginalAlignmentRecordsByNameSparkIntegrationTest");
+
+        FileUtils.writeLinesToSingleFile(Collections.singleton("asm013903:tig00002").iterator(), tempWorkingDir + "/names.txt");
+
+        final SAMFileHeader expectedHeader;
+        final List<SAMRecord> expectedRecords;
+        try (final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_CONTIG_SAM))) {
+            expectedHeader = readsSource.getHeader();
+            expectedRecords = Utils.stream(readsSource.iterator()).filter(r -> r.getName().equals("asm013903:tig00002"))
+                    .sorted(Comparator.comparingInt(GATKRead::getAssignedStart)).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
+        }
+
+        final List<String> args = Arrays.asList("-I", SVIntegrationTestDataProvider.TEST_CONTIG_SAM,
+                "-O", tempWorkingDir.getAbsolutePath() + "/names.bam",
+                "--readNameFile", tempWorkingDir.getAbsolutePath() + "/names.txt");
+
+        runCommandLine(args);
+
+        try (final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(tempWorkingDir+"/names.bam"))) {
+            Assert.assertEquals(readsSource.getHeader(), expectedHeader);
+            final List<SAMRecord> samRecords = Utils.stream(readsSource.iterator()).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
+            Assert.assertEquals(samRecords.stream().map(SAMRecord::getSAMString).collect(Collectors.toList()),
+                                expectedRecords.stream().map(SAMRecord::getSAMString).collect(Collectors.toList()));
+        }
+    }
+}


### PR DESCRIPTION
…containing read names. `PrintReadsSpark` requires bam to be coordinate sorted, this doesn't.

I find myself frequently using this tool for looking at the SAM records of some templates. Maybe useful for others as well. So I'm putting it in, but hiding it from displaying in help.

@vruano  mind reviewing?