### PR TITLE
Add omitFromCommandLine=true for example tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalker.java
@@ -23,7 +23,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Example AssemblyRegionWalker that prints out the bounds of each assembly region with and without padding, as well as the number of reads in each region",
         oneLineSummary = "Example AssemblyRegionWalker",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleAssemblyRegionWalker extends AssemblyRegionWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSpark.java
@@ -25,7 +25,8 @@ import java.io.Serializable;
 @CommandLineProgramProperties(
         summary = "Example AssemblyRegionWalker that prints out the bounds of each assembly region with and without padding, as well as the number of reads in each region",
         oneLineSummary = "Example AssemblyRegionWalker",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleAssemblyRegionWalkerSpark extends AssemblyRegionWalkerSpark {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleFeatureWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleFeatureWalker.java
@@ -22,7 +22,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Example tool that prints features supplied to the specified output file (stdout if none provided), along with overlapping reads/reference bases/variants (if provided)",
         oneLineSummary = "Example tool that prints features with optional contextual data",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleFeatureWalker extends FeatureWalker<BEDFeature> {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalker.java
@@ -23,7 +23,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Example tool that prints intervals supplied via -L to the specified output file (stdout if none provided), along with overlapping reads/reference bases/variants (if provided)",
         oneLineSummary = "Print intervals with optional contextual data",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleIntervalWalker extends IntervalWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleIntervalWalkerSpark.java
@@ -26,7 +26,8 @@ import java.util.List;
 @CommandLineProgramProperties(
         summary = "Example tool that prints intervals supplied via -L to the specified output file (stdout if none provided), along with overlapping reads/reference bases/variants (if provided)",
         oneLineSummary = "Print intervals with optional contextual data",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleIntervalWalkerSpark extends IntervalWalkerSpark {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleLocusWalker.java
@@ -23,7 +23,8 @@ import java.util.List;
 @CommandLineProgramProperties(
     summary = "Example tool that prints locus-based coverage from supplied read to the specified output file (stdout if none provided), along with overlapping reference bases/features (if provided)",
     oneLineSummary = "Example tool that prints locus-based coverage with optional contextual data",
-    programGroup = ExampleProgramGroup.class
+    programGroup = ExampleProgramGroup.class,
+    omitFromCommandLine = true
 )
 public class ExampleLocusWalker extends LocusWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleNioCountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleNioCountReads.java
@@ -19,7 +19,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
     summary = "Example of how to use Spark on Google Cloud Storage directly, without using the GCS Hadoop Connector",
     oneLineSummary = "Example of how to use Spark on Google Cloud Storage directly, without using the GCS Hadoop Connector",
-    programGroup = ExampleProgramGroup.class
+    programGroup = ExampleProgramGroup.class,
+    omitFromCommandLine = true
 )
 public class ExampleNioCountReads extends SparkCommandLineProgram {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExamplePostTraversalPythonExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExamplePostTraversalPythonExecutor.java
@@ -28,7 +28,8 @@ import java.util.Arrays;
 @CommandLineProgramProperties(
         summary = "Example/toy program that uses a Python script.",
         oneLineSummary = "Example/toy program that uses a Python script.",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public class ExamplePostTraversalPythonExecutor extends ReadWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReference.java
@@ -21,7 +21,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Prints reads from the provided file(s) with corresponding reference bases (if a reference is provided) to the specified output file (or STDOUT if none specified)",
         oneLineSummary = "Print reads with reference context",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleReadWalkerWithReference extends ReadWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithReferenceSpark.java
@@ -19,7 +19,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 @CommandLineProgramProperties(
         summary = "Prints reads from the provided file(s) with corresponding reference bases (if a reference is provided) to the specified output file (or STDOUT if none specified)",
         oneLineSummary = "Print reads with reference context",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleReadWalkerWithReferenceSpark extends ReadWalkerSpark {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleReadWalkerWithVariants.java
@@ -24,7 +24,8 @@ import java.util.List;
 @CommandLineProgramProperties(
         summary = "Prints reads from the provided file(s) along with overlapping variants (if a source of variants is provided) to the specified output file (or STDOUT if none specified)",
         oneLineSummary = "Print reads with overlapping variants",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleReadWalkerWithVariants extends ReadWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalker.java
@@ -20,7 +20,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Example tool that prints variants supplied to the specified output file (stdout if none provided), along with overlapping reads/reference bases/variants (if provided)",
         oneLineSummary = "Example tool that prints variants with optional contextual data",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleVariantWalker extends VariantWalker {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleVariantWalkerSpark.java
@@ -22,7 +22,8 @@ import java.io.PrintStream;
 @CommandLineProgramProperties(
         summary = "Example tool that prints variants supplied to the specified output file (stdout if none provided), along with overlapping reads/reference bases/variants (if provided)",
         oneLineSummary = "Example tool that prints variants with optional contextual data",
-        programGroup = ExampleProgramGroup.class
+        programGroup = ExampleProgramGroup.class,
+        omitFromCommandLine = true
 )
 public final class ExampleVariantWalkerSpark extends VariantWalkerSpark {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleCollectMultiMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/multi/ExampleCollectMultiMetricsSpark.java
@@ -33,7 +33,8 @@ import java.util.List;
 @CommandLineProgramProperties(
         summary        = "Program to collect example multi-level metrics in SAM/BAM/CRAM file(s)",
         oneLineSummary = "Collect example multi-level metrics on Spark",
-        programGroup   = ExampleProgramGroup.class)
+        programGroup   = ExampleProgramGroup.class,
+        omitFromCommandLine = true)
 public final class ExampleCollectMultiMetricsSpark
         extends MetricsCollectorSparkTool<ExampleMultiMetricsArgumentCollection> {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleCollectSingleMetricsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/metrics/single/ExampleCollectSingleMetricsSpark.java
@@ -31,7 +31,8 @@ import java.util.List;
 @CommandLineProgramProperties(
         summary        = "Program to collect example single-level metrics in SAM/BAM/CRAM file(s)",
         oneLineSummary = "Collect example single-level metrics on Spark",
-        programGroup   = ExampleProgramGroup.class)
+        programGroup   = ExampleProgramGroup.class,
+        omitFromCommandLine = true)
 public final class ExampleCollectSingleMetricsSpark
         extends MetricsCollectorSparkTool<ExampleSingleMetricsArgumentCollection> {
 


### PR DESCRIPTION
Example tools are not documented features, and are provided for being examples for developers to build their own traversals and for testing purposes. Thus, it is unnecessary to show them in the command line help, which already contains a huge list of tools (GATK, Picard, etc).

Although they can still be run from the command line if you know its existence, they won't be shown after #3486.