### PR TITLE
Added Utils::split (and tests).  Added performance test for string splitting.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.primitives.Ints;
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.tribble.util.ParsingUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -1143,9 +1144,9 @@ public final class Utils {
      *
      * @param str the string to split.
      * @param delimiter the delimiter used to split the string.
-     * @return an array of tokens.
+     * @return A {@link String} Array of tokens.
      */
-    public static ArrayList<String> split(final String str, final String delimiter) {
+    public static String[] split(final String str, final String delimiter) {
         // This is 10 because the ArrayList default capacity is 10 (but private).
         return split(str, delimiter, 10);
     }
@@ -1155,9 +1156,9 @@ public final class Utils {
      * @param str The {@link String} to split.
      * @param delimiter The delimiter used to split the {@link String}.
      * @param expectedNumTokens The number of tokens expected (used to initialize the capacity of the {@link ArrayList}).
-     * @return An {@link ArrayList} of tokens.
+     * @return A {@link String} Array of tokens.
      */
-    public static ArrayList<String> split(final String str, final String delimiter, final int expectedNumTokens) {
+    public static String[] split(final String str, final String delimiter, final int expectedNumTokens) {
         final ArrayList<String> result =  new ArrayList<>(expectedNumTokens);
 
         if ( str.length() == 0) {
@@ -1167,6 +1168,9 @@ public final class Utils {
             for ( int i = 0; i < str.length(); ++i ) {
                 result.add( str.substring(i, i+1) );
             }
+        }
+        else if ( delimiter.length() == 1) {
+            return ParsingUtils.split(str, delimiter.charAt(0)).toArray(new String[]{});
         }
         else {
             int delimiterIdx = -1;
@@ -1178,6 +1182,6 @@ public final class Utils {
             } while (delimiterIdx != -1);
         }
 
-        return result;
+        return result.toArray(new String[]{});
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -1137,4 +1137,47 @@ public final class Utils {
         return sorted.get(sorted.size() / 2);
     }
 
+
+    /**
+     * Splits a String using indexOf instead of regex to speed things up.
+     *
+     * @param str the string to split.
+     * @param delimiter the delimiter used to split the string.
+     * @return an array of tokens.
+     */
+    public static ArrayList<String> split(final String str, final String delimiter) {
+        // This is 10 because the ArrayList default capacity is 10 (but private).
+        return split(str, delimiter, 10);
+    }
+
+    /**
+     * Splits a given {@link String} using {@link String#indexOf} instead of regex to speed things up.
+     * @param str The {@link String} to split.
+     * @param delimiter The delimiter used to split the {@link String}.
+     * @param expectedNumTokens The number of tokens expected (used to initialize the capacity of the {@link ArrayList}).
+     * @return An {@link ArrayList} of tokens.
+     */
+    public static ArrayList<String> split(final String str, final String delimiter, final int expectedNumTokens) {
+        final ArrayList<String> result =  new ArrayList<>(expectedNumTokens);
+
+        if ( str.length() == 0) {
+            result.add("");
+        }
+        else if ( delimiter.length() == 0) {
+            for ( int i = 0; i < str.length(); ++i ) {
+                result.add( str.substring(i, i+1) );
+            }
+        }
+        else {
+            int delimiterIdx = -1;
+            do {
+                final int tokenStartIdx = delimiterIdx + 1;
+                delimiterIdx = str.indexOf(delimiter, tokenStartIdx);
+                final String token = (delimiterIdx != -1 ? str.substring(tokenStartIdx, delimiterIdx) : str.substring(tokenStartIdx));
+                result.add(token);
+            } while (delimiterIdx != -1);
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -1190,7 +1190,7 @@ public final class Utils {
      * @param expectedNumTokens The number of tokens expected (used to initialize the capacity of the {@link ArrayList}).
      * @return A {@link List} of {@link String} tokens.
      */
-    public static List<String> split(final String str, final String delimiter, final int expectedNumTokens) {
+    private static List<String> split(final String str, final String delimiter, final int expectedNumTokens) {
         final List<String> result;
 
         if ( str.isEmpty() ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -6,7 +6,6 @@ import com.google.common.primitives.Ints;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.tribble.util.ParsingUtils;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.random.RandomDataGenerator;
@@ -1160,7 +1159,7 @@ public final class Utils {
      * @return A {@link List} of {@link String} tokens.
      */
     public static List<String> split(final String str, final char delimiter) {
-        List<String> tokens = ParsingUtils.split( str, delimiter );
+        final List<String> tokens = ParsingUtils.split( str, delimiter );
 
         // We must adjust for splitting on the last character so that the results here will be the same as
         // the results of String.split:
@@ -1181,26 +1180,24 @@ public final class Utils {
      * @return A {@link List} of {@link String} tokens.
      */
     public static List<String> split(final String str, final String delimiter, final int expectedNumTokens) {
-        List<String> result =  new ArrayList<>(expectedNumTokens);
+        final List<String> result;
 
         if ( str.isEmpty() ) {
+            result = new ArrayList<>(1);
             result.add("");
         }
         else if ( delimiter.isEmpty() ) {
+            result = new ArrayList<>( str.length() );
             for ( int i = 0; i < str.length(); ++i ) {
                 result.add( str.substring(i, i+1) );
             }
         }
         else if ( delimiter.length() == 1) {
-            result = ParsingUtils.split(str, delimiter.charAt(0));
-
-            // We must adjust for splitting on the last character so that the results here will be the same as
-            // the results of String.split:
-            if ( delimiter.charAt(0) == str.charAt(str.length() - 1)) {
-                result.remove( result.size() - 1 );
-            }
+            result = split(str, delimiter.charAt(0));
         }
         else {
+            result = new ArrayList<>(expectedNumTokens);
+
             int delimiterIdx = -1;
             int tokenStartIdx = delimiterIdx + 1;
             do {

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -1141,8 +1141,36 @@ public final class Utils {
 
     /**
      * Splits a String using indexOf instead of regex to speed things up.
+     * This method produces the same results as {@link String#split(String)} and {@code String.split(String, 0)},
+     * but has been measured to be ~2x faster (see {@code StringSplitSpeedUnitTest} for details).
+     *
+     * @param str       the string to split.
+     * @param delimiter the delimiter used to split the string.
+     * @return A {@link List} of {@link String} tokens.
+     */
+    public static List<String> split(final String str, final char delimiter) {
+
+        final List<String> tokens;
+
+        if ( str.isEmpty() ) {
+            tokens = new ArrayList<>(1);
+            tokens.add("");
+        }
+        else {
+            tokens = ParsingUtils.split(str, delimiter);
+            removeTrailingEmptyStringsFromEnd(tokens);
+        }
+
+        return tokens;
+    }
+
+    /**
+     * Splits a String using indexOf instead of regex to speed things up.
      * If given an empty delimiter, will return each character in the string as a token.
-     * @param str the string to split.
+     * This method produces the same results as {@link String#split(String)} and {@code String.split(String, 0)},
+     * but has been measured to be ~2x faster (see {@code StringSplitSpeedUnitTest} for details).
+     *
+     * @param str       the string to split.
      * @param delimiter the delimiter used to split the string.
      * @return A {@link List} of {@link String} tokens.
      */
@@ -1152,30 +1180,13 @@ public final class Utils {
     }
 
     /**
-     * Splits a String using indexOf instead of regex to speed things up.
-     *
-     * @param str the string to split.
-     * @param delimiter the delimiter used to split the string.
-     * @return A {@link List} of {@link String} tokens.
-     */
-    public static List<String> split(final String str, final char delimiter) {
-        final List<String> tokens = ParsingUtils.split( str, delimiter );
-
-        // We must adjust for splitting on the last character so that the results here will be the same as
-        // the results of String.split:
-        if ( delimiter == str.charAt(str.length() - 1)) {
-            tokens.remove( tokens.size() - 1 );
-        }
-
-        return tokens;
-    }
-
-
-    /**
      * Splits a given {@link String} using {@link String#indexOf} instead of regex to speed things up.
      * If given an empty delimiter, will return each character in the string as a token.
-     * @param str The {@link String} to split.
-     * @param delimiter The delimiter used to split the {@link String}.
+     * This method produces the same results as {@link String#split(String)} and {@code String.split(String, 0)},
+     * but has been measured to be ~2x faster (see {@code StringSplitSpeedUnitTest} for details).
+     *
+     * @param str               The {@link String} to split.
+     * @param delimiter         The delimiter used to split the {@link String}.
      * @param expectedNumTokens The number of tokens expected (used to initialize the capacity of the {@link ArrayList}).
      * @return A {@link List} of {@link String} tokens.
      */
@@ -1187,12 +1198,12 @@ public final class Utils {
             result.add("");
         }
         else if ( delimiter.isEmpty() ) {
-            result = new ArrayList<>( str.length() );
+            result = new ArrayList<>(str.length());
             for ( int i = 0; i < str.length(); ++i ) {
-                result.add( str.substring(i, i+1) );
+                result.add(str.substring(i, i + 1));
             }
         }
-        else if ( delimiter.length() == 1) {
+        else if ( delimiter.length() == 1 ) {
             result = split(str, delimiter.charAt(0));
         }
         else {
@@ -1205,16 +1216,21 @@ public final class Utils {
                 final String token = (delimiterIdx != -1 ? str.substring(tokenStartIdx, delimiterIdx) : str.substring(tokenStartIdx));
                 result.add(token);
                 tokenStartIdx = delimiterIdx + delimiter.length();
-            } while (delimiterIdx != -1);
+            } while ( delimiterIdx != -1 );
 
-            // Check to see if the last entry is empty.
-            // String.split doesn't give us empty last elements of the token list, so we remove it.
-            if ( result.get(result.size() - 1).isEmpty() ) {
-                result.remove( result.size() - 1 );
-            }
-
+            removeTrailingEmptyStringsFromEnd(result);
         }
 
         return result;
+    }
+
+    private static void removeTrailingEmptyStringsFromEnd(final List<String> result) {
+        // Remove all trailing empty strings to emulate the behavior of String.split:
+        // We remove items from the end of the list to our index
+        // so that we can take advantage of better performance of removing items from the end
+        // of certain concrete lists:
+        while ( (!result.isEmpty()) && (result.get(result.size() - 1).isEmpty()) ) {
+            result.remove(result.size() - 1);
+        }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
@@ -130,19 +130,18 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
     //==================================================================================================================
 
     // Disabled so that we don't waste time.
-    // It takes 216.95812968 seconds (about 3.5 minutes) to run this test.
     // Cached results here:
-//    --------------------------------------------------------------------------------
-//    Timing Results:
-//    --------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------
+//    Overall Elapsed Time: 194969742609ns, 194969.742609ms, 3.25min
+//--------------------------------------------------------------------------------
 //    Java Split String:
-//          Words Total Time:	131867865203ns	131867.865203ms	Per Split:	6048.98464233945ns		0.00604898464233945ms
-//	        "Chars" Total Time:	12917243085ns	12917.243085ms	Per Split:	3004.010019767442ns		0.003004010019767442ms
+//    Words Total Time:	123581339505ns	123581.339505ms	Per Split:	5668.868784633028ns		0.0056688687846330275ms
+//	"Chars" Total Time:	13324148242ns	13324.148242ms	Per Split:	3098.6391260465116ns		0.0030986391260465116ms
 //    HTSJDK ParsingUtils::split
-//	        "Chars" Total Time:	5882790859ns	5882.790859ms	Per Split:	1368.0908974418605ns	0.0013680908974418606ms
+//	"Chars" Total Time:	6054845269ns	6054.845269ms	Per Split:	1408.1035509302328ns		0.0014081035509302328ms
 //    GATK Utils::split
-//          Words Total Time:	38734463275ns	38734.463275ms	Per Split:	1776.8102419724771ns	0.0017768102419724772ms
-//	        "Chars" Total Time:	7120052467ns	7120.052467ms	Per Split:	1655.826155116279ns		0.0016558261551162792ms
+//    Words Total Time:	45913524687ns	45913.524687ms	Per Split:	2106.124985642202ns		0.002106124985642202ms
+//	"Chars" Total Time:	6095292091ns	6095.292091ms	Per Split:	1417.509788604651ns		0.001417509788604651ms
 //================================================================================
     @Test(enabled = false)
     void compareTimingForSplitString() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
@@ -1,0 +1,190 @@
+package org.broadinstitute.hellbender.utils;
+
+import htsjdk.tribble.util.ParsingUtils;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A class to test the speed of different string.split implementations.
+ * Created by jonn on 11/1/17.
+ */
+public class StringSplitSpeedUnitTest extends GATKBaseTest {
+
+    private static final String stringToSplit =
+            "Arma virumque cano, Troiae qui primus ab oris " +
+            "Italiam, fato profugus, Laviniaque venit " +
+            "litora, multum ille et terris iactatus et alto " +
+            "vi superum saevae memorem Iunonis ob iram; " +
+            "multa quoque et bello passus, dum conderet urbem, " +
+            "inferretque deos Latio, genus unde Latinum, " +
+            "Albanique patres, atque altae moenia Romae.  " +
+            "Musa, mihi causas memora, quo numine laeso, " +
+            "quidve dolens, regina deum tot volvere casus " +
+            "insignem pietate virum, tot adire labores " +
+            "impulerit. Tantaene animis caelestibus irae?  " +
+            "Urbs antiqua fuit, Tyrii tenuere coloni, " +
+            "Karthago, Italiam contra Tiberinaque longe " +
+            "ostia, dives opum studiisque asperrima belli; " +
+            "quam Iuno fertur terris magis omnibus unam " +
+            "posthabita coluisse Samo; hic illius arma, " +
+            "hic currus fuit; hoc regnum dea gentibus esse, " +
+            "si qua fata sinant, iam tum tenditque fovetque. " +
+            "Progeniem sed enim Troiano a sanguine duci " +
+            "audierat, Tyrias olim quae verteret arces; " +
+            "hinc populum late regem belloque superbum " +
+            "venturum excidio Libyae: sic volvere Parcas.  " +
+            "Id metuens, veterisque memor Saturnia belli, " +
+            "prima quod ad Troiam pro caris gesserat Argis- " +
+            "necdum etiam causae irarum saevique dolores " +
+            "exciderant animo: manet alta mente repostum " +
+            "iudicium Paridis spretaeque iniuria formae, " +
+            "et genus invisum, et rapti Ganymedis honores.  " +
+            "His accensa super, iactatos aequore toto " +
+            "Troas, reliquias Danaum atque immitis Achilli,  " +
+            "arcebat longe Latio, multosque per annos " +
+            "errabant, acti fatis, maria omnia circum.  " +
+            "Tantae molis erat Romanam condere gentem!";
+
+    private static final List<String> wordsToSplitOn = new ArrayList<>( Arrays.asList(stringToSplit.split(" ")) );
+
+    private static final Set<String> singleCharStringsToSplitOn =
+                        Arrays.stream(stringToSplit.split(""))
+                                .map(s -> (s.equals("?")) ? "\\?" : s)
+                                .collect(Collectors.toSet());
+
+    private static final int numIterations = 100000;
+
+    //=========================================================================
+
+    void printTimingString(final String decorator,
+                           final long time_ns,
+                           final int numSplits) {
+
+        final double time_ms =  time_ns / 1000000.0;
+
+        final double timePerSplit_ns = ((double)time_ns) / ((double)numSplits) / ((double)numIterations);
+        final double timePerSplit_ms = timePerSplit_ns / 1000000.0;
+
+        System.out.println("\t" + decorator + " Total Time:\t" + time_ns + "ns\t" + time_ms +
+                            "ms\tPer Split:\t" + timePerSplit_ns + "ns\t\t" + timePerSplit_ms + "ms");
+    }
+
+    //==================================================================================================================
+
+    // Disabled so that we don't waste time.
+    // Cached results here:
+//    --------------------------------------------------------------------------------
+//    Timing Results:
+//    --------------------------------------------------------------------------------
+//    Java Split String:
+//          Words Total Time:	131867865203ns	131867.865203ms	Per Split:	6048.98464233945ns		0.00604898464233945ms
+//	        "Chars" Total Time:	12917243085ns	12917.243085ms	Per Split:	3004.010019767442ns		0.003004010019767442ms
+//    HTSJDK ParsingUtils::split
+//	        "Chars" Total Time:	5882790859ns	5882.790859ms	Per Split:	1368.0908974418605ns	0.0013680908974418606ms
+//    GATK Utils::split
+//          Words Total Time:	38734463275ns	38734.463275ms	Per Split:	1776.8102419724771ns	0.0017768102419724772ms
+//	        "Chars" Total Time:	7120052467ns	7120.052467ms	Per Split:	1655.826155116279ns		0.0016558261551162792ms
+//================================================================================
+    @Test(enabled = false)
+    void compareTimingForSplitString() {
+
+//    Java String.split,
+//    HTSJDK's ParsingUtils::split
+//    GATK3's Utils::split.
+
+        //------------------------------------------------------------------------------------------------------------------
+        // Baseline Java String.split:
+
+        //-------------------------------------------------
+        // First we do words:
+        final long javaSplitWordStartTime = System.nanoTime();
+
+        for ( int i = 0; i < numIterations; ++i ) {
+            for ( final String word : wordsToSplitOn ) {
+                stringToSplit.split(word);
+            }
+        }
+        final long javaSplitWordStopTime = System.nanoTime();
+        final long javaSplitWordTotalTime_ns = javaSplitWordStopTime - javaSplitWordStartTime;
+
+        //-------------------------------------------------
+        // Now we do single char words:
+        final long javaSplitSingleCharStringStartTime = System.nanoTime();
+
+        for ( int i = 0; i < numIterations; ++i ) {
+            for ( final String word : singleCharStringsToSplitOn ) {
+                stringToSplit.split(word);
+            }
+        }
+        final long javaSplitSingleCharStringStopTime = System.nanoTime();
+        final long javaSplitSingleCharStringTotalTime_ns = javaSplitSingleCharStringStopTime - javaSplitSingleCharStringStartTime;
+
+        //------------------------------------------------------------------------------------------------------------------
+        // HTSJDK's ParsingUtils::split:
+
+        //-------------------------------------------------
+        // First we do words:
+
+        // NOT APPLICABLE FOR HTSJDK's ParsingUtils::split!
+
+        //-------------------------------------------------
+        // Now we do single char words:
+        final long htsjdkSplitSingleCharStringStartTime = System.nanoTime();
+
+        for ( int i = 0; i < numIterations; ++i ) {
+            for ( final String word : singleCharStringsToSplitOn ) {
+                ParsingUtils.split( stringToSplit, word.charAt(0) );
+            }
+        }
+        final long htsjdkSplitSingleCharStringStopTime = System.nanoTime();
+        final long htsjdkSplitSingleCharTotalTime_ns = htsjdkSplitSingleCharStringStopTime - htsjdkSplitSingleCharStringStartTime;
+
+        //------------------------------------------------------------------------------------------------------------------
+        // GATK's Utils::split:
+
+        //-------------------------------------------------
+        // First we do words:
+        final long gatkSplitWordStartTime = System.nanoTime();
+
+        for ( int i = 0; i < numIterations; ++i ) {
+            for ( final String word : wordsToSplitOn ) {
+                Utils.split( stringToSplit, word );
+            }
+        }
+        final long gatkSplitWordStopTime = System.nanoTime();
+        final long gatkSplitWordTotalTime_ns = gatkSplitWordStopTime - gatkSplitWordStartTime;
+
+        //-------------------------------------------------
+        // Now we do single char words:
+        final long gatkSplitSingleCharStringStartTime = System.nanoTime();
+
+        for ( int i = 0; i < numIterations; ++i ) {
+            for ( final String word : singleCharStringsToSplitOn ) {
+                Utils.split( stringToSplit, word );
+            }
+        }
+        final long gatkSplitSingleCharStringStopTime = System.nanoTime();
+        final long gatkSplitSingleCharStringTotalTime_ns = gatkSplitSingleCharStringStopTime - gatkSplitSingleCharStringStartTime;
+
+        //------------------------------------------------------------------------------------------------------------------
+
+        // Print results:
+        System.out.println("================================================================================");
+        System.out.println("Timing Results:");
+        System.out.println("--------------------------------------------------------------------------------");
+        System.out.println("Java Split String:");
+        printTimingString("Words", javaSplitWordTotalTime_ns, wordsToSplitOn.size());
+        printTimingString("\"Chars\"", javaSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size());
+        System.out.println("HTSJDK ParsingUtils::split");
+        printTimingString("\"Chars\"", htsjdkSplitSingleCharTotalTime_ns, singleCharStringsToSplitOn.size());
+        System.out.println("GATK Utils::split");
+        printTimingString("Words", gatkSplitWordTotalTime_ns, wordsToSplitOn.size());
+        printTimingString("\"Chars\"", gatkSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size());
+        System.out.println("================================================================================");
+        
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
@@ -99,25 +99,25 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
         System.out.println("================================================================================");
     }
 
-    private static void printTimingTableMarkup(final long   javaSplitWordTotalTime_ns,
-                                               final long   javaSplitSingleCharStringTotalTime_ns,
-                                               final long   htsjdkSplitSingleCharTotalTime_ns,
-                                               final long   gatkSplitWordTotalTime_ns,
-                                               final long   gatkSplitSingleCharStringTotalTime_ns ) {
+    private static void printTimingTableMarkdown(final long   javaSplitWordTotalTime_ns,
+                                                 final long   javaSplitSingleCharStringTotalTime_ns,
+                                                 final long   htsjdkSplitSingleCharTotalTime_ns,
+                                                 final long   gatkSplitWordTotalTime_ns,
+                                                 final long   gatkSplitSingleCharStringTotalTime_ns ) {
 
         System.out.println( "| Method | Benchmark | Total Time (ns) | Total Time (ms) | Time Per Split Operation (ns) | Time Per Split Operation (ms) |" );
         System.out.println( "| --- | --- | --- | --- | --- | --- |" );
-        printTimingMarkupLine( "| Java String::split | Split on Words | ", javaSplitWordTotalTime_ns, wordsToSplitOn.size() );
-        printTimingMarkupLine( "| Java String::split | Split on Chars | ", javaSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size() );
+        printTimingMarkdownLine( "| Java String::split | Split on Words | ", javaSplitWordTotalTime_ns, wordsToSplitOn.size() );
+        printTimingMarkdownLine( "| Java String::split | Split on Chars | ", javaSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size() );
         System.out.println( "| HTSJDK ParsingUtils::split | Split on Words | NA | NA | NA | NA |" );
-        printTimingMarkupLine( "| HTSJDK ParsingUtils::split | Split on Chars | ", htsjdkSplitSingleCharTotalTime_ns, singleCharStringsToSplitOn.size() );
-        printTimingMarkupLine( "| GATK Utils::split | Split on Words | ", gatkSplitWordTotalTime_ns, wordsToSplitOn.size() );
-        printTimingMarkupLine( "| GATK Utils::split | Split on Chars | ", gatkSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size() );
+        printTimingMarkdownLine( "| HTSJDK ParsingUtils::split | Split on Chars | ", htsjdkSplitSingleCharTotalTime_ns, singleCharStringsToSplitOn.size() );
+        printTimingMarkdownLine( "| GATK Utils::split | Split on Words | ", gatkSplitWordTotalTime_ns, wordsToSplitOn.size() );
+        printTimingMarkdownLine( "| GATK Utils::split | Split on Chars | ", gatkSplitSingleCharStringTotalTime_ns, singleCharStringsToSplitOn.size() );
     }
 
-    private static void printTimingMarkupLine( final String rowHeader,
-                                               final long time_ns,
-                                               final int numSplits) {
+    private static void printTimingMarkdownLine(final String rowHeader,
+                                                final long time_ns,
+                                                final int numSplits) {
 
         final double time_ms =  time_ns / MS_TO_NS;
 
@@ -248,7 +248,7 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
         System.out.println("====");
         System.out.println("");
 
-        printTimingTableMarkup(javaSplitWordTotalTime_ns, javaSplitSingleCharStringTotalTime_ns, htsjdkSplitSingleCharTotalTime_ns, gatkSplitWordTotalTime_ns, gatkSplitSingleCharStringTotalTime_ns );
+        printTimingTableMarkdown(javaSplitWordTotalTime_ns, javaSplitSingleCharStringTotalTime_ns, htsjdkSplitSingleCharTotalTime_ns, gatkSplitWordTotalTime_ns, gatkSplitSingleCharStringTotalTime_ns );
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/StringSplitSpeedUnitTest.java
@@ -75,6 +75,7 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
     //==================================================================================================================
 
     // Disabled so that we don't waste time.
+    // It takes 216.95812968 seconds (about 3.5 minutes) to run this test.
     // Cached results here:
 //    --------------------------------------------------------------------------------
 //    Timing Results:
@@ -91,9 +92,7 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
     @Test(enabled = false)
     void compareTimingForSplitString() {
 
-//    Java String.split,
-//    HTSJDK's ParsingUtils::split
-//    GATK3's Utils::split.
+        final long overallStartTime = System.nanoTime();
 
         //------------------------------------------------------------------------------------------------------------------
         // Baseline Java String.split:
@@ -171,9 +170,17 @@ public class StringSplitSpeedUnitTest extends GATKBaseTest {
 
         //------------------------------------------------------------------------------------------------------------------
 
+        final long overallEndTime = System.nanoTime();
+        final long overallElapsedTime_ns = overallEndTime - overallStartTime;
+        final double overallElapsedTime_ms = overallElapsedTime_ns / 1000000.0;
+
+        //------------------------------------------------------------------------------------------------------------------
+
         // Print results:
         System.out.println("================================================================================");
         System.out.println("Timing Results:");
+        System.out.println("--------------------------------------------------------------------------------");
+        System.out.println("Overall Elapsed Time: " + overallElapsedTime_ns + "ns, " + overallElapsedTime_ms + "ms");
         System.out.println("--------------------------------------------------------------------------------");
         System.out.println("Java Split String:");
         printTimingString("Words", javaSplitWordTotalTime_ns, wordsToSplitOn.size());

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -731,4 +731,50 @@ public final class UtilsUnitTest extends GATKBaseTest {
         final Set<?> result = Utils.getDuplicatedItems(collection);
         Assert.assertEquals(result, duplicated);
     }
+
+    @DataProvider
+    public Object[][] provideDataForTestUtilsSplitString() {
+
+        final String s = "The quick fox jumped over the lazy brown dog.";
+
+        return new Object[][] {
+                { "", "", new ArrayList<>(Arrays.asList("".split(""))) },
+                { "", "1", new ArrayList<>(Arrays.asList("".split("1"))) },
+                { s, "1", new ArrayList<>(Arrays.asList(s.split("1"))) },
+                { s, "",  new ArrayList<>(Arrays.asList(s.split(""))) },
+                { s, "a", new ArrayList<>(Arrays.asList(s.split("a"))) },
+                { s, "b", new ArrayList<>(Arrays.asList(s.split("b"))) },
+                { s, "c", new ArrayList<>(Arrays.asList(s.split("c"))) },
+                { s, "d", new ArrayList<>(Arrays.asList(s.split("d"))) },
+                { s, "e", new ArrayList<>(Arrays.asList(s.split("e"))) },
+                { s, "f", new ArrayList<>(Arrays.asList(s.split("f"))) },
+                { s, "g", new ArrayList<>(Arrays.asList(s.split("g"))) },
+                { s, "h", new ArrayList<>(Arrays.asList(s.split("h"))) },
+                { s, "i", new ArrayList<>(Arrays.asList(s.split("i"))) },
+                { s, "j", new ArrayList<>(Arrays.asList(s.split("j"))) },
+                { s, "k", new ArrayList<>(Arrays.asList(s.split("k"))) },
+                { s, "l", new ArrayList<>(Arrays.asList(s.split("l"))) },
+                { s, "m", new ArrayList<>(Arrays.asList(s.split("m"))) },
+                { s, "n", new ArrayList<>(Arrays.asList(s.split("n"))) },
+                { s, "o", new ArrayList<>(Arrays.asList(s.split("o"))) },
+                { s, "p", new ArrayList<>(Arrays.asList(s.split("p"))) },
+                { s, "q", new ArrayList<>(Arrays.asList(s.split("q"))) },
+                { s, "r", new ArrayList<>(Arrays.asList(s.split("r"))) },
+                { s, "s", new ArrayList<>(Arrays.asList(s.split("s"))) },
+                { s, "t", new ArrayList<>(Arrays.asList(s.split("t"))) },
+                { s, "u", new ArrayList<>(Arrays.asList(s.split("u"))) },
+                { s, "v", new ArrayList<>(Arrays.asList(s.split("v"))) },
+                { s, "w", new ArrayList<>(Arrays.asList(s.split("w"))) },
+                { s, "x", new ArrayList<>(Arrays.asList(s.split("x"))) },
+                { s, "y", new ArrayList<>(Arrays.asList(s.split("y"))) },
+                { s, "z", new ArrayList<>(Arrays.asList(s.split("z"))) },
+                { s, " ", new ArrayList<>(Arrays.asList(s.split(" "))) },
+        };
+    }
+
+    @Test(dataProvider = "provideDataForTestUtilsSplitString")
+    public void testUtilsSplitString( final String str, final String delimiter, final ArrayList<String> expected ) {
+        Assert.assertEquals( Utils.split(str, delimiter), expected );
+        Assert.assertEquals( Utils.split(str, delimiter, expected.size()), expected );
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -738,43 +738,43 @@ public final class UtilsUnitTest extends GATKBaseTest {
         final String s = "The quick fox jumped over the lazy brown dog.";
 
         return new Object[][] {
-                { "", "", new ArrayList<>(Arrays.asList("".split(""))) },
-                { "", "1", new ArrayList<>(Arrays.asList("".split("1"))) },
-                { s, "1", new ArrayList<>(Arrays.asList(s.split("1"))) },
-                { s, "",  new ArrayList<>(Arrays.asList(s.split(""))) },
-                { s, "a", new ArrayList<>(Arrays.asList(s.split("a"))) },
-                { s, "b", new ArrayList<>(Arrays.asList(s.split("b"))) },
-                { s, "c", new ArrayList<>(Arrays.asList(s.split("c"))) },
-                { s, "d", new ArrayList<>(Arrays.asList(s.split("d"))) },
-                { s, "e", new ArrayList<>(Arrays.asList(s.split("e"))) },
-                { s, "f", new ArrayList<>(Arrays.asList(s.split("f"))) },
-                { s, "g", new ArrayList<>(Arrays.asList(s.split("g"))) },
-                { s, "h", new ArrayList<>(Arrays.asList(s.split("h"))) },
-                { s, "i", new ArrayList<>(Arrays.asList(s.split("i"))) },
-                { s, "j", new ArrayList<>(Arrays.asList(s.split("j"))) },
-                { s, "k", new ArrayList<>(Arrays.asList(s.split("k"))) },
-                { s, "l", new ArrayList<>(Arrays.asList(s.split("l"))) },
-                { s, "m", new ArrayList<>(Arrays.asList(s.split("m"))) },
-                { s, "n", new ArrayList<>(Arrays.asList(s.split("n"))) },
-                { s, "o", new ArrayList<>(Arrays.asList(s.split("o"))) },
-                { s, "p", new ArrayList<>(Arrays.asList(s.split("p"))) },
-                { s, "q", new ArrayList<>(Arrays.asList(s.split("q"))) },
-                { s, "r", new ArrayList<>(Arrays.asList(s.split("r"))) },
-                { s, "s", new ArrayList<>(Arrays.asList(s.split("s"))) },
-                { s, "t", new ArrayList<>(Arrays.asList(s.split("t"))) },
-                { s, "u", new ArrayList<>(Arrays.asList(s.split("u"))) },
-                { s, "v", new ArrayList<>(Arrays.asList(s.split("v"))) },
-                { s, "w", new ArrayList<>(Arrays.asList(s.split("w"))) },
-                { s, "x", new ArrayList<>(Arrays.asList(s.split("x"))) },
-                { s, "y", new ArrayList<>(Arrays.asList(s.split("y"))) },
-                { s, "z", new ArrayList<>(Arrays.asList(s.split("z"))) },
-                { s, " ", new ArrayList<>(Arrays.asList(s.split(" "))) },
+                { "", "",  "".split("" ) },
+                { "", "1", "".split("1") },
+                { s, "1",   s.split("1") },
+                { s, "",    s.split("" ) },
+                { s, "a",   s.split("a") },
+                { s, "b",   s.split("b") },
+                { s, "c",   s.split("c") },
+                { s, "d",   s.split("d") },
+                { s, "e",   s.split("e") },
+                { s, "f",   s.split("f") },
+                { s, "g",   s.split("g") },
+                { s, "h",   s.split("h") },
+                { s, "i",   s.split("i") },
+                { s, "j",   s.split("j") },
+                { s, "k",   s.split("k") },
+                { s, "l",   s.split("l") },
+                { s, "m",   s.split("m") },
+                { s, "n",   s.split("n") },
+                { s, "o",   s.split("o") },
+                { s, "p",   s.split("p") },
+                { s, "q",   s.split("q") },
+                { s, "r",   s.split("r") },
+                { s, "s",   s.split("s") },
+                { s, "t",   s.split("t") },
+                { s, "u",   s.split("u") },
+                { s, "v",   s.split("v") },
+                { s, "w",   s.split("w") },
+                { s, "x",   s.split("x") },
+                { s, "y",   s.split("y") },
+                { s, "z",   s.split("z") },
+                { s, " ",   s.split(" ") },
         };
     }
 
     @Test(dataProvider = "provideDataForTestUtilsSplitString")
-    public void testUtilsSplitString( final String str, final String delimiter, final ArrayList<String> expected ) {
+    public void testUtilsSplitString( final String str, final String delimiter, final String[] expected ) {
         Assert.assertEquals( Utils.split(str, delimiter), expected );
-        Assert.assertEquals( Utils.split(str, delimiter, expected.size()), expected );
+        Assert.assertEquals( Utils.split(str, delimiter, expected.length), expected );
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -735,46 +735,80 @@ public final class UtilsUnitTest extends GATKBaseTest {
     @DataProvider
     public Object[][] provideDataForTestUtilsSplitString() {
 
-        final String s = "The quick fox jumped over the lazy brown dog.";
+        final String stringData = "The quick fox jumped over the lazy brown dog.  " +
+                "Arma virumque cano, Troiae qui primus ab oris " +
+                "Italiam, fato profugus, Laviniaque venit " +
+                "litora, multum ille et terris iactatus et alto " +
+                "vi superum saevae memorem Iunonis ob iram; " +
+                "multa quoque et bello passus, dum conderet urbem, " +
+                "inferretque deos Latio, genus unde Latinum, " +
+                "Albanique patres, atque altae moenia Romae.  " +
+                "Musa, mihi causas memora, quo numine laeso, " +
+                "quidve dolens, regina deum tot volvere casus " +
+                "insignem pietate virum, tot adire labores " +
+                "impulerit. Tantaene animis caelestibus irae9";
 
-        return new Object[][] {
-                { "", "",  "".split("" ) },
-                { "", "1", "".split("1") },
-                { s, "1",   s.split("1") },
-                { s, "",    s.split("" ) },
-                { s, "a",   s.split("a") },
-                { s, "b",   s.split("b") },
-                { s, "c",   s.split("c") },
-                { s, "d",   s.split("d") },
-                { s, "e",   s.split("e") },
-                { s, "f",   s.split("f") },
-                { s, "g",   s.split("g") },
-                { s, "h",   s.split("h") },
-                { s, "i",   s.split("i") },
-                { s, "j",   s.split("j") },
-                { s, "k",   s.split("k") },
-                { s, "l",   s.split("l") },
-                { s, "m",   s.split("m") },
-                { s, "n",   s.split("n") },
-                { s, "o",   s.split("o") },
-                { s, "p",   s.split("p") },
-                { s, "q",   s.split("q") },
-                { s, "r",   s.split("r") },
-                { s, "s",   s.split("s") },
-                { s, "t",   s.split("t") },
-                { s, "u",   s.split("u") },
-                { s, "v",   s.split("v") },
-                { s, "w",   s.split("w") },
-                { s, "x",   s.split("x") },
-                { s, "y",   s.split("y") },
-                { s, "z",   s.split("z") },
-                { s, " ",   s.split(" ") },
-        };
+        final List<String> wordsToSplitOn = Arrays.stream(stringData.split(" "))
+                .map(ssss -> (ssss.contains("?")) ? ssss.replace("?", "\\?") : ssss)
+                .collect(Collectors.toList());
+
+        final List<String> repeatedSubstringsToSplitOn = Arrays.asList( "us", "is", "it", "et", " et", " et ", "que ", " mult" );
+
+        final List<Object[]> testCases = new ArrayList<>();
+        testCases.addAll(
+                Arrays.asList(
+                    new Object[] { "", "",   Arrays.asList( "".split(""  ) ) },
+                    new Object[] { "", "1",  Arrays.asList( "".split("1" ) ) },
+                    new Object[] { stringData, "1",   Arrays.asList( stringData.split("1"  ) ) },
+                    new Object[] { stringData, "",    Arrays.asList( stringData.split(""   ) ) },
+                    new Object[] { stringData, "a",   Arrays.asList( stringData.split("a"  ) ) },
+                    new Object[] { stringData, "b",   Arrays.asList( stringData.split("b"  ) ) },
+                    new Object[] { stringData, "c",   Arrays.asList( stringData.split("c"  ) ) },
+                    new Object[] { stringData, "d",   Arrays.asList( stringData.split("d"  ) ) },
+                    new Object[] { stringData, "e",   Arrays.asList( stringData.split("e"  ) ) },
+                    new Object[] { stringData, "f",   Arrays.asList( stringData.split("f"  ) ) },
+                    new Object[] { stringData, "g",   Arrays.asList( stringData.split("g"  ) ) },
+                    new Object[] { stringData, "h",   Arrays.asList( stringData.split("h"  ) ) },
+                    new Object[] { stringData, "i",   Arrays.asList( stringData.split("i"  ) ) },
+                    new Object[] { stringData, "j",   Arrays.asList( stringData.split("j"  ) ) },
+                    new Object[] { stringData, "k",   Arrays.asList( stringData.split("k"  ) ) },
+                    new Object[] { stringData, "l",   Arrays.asList( stringData.split("l"  ) ) },
+                    new Object[] { stringData, "m",   Arrays.asList( stringData.split("m"  ) ) },
+                    new Object[] { stringData, "n",   Arrays.asList( stringData.split("n"  ) ) },
+                    new Object[] { stringData, "o",   Arrays.asList( stringData.split("o"  ) ) },
+                    new Object[] { stringData, "p",   Arrays.asList( stringData.split("p"  ) ) },
+                    new Object[] { stringData, "q",   Arrays.asList( stringData.split("q"  ) ) },
+                    new Object[] { stringData, "r",   Arrays.asList( stringData.split("r"  ) ) },
+                    new Object[] { stringData, "s",   Arrays.asList( stringData.split("s"  ) ) },
+                    new Object[] { stringData, "t",   Arrays.asList( stringData.split("t"  ) ) },
+                    new Object[] { stringData, "u",   Arrays.asList( stringData.split("u"  ) ) },
+                    new Object[] { stringData, "v",   Arrays.asList( stringData.split("v"  ) ) },
+                    new Object[] { stringData, "w",   Arrays.asList( stringData.split("w"  ) ) },
+                    new Object[] { stringData, "x",   Arrays.asList( stringData.split("x"  ) ) },
+                    new Object[] { stringData, "y",   Arrays.asList( stringData.split("y"  ) ) },
+                    new Object[] { stringData, "z",   Arrays.asList( stringData.split("z"  ) ) },
+                    new Object[] { stringData, " ",   Arrays.asList( stringData.split(" "  ) ) },
+                    new Object[] { stringData, "T",   Arrays.asList( stringData.split("T"  ) ) },
+                    new Object[] { stringData, "9",   Arrays.asList( stringData.split("9") ) }
+                )
+        );
+
+        // Create test cases for words:
+        for ( final String delim : wordsToSplitOn ) {
+            testCases.add( new Object[] { stringData, delim, Arrays.asList( stringData.split(delim) ) } );
+        }
+
+        // Create test cases for repeated substrings:
+        for ( final String delim : repeatedSubstringsToSplitOn ) {
+            testCases.add( new Object[] { stringData, delim, Arrays.asList( stringData.split(delim) ) } );
+        }
+
+        return testCases.toArray( new Object[][] {} );
     }
 
     @Test(dataProvider = "provideDataForTestUtilsSplitString")
-    public void testUtilsSplitString( final String str, final String delimiter, final String[] expected ) {
+    public void testUtilsSplitString( final String str, final String delimiter, final List<String> expected ) {
         Assert.assertEquals( Utils.split(str, delimiter), expected );
-        Assert.assertEquals( Utils.split(str, delimiter, expected.length), expected );
+        Assert.assertEquals( Utils.split(str, delimiter, expected.size()), expected );
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -733,7 +733,7 @@ public final class UtilsUnitTest extends GATKBaseTest {
     }
 
     @DataProvider
-    public Object[][] provideDataForTestUtilsSplitString() {
+    public Iterator<Object[]> provideDataForTestUtilsSplitString() {
 
         final String stringData = "The quick fox jumped over the lazy brown dog.  " +
                 "Arma virumque cano, Troiae qui primus ab oris " +
@@ -754,13 +754,20 @@ public final class UtilsUnitTest extends GATKBaseTest {
 
         final List<String> repeatedSubstringsToSplitOn = Arrays.asList( "us", "is", "it", "et", " et", " et ", "que ", " mult" );
 
+        final String allDelimiterTestString = "::::::::::::::::::::::::::::::";
+        final String frontDelimiterTestString = "::::::::::1:23::::::::::456:7890";
+        final String middleDelimiterTestString = "1:23::::::::::456:7890";
+        final String backDelimiterTestString = "1:23::::::::::456:7890::::::::::";
+        final String fullDelimiterTestString = "::::::::::1:23::::::::::456:7890::::::::::";
+
         final List<Object[]> testCases = new ArrayList<>();
         testCases.addAll(
                 Arrays.asList(
                     new Object[] { "", "",   Arrays.asList( "".split(""  ) ) },
                     new Object[] { "", "1",  Arrays.asList( "".split("1" ) ) },
-                    new Object[] { stringData, "1",   Arrays.asList( stringData.split("1"  ) ) },
+                    new Object[] { ":", ":",   Arrays.asList( ":".split(":"  ) ) },
                     new Object[] { stringData, "",    Arrays.asList( stringData.split(""   ) ) },
+                    new Object[] { stringData, "1",   Arrays.asList( stringData.split("1"  ) ) },
                     new Object[] { stringData, "a",   Arrays.asList( stringData.split("a"  ) ) },
                     new Object[] { stringData, "b",   Arrays.asList( stringData.split("b"  ) ) },
                     new Object[] { stringData, "c",   Arrays.asList( stringData.split("c"  ) ) },
@@ -789,7 +796,17 @@ public final class UtilsUnitTest extends GATKBaseTest {
                     new Object[] { stringData, "z",   Arrays.asList( stringData.split("z"  ) ) },
                     new Object[] { stringData, " ",   Arrays.asList( stringData.split(" "  ) ) },
                     new Object[] { stringData, "T",   Arrays.asList( stringData.split("T"  ) ) },
-                    new Object[] { stringData, "9",   Arrays.asList( stringData.split("9") ) }
+                    new Object[] { stringData, "9",   Arrays.asList( stringData.split("9") ) },
+                    new Object[] { allDelimiterTestString,    ":",   Arrays.asList( allDelimiterTestString.split(":") ) },
+                    new Object[] { frontDelimiterTestString,  ":",   Arrays.asList( frontDelimiterTestString.split(":") ) },
+                    new Object[] { middleDelimiterTestString, ":",   Arrays.asList( middleDelimiterTestString.split(":") ) },
+                    new Object[] { backDelimiterTestString ,  ":",   Arrays.asList( backDelimiterTestString.split(":") ) },
+                    new Object[] { fullDelimiterTestString ,  ":",   Arrays.asList( fullDelimiterTestString.split(":") ) },
+                    new Object[] { allDelimiterTestString.replace(":", "TS"),    "TS",   Arrays.asList( allDelimiterTestString.replace(":", "TS").split("TS") ) },
+                    new Object[] { frontDelimiterTestString.replace(":", "TS"),  "TS",   Arrays.asList( frontDelimiterTestString.replace(":", "TS").split("TS") ) },
+                    new Object[] { middleDelimiterTestString.replace(":", "TS"), "TS",   Arrays.asList( middleDelimiterTestString.replace(":", "TS").split("TS") ) },
+                    new Object[] { backDelimiterTestString.replace(":", "TS") ,  "TS",   Arrays.asList( backDelimiterTestString.replace(":", "TS").split("TS") ) },
+                    new Object[] { fullDelimiterTestString.replace(":", "TS") ,  "TS",   Arrays.asList( fullDelimiterTestString.replace(":", "TS").split("TS") ) }
                 )
         );
 
@@ -803,12 +820,22 @@ public final class UtilsUnitTest extends GATKBaseTest {
             testCases.add( new Object[] { stringData, delim, Arrays.asList( stringData.split(delim) ) } );
         }
 
-        return testCases.toArray( new Object[][] {} );
+        return testCases.iterator();
     }
 
     @Test(dataProvider = "provideDataForTestUtilsSplitString")
     public void testUtilsSplitString( final String str, final String delimiter, final List<String> expected ) {
-        Assert.assertEquals( Utils.split(str, delimiter), expected );
-        Assert.assertEquals( Utils.split(str, delimiter, expected.size()), expected );
+
+        List<String> splitStrings;
+        if ( delimiter.length() == 1 ) {
+            splitStrings = Utils.split( str, delimiter.charAt(0) );
+            Assert.assertEquals( splitStrings, expected );
+        }
+
+        splitStrings = Utils.split(str, delimiter);
+        Assert.assertEquals( splitStrings, expected );
+
+        splitStrings = Utils.split(str, delimiter, expected.size());
+        Assert.assertEquals( splitStrings, expected );
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -762,62 +762,63 @@ public final class UtilsUnitTest extends GATKBaseTest {
 
         final List<Object[]> testCases = new ArrayList<>();
         testCases.addAll(
-                Arrays.asList(
-                    new Object[] { "", "",   Arrays.asList( "".split(""  ) ) },
-                    new Object[] { "", "1",  Arrays.asList( "".split("1" ) ) },
-                    new Object[] { ":", ":",   Arrays.asList( ":".split(":"  ) ) },
-                    new Object[] { stringData, "",    Arrays.asList( stringData.split(""   ) ) },
-                    new Object[] { stringData, "1",   Arrays.asList( stringData.split("1"  ) ) },
-                    new Object[] { stringData, "a",   Arrays.asList( stringData.split("a"  ) ) },
-                    new Object[] { stringData, "b",   Arrays.asList( stringData.split("b"  ) ) },
-                    new Object[] { stringData, "c",   Arrays.asList( stringData.split("c"  ) ) },
-                    new Object[] { stringData, "d",   Arrays.asList( stringData.split("d"  ) ) },
-                    new Object[] { stringData, "e",   Arrays.asList( stringData.split("e"  ) ) },
-                    new Object[] { stringData, "f",   Arrays.asList( stringData.split("f"  ) ) },
-                    new Object[] { stringData, "g",   Arrays.asList( stringData.split("g"  ) ) },
-                    new Object[] { stringData, "h",   Arrays.asList( stringData.split("h"  ) ) },
-                    new Object[] { stringData, "i",   Arrays.asList( stringData.split("i"  ) ) },
-                    new Object[] { stringData, "j",   Arrays.asList( stringData.split("j"  ) ) },
-                    new Object[] { stringData, "k",   Arrays.asList( stringData.split("k"  ) ) },
-                    new Object[] { stringData, "l",   Arrays.asList( stringData.split("l"  ) ) },
-                    new Object[] { stringData, "m",   Arrays.asList( stringData.split("m"  ) ) },
-                    new Object[] { stringData, "n",   Arrays.asList( stringData.split("n"  ) ) },
-                    new Object[] { stringData, "o",   Arrays.asList( stringData.split("o"  ) ) },
-                    new Object[] { stringData, "p",   Arrays.asList( stringData.split("p"  ) ) },
-                    new Object[] { stringData, "q",   Arrays.asList( stringData.split("q"  ) ) },
-                    new Object[] { stringData, "r",   Arrays.asList( stringData.split("r"  ) ) },
-                    new Object[] { stringData, "s",   Arrays.asList( stringData.split("s"  ) ) },
-                    new Object[] { stringData, "t",   Arrays.asList( stringData.split("t"  ) ) },
-                    new Object[] { stringData, "u",   Arrays.asList( stringData.split("u"  ) ) },
-                    new Object[] { stringData, "v",   Arrays.asList( stringData.split("v"  ) ) },
-                    new Object[] { stringData, "w",   Arrays.asList( stringData.split("w"  ) ) },
-                    new Object[] { stringData, "x",   Arrays.asList( stringData.split("x"  ) ) },
-                    new Object[] { stringData, "y",   Arrays.asList( stringData.split("y"  ) ) },
-                    new Object[] { stringData, "z",   Arrays.asList( stringData.split("z"  ) ) },
-                    new Object[] { stringData, " ",   Arrays.asList( stringData.split(" "  ) ) },
-                    new Object[] { stringData, "T",   Arrays.asList( stringData.split("T"  ) ) },
-                    new Object[] { stringData, "9",   Arrays.asList( stringData.split("9") ) },
-                    new Object[] { allDelimiterTestString,    ":",   Arrays.asList( allDelimiterTestString.split(":") ) },
-                    new Object[] { frontDelimiterTestString,  ":",   Arrays.asList( frontDelimiterTestString.split(":") ) },
-                    new Object[] { middleDelimiterTestString, ":",   Arrays.asList( middleDelimiterTestString.split(":") ) },
-                    new Object[] { backDelimiterTestString ,  ":",   Arrays.asList( backDelimiterTestString.split(":") ) },
-                    new Object[] { fullDelimiterTestString ,  ":",   Arrays.asList( fullDelimiterTestString.split(":") ) },
-                    new Object[] { allDelimiterTestString.replace(":", "TS"),    "TS",   Arrays.asList( allDelimiterTestString.replace(":", "TS").split("TS") ) },
-                    new Object[] { frontDelimiterTestString.replace(":", "TS"),  "TS",   Arrays.asList( frontDelimiterTestString.replace(":", "TS").split("TS") ) },
-                    new Object[] { middleDelimiterTestString.replace(":", "TS"), "TS",   Arrays.asList( middleDelimiterTestString.replace(":", "TS").split("TS") ) },
-                    new Object[] { backDelimiterTestString.replace(":", "TS") ,  "TS",   Arrays.asList( backDelimiterTestString.replace(":", "TS").split("TS") ) },
-                    new Object[] { fullDelimiterTestString.replace(":", "TS") ,  "TS",   Arrays.asList( fullDelimiterTestString.replace(":", "TS").split("TS") ) }
-                )
+            Arrays.asList(
+                new Object[] { "", "" },
+                new Object[] { ":", "" },
+                new Object[] { "SOME MORE TESTS", "" },
+                new Object[] { ":", ":" },
+                new Object[] { stringData, ""  },
+                new Object[] { stringData, "1" },
+                new Object[] { stringData, "a" },
+                new Object[] { stringData, "b" },
+                new Object[] { stringData, "c" },
+                new Object[] { stringData, "d" },
+                new Object[] { stringData, "e" },
+                new Object[] { stringData, "f" },
+                new Object[] { stringData, "g" },
+                new Object[] { stringData, "h" },
+                new Object[] { stringData, "i" },
+                new Object[] { stringData, "j" },
+                new Object[] { stringData, "k" },
+                new Object[] { stringData, "l" },
+                new Object[] { stringData, "m" },
+                new Object[] { stringData, "n" },
+                new Object[] { stringData, "o" },
+                new Object[] { stringData, "p" },
+                new Object[] { stringData, "q" },
+                new Object[] { stringData, "r" },
+                new Object[] { stringData, "s" },
+                new Object[] { stringData, "t" },
+                new Object[] { stringData, "u" },
+                new Object[] { stringData, "v" },
+                new Object[] { stringData, "w" },
+                new Object[] { stringData, "x" },
+                new Object[] { stringData, "y" },
+                new Object[] { stringData, "z" },
+                new Object[] { stringData, " " },
+                new Object[] { stringData, "T" },
+                new Object[] { stringData, "9" },
+                new Object[] { allDelimiterTestString,    ":" },
+                new Object[] { frontDelimiterTestString,  ":" },
+                new Object[] { middleDelimiterTestString, ":" },
+                new Object[] { backDelimiterTestString ,  ":" },
+                new Object[] { fullDelimiterTestString ,  ":" },
+                new Object[] { allDelimiterTestString.replace(":", "TS"),    "TS" },
+                new Object[] { frontDelimiterTestString.replace(":", "TS"),  "TS" },
+                new Object[] { middleDelimiterTestString.replace(":", "TS"), "TS" },
+                new Object[] { backDelimiterTestString.replace(":", "TS") ,  "TS" },
+                new Object[] { fullDelimiterTestString.replace(":", "TS") ,  "TS" }
+            )
         );
 
         // Create test cases for words:
         for ( final String delim : wordsToSplitOn ) {
-            testCases.add( new Object[] { stringData, delim, Arrays.asList( stringData.split(delim) ) } );
+            testCases.add( new Object[] { stringData, delim } );
         }
 
         // Create test cases for repeated substrings:
         for ( final String delim : repeatedSubstringsToSplitOn ) {
-            testCases.add( new Object[] { stringData, delim, Arrays.asList( stringData.split(delim) ) } );
+            testCases.add( new Object[] { stringData, delim } );
         }
 
         return testCases.iterator();
@@ -836,7 +837,9 @@ public final class UtilsUnitTest extends GATKBaseTest {
 
         // Create multi-character delimiter strings:
         final String multiCharDelimiter = "oz";
-        // Must include the individual characters of the multi-char delimiter here:
+
+        // Must include the individual characters of the multi-char delimiter here
+        // so we can pass them into Utils.makePermutations to create the permutations of strings to split.
         final List<String> multiCharTestStrings = Arrays.asList("X", "o", "z", multiCharDelimiter);
         final List<List<String>> exhaustiveListsForMultiChar = Utils.makePermutations( multiCharTestStrings, maxStringLength, true );
 
@@ -844,40 +847,36 @@ public final class UtilsUnitTest extends GATKBaseTest {
 
         // Add single-char cases:
         for ( final List<String> testCase : exhaustiveListsForSingleChar ) {
-            testCases.add( new Object[] { String.join( "", testCase ), singleCharDelimiter, Arrays.asList( String.join( "", testCase ).split(singleCharDelimiter)) } );
+            testCases.add( new Object[] { String.join( "", testCase ), singleCharDelimiter } );
         }
 
         // Add multi-char cases:
         for ( final List<String> testCase : exhaustiveListsForMultiChar ) {
-            testCases.add( new Object[] { String.join( "", testCase ), multiCharDelimiter, Arrays.asList( String.join( "", testCase ).split(multiCharDelimiter)) } );
+            testCases.add( new Object[] { String.join( "", testCase ), multiCharDelimiter } );
         }
 
         return testCases.iterator();
     }
 
     private void exhaustiveStringSplitHelper(final String str,
-                                             final String delimiter,
-                                             final List<String> expected) {
+                                             final String delimiter) {
         List<String> splitStrings;
         if ( delimiter.length() == 1 ) {
             splitStrings = Utils.split( str, delimiter.charAt(0) );
-            Assert.assertEquals( splitStrings, expected );
+            Assert.assertEquals( splitStrings, Arrays.asList(str.split(delimiter)) );
         }
 
         splitStrings = Utils.split(str, delimiter);
-        Assert.assertEquals( splitStrings, expected );
-
-        splitStrings = Utils.split(str, delimiter, expected.size());
-        Assert.assertEquals( splitStrings, expected );
+        Assert.assertEquals( splitStrings, Arrays.asList(str.split(delimiter)) );
     }
 
     @Test(dataProvider = "provideDataForTestUtilsSplitString")
-    public void testUtilsSplitString( final String str, final String delimiter, final List<String> expected ) {
-        exhaustiveStringSplitHelper(str, delimiter, expected);
+    public void testUtilsSplitString( final String str, final String delimiter ) {
+        exhaustiveStringSplitHelper(str, delimiter);
     }
 
     @Test(dataProvider = "provideDataForTestUtilsSplitStringExhaustively")
-    public void testUtilsSplitStringExhaustively( final String str, final String delimiter, final List<String> expected ) {
-        exhaustiveStringSplitHelper(str, delimiter, expected);
+    public void testUtilsSplitStringExhaustively( final String str, final String delimiter ) {
+        exhaustiveStringSplitHelper(str, delimiter);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -823,9 +823,41 @@ public final class UtilsUnitTest extends GATKBaseTest {
         return testCases.iterator();
     }
 
-    @Test(dataProvider = "provideDataForTestUtilsSplitString")
-    public void testUtilsSplitString( final String str, final String delimiter, final List<String> expected ) {
+    @DataProvider
+    private Iterator<Object[]> provideDataForTestUtilsSplitStringExhaustively() {
 
+        // Length that we want to test through:
+        final int maxStringLength = 7;
+
+        // Create single character delimiter strings:
+        final String singleCharDelimiter = "o";
+        final List<String> singleCharTestStrings = Arrays.asList("X", singleCharDelimiter);
+        final List<List<String>> exhaustiveListsForSingleChar = Utils.makePermutations( singleCharTestStrings, maxStringLength, true );
+
+        // Create multi-character delimiter strings:
+        final String multiCharDelimiter = "oz";
+        // Must include the individual characters of the multi-char delimiter here:
+        final List<String> multiCharTestStrings = Arrays.asList("X", "o", "z", multiCharDelimiter);
+        final List<List<String>> exhaustiveListsForMultiChar = Utils.makePermutations( multiCharTestStrings, maxStringLength, true );
+
+        final List<Object[]> testCases = new ArrayList<>();
+
+        // Add single-char cases:
+        for ( final List<String> testCase : exhaustiveListsForSingleChar ) {
+            testCases.add( new Object[] { String.join( "", testCase ), singleCharDelimiter, Arrays.asList( String.join( "", testCase ).split(singleCharDelimiter)) } );
+        }
+
+        // Add multi-char cases:
+        for ( final List<String> testCase : exhaustiveListsForMultiChar ) {
+            testCases.add( new Object[] { String.join( "", testCase ), multiCharDelimiter, Arrays.asList( String.join( "", testCase ).split(multiCharDelimiter)) } );
+        }
+
+        return testCases.iterator();
+    }
+
+    private void exhaustiveStringSplitHelper(final String str,
+                                             final String delimiter,
+                                             final List<String> expected) {
         List<String> splitStrings;
         if ( delimiter.length() == 1 ) {
             splitStrings = Utils.split( str, delimiter.charAt(0) );
@@ -837,5 +869,15 @@ public final class UtilsUnitTest extends GATKBaseTest {
 
         splitStrings = Utils.split(str, delimiter, expected.size());
         Assert.assertEquals( splitStrings, expected );
+    }
+
+    @Test(dataProvider = "provideDataForTestUtilsSplitString")
+    public void testUtilsSplitString( final String str, final String delimiter, final List<String> expected ) {
+        exhaustiveStringSplitHelper(str, delimiter, expected);
+    }
+
+    @Test(dataProvider = "provideDataForTestUtilsSplitStringExhaustively")
+    public void testUtilsSplitStringExhaustively( final String str, final String delimiter, final List<String> expected ) {
+        exhaustiveStringSplitHelper(str, delimiter, expected);
     }
 }


### PR DESCRIPTION
Based on timing results (see below), we should do two things:
	1) Switch to the HTSJDK `ParsingUtils::split` method for all
	   cases where we split a string using a single character.
	2) Switch to the `Utils::split` method for all cases where
	   we split a string by another string of length > 1.

A quick stopgap that will reduce splitting time by ~1/2 is to just
replace all calls to Java's `String::split` with `Utils::split` (since
they both take two Strings as arguments, it should be very easy).

Also, I have disabled the test so that it doesn't slow down testing cycles.

Fixes #3759

| Method | Benchmark | Total Time (ns) | Total Time (ms) | Time Per Split Operation (ns) | Time Per Split Operation (ms) |   
| --- | --- | --- | --- | --- | --- |
| Java String::split | Split on Words | 131867865203 | 131867.865203 | 6048.98464233945 | 0.00604898464233945 |
| Java String::split | Split on Chars | 12917243085 | 12917.243085 | 3004.010019767442 | 0.003004010019767442 |
| HTSJDK ParsingUtils::split | Split on Words | N/A | N/A | N/A | N/A | 
| HTSJDK ParsingUtils::split | Split on Chars | 5882790859 | 5882.790859 | 1368.0908974418605 | 0.0013680908974418606 | 
| GATK Utils::split | Split on Words | 38734463275 | 38734.463275 | 1776.8102419724771 | 0.0017768102419724772 |
| GATK Utils::split | Split on Chars | 7120052467 | 7120.052467 | 1655.826155116279 | 0.0016558261551162792 |