### PR TITLE
Turn off verbose for gatkDoc/gatkTabComplete tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -511,7 +511,6 @@ task gatkDoc(type: Javadoc, dependsOn: classes) {
     }
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
-    options.addStringOption("verbose")
 }
 
 // Generate GATK Bash Tab Completion File
@@ -563,8 +562,6 @@ task gatkTabComplete(type: Javadoc, dependsOn: classes) {
     options.addStringOption("caller-post-alias-args", "")
     options.addStringOption("caller-post-arg-min-occurs", "0 0 0 0 0 0 0 0 0 0")
     options.addStringOption("caller-post-arg-max-occurs", "1 1 1 1 1 1 1 1 1 1")
-
-    options.addStringOption("verbose", "-verbose")
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/3710. This change suppresses about 600k of output from the gatkTabComplete task, which should allow the nightly cron job to complete. Note that the gatkDoc task was also setting verbose, but it didn't actually result in verbose output due to https://github.com/gradle/gradle/issues/2354.