### PR TITLE
Fixing an ASCII warning.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMerger.java
@@ -508,7 +508,7 @@ public final class ReferenceConfidenceVariantContextMerger {
 
         // create the index mapping, using the <NON-REF> allele whenever such a mapping doesn't exist
         for ( int i = 1; i < targetAlleles.size(); i++ ) {
-            // if there’s more than 1 DEL allele then we need to use the best one
+            // if there's more than 1 DEL allele then we need to use the best one
             if ( targetAlleles.get(i) == Allele.SPAN_DEL && g.hasPL() ) {
                 final int occurrences = Collections.frequency(remappedAlleles, Allele.SPAN_DEL);
                 if ( occurrences > 1 ) {


### PR DESCRIPTION
Noticed some compile warnings in the Travis logs, looks like a funky apostrophe is to blame?

    :compileJava/gatk/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMerger.java:511: error: unmappable character for encoding ASCII
            // if there???s more than 1 DEL allele then we need to use the best one
                       ^