### PR TITLE
Imprecise deletion evidence annotation and variant calling

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -175,6 +175,8 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         public static final int MISSING_NM = Integer.MIN_VALUE;
         public static final int ARTIFICIAL_MISMATCH = MISSING_NM;
         public static final int DEFAULT_MIN_ALIGNMENT_LENGTH = 50; // Minimum flanking alignment length filters used when going through contig alignments.
+        public static final int DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY = 100;
+        public static final int DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD = 7;
 
         // todo: document this better
         // Currently the discovery stage requires a reference parameter in 2bit format (to broadcast) and
@@ -186,6 +188,13 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         @Argument(doc = "Minimum flanking alignment length", shortName = "minAlignLength",
                 fullName = "minAlignLength", optional = true)
         public Integer minAlignLength = DEFAULT_MIN_ALIGNMENT_LENGTH;
+
+        @Argument(doc = "Uncertainty in overlap of assembled breakpoints and evidence target links.", fullName = "assemblyImpreciseEvidenceOverlapUncertainty")
+        public int assemblyImpreciseEvidenceOverlapUncertainty = DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY;
+
+        @Argument(doc = "Number of pieces of imprecise evidence necessary to call a variant in the absence of an assembled breakpoint.", fullName = "impreciseEvidenceVariantCallingThreshold")
+        public int impreciseEvidenceVariantCallingThreshold = DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD;
+
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery;
 
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 
 import java.util.Collections;
 import java.util.Map;
@@ -116,4 +119,35 @@ public abstract class SimpleSVType extends SvType {
                     + novelAdjacencyReferenceLocations.leftJustifiedRightRefLoc.getStart();
         }
     }
