### PR TITLE
Pass Intel inflater and deflater settings to Hadoop-BAM.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -251,7 +251,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
                 throw new UserException.MissingReference("A reference file is required when using CRAM files.");
             }
             final String refPath = hasReference() ?  referenceArguments.getReferenceFileName() : null;
-            return readsSource.getParallelReads(readInput, refPath, traversalParameters, bamPartitionSplitSize);
+            return readsSource.getParallelReads(readInput, refPath, traversalParameters, bamPartitionSplitSize, !useJdkInflater, !useJdkDeflater);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -32,10 +32,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadConstants;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
-import org.seqdoop.hadoop_bam.AnySAMInputFormat;
-import org.seqdoop.hadoop_bam.BAMInputFormat;
-import org.seqdoop.hadoop_bam.CRAMInputFormat;
-import org.seqdoop.hadoop_bam.SAMRecordWritable;
+import org.seqdoop.hadoop_bam.*;
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
 
 import java.io.File;
@@ -75,7 +72,7 @@ public final class ReadsSparkSource implements Serializable {
      * @return RDD of (SAMRecord-backed) GATKReads from the file.
      */
     public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, final TraversalParameters traversalParameters) {
-        return getParallelReads(readFileName, referencePath, traversalParameters, 0);
+        return getParallelReads(readFileName, referencePath, traversalParameters, 0, false, false);
     }
 
     /**
@@ -86,9 +83,11 @@ public final class ReadsSparkSource implements Serializable {
      * @param traversalParameters parameters controlling which reads to include. If <code>null</code> then all the reads (both mapped and unmapped) will be returned.
      * @param splitSize maximum bytes of bam file to read into a single partition, increasing this will result in fewer partitions. A value of zero means
      *                  use the default split size (determined by the Hadoop input format, typically the size of one HDFS block).
+     * @param useIntelInflater whether to use the Intel inflater to decompress DEFLATE streams
+     * @param useIntelDeflater whether to use the Intel deflater to compress DEFLATE streams
      * @return RDD of (SAMRecord-backed) GATKReads from the file.
      */
