### PR TITLE
removing required FASTA reference input in SV discovery pipeline

### DIFF
--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -8,7 +8,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "  [2] cluster name (required)"
     echo -e "  [3] absolute path to the output directory on the cluster (HDFS,required)"
     echo -e "  [4] absolute path to the BAM on the cluster (index assumed accompanying the bam) (HDFS,required)"
-    echo -e "  [5] absolute path to the reference fasta on the cluster (2bit is assumed accompanying with same basename and extension \".2bit\", skiplist with extension \".kill.intervals\") (HDFS,required)"
+    echo -e "  [5] absolute path to the 2 bit reference on the cluster (skip list is assumed accompanying with same basename and extension \".kill.intervals\") (HDFS,required)"
     echo -e "  [6] absolute path to the reference index image on each worker node's local file system (required)"
     echo -e "  [*] extra command-line arguments to StructuralVariationDiscoveryPipelineSpark"
     echo -e "Example:"
@@ -17,7 +17,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "      my-test-cluster \\"
     echo -e "      /test-sample \\"
     echo -e "      /data/NA12878_test.bam \\"
-    echo -e "      /reference/Homo_sapiens_assembly38.fasta"
+    echo -e "      /reference/Homo_sapiens_assembly38.2bit"
     echo -e "      /mnt/1/reference/Homo_sapiens_assembly38.fasta.img (the /mnt/1/ prefix is the default mounting location of the ssd if the cluster is created with a local ssd for the worker nodes)"
     exit 1
 fi
@@ -28,12 +28,11 @@ CLUSTER_NAME="$2"
 MASTER_NODE="hdfs://${CLUSTER_NAME}-m:8020"
 PROJECT_OUTPUT_DIR="${MASTER_NODE}$3"
 INPUT_BAM="${MASTER_NODE}$4"
-REF_FASTA="${MASTER_NODE}$5"
+REF_TWOBIT="${MASTER_NODE}$5"
 REF_INDEX_IMAGE="$6"
