### PR TITLE
Fixing contig ordering issue when calling CombineBreakpoints

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CombineSegmentBreakpoints.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CombineSegmentBreakpoints.java
@@ -109,7 +109,7 @@ public class CombineSegmentBreakpoints extends GATKTool {
     }
 
     /**
-     *  Create intervals with breakpoints of segments1 and segments2 as described in {@link IntervalUtils::combineBreakpoints} and annotate
+     *  Create intervals with breakpoints of segments1 and segments2 as described in {@link IntervalUtils::combineAndSortBreakpoints} and annotate
      *   the new intervals with annotations of interest in segments1 and segments2.
      *
      * @param segments1 a list of simple annotated regions

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CombineSegmentBreakpoints.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CombineSegmentBreakpoints.java
@@ -127,7 +127,7 @@ public class CombineSegmentBreakpoints extends GATKTool {
 
         final List<List<SimpleAnnotatedGenomicRegion>> segmentLists = Arrays.asList(segments1, segments2);
 
-        final List<Locatable> combinedIntervals = IntervalUtils.combineBreakpointsWithSorting(
+        final List<Locatable> combinedIntervals = IntervalUtils.combineAndSortBreakpoints(
                 segmentLists.get(0).stream().map(SimpleAnnotatedGenomicRegion::getInterval)
                         .collect(Collectors.toList()),
                 segmentLists.get(1).stream().map(SimpleAnnotatedGenomicRegion::getInterval)

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1154,15 +1154,16 @@ public final class IntervalUtils {
      *
      * Intervals are assumed to include the start and end bases.
      *
-     * Output contigs will be unordered.
-     *
      * @param locatables1 list of locatables
      * @param locatables2 list of locatables
+     * @param dictionary Sequence dictionary to base the sort.  The order of contigs/sequences in the dictionary is the order of the sorting here.
      * @return Locatables from the combined breakpoints of locatable1 and locatable2.  If both inputs are null, return an
      *   empty list.  Please note that returned values are new copies.  If exactly one of the inputs is null, this method
-     *   returns a copy of of the non-null input.  Contigs will be unordered.
+     *   returns a copy of of the non-null input.
      */
