### PR TITLE
PSUtils getMatchesLessDeletions() should not throw error if number of…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -101,7 +101,6 @@ public final class PSUtils {
                 numDeletions += e.getLength();
             }
         }
-        if (numMatches < 0) throw new IllegalArgumentException("numMismatches was greater than the number of matches/mismatches in the cigar");
         return numMatches - numDeletions;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import htsjdk.samtools.*;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -15,6 +16,8 @@ import java.util.stream.Collectors;
  * Common functions for PathSeq
  */
 public final class PSUtils {
+
+    protected static final Logger logger = LogManager.getLogger(PSUtils.class);
 
     public static JavaRDD<GATKRead> primaryReads(final JavaRDD<GATKRead> reads) {
         return reads.filter(read -> !(read.isSecondaryAlignment() || read.isSupplementaryAlignment()));
@@ -100,6 +103,10 @@ public final class PSUtils {
             } else if (e.getOperator().equals(CigarOperator.DELETION)) {
                 numDeletions += e.getLength();
             }
+        }
+        if (numMatches < 0)  {
+            logger.warn("Invalid arguments passed to getMatchesLessDeletions(): numMismatches was greater than the number of matches/mismatches in the cigar. Returning 0.");
+            return 0;
         }
         return numMatches - numDeletions;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSUtils.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  */
 public final class PSUtils {
 
-    protected static final Logger logger = LogManager.getLogger(PSUtils.class);
+    private static final Logger logger = LogManager.getLogger(PSUtils.class);
 
     public static JavaRDD<GATKRead> primaryReads(final JavaRDD<GATKRead> reads) {
         return reads.filter(read -> !(read.isSecondaryAlignment() || read.isSupplementaryAlignment()));
@@ -104,9 +104,8 @@ public final class PSUtils {
                 numDeletions += e.getLength();
             }
         }
-        if (numMatches < 0)  {
+        if (numMatches < 0) {
             logger.warn("Invalid arguments passed to getMatchesLessDeletions(): numMismatches was greater than the number of matches/mismatches in the cigar. Returning 0.");
-            return 0;
         }
         return numMatches - numDeletions;
     }


### PR DESCRIPTION
… mismatches is too large

Removes an error that is thrown when the number of mismatches is greater than the number of mismatches/mismatches in the cigar. 

It appears that some aligners do this. I am seeing it frequently in soft-clipped reads in TCGA RNA-seq BAMs (maybe a STAR bug?). 

I would prefer to remove the thrown error rather than assume the dev will be aware of this issue and will catch it externally.