-INTERVAL_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.intervals/')
-KMER_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.kmers/')
-ALTS_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.alts/')
-REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
+INTERVAL_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.intervals/')
+KMER_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.kmers/')
+ALTS_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.alts/')
 
 # extract any extra arguments to StructuralVariationDiscoveryPipelineSpark
 shift $(($# < 6 ? $# : 6))
@@ -57,7 +56,6 @@ NUM_EXECUTORS=$((2 * ${NUM_WORKERS}))
     -I "${INPUT_BAM}" \
     -O "${PROJECT_OUTPUT_DIR}/variants/inv_del_ins.vcf" \
     -R "${REF_TWOBIT}" \
-    --fastaReference "${REF_FASTA}" \
     --alignerIndexImage "${REF_INDEX_IMAGE}" \
     --exclusionIntervals "${INTERVAL_KILL_LIST}" \
     --kmersToIgnore "${KMER_KILL_LIST}" \

--- a/scripts/sv/stepByStep/discoverVariants.sh
+++ b/scripts/sv/stepByStep/discoverVariants.sh
@@ -6,7 +6,7 @@ if [[ "$#" -ne 4 ]]; then
     echo -e "  [1] local directory of GATK build (required)"
     echo -e "  [2] cluster name (required)"
     echo -e "  [3] absolute path to the output directory on the cluster (HDFS,required)"
-    echo -e "  [4] absolute path to the reference fasta on the cluster (2bit is assumed accompanying with same basename and extension \".2bit\") (HDFS,required)"
+    echo -e "  [4] absolute path to the 2 bit reference on the cluster (HDFS,required)"
 
     exit 1
 fi
@@ -15,14 +15,12 @@ GATK_DIR="$1"
 CLUSTER_NAME="$2"
 MASTER_NODE="hdfs://${CLUSTER_NAME}-m:8020"
 PROJECT_OUTPUT_DIR="${MASTER_NODE}$3"
-REF_FASTA="${MASTER_NODE}$4"
-REF_TWOBIT=$(echo "${REF_FASTA}" | sed 's/.fasta$/.2bit/')
+REF_TWOBIT="${MASTER_NODE}$4"
 
 "${GATK_DIR}/gatk-launch" DiscoverVariantsFromContigAlignmentsSAMSpark \
     -I "${PROJECT_OUTPUT_DIR}/assemblies.sam" \
     -O "${PROJECT_OUTPUT_DIR}/variants/inv_del_ins.vcf" \
     -R "${REF_TWOBIT}" \
-    --fastaReference "${REF_FASTA}" \
     -- \
     --sparkRunner GCS \
     --cluster "${CLUSTER_NAME}" \

--- a/scripts/sv/stepByStep/scanBam.sh
+++ b/scripts/sv/stepByStep/scanBam.sh
@@ -8,7 +8,7 @@ if [[ "$#" -ne 6 ]]; then
     echo -e "  [2] cluster name (required)"
     echo -e "  [3] absolute path to the output directory on the cluster (required)"
     echo -e "  [4] absolute path to the BAM on the cluster (index assumed accompanying the bam) (required)"
-    echo -e "  [5] absolute path to the reference fasta on the cluster (required)"
+    echo -e "  [5] absolute path to the 2bit reference on the cluster (required)"
     echo -e "  [6] absolute path to the reference index image on each worker (required)"
     exit 1
 fi
@@ -18,11 +18,11 @@ CLUSTER_NAME="$2"
 MASTER_NODE="hdfs://${CLUSTER_NAME}-m:8020"
 PROJECT_OUTPUT_DIR="${MASTER_NODE}$3"
 INPUT_BAM="${MASTER_NODE}$4"
-REF_FASTA="${MASTER_NODE}$5"
+REF_TWOBIT="${MASTER_NODE}$5"
 REF_INDEX_IMAGE="$6"
-INTERVAL_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.intervals/')
-KMER_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.kmers/')
-ALTS_KILL_LIST=$(echo "${REF_FASTA}" | sed 's/.fasta$/.kill.alts/')
+INTERVAL_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.intervals/')
+KMER_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.kmers/')
+ALTS_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.alts/')
 
 "${GATK_DIR}/gatk-launch" FindBreakpointEvidenceSpark \
     -I "${INPUT_BAM}" \

--- a/scripts/sv/stepByStep/svDiscover.sh
+++ b/scripts/sv/stepByStep/svDiscover.sh
@@ -8,7 +8,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "  [2] cluster name (required)"
     echo -e "  [3] absolute path to the output directory on the cluster (HDFS,required)"
     echo -e "  [4] absolute path to the BAM on the cluster (index assumed accompanying the bam) (HDFS,required)"
-    echo -e "  [5] absolute path to the reference fasta on the cluster (2bit is assumed accompanying with same basename and extension \".2bit\", skiplist with extension \".kill.intervals\") (HDFS,required)"
+    echo -e "  [5] absolute path to the 2 bit reference on the cluster (skip list is assumed accompanying with same basename and extension \".kill.intervals\") (HDFS,required)"
     echo -e "  [6] absolute path to the reference index image on each worker node's local file system (required)"
     echo -e "Example:"
     echo -e " bash svDiscover.sh \\"
@@ -16,7 +16,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "      my-test-cluster \\"
     echo -e "      /test-sample \\"
     echo -e "      /data/NA12878_test.bam \\"
-    echo -e "      /reference/Homo_sapiens_assembly38.fasta"
+    echo -e "      /reference/Homo_sapiens_assembly38.2bit"
     echo -e "      /reference/Homo_sapiens_assembly38.fasta.img"
     exit 1
 fi

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -178,13 +178,6 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         public static final int DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY = 100;
         public static final int DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD = 7;
 
-        // todo: document this better
-        // Currently the discovery stage requires a reference parameter in 2bit format (to broadcast) and
-        // a reference in FASTA format (to get a good sequence dictionary for sorting variants).
-        @Argument(doc = "FASTA formatted reference", shortName = "fastaReference",
-                fullName = "fastaReference")
-        public String fastaReference;
-
         @Argument(doc = "Minimum flanking alignment length", shortName = "minAlignLength",
                 fullName = "minAlignLength", optional = true)
         public Integer minAlignLength = DEFAULT_MIN_ALIGNMENT_LENGTH;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/InsDelVariantDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/InsDelVariantDetector.java
@@ -1,13 +1,12 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
-import org.broadinstitute.hellbender.engine.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
@@ -25,7 +24,7 @@ final class InsDelVariantDetector implements VariantDetectorFromLocalAssemblyCon
 
     @Override
     public void inferSvAndWriteVCF(final JavaRDD<AlignedContig> localAssemblyContigs, final String vcfOutputFileName,
-                                   final Broadcast<ReferenceMultiSource> broadcastReference, final String fastaReference,
+                                   final Broadcast<ReferenceMultiSource> broadcastReference, final SAMSequenceDictionary refSequenceDictionary,
                                    final Logger toolLogger){
 
         final JavaPairRDD<byte[], List<ChimericAlignment>> chimericAlignments =
@@ -43,10 +42,7 @@ final class InsDelVariantDetector implements VariantDetectorFromLocalAssemblyCon
                         .map(noveltyTypeAndEvidence -> DiscoverVariantsFromContigAlignmentsSAMSpark.annotateVariant(noveltyTypeAndEvidence._1,
                                 noveltyTypeAndEvidence._2._1, null, noveltyTypeAndEvidence._2._2, broadcastReference));
 
-
-        final PipelineOptions pipelineOptions = null;
-        SVVCFWriter.writeVCF(annotatedVariants.collect(), vcfOutputFileName, new ReferenceMultiSource(pipelineOptions, fastaReference,
-                ReferenceWindowFunctions.IDENTITY_FUNCTION).getReferenceSequenceDictionary(null), toolLogger);
+        SVVCFWriter.writeVCF(annotatedVariants.collect(), vcfOutputFileName, refSequenceDictionary, toolLogger);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/VariantDetectorFromLocalAssemblyContigAlignments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/VariantDetectorFromLocalAssemblyContigAlignments.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
 
+import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.broadcast.Broadcast;
@@ -12,7 +13,8 @@ import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
  */
 interface VariantDetectorFromLocalAssemblyContigAlignments {
 
+    // TODO: 10/6/17 requires a ReferenceMultiSource and SAMSequenceDictionary at the same time because the 2bit reference gives a scrambled reference contig order (see #2037)
     void inferSvAndWriteVCF(final JavaRDD<AlignedContig> localAssemblyContigs, final String vcfOutputFileName,
-                            final Broadcast<ReferenceMultiSource> broadcastReference, final String fastaReference,
+                            final Broadcast<ReferenceMultiSource> broadcastReference, final SAMSequenceDictionary refSequenceDictionary,
                             final Logger toolLogger);
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
@@ -29,10 +29,6 @@ import java.util.stream.Collectors;
  */
 public class SVVCFWriter {
 
-    /**
-     * FASTA and Broadcast references are both required because 2bit Broadcast references currently order their
-     * sequence dictionaries in a scrambled order, see https://github.com/broadinstitute/gatk/issues/2037.
-     */
     public static void writeVCF(final List<VariantContext> localVariants, final String vcfFileName,
                                 final SAMSequenceDictionary referenceSequenceDictionary, final Logger logger) {
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest.java
@@ -10,7 +10,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,14 +34,13 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest extends
         String getCommandLineNoApiKey() {
             return  " -R " + SVIntegrationTestDataProvider.reference_2bit +
                     " -I " + SVIntegrationTestDataProvider.TEST_CONTIG_SAM +
-                    " -O " + outputDir + "/variants.vcf" +
-                    " --fastaReference " + SVIntegrationTestDataProvider.reference;
+                    " -O " + outputDir + "/variants.vcf";
         }
 
     }
 
     @DataProvider(name = "discoverVariantsFromContigAlignmentsSparkIntegrationTest")
-    public Object[][] createTestData() throws IOException {
+    public Object[][] createTestData() {
         List<Object[]> tests = new ArrayList<>();
         final File tempDirLeft = BaseTest.createTempDir("forLeft");
         tempDirLeft.deleteOnExit();
@@ -55,7 +53,8 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest extends
 
         final List<String> args = Arrays.asList( new ArgumentsBuilder().add(params.getCommandLineNoApiKey()).getArgsArray() );
         runCommandLine(args);
-        StructuralVariationDiscoveryPipelineSparkIntegrationTest.svDiscoveryVCFEquivalenceTest(args.get(args.indexOf("-O")+1), SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF, annotationsToIgnoreWhenComparingVariants, false);
+        StructuralVariationDiscoveryPipelineSparkIntegrationTest.svDiscoveryVCFEquivalenceTest(args.get(args.indexOf("-O")+1),
+                SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF, annotationsToIgnoreWhenComparingVariants, false);
     }
 
     @Test(dataProvider = "discoverVariantsFromContigAlignmentsSparkIntegrationTest", groups = "sv")
@@ -80,17 +79,6 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest extends
             cluster.getFileSystem().copyFromLocalFile(new Path(file.toURI()), path);
             argsToBeModified.set(idx+1, path.toUri().toString());
 
-            idx = argsToBeModified.indexOf("--fastaReference");
-            path = new Path(workingDirectory, "reference.fasta");
-            file = new File(argsToBeModified.get(idx+1));
-            cluster.getFileSystem().copyFromLocalFile(new Path(file.toURI()), path);
-            argsToBeModified.set(idx+1, path.toUri().toString());
-
-            path = new Path(workingDirectory, "reference.fasta.fai");
-            cluster.getFileSystem().copyFromLocalFile(new Path(SVIntegrationTestDataProvider.reference_fai.toURI()), path);
-            path = new Path(workingDirectory, "reference.dict");
-            cluster.getFileSystem().copyFromLocalFile(new Path(SVIntegrationTestDataProvider.reference_dict.toURI()), path);
-
             // outputs, prefix with hdfs address
             idx = argsToBeModified.indexOf("-O");
             path = new Path(workingDirectory, "variants.vcf");
@@ -98,7 +86,8 @@ public class DiscoverVariantsFromContigAlignmentsSAMSparkIntegrationTest extends
             argsToBeModified.set(idx+1, vcfOnHDFS);
 
             runCommandLine(argsToBeModified);
-            StructuralVariationDiscoveryPipelineSparkIntegrationTest.svDiscoveryVCFEquivalenceTest(vcfOnHDFS, SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF, annotationsToIgnoreWhenComparingVariants, true);
+            StructuralVariationDiscoveryPipelineSparkIntegrationTest.svDiscoveryVCFEquivalenceTest(vcfOnHDFS,
+                    SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF, annotationsToIgnoreWhenComparingVariants, true);
         });
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
@@ -49,7 +49,6 @@ public class StructuralVariationDiscoveryPipelineSparkIntegrationTest extends Co
             return  " -R " + SVIntegrationTestDataProvider.reference_2bit +
                     " -I " + bamLoc +
                     " -O " + outputDir        + "/variants.vcf" +
-                    " --fastaReference " + SVIntegrationTestDataProvider.reference +
                     " --alignerIndexImage " + alignerRefIndexImgLoc +
                     " --kmersToIgnore " + kmerIgnoreListLoc +
                     " --contigSAMFile "       + outputDir + "/assemblies.sam" +
@@ -113,22 +112,11 @@ public class StructuralVariationDiscoveryPipelineSparkIntegrationTest extends Co
             cluster.getFileSystem().copyFromLocalFile(new Path(file.toURI()), path);
             argsToBeModified.set(idx+1, path.toUri().toString());
 
-            idx = argsToBeModified.indexOf("--fastaReference");
-            path = new Path(workingDirectory, "reference.fasta");
-            file = new File(argsToBeModified.get(idx+1));
-            cluster.getFileSystem().copyFromLocalFile(new Path(file.toURI()), path);
-            argsToBeModified.set(idx+1, path.toUri().toString());
-
             idx = argsToBeModified.indexOf("--kmersToIgnore");
             path = new Path(workingDirectory, "dummy.kill.kmers");
             file = new File(argsToBeModified.get(idx+1));
             cluster.getFileSystem().copyFromLocalFile(new Path(file.toURI()), path);
             argsToBeModified.set(idx+1, path.toUri().toString());
-
-            path = new Path(workingDirectory, "reference.fasta.fai");
-            cluster.getFileSystem().copyFromLocalFile(new Path(SVIntegrationTestDataProvider.reference_fai.toURI()), path);
-            path = new Path(workingDirectory, "reference.dict");
-            cluster.getFileSystem().copyFromLocalFile(new Path(SVIntegrationTestDataProvider.reference_dict.toURI()), path);
 
             // outputs, prefix with hdfs address
             idx = argsToBeModified.indexOf("-O");
@@ -149,7 +137,8 @@ public class StructuralVariationDiscoveryPipelineSparkIntegrationTest extends Co
             argsToBeModified.set(idx+1, path.toUri().toString());
 
             runCommandLine(argsToBeModified);
-            svDiscoveryVCFEquivalenceTest(vcfOnHDFS, SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF, annotationsToIgnoreWhenComparingVariants, true);
+            svDiscoveryVCFEquivalenceTest(vcfOnHDFS, SVIntegrationTestDataProvider.EXPECTED_SIMPLE_DEL_VCF,
+                    annotationsToIgnoreWhenComparingVariants, true);
         });
     }
 


### PR DESCRIPTION
(for its dict) for sorting variants in output VCF, now using header in input SAM/BAM