+
+    public static final class ImpreciseDeletion extends SimpleSVType {
+
+        @Override
+        public String toString() {
+            return TYPES.DEL.name();
+        }
+
+        @SuppressWarnings("unchecked")
+        ImpreciseDeletion(final EvidenceTargetLink evidenceTargetLink, final SAMSequenceDictionary sequenceDictionary) {
+
+            super(getIDString(evidenceTargetLink, sequenceDictionary),
+                    Allele.create(createBracketedSymbAlleleString(GATKSVVCFConstants.SYMB_ALT_ALLELE_DEL_IN_HEADER)),
+                    (evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().midpoint() -
+                            evidenceTargetLink.getPairedStrandedIntervals().getRight().getInterval().midpoint()),
+                    Collections.EMPTY_MAP);
+        }
+
+        private static String getIDString(final EvidenceTargetLink evidenceTargetLink, final SAMSequenceDictionary sequenceDictionary) {
+
+            return  TYPES.DEL.name()
+                    + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + GATKSVVCFConstants.IMPRECISE + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + sequenceDictionary.getSequence(evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getContig()).getSequenceName() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getEnd() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + evidenceTargetLink.getPairedStrandedIntervals().getRight().getInterval().getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + evidenceTargetLink.getPairedStrandedIntervals().getRight().getInterval().getEnd();
+        }
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/InsDelVariantDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/InsDelVariantDetector.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
 
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
@@ -41,7 +43,9 @@ final class InsDelVariantDetector implements VariantDetectorFromLocalAssemblyCon
                         .map(noveltyTypeAndEvidence -> DiscoverVariantsFromContigAlignmentsSAMSpark.annotateVariant(noveltyTypeAndEvidence._1,
                                 noveltyTypeAndEvidence._2._1, noveltyTypeAndEvidence._2._2, broadcastReference));
 
-        SVVCFWriter.writeVCF(null, vcfOutputFileName, fastaReference, annotatedVariants, toolLogger);
+        final PipelineOptions pipelineOptions = null;
+        SVVCFWriter.writeVCF(vcfOutputFileName, toolLogger, annotatedVariants.collect(), new ReferenceMultiSource(pipelineOptions, fastaReference,
+                ReferenceWindowFunctions.IDENTITY_FUNCTION).getReferenceSequenceDictionary(null));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/LibraryStatistics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/LibraryStatistics.java
@@ -66,7 +66,7 @@ public final class LibraryStatistics {
     public IntHistogram createEmptyHistogram() { return fragmentSizeCDF.createEmptyHistogram(); }
 
     public int getMaxNonOutlierFragmentSize() {
-        return fragmentSizeCDF.popStat(.9f);
+        return fragmentSizeCDF.popStat(.90f);
     }
 
     public final static class Serializer extends com.esotericsoftware.kryo.Serializer<LibraryStatistics> {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/sga/DiscoverVariantsFromContigAlignmentsSGASpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/sga/DiscoverVariantsFromContigAlignmentsSGASpark.java
@@ -66,8 +66,8 @@ public final class DiscoverVariantsFromContigAlignmentsSGASpark extends GATKSpar
         final JavaRDD<AlignedContig> parsedContigAlignments
                 = new SGATextFormatAlignmentParser(ctx, inputAssemblies, inputAlignments, logContigAlignmentSimpleStats ? localLogger : null).getAlignedContigs();
 
-        DiscoverVariantsFromContigAlignmentsSAMSpark.discoverVariantsAndWriteVCF(parsedContigAlignments, fastaReference,
-                ctx.broadcast(getReference()), getAuthenticatedGCSOptions(), vcfOutput, localLogger);
+        DiscoverVariantsFromContigAlignmentsSAMSpark.discoverVariantsAndWriteVCF(parsedContigAlignments, null,
+                ctx.broadcast(getReference()), vcfOutput, localLogger, getReferenceSequenceDictionary());
     }
 
     public static final class SGATextFormatAlignmentParser extends AlignedContigGenerator {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
@@ -6,6 +6,9 @@ public class GATKSVVCFConstants {
     // todo: add these and the other standard SV info fields from the VCF spec to htsjdk VCFStandardHeaderLines
     public static final String SVTYPE = "SVTYPE";
     public static final String SVLEN = "SVLEN";
+    public static final String IMPRECISE = "IMPRECISE";
+    public static final String CIPOS = "CIPOS";
+    public static final String CIEND = "CIEND";
 
     public static final String BREAKEND_STR = "BND";
     public static final String BND_MATEID_STR = "MATEID";
@@ -44,4 +47,6 @@ public class GATKSVVCFConstants {
     public static final String INTERVAL_VARIANT_ID_FIELD_SEPARATOR = "_";
     public static final String TANDUP_CONTRACTION_INTERNAL_ID_START_STRING = "DEL-DUPLICATION-TANDEM-CONTRACTION";
     public static final String TANDUP_EXPANSION_INTERNAL_ID_START_STRING = "INS-DUPLICATION-TANDEM-EXPANSION";
+    public static final String READ_PAIR_SUPPORT = "READ_PAIR_SUPPORT";
+    public static final String SPLIT_READ_SUPPORT = "SPLIT_READ_SUPPORT";
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFHeaderLines.java
@@ -65,6 +65,10 @@ public class GATKSVVCFHeaderLines {
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.SVTYPE, 1, VCFHeaderLineType.String, "Type of structural variant"));
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.SVLEN, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "Difference in length between REF and ALT alleles"));
 
+        addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.IMPRECISE, 0, VCFHeaderLineType.Flag, "Imprecise structural variation"));
+        addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.CIPOS, 2, VCFHeaderLineType.Integer, "Confidence interval around POS for imprecise variants"));
+        addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.CIEND, 2, VCFHeaderLineType.Integer, "Confidence interval around END for imprecise variants"));
+
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TOTAL_MAPPINGS, 1, VCFHeaderLineType.Integer, "Number of contig alignments that support the variant"));
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.HQ_MAPPINGS, 1, VCFHeaderLineType.Integer, "Number of high-quality contig alignments that support the variant"));
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.MAPPING_QUALITIES, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "Mapping qualities of the contig alignments that support the variant"));
@@ -92,5 +96,9 @@ public class GATKSVVCFHeaderLines {
 
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TANDUP_CONTRACTION_STRING, 0, VCFHeaderLineType.Flag, "Tandem repeats contraction compared to reference"));
         addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TANDUP_EXPANSION_STRING, 0, VCFHeaderLineType.Flag, "Tandem repeats expansion compared to reference"));
