### PR TITLE
Changed StrandArtifact to warn and not annotate if the 'TLOD' attribute is missing from the VariantContext

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandArtifact.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandArtifact.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
 import java.util.*;
@@ -25,6 +26,8 @@ import static org.broadinstitute.hellbender.tools.walkers.annotator.StrandArtifa
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Annotations for strand artifact filter (SA_POST_PROB, SA_MAP_AF)")
 public class StrandArtifact extends GenotypeAnnotation implements StandardMutectAnnotation {
+    protected final OneShotLogger warning = new OneShotLogger(this.getClass());
+
     public static final String POSTERIOR_PROBABILITIES_KEY = "SA_POST_PROB";
     public static final String MAP_ALLELE_FRACTIONS_KEY = "SA_MAP_AF";
 
@@ -72,6 +75,11 @@ public class StrandArtifact extends GenotypeAnnotation implements StandardMutect
 
         // We use the allele with highest LOD score
         final double[] tumorLods = GATKProtectedVariantContextUtils.getAttributeAsDoubleArray(vc, GATKVCFConstants.TUMOR_LOD_KEY, () -> null, -1);
+
+        if (tumorLods==null) {
+            warning.warn("One or more variant contexts is missing the 'TLOD' annotation, StrandArtifact will not be computed for these VariantContexts");
+            return;
+        }
         final int indexOfMaxTumorLod = MathUtils.maxElementIndex(tumorLods);
         final Allele altAlelle = vc.getAlternateAllele(indexOfMaxTumorLod);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngineUnitTest.java
@@ -272,10 +272,9 @@ public final class VariantAnnotatorEngineUnitTest extends GATKBaseTest {
     @Test
     public void testAllAnnotations() throws Exception {
         /**
-         * exclude {@link StrandArtifact} until https://github.com/broadinstitute/gatk/issues/2797 is fixed
          * exclude {@link ReferenceBases} until https://github.com/broadinstitute/gatk/issues/2799 is fixed
          * */
-        final List<String> annotationsToExclude= Arrays.asList("StrandArtifact", "ReferenceBases");
+        final List<String> annotationsToExclude= Arrays.asList( "ReferenceBases");
         final FeatureInput<VariantContext> dbSNPBinding = null;
         final List<FeatureInput<VariantContext>> features = Collections.emptyList();
         final VariantAnnotatorEngine vae = VariantAnnotatorEngine.ofAllMinusExcluded(annotationsToExclude, dbSNPBinding, features);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/StrandArtifactUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/StrandArtifactUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.genotyper.*;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.ArtificialAnnotationUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -195,4 +196,25 @@ public class StrandArtifactUnitTest {
 
     }
 
+    @Test
+    // Asserting that when the annotation is run without the "TLOD" key on the vc then the annotation does nothing
+    public void testMissingTumorLod() throws IOException {
+        final ReadLikelihoods<Allele> likelihoods = ArtificialAnnotationUtils.makeLikelihoods(sampleName, Collections.singletonList(ArtificialAnnotationUtils.makeRead(100, 100)), 100, Allele.create((byte) 'C', true),   Allele.create((byte) 'A', false));
+        
+        VariantContext variantContextNoTLOD = new VariantContextBuilder(vc).rmAttribute(GATKVCFConstants.TUMOR_LOD_KEY).make();
+
+        final StrandArtifact strandArtifactAnnotation = new StrandArtifact();
+        final GenotypeBuilder genotypeBuilder = new GenotypeBuilder(sampleName);
+        strandArtifactAnnotation.annotate(null, variantContextNoTLOD, genotypeBuilder.make(), genotypeBuilder, likelihoods);
+
+        final Genotype genotype = genotypeBuilder.make();
+        final double[] posteriorProbabilities =
+                GATKProtectedVariantContextUtils.getAttributeAsDoubleArray(genotype, StrandArtifact.POSTERIOR_PROBABILITIES_KEY, () -> null, -1);
+        final double[] mapAlleleFractionEstimates =
+                GATKProtectedVariantContextUtils.getAttributeAsDoubleArray(genotype, StrandArtifact.MAP_ALLELE_FRACTIONS_KEY, () -> null, -1);
+
+        // Asserting that the tool passed through without annotating
+        Assert.assertNull(posteriorProbabilities);
+        Assert.assertNull(mapAlleleFractionEstimates);
+    }
 }


### PR DESCRIPTION
Before it was throwing a NullPointerError.

Fixes #2797