### PR TITLE
re-enable snappy use in htsjdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ import javax.tools.ToolProvider;
 mainClassName = "org.broadinstitute.hellbender.Main"
 
 //Note: the test suite must use the same defaults. If you change system properties in this list you must also update the one in the test task
-applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=1", "-Dsnappy.disable=true"]
+applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=1"]
 
 //Delete the windows script - we never test on Windows so let's not pretend it works
 startScripts {
@@ -292,7 +292,6 @@ test {
     systemProperty "samjdk.use_async_io_write_samtools", "true"
     systemProperty "samjdk.use_async_io_write_tribble", "false"
     systemProperty "samjdk.compression_level", "1"
-    systemProperty "snappy.disable", "true"
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     // Nd4j

--- a/gatk-launch
+++ b/gatk-launch
@@ -37,14 +37,12 @@ EXTRA_JAVA_OPTIONS_SPARK= "-DGATK_STACKTRACE_ON_USER_EXCEPTION=true " \
                    "-Dsamjdk.use_async_io_read_samtools=false " \
                    "-Dsamjdk.use_async_io_write_samtools=false " \
                    "-Dsamjdk.use_async_io_write_tribble=false " \
-                   "-Dsamjdk.compression_level=1 " \
-                   "-Dsnappy.disable=true "
+                   "-Dsamjdk.compression_level=1 " 
 
 PACKAGED_LOCAL_JAR_OPTIONS= ["-Dsamjdk.use_async_io_read_samtools=false",
                   "-Dsamjdk.use_async_io_write_samtools=true",
                   "-Dsamjdk.use_async_io_write_tribble=false",
-                  "-Dsamjdk.compression_level=1",
-                  "-Dsnappy.disable=true"]
+                  "-Dsamjdk.compression_level=1"]
 
 DEFAULT_SPARK_ARGS_PREFIX = '--conf'
 DEFAULT_SPARK_ARGS = {


### PR DESCRIPTION
htsjdk has updated to a newer version of snappy (https://github.com/samtools/htsjdk/pull/872) which makes it compatible with the rest of the world's snappy

this means we can re-enable snappy usage in htsjdk which should give performance improvements in tools that use `SortingCollection`

this is a permanent solution to #2026 that replaces the changes we made in #2028