### PR TITLE
Cpx SV PR series, part-7: Finetune multiple/chimeric alignment of a single assembly contig

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/AssemblyContigAlignmentSignatureClassifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/AssemblyContigAlignmentSignatureClassifier.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
 
-import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
@@ -10,14 +9,16 @@ import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.ChimericAlignment;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.StrandSwitch;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.RDDUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import scala.Tuple2;
 
-import java.util.EnumMap;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 final class AssemblyContigAlignmentSignatureClassifier {
+
+    public static final int ALIGNMENT_MAPQUAL_THREHOLD = 20;
+    public static final int ALIGNMENT_READSPAN_THRESHOLD = 10;
 
     enum RawTypes {
         InsDel,                 // 2 alignments, indicating ins/del, simple duplication expansion/contractions
@@ -25,158 +26,401 @@ final class AssemblyContigAlignmentSignatureClassifier {
         MappedInsertionBkpt,    // breakpoint for events involving suspected insertions where the inserted sequence could be mapped to either an 1) same-chromosome location without strand switch (tandem duplication suspect) OR 2) diff-chromosome location (MEI/dispersed dup suspect with or without strand switch)
         Cpx,                    // complex sv that seemingly have the complete event assembled
         Incomplete,             // alignment signature indicates the complete picture is not inferable from alignment signature alone
-        Ambiguous;              // assembly contig has more than 1 best alignment configuration hence painting multiple pictures
+        Ambiguous,              // assembly contig has more than 1 best alignment configuration hence painting multiple pictures
+        MisAssemblySuspect;     // suspected to be misassembly due to alignment signature that despite multiple alignments, no or only 1 good alignment
     }
 
-    @VisibleForTesting
-    static EnumMap<RawTypes, JavaRDD<AlignedContig>> classifyContigs(final JavaRDD<AlignedContig> contigs,
-                                                                     final Broadcast<SAMSequenceDictionary> broadcastSequenceDictionary,
-                                                                     final Logger toolLogger) {
-
-        final EnumMap<RawTypes, JavaRDD<AlignedContig>> contigsByRawTypes = new EnumMap<>(RawTypes.class);
-
-        // long reads with more than 1 best configurations
-        contigsByRawTypes.put(RawTypes.Ambiguous,
-                contigs.filter(tig -> tig.hasEquallyGoodAlnConfigurations));
+    static EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> classifyContigs(final JavaRDD<AlignedContig> contigs,
+                                                                                             final Broadcast<SAMSequenceDictionary> broadcastSequenceDictionary,
+                                                                                             final Logger toolLogger) {
 
         // long reads with only 1 best configuration
         final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfig =
                 contigs.filter(lr -> !lr.hasEquallyGoodAlnConfigurations).cache();
 
-        // divert away those likely suggesting cpx sv
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> twoAlignmentAndManyAlignmentTigSets =
+        // primary split between 2 vs more than 2 alignments
+        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> twoAlignmentsOrMore =
                 RDDUtils.split(contigsWithOnlyOneBestConfig, AlignedContig::hasOnly2Alignments, true);
 
-        // TODO: 10/29/17 multiple alignments decision tree return contigs with only 2 fine-tuned alignments
-        //       the implementation should send back a Tuple2 of {fine-tuned alignments going to be used for analysis, and List(string, ...) of insertion mappings}
+        // special treatment for alignments with more than 2 alignments
+        final JavaRDD<AlignedContig> moreThanTwoAlignments = twoAlignmentsOrMore._2;
+        final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> contigsByRawTypesFromMultiAlignment = new EnumMap<>(RawTypes.class);
+        final MultipleAlignmentReclassificationResults multipleAlignmentReclassificationResults =
+                reClassifyContigsWithMultipleAlignments(moreThanTwoAlignments,
+                        ALIGNMENT_MAPQUAL_THREHOLD, ALIGNMENT_READSPAN_THRESHOLD);
+        contigsByRawTypesFromMultiAlignment.put(RawTypes.MisAssemblySuspect,
+                multipleAlignmentReclassificationResults.nonInformativeContigs);
+        contigsByRawTypesFromMultiAlignment.put(RawTypes.Incomplete,
+                multipleAlignmentReclassificationResults.contigsWithMoreThanTwoGoodAlignmentsButIncompletePicture);
+        contigsByRawTypesFromMultiAlignment.put(RawTypes.Cpx,
+                multipleAlignmentReclassificationResults.contigsWithMoreThanTwoGoodAlignments);
 
-        contigsByRawTypes.put(RawTypes.Cpx, twoAlignmentAndManyAlignmentTigSets._2);
+        // merge the two sources of contigs with two alignments
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> twoAlignmentsUnion =
+                twoAlignmentsOrMore._1.map(AssemblyContigWithFineTunedAlignments::new)
+                        .union(multipleAlignmentReclassificationResults.contigsWithTwoGoodAlignments);
 
-        processContigsWithTwoAlignments(twoAlignmentAndManyAlignmentTigSets._1, contigsByRawTypes, broadcastSequenceDictionary);
+        final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> contigsByRawTypesFromTwoAlignment =
+                processContigsWithTwoAlignments(twoAlignmentsUnion, broadcastSequenceDictionary);
 
-        return contigsByRawTypes;
+        final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> result =
+                mergeMaps(contigsByRawTypesFromMultiAlignment, contigsByRawTypesFromTwoAlignment);
+
+        // TODO: 11/21/17 later we may decide to salvage ambiguous contigs with some heuristic logic, but later
+        // long reads with more than 1 best configurations, i.e. ambiguous raw types
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> ambiguous =
+                contigs.filter(tig -> tig.hasEquallyGoodAlnConfigurations).map(AssemblyContigWithFineTunedAlignments::new);
+        result.put(RawTypes.Ambiguous, ambiguous);
+
+        return result;
+    }
+
+    private static EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> mergeMaps(
+            final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> one,
+            final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> two) {
+
+        final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> result = new EnumMap<>(RawTypes.class);
+        for (final RawTypes type: RawTypes.values()) {
+            final JavaRDD<AssemblyContigWithFineTunedAlignments> first = one.get(type);
+            final JavaRDD<AssemblyContigWithFineTunedAlignments> second = two.get(type);
+
+            if (first == null) {
+                if (second != null) {
+                    result.put(type, second);
+                }
+            } else {
+                result.put(type, second == null ? first : first.union(second));
+            }
+        }
+        return result;
     }
 
     //==================================================================================================================
+    // FOR ASSEMBLY CONTIGS WITH TWO ALIGNMENTS
 
-    private static void processContigsWithTwoAlignments(final JavaRDD<AlignedContig> contigsWithOnlyOneBestConfigAnd2AI,
-                                                        final EnumMap<RawTypes, JavaRDD<AlignedContig>> contigsByRawTypes,
-                                                        final Broadcast<SAMSequenceDictionary> broadcastSequenceDictionary) {
-        // first remove overlap
-        final JavaRDD<AlignedContig> preprocessedContigs = contigsWithOnlyOneBestConfigAnd2AI.map(
-                contig -> {
+    static EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> processContigsWithTwoAlignments(
+            final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithOnlyOneBestConfigAnd2AI,
+            final Broadcast<SAMSequenceDictionary> broadcastSequenceDictionary) {
+
+        final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> contigsByRawTypes = new EnumMap<>(RawTypes.class);
+
+        // first remove overlap, if any
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> preprocessedContigs = contigsWithOnlyOneBestConfigAnd2AI.map(
+                decoratedContig -> {
+                    final AlignedContig contig = decoratedContig.contig;
+                    final AlignmentInterval one = contig.alignmentIntervals.get(0),
+                                            two = contig.alignmentIntervals.get(1);
                     final List<AlignmentInterval> deOverlappedAlignments =
-                            ContigAlignmentsModifier.removeOverlap(contig.alignmentIntervals.get(0),
-                                    contig.alignmentIntervals.get(1), broadcastSequenceDictionary.getValue());
-                    return new AlignedContig(contig.contigName, contig.contigSequence, deOverlappedAlignments,
-                            contig.hasEquallyGoodAlnConfigurations);
+                            ContigAlignmentsModifier.removeOverlap(one, two, broadcastSequenceDictionary.getValue());
+
+                    final AlignedContig contigWithDeOverlappedAlignments =
+                            new AlignedContig(contig.contigName, contig.contigSequence, deOverlappedAlignments,
+                                    contig.hasEquallyGoodAlnConfigurations);
+                    return new AssemblyContigWithFineTunedAlignments(contigWithDeOverlappedAlignments);
                 }
         );
 
         // split between the case where both alignments has unique ref span or not
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> hasFullyContainedRefSpanOrNot =
-                RDDUtils.split(preprocessedContigs, AssemblyContigAlignmentSignatureClassifier::hasIncompletePicture, false);
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> hasFullyContainedRefSpanOrNot =
+                RDDUtils.split(preprocessedContigs, AssemblyContigWithFineTunedAlignments::hasIncompletePictureFromTwoAlignments, false);
         contigsByRawTypes.put(RawTypes.Incomplete, hasFullyContainedRefSpanOrNot._1);
 
         // split between same chromosome mapping or not
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> sameChrOrNot =
-                RDDUtils.split(hasFullyContainedRefSpanOrNot._2, AssemblyContigAlignmentSignatureClassifier::isSameChromosomeMapping, false);
-        final JavaRDD<AlignedContig> diffChrBreakpoints = sameChrOrNot._2;
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> sameChrOrNot =
+                RDDUtils.split(hasFullyContainedRefSpanOrNot._2, AssemblyContigWithFineTunedAlignments::firstAndLastAlignmentMappedToSameChr, false);
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> diffChrBreakpoints = sameChrOrNot._2;
 
         // split between strand switch or not (NOTE BOTH SAME CHROMOSOME MAPPING)
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> strandSwitchOrNot =
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> strandSwitchOrNot =
                 RDDUtils.split(sameChrOrNot._1, AssemblyContigAlignmentSignatureClassifier::indicatesIntraChrStrandSwitchBkpts, false);
         contigsByRawTypes.put(RawTypes.IntraChrStrandSwitch, strandSwitchOrNot._1);
 
         // split between ref block switch or not (NOTE BOTH SAME CHROMOSOME MAPPING AND NO STRAND SWITCH)
-        final Tuple2<JavaRDD<AlignedContig>, JavaRDD<AlignedContig>> tandemDupBkptOrSimpleInsDel =
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> tandemDupBkptOrSimpleInsDel =
                 RDDUtils.split(strandSwitchOrNot._2, AssemblyContigAlignmentSignatureClassifier::indicatesIntraChrTandemDupBkpts, false);
         contigsByRawTypes.put(RawTypes.InsDel, tandemDupBkptOrSimpleInsDel._2);
 
-        final JavaRDD<AlignedContig> mappedInsertionBreakpointSuspects = diffChrBreakpoints.union(tandemDupBkptOrSimpleInsDel._1);
-        contigsByRawTypes.replace(RawTypes.MappedInsertionBkpt, mappedInsertionBreakpointSuspects);
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> mappedInsertionBreakpointSuspects = diffChrBreakpoints.union(tandemDupBkptOrSimpleInsDel._1);
+        contigsByRawTypes.put(RawTypes.MappedInsertionBkpt, mappedInsertionBreakpointSuspects);
+
+        return contigsByRawTypes;
+    }
+
+    static boolean indicatesIntraChrStrandSwitchBkpts(final AssemblyContigWithFineTunedAlignments decoratedContig) {
+        return indicatesIntraChrStrandSwitchBkpts(decoratedContig.contig);
+    }
+
+    static boolean indicatesIntraChrStrandSwitchBkpts(final AlignedContig contig) {
+
+        if (contig.alignmentIntervals.size() != 2)
+            return false;
+
+        final AlignmentInterval first = contig.alignmentIntervals.get(0);
+        final AlignmentInterval last = contig.alignmentIntervals.get(1);
+        if ( !first.referenceSpan.getContig().equals(last.referenceSpan.getContig()) )
+            return false;
+
+        return first.forwardStrand ^ last.forwardStrand;
+    }
+
+    static boolean indicatesIntraChrTandemDupBkpts(final AssemblyContigWithFineTunedAlignments decoratedContig) {
+        return indicatesIntraChrTandemDupBkpts(decoratedContig.contig);
+    }
+
+    static boolean indicatesIntraChrTandemDupBkpts(final AlignedContig contig) {
+
+        if (contig.alignmentIntervals.size() != 2)
+            return false;
+
+        final AlignmentInterval first = contig.alignmentIntervals.get(0);
+        final AlignmentInterval last = contig.alignmentIntervals.get(1);
+        if ( !first.referenceSpan.getContig().equals(last.referenceSpan.getContig()) )
+            return false;
+
+        if (first.forwardStrand != last.forwardStrand)
+            return false;
+
+        return ChimericAlignment.isLikelySimpleTranslocation(first, last, StrandSwitch.NO_SWITCH);
     }
 
     //==================================================================================================================
+    // FOR ASSEMBLY CONTIGS WITH MORE THAN TWO ALIGNMENTS
 
-    // TODO: 10/27/17 add tests for these predicates
-
-    static boolean hasIncompletePicture(final AlignedContig contigWithOnlyOneConfigAnd2Aln) {
-        return hasIncompletePictureDueToRefSpanContainment(contigWithOnlyOneConfigAnd2Aln)
-                ||
-                (isSameChromosomeMapping(contigWithOnlyOneConfigAnd2Aln) && hasIncompletePictureDueToOverlappingRefOrderSwitch(contigWithOnlyOneConfigAnd2Aln));
-    }
-
-    @VisibleForTesting
-    static boolean hasIncompletePictureDueToRefSpanContainment(final AlignedContig contigWithOnlyOneConfigAnd2Aln) {
-
-        final AlignmentInterval one = contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(0),
-                                two = contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(1);
-        return one.referenceSpan.contains(two.referenceSpan)
-                ||
-                two.referenceSpan.contains(one.referenceSpan);
-    }
-
-    @VisibleForTesting
-    static boolean hasIncompletePictureDueToOverlappingRefOrderSwitch(final AlignedContig contigWithOnlyOneConfigAnd2AlnToSameChr) {
-
-        final AlignmentInterval one = contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(0),
-                                two = contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(1);
-        final SimpleInterval referenceSpanOne = one.referenceSpan,
-                             referenceSpanTwo = two.referenceSpan;
-
-        if (referenceSpanOne.contains(referenceSpanTwo) || referenceSpanTwo.contains(referenceSpanOne))
-            return true;
-
-        // TODO: 10/29/17 this obsoletes the inverted duplication call code we have now, but those could be used to figure out how to annotate which known ref regions are invert duplicated 
-        if (one.forwardStrand != two.forwardStrand) {
-            return referenceSpanOne.overlaps(referenceSpanTwo);
-        } else {
-            if (one.forwardStrand) {
-                return referenceSpanOne.getStart() > referenceSpanTwo.getStart() &&
-                        referenceSpanOne.getStart() <= referenceSpanTwo.getEnd();
-            } else {
-                return referenceSpanTwo.getStart() > referenceSpanOne.getStart() &&
-                        referenceSpanTwo.getStart() <= referenceSpanOne.getEnd();
-            }
+    /**
+     * convenience struct holding 4 classes:
+     *      1) contigs with 2 good alignments and bad alignments encoded as strings
+     *      2) contigs with more than 2 good alignments and seemingly have picture complete as defined by
+     *          {@link AssemblyContigWithFineTunedAlignments#hasIncomePicture()}
+     *      3) contigs with more than 2 good alignments but doesn't seem to have picture complete as defined by
+     *          {@link AssemblyContigWithFineTunedAlignments#hasIncomePicture()}
+     *      4) non-informative contigs who after fine tuning has 0 or 1 good alignment left
+     */
+    static final class MultipleAlignmentReclassificationResults {
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithTwoGoodAlignments;
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithMoreThanTwoGoodAlignments;
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithMoreThanTwoGoodAlignmentsButIncompletePicture;
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> nonInformativeContigs;
+        MultipleAlignmentReclassificationResults(final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithTwoGoodAlignments,
+                                                 final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithMoreThanTwoGoodAlignments,
+                                                 final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithMoreThanTwoGoodAlignmentsButIncompletePicture,
+                                                 final JavaRDD<AssemblyContigWithFineTunedAlignments> nonInformativeContigs) {
+            this.contigsWithTwoGoodAlignments = contigsWithTwoGoodAlignments;
+            this.contigsWithMoreThanTwoGoodAlignments = contigsWithMoreThanTwoGoodAlignments;
+            this.contigsWithMoreThanTwoGoodAlignmentsButIncompletePicture = contigsWithMoreThanTwoGoodAlignmentsButIncompletePicture;
+            this.nonInformativeContigs = nonInformativeContigs;
         }
     }
 
     /**
-     * @param contigWithOnlyOneConfigAnd2Aln assumed to have only two alignments
+     * Reclassify assembly contigs based on alignment fine tuning as implemented in
+     * {@link #removeNonUniqueMappings(List, int, int)}.
      */
-    @VisibleForTesting
-    static boolean isSameChromosomeMapping(final AlignedContig contigWithOnlyOneConfigAnd2Aln) {
-        Utils.validateArg(!hasIncompletePictureDueToRefSpanContainment(contigWithOnlyOneConfigAnd2Aln),
-                "assumption that input contig has alignments whose ref span is not completely covered by the other's is violated \n" +
-                        contigWithOnlyOneConfigAnd2Aln.toString());
-        return contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(0).referenceSpan.getContig()
-                .equals(contigWithOnlyOneConfigAnd2Aln.alignmentIntervals.get(1).referenceSpan.getContig());
+    static MultipleAlignmentReclassificationResults reClassifyContigsWithMultipleAlignments(
+            final JavaRDD<AlignedContig> localAssemblyContigs,
+            final int mapQThresholdInclusive, final int uniqReadLenInclusive) {
+
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> contigsWithFineTunedAlignments =
+                localAssemblyContigs
+                        .map(tig -> {
+                            final Tuple2<List<AlignmentInterval>, List<AlignmentInterval>> goodAndBadAlignments =
+                                    removeNonUniqueMappings(tig.alignmentIntervals, mapQThresholdInclusive, uniqReadLenInclusive);
+                            final List<AlignmentInterval> goodAlignments = goodAndBadAlignments._1;
+                            final List<String> insertionMappings =
+                                    goodAndBadAlignments._2.stream().map(AlignmentInterval::toPackedString).collect(Collectors.toList());
+
+                            return
+                                    new AssemblyContigWithFineTunedAlignments(
+                                            new AlignedContig(tig.contigName, tig.contigSequence, goodAlignments,
+                                                    tig.hasEquallyGoodAlnConfigurations),
+                                            insertionMappings);
+                        });
+
+        // first take down non-informative assembly contigs
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> informativeAndNotSo =
+                RDDUtils.split(contigsWithFineTunedAlignments, AssemblyContigAlignmentSignatureClassifier::isInformative, false);
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> garbage = informativeAndNotSo._2;
+
+        // assembly contigs with 2 good alignments and bad alignments encoded as strings
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> informativeContigs = informativeAndNotSo._1;
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> split =
+                RDDUtils.split(informativeContigs, AssemblyContigAlignmentSignatureClassifier::hasOnly2GoodAlignments, false);
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> twoGoodAlignments = split._1;
+
+        // assembly contigs with more than 2 good alignments: without and with a complete picture
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> multipleAlignments = split._2;
+        final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> split1 =
+                RDDUtils.split(multipleAlignments, AssemblyContigAlignmentSignatureClassifier::hasIncompletePicture, false);
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> multipleAlignmentsIncompletePicture = split1._1;
+        final JavaRDD<AssemblyContigWithFineTunedAlignments> multipleAlignmentsCompletePicture = split1._2;
+
+        return new MultipleAlignmentReclassificationResults(twoGoodAlignments, multipleAlignmentsIncompletePicture, multipleAlignmentsCompletePicture, garbage);
+    }
+
+    // below are dummy predicates
+    private static boolean isInformative(final AssemblyContigWithFineTunedAlignments contig) {
+        return contig.isInformative();
+    }
+
+    private static boolean hasOnly2GoodAlignments(final AssemblyContigWithFineTunedAlignments contig) {
+        return contig.hasOnly2GoodAlignments();
+    }
+
+    private static boolean hasIncompletePicture(final AssemblyContigWithFineTunedAlignments contig) {
+        return contig.hasIncomePicture();
     }
 
     /**
-     * @param contigWithOnlyOneConfigAnd2AlnToSameChr assumed to have only two alignments mapped to the same chromosome
+     * Process provided {@code originalConfiguration} of an assembly contig and split between good and bad alignments.
+     * The returned pair has good alignments as its first (i.e. updated configuration),
+     * and bad ones as its second (could be used for, e.g. annotating mappings of inserted sequence).
+     *
+     * <p>
+     *     What is considered good and bad?
+     *     For a particular mapping/alignment, it may offer low uniqueness in two sense:
+     *     <ul>
+     *         <li>
+     *             low REFERENCE UNIQUENESS: meaning the sequence being mapped match multiple locations on the reference;
+     *         </li>
+     *         <li>
+     *             low READ UNIQUENESS: with only a very short part of the read uniquely explained by this particular alignment;
+     *         </li>
+     *     </ul>
+     *     Good alignments offer both high reference uniqueness and read uniqueness, as judged by the requested
+     *     {@code mapQThresholdInclusive} and {@code uniqReadLenInclusive}
+     *     (yes we are doing a hard-filtering but more advanced model is not our priority right now 2017-11-20).
+     * </p>
+     *
+     * Note that "original" is meant to be possibly different from the returned configuration,
+     * but DOES NOT mean the alignments of the contig as given by the aligner,
+     * i.e. the configuration should be one of the best given by
+     * {@link FilterLongReadAlignmentsSAMSpark#pickBestConfigurations(AlignedContig, Set, Double)}.
      */
-    @VisibleForTesting
-    static boolean indicatesIntraChrStrandSwitchBkpts(final AlignedContig contigWithOnlyOneConfigAnd2AlnToSameChr) {
-        Utils.validateArg(isSameChromosomeMapping(contigWithOnlyOneConfigAnd2AlnToSameChr),
-                "assumption that input contig's 2 alignments map to the same chr is violated. \n" +
-                        contigWithOnlyOneConfigAnd2AlnToSameChr.toString());
-        return contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(0).forwardStrand
-                ^
-                contigWithOnlyOneConfigAnd2AlnToSameChr.alignmentIntervals.get(1).forwardStrand;
+    static Tuple2<List<AlignmentInterval>, List<AlignmentInterval>> removeNonUniqueMappings(final List<AlignmentInterval> originalConfiguration,
+                                                                                            final int mapQThresholdInclusive,
+                                                                                            final int uniqReadLenInclusive) {
+        Utils.validateArg(originalConfiguration.size() > 2,
+                "assumption that input configuration to be fine tuned has more than 2 alignments is violated.\n" +
+                        originalConfiguration.stream().map(AlignmentInterval::toPackedString).collect(Collectors.toList()));
+
+        // two pass, each focusing on removing the alignments of a contig that offers low uniqueness in one sense:
+
+        // first pass is for removing alignments with low REFERENCE UNIQUENESS, using low mapping quality as the criterion
+        final List<AlignmentInterval> selectedAlignments = new ArrayList<>(originalConfiguration.size());
+        final List<AlignmentInterval> lowUniquenessMappings = new ArrayList<>(originalConfiguration.size());
+
+        for (final AlignmentInterval alignment : originalConfiguration) {
+            if (alignment.mapQual >= mapQThresholdInclusive)
+                selectedAlignments.add(alignment);
+            else
+                lowUniquenessMappings.add(alignment);
+        }
+
+        // second pass, the slower one, is to remove alignments offering low READ UNIQUENESS,
+        // i.e. with only a very short part of the read being uniquely explained by this particular alignment;
+        // the steps are:
+        //      search bi-directionally until cannot find overlap any more,
+        //      subtract the overlap from the distance covered on the contig by the alignment.
+        //      This gives unique read region it explains.
+        //      If this unique read region is "short": shorter than {@code uniqReadLenInclusive}), drop it.
+
+        // each alignment has an entry of a tuple2, one for max overlap maxFront, one for max overlap maxRear,
+        // max overlap maxFront is a tuple2 registering the index and overlap bases count
+        final Map<AlignmentInterval, Tuple2<Integer, Integer>> maxOverlapMap = getMaxOverlapPairs(selectedAlignments);
+        for(Iterator<AlignmentInterval> iterator = selectedAlignments.iterator(); iterator.hasNext();) {
+            final AlignmentInterval alignment = iterator.next();
+
+            final Tuple2<Integer, Integer> maxOverlapFrontAndRear = maxOverlapMap.get(alignment);
+            final int maxOverlapFront = Math.max(0, maxOverlapFrontAndRear._1);
+            final int maxOverlapRear = Math.max(0, maxOverlapFrontAndRear._2);
+
+            // theoretically this could be negative for an alignment whose maxFront and maxRear sums together bigger than the read span
+            // but earlier configuration scoring would make this impossible because such alignments should be filtered out already
+            // considering that it brings more penalty than value, i.e. read bases explained (even if the MQ is 60),
+            // but even if it is kept, a negative value won't hurt unless a stupid threshold value is passed in
+            final int uniqReadSpan = alignment.endInAssembledContig - alignment.startInAssembledContig + 1
+                                        - maxOverlapFront - maxOverlapRear;
+            if (uniqReadSpan < uniqReadLenInclusive) {
+                lowUniquenessMappings.add(alignment);
+                iterator.remove();
+            }
+        }
+
+        return new Tuple2<>(selectedAlignments, lowUniquenessMappings);
     }
 
     /**
-     * @param contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch assumed to have only two alignments mapped to the same chromosome and the same strand
+     * Each alignment in a specific configuration has an entry,
+     * pointing to the alignments that comes before and after it,
+     * that overlaps maximally (i.e. no other front or rear alignments have more overlaps)
+     * with the current alignment.
      */
-    @VisibleForTesting
-    static boolean indicatesIntraChrTandemDupBkpts(final AlignedContig contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch) {
+    private static final class TempMaxOverlapInfo {
+        final Tuple2<Integer, Integer> maxFront; // 1st holds index pointing to another alignment before this, 2nd holds the count of overlapping bases
+        final Tuple2<Integer, Integer> maxRear;  // same intention as above, but for alignments after this
 
-        final AlignmentInterval one = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(0),
-                                two = contigWithOnlyOneConfigAnd2AlnToSameChrWithoutStrandSwitch.alignmentIntervals.get(1);
-        return ChimericAlignment.isLikelySimpleTranslocation(one, two, StrandSwitch.NO_SWITCH);
+        TempMaxOverlapInfo() {
+            maxFront = new Tuple2<>(-1, -1);
+            maxRear = new Tuple2<>(-1 ,-1);
+        }
+
+        TempMaxOverlapInfo(final Tuple2<Integer, Integer> maxFront, final Tuple2<Integer, Integer> maxRear) {
+            this.maxFront = maxFront;
+            this.maxRear = maxRear;
+        }
     }
+
+    /**
+     * Extract the max overlap information, front and back, for each alignment in {@code configuration}.
+     * For each alignment, the corresponding tuple2 has the max (front, rear) overlap base counts.
+     */
+    private static Map<AlignmentInterval, Tuple2<Integer, Integer>> getMaxOverlapPairs(final List<AlignmentInterval> configuration) {
+
+        final List<TempMaxOverlapInfo> intermediateResult =
+                new ArrayList<>(Collections.nCopies(configuration.size(), new TempMaxOverlapInfo()));
+
+        // We iterate through all alignments except the last one
+        // For the last alignment, which naturally doesn't have any maxRear,
+        //     the following implementation sets its maxFront during the iteration, if available at all (it may overlap with nothing)
+        for(int i = 0; i < configuration.size() - 1; ++i) {
+
+            final AlignmentInterval cur = configuration.get(i);
+            // For the i-th alignment, we only look at alignments after it (note j starts from i+1) and find max overlap
+            int maxOverlapRearBases = -1;
+            int maxOverlapRearIndex = -1;
+            for (int j = i + 1; j < configuration.size(); ++j) { // note j > i
+                final int overlap = AlignmentInterval.overlapOnContig(cur, configuration.get(j));
+                if (overlap > maxOverlapRearBases) {
+                    maxOverlapRearBases = overlap;
+                    maxOverlapRearIndex = j;
+                } else { // following ones, as guaranteed by the ordering of alignments in the contig, cannot overlap
+                    break;
+                }
+            }
+
+            if (maxOverlapRearBases > 0){
+                // for current alignment (i-th), set its max_overlap_rear, which would not change in later iterations and copy old max_overlap_front
+                final Tuple2<Integer, Integer> maxRear = new Tuple2<>(maxOverlapRearIndex, maxOverlapRearBases);
+                final Tuple2<Integer, Integer> maxFrontToCopy = intermediateResult.get(i).maxFront;
+                intermediateResult.set(i, new TempMaxOverlapInfo(maxFrontToCopy, maxRear));
+
+                // then conditionally set the max_overlap_front of the
+                // maxOverlapRearIndex-th alignment
+                // that maximally overlaps with the current, i.e. i-th, alignment
+                final TempMaxOverlapInfo oldValue = intermediateResult.get(maxOverlapRearIndex);// maxOverlapRearIndex cannot be -1 here
+                if (oldValue.maxFront._2 < maxOverlapRearBases)
+                    intermediateResult.set(maxOverlapRearIndex, new TempMaxOverlapInfo(new Tuple2<>(i, maxOverlapRearBases), oldValue.maxRear));
+            }
+        }
+
+        final Map<AlignmentInterval, Tuple2<Integer, Integer>> maxOverlapMap = new HashMap<>(configuration.size());
+        for (int i = 0; i < configuration.size(); ++i) {
+            maxOverlapMap.put(configuration.get(i),
+                    new Tuple2<>(intermediateResult.get(i).maxFront._2, intermediateResult.get(i).maxRear._2));
+        }
+
+        return maxOverlapMap;
+    }
+
 
     //==================================================================================================================
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/AssemblyContigWithFineTunedAlignments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/prototype/AssemblyContigWithFineTunedAlignments.java
@@ -1,0 +1,207 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.prototype;
+
+import com.esotericsoftware.kryo.DefaultSerializer;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignedContig;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.AlignmentInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@DefaultSerializer(Serializer.class)
+final class AssemblyContigWithFineTunedAlignments {
+    private static final AlignedContig.Serializer contigSerializer = new AlignedContig.Serializer();
+    public static final List<String> emptyInsertionMappings = Collections.emptyList();
+
+    final AlignedContig contig;
+    final List<String> insertionMappings;
+
+    AssemblyContigWithFineTunedAlignments(final AlignedContig contig) {
+        this(contig, emptyInsertionMappings);
+    }
+
+    AssemblyContigWithFineTunedAlignments(final AlignedContig contig,
+                                          final List<String> insertionMappings) {
+        this.contig = contig;
+        this.insertionMappings = Utils.nonNull(insertionMappings);
+    }
+
+    AssemblyContigWithFineTunedAlignments(final Kryo kryo, final Input input) {
+        contig = contigSerializer.read(kryo, input, AlignedContig.class);
+        final int insertionMappingsSize = input.readInt();
+        insertionMappings = new ArrayList<>(insertionMappingsSize);
+        if (insertionMappingsSize != 0) {
+            for (int i = 0; i < insertionMappingsSize; ++i) {
+                insertionMappings.add(input.readString());
+            }
+        }
+    }
+
+    // TODO: 11/21/17 push these predicates to AlignedContig class in a later PR
+    // after fine tuning, a contig may have no good alignment left, or only 1
+    final boolean isInformative() {
+        return contig.alignmentIntervals.size() > 1;
+    }
+
+    final boolean hasOnly2GoodAlignments () {
+        return contig.alignmentIntervals.size() == 2;
+    }
+
+    final boolean hasIncomePicture() {
+        if ( hasOnly2GoodAlignments() )
+            return hasIncompletePictureFromTwoAlignments();
+        else
+            return hasIncompletePictureFromMultipleAlignments();
+    }
+
+    //==================================================================================================================
+
+    boolean hasIncompletePictureFromTwoAlignments() {
+        return hasIncompletePictureDueToRefSpanContainment()
+                ||
+                (firstAndLastAlignmentMappedToSameChr() && hasIncompletePictureDueToOverlappingRefOrderSwitch());
+    }
+
+    boolean hasIncompletePictureDueToRefSpanContainment() {
+
+        final AlignmentInterval one = contig.alignmentIntervals.get(0);
+        final AlignmentInterval two = contig.alignmentIntervals.get(1);
+        return one.referenceSpan.contains(two.referenceSpan)
+                ||
+                two.referenceSpan.contains(one.referenceSpan);
+    }
+
+    boolean hasIncompletePictureDueToOverlappingRefOrderSwitch() {
+
+        final AlignmentInterval one = contig.alignmentIntervals.get(0);
+        final AlignmentInterval two = contig.alignmentIntervals.get(1);
+        final SimpleInterval referenceSpanOne = one.referenceSpan;
+        final SimpleInterval referenceSpanTwo = two.referenceSpan;
+
+        if (referenceSpanOne.contains(referenceSpanTwo) || referenceSpanTwo.contains(referenceSpanOne))
+            return true;
+
+        // TODO: 10/29/17 this obsoletes the inverted duplication call code we have now, but those could be used to figure out how to annotate which known ref regions are invert duplicated
+        if (one.forwardStrand != two.forwardStrand) {
+            return referenceSpanOne.overlaps(referenceSpanTwo);
+        } else {
+            if (one.forwardStrand) {
+                return referenceSpanOne.getStart() > referenceSpanTwo.getStart() &&
+                        referenceSpanOne.getStart() <= referenceSpanTwo.getEnd();
+            } else {
+                return referenceSpanTwo.getStart() > referenceSpanOne.getStart() &&
+                        referenceSpanTwo.getStart() <= referenceSpanOne.getEnd();
+            }
+        }
+    }
+
+    boolean firstAndLastAlignmentMappedToSameChr() {
+        Utils.validateArg(!hasIncompletePictureDueToRefSpanContainment(),
+                "assumption that input contig has alignments whose ref span is not completely covered by the other's is violated \n" +
+                        contig.toString());
+
+        final String firstMappedChr = this.contig.alignmentIntervals.get(0).referenceSpan.getContig();
+        final String lastMappedChr  = this.contig.alignmentIntervals.get(this.contig.alignmentIntervals.size() - 1).referenceSpan.getContig();
+
+        return firstMappedChr.equals(lastMappedChr);
+    }
+
+    //==================================================================================================================
+
+    /**
+     * This predicate tests if an assembly contig has the full event (i.e. alt haplotype) assembled
+     * Of course, the grand problem of SV is always not getting the big-enough picture
+     * but here we have a more workable definition of what is definitely not big-enough:
+     *
+     * If the assembly contig, with its (picked) alignments, shows any of the following signature,
+     * it is definitely not giving the whole picture of the alt haplotype,
+     * hence without other types of evidence (or linking breakpoints, which itself needs other evidence anyway),
+     * human-friendly interpretation for them is unreliable.
+     * <ul>
+     *     <li>
+     *         head and tail alignment contain each other in terms of their reference span
+     *     </li>
+     *     <li>
+     *         head and tail alignment mapped to different chromosome
+     *     </li>
+     *     <li>
+     *         head and tail alignment mapped to different strands
+     *     </li>
+     *     <li>
+     *         head and tail alignment have reference order switch, indicating we have likely
+     *         assembled across a complicated tandem duplication breakpoint
+     *     </li>
+     *     <li>
+     *         valid region, as defined by the region bounded by the outer most boundaries of head and tail alignments,
+     *         overlaps with any of the middle alignments but does not completely contain them
+     *         (note that middle alignments completely disjoint from the valid region are OK,
+     *          they indicate remote parts of reference being duplicated and inserted between head/tail)
+     *     </li>
+     * </ul>
+     * In summary, the assembly contig should "resume the normal flow" as defined by the reference,
+     * even though we allow the flow to be interrupted in the middle.
+     * This is similar to the case where a particular mapping is unreliable without confident left and right flanking.
+     */
+    private boolean hasIncompletePictureFromMultipleAlignments() {
+        final int goodAlignmentsCount = contig.alignmentIntervals.size();
+
+        final AlignmentInterval head = contig.alignmentIntervals.get(0),
+                                tail = contig.alignmentIntervals.get(goodAlignmentsCount-1);
+
+        // mapped to different chr or strand
+        if ( !head.referenceSpan.getContig().equals(tail.referenceSpan.getContig()) || head.forwardStrand != tail.forwardStrand)
+            return true;
+
+        final SimpleInterval referenceSpanHead = head.referenceSpan,
+                             referenceSpanTail = tail.referenceSpan;
+
+        // head or tail's ref span contained in the other's
+        if (referenceSpanHead.contains(referenceSpanTail) || referenceSpanTail.contains(referenceSpanHead))
+            return true;
+
+        // middle alignments' ref span should be either 1) disjoint from valid region, or 2) completely contained in valid region
+        final SimpleInterval validRegion = new SimpleInterval(referenceSpanHead.getContig(),
+                                                              Math.min(referenceSpanHead.getStart(), referenceSpanTail.getStart()),
+                                                              Math.max(referenceSpanHead.getEnd(), referenceSpanTail.getEnd()));
+        final boolean notCompleteDupRegion =
+                contig.alignmentIntervals
+                        .subList(1, goodAlignmentsCount - 1) // take middle (no head no tail) alignments' ref span
+                        .stream().map(ai -> ai.referenceSpan)
+                        .anyMatch( middle -> middle.overlaps(validRegion) && !validRegion.contains(middle));
+        if (notCompleteDupRegion)
+            return true;
+
+        // reference order switch, indicating a complicated tandem duplication breakpoint
+        if (head.forwardStrand) {
+            return referenceSpanHead.getStart() >= referenceSpanTail.getStart();
+        } else {
+            return referenceSpanHead.getEnd() <= referenceSpanHead.getEnd();
+        }
+    }
+
+    void serialize(final Kryo kryo, final Output output) {
+        contigSerializer.write(kryo, output, contig);
+        output.writeInt(insertionMappings.size());
+        for (final String mapping : insertionMappings) {
+            output.writeString(mapping);
+        }
+    }
+
+    public static final class Serializer extends com.esotericsoftware.kryo.Serializer<AssemblyContigWithFineTunedAlignments> {
+        @Override
+        public void write(final Kryo kryo, final Output output, final AssemblyContigWithFineTunedAlignments alignedContig) {
+            alignedContig.serialize(kryo, output);
+        }
+
+        @Override
+        public AssemblyContigWithFineTunedAlignments read(final Kryo kryo, final Input input, final Class<AssemblyContigWithFineTunedAlignments> clazz) {
+            return new AssemblyContigWithFineTunedAlignments(kryo, input);
+        }
+    }
+}


### PR DESCRIPTION
for multiple alignment fine tuning for 
* sending back some contigs back to the 2 alignment logic tree, as handled by #3752 , and 
* capturing more incomplete picture assemblies, and 
* sending the assembly contig seemingly has a complete picture down the multiple alignment logic tree, which is being finalized.

To be merged after #3752 is reviewed.

Code for hooking it up exists and is minimal.