-    public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, final TraversalParameters traversalParameters, final long splitSize) {
+    public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, final TraversalParameters traversalParameters, final long splitSize, boolean useIntelInflater, boolean useIntelDeflater) {
         SAMFileHeader header = getHeader(readFileName, referencePath);
 
         // use the Hadoop configuration attached to the Spark context to maintain cumulative settings
@@ -99,7 +98,7 @@ public final class ReadsSparkSource implements Serializable {
 
         final JavaPairRDD<LongWritable, SAMRecordWritable> rdd2;
 
-        setHadoopBAMConfigurationProperties(readFileName, referencePath);
+        setHadoopBAMConfigurationProperties(readFileName, referencePath, useIntelInflater, useIntelDeflater);
 
         boolean isBam = IOUtils.isBamFileName(readFileName);
         if (isBam) {
@@ -145,7 +144,7 @@ public final class ReadsSparkSource implements Serializable {
      * @return RDD of (SAMRecord-backed) GATKReads from the file.
      */
     public JavaRDD<GATKRead> getParallelReads(final String readFileName, final String referencePath, int splitSize) {
-        return getParallelReads(readFileName, referencePath, null /* all reads */, splitSize);
+        return getParallelReads(readFileName, referencePath, null /* all reads */, splitSize, false, false);
     }
 
     /**
@@ -202,7 +201,7 @@ public final class ReadsSparkSource implements Serializable {
                 }
                 path = bamFiles[0].getPath(); // Hadoop-BAM writes the same header to each shard, so use the first one
             }
-            setHadoopBAMConfigurationProperties(filePath, referencePath);
+            setHadoopBAMConfigurationProperties(filePath, referencePath, false, false);
             return SAMHeaderReader.readSAMHeaderFrom(path, ctx.hadoopConfiguration());
         } catch (IOException | IllegalArgumentException e) {
             throw new UserException("Failed to read bam header from " + filePath + "\n Caused by:" + e.getMessage(), e);
@@ -282,10 +281,22 @@ public final class ReadsSparkSource implements Serializable {
      *     from passing a stale value through to htsjdk when multiple read calls are made serially
      *     with different inputs but the same Spark context
      */
-    private void setHadoopBAMConfigurationProperties(final String inputName, final String referenceName) {
+    private void setHadoopBAMConfigurationProperties(final String inputName, final String referenceName, final boolean useIntelInflater, final boolean useIntelDeflater) {
         // use the Hadoop configuration attached to the Spark context to maintain cumulative settings
         final Configuration conf = ctx.hadoopConfiguration();
         conf.set(SAMHeaderReader.VALIDATION_STRINGENCY_PROPERTY, validationStringency.name());
+
+        if (useIntelInflater) {
+            conf.setBoolean(BAMInputFormat.USE_INTEL_INFLATER_PROPERTY, true);
+        } else {
+            conf.unset(BAMInputFormat.USE_INTEL_INFLATER_PROPERTY);
+        }
+
+        if (useIntelDeflater) {
+            conf.setBoolean(BAMOutputFormat.USE_INTEL_DEFLATER_PROPERTY, true);
+        } else {
+            conf.unset(BAMOutputFormat.USE_INTEL_DEFLATER_PROPERTY);
+        }
 
         if (!IOUtils.isCramFileName(inputName)) {
             // only set the reference for CRAM input

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
@@ -157,7 +157,7 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
                 throw new UserException.BadInput("Input BAM should be unaligned, but found one or more sequences in the header.");
             }
             PSBwaUtils.addReferenceSequencesToHeader(header, bwaArgs.referencePath, getReferenceWindowFunction());
-            final JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize);
+            final JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize, !useJdkInflater, !useJdkDeflater);
             return new Tuple2<>(header, reads);
         }
         logger.warn("Could not find file " + path + ". Skipping...");

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreSpark.java
@@ -142,7 +142,7 @@ public class PathSeqScoreSpark extends GATKSparkTool {
             if (BucketUtils.fileExists(path)) {
                 recommendedNumReducers += PSUtils.pathseqGetRecommendedNumReducers(path, numReducers, getTargetPartitionSize());
                 final SAMFileHeader header = readsSource.getHeader(path, null);
-                JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize);
+                JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize, !useJdkInflater, !useJdkDeflater);
                 reads = PSUtils.primaryReads(reads);
                 return new Tuple2<>(reads, header);
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/validation/CompareDuplicatesSpark.java
@@ -113,7 +113,7 @@ public final class CompareDuplicatesSpark extends GATKSparkTool {
         } else {
             traversalParameters = null;
         }
-        JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, traversalParameters, bamPartitionSplitSize), input2);
+        JavaRDD<GATKRead> secondReads =  filteredReads(readsSource2.getParallelReads(input2, null, traversalParameters, bamPartitionSplitSize, !useJdkInflater, !useJdkDeflater), input2);
 
         // Start by verifying that we have same number of reads and duplicates in each BAM.
         long firstBamSize = firstReads.count();

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSparkUnitTest.java
@@ -40,7 +40,7 @@ public final class FindBreakpointEvidenceSparkUnitTest extends GATKBaseTest {
     private final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
     private final ReadsSparkSource readsSource = new ReadsSparkSource(ctx);
     private final SAMFileHeader header = readsSource.getHeader(readsFile, null);
-    private final JavaRDD<GATKRead> reads = readsSource.getParallelReads(readsFile, null, null, 0L);
+    private final JavaRDD<GATKRead> reads = readsSource.getParallelReads(readsFile, null, null);
     private final SVReadFilter filter = new SVReadFilter(params);
     private final ReadMetadata readMetadataExpected =
             new ReadMetadata(Collections.emptySet(), header,


### PR DESCRIPTION
Relies on https://github.com/HadoopGenomics/Hadoop-BAM/pull/167; fixes #2281.

I ran MD on an exome-sized BAM, and this change improved the final stage (writing a BAM) by around 20% (which works out as a few seconds since the stage takes ~1min); but made no real difference on the first stage (reading a BAM). So probably worth having, but not a huge improvement.