### PR TITLE
Fix bad version check in manage_sv_pipeline.sh

### DIFF
--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -211,11 +211,11 @@ echo
 if [[ ! -f ${GATK_DIR}/build/libs/gatk-spark.jar ]]; then
     echo "Cannot find GATK spark jar, maybe you forgot to build? Given GATK dir.: ${GATK_DIR}"
 fi
-GATK_GIT_HASH=$(readlink ${GATK_DIR}/build/libs/gatk-spark.jar | cut -d- -f5 | cut -c2-)
+GATK_GIT_HASH=$(readlink ${GATK_DIR}/build/libs/gatk-spark.jar | awk 'BEGIN {FS="-g"} {print $2}' | cut -d- -f 1)
 CURRENT_GIT_HASH=$(git -C ${GATK_DIR} rev-parse --short HEAD | cut -c1-7)
 if [ "${QUIET}" != "Y" ] && [ "${GATK_GIT_HASH}" != "${CURRENT_GIT_HASH}" ]; then
     while true; do
-        read -p "Current git hash does not match GATK git hash. Run anyway?" yn
+        read -p "gatk-spark.jar version (${GATK_GIT_HASH}) does not match current git commit (${CURRENT_GIT_HASH}). Run anyway? (yes/no)" yn
         case $yn in
             [Yy]*)  break
                     ;;


### PR DESCRIPTION
manage_sv_pipeline checks version from gatk-spark.jar and compares it
to the current git hash (to ensure the correct version is run). Newer
gatk versions had a slightly different file name format and caused
errors parsing the hash. This updates the hash check and produces
more comprehensible error messages when it fails.

Resolves: #3593