+
+        addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.READ_PAIR_SUPPORT, 1, VCFHeaderLineType.Integer, "Number of discordant read pairs supporting the variant"));
+        addInfoLine(new VCFInfoHeaderLine(GATKSVVCFConstants.SPLIT_READ_SUPPORT, 1, VCFHeaderLineType.Integer, "Number of split read supplementary mappings supporting the variant"));
+
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVInterval.java
@@ -77,6 +77,10 @@ public final class SVInterval implements Comparable<SVInterval> {
         return new SVInterval(this.getContig(), Math.max(this.start, that.start), Math.min(this.end, that.end));
     }
 
+    public int midpoint() {
+        return (start + end) / 2;
+    }
+
     @Override
     public boolean equals( final Object obj ) {
         if ( !(obj instanceof SVInterval) ) return false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalTree.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalTree.java
@@ -1011,7 +1011,7 @@ public final class SVIntervalTree<V> implements Iterable<SVIntervalTree.Entry<V>
 
         @Override
         public SVIntervalTree<T> read( final Kryo kryo, final Input input, final Class<SVIntervalTree<T>> klass ) {
-            return new SVIntervalTree<T>(kryo, input);
+            return new SVIntervalTree<>(kryo, input);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.spark.sv.utils;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -12,9 +11,6 @@ import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
 import org.apache.logging.log4j.Logger;
-import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
-import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
@@ -37,14 +33,10 @@ public class SVVCFWriter {
      * FASTA and Broadcast references are both required because 2bit Broadcast references currently order their
      * sequence dictionaries in a scrambled order, see https://github.com/broadinstitute/gatk/issues/2037.
      */
-    public static void writeVCF(final PipelineOptions pipelineOptions, final String vcfFileName,
-                                final String fastaReference, final JavaRDD<VariantContext> variantContexts,
-                                final Logger logger) {
+    public static void writeVCF(final String vcfFileName,
+                                final Logger logger, final List<VariantContext> localVariants, final SAMSequenceDictionary referenceSequenceDictionary) {
 
-        final SAMSequenceDictionary referenceSequenceDictionary = new ReferenceMultiSource(pipelineOptions, fastaReference,
-                ReferenceWindowFunctions.IDENTITY_FUNCTION).getReferenceSequenceDictionary(null);
-
-        final List<VariantContext> sortedVariantsList = sortVariantsByCoordinate(variantContexts.collect(), referenceSequenceDictionary);
+        final List<VariantContext> sortedVariantsList = sortVariantsByCoordinate(localVariants, referenceSequenceDictionary);
 
         logNumOfVarByTypes(sortedVariantsList, logger);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/StrandedInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/StrandedInterval.java
@@ -6,6 +6,14 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.broadinstitute.hellbender.utils.Utils;
 
+/**
+ * Represents an interval and strand from the reference genome. Users of this class can choose their own interpretation
+ * of what strand means. In the context of imprecise variant calling from unassembled breakpoint evidence, strand is set
+ * as defined in BreakpointEvidence.isEvidenceUpstreamOfBreakpoint():
+ *
+ * If true: the evidence suggests a breakpoint at a reference location upstream of the interval's start coordinate
+ * If false: the evidence suggests a breakpoint downstream of the interval's end coordinate
+ */
 @DefaultSerializer(StrandedInterval.Serializer.class)
 public class StrandedInterval {
     private static final SVInterval.Serializer intervalSerializer = new SVInterval.Serializer();

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
@@ -1,0 +1,141 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery;
+
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
+import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.ReadMetadata;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.PairedStrandedIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.StrandedInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+public class DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest extends BaseTest {
+
+
+    private final Logger localLogger = LogManager.getLogger(DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.class);
+    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+
+    @DataProvider(name = "evidenceTargetLinksAndVariants")
+    public Object[][] getEvidenceTargetLinksAndVariants() {
+        final VariantContext unAnnotatedVC = new VariantContextBuilder()
+                .id("TESTID")
+                .chr("20").start(200).stop(300)
+                .alleles("N", SimpleSVType.ImpreciseDeletion.createBracketedSymbAlleleString(GATKSVVCFConstants.SYMB_ALT_ALLELE_DEL_IN_HEADER))
+                .attribute(VCFConstants.END_KEY, 300)
+                .attribute(GATKSVVCFConstants.SVTYPE, SimpleSVType.TYPES.DEL.toString())
+                .make();
+
+        final VariantContext annotatedVC = new VariantContextBuilder()
+                .id("TESTID")
+                .chr("20").start(200).stop(300)
+                .alleles("N", SimpleSVType.ImpreciseDeletion.createBracketedSymbAlleleString(GATKSVVCFConstants.SYMB_ALT_ALLELE_DEL_IN_HEADER))
+                .attribute(VCFConstants.END_KEY, 300)
+                .attribute(GATKSVVCFConstants.SVTYPE, SimpleSVType.TYPES.DEL.toString())
+                .attribute(GATKSVVCFConstants.READ_PAIR_SUPPORT, 7)
+                .attribute(GATKSVVCFConstants.SPLIT_READ_SUPPORT, 5)
+                .make();
+
+        final VariantContext impreciseDeletion = new VariantContextBuilder()
+                .id("DEL_IMPRECISE_20_950_1050_1975_2025")
+                .chr("20").start(1000).stop(2000)
+                .alleles("N", SimpleSVType.ImpreciseDeletion.createBracketedSymbAlleleString(GATKSVVCFConstants.SYMB_ALT_ALLELE_DEL_IN_HEADER))
+                .attribute(VCFConstants.END_KEY, 2000)
+                .attribute(GATKSVVCFConstants.SVTYPE, SimpleSVType.TYPES.DEL.toString())
+                .attribute(GATKSVVCFConstants.READ_PAIR_SUPPORT, 7)
+                .attribute(GATKSVVCFConstants.SPLIT_READ_SUPPORT, 5)
+                .attribute(GATKSVVCFConstants.IMPRECISE, true)
+                .attribute(GATKSVVCFConstants.CIPOS, "-50,50")
+                .attribute(GATKSVVCFConstants.CIEND, "-25,25")
+                .attribute(GATKSVVCFConstants.SVLEN, -1000)
+                .make();
+
+        List<Object[]> tests = new ArrayList<>();
+        tests.add(new Object[] {
+                Arrays.asList(
+                        new EvidenceTargetLink(
+                                new StrandedInterval(new SVInterval(0, 190, 210), true),
+                                new StrandedInterval(new SVInterval(0, 310, 320), false),
+                                5, 7, new HashSet<>(), new HashSet<>())),
+                Arrays.asList( unAnnotatedVC ),
+                Arrays.asList( annotatedVC ) }
+                );
+        tests.add(new Object[] {
+                Arrays.asList(
+                        new EvidenceTargetLink(
+                                new StrandedInterval(new SVInterval(0, 190, 210), true),
+                                new StrandedInterval(new SVInterval(0, 310, 320), true),
+                                5, 7, new HashSet<>(), new HashSet<>())),
+                Arrays.asList( unAnnotatedVC ),
+                Arrays.asList( unAnnotatedVC ) }
+        );
+        tests.add(new Object[] {
+                Arrays.asList(
+                        new EvidenceTargetLink(
+                                new StrandedInterval(new SVInterval(0, 950, 1050), true),
+                                new StrandedInterval(new SVInterval(0, 1975, 2025), false),
+                                5, 7, new HashSet<>(), new HashSet<>())),
+                Arrays.asList( unAnnotatedVC ),
+                Arrays.asList( unAnnotatedVC, impreciseDeletion ) }
+        );
+        tests.add(new Object[] {
+                Arrays.asList(
+                        new EvidenceTargetLink(
+                                new StrandedInterval(new SVInterval(0, 190, 210), true),
+                                new StrandedInterval(new SVInterval(0, 310, 320), false),
+                                3, 4, new HashSet<>(), new HashSet<>()),
+                        new EvidenceTargetLink(
+                                new StrandedInterval(new SVInterval(0, 192, 215), true),
+                                new StrandedInterval(new SVInterval(0, 299, 303), false),
+                                2, 3, new HashSet<>(), new HashSet<>())),
+                Arrays.asList( unAnnotatedVC ),
+                Arrays.asList( annotatedVC ) }
+        );
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "evidenceTargetLinksAndVariants")
+    public void testProcessEvidenceTargetLinks(final List<EvidenceTargetLink> etls,
+                                               final List<VariantContext> inputVariants,
+                                               final List<VariantContext> expectedVariants) throws Exception {
+        final StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection params =
+                new StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection();
+
+        final PipelineOptions options = null;
+        final ReferenceMultiSource referenceMultiSource = new ReferenceMultiSource(options, twoBitRefURL, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+
+        ReadMetadata metadata = Mockito.mock(ReadMetadata.class);
+        when(metadata.getMaxMedianFragmentSize()).thenReturn(300);
+
+
+        PairedStrandedIntervalTree<EvidenceTargetLink> evidenceTree = new PairedStrandedIntervalTree<>();
+        etls.forEach(e -> evidenceTree.put(e.getPairedStrandedIntervals(), e));
+
+        final List<VariantContext> processedVariantContexts =
+                DiscoverVariantsFromContigAlignmentsSAMSpark.processEvidenceTargetLinks(params, localLogger, evidenceTree,
+                        metadata, inputVariants, referenceMultiSource);
+
+        VariantContextTestUtils.assertEqualVariants(processedVariantContexts, expectedVariants);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest.java
@@ -21,7 +21,9 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest extends
             Arrays.asList(GATKSVVCFConstants.ALIGN_LENGTHS,
                     GATKSVVCFConstants.CONTIG_NAMES,
                     GATKSVVCFConstants.INSERTED_SEQUENCE_MAPPINGS,
-                    GATKSVVCFConstants.TOTAL_MAPPINGS);
+                    GATKSVVCFConstants.TOTAL_MAPPINGS,
+                    GATKSVVCFConstants.SPLIT_READ_SUPPORT,
+                    GATKSVVCFConstants.READ_PAIR_SUPPORT);
 
     private static final class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTestArgs {
         final String outputDir;

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContextUnitTest.java
@@ -153,7 +153,7 @@ public class SVContextUnitTest {
 
 
     /**
-     * Tests {@link SVContext#getBreakPointIntervals(int, SAMSequenceDictionary)}.
+     * Tests {@link SVContext#getBreakPointIntervals(int, SAMSequenceDictionary, boolean)}.
      * to obtain the reference haplotype.
      * @param vc input variant context.
      */
@@ -168,13 +168,13 @@ public class SVContextUnitTest {
         if (svc.getStructuralVariantType() != StructuralVariantType.INS && svc.getStructuralVariantType() != StructuralVariantType.DEL) {
             throw new SkipException("unsupported type; skipped for now");
         }
-        final List<SimpleInterval> breakPoints = svc.getBreakPointIntervals(paddingSize, reference.getReferenceSequenceDictionary(null));
+        final List<SimpleInterval> breakPoints = svc.getBreakPointIntervals(paddingSize, reference.getReferenceSequenceDictionary(null), false);
         final int contigLength = reference.getReferenceSequenceDictionary(null).getSequence(vc.getContig()).getSequenceLength();
         final List<Integer> expectedOffsets = new ArrayList<>();
         if (svc.getStructuralVariantType() == StructuralVariantType.INS) {
             expectedOffsets.add(vc.getStart());
         } else if (svc.getStructuralVariantType() == StructuralVariantType.DEL) {
-            expectedOffsets.add(vc.getStart());
+            expectedOffsets.add(vc.getStart() + 1);
             expectedOffsets.add(vc.getEnd());
         }
         final List<SimpleInterval> expectedBreakPoints = expectedOffsets.stream()

--- a/src/test/resources/org/broadinstitute/hellbender/tools/spark/sv/integration/hg19_DEL.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/spark/sv/integration/hg19_DEL.vcf
@@ -4,6 +4,8 @@
 ##ALT=<ID=INS,Description="Insertion of novel sequence relative to the reference">
 ##ALT=<ID=INV,Description="Inversion of reference sequence">
 ##INFO=<ID=ALIGN_LENGTHS,Number=.,Type=Integer,Description="Minimum lengths of the flanking aligned region from each contig alignment">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
 ##INFO=<ID=CONTRACTION,Number=0,Type=Flag,Description="Tandem repeats contraction compared to reference">
 ##INFO=<ID=CTG_NAMES,Number=.,Type=String,Description="Name of contigs that evidenced this variant, formatted as \"asm%06d:tig%05d\"">
 ##INFO=<ID=DUP_ANNOTATIONS_IMPRECISE,Number=0,Type=Flag,Description="Whether the duplication annotations are from an experimental optimization procedure">
@@ -17,14 +19,17 @@
 ##INFO=<ID=HQ_MAPPINGS,Number=1,Type=Integer,Description="Number of high-quality contig alignments that support the variant">
 ##INFO=<ID=INSERTED_SEQUENCE,Number=.,Type=String,Description="Inserted sequence at the breakpoint">
 ##INFO=<ID=INSERTED_SEQUENCE_MAPPINGS,Number=.,Type=String,Description="Alignments of inserted sequence">
+##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
 ##INFO=<ID=INV33,Number=0,Type=Flag,Description="Whether the event represents a 3' to 5' inversion">
 ##INFO=<ID=INV55,Number=0,Type=Flag,Description="Whether the event represents a 5' to 3' inversion">
 ##INFO=<ID=MAPPING_QUALITIES,Number=.,Type=Integer,Description="Mapping qualities of the contig alignments that support the variant">
 ##INFO=<ID=MAX_ALIGN_LENGTH,Number=1,Type=Integer,Description="Maximum of the minimum aligned lengths of flanking regions from each contig alignment">
+##INFO=<ID=READ_PAIR_SUPPORT,Number=1,Type=Integer,Description="Number of discordant read pairs supporting the variant">
+##INFO=<ID=SPLIT_READ_SUPPORT,Number=1,Type=Integer,Description="Number of split read supplementary mappings supporting the variant">
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=TOTAL_MAPPINGS,Number=1,Type=Integer,Description="Number of contig alignments that support the variant">
 ##contig=<ID=20,length=63025520>
 ##contig=<ID=21,length=48129895>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-21	43350116	DEL_21_43350116_43353485	G	<DEL>	.	.	ALIGN_LENGTHS=200,200;CTG_NAMES=asm000000:tig00008,asm000001:tig00002;END=43353485;HOMOLOGY=GAGGAA;HOMOLOGY_LENGTH=6;HQ_MAPPINGS=2;MAPPING_QUALITIES=60,60;MAX_ALIGN_LENGTH=200;SVLEN=-3369;SVTYPE=DEL;TOTAL_MAPPINGS=2
+21	43350116	DEL_21_43350116_43353485	G	<DEL>	.	.	ALIGN_LENGTHS=200,200;CTG_NAMES=asm000000:tig00008,asm000001:tig00002;END=43353485;HOMOLOGY=GAGGAA;HOMOLOGY_LENGTH=6;HQ_MAPPINGS=2;MAPPING_QUALITIES=60,60;MAX_ALIGN_LENGTH=200;READ_PAIR_SUPPORT=23;SPLIT_READ_SUPPORT=8;SVLEN=-3369;SVTYPE=DEL;TOTAL_MAPPINGS=2


### PR DESCRIPTION
This PR adds logic to use imprecise evidence (gathered from discordant read pair mappings and split reads with supplementary alignments) to:

- Annotate events that we are calling from assembled breakpoints with the number of discordant read pairs and split reads that support those events.
- Call new variants when an imprecise evidence link supporting a deletion is supported by a minimum number of pieces of evidence (set to 7 by default in this PR; parameters can be tuned later).

In an initial run on the CHM mix this uses 3500 evidence-target clusters to annotate our existing deletion calls and makes an additional 670 IMPRECISE deletion calls. Initial visual evaluations against the CHM truth set looks good on visual inspection; more detailed evaluations will follow.