-    protected static <T extends Locatable> List<Locatable> combineBreakpoints(final List<T> locatables1, final List<T> locatables2) {
+    protected static <T extends Locatable> List<Locatable> combineAndSortBreakpoints(final List<T> locatables1,
+                                                                                     final List<T> locatables2,
+                                                                                     final SAMSequenceDictionary dictionary) {
         if ((locatables1 == null) && (locatables2 == null)) {
             return Collections.emptyList();
         }
@@ -1171,10 +1172,10 @@ public final class IntervalUtils {
         validateNoOverlappingIntervals(locatables2);
 
         if (CollectionUtils.isEmpty(locatables1)) {
-            return locatables2.stream().map(SimpleInterval::new).collect(Collectors.toList());
+            return sortLocatablesBySequenceDictionary(locatables2.stream().map(SimpleInterval::new).collect(Collectors.toList()), dictionary);
         }
         if (CollectionUtils.isEmpty(locatables2)) {
-            return locatables1.stream().map(SimpleInterval::new).collect(Collectors.toList());
+            return sortLocatablesBySequenceDictionary(locatables1.stream().map(SimpleInterval::new).collect(Collectors.toList()), dictionary);
         }
 
         final List<Locatable> masterList = new ArrayList<>();
@@ -1250,7 +1251,7 @@ public final class IntervalUtils {
                 }
             }
         }
-        return result;
+        return sortLocatablesBySequenceDictionary(result, dictionary);
     }
 
     /**
@@ -1280,16 +1281,16 @@ public final class IntervalUtils {
     }
 
     /**
-     *  Same as {@link IntervalUtils::combineBreakpoints}, but sorts the inputs first.  Sorted versions are kept in a new list.
+     *  Same as {@link IntervalUtils::combineAndSortBreakpoints}, but sorts the inputs first.  Sorted versions are kept in a new list.
      *
      * Sorts using sequence dictionary sort.
      *
-     * @param locatables1 See {@link IntervalUtils::combineBreakpoints}, but can be unsorted.
-     * @param locatables2 See {@link IntervalUtils::combineBreakpoints}, but can be unsorted.
+     * @param locatables1 See {@link IntervalUtils::combineAndSortBreakpoints}, but can be unsorted.
+     * @param locatables2 See {@link IntervalUtils::combineAndSortBreakpoints}, but can be unsorted.
      * @param dictionary Sequence dictionary to base the sort.  The order of contigs/sequences in the dictionary is the order of the sorting here.
      *                   Never {@code null}
-     * @param <T> See {@link IntervalUtils::combineBreakpoints}
-     * @return See {@link IntervalUtils::combineBreakpoints}.  Please note that the output will be sorted.  Never {@code null}
+     * @param <T> See {@link IntervalUtils::combineAndSortBreakpoints}
+     * @return See {@link IntervalUtils::combineAndSortBreakpoints}.  Please note that the output will be sorted.  Never {@code null}
      */
     public static <T extends Locatable> List<Locatable> combineBreakpointsWithSorting(final List<T> locatables1, final List<T> locatables2,
                                                                                       final SAMSequenceDictionary dictionary) {
@@ -1298,7 +1299,7 @@ public final class IntervalUtils {
         final List<T> sortedLocatables1 = sortLocatablesBySequenceDictionary(locatables1, dictionary);
         final List<T> sortedLocatables2 = sortLocatablesBySequenceDictionary(locatables2, dictionary);
 
-        return  sortLocatablesBySequenceDictionary(combineBreakpoints(sortedLocatables1, sortedLocatables2), dictionary);
+        return combineAndSortBreakpoints(sortedLocatables1, sortedLocatables2, dictionary);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1151,11 +1151,13 @@ public final class IntervalUtils {
      *
      * Intervals are assumed to include the start and end bases.
      *
+     * Output contigs will be shuffled.
+     *
      * @param locatables1 list of locatables
      * @param locatables2 list of locatables
      * @return Locatables from the combined breakpoints of locatable1 and locatable2.  If both inputs are null, return an
      *   empty list.  Please note that returned values are new copies.  If exactly one of the inputs is null, this method
-     *   returns a copy of of the non-null input.
+     *   returns a copy of of the non-null input.  Contigs will be shuffled.
      */
     protected static <T extends Locatable> List<Locatable> combineBreakpoints(final List<T> locatables1, final List<T> locatables2) {
         if ((locatables1 == null) && (locatables2 == null)) {
@@ -1293,6 +1295,7 @@ public final class IntervalUtils {
         final List<T> sortedLocatables1 = sortLocatablesBySequenceDictionary(locatables1, dictionary);
         final List<T> sortedLocatables2 = sortLocatablesBySequenceDictionary(locatables2, dictionary);
 
+//        return  sortLocatablesBySequenceDictionary(combineBreakpoints(sortedLocatables1, sortedLocatables2), dictionary);
         return combineBreakpoints(sortedLocatables1, sortedLocatables2);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1115,6 +1115,9 @@ public final class IntervalUtils {
     // (end of shard-related code)
 
     /**
+     *
+     * For most uses, developers will want to call {@link IntervalUtils#combineBreakpointsWithSorting(List, List, SAMSequenceDictionary)} rather than this method.  This method has unsorted output.
+     *
      * Combine the breakpoints of multiple intervals and return a list of locatables based on the updated breakpoints.
      *
      * Suppose we have two lists of locatables:
@@ -1151,13 +1154,13 @@ public final class IntervalUtils {
      *
      * Intervals are assumed to include the start and end bases.
      *
-     * Output contigs will be shuffled.
+     * Output contigs will be unordered.
      *
      * @param locatables1 list of locatables
      * @param locatables2 list of locatables
      * @return Locatables from the combined breakpoints of locatable1 and locatable2.  If both inputs are null, return an
      *   empty list.  Please note that returned values are new copies.  If exactly one of the inputs is null, this method
-     *   returns a copy of of the non-null input.  Contigs will be shuffled.
+     *   returns a copy of of the non-null input.  Contigs will be unordered.
      */
     protected static <T extends Locatable> List<Locatable> combineBreakpoints(final List<T> locatables1, final List<T> locatables2) {
         if ((locatables1 == null) && (locatables2 == null)) {
@@ -1295,8 +1298,7 @@ public final class IntervalUtils {
         final List<T> sortedLocatables1 = sortLocatablesBySequenceDictionary(locatables1, dictionary);
         final List<T> sortedLocatables2 = sortLocatablesBySequenceDictionary(locatables2, dictionary);
 
-//        return  sortLocatablesBySequenceDictionary(combineBreakpoints(sortedLocatables1, sortedLocatables2), dictionary);
-        return combineBreakpoints(sortedLocatables1, sortedLocatables2);
+        return  sortLocatablesBySequenceDictionary(combineBreakpoints(sortedLocatables1, sortedLocatables2), dictionary);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -1577,6 +1577,11 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
                 new SimpleInterval("10", 7000, 8000),
                 new SimpleInterval("10", 10000, 11000),
                 new SimpleInterval("10", 12000, 14000),
+                new SimpleInterval("11", 1000, 2000),
+                new SimpleInterval("11", 5000, 6000),
+                new SimpleInterval("11", 7000, 8000),
+                new SimpleInterval("11", 10000, 11000),
+                new SimpleInterval("11", 12000, 14000),
                 new SimpleInterval("3", 1000, 2000),
                 new SimpleInterval("3", 5000, 6000),
                 new SimpleInterval("3", 7000, 8000),
@@ -1624,8 +1629,13 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
                 new SimpleInterval("10", 7000, 8000),
                 new SimpleInterval("10", 10000, 10500),
                 new SimpleInterval("10", 10501, 11000),
-                new SimpleInterval("10", 12000, 14000)
-        );
+                new SimpleInterval("10", 12000, 14000),
+                new SimpleInterval("11", 1000, 2000),
+                new SimpleInterval("11", 5000, 6000),
+                new SimpleInterval("11", 7000, 8000),
+                new SimpleInterval("11", 10000, 11000),
+                new SimpleInterval("11", 12000, 14000)
+                );
 
         return new Object[][]{
                 {input1_1, input1_2, output1},
@@ -1646,13 +1656,6 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
                 {input16_1, input16_2, output16},
                 {input17_1, input17_2, output17},
         };
-    }
-
-    @Test(dataProvider = "combineIntervalsTesting")
-    public void testCombineIntervals(List<Locatable> locatables1, List<Locatable> locatables2, List<Locatable> gtOutput) {
-        final List<Locatable> outputs = IntervalUtils.combineBreakpoints(locatables1, locatables2);
-        Assert.assertEquals(outputs.size(), gtOutput.size());
-        Assert.assertEquals(outputs, gtOutput);
     }
 
     @Test(expectedExceptions = UserException.BadInput.class)
@@ -1705,7 +1708,8 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
                         new SAMSequenceRecord("2", 500000),
                         new SAMSequenceRecord("3", 500000),
                         new SAMSequenceRecord("4", 500000),
-                        new SAMSequenceRecord("10", 500000)));
+                        new SAMSequenceRecord("10", 500000),
+                        new SAMSequenceRecord("11", 500000)));
     }
 
     @DataProvider(name = "overlappingData")

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -1697,7 +1697,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
 
         final SAMSequenceDictionary dictionary = getSamSequenceDictionaryForCombineIntervalTests();
 
-        final List<Locatable> outputs = IntervalUtils.combineBreakpointsWithSorting(locatables1, locatables2, dictionary);
+        final List<Locatable> outputs = IntervalUtils.combineAndSortBreakpoints(locatables1, locatables2, dictionary);
         Assert.assertEquals(outputs.size(), gtOutput.size());
         Assert.assertEquals(outputs, gtOutput);
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -1565,6 +1565,68 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         output16.add(new SimpleInterval("2", 16001, 35000));
 
 
+        // Trivial to combine but has a lot of contigs
+        final List<Locatable> input17_1 = Lists.newArrayList(
+                new SimpleInterval("1", 1000, 2000),
+                new SimpleInterval("1", 5000, 6000),
+                new SimpleInterval("1", 7000, 8000),
+                new SimpleInterval("1", 10000, 11000),
+                new SimpleInterval("1", 12000, 14000),
+                new SimpleInterval("10", 1000, 2000),
+                new SimpleInterval("10", 5000, 6000),
+                new SimpleInterval("10", 7000, 8000),
+                new SimpleInterval("10", 10000, 11000),
+                new SimpleInterval("10", 12000, 14000),
+                new SimpleInterval("3", 1000, 2000),
+                new SimpleInterval("3", 5000, 6000),
+                new SimpleInterval("3", 7000, 8000),
+                new SimpleInterval("3", 10000, 11000),
+                new SimpleInterval("3", 12000, 14000),
+                new SimpleInterval("2", 1000, 2000),
+                new SimpleInterval("2", 5000, 6000),
+                new SimpleInterval("2", 7000, 8000),
+                new SimpleInterval("2", 10000, 11000),
+                new SimpleInterval("2", 12000, 14000));
+        final List<Locatable> input17_2 = Lists.newArrayList(
+                new SimpleInterval("10", 1000, 2000),
+                new SimpleInterval("10", 5000, 6000),
+                new SimpleInterval("10", 7000, 8000),
+                new SimpleInterval("10", 10000, 10500),
+                new SimpleInterval("10", 12000, 14000),
+                new SimpleInterval("2", 1000, 2000),
+                new SimpleInterval("2", 5000, 6000),
+                new SimpleInterval("2", 7000, 8000),
+                new SimpleInterval("2", 10000, 11000),
+                new SimpleInterval("2", 12000, 14000),
+                new SimpleInterval("3", 1000, 2000),
+                new SimpleInterval("3", 5000, 6000),
+                new SimpleInterval("3", 7000, 8000),
+                new SimpleInterval("3", 10000, 11000),
+                new SimpleInterval("3", 12000, 14000));
+        final List<Locatable> output17 = Lists.newArrayList(
+                new SimpleInterval("1", 1000, 2000),
+                new SimpleInterval("1", 5000, 6000),
+                new SimpleInterval("1", 7000, 8000),
+                new SimpleInterval("1", 10000, 11000),
+                new SimpleInterval("1", 12000, 14000),
+                new SimpleInterval("2", 1000, 2000),
+                new SimpleInterval("2", 5000, 6000),
+                new SimpleInterval("2", 7000, 8000),
+                new SimpleInterval("2", 10000, 11000),
+                new SimpleInterval("2", 12000, 14000),
+                new SimpleInterval("3", 1000, 2000),
+                new SimpleInterval("3", 5000, 6000),
+                new SimpleInterval("3", 7000, 8000),
+                new SimpleInterval("3", 10000, 11000),
+                new SimpleInterval("3", 12000, 14000),
+                new SimpleInterval("10", 1000, 2000),
+                new SimpleInterval("10", 5000, 6000),
+                new SimpleInterval("10", 7000, 8000),
+                new SimpleInterval("10", 10000, 10500),
+                new SimpleInterval("10", 10501, 11000),
+                new SimpleInterval("10", 12000, 14000)
+        );
+
         return new Object[][]{
                 {input1_1, input1_2, output1},
                 {input2_1, input2_2, output2},
@@ -1582,6 +1644,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
                 {input14_1, input14_2, output14},
                 {input15_1, input15_2, output15},
                 {input16_1, input16_2, output16},
+                {input17_1, input17_2, output17},
         };
     }
 
@@ -1639,7 +1702,10 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
     private SAMSequenceDictionary getSamSequenceDictionaryForCombineIntervalTests() {
         return new SAMSequenceDictionary(
                 Arrays.asList(new SAMSequenceRecord("1", 500000),
-                        new SAMSequenceRecord("2", 500000)));
+                        new SAMSequenceRecord("2", 500000),
+                        new SAMSequenceRecord("3", 500000),
+                        new SAMSequenceRecord("4", 500000),
+                        new SAMSequenceRecord("10", 500000)));
     }
 
     @DataProvider(name = "overlappingData")

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -15,9 +15,9 @@ import htsjdk.tribble.SimpleFeature;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.barclay.argparser.CommandLineException;
+import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
-import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -1667,7 +1667,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         input1_2.add(new SimpleInterval("1", 500, 2500));
         input1_2.add(new SimpleInterval("1", 2501, 3000));
         input1_2.add(new SimpleInterval("1", 4000, 5000));
-        IntervalUtils.combineBreakpoints(input1_1, input1_2);
+        IntervalUtils.combineAndSortBreakpoints(input1_1, input1_2, getSamSequenceDictionaryForCombineIntervalTests());
     }
 
     @Test(expectedExceptions = UserException.BadInput.class)
@@ -1679,7 +1679,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         input1_2.add(new SimpleInterval("1", 2501, 3000));
         input1_2.add(new SimpleInterval("1", 4000, 5000));
         input1_2.add(new SimpleInterval("1", 4000, 5000));
-        IntervalUtils.combineBreakpoints(input1_1, input1_2);
+        IntervalUtils.combineAndSortBreakpoints(input1_1, input1_2, getSamSequenceDictionaryForCombineIntervalTests());
     }
 
     /**


### PR DESCRIPTION
- expanding unit tests to actually replicate the error if we have a regression.
- applied fix that sorts the output.