### PR TITLE
specifying com.github.fommil native dependencies explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,8 +216,11 @@ dependencies {
     compile('org.objenesis:objenesis:1.2')
     testCompile('org.objenesis:objenesis:2.1')
 
-    // Comment the next line to disable native code proxies in Spark MLLib
-    compile('com.github.fommil.netlib:all:1.1.2')
+    // Comment the next lines to disable native code proxies in Spark MLLib
+    compile('com.github.fommil.netlib:netlib-native_ref-osx-x86_64:1.1:natives')
+    compile('com.github.fommil.netlib:netlib-native_ref-linux-x86_64:1.1:natives')
+    compile('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1:natives')
+    compile('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1:natives')
 
     // Dependency change for including MLLib
     compile('com.esotericsoftware:kryo:3.0.3'){


### PR DESCRIPTION
previously we dependend on com.github.fommil.netlib:netlib:all which is a pom only dependency that includes a number of jars containing native code

this caused problems when importing GATK using maven, see #3724

to fix this, I've added the exact versions of the transitive dependencies that we want
an added bonus is that it means we are no longer including  native code for systems we don't support, like arm, 32 bit systems, and windows