### PR TITLE
Added allele order independent VariantContext equality comparison

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtils.java
@@ -33,6 +33,8 @@ public final class AlleleSubsettingUtils {
     /**
      * Create the new GenotypesContext with the subsetted PLs and ADs
      *
+     * Will reorder subsetted alleles according to the ordering provided by the list allelesToKeep
+     *
      * @param originalGs               the original GenotypesContext
      * @param originalAlleles          the original alleles
      * @param allelesToKeep            the subset of alleles to use with the new Genotypes
@@ -271,7 +273,7 @@ public final class AlleleSubsettingUtils {
      * @param newAlleles            New alleles -- must be a subset of {@code originalAlleles}
      * @return                      old PL indices of new genotypes
      */
-    private static int[] subsettedPLIndices(final int ploidy, final List<Allele> originalAlleles, final List<Allele> newAlleles) {
+    public static int[] subsettedPLIndices(final int ploidy, final List<Allele> originalAlleles, final List<Allele> newAlleles) {
         final int[] result = new int[GenotypeLikelihoods.numLikelihoods(newAlleles.size(), ploidy)];
         final Permutation<Allele> allelePermutation = new IndexedAlleleList<>(originalAlleles).permutation(new IndexedAlleleList<>(newAlleles));
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtils.java
@@ -1,10 +1,20 @@
 package org.broadinstitute.hellbender.utils.test;
 
 import com.google.common.annotations.VisibleForTesting;
-import htsjdk.variant.variantcontext.Genotype;
-import htsjdk.variant.variantcontext.VariantContext;
-import htsjdk.variant.vcf.VCFConstants;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import htsjdk.variant.variantcontext.*;
+import htsjdk.variant.vcf.*;
+import org.apache.commons.collections4.CollectionUtils;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.walkers.genotyper.AlleleSubsettingUtils;
+import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAssignmentMethod;
+import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.collections.Permutation;
+import org.broadinstitute.hellbender.utils.genotyper.IndexedAlleleList;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 import org.testng.Assert;
 
 import java.util.*;
@@ -70,10 +80,158 @@ public final class VariantContextTestUtils {
         return attribute;
     }
 
+    /**
+     * Method which reorders the AltAlleles of a VariantContext so that they are in alphabetical order.
+     *
+     * It also reorders all annotation fields and the PL,AD, and SAC fields of each sample genotype in the variant context
+     * to be consistent with the new ordering
+     *
+     * NOTE: this method relies on the correctness of AlleleSubsettingUtils.subsetAlleles() for reordering alleles
+     *
+     * @param vc        Variant context to reorder
+     * @param header
+     * @return
+     */
+    public static VariantContext sortAlleles(final VariantContext vc, final VCFHeader header){
+        final List<Allele> originalAltAlleles = vc.getAlternateAlleles();
+        final List<Allele> sortedAltAlleles = originalAltAlleles.stream().sorted().collect(Collectors.toList());
+        final List<Allele> sortedAlleles = new ArrayList<>(vc.getNAlleles());
+
+        sortedAlleles.add(vc.getReference());
+        sortedAlleles.addAll(sortedAltAlleles);
+
+        final VariantContextBuilder result = new VariantContextBuilder(vc);
+        result.alleles(sortedAlleles);
+
+        GenotypesContext newGT = AlleleSubsettingUtils.subsetAlleles(vc.getGenotypes(),2,vc.getAlleles(),sortedAlleles,
+                GenotypeAssignmentMethod.SET_TO_NO_CALL, vc.getAttributeAsInt(VCFConstants.DEPTH_KEY,0));
+
+        // Asserting that the new genotypes were calculated properly in case AlleleSubsettingUtils behavior changes
+        if (newGT.getSampleNames().size() != vc.getGenotypes().size()) throw new IllegalStateException("Sorting this variant context resulted in a different number of genotype alleles, check that AlleleSubsettingUtils still supports reordering:" + vc.toString());
+        for (int i =0; i<newGT.size(); i++){
+            if (vc.getGenotype(i).hasAD()) {
+                if (newGT.get(i).getAD().length != vc.getGenotype(i).getAD().length) throw new IllegalStateException("Sorting this variant context resulted in a different number of genotype alleles, check that AlleleSubsettingUtils still supports reordering:" + vc.toString());
+            }
+            if (vc.getGenotype(i).hasPL()) {
+                if (newGT.get(i).getPL().length != vc.getGenotype(i).getPL().length) throw new IllegalStateException("Sorting this variant context resulted in a different number of genotype alleles, check that AlleleSubsettingUtils still supports reordering:" + vc.toString());
+            }
+        }
+
+        final HashMap<String, Object> newAttributes = new HashMap<>(vc.getAttributes());
+        for (Map.Entry<String, Object> entry : newAttributes.entrySet()) {
+            VCFHeaderLineCount type = header.hasInfoLine(entry.getKey())?header.getInfoHeaderLine(entry.getKey()).getCountType():VCFHeaderLineCount.UNBOUNDED;
+            int ploidy = vc.getGenotypes().getMaxPloidy(2);
+
+            newAttributes.replace(entry.getKey(), updateAttribute(entry.getKey(), entry.getValue(), vc.getAlleles(), sortedAlleles, type, ploidy));
+        }
+
+        // The above will have built new genotype for PL,AD, and SAC fields excluding the GT and GQ field, thus we must re-add them for comparison.
+        for (int i = 0; i < newGT.size(); i++) {
+            Genotype replacementGenotype = new GenotypeBuilder(newGT.get(i))
+                    .GQ(vc.getGenotype(i).getGQ())
+                    .phased(vc.getGenotype(i).isPhased())
+                    .alleles(vc.getGenotype(i).getAlleles()).make();
+            newGT.replace(replacementGenotype);
+        }
+
+        result.attributes(newAttributes).genotypes(newGT);
+
+        return result.make();
+
+    }
+
+    private static Object updateAttribute(final String key, final Object value,
+                                          final List<Allele> originalAlleles, final List<Allele> sortedAlleles,
+                                          final VCFHeaderLineCount count, int ploidy) {
+        if (key.startsWith("AS_")) {
+            return remapASValues((String) value, createAlleleIndexMap(originalAlleles, sortedAlleles));
+        }else {
+            switch (count) {
+                case INTEGER:
+                    return value;
+                case UNBOUNDED:
+                    //doesn't depend on allele ordering
+                    return value;
+                case A:
+                    return remapATypeValues(attributeToList(value), createAlleleIndexMap(originalAlleles, sortedAlleles));
+                case R:
+                    return remapRTypeValues(attributeToList(value), createAlleleIndexMap(originalAlleles, sortedAlleles));
+                case G:
+                    return remapGTypeValues(attributeToList(value), originalAlleles, ploidy, sortedAlleles);
+                default:
+                    throw new GATKException("found unexpected vcf header count type: " + count);
+            }
+        }
+    }
+
+    static List<Integer> createAlleleIndexMap(final List<Allele> originalAlleles, final List<Allele> sortedAlleles){
+        final List<Integer> mapping = new ArrayList<>(originalAlleles.size());
+        for ( final Allele a: originalAlleles){
+            final int newIndex = sortedAlleles.indexOf(a);
+            mapping.add(newIndex);
+        }
+        return mapping;
+    }
+
+    static List<Object> remapRTypeValues(List<?> oldValue, List<Integer> mapping){
+        return remapListValues(oldValue, mapping, 0);
+    }
+
+    private static List<Object> remapListValues(List<?> oldValue, List<Integer> mapping, int offset) {
+        for( int i = 0; i < offset; i++){
+            Utils.validate(mapping.get(i) == i, "values within the offset must not map outside the offset ");
+        }
+        final ArrayList<Object> reordered = new ArrayList<>(oldValue.size());
+        for(int i = 0; i < oldValue.size(); i++){
+            reordered.add(oldValue.get(mapping.get(i+offset) - offset));
+        }
+        return reordered;
+    }
+
+    static List<Object> remapATypeValues(List<?> oldValue, List<Integer> mapping){
+        return remapListValues(oldValue, mapping, 1 );
+    }
+
+    static List<Object> remapGTypeValues(List<?> oldValue, List<Allele> originalAlleles, int ploidy, List<Allele> remappedAlleles){
+        if (oldValue.size() == 1 && oldValue.get(0) instanceof String) {
+            oldValue = Arrays.stream(((String) oldValue.get(0)).split(",")).collect(Collectors.toList());
+        }
+
+        List<Object> newValues = new ArrayList<>(oldValue.size());
+        int[] subsettedGenotypes = AlleleSubsettingUtils.subsettedPLIndices(ploidy, originalAlleles, remappedAlleles);
+        List<?> finalOldValue = oldValue;
+        newValues.addAll(Arrays.stream(subsettedGenotypes).mapToObj(idx -> finalOldValue.get(idx)).collect(Collectors.toList()));
+
+        return newValues;
+    }
+
+    static List<Object> remapASValues(String oldValue, List<Integer> mapping) {
+        return remapListValues(Arrays.asList(oldValue.split("\\|")), mapping, 0);
+    }
+
+    //copied from htsjdk.variant.variantcontext.CommonInfo.getAttributeAsList for simplicity
+    //maybe we should expose this as a static method in htsjdk?
+    @SuppressWarnings("unchecked")
+    private static List<Object> attributeToList(final Object attribute){
+        if ( attribute == null ) return Collections.emptyList();
+        if ( attribute instanceof List) return (List<Object>)attribute;
+        if ( attribute.getClass().isArray() ) {
+            if (attribute instanceof int[]) {
+                return Arrays.stream((int[])attribute).boxed().collect(Collectors.toList());
+            } else if (attribute instanceof double[]) {
+                return Arrays.stream((double[])attribute).boxed().collect(Collectors.toList());
+            }
+            return Arrays.asList((Object[])attribute);
+        }
+        return Collections.singletonList(attribute);
+    }
+
+
     public static void assertGenotypesAreEqual(final Genotype actual, final Genotype expected) {
         Assert.assertEquals(actual.getSampleName(), expected.getSampleName(), "Genotype names");
-        Assert.assertEquals(actual.getAlleles(), expected.getAlleles(), "Genotype alleles");
         Assert.assertEquals(actual.getGenotypeString(), expected.getGenotypeString(), "Genotype string");
+        Assert.assertTrue(CollectionUtils.isEqualCollection(actual.getAlleles(), expected.getAlleles()), "Genotype alleles");
+        Assert.assertEquals(actual.getGenotypeString(false), expected.getGenotypeString(false), "Genotype string");
         Assert.assertEquals(actual.getType(), expected.getType(), "Genotype type");
 
         // filters are the same
@@ -84,11 +242,11 @@ public final class VariantContextTestUtils {
         Assert.assertEquals(actual.hasDP(), expected.hasDP(), "Genotype hasDP");
         Assert.assertEquals(actual.getDP(), expected.getDP(), "Genotype dp");
         Assert.assertEquals(actual.hasAD(), expected.hasAD(), "Genotype hasAD");
-        Assert.assertTrue(Arrays.equals(actual.getAD(), expected.getAD()));
+        Assert.assertEquals(actual.getAD(), expected.getAD(), "Genotype AD");
         Assert.assertEquals(actual.hasGQ(), expected.hasGQ(), "Genotype hasGQ");
         Assert.assertEquals(actual.getGQ(), expected.getGQ(), "Genotype gq");
         Assert.assertEquals(actual.hasPL(), expected.hasPL(), "Genotype hasPL");
-        Assert.assertTrue(Arrays.equals(actual.getPL(), expected.getPL()));
+        Assert.assertEquals(actual.getPL(), expected.getPL(), "Genotype PL");
 
         Assert.assertEquals(actual.hasLikelihoods(), expected.hasLikelihoods(), "Genotype haslikelihoods");
         Assert.assertEquals(actual.getLikelihoodsString(), expected.getLikelihoodsString(), "Genotype getlikelihoodsString");
@@ -192,7 +350,7 @@ public final class VariantContextTestUtils {
 
         Assert.assertEquals(actual.filtersWereApplied(), expected.filtersWereApplied(), "filtersWereApplied");
         Assert.assertEquals(actual.isFiltered(), expected.isFiltered(), "isFiltered");
-        BaseTest.assertEqualsSet(actual.getFilters(), expected.getFilters(), "filters");
+        Assert.assertEquals(actual.getFilters(), expected.getFilters(), "filters");
         BaseTest.assertEqualsDoubleSmart(actual.getPhredScaledQual(), expected.getPhredScaledQual());
 
         assertVariantContextsHaveSameGenotypes(actual, expected);
@@ -214,5 +372,52 @@ public final class VariantContextTestUtils {
                 assertGenotypesAreEqual(actual.getGenotype(sample), expected.getGenotype(sample));
             }
         }
+    }
+
+    /**
+     * Method which compares two variant contexts for equality regardless of different allele ordering.
+     *
+     * It functions by sorting the alleles in each variant context, and using the header to parse its attributes and
+     * reorder them based on the new allele ordering.
+     *
+     * NOTES:
+     * - For genotype fields, the order dependant fields PL, AD, and SAC are all recalculated, no guarantee
+     *   is made about any other genotype fields which depend on the number of Alleles which might result in false negatives.
+     * - This test requires that all attribute keys from the variant context are present, if one is writing a test and needs
+     *   a complete header, consider {GATKVCFHeaderLine.getCompleteHeader()}
+     *
+     * @param actual                Variant context to test for equality
+     * @param expected              Expected result
+     * @param attributesToIgnore    Attributes we want to exclude from comparision
+     * @param header                Header used to map behavior of annotations
+     */
+    public static void assertVariantContextsAreEqualAlleleOrderIndependent(final VariantContext actual, final VariantContext expected, final List<String> attributesToIgnore, VCFHeader header) {
+        if (actual.getAlleles().equals(expected.getAlleles())) {
+            assertVariantContextsAreEqual(actual, expected, attributesToIgnore);
+
+        } else {
+            VariantContext actualReordered = sortAlleles(actual, header);
+            VariantContext expectedReordered = sortAlleles(expected, header);
+            assertVariantContextsAreEqual(actualReordered, expectedReordered, attributesToIgnore);
+        }
+    }
+
+    /**
+     * Method which returns a complete header with all the GATK and HTSJDK standard header lines for testing purposes
+     *
+     * @return
+     */
+    public static VCFHeader getCompleteHeader() {
+        Set<VCFHeaderLine> lines = new HashSet<>();
+
+        // Adding HTSJDK lines
+        VCFStandardHeaderLines.addStandardInfoLines(lines,false, Collections.emptyList());
+        VCFStandardHeaderLines.addStandardFormatLines(lines,false, Collections.emptyList());
+
+        lines.addAll(GATKVCFHeaderLines.getAllInfoLines());
+        lines.addAll(GATKVCFHeaderLines.getAllFormatLines());
+        lines.addAll(GATKVCFHeaderLines.getAllFilterLines());
+
+        return new VCFHeader(lines);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -1,16 +1,10 @@
 package org.broadinstitute.hellbender.utils.variant;
 
-import htsjdk.variant.vcf.VCFFilterHeaderLine;
-import htsjdk.variant.vcf.VCFFormatHeaderLine;
-import htsjdk.variant.vcf.VCFHeaderLine;
-import htsjdk.variant.vcf.VCFHeaderLineCount;
-import htsjdk.variant.vcf.VCFHeaderLineType;
-import htsjdk.variant.vcf.VCFInfoHeaderLine;
-import htsjdk.variant.vcf.VCFStandardHeaderLines;
+import htsjdk.variant.vcf.*;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.broadinstitute.hellbender.utils.variant.GATKVCFConstants.*;
 
@@ -23,6 +17,10 @@ public class GATKVCFHeaderLines {
     public static VCFInfoHeaderLine getInfoLine(final String id) { return infoLines.get(id); }
     public static VCFFormatHeaderLine getFormatLine(final String id) { return formatLines.get(id); }
     public static VCFFilterHeaderLine getFilterLine(final String id) { return filterLines.get(id); }
+
+    public static Set<VCFInfoHeaderLine> getAllInfoLines() { return Collections.unmodifiableSet(new HashSet<>(infoLines.values())); }
+    public static Set<VCFFormatHeaderLine> getAllFormatLines() { return Collections.unmodifiableSet(new HashSet<>(formatLines.values())); }
+    public static Set<VCFFilterHeaderLine> getAllFilterLines() { return Collections.unmodifiableSet(new HashSet<>(filterLines.values())); }
 
     private static final Map<String, VCFInfoHeaderLine> infoLines = new LinkedHashMap<>(60);
     private static final Map<String, VCFFormatHeaderLine> formatLines = new LinkedHashMap<>(25);

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -41,6 +41,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     private static final String COMBINED = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
     private static final SimpleInterval INTERVAL = new SimpleInterval("chr20", 17960187, 17981445);
+    private static final VCFHeader VCF_HEADER = VariantContextTestUtils.getCompleteHeader();
 
     @Override
     public String getTestedClassName() {
@@ -192,14 +193,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
                      combinedVCFReader.query(interval.getContig(), interval.getStart(), interval.getEnd())) {
 
             BaseTest.assertCondition(actualVcs, expectedVcs, (a, e) -> {
-                // TODO: Temporary hacks to make this test pass. Must be removed later
-                if (// allele order
-                        e.getStart() != 17967343 && e.getStart() != 17966384 &&
-                                // split block
-                                e.getEnd() != 17981447
-                        ) {
-                    VariantContextTestUtils.assertVariantContextsAreEqual(a, e, Collections.emptyList());
-                }
+                VariantContextTestUtils.assertVariantContextsAreEqualAlleleOrderIndependent(a, e, Collections.emptyList(), VCF_HEADER);
             });
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtilsUnitTest.java
@@ -302,4 +302,18 @@ public class AlleleSubsettingUtilsUnitTest extends BaseTest {
         Assert.assertEquals(AlleleSubsettingUtils.calculateLikelihoodSums(vc3, 3)[1], 3.5, 1.0e-8);
     }
 
+    // This test exists to enforce the behavior that AlleleSubsetting utils can be used to reorder alleles, if a developer
+    // ever changes this behavior then they must be mindful that VariantContextTestUtils.sortAlleles relies on this behavior.
+    @Test
+    public void testAlleleReorderingBehavior() {
+        final List<Allele> threeAlleles = Arrays.asList(Aref, G, C);
+        final List<Allele> threeAllelesSorted = Arrays.asList(Aref, C, G);
+        final Genotype g5 = new GenotypeBuilder("sample2", Arrays.asList(Aref, C)).PL(new double[] {0.0, 1.0, 2.0, 3.0, 4.0, 5.0}).make();
+
+        final GenotypesContext newGs = AlleleSubsettingUtils.subsetAlleles(GenotypesContext.create(g5),
+                2, threeAlleles, threeAllelesSorted,
+                GenotypeAssignmentMethod.DO_NOT_ASSIGN_GENOTYPES, 10);
+
+        Assert.assertEquals(newGs.get(0).getPL(), new int[] {50, 20, 0, 40, 10, 30});
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/VariantContextTestUtilsUnitTest.java
@@ -1,10 +1,21 @@
 package org.broadinstitute.hellbender.utils.test;
 
+import htsjdk.variant.variantcontext.*;
+import htsjdk.variant.vcf.VCFHeader;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.*;
+
 public class VariantContextTestUtilsUnitTest {
+
+    private static final Allele ARef = Allele.create("A", true);
+    private static final Allele T = Allele.create("T");
+    private static final Allele C = Allele.create("C");
+    private static final Allele G = Allele.create("G");
+    private static final String SAMPLE_1 = "NA1";
+    private static final String SAMPLE_2 = "NA2";
 
     @DataProvider(name="scientificNotationValuesToNormalize")
     public Object[][] getScientificNotationValuesToNormalize(){
@@ -52,4 +63,119 @@ public class VariantContextTestUtilsUnitTest {
         Assert.assertEquals(VariantContextTestUtils.normalizeToInteger(toNormalize), expected);
     }
 
+
+    @DataProvider
+    public Object[][] getTListsToRemap(){
+        return new Object[][]{
+                {Arrays.asList(1, 2, 3, 4), Arrays.asList(1, 3, 4, 2), Arrays.asList(0, 2, 3, 1)},
+                {Arrays.asList(1, 2, 3, 4), Arrays.asList(1, 2, 3, 4), Arrays.asList(0, 1, 2, 3)},
+                {Arrays.asList("a", "b", "c","d"), Arrays.asList("a", "d", "c", "b"), Arrays.asList(0, 3,2,1)}
+        };
+    }
+
+
+    @Test(dataProvider = "getTListsToRemap")
+    public void testRemapping(List<Integer> original, List<Integer> expectedRemappedValues, List<Integer> mapping){
+        Assert.assertEquals(VariantContextTestUtils.remapRTypeValues(original, mapping), expectedRemappedValues);
+    }
+
+    @DataProvider
+    public Object[][] getAListsToRemap(){
+        return new Object[][]{
+                {Arrays.asList(1, 2, 3), Arrays.asList(2, 3, 1), Arrays.asList(0, 2, 3, 1)},
+                {Arrays.asList(1, 2, 3), Arrays.asList(1, 2, 3), Arrays.asList(0, 1, 2, 3)},
+                {Arrays.asList("a", "b", "c"), Arrays.asList("c", "b" , "a"), Arrays.asList(0, 3, 2, 1)}
+        };
+    }
+
+    @Test(dataProvider = "getAListsToRemap")
+    public void testARemapping(List<Integer> original, List<Integer> expectedRemappedValues, List<Integer> mapping){
+        Assert.assertEquals(VariantContextTestUtils.remapATypeValues(original, mapping), expectedRemappedValues);
+    }
+
+
+    @DataProvider
+    public Object[][] getGListsToRemap() {
+        return new Object[][]{
+            {Arrays.asList(0,1,2), Arrays.asList(2,1,0), Arrays.asList(ARef, T), Arrays.asList(T, ARef), 2},
+            {Arrays.asList(0,1,2,3,4,5), Arrays.asList(2,1,0,4,3,5), Arrays.asList(ARef, T, C), Arrays.asList(T, ARef, C), 2}
+        };
+    }
+
+    @Test(dataProvider = "getGListsToRemap")
+    public void testGListsToRemap(List<Object> original, List<Object> expected, List<Allele> originalAlleles, List<Allele> remappedAlleles, int ploidy){
+        Assert.assertEquals(VariantContextTestUtils.remapGTypeValues(original, originalAlleles, ploidy, remappedAlleles), expected);
+    }
+
+    @DataProvider
+    public Object[][] getASTListsToRemap(){
+        return new Object[][]{
+                {"1|2|3|4", "1|3|4|2", Arrays.asList(0, 2, 3, 1)},
+                {"|1, 2|3, 4", "|3, 4|1, 2", Arrays.asList(0, 2, 1)},
+        };
+    }
+
+    @Test(dataProvider = "getTListsToRemap")
+    public void testASRemapping(List<Integer> original, List<Integer> expectedRemappedValues, List<Integer> mapping){
+        Assert.assertEquals(VariantContextTestUtils.remapRTypeValues(original, mapping), expectedRemappedValues);
+    }
+
+    @DataProvider
+    public Object[][] alleleRemapExamples(){
+        final double[] genotypeLikelihoods1 = {30,0,190};
+        VariantContextBuilder builderA = new VariantContextBuilder("a","20",10433328,10433328,  Arrays.asList(ARef,G,C));
+        VariantContextBuilder builderB = new VariantContextBuilder("a","20",10433328,10433328,  Arrays.asList(ARef,C,G));
+        VariantContextBuilder builderC = new VariantContextBuilder("a","20",10433328,10433328,  Arrays.asList(ARef,C,T));
+        VariantContext A = builderA.make();
+        VariantContext B = builderB.make();
+        VariantContext C = builderC.make();
+
+        // TESTING ATTRIBUTES
+        builderA.attribute("AS_RAW_MQ","40|20|10").attribute("RAW_MQ","20").attribute("PG", "10,20,30,40,50,60");
+        builderB.attribute("AS_RAW_MQ","40|10|20").attribute("RAW_MQ","20").attribute("PG", "10,40,60,20,50,30");
+        VariantContext A_RAWMQ = builderA.make();
+        VariantContext B_RAWMQ = builderB.make();
+
+        // TESTING GENOTYPES
+        builderA.genotypes(Arrays.asList(new GenotypeBuilder(SAMPLE_1).alleles(Arrays.asList(ARef, G)).PL(new double[]{30,0,190,0,0,0}).GQ(30).AD(new int[]{1,2,3}).make(),
+                                         new GenotypeBuilder(SAMPLE_2).alleles(Arrays.asList(VariantContextTestUtilsUnitTest.G, VariantContextTestUtilsUnitTest.C)).PL(new double[]{10,20,30,40,50,60}).GQ(30).AD(new int[]{3,4,5}).make()));
+        builderB.genotypes(Arrays.asList(new GenotypeBuilder(SAMPLE_1).alleles(Arrays.asList(ARef, G)).PL(new double[]{30,0,0,0,0,190}).GQ(30).AD(new int[]{1,3,2}).make(),
+                                         new GenotypeBuilder(SAMPLE_2).alleles(Arrays.asList(VariantContextTestUtilsUnitTest.G, VariantContextTestUtilsUnitTest.C)).PL(new double[]{10,40,60,20,50,30}).GQ(30).AD(new int[]{3,5,4}).make()));
+        VariantContext A_withGenotypes = builderA.make();
+        VariantContext B_withGenotypes = builderB.make();
+
+        // NEGATIVE TESTS
+        VariantContext B_RAWMQ_BAD = new VariantContextBuilder(B_RAWMQ).attribute("AS_RAW_MQ","40|10|10").make();
+        VariantContext B_PG_BAD = new VariantContextBuilder(B_RAWMQ).attribute("PG","10,20,30,40,50,60").make();
+        VariantContext B_withGenotypes_BADGQ = builderB.copy().genotypes(Arrays.asList(new GenotypeBuilder(SAMPLE_1).alleles(Arrays.asList(ARef, G)).PL(new double[]{30,0,0,0,0,190}).GQ(30).AD(new int[]{1,3,2}).make(),
+                                                                                        new GenotypeBuilder(SAMPLE_2).alleles(Arrays.asList(VariantContextTestUtilsUnitTest.G, VariantContextTestUtilsUnitTest.C)).PL(new double[]{10,40,60,20,50,30}).AD(new int[]{3,5,4}).GQ(40).make())).make();
+        VariantContext B_withGenotypes_BADPL = builderB.copy().genotypes(Arrays.asList(new GenotypeBuilder(SAMPLE_1).alleles(Arrays.asList(ARef, G)).PL(new double[]{30,0,190,0,0,0}).GQ(30).AD(new int[]{1,3,2}).make(),
+                                                                                        new GenotypeBuilder(SAMPLE_2).alleles(Arrays.asList(VariantContextTestUtilsUnitTest.G, VariantContextTestUtilsUnitTest.C)).PL(new double[]{10,20,30,40,50,60}).GQ(30).AD(new int[]{3,5,4}).make())).make();
+        VariantContext B_withGenotypes_BADAD = builderB.copy().genotypes(Arrays.asList(new GenotypeBuilder(SAMPLE_1).alleles(Arrays.asList(ARef, G)).PL(new double[]{30,0,0,0,0,190}).GQ(30).AD(new int[]{1,3,2}).make(),
+                                                                                        new GenotypeBuilder(SAMPLE_2).alleles(Arrays.asList(VariantContextTestUtilsUnitTest.G, VariantContextTestUtilsUnitTest.C)).PL(new double[]{10,40,60,20,50,30}).GQ(30).AD(new int[]{3,4,4}).make())).make();
+
+
+        return new Object[][]{{A,B,true},
+                {A,C,false},
+                {A_RAWMQ,B_RAWMQ,true},
+                {A_RAWMQ,B_RAWMQ_BAD,false},
+                {A_RAWMQ,B_PG_BAD,false},
+                {A_withGenotypes,B_withGenotypes,true},
+                {A_withGenotypes,B_withGenotypes_BADGQ,false},
+                {A_withGenotypes,B_withGenotypes_BADPL,false},
+                {A_withGenotypes,B_withGenotypes_BADAD,false},};
+    }
+
+    @Test(dataProvider = "alleleRemapExamples")
+    public void testOrderSortAlleles(VariantContext actual, VariantContext expected, boolean shouldSucceed) {
+        VCFHeader header = VariantContextTestUtils.getCompleteHeader();
+
+        if (shouldSucceed) {
+            VariantContextTestUtils.assertVariantContextsAreEqualAlleleOrderIndependent(actual, expected, Collections.emptyList(), header);
+        } else {
+            Assert.assertThrows(AssertionError.class, () -> VariantContextTestUtils.assertVariantContextsAreEqualAlleleOrderIndependent(actual, expected, Collections.emptyList(), header));
+        }
+    }
 }
+
+


### PR DESCRIPTION
Thanks to the work already done by @lbergelson, I added the ability to compare two variant contexts for equality by sorting them and remapping their attributes to the correct value and then comparing the sorted variant contexts for equality. 

Fixes #2599