### PR TITLE
Have PSFilter strip mate number from read names

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
@@ -228,6 +228,9 @@ public final class PSFilter implements AutoCloseable {
         //Clear alignment data from the reads
         reads = clearAllAlignments(reads, header);
 
+        //Remove /1 and /2 from read names
+        reads = reads.map(new ReadTransformerSparkifier(new StripMateNumberTransformer()));
+
         if (!filterArgs.skipFilters) {
 
             //Adapter trimming

--- a/src/main/java/org/broadinstitute/hellbender/transformers/StripMateNumberTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/StripMateNumberTransformer.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.fastq.FastqConstants;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+/**
+ * Removes /1 or /2 and any whitespace from the end of the read name if present
+ */
+
+public class StripMateNumberTransformer implements ReadTransformer {
+    public static final long serialVersionUID = 1L;
+
+    @Override
+    public GATKRead apply(final GATKRead read) {
+        if (read == null) throw new IllegalArgumentException("Read cannot be null");
+        final String name = read.getName().trim();
+        if (name.endsWith(FastqConstants.FIRST_OF_PAIR) || name.endsWith(FastqConstants.SECOND_OF_PAIR)) {
+            read.setName(name.substring(0, name.length() - 2).trim());
+        }
+        return read;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/transformers/StripMateNumberTransformerTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/StripMateNumberTransformerTest.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class StripMateNumberTransformerTest extends BaseTest {
+
+
+    @DataProvider(name = "testData")
+    public Object[][] getTestData() {
+        return new Object[][]{
+                {"TEST_READ/1", "TEST_READ"},
+                {"TEST_READ/2", "TEST_READ"},
+                {"TEST_READ/1 ", "TEST_READ"},
+                {"TEST_READ/2  ", "TEST_READ"},
+                {"TEST_READ /1", "TEST_READ"},
+                {"TEST_READ /2", "TEST_READ"},
+                {"TEST_READ/1/2", "TEST_READ/1"},
+                {"TEST_READ/2/1", "TEST_READ/2"},
+                {"TEST/1READ", "TEST/1READ"},
+                {"TEST/2READ", "TEST/2READ"},
+                {"TEST/1READ/1", "TEST/1READ"},
+                {"TEST/2READ/1", "TEST/2READ"},
+        };
+    }
+
+    @Test(dataProvider = "testData")
+    public void test(final String nameIn, final String nameOut) {
+        final StripMateNumberTransformer trans = new StripMateNumberTransformer();
+        final GATKRead read = new SAMRecordToGATKReadAdapter(new SAMRecord(null));
+        read.setName(nameIn);
+        Assert.assertEquals(trans.apply(read).getName(), nameOut);
+    }
+
+}


### PR DESCRIPTION
Adds a read transformer that removes the "/1" and "/2" from read names to the PathSeq filter phase. This seems to be the way TCGA RNA-seq BAMs are formatted.