### PR TITLE
google-cloud-java: switch to a snapshot that retries on 403 errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.20.4-alpha-20170727.190814-1:shaded'
+    compile 'com.google.cloud:google-cloud-nio:0.20.4-alpha-20171031.194208-5:shaded'
     compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.15'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     // this comes built-in when running on Google Dataproc, but the library

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -304,7 +304,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
 
         logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration(NIO_MAX_REOPENS).maxChannelReopens());
-        logger.info("Using google-cloud-java patch c035098b5e62cb4fe9155eff07ce88449a361f5d from https://github.com/droazen/google-cloud-java/tree/dr_all_nio_fixes");
+        logger.info("Using google-cloud-java patch 6d11bef1c81f885c26b2b56c8616b7a705171e4f from https://github.com/droazen/google-cloud-java/tree/dr_all_nio_fixes");
     }
 
     /**


### PR DESCRIPTION
We've been encountering transient 403 errors when using GCS NIO.
It seems that some GCS-related service is incorrectly returning 403 in
certain cases where we do actually have permission to access a resource.
This commit moves us to a google-cloud-java snapshot that retries upon
403 errors:

https://github.com/droazen/google-cloud-java/commit/6d11bef1c81f885c26b2b56c8616b7a705171e4f

Resolves #3735