### PR TITLE
Add GATKTool unit test for picard interval lists.

### DIFF
--- a/src/test/resources/picard_intervals.list
+++ b/src/test/resources/picard_intervals.list
@@ -1,0 +1,9 @@
+@HD	VN:1.4	SO:unsorted
+@SQ	SN:1	LN:16000	M5:8c0c38e352d8f3309eabe4845456f274	UR:file:/Users/louisb/Workspace/hellbender/hg19mini.fasta
+@SQ	SN:2	LN:16000	M5:5f8388fe3fb34aa38375ae6cf5e45b89	UR:file:/Users/louisb/Workspace/hellbender/hg19mini.fasta
+@SQ	SN:3	LN:16000	M5:94de808a3a2203dbb02434a47bd8184f	UR:file:/Users/louisb/Workspace/hellbender/hg19mini.fasta
+@SQ	SN:4	LN:16000	M5:7d397ee919e379328d8f52c57a54c778	UR:file:/Users/louisb/Workspace/hellbender/hg19mini.fasta
+1	1	5	+	test_1
+1	6	10	+	test_2
+2	1	5	+	test_3
+3	1	5	+	test_4


### PR DESCRIPTION
Test to verify that picard interval lists are handled properly by GATK tools. Validates the fix for https://github.com/broadinstitute/gatk/issues/3555.