### PR TITLE
fix bug causing error finding ref base for imprecise deletions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AnnotatedVariantProducer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/AnnotatedVariantProducer.java
@@ -119,9 +119,9 @@ public class AnnotatedVariantProducer implements Serializable {
 
     public static VariantContext produceAnnotatedVcFromEvidenceTargetLink(final EvidenceTargetLink e,
                                                                           final SvType svType,
-                                                                          final SAMSequenceDictionary sequenceDictionary,
+                                                                          final ReadMetadata metadata,
                                                                           final ReferenceMultiSource reference) {
-        final String sequenceName = sequenceDictionary.getSequence(e.getPairedStrandedIntervals().getLeft().getInterval().getContig()).getSequenceName();
+        final String sequenceName = metadata.getContigName(e.getPairedStrandedIntervals().getLeft().getInterval().getContig());
         final int start = e.getPairedStrandedIntervals().getLeft().getInterval().midpoint();
         final int end = e.getPairedStrandedIntervals().getRight().getInterval().midpoint();
         try {
@@ -212,7 +212,7 @@ public class AnnotatedVariantProducer implements Serializable {
         if (variant.getStructuralVariantType() == StructuralVariantType.DEL) {
             SVContext svc = SVContext.of(variant);
             final int padding = (metadata == null) ? defaultUncertainty : (metadata.getMaxMedianFragmentSize() / 2);
-            PairedStrandedIntervals svcIntervals = svc.getPairedStrandedIntervals(referenceSequenceDictionary, padding);
+            PairedStrandedIntervals svcIntervals = svc.getPairedStrandedIntervals(metadata, referenceSequenceDictionary, padding);
 
             final Iterator<Tuple2<PairedStrandedIntervals, EvidenceTargetLink>> overlappers = evidenceTargetLinks.overlappers(svcIntervals);
             int readPairs = 0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SimpleSVType.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.spark.sv.discovery;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.ReadMetadata;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 
@@ -128,21 +129,22 @@ public abstract class SimpleSVType extends SvType {
         }
 
         @SuppressWarnings("unchecked")
-        ImpreciseDeletion(final EvidenceTargetLink evidenceTargetLink, final SAMSequenceDictionary sequenceDictionary) {
+        ImpreciseDeletion(final EvidenceTargetLink evidenceTargetLink, final ReadMetadata metadata) {
 
-            super(getIDString(evidenceTargetLink, sequenceDictionary),
+            super(getIDString(evidenceTargetLink, metadata),
                     Allele.create(createBracketedSymbAlleleString(GATKSVVCFConstants.SYMB_ALT_ALLELE_DEL)),
                     (evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().midpoint() -
                             evidenceTargetLink.getPairedStrandedIntervals().getRight().getInterval().midpoint()),
                     Collections.EMPTY_MAP);
         }
 
-        private static String getIDString(final EvidenceTargetLink evidenceTargetLink, final SAMSequenceDictionary sequenceDictionary) {
+        private static String getIDString(final EvidenceTargetLink evidenceTargetLink, final ReadMetadata metadata) {
 
             return TYPES.DEL.name()
                     + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
                     + GATKSVVCFConstants.IMPRECISE + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
-                    + sequenceDictionary.getSequence(evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getContig()).getSequenceName() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                    + metadata.getContigName(evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getContig())
+                    + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
                     + evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
                     + evidenceTargetLink.getPairedStrandedIntervals().getLeft().getInterval().getEnd() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR
                     + evidenceTargetLink.getPairedStrandedIntervals().getRight().getInterval().getStart() + GATKSVVCFConstants.INTERVAL_VARIANT_ID_FIELD_SEPARATOR

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContext.java
@@ -306,18 +306,18 @@ public final class SVContext extends VariantContext {
 
     }
 
-    public PairedStrandedIntervals getPairedStrandedIntervals(final SAMSequenceDictionary samSequenceDictionary, final int padding) {
+    public PairedStrandedIntervals getPairedStrandedIntervals(final ReadMetadata metadata, final SAMSequenceDictionary referenceSequenceDictionary, final int padding) {
         final StructuralVariantType type = getStructuralVariantType();
         if (type == StructuralVariantType.DEL) {
-            final List<SimpleInterval> breakPointIntervals = getBreakPointIntervals(padding, samSequenceDictionary, true);
+            final List<SimpleInterval> breakPointIntervals = getBreakPointIntervals(padding, referenceSequenceDictionary, true);
             final SimpleInterval leftBreakpointSimpleInterval = breakPointIntervals.get(0);
             final SVInterval leftBreakpointInterval = new SVInterval(
-                    samSequenceDictionary.getSequenceIndex(leftBreakpointSimpleInterval.getContig()),
+                    metadata.getContigID(leftBreakpointSimpleInterval.getContig()),
                     leftBreakpointSimpleInterval.getStart(),
                     leftBreakpointSimpleInterval.getEnd() + 1);
             final SimpleInterval rightBreakpointSimpleInterval = breakPointIntervals.get(1);
             final SVInterval rightBreakpointInterval = new SVInterval(
-                    samSequenceDictionary.getSequenceIndex(rightBreakpointSimpleInterval.getContig()),
+                    metadata.getContigID(rightBreakpointSimpleInterval.getContig()),
                     rightBreakpointSimpleInterval.getStart(),
                     rightBreakpointSimpleInterval.getEnd() + 1);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest.java
@@ -126,7 +126,7 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkUnitTest extends BaseTe
 
         ReadMetadata metadata = Mockito.mock(ReadMetadata.class);
         when(metadata.getMaxMedianFragmentSize()).thenReturn(300);
-
+        when(metadata.getContigName(0)).thenReturn("20");
 
         PairedStrandedIntervalTree<EvidenceTargetLink> evidenceTree = new PairedStrandedIntervalTree<>();
         etls.forEach(e -> evidenceTree.put(e.getPairedStrandedIntervals(), e));


### PR DESCRIPTION
This PR fixes a critical error that was causing an "invalid interval" exception to be thrown while calling imprecise deletion intervals. The problem was a mismatch between the sequence dictionary in the reference and the read metadata's contig ID - contig name mapping. I've modified the code to always use the read metadata when translating the contig ID in `EvidenceTargetLink` intervals into contig names.