### PR TITLE
fixing sample name reordering in GenomicsDBImport

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -199,7 +199,7 @@ public final class GenomicsDBImport extends GATKTool {
 
     // Sorted mapping between sample names and corresponding GVCF file name
     //
-    // This must be sorted or it will result in sample name swaps in the output database.
+    // IMPORTANT: This must be sorted or it will result in sample name swaps in the output database.
     // This happens because the callset json is generated independently from the import process
     // each imported batch is then sorted, so if we have an unsorted list we'll end up with different global vs batch
     // sorting.
@@ -351,7 +351,7 @@ public final class GenomicsDBImport extends GATKTool {
         logger.info("Callset Map JSON file will be written to " + callsetMapJSONFile);
         logger.info("Importing to array - " + workspace + "/" + GenomicsDBConstants.DEFAULT_ARRAY_NAME);
 
-        //use the given order so this is consistent with the batch importing
+        //Pass in true here to use the given ordering, since sampleNameToVcfPath is already sorted
         callsetMappingPB = GenomicsDBImporter.generateSortedCallSetMap(new ArrayList<>(sampleNameToVcfPath.keySet()), true);
         initializeInputPreloadExecutorService();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -203,7 +203,7 @@ public final class GenomicsDBImport extends GATKTool {
     // This happens because the callset json is generated independently from the import process
     // each imported batch is then sorted, so if we have an unsorted list we'll end up with different global vs batch
     // sorting.
-    // We presumptively sort here so we will have consistent sorting.
+    // We preemptively sort here so we will have consistent sorting.
     private SortedMap<String, Path> sampleNameToVcfPath = new TreeMap<>();
 
     // Needed as smartMergeHeaders() returns a set of VCF header lines

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
@@ -152,4 +152,8 @@ public final class ArgumentsBuilder {
         return String.join(" ", args);
     }
 
+    @Override
+    public String toString(){
+        return getString();
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -199,33 +199,35 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     }
 
     @Test
-    public void testSampleMappingFileInsteadOfVCFs() throws IOException {
-        final File sampleNameFile = createTempSampleMapFile();
+    public void testSampleMappingFileInsteadOfVCFsWithMultipleBatches() throws IOException {
+        final File sampleNameFile = createOutOfOrderTempSampleMapFile();
 
         final String workspace = createTempDir("gendbtest").getAbsolutePath() + "/workspace";
 
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .addArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, sampleNameFile.getAbsolutePath())
                 .addArgument("L", IntervalUtils.locatableToString(INTERVAL))
-                .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, workspace);
+                .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, workspace)
+                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, "2");
 
         runCommandLine(args);
         checkJSONFilesAreWritten(workspace);
         checkGenomicsDBAgainstExpected(workspace, INTERVAL, COMBINED);
     }
 
-    private static File createTempSampleMapFile() {
+    private static File createOutOfOrderTempSampleMapFile() {
         final String sampleFileContents =
-                "HG00096\t" + HG_00096 +"\n" +
                 "HG00268\t"+ HG_00268 + "\n" +
-                "NA19625\t"+ NA_19625;
+                "NA19625\t"+ NA_19625 + "\n" +
+                "HG00096\t" +HG_00096;
+
         return IOUtils.writeTempFile(sampleFileContents, "sampleNameMap", ".txt");
     }
 
     @Test(expectedExceptions = CommandLineException.class)
     public void testCantSpecifyVCFAndSampleNameFile(){
         final ArgumentsBuilder args = new ArgumentsBuilder()
-                .addArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, createTempSampleMapFile().getAbsolutePath())
+                .addArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, createOutOfOrderTempSampleMapFile().getAbsolutePath())
                 .addArgument(StandardArgumentDefinitions.VARIANT_LONG_NAME, HG_00096)
                 .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, createTempDir("workspace").getAbsolutePath())
                 .addArgument("L",  IntervalUtils.locatableToString(INTERVAL));

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -230,12 +230,18 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
             results.add(new Object[] {new ArgumentsBuilder()
                     .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
                     .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, outOfOrderSampleMap)});
+
+            //out of order sample map with multiple threads
+            results.add(new Object[] {new ArgumentsBuilder()
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, outOfOrderSampleMap)
+                    .addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, "2")});
         }
         return results.iterator();
     }
 
     @Test(dataProvider = "getOrderingTests")
-    public void testOrdering(final ArgumentsBuilder args) throws IOException {
+    public void testSampleNameOrdering(final ArgumentsBuilder args) throws IOException {
         final String workspace = createTempDir("gendbtest").getAbsolutePath() + "/workspace";
 
         args.addArgument("L", IntervalUtils.locatableToString(INTERVAL))

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -6,16 +6,13 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
-import org.mockito.internal.util.io.IOUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import spire.math.Sort;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.SortedMap;

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -10,6 +10,7 @@ import org.mockito.internal.util.io.IOUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import spire.math.Sort;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.SortedMap;
 
 public class GenomicsDBImportUnitTest extends BaseTest{
 
@@ -56,7 +57,7 @@ public class GenomicsDBImportUnitTest extends BaseTest{
         expected.put("Sample1", Paths.get("file1"));
         expected.put("Sample2", Paths.get("file2"));
         expected.put("Sample3", Paths.get("file3"));
-        final LinkedHashMap<String, Path> actual = GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath());
+        final SortedMap<String, Path> actual = GenomicsDBImport.loadSampleNameMapFile(sampleFile.toPath());
         Assert.assertEquals(actual, expected);
         Assert.assertEquals(actual.keySet().iterator().next(), "Sample1");
     }


### PR DESCRIPTION
the sample swap issue seems to have been caused by the fact that the callset.json files had the sample names globally sorted
the actual data was entered in the order the sample names were input, but each bactch was sorted within the batch

this produced a mismatch between data and samplename mapping

fixing it by using sorted map everywhere sample names are handled
modifying our tests to use an out of order sample map file and multiple batches