### PR TITLE
quick fix for broken read (mapped to no ref bases)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVFastqUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVFastqUtils.java
@@ -173,7 +173,7 @@ public class SVFastqUtils {
          */
         public static String toString(final GATKRead read) {
             Utils.nonNull(read);
-            if (read.isUnmapped()) {
+            if ( read.isUnmapped() || read.getCigar().getPaddedReferenceLength() == 0 ) {
                 return UNMAPPED_STR;
             } else {
                 final StringBuilder builder = new StringBuilder(100);


### PR DESCRIPTION
there is a read with the cigar 44I107S, which is complete gibberish, in the NA12878 bam.
it's nonsense, but we can't afford to blow up.