### PR TITLE
Turn off verbose for gatkDoc/gatkTabComplete tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -511,7 +511,6 @@ task gatkDoc(type: Javadoc, dependsOn: classes) {
     }
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
-    options.addStringOption("verbose")
 }
 
 // Generate GATK Bash Tab Completion File
@@ -563,8 +562,6 @@ task gatkTabComplete(type: Javadoc, dependsOn: classes) {
     options.addStringOption("caller-post-alias-args", "")
     options.addStringOption("caller-post-arg-min-occurs", "0 0 0 0 0 0 0 0 0 0")
     options.addStringOption("caller-post-arg-max-occurs", "1 1 1 1 1 1 1 1 1 1")
-
-    options.addStringOption("verbose", "-verbose")
 }
 
 /**


### PR DESCRIPTION
This change suppresses about 600k of output from the gatkTabComplete task, which should fix #3710 and allow the nightly cron job to complete. Note that this doesn't actually suppress the excessive "backtrace" messages we're seeing with the addition of Picard tools when running javadoc using openjdk (see the note in #3710), which we'll need to do separately in Barclay.

To test this change, I added a temporary travis matrix entry that runs the target that is causing the cron job to fail (./gradlew bundle). That branch [fails](https://travis-ci.org/broadinstitute/gatk/builds/289636845) the same way as the cron job does without this change, and [succeeds](https://travis-ci.org/broadinstitute/gatk/builds/289569595) with it. But that doesn't guaranty that the cron job will succeed, since cron job does other things (like upload).

Finally, note that the gatkDoc gradle task was also setting the verbose flag, but it didn't actually result in verbose output due to gradle/gradle#2354, so I removed that call in this PR as well.
