### PR TITLE
Automatically distribute the BWA-MEM index image file to executors for BwaSpark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSpark.java
@@ -25,18 +25,11 @@ public final class BwaSpark extends GATKSparkTool {
 
     public static final String SINGLE_END_ALIGNMENT_FULL_NAME = "singleEndAlignment";
     public static final String SINGLE_END_ALIGNMENT_SHORT_NAME = "SE";
-    public static final String BWA_MEM_INDEX_IMAGE_FULL_NAME = "bwaMemIndexImage";
-    public static final String BWA_MEM_INDEX_IMAGE_SHORT_NAME = "image";
 
     @Argument(doc = "the output bam",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
     private String output;
-
-    @Argument(doc = "the bwa mem index image file name that you've distributed to each executor",
-            fullName = BWA_MEM_INDEX_IMAGE_FULL_NAME,
-            shortName = BWA_MEM_INDEX_IMAGE_SHORT_NAME )
-    private String indexImageFile;
 
     @Argument(doc = "run single end instead of paired-end alignment",
               fullName = SINGLE_END_ALIGNMENT_FULL_NAME,
@@ -57,7 +50,7 @@ public final class BwaSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         try ( final BwaSparkEngine engine =
-                      new BwaSparkEngine(ctx, indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary()) ) {
+                      new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), getHeaderForReads(), getReferenceSequenceDictionary()) ) {
             final JavaRDD<GATKRead> reads = !singleEndAlignment ? engine.alignPaired(getReads()) : engine.alignUnpaired(getReads());
 
             try {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSpark.java
@@ -25,11 +25,19 @@ public final class BwaSpark extends GATKSparkTool {
 
     public static final String SINGLE_END_ALIGNMENT_FULL_NAME = "singleEndAlignment";
     public static final String SINGLE_END_ALIGNMENT_SHORT_NAME = "SE";
+    public static final String BWA_MEM_INDEX_IMAGE_FULL_NAME = "bwaMemIndexImage";
+    public static final String BWA_MEM_INDEX_IMAGE_SHORT_NAME = "image";
 
     @Argument(doc = "the output bam",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
     private String output;
+
+    @Argument(doc = "the bwa mem index image file name that you've distributed to each executor",
+            fullName = BWA_MEM_INDEX_IMAGE_FULL_NAME,
+            shortName = BWA_MEM_INDEX_IMAGE_SHORT_NAME,
+            optional = true)
+    private String indexImageFile;
 
     @Argument(doc = "run single end instead of paired-end alignment",
               fullName = SINGLE_END_ALIGNMENT_FULL_NAME,
@@ -50,7 +58,7 @@ public final class BwaSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         try ( final BwaSparkEngine engine =
-                      new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), getHeaderForReads(), getReferenceSequenceDictionary()) ) {
+                      new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary()) ) {
             final JavaRDD<GATKRead> reads = !singleEndAlignment ? engine.alignPaired(getReads()) : engine.alignUnpaired(getReads());
 
             try {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkEngine.java
@@ -31,18 +31,34 @@ public final class BwaSparkEngine implements AutoCloseable {
     private static final String REFERENCE_INDEX_IMAGE_FILE_SUFFIX = ".img";
     private final JavaSparkContext ctx;
     private final String indexFileName;
+    private final boolean resolveIndexFileName;
     private final Broadcast<SAMFileHeader> broadcastHeader;
 
+    /**
+     * @param ctx           the Spark context
+     * @param referenceFile the path to the reference file named <i>_prefix_.fa</i>, which is used to find the image file with name <i>_prefix_.fa.img</i>.
+     *                      Can be <code>null</code> if the indexFileName is provided.
+     * @param indexFileName the index image file name that already exists, or <code>null</code> to have the image file automatically distributed.
+     * @param inputHeader   the SAM file header to use for reads
+     * @param refDictionary the sequence dictionary to use for reads if the SAM file header doesn't have one (or it's empty)
+     */
     public BwaSparkEngine(final JavaSparkContext ctx,
                           final String referenceFile,
+                          final String indexFileName,
                           SAMFileHeader inputHeader,
                           final SAMSequenceDictionary refDictionary) {
         Utils.nonNull(referenceFile);
         Utils.nonNull(inputHeader);
         this.ctx = ctx;
-        String indexFile = referenceFile + REFERENCE_INDEX_IMAGE_FILE_SUFFIX;
-        ctx.addFile(indexFile);
-        this.indexFileName = IOUtils.getPath(indexFile).getFileName().toString();
+        if (indexFileName != null) {
+            this.indexFileName = indexFileName;
+            this.resolveIndexFileName = false;
+        } else {
+            String indexFile = referenceFile + REFERENCE_INDEX_IMAGE_FILE_SUFFIX;
+            ctx.addFile(indexFile); // distribute index file to all executors
+            this.indexFileName = IOUtils.getPath(indexFile).getFileName().toString();
+            this.resolveIndexFileName = true;
+        }
 
         if (inputHeader.getSequenceDictionary() == null || inputHeader.getSequenceDictionary().isEmpty()) {
             Utils.nonNull(refDictionary);
@@ -82,7 +98,9 @@ public final class BwaSparkEngine implements AutoCloseable {
     public JavaRDD<GATKRead> align(final JavaRDD<GATKRead> unalignedReads, final boolean pairedAlignment) {
         final Broadcast<SAMFileHeader> broadcastHeader = this.broadcastHeader;
         final String indexFileName = this.indexFileName;
-        return unalignedReads.mapPartitions(itr -> new ReadAligner(indexFileName, broadcastHeader.value(), pairedAlignment).apply(itr));
+        final boolean resolveIndexFileName = this.resolveIndexFileName;
+        return unalignedReads.mapPartitions(itr ->
+                new ReadAligner(resolveIndexFileName ? SparkFiles.get(indexFileName) : indexFileName, broadcastHeader.value(), pairedAlignment).apply(itr));
     }
 
     @Override
@@ -100,7 +118,7 @@ public final class BwaSparkEngine implements AutoCloseable {
         private static final int READS_PER_PARTITION_GUESS = 1500000;
 
         ReadAligner( final String indexFileName, final SAMFileHeader readsHeader, final boolean alignsPairs) {
-            this.bwaMemIndex = BwaMemIndexCache.getInstance(SparkFiles.get(indexFileName));
+            this.bwaMemIndex = BwaMemIndexCache.getInstance(indexFileName);
             this.readsHeader = readsHeader;
             this.alignsPairs = alignsPairs;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
@@ -41,10 +41,6 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
     @Override
     public boolean requiresReference() { return true; }
 
-    @Argument(doc = "the bwa mem index image file name that you've distributed to each executor",
-            fullName = "bwamemIndexImage")
-    private String indexImageFile;
-
     @Argument(shortName = "DS", fullName ="duplicates_scoring_strategy", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
     public MarkDuplicatesScoringStrategy duplicatesScoringStrategy = MarkDuplicatesScoringStrategy.SUM_OF_BASE_QUALITIES;
 
@@ -54,7 +50,7 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        try (final BwaSparkEngine engine = new BwaSparkEngine(ctx, indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary())) {
+        try (final BwaSparkEngine engine = new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), getHeaderForReads(), getReferenceSequenceDictionary())) {
             final JavaRDD<GATKRead> alignedReads = engine.alignPaired(getReads());
             final JavaRDD<GATKRead> markedReadsWithOD = MarkDuplicatesSpark.mark(alignedReads, engine.getHeader(), duplicatesScoringStrategy, new OpticalDuplicateFinder(), getRecommendedNumReducers());
             final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.cleanupTemporaryAttributes(markedReadsWithOD);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
@@ -41,6 +41,11 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
     @Override
     public boolean requiresReference() { return true; }
 
+    @Argument(doc = "the bwa mem index image file name that you've distributed to each executor",
+            fullName = "bwamemIndexImage",
+            optional = true)
+    private String indexImageFile;
+
     @Argument(shortName = "DS", fullName ="duplicates_scoring_strategy", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
     public MarkDuplicatesScoringStrategy duplicatesScoringStrategy = MarkDuplicatesScoringStrategy.SUM_OF_BASE_QUALITIES;
 
@@ -50,7 +55,7 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        try (final BwaSparkEngine engine = new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), getHeaderForReads(), getReferenceSequenceDictionary())) {
+        try (final BwaSparkEngine engine = new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary())) {
             final JavaRDD<GATKRead> alignedReads = engine.alignPaired(getReads());
             final JavaRDD<GATKRead> markedReadsWithOD = MarkDuplicatesSpark.mark(alignedReads, engine.getHeader(), duplicatesScoringStrategy, new OpticalDuplicateFinder(), getRecommendedNumReducers());
             final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.cleanupTemporaryAttributes(markedReadsWithOD);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
@@ -32,7 +32,6 @@ public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends Comm
         args.addReference(ref);
         args.addInput(input);
         args.addOutput(output);
-        args.addArgument("bwamemIndexImage", b37_reference_20_21+".img");
         args.addBooleanArgument("disableSequenceDictionaryValidation", true);
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
@@ -32,7 +32,6 @@ public final class BwaSparkIntegrationTest extends CommandLineProgramTest {
         args.addArgument("shardedOutput", "true");
         args.add("numReducers=1");
         args.addOutput(output);
-        args.addFileArgument( BwaSpark.BWA_MEM_INDEX_IMAGE_FULL_NAME, getTestFile("ref.fa.img"));
         this.runCommandLine(args.getArgsArray());
 
         SamAssertionUtils.assertSamsEqual(new File(output, "part-r-00000.bam"), expectedSam);
@@ -54,7 +53,6 @@ public final class BwaSparkIntegrationTest extends CommandLineProgramTest {
         args.addArgument("shardedOutput", "true");
         args.add("numReducers=1");
         args.addOutput(output);
-        args.addFileArgument("bwaMemIndexImage", getTestFile("ref.fa.img"));
         args.add("--" + BwaSpark.SINGLE_END_ALIGNMENT_FULL_NAME);
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaSparkIntegrationTest.java
@@ -32,6 +32,7 @@ public final class BwaSparkIntegrationTest extends CommandLineProgramTest {
         args.addArgument("shardedOutput", "true");
         args.add("numReducers=1");
         args.addOutput(output);
+        args.addFileArgument( BwaSpark.BWA_MEM_INDEX_IMAGE_FULL_NAME, getTestFile("ref.fa.img"));
         this.runCommandLine(args.getArgsArray());
 
         SamAssertionUtils.assertSamsEqual(new File(output, "part-r-00000.bam"), expectedSam);


### PR DESCRIPTION
This removes the need to use the Spark `--files` argument and the `BwaSpark` `--bwaMemIndexImage` argument, since instead the `.img` file will be distributed for the user based on the reference argument (`-R`).