### PR TITLE
Dump more evidence info for SV pipeline debugging

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -110,6 +110,9 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         @Argument(doc = "directory for evidence output", fullName = "breakpointEvidenceDir", optional = true)
         public String evidenceDir;
 
+        @Argument(doc = "directory for evidence output", fullName = "unfilteredBreakpointEvidenceDir", optional = true)
+        public String unfilteredEvidenceDir;
+
         @Argument(doc = "file for breakpoint intervals output", fullName = "breakpointIntervals", optional = true)
         public String intervalFile;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSpark.java
@@ -805,6 +805,12 @@ public final class FindBreakpointEvidenceSpark extends GATKSparkTool {
                 }, true);
         evidenceRDD.cache();
 
+        // record the evidence
+        if ( params.unfilteredEvidenceDir != null ) {
+            evidenceRDD.map(e -> e.stringRep(broadcastMetadata.getValue(), filter.getMinEvidenceMapQ()))
+                       .saveAsTextFile(params.unfilteredEvidenceDir);
+        }
+
         final JavaRDD<EvidenceTargetLink> evidenceTargetLinkJavaRDD = evidenceRDD.mapPartitions(
                 itr -> {
                     final ReadMetadata readMetadata = broadcastMetadata.getValue();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadMetadata.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadMetadata.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A bag of data about reads:  contig name to id mapping, fragment length statistics by read group, mean length.
@@ -328,6 +330,14 @@ public class ReadMetadata {
                 final PartitionBounds bounds = partitionBounds[idx];
                 writer.write(idx + "\t" + bounds.firstContigID + "\t" + bounds.getFirstStart() + "\t" +
                         bounds.getLastContigID() + "\t" + bounds.getLastStart() + "\n");
+            }
+            writer.write("contigs map:\n");
+            try {
+                for (int i = 0; i < readMetadata.contigIDToName.length; ++i) {
+                    writer.write(i + ":" + readMetadata.contigIDToName[i] + "\n");
+                }
+            } catch (IOException ex) {
+                throw new GATKException("Can't write metadata contig entry", ex);
             }
         } catch ( final IOException ioe ) {
             throw new GATKException("Can't write metadata file.", ioe);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/BreakpointDensityFilterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/BreakpointDensityFilterTest.java
@@ -238,6 +238,7 @@ public class BreakpointDensityFilterTest extends BaseTest {
 
     private BreakpointEvidence.ReadEvidence makeEvidence( final int start ) {
         return new BreakpointEvidence.ReadEvidence(new SVInterval(0,start,start+100),1,
-                "Test", TemplateFragmentOrdinal.UNPAIRED,false, true);
+                "Test", TemplateFragmentOrdinal.UNPAIRED,false, true,
+                "151M", 60);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/BreakpointEvidenceTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/BreakpointEvidenceTest.java
@@ -36,7 +36,8 @@ public class BreakpointEvidenceTest extends BaseTest {
         read.setIsPaired(false);
         read.setIsReverseStrand(false);
         read.setReadGroup(groupName);
-        final BreakpointEvidence.ReadEvidence evidence1 = new BreakpointEvidence.ReadEvidence(read, readMetadata);
+        final int readWeight = 1;
+        final BreakpointEvidence.ReadEvidence evidence1 = new BreakpointEvidence.ReadEvidence(read, readMetadata, readWeight);
 
         final int evidenceWidth = readMetadata.getFragmentLengthStatistics(groupName).getMaxNonOutlierFragmentSize() - readSize;
         final int uncertainty = evidenceWidth /2;
@@ -48,14 +49,14 @@ public class BreakpointEvidenceTest extends BaseTest {
         Assert.assertEquals(evidence1.getFragmentOrdinal(), TemplateFragmentOrdinal.UNPAIRED);
 
         read.setIsReverseStrand(true);
-        final BreakpointEvidence evidence2 = new BreakpointEvidence.ReadEvidence(read, readMetadata);
+        final BreakpointEvidence evidence2 = new BreakpointEvidence.ReadEvidence(read, readMetadata, readWeight);
 
         final int evidenceLocus2 = read.getStart() - 1 - uncertainty;
         Assert.assertEquals(evidence2.getLocation(), new SVInterval(0,evidenceLocus2-uncertainty,evidenceLocus2+ uncertainty + (evidenceWidth % 2 == 0 ? 0 : 1)));
         Assert.assertEquals(evidence2.getLocation().getLength(), 2*uncertainty + (evidenceWidth % 2 == 0 ? 0 : 1));
 
         read.setAttribute("MD", "149AT");
-        final BreakpointEvidence evidence3 = new BreakpointEvidence.ReadEvidence(read, readMetadata);
+        final BreakpointEvidence evidence3 = new BreakpointEvidence.ReadEvidence(read, readMetadata, readWeight);
         Assert.assertEquals(evidence2.getLocation().getStart(), evidence3.getLocation().getStart());
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadMetadataTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadMetadataTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +30,8 @@ public class ReadMetadataTest extends BaseTest {
         final Set<Integer> crossContigIgnoreSet = new HashSet<>(3);
         crossContigIgnoreSet.add(1);
         final ReadMetadata readMetadata =
-                new ReadMetadata(crossContigIgnoreSet, header, LIBRARY_STATISTICS, null, 1L, 1L, 1);
+                new ReadMetadata(crossContigIgnoreSet, header, LIBRARY_STATISTICS, new ReadMetadata.PartitionBounds[0],
+                                1L, 1L, 1);
         Assert.assertEquals(readMetadata.getContigID(chr1Name), 0);
         Assert.assertEquals(readMetadata.getContigID(chr2Name), 1);
         Assert.assertFalse(readMetadata.ignoreCrossContigID(0));
@@ -38,6 +40,9 @@ public class ReadMetadataTest extends BaseTest {
         Assert.assertEquals(readMetadata.getLibraryStatistics(readMetadata.getLibraryName(groupName)),
                 LIBRARY_STATISTICS);
         Assert.assertThrows(() -> readMetadata.getLibraryName("not a real name"));
+
+        final File metadataFile = BaseTest.createTempFile("metadata", "");
+        ReadMetadata.writeMetadata(readMetadata, metadataFile.toString());
     }
 
     @Test(groups = "sv")


### PR DESCRIPTION
* Added new option --unfilteredBreakpointEvidenceDir
When set, this option dumps all evidence (even evidence that is
ultimately rejected) in an easy to parse text format. Some additional
info (cigarString, mappingQuality) is stored in ReadEvidence to output
information related to read quality.
* Updated option --readMetadata
When set, will additionaly output the map from contig number to contig
name. Added non-null ParitionBounds to readMetadata in
ReadMetadataTest::testEverything to prevent crash.