### PR TITLE
Identify Picard tools in help/doc using " (Picard)" suffix.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -11,6 +11,7 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.ClassUtils;
+import org.broadinstitute.hellbender.utils.runtime.RuntimeUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.PrintStream;
@@ -246,7 +247,7 @@ public class Main {
     /**
      * Returns the command line program specified, or prints the usage and exits with exit code 1 *
      */
-    private static CommandLineProgram extractCommandLineProgram(final String[] args, final List<String> packageList, final List<Class<? extends CommandLineProgram>> classList, final String commandLineName) {
+    private CommandLineProgram extractCommandLineProgram(final String[] args, final List<String> packageList, final List<Class<? extends CommandLineProgram>> classList, final String commandLineName) {
 
         /** Get the set of classes that are our command line programs **/
         final ClassFinder classFinder = new ClassFinder();
@@ -314,11 +315,11 @@ public class Main {
 
         @Override
         public int compare(final Class<?> aClass, final Class<?> bClass) {
-            return aClass.getSimpleName().compareTo(bClass.getSimpleName());
+            return RuntimeUtils.toolDisplayName(aClass).compareTo(RuntimeUtils.toolDisplayName(bClass));
         }
     }
 
-    private static void printUsage(final PrintStream destinationStream, final Set<Class<?>> classes, final String commandLineName) {
+    private void printUsage(final PrintStream destinationStream, final Set<Class<?>> classes, final String commandLineName) {
         final StringBuilder builder = new StringBuilder();
         builder.append(BOLDRED + "USAGE: " + commandLineName + " " + GREEN + "<program name>" + BOLDRED + " [-h]\n\n" + KNRM)
                 .append(BOLDRED + "Available Programs:\n" + KNRM);
@@ -375,16 +376,24 @@ public class Main {
                         betaFeature == null ?
                                 String.format("%s%s", CYAN, property.oneLineSummary()) :
                                 String.format("%s%s %s%s", RED, "(BETA Tool)", CYAN, property.oneLineSummary());
+                final String annotatedToolName = getDisplayNameForToolClass(clazz);
                 if (clazz.getSimpleName().length() >= 45) {
-                    builder.append(String.format("%s    %s    %s%s\n", GREEN, clazz.getSimpleName(), summaryLine, KNRM));
+                    builder.append(String.format("%s    %s    %s%s\n", GREEN, annotatedToolName, summaryLine, KNRM));
                 } else {
-                    builder.append(String.format("%s    %-45s%s%s\n", GREEN, clazz.getSimpleName(), summaryLine, KNRM));
+                    builder.append(String.format("%s    %-45s%s%s\n", GREEN, annotatedToolName, summaryLine, KNRM));
                 }
             }
             builder.append(String.format("\n"));
         }
         builder.append(WHITE + "--------------------------------------------------------------------------------------\n" + KNRM);
         destinationStream.println(builder.toString());
+    }
+
+    /**
+     * @return A display name to be used for the tool who's class is {@code clazz}.
+     */
+    protected String getDisplayNameForToolClass(Class<?> clazz) {
+        return RuntimeUtils.toolDisplayName(clazz);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKDocWorkUnit.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKDocWorkUnit.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.hellbender.utils.help;
+
+import com.sun.javadoc.ClassDoc;
+import org.broadinstitute.barclay.help.DocWorkUnit;
+import org.broadinstitute.barclay.help.DocWorkUnitHandler;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+
+import org.broadinstitute.hellbender.utils.runtime.RuntimeUtils;
+
+/**
+ * Custom DocWorkUnit used for generating GATK help/documentation. Overrides the defaults to provide tool
+ * names that are annotated with a " (Picard)" suffix for Picard tools.
+ *
+ * NOTE: Methods in this class are intended to be called by Gradle/Javadoc only, and should not be called
+ * by methods that are used by the GATK runtime. This class has a dependency on com.sun.javadoc classes,
+ * which may not be present since they're not provided as part of the normal GATK runtime classpath.
+ */
+public class GATKDocWorkUnit extends DocWorkUnit {
+
+    public GATKDocWorkUnit(
+            final DocWorkUnitHandler workUnitHandler,
+            final DocumentedFeature documentedFeatureAnnotation,
+            final ClassDoc classDoc,
+            final Class<?> clazz) {
+        super(workUnitHandler, documentedFeatureAnnotation, classDoc, clazz);
+    }
+
+    @Override
+    public String getName() {
+        // Override getName to return a display name that annotates Picard tool names with " (Picard)"
+        return RuntimeUtils.toolDisplayName(getClazz());
+    }
+
+    /**
+     * Sort in order of the name of this WorkUnit
+     */
+    @Override
+    public int compareTo(DocWorkUnit other) {
+        return this.getName().compareTo(other.getName());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDoclet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDoclet.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.utils.help;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.RootDoc;
 
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.barclay.help.DocWorkUnit;
 import org.broadinstitute.barclay.help.GSONWorkUnit;
@@ -59,7 +58,7 @@ public class GATKHelpDoclet extends HelpDoclet {
             final ClassDoc classDoc,
             final Class<?> clazz)
     {
-        return new DocWorkUnit(
+        return new GATKDocWorkUnit(
                 new GATKHelpDocWorkUnitHandler(this),
                 documentedFeature,
                 classDoc,

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/RuntimeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/RuntimeUtils.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 
+import org.broadinstitute.hellbender.utils.Utils;
+
 public final class RuntimeUtils {
     public static final String[] PATHS;
 
@@ -31,4 +33,21 @@ public final class RuntimeUtils {
         }
         return null;
     }
+
+    /**
+     * Given a Class that is a CommandLineProgram, either GATK or Picard, return a display name suitable for
+     * presentation to the user that distinguishes GATK tools from Picard tools by including a " (Picard)" suffix;
+     * @param toolClass A CommandLineProgram class object may not be null
+     * @return tool display name
+     */
+    public static String toolDisplayName(final Class<?> toolClass) {
+        Utils.nonNull(toolClass, "A valid class is required to get a display name");
+
+        final String picardToolSuffix = " (Picard)";
+        final Class<?> picardCommandLineProgramClass = picard.cmdline.CommandLineProgram.class;
+        return picardCommandLineProgramClass.isAssignableFrom(toolClass) ?
+                toolClass.getSimpleName() + picardToolSuffix :
+                toolClass.getSimpleName();
+    }
+
 }


### PR DESCRIPTION
Consolidate program GATK program groups with Picard, and identify Picard tools in doc and help output:

<img width="882" alt="screen shot 2017-11-13 at 3 30 43 pm" src="https://user-images.githubusercontent.com/10062863/32747756-bdbfa102-c887-11e7-98a8-59983da15e3e.png">

<img width="808" alt="screen shot 2017-11-13 at 3 26 41 pm" src="https://user-images.githubusercontent.com/10062863/32747559-2805f526-c887-11e7-98ad-5be2b0b9ff37.png">
