### PR TITLE
Revert use of deprecated travis image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
 sudo: required
 dist: trusty
-# Request an older travis image, as newer ones have less space.
-# See https://blog.travis-ci.com/2017-08-29-trusty-image-updates
-group: deprecated-2017Q3
 git:
   depth: 9999999
   lfs_skip_smudge: true


### PR DESCRIPTION
I asked about a status update on the travis image space issue in the travis ticket, and based on feedback I tried moving to the new image. It seems to work now. Fixes https://github.com/broadinstitute/gatk/issues/3559.