### PR TITLE
Making -A become -AM in FilterByOrientationBias.

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -380,7 +380,7 @@ task Filter {
 
     # FilterByOrientationBias must come after all of the other filtering.
     if [[ ! -z "${pre_adapter_metrics}" ]]; then
-        java -Xmx4g -jar $GATK_JAR FilterByOrientationBias -A ${sep=" -A " artifact_modes} \
+        java -Xmx4g -jar $GATK_JAR FilterByOrientationBias -AM ${sep=" -AM " artifact_modes} \
             -V filtered.vcf -P ${pre_adapter_metrics} --output ${filtered_vcf_name}
     else
         mv filtered.vcf ${filtered_vcf_name}

--- a/scripts/mutect2_wdl/unsupported/mutect2_opt.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2_opt.wdl
@@ -596,7 +596,7 @@ task FilterByOrientationBias {
     sed -r "s/picard\.analysis\.artifacts\.SequencingArtifactMetrics\\\$PreAdapterDetailMetrics/org\.broadinstitute\.hellbender\.tools\.picard\.analysis\.artifacts\.SequencingArtifactMetrics\$PreAdapterDetailMetrics/g" \
       "${pre_adapter_metrics}" > "gatk.pre_adapter_detail_metrics"
 
-     java -Xmx${command_mem}m -jar ${default="/root/gatk.jar" gatk4_jar_override} FilterByOrientationBias -A ${sep=" -A " artifact_modes} \
+     java -Xmx${command_mem}m -jar ${default="/root/gatk.jar" gatk4_jar_override} FilterByOrientationBias -AM ${sep=" -AM " artifact_modes} \
        -V ${input_vcf} -P gatk.pre_adapter_detail_metrics --output "${output_vcf_name}-filtered.vcf"
   }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
@@ -18,8 +18,8 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.exome.orientationbiasvariantfilter.OrientationBiasFilterer;
 import org.broadinstitute.hellbender.tools.exome.orientationbiasvariantfilter.OrientationBiasUtils;
 import org.broadinstitute.hellbender.tools.exome.orientationbiasvariantfilter.PreAdapterOrientationScorer;
-import picard.analysis.artifacts.SequencingArtifactMetrics;
 import org.broadinstitute.hellbender.utils.artifacts.Transition;
+import picard.analysis.artifacts.SequencingArtifactMetrics;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -89,7 +89,7 @@ public class FilterByOrientationBias extends VariantWalker {
 
     public static final String PRE_ADAPTER_METRICS_DETAIL_FILE_SHORT_NAME = "P";
     public static final String PRE_ADAPTER_METRICS_DETAIL_FILE_FULL_NAME = "preAdapterDetailFile";
-    public static final String ARTIFACT_MODES_SHORT_NAME = "A";
+    public static final String ARTIFACT_MODES_SHORT_NAME = "AM";
     public static final String ARTIFACT_MODES_FULL_NAME = "artifactModes";
 
     public static final String DEFAULT_ARTIFACT_MODE = "G/T";


### PR DESCRIPTION
So as to avoid a conflict with -A for annotations.

closes #3875 