### PR TITLE
Upgrade Picard to 2.14.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
 }
 
 final htsjdkVersion = System.getProperty('htsjdk.version','2.12.0')
-final picardVersion = System.getProperty('picard.version','2.12.2')
+final picardVersion = System.getProperty('picard.version','2.14.0')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.7.0-proto-3.0.0-beta-1')


### PR DESCRIPTION
Picks up https://github.com/broadinstitute/picard/pull/875, which was a backport from GATK.