### PR TITLE
Docs/Args cleanup for HaplotypeCaller and other tools, and SplitNCigarReads change

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -240,7 +240,7 @@ task M2 {
     ${"-pon " + pon} \
     ${"-L " + intervals} \
     -O "output.vcf" \
-    ${true='--bamOutput bamout.bam' false='' is_bamOut} \
+    ${true='--bam-output bamout.bam' false='' is_bamOut} \
     ${m2_extra_args}
   >>>
 

--- a/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
+++ b/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
@@ -280,7 +280,7 @@ task Jaccard {
         count=0
         for vcf in ${sep = ' ' calls}; do
             ((count++))
-            java -jar ${gatk} SelectVariants -V $vcf -selectType ${type} -O ${type}_only_$count.vcf
+            java -jar ${gatk} SelectVariants -V $vcf --select-type-to-include ${type} -O ${type}_only_$count.vcf
         done
 
         for file1 in ${type}_only*.vcf; do

--- a/scripts/mutect2_wdl/unsupported/mutect2_opt.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2_opt.wdl
@@ -339,8 +339,8 @@ task M2 {
     -I ${tumor_bam} \
     -tumor `cat tumor_name.txt` \
     $normal_command_line \
-    ${"--germline_resource " + gnomad} \
-    ${"--normal_panel " + pon} \
+    ${"--germline-resource " + gnomad} \
+    ${"--panel-of-normals " + pon} \
     ${"-L " + intervals} \
     -O "${output_vcf_name}.vcf" \
     ${true='--bamOutput bamout.bam' false='' is_bamOut} \
@@ -546,7 +546,7 @@ task Filter {
     fi
 
     java -Xmx${command_mem}m -jar ${default="/root/gatk.jar" gatk4_jar_override} FilterMutectCalls -V ${unfiltered_vcf} \
-      -O ${output_vcf_name}-filtered.vcf ${"-contaminationTable " + contamination_table} \
+      -O ${output_vcf_name}-filtered.vcf ${"--contamination-table " + contamination_table} \
       ${m2_extra_filtering_args}
   }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -66,13 +66,13 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
     @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)
     public Boolean QUIET = false;
 
-    @Argument(fullName = "use_jdk_deflater", shortName = "jdk_deflater", doc = "Whether to use the JdkDeflater (as opposed to IntelDeflater)", common=true)
+    @Argument(fullName = "use-jdk-deflater", shortName = "jdk-deflater", doc = "Whether to use the JdkDeflater (as opposed to IntelDeflater)", common=true)
     public boolean useJdkDeflater = false;
 
-    @Argument(fullName = "use_jdk_inflater", shortName = "jdk_inflater", doc = "Whether to use the JdkInflater (as opposed to IntelInflater)", common=true)
+    @Argument(fullName = "use-jdk-inflater", shortName = "jdk-inflater", doc = "Whether to use the JdkInflater (as opposed to IntelInflater)", common=true)
     public boolean useJdkInflater = false;
 
-    @Argument(fullName = "gcs_max_retries", shortName = "gcs_retries", doc = "If the GCS bucket channel errors out, how many times it will attempt to re-initiate the connection", optional = true)
+    @Argument(fullName = "gcs-max-retries", shortName = "gcs-retries", doc = "If the GCS bucket channel errors out, how many times it will attempt to re-initiate the connection", optional = true)
     public int NIO_MAX_REOPENS = ConfigFactory.getInstance().getGATKConfig().gcsMaxRetries();
 
     // This option is here for documentation completeness.

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -13,7 +13,7 @@ public final class StandardArgumentDefinitions {
     public static final String VARIANT_LONG_NAME = "variant";
     public static final String FEATURE_LONG_NAME = "feature";
     public static final String INTERVALS_LONG_NAME = "intervals";
-    public static final String READ_INDEX_LONG_NAME = "readIndex";
+    public static final String READ_INDEX_LONG_NAME = "read-index";
     public static final String USE_ORIGINAL_QUALITIES_LONG_NAME = "use-original-qualities";
     public static final String LENIENT_LONG_NAME = "lenient";
     public static final String VERBOSITY_NAME = "verbosity";
@@ -37,6 +37,8 @@ public final class StandardArgumentDefinitions {
     public static final String ANNOTATION_LONG_NAME = "annotation";
     public static final String ANNOTATION_GROUP_LONG_NAME = "annotation-group";
     public static final String ANNOTATIONS_TO_EXCLUDE_LONG_NAME = "annotations-to-exclude";
+    public static final String SAMPLE_NAME_LONG_NAME = "sample-name";
+    public static final String PEDIGREE_FILE_LONG_NAME = "pedigree";
 
     public static final String INPUT_SHORT_NAME = "I";
     public static final String OUTPUT_SHORT_NAME = "O";
@@ -72,6 +74,8 @@ public final class StandardArgumentDefinitions {
     public static final String ANNOTATION_SHORT_NAME = "A";
     public static final String ANNOTATION_GROUP_SHORT_NAME = "G";
     public static final String ANNOTATIONS_TO_EXCLUDE_SHORT_NAME = "AX";
+    public static final String SAMPLE_NAME_SHORT_NAME = "sn";
+    public static final String PEDIGREE_FILE_SHORT_NAME = "ped";
 
     public static final String SPARK_PROPERTY_NAME = "conf";
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -45,27 +45,37 @@ import java.util.List;
  */
 public abstract class AssemblyRegionWalker extends GATKTool {
 
+    //NOTE: these argument names are referenced by HaplotypeCallerSpark
+    public static final String MIN_ASSEMBLY_LONG_NAME = "min-assembly-region-size";
+    public static final String MAX_ASSEMBLY_LONG_NAME = "max-assembly-region-size";
+    public static final String ASSEMBLY_PADDING_LONG_NAME = "assembly-region-padding";
+    public static final String MAX_STARTS_LONG_NAME = "max-reads-per-alignment-start";
+    public static final String THRESHOLD_LONG_NAME = "active-probability-threshold";
+    public static final String PROPAGATION_LONG_NAME = "max-prob-propagation-distance";
+    public static final String PROFILE_OUT_LONG_NAME = "activity-profile-out";
+    public static final String ASSEMBLY_REGION_OUT_LONG_NAME = "assembly-region-out";
+
     @Advanced
-    @Argument(fullName = "minAssemblyRegionSize", shortName = "minAssemblyRegionSize", doc = "Minimum size of an assembly region", optional = true)
+    @Argument(fullName = MIN_ASSEMBLY_LONG_NAME, doc = "Minimum size of an assembly region", optional = true)
     protected int minAssemblyRegionSize = defaultMinAssemblyRegionSize();
 
     @Advanced
-    @Argument(fullName = "maxAssemblyRegionSize", shortName = "maxAssemblyRegionSize", doc = "Maximum size of an assembly region", optional = true)
+    @Argument(fullName = MAX_ASSEMBLY_LONG_NAME, doc = "Maximum size of an assembly region", optional = true)
     protected int maxAssemblyRegionSize = defaultMaxAssemblyRegionSize();
 
     @Advanced
-    @Argument(fullName = "assemblyRegionPadding", shortName = "assemblyRegionPadding", doc = "Number of additional bases of context to include around each assembly region", optional = true)
+    @Argument(fullName = ASSEMBLY_PADDING_LONG_NAME, doc = "Number of additional bases of context to include around each assembly region", optional = true)
     protected int assemblyRegionPadding = defaultAssemblyRegionPadding();
 
-    @Argument(fullName = "maxReadsPerAlignmentStart", shortName = "maxReadsPerAlignmentStart", doc = "Maximum number of reads to retain per alignment start position. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
+    @Argument(fullName = MAX_STARTS_LONG_NAME, doc = "Maximum number of reads to retain per alignment start position. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
     protected int maxReadsPerAlignmentStart = defaultMaxReadsPerAlignmentStart();
 
     @Advanced
-    @Argument(fullName = "activeProbabilityThreshold", shortName = "activeProbabilityThreshold", doc="Minimum probability for a locus to be considered active.", optional = true)
+    @Argument(fullName = THRESHOLD_LONG_NAME, doc="Minimum probability for a locus to be considered active.", optional = true)
     protected double activeProbThreshold = defaultActiveProbThreshold();
 
     @Advanced
-    @Argument(fullName = "maxProbPropagationDistance", shortName = "maxProbPropagationDistance", doc="Upper limit on how many bases away probability mass can be moved around when calculating the boundaries between active and inactive assembly regions", optional = true)
+    @Argument(fullName = PROPAGATION_LONG_NAME, doc="Upper limit on how many bases away probability mass can be moved around when calculating the boundaries between active and inactive assembly regions", optional = true)
     protected int maxProbPropagationDistance = defaultMaxProbPropagationDistance();
 
     /**
@@ -76,7 +86,7 @@ public abstract class AssemblyRegionWalker extends GATKTool {
      *
      * Intended to make debugging the activity profile calculations easier
      */
-    @Argument(fullName="activityProfileOut", shortName="APO", doc="Output the raw activity profile results in IGV format", optional = true)
+    @Argument(fullName = PROFILE_OUT_LONG_NAME, doc="Output the raw activity profile results in IGV format", optional = true)
     protected String activityProfileOut = null;
 
     private PrintStream activityProfileOutStream;
@@ -89,7 +99,7 @@ public abstract class AssemblyRegionWalker extends GATKTool {
      *
      * Intended to make debugging the active region calculations easier
      */
-    @Argument(fullName="assemblyRegionOut", shortName="ARO", doc="Output the assembly region to this IGV formatted file", optional = true)
+    @Argument(fullName = ASSEMBLY_REGION_OUT_LONG_NAME, doc="Output the assembly region to this IGV formatted file", optional = true)
     protected String assemblyRegionOut = null;
 
     private PrintStream assemblyRegionOutStream;

--- a/src/main/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrdering.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrdering.java
@@ -44,7 +44,7 @@ public final class FixCallSetSampleOrdering extends VariantWalker {
             optional = false)
     public String sampleNameMapPath;
 
-    @Argument(fullName = GenomicsDBImport.BATCHSIZE_ARG_NAME,
+    @Argument(fullName = GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME,
             doc="the exact batch size that was used to import the callset using GenomicsDBImport",
             minValue = 0,
             optional = false)
@@ -55,7 +55,7 @@ public final class FixCallSetSampleOrdering extends VariantWalker {
             optional = false)
     public Integer readerThreads;
 
-    @Argument(fullName = "gvcfToHeaderSampleMapFile",
+    @Argument(fullName = "gvcf-to-header-sample-map-file",
             doc="A mapping of GVCF to actual sample name in the GVCF header. You must provide this file if and only if " +
                     "GenomicsDBImport was run with --" + GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME + " > 1. " +
                     "Each line in this file should contain a GVCF path (matching the one from the sample name " +
@@ -87,7 +87,7 @@ public final class FixCallSetSampleOrdering extends VariantWalker {
         assertThatTheyReallyWantToProceed();
 
         if (batchSize == 0) {
-            throw new SampleNameFixingCannotProceedException("your callset is not affected by the bug if you ran with --"+ GenomicsDBImport.BATCHSIZE_ARG_NAME +" 0");
+            throw new SampleNameFixingCannotProceedException("your callset is not affected by the bug if you ran with --"+ GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME +" 0");
         }
 
         if ( readerThreads > 1 ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -50,12 +50,19 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * Call germline SNPs and indels via local re-assembly of haplotypes
+ * Call germline SNPs and indels via local re-assembly of haplotypes.
  *
- * This is an implementation of {@link HaplotypeCaller} using spark to distribute the computation.
+ * <p>This is an implementation of {@link HaplotypeCaller} using spark to distribute the computation.
  * It is still in an early stage of development and does not yet support all the options that the non-spark version does.
+ * Specifically it does not support the --dbsnp, --comp, and --bamOutput options.</p>
  *
- * Specifically it does not support the --dbsnp, --comp, and --bamOutput options.
+ * <h3>Usage Example</h3>
+ * <pre>
+ * gatk HaplotypeCallerSpark \
+ * -R Homo_sapiens_assembly38.fasta \
+ * -I input.bam \
+ * -O output.vcf.gz
+ * </pre>
  *
  */
 @CommandLineProgramProperties(summary = "HaplotypeCaller on Spark", oneLineSummary = "HaplotypeCaller on Spark", programGroup = SparkProgramGroup.class)
@@ -75,30 +82,30 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
     public static class ShardingArgumentCollection implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        @Argument(fullName="readShardSize", shortName="readShardSize", doc = "Maximum size of each read shard, in bases. For good performance, this should be much larger than the maximum assembly region size.", optional = true)
+        @Argument(fullName="read-shard-size", doc = "Maximum size of each read shard, in bases. For good performance, this should be much larger than the maximum assembly region size.", optional = true)
         public int readShardSize = DEFAULT_READSHARD_SIZE;
 
-        @Argument(fullName="readShardPadding", shortName="readShardPadding", doc = "Each read shard has this many bases of extra context on each side. Read shards must have as much or more padding than assembly regions.", optional = true)
+        @Argument(fullName="read-shard-padding", doc = "Each read shard has this many bases of extra context on each side. Read shards must have as much or more padding than assembly regions.", optional = true)
         public int readShardPadding = HaplotypeCaller.DEFAULT_ASSEMBLY_REGION_PADDING;
 
-        @Argument(fullName = "minAssemblyRegionSize", shortName = "minAssemblyRegionSize", doc = "Minimum size of an assembly region", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.MIN_ASSEMBLY_LONG_NAME, doc = "Minimum size of an assembly region", optional = true)
         public int minAssemblyRegionSize = HaplotypeCaller.DEFAULT_MIN_ASSEMBLY_REGION_SIZE;
 
-        @Argument(fullName = "maxAssemblyRegionSize", shortName = "maxAssemblyRegionSize", doc = "Maximum size of an assembly region", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.MAX_ASSEMBLY_LONG_NAME, doc = "Maximum size of an assembly region", optional = true)
         public int maxAssemblyRegionSize = HaplotypeCaller.DEFAULT_MAX_ASSEMBLY_REGION_SIZE;
 
-        @Argument(fullName = "assemblyRegionPadding", shortName = "assemblyRegionPadding", doc = "Number of additional bases of context to include around each assembly region", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.ASSEMBLY_PADDING_LONG_NAME, doc = "Number of additional bases of context to include around each assembly region", optional = true)
         public int  assemblyRegionPadding = HaplotypeCaller.DEFAULT_ASSEMBLY_REGION_PADDING;
 
-        @Argument(fullName = "maxReadsPerAlignmentStart", shortName = "maxReadsPerAlignmentStart", doc = "Maximum number of reads to retain per alignment start position. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.MAX_STARTS_LONG_NAME, doc = "Maximum number of reads to retain per alignment start position. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
         public int  maxReadsPerAlignmentStart = HaplotypeCaller.DEFAULT_MAX_READS_PER_ALIGNMENT;
 
         @Advanced
-        @Argument(fullName = "activeProbabilityThreshold", shortName = "activeProbabilityThreshold", doc="Minimum probability for a locus to be considered active.", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.THRESHOLD_LONG_NAME, doc="Minimum probability for a locus to be considered active.", optional = true)
         public double activeProbThreshold = HaplotypeCaller.DEFAULT_ACTIVE_PROB_THRESHOLD;
 
         @Advanced
-        @Argument(fullName = "maxProbPropagationDistance", shortName = "maxProbPropagationDistance", doc="Upper limit on how many bases away probability mass can be moved around when calculating the boundaries between active and inactive assembly regions", optional = true)
+        @Argument(fullName = AssemblyRegionWalker.PROPAGATION_LONG_NAME, doc="Upper limit on how many bases away probability mass can be moved around when calculating the boundaries between active and inactive assembly regions", optional = true)
         public int maxProbPropagationDistance = HaplotypeCaller.DEFAULT_MAX_PROB_PROPAGATION_DISTANCE;
 
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -40,14 +40,80 @@ import java.util.function.Function;
 
 
 /**
- * This tool imports GVCFs to GenomicsDB. To run this tool,
- * 1. A single interval must be provided
- * 2. The tool accepts multiple GVCFs each of which must contain data
- *    for one sample
- * 3. The path to the GenomicsDB workspace must be specified
- * 4. User may optionally specify paths to which to write JSON files
+ * Import single-sample GVCFs into GenomicsDB before joint genotyping.
  *
- * To read data from GenomicsDB, use the query interface GenomicsDBFeatureReader
+ * <p>The GATK4 Best Practice Workflow for SNP and Indel calling uses GenomicsDBImport to merge GVCFs from multiple samples.
+ * GenomicsDBImport offers the same functionality as CombineGVCFs and comes from the <i>Intel-Broad Center for Genomics</i>.
+ * The datastore transposes sample-centric variant information across genomic loci to make data more accessible to tools.
+ * </p>
+ *
+ * <p>To query the contents of the GenomicsDB datastore, use
+ * <a href='https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_gatk_tools_walkers_variantutils_SelectVariants.php'>SelectVariants</a>.
+ * See <a href='https://software.broadinstitute.org/gatk/documentation/article?id=10061'>Tutorial#10061</a> to get started. </p>
+ *
+ * <p>Details on GenomicsDB are at
+ * <a href='https://github.com/Intel-HLS/GenomicsDB/wiki'>https://github.com/Intel-HLS/GenomicsDB/wiki</a>.
+ * In brief, GenomicsDB is a utility built on top of TileDB. TileDB is a format for efficiently representing sparse data.
+ * Genomics data is typically sparse in that each sample has few variants with respect to the entire reference genome.
+ * GenomicsDB contains code to specialize TileDB for genomics applications, such as VCF parsing and INFO field annotation
+ * calculation.
+ * </p>
+ *
+ * <h3>Input</h3>
+ * <p>
+ * One or more GVCFs produced by in HaplotypeCaller with the `-ERC GVCF` or `-ERC BP_RESOLUTION` settings, containing
+ * the samples to joint-genotype.
+ * </p>
+ *
+ * <h3>Output</h3>
+ * <p>
+ * A GenomicsDB workspace
+ * </p>
+ *
+ *  <h3>Usage examples</h3>
+ *
+ *  Provide each sample GVCF separately.
+ *  <pre>
+ *    gatk --java-options "-Xmx4g -Xms4g" GenomicsDBImport \
+ *      -V data/gvcfs/mother.g.vcf.gz \
+ *      -V data/gvcfs/father.g.vcf.gz \
+ *      -V data/gvcfs/son.g.vcf.gz \
+ *      --genomicsdb-workspace-path my_database \
+ *      -L 20
+ *  </pre>
+ *
+ *  Provide sample GVCFs in a map file.
+ *
+ *  <pre>
+ *    gatk --java-options "-Xmx4g -Xms4g" \
+ *       GenomicsDBImport \
+ *       --genomicsdb-workspace-path my_database \
+ *       --batch-size 50 \
+ *       -L chr1:1000-10000 \
+ *       --sample-name-map cohort.sample_map \
+ *       --reader-threads 5
+ *  </pre>
+ *
+ *  The sample map is a tab-delimited text file with sample_name--tab--path_to_sample_vcf per line. Using a sample map
+ *  saves the tool from having to download the GVCF headers in order to determine the sample names.
+ *
+ *  <pre>
+ *  sample1      sample1.vcf.gz
+ *  sample2      sample2.vcf.gz
+ *  sample3      sample3.vcf.gz
+ *  </pre>
+ *
+ * <h3>Caveats</h3>
+ * <ul>
+ *     <li>IMPORTANT: The -Xmx value the tool is run with should be less than the total amount of physical memory available by at least a few GB, as the native TileDB library requires additional memory on top of the Java memory. Failure to leave enough memory for the native code can result in confusing error messages!</li>
+ *     <li>A single interval must be provided. This means each import is limited to a maximum of one contig</li>
+ *     <li>Currently, only supports diploid data</li>
+ *     <li>Input GVCFs cannot contain multiple entries for a single genomic position</li>
+ *     <li>The --genomicsdb-workspace-path must point to a non-existent or empty directory.</li>
+ * </ul>
+ *
+ * <h3>Developer Note</h3>
+ * To read data from GenomicsDB, use the query interface {@link com.intel.genomicsdb.GenomicsDBFeatureReader}
  */
 @DocumentedFeature
 @CommandLineProgramProperties(
@@ -61,25 +127,24 @@ public final class GenomicsDBImport extends GATKTool {
     private static final long DEFAULT_SEGMENT_SIZE = 1048576L;
     private static final int DEFAULT_ZERO_BATCH_SIZE = 0;
 
-    public static final String WORKSPACE_ARG_NAME = "genomicsDBWorkspace";
-    public static final String SEGMENT_SIZE_ARG_NAME = "genomicsDBSegmentSize";
-    public static final String OVERWRITE_WORKSPACE_NAME = "overwriteExistingGenomicsDBWorkspace";
+    public static final String WORKSPACE_ARG_LONG_NAME = "genomicsdb-workspace-path";
+    public static final String SEGMENT_SIZE_ARG_LONG_NAME = "genomicsdb-segment-size";
+    public static final String OVERWRITE_WORKSPACE_LONG_NAME = "overwrite-existing-genomicsdb-workspace";
 
-    public static final String VCF_BUFFER_SIZE_ARG_NAME = "genomicsDBVCFBufferSize";
+    public static final String VCF_BUFFER_SIZE_ARG_NAME = "genomicsdb-vcf-buffer-size";
 
-    public static final String BATCHSIZE_ARG_NAME = "batchSize";
+    public static final String BATCHSIZE_ARG_LONG_NAME = "batch-size";
     public static final String CONSOLIDATE_ARG_NAME = "consolidate";
-    public static final String SAMPLE_NAME_MAP_LONG_NAME = "sampleNameMap";
-    public static final String VALIDATE_SAMPLE_MAP_LONG_NAME = "validateSampleNameMap";
-    public static final String VCF_INITIALIZER_THREADS_LONG_NAME = "readerThreads";
+    public static final String SAMPLE_NAME_MAP_LONG_NAME = "sample-name-map";
+    public static final String VALIDATE_SAMPLE_MAP_LONG_NAME = "validate-sample-name-map";
+    public static final String VCF_INITIALIZER_THREADS_LONG_NAME = "reader-threads";
 
-    @Argument(fullName = WORKSPACE_ARG_NAME,
-              shortName = WORKSPACE_ARG_NAME,
-              doc = "Workspace for GenomicsDB. Has to be a POSIX file system path")
+    @Argument(fullName = WORKSPACE_ARG_LONG_NAME,
+              doc = "Workspace for GenomicsDB. Must be a POSIX file system path, but can be a relative path." +
+                      " Must be an empty or non-existent directory.")
     private String workspace;
 
-    @Argument(fullName = SEGMENT_SIZE_ARG_NAME,
-              shortName = SEGMENT_SIZE_ARG_NAME,
+    @Argument(fullName = SEGMENT_SIZE_ARG_LONG_NAME,
               doc = "Buffer size in bytes allocated for GenomicsDB attributes during " +
                     "import. Should be large enough to hold data from one site. " +
                     " Defaults to " + DEFAULT_SEGMENT_SIZE,
@@ -106,16 +171,14 @@ public final class GenomicsDBImport extends GATKTool {
               minRecommendedValue = 10 * 1024)
     private long vcfBufferSizePerSample = DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE;
 
-    @Argument(fullName = OVERWRITE_WORKSPACE_NAME,
-              shortName = OVERWRITE_WORKSPACE_NAME,
+    @Argument(fullName = OVERWRITE_WORKSPACE_LONG_NAME,
               doc = "Will overwrite given workspace if it exists. " +
                     "Otherwise a new workspace is created. " +
                     "Defaults to false",
               optional = true)
     private Boolean overwriteExistingWorkspace = false;
 
-    @Argument(fullName = BATCHSIZE_ARG_NAME,
-              shortName = BATCHSIZE_ARG_NAME,
+    @Argument(fullName = BATCHSIZE_ARG_LONG_NAME,
               doc = "Batch size controls the number of samples for which readers are open at once " +
                     "and therefore provides a way to minimize memory consumption. However, it can take longer to complete. " +
                     "Use the consolidate flag if more than a hundred batches were used. This will improve feature read time. " +
@@ -138,7 +201,6 @@ public final class GenomicsDBImport extends GATKTool {
 
     @Advanced
     @Argument(fullName = SAMPLE_NAME_MAP_LONG_NAME,
-            shortName = SAMPLE_NAME_MAP_LONG_NAME,
             doc = "Path to file containing a mapping of sample name to file uri in tab delimited format.  If this is " +
                     "specified then the header from the first sample will be treated as the merged header rather than " +
                     "merging the headers, and the sample names will be taken from this file.  This may be used to rename " +
@@ -151,7 +213,7 @@ public final class GenomicsDBImport extends GATKTool {
     @Argument(fullName = VALIDATE_SAMPLE_MAP_LONG_NAME,
             shortName = VALIDATE_SAMPLE_MAP_LONG_NAME,
             doc = "Boolean flag to enable checks on the sampleNameMap file. If true, tool checks whether" +
-                "feature readers are valid and shows a warning if sample names do not match with the headers." +
+                "feature readers are valid and shows a warning if sample names do not match with the headers. " +
                 "Defaults to false",
             optional = true)
     private Boolean validateSampleToReaderMap = false;
@@ -159,7 +221,7 @@ public final class GenomicsDBImport extends GATKTool {
     @Advanced
     @Argument(fullName = VCF_INITIALIZER_THREADS_LONG_NAME,
             shortName = VCF_INITIALIZER_THREADS_LONG_NAME,
-            doc = "how many simultaneous threads to use when opening VCFs in batches, higher values may improve performance " +
+            doc = "How many simultaneous threads to use when opening VCFs in batches; higher values may improve performance " +
                     "when network latency is an issue",
             optional = true,
             minValue = 1)

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -59,10 +59,10 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
         return BaseRecalibrator.getStandardBQSRReadFilterList();
     }
 
-    @Argument(doc = "the known variants", shortName = "knownSites", fullName = "knownSites", optional = false)
+    @Argument(doc = "the known variants", fullName = "known-sites", optional = false)
     private List<String> knownVariants;
 
-    @Argument(doc = "the join strategy for reference bases and known variants", shortName = "joinStrategy", fullName = "joinStrategy", optional = true)
+    @Argument(doc = "the join strategy for reference bases and known variants", fullName = "join-strategy", optional = true)
     private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
 
     @Argument(doc = "Path to save the final recalibration tables to.",
@@ -75,10 +75,10 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
     @ArgumentCollection(doc = "all the command line arguments for BQSR and its covariates")
     private final RecalibrationArgumentCollection bqsrArgs = new RecalibrationArgumentCollection();
 
-    @Argument(fullName="readShardSize", shortName="readShardSize", doc = "Maximum size of each read shard, in bases. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
+    @Argument(fullName="read-shard-size", doc = "Maximum size of each read shard, in bases. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
     public int readShardSize = 10000;
 
-    @Argument(fullName="readShardPadding", shortName="readShardPadding", doc = "Each read shard has this many bases of extra context on each side. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
+    @Argument(fullName="read-shard-padding", doc = "Each read shard has this many bases of extra context on each side. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
     public int readShardPadding = 1000;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -70,23 +70,23 @@ public class ReadsPipelineSpark extends GATKSparkTool {
     @Argument(doc = "whether to perform alignment using BWA-MEM", shortName = "align", fullName = "align", optional = true)
     private boolean align;
 
-    @Argument(doc = "the known variants", shortName = "knownSites", fullName = "knownSites", optional = false)
+    @Argument(doc = "the known variants", fullName = "known-sites", optional = false)
     protected List<String> baseRecalibrationKnownVariants;
 
     @Argument(doc = "the output vcf", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     protected String output;
 
-    @Argument(doc = "the output bam", shortName = "outputBam", fullName = "outputBam", optional = true)
+    @Argument(doc = "the output bam", fullName = "output-bam", optional = true)
     protected String outputBam;
 
-    @Argument(doc = "the join strategy for reference bases and known variants", shortName = "joinStrategy", fullName = "joinStrategy", optional = true)
+    @Argument(doc = "the join strategy for reference bases and known variants", fullName = "join-strategy", optional = true)
     private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
 
     @ArgumentCollection
     public final BwaArgumentCollection bwaArgs = new BwaArgumentCollection();
 
-    @Argument(shortName = "DS", fullName ="duplicates_scoring_strategy", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
+    @Argument(shortName = "DS", fullName ="duplicates-scoring-strategy", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
     public MarkDuplicatesScoringStrategy duplicatesScoringStrategy = MarkDuplicatesScoringStrategy.SUM_OF_BASE_QUALITIES;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -30,15 +30,16 @@ import java.util.*;
  * Perform joint genotyping on one or more samples pre-called with HaplotypeCaller
  *
  * <p>
- * This tool is designed to perform joint genotyping on multiple samples pre-called with HaplotypeCaller to produce a
- * multi-sample callset in a highly scalable manner. However it can also be run on a single sample at a time to produce
- * a single-sample callset. In any case, the input samples must possess genotype likelihoods produced by HaplotypeCaller
- * with `-ERC GVCF` or `-ERC BP_RESOLUTION`.
+ * This tool is designed to perform joint genotyping on a single input, which may contain one or many samples. In any
+ * case, the input samples must possess genotype likelihoods produced by HaplotypeCaller with `-ERC GVCF` or
+ * `-ERC BP_RESOLUTION`.
+ *
  *
  * <h3>Input</h3>
  * <p>
- * One or more GVCFs produced by in HaplotypeCaller with the `-ERC GVCF` or `-ERC BP_RESOLUTION` settings, containing
- * the samples to joint-genotype.
+ * The GATK4 GenotypeGVCFs tool can take only one input track.  Options are 1) a single single-sample GVCF 2) a single
+ * multi-sample GVCF created by CombineGVCFs or 3) a GenomicsDB workspace created by GenomicsDBImport.
+ * A sample-level GVCF is produced by HaplotypeCaller with the `-ERC GVCF` setting.
  * </p>
  *
  * <h3>Output</h3>
@@ -48,47 +49,51 @@ import java.util.*;
  *
  * <h3>Usage example</h3>
  *
- * <h4>Perform joint genotyping on a set of GVCFs enumerated in the command line</h4>
+ * <h4>Perform joint genotyping on a singular sample by providing a single-sample GVCF or on a cohort by providing a combined multi-sample GVCF</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" GenotypeGVCFs \
- *   -R reference.fasta \
- *   -V input1.g.vcf \
- *   -V input2.g.vcf \
- *   -V input3.g.vcf \
- *   -O output.vcf
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V input.g.vcf.gz \
+ *   -O output.vcf.gz
  * </pre>
  *
- * <h4>Perform joint genotyping on a set of GVCFs listed in a text file, one per line</h4>
+ * <h4>Perform joint genotyping on GenomicsDB workspace created with GenomicsDBImport</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" GenotypeGVCFs \
- *   -R reference.fasta \
- *   -V input_gvcfs.list \
- *   -O output.vcf
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V gendb://my_database \
+ *   -O output.vcf.gz
  * </pre>
  *
- * <h3>Caveat</h3>
- * <p>Only GVCF files produced by HaplotypeCaller (or CombineGVCFs) can be used as input for this tool. Some other
+ * <h3>Caveats</h3>
+ * <ul>
+ *   <li>Only GVCF files produced by HaplotypeCaller (or CombineGVCFs) can be used as input for this tool. Some other
  * programs produce files that they call GVCFs but those lack some important information (accurate genotype likelihoods
- * for every position) that GenotypeGVCFs requires for its operation.</p>
+ * for every position) that GenotypeGVCFs requires for its operation.</li>
+ *   <li>Cannot take multiple GVCF files in one command.</li>
+ * </ul>
  *
  * <h3>Special note on ploidy</h3>
  * <p>This tool is able to handle any ploidy (or mix of ploidies) intelligently; there is no need to specify ploidy
  * for non-diploid organisms.</p>
  *
  */
-@CommandLineProgramProperties(summary = "Perform joint genotyping on one or more samples pre-called with HaplotypeCaller", oneLineSummary = "Perform joint genotyping on one or more samples pre-called with HaplotypeCaller", programGroup = VariantProgramGroup.class)
+@CommandLineProgramProperties(summary = "Perform joint genotyping on a single-sample GVCF from HaplotypeCaller or a multi-sample GVCF from CombineGVCFs or GenomicsDBImport",
+        oneLineSummary = "Perform joint genotyping on one or more samples pre-called with HaplotypeCaller",
+        programGroup = VariantProgramGroup.class)
 @DocumentedFeature
 public final class GenotypeGVCFs extends VariantWalker {
 
     public static final String PHASED_HOM_VAR_STRING = "1|1";
-    public static final String ONLY_OUTPUT_CALLS_STARTING_IN_INTERVALS_FULL_NAME = "onlyOutputCallsStartingInIntervals";
+    public static final String ONLY_OUTPUT_CALLS_STARTING_IN_INTERVALS_FULL_NAME = "only-output-calls-starting-in-intervals";
+    public static final String ALL_SITES_LONG_NAME = "include-non-variant-sites";
     private static final String GVCF_BLOCK = "GVCFBlock";
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             doc="File to which variants should be written", optional=false)
     private File outputFile;
 
-    //@Argument(fullName="includeNonVariantSites", shortName="allSites", doc="Include loci found to be non-variant after genotyping", optional=true)
+    //@Argument(fullName=ALL_SITES_LONG_NAME, shortName="allSites", doc="Include loci found to be non-variant after genotyping", optional=true)
     //TODO This option is currently not supported.
     private boolean includeNonVariants = false;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
@@ -26,8 +26,21 @@ import java.util.*;
 
 /**
  * Phred-scaled p-value for exact test of excess heterozygosity.
- * Using implementation from
- * Wigginton JE, Cutler DJ, Abecasis GR. A Note on Exact Tests of Hardy-Weinberg Equilibrium. American Journal of Human Genetics. 2005;76(5):887-893.
+ *
+ * <p>This annotation estimates the probability of the called samples exhibiting excess heterozygosity with respect to the null hypothesis that the samples are unrelated. The higher the score, the
+ * higher the chance that the variant is a technical artifact or that there is consanguinuity among the samples. In
+ * contrast to Inbreeding Coefficient, there is no minimal number of samples for this annotation. If samples are known to be related, a pedigree file can be provided so
+ * that the calculation is only performed on founders and offspring are excluded.</p>
+ *
+ * <h3>Statistical notes</h3>
+ * <p>This annotation uses the implementation from
+ * <a href='http://www.sciencedirect.com/science/article/pii/S0002929707607356?via%3Dihub'>Wigginton JE, Cutler DJ, Abecasis GR. <i>A Note on Exact Tests of Hardy-Weinberg Equilibrium. American Journal of Human Genetics</i>. 2005;76(5):887-893</a>.
+ *
+ * <h3>Caveat</h3>
+ * <p>The Excess Heterozygosity annotation can only be calculated for diploid samples.</p>
+ *
+ * <h3>Related annotations</h3>
+ * <p><b>InbreedingCoeff</b> also describes the heterozygosity of the called samples, though without explicitly taking into account the number of samples</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Phred-scaled p-value for exact test of excess heterozygosity (ExcessHet)")
 public final class ExcessHet extends PedigreeAnnotation implements StandardAnnotation {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -24,9 +24,11 @@ import java.util.*;
 
 
 /**
- * Likelihood-based test for the inbreeding among samples
+ * Likelihood-based test for the consanguinuity among samples
  *
- * <p>This annotation estimates whether there is evidence of inbreeding in a population. The higher the score, the higher the chance that there is inbreeding.</p>
+ * <p>This annotation estimates whether there is evidence of consanguinuity in a population. The higher the score, the
+ * higher the chance that some samples are related. If samples are known to be related, a pedigree file can be provided so
+ * that the calculation is only performed on founders and offspring are excluded.</p>
  *
  * <h3>Statistical notes</h3>
  * <p>The calculation is a continuous generalization of the Hardy-Weinberg test for disequilibrium that works well with limited coverage per sample. The output is a Phred-scaled p-value derived from running the HW test for disequilibrium with PL values. See the <a href="http://www.broadinstitute.org/gatk/guide/article?id=4732">method document on statistical tests</a> for a more detailed explanation of this statistical test.</p>
@@ -35,9 +37,10 @@ import java.util.*;
  * <ul>
  * <li>The Inbreeding Coefficient annotation can only be calculated for cohorts containing at least 10 founder samples.</li>
  * <li>The Inbreeding Coefficient annotation can only be calculated for diploid samples.</li>
- * <li>This annotation is used in variant recalibration, but may not be appropriate for that purpose if the cohort being analyzed contains many closely related individuals.</li>
  * </ul>
  *
+ * <h3>Related annotations</h3>
+ * <p><b>ExcessHet</b> also describes the heterozygosity of the called samples, giving a probability of excess heterozygosity being observed</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Likelihood-based test for the consanguinity among samples (InbreedingCoeff)")
 public final class InbreedingCoeff extends PedigreeAnnotation implements StandardAnnotation {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/SampleList.java
@@ -17,11 +17,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * List samples that are non-reference at a given site
+ * List samples that are non-reference at a given variant site
  *
- * <p>The output is a list of the samples that are genotyped as having one or more variant alleles. This allows you to easily determine which samples are non-reference (heterozygous or homozygous-variant) and compare them to samples that are homozygous-reference.</p>
+ * <p>The output is a list of the samples that are genotyped as having one or more variant alleles. This allows you to
+ * easily determine which samples are non-reference (heterozygous or homozygous-variant) and compare them to samples
+ * that are homozygous-reference. This annotation is particularly useful for large cohorts where the genotype fields are
+ * difficult to manually match with sample names.</p>
  */
-@DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="List samples that are non-REF at site (Samples)")
+@DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="List of samples that are not homozygous reference at a variant site (Samples)")
 public final class SampleList extends InfoFieldAnnotation {
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -25,7 +25,7 @@ import static java.util.Collections.singleton;
 
 
 /**
- * Filter variant calls based on INFO and FORMAT annotations
+ * Filter variant calls based on INFO and/or FORMAT annotations
  *
  * <p>
  * This tool is designed for hard-filtering variant calls based on certain criteria. Records are hard-filtered by
@@ -48,8 +48,8 @@ import static java.util.Collections.singleton;
  * <pre>
  *   gatk VariantFiltration \
  *   -R reference.fasta \
- *   -V input.vcf \
- *   -O output.vcf \
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
  *   --filterExpression "AB < 0.2 || MQ0 > 50" \
  *   --filterName "my_filters"
  * </pre>
@@ -61,12 +61,29 @@ import static java.util.Collections.singleton;
  *
  */
 @CommandLineProgramProperties(
-        summary = "Filter variant calls based on INFO and FORMAT annotations.",
-        oneLineSummary = "Filter variant calls based on INFO and FORMAT annotations",
+        summary = "Filter variant calls based on INFO and/or FORMAT annotations.",
+        oneLineSummary = "Filter variant calls based on INFO and/or FORMAT annotations",
         programGroup = VariantProgramGroup.class
 )
 @DocumentedFeature
 public final class VariantFiltration extends VariantWalker {
+
+    public static final String FILTER_EXPRESSION_LONG_NAME = "filter-expression";
+    public static final String FILTER_NAME_LONG_NAME = "filter-name";
+    public static final String GENOTYPE_FILTER_EXPRESSION_LONG_NAME = "genotype-filter-expression";
+    public static final String GENOTYPE_FILTER_NAME_LONG_NAME = "genotype-filter-name";
+    public static final String CLUSTER_SIZE_LONG_NAME = "cluster-size";
+    public static final String CLUSTER_WINDOW_SIZE_LONG_NAME = "cluster-window-size";
+    public static final String MASK_EXTENSION_LONG_NAME = "mask-extension";
+    public static final String MASK_NAME_LONG_NAME = "mask-name";
+    public static final String FILTER_NOT_IN_MASK_LONG_NAME = "filter-not-in-mask";
+    public static final String MISSING_VAL_LONG_NAME = "missing-values-evaluate-as-failing";
+    public static final String INVALIDATE_LONG_NAME = "invalidate-previous-filters";
+    public static final String INVERT_LONG_NAME = "invert-filter-expression";
+    public static final String INVERT_GT_LONG_NAME = "invert-genotype-filter-expression";
+    public static final String NO_CALL_GTS_LONG_NAME = "set-filtered-genotype-to-no-call";
+
+    private static final String FILTER_DELIMITER = ";";
 
     /**
      * Any variant which overlaps entries from the provided mask file will be filtered. If the user wants logic to be reversed,
@@ -84,13 +101,13 @@ public final class VariantFiltration extends VariantWalker {
      * VariantFiltration accepts any number of JEXL expressions (so you can have two named filters by using
      * --filterName One --filterExpression "X < 1" --filterName Two --filterExpression "X > 2").
      */
-    @Argument(fullName="filterExpression", shortName="filter", doc="One or more expression used with INFO fields to filter", optional=true)
+    @Argument(fullName=FILTER_EXPRESSION_LONG_NAME, shortName="filter", doc="One or more expression used with INFO fields to filter", optional=true)
     public List<String> filterExpressions = new ArrayList<>();
 
     /**
      * This name is put in the FILTER field for variants that get filtered.  Note that there must be a 1-to-1 mapping between filter expressions and filter names.
      */
-    @Argument(fullName="filterName", shortName="filterName", doc="Names to use for the list of filters", optional=true)
+    @Argument(fullName=FILTER_NAME_LONG_NAME, doc="Names to use for the list of filters", optional=true)
     public List<String> filterNames = new ArrayList<>();
 
     /**
@@ -100,37 +117,37 @@ public final class VariantFiltration extends VariantWalker {
      * methods so that one can now filter out hets ("isHet == 1"), refs ("isHomRef == 1"), or homs ("isHomVar == 1"). Also available are
      * expressions isCalled, isNoCall, isMixed, and isAvailable, in accordance with the methods of the Genotype object.
      */
-    @Argument(fullName="genotypeFilterExpression", shortName="G_filter", doc="One or more expression used with FORMAT (sample/genotype-level) fields to filter (see documentation guide for more info)", optional=true)
+    @Argument(fullName=GENOTYPE_FILTER_EXPRESSION_LONG_NAME, shortName="G-filter", doc="One or more expression used with FORMAT (sample/genotype-level) fields to filter (see documentation guide for more info)", optional=true)
     public List<String> genotypeFilterExpressions = new ArrayList<>();
 
     /**
      * Similar to the INFO field based expressions, but used on the FORMAT (genotype) fields instead.
      */
-    @Argument(fullName="genotypeFilterName", shortName="G_filterName", doc="Names to use for the list of sample/genotype filters (must be a 1-to-1 mapping); this name is put in the FILTER field for variants that get filtered", optional=true)
+    @Argument(fullName=GENOTYPE_FILTER_NAME_LONG_NAME, shortName="G-filter-name", doc="Names to use for the list of sample/genotype filters (must be a 1-to-1 mapping); this name is put in the FILTER field for variants that get filtered", optional=true)
     public List<String> genotypeFilterNames = new ArrayList<>();
 
     /**
-     * Works together with the --clusterWindowSize argument.
+     * Works together with the --cluster-window-size argument.
      */
-    @Argument(fullName="clusterSize", shortName="cluster", doc="The number of SNPs which make up a cluster. Must be at least 2", optional=true)
+    @Argument(fullName=CLUSTER_SIZE_LONG_NAME, shortName="cluster", doc="The number of SNPs which make up a cluster. Must be at least 2", optional=true)
     public Integer clusterSize = 3;
 
     /**
-     * Works together with the --clusterSize argument.  To disable the clustered SNP filter, set this value to less than 1.
+     * Works together with the --cluster-size argument.  To disable the clustered SNP filter, set this value to less than 1.
      */
-    @Argument(fullName="clusterWindowSize", shortName="window", doc="The window size (in bases) in which to evaluate clustered SNPs", optional=true)
+    @Argument(fullName=CLUSTER_WINDOW_SIZE_LONG_NAME, shortName="window", doc="The window size (in bases) in which to evaluate clustered SNPs", optional=true)
     public Integer clusterWindow = 0;
 
-    @Argument(fullName="maskExtension", shortName="maskExtend", doc="How many bases beyond records from a provided 'mask' should variants be filtered", optional=true)
+    @Argument(fullName=MASK_EXTENSION_LONG_NAME, doc="How many bases beyond records from a provided 'mask' should variants be filtered", optional=true)
     public Integer maskExtension = 0;
 
     /**
      * When using the -mask argument, the maskName will be annotated in the variant record.
-     * Note that when using the -filterNotInMask argument to reverse the masking logic,
+     * Note that when using the -filter-not-in-mask argument to reverse the masking logic,
      * it is up to the user to adapt the name of the mask to make it clear that the reverse logic was used
-     * (e.g. if masking against Hapmap, use -maskName=hapmap for the normal masking and -maskName=not_hapmap for the reverse masking).
+     * (e.g. if masking against Hapmap, use -mask-name=hapmap for the normal masking and -mask-name=not_hapmap for the reverse masking).
      */
-    @Argument(fullName="maskName", shortName="maskName", doc="The text to put in the FILTER field if a 'mask' is provided and overlaps with a variant call", optional=true)
+    @Argument(fullName=MASK_NAME_LONG_NAME, doc="The text to put in the FILTER field if a 'mask' is provided and overlaps with a variant call", optional=true)
     public String maskName = "Mask";
 
     /**
@@ -138,40 +155,40 @@ public final class VariantFiltration extends VariantWalker {
      * If this argument is used, logic is reversed, and variants falling outside a given mask will be filtered.
      * Use case is, for example, if we have an interval list or BED file with "good" sites.
      * Note that it is up to the user to adapt the name of the mask to make it clear that the reverse logic was used
-     * (e.g. if masking against Hapmap, use -maskName=hapmap for the normal masking and -maskName=not_hapmap for the reverse masking).
+     * (e.g. if masking against Hapmap, use -mask-name=hapmap for the normal masking and -mask-name=not_hapmap for the reverse masking).
      */
-    @Argument(fullName="filterNotInMask", shortName="filterNotInMask", doc="Filter records NOT in given input mask.", optional=true)
+    @Argument(fullName=FILTER_NOT_IN_MASK_LONG_NAME, doc="Filter records NOT in given input mask.", optional=true)
     public boolean filterRecordsNotInMask = false;
 
     /**
      * By default, if JEXL cannot evaluate your expression for a particular record because one of the annotations is not present, the whole expression evaluates as PASSing.
      * Use this argument to have it evaluate as failing filters instead for these cases.
      */
-    @Argument(fullName="missingValuesInExpressionsShouldEvaluateAsFailing", doc="When evaluating the JEXL expressions, missing values should be considered failing the expression", optional=true)
+    @Argument(fullName=MISSING_VAL_LONG_NAME, doc="When evaluating the JEXL expressions, missing values should be considered failing the expression", optional=true)
     public Boolean failMissingValues = false;
 
     /**
      * Invalidate previous filters applied to the VariantContext, applying only the filters here
      */
-    @Argument(fullName="invalidatePreviousFilters",doc="Remove previous filters applied to the VCF",optional=true)
+    @Argument(fullName=INVALIDATE_LONG_NAME,doc="Remove previous filters applied to the VCF",optional=true)
     boolean invalidatePreviousFilters = false;
 
     /**
-     * Invert the selection criteria for --filterExpression
+     * Invert the selection criteria for --filter-expression
      */
-    @Argument(fullName="invertFilterExpression", shortName="invfilter", doc="Invert the selection criteria for --filterExpression", optional=true)
+    @Argument(fullName=INVERT_LONG_NAME, shortName="invfilter", doc="Invert the selection criteria for --filterExpression", optional=true)
     public boolean invertFilterExpression = false;
 
     /**
-     * Invert the selection criteria for --genotypeFilterExpression
+     * Invert the selection criteria for --genotype-filter-expression
      */
-    @Argument(fullName="invertGenotypeFilterExpression", shortName="invG_filter", doc="Invert the selection criteria for --genotypeFilterExpression", optional=true)
+    @Argument(fullName=INVERT_GT_LONG_NAME, shortName="invG-filter", doc="Invert the selection criteria for --genotypeFilterExpression", optional=true)
     public boolean invertGenotypeFilterExpression = false;
 
     /**
      * If this argument is provided, set filtered genotypes to no-call (./.).
      */
-    @Argument(fullName="setFilteredGtToNocall", optional=true, doc="Set filtered genotypes to no-call")
+    @Argument(fullName=NO_CALL_GTS_LONG_NAME, optional=true, doc="Set filtered genotypes to no-call")
     public boolean setFilteredGenotypesToNocall = false;
 
     // JEXL expressions for the filters
@@ -255,14 +272,14 @@ public final class VariantFiltration extends VariantWalker {
     @Override
     public void onTraversalStart() {
         if (clusterSize <= 1){
-            throw new CommandLineException.BadArgumentValue("clusterSize", "values lower than 2 are not allowed");
+            throw new CommandLineException.BadArgumentValue(CLUSTER_SIZE_LONG_NAME, "values lower than 2 are not allowed");
         }
         if ( maskExtension < 0 ) {
-            throw new CommandLineException.BadArgumentValue("maskExtension", "negative values are not allowed");
+            throw new CommandLineException.BadArgumentValue(MASK_EXTENSION_LONG_NAME, "negative values are not allowed");
         }
 
         if (filterRecordsNotInMask && mask == null) {
-            throw new CommandLineException.BadArgumentValue("filterNotInMask", "argument not allowed if mask argument is not provided");
+            throw new CommandLineException.BadArgumentValue(FILTER_NOT_IN_MASK_LONG_NAME, "argument not allowed if mask argument is not provided");
         }
         filterExps = VariantContextUtils.initializeMatchExps(filterNames, filterExpressions);
         genotypeFilterExps = VariantContextUtils.initializeMatchExps(genotypeFilterNames, genotypeFilterExpressions);
@@ -343,7 +360,7 @@ public final class VariantFiltration extends VariantWalker {
     private List<String> getGenotypeFilters(final VariantContext vc, final Genotype g) {
         final List<String> filters = new ArrayList<>();
         if (g.isFiltered()) {
-            filters.addAll(Arrays.asList(g.getFilters().split(";")));
+            filters.addAll(Arrays.asList(g.getFilters().split(FILTER_DELIMITER)));
         }
 
         // Add if expression filters the variant context

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -39,14 +39,14 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
     /**
      * Use the new allele frequency / QUAL score model
      */
-    @Argument(fullName = "useNewAFCalculator", shortName = "newQual", doc = "If provided, we will use the new AF model instead of the so-called exact model", optional = true)
+    @Argument(fullName = "use-new-qual-calculator", shortName = "new-qual", doc = "If provided, we will use the new AF model instead of the so-called exact model", optional = true)
     public boolean USE_NEW_AF_CALCULATOR = false;
 
     /**
      * Depending on the value of the --max_alternate_alleles argument, we may genotype only a fraction of the alleles being sent on for genotyping.
      * Using this argument instructs the genotyper to annotate (in the INFO field) the number of alternate alleles that were originally discovered at the site.
      */
-    @Argument(fullName = "annotateNDA", shortName = "nda", doc = "If provided, we will annotate records with the number of alternate alleles that were discovered (but not necessarily genotyped) at a given site", optional = true)
+    @Argument(fullName = "annotate-with-num-discovered-alleles", doc = "If provided, we will annotate records with the number of alternate alleles that were discovered (but not necessarily genotyped) at a given site", optional = true)
     public boolean ANNOTATE_NUMBER_OF_ALLELES_DISCOVERED = false;
 
     /**
@@ -77,20 +77,20 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * The quantity that changes whether the GATK considers the possibility of a het genotype at all is the ploidy,
      * which determines how many chromosomes each individual in the species carries.
      */
-    @Argument(fullName = "heterozygosity", shortName = "hets", doc = "Heterozygosity value used to compute prior likelihoods for any locus.  See the GATKDocs for full details on the meaning of this population genetics concept", optional = true)
+    @Argument(fullName = "heterozygosity", doc = "Heterozygosity value used to compute prior likelihoods for any locus.  See the GATKDocs for full details on the meaning of this population genetics concept", optional = true)
     public Double snpHeterozygosity = HomoSapiensConstants.SNP_HETEROZYGOSITY;
 
     /**
      * This argument informs the prior probability of having an indel at a site.
      */
-    @Argument(fullName = "indel_heterozygosity", shortName = "indelHeterozygosity", doc = "Heterozygosity for indel calling.  See the GATKDocs for heterozygosity for full details on the meaning of this population genetics concept", optional = true)
+    @Argument(fullName = "indel-heterozygosity", doc = "Heterozygosity for indel calling.  See the GATKDocs for heterozygosity for full details on the meaning of this population genetics concept", optional = true)
     public double indelHeterozygosity = HomoSapiensConstants.INDEL_HETEROZYGOSITY;
 
     /**
      * The standard deviation of the distribution of alt allele fractions.  The above heterozygosity parameters give the
      * *mean* of this distribution; this parameter gives its spread.
      */
-    @Argument(fullName = "heterozygosity_stdev", shortName = "heterozygosityStandardDeviation", doc = "Standard deviation of eterozygosity for SNP and indel calling.", optional = true)
+    @Argument(fullName = "heterozygosity-stdev", doc = "Standard deviation of eterozygosity for SNP and indel calling.", optional = true)
     public double heterozygosityStandardDeviation = 0.01;
 
     /**
@@ -102,7 +102,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * (using either -ERC GVCF or -ERC BP_RESOLUTION) the call threshold is automatically set to zero. Call confidence thresholding
      * will then be performed in the subsequent GenotypeGVCFs command.
      */
-    @Argument(fullName = "standard_min_confidence_threshold_for_calling", shortName = "stand_call_conf", doc = "The minimum phred-scaled confidence threshold at which variants should be called", optional = true)
+    @Argument(fullName = "standard-min-confidence-threshold-for-calling", shortName = "stand-call-conf", doc = "The minimum phred-scaled confidence threshold at which variants should be called", optional = true)
     public double STANDARD_CONFIDENCE_FOR_CALLING = 10.0;
 
     /**
@@ -114,7 +114,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * See also {@link #MAX_GENOTYPE_COUNT}.
      */
     @Advanced
-    @Argument(fullName = "max_alternate_alleles", shortName = "maxAltAlleles", doc = "Maximum number of alternate alleles to genotype", optional = true)
+    @Argument(fullName = "max-alternate-alleles", doc = "Maximum number of alternate alleles to genotype", optional = true)
     public int MAX_ALTERNATE_ALLELES = 6;
 
     /**
@@ -134,7 +134,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * See also {@link #MAX_ALTERNATE_ALLELES}.
      */
     @Advanced
-    @Argument(fullName = "max_genotype_count", shortName = "maxGT", doc = "Maximum number of genotypes to consider at any site", optional = true)
+    @Argument(fullName = "max-genotype-count", doc = "Maximum number of genotypes to consider at any site", optional = true)
     public int MAX_GENOTYPE_COUNT = 1024;
 
     /**
@@ -157,12 +157,12 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * for the single-sample diploid case.
      */
     @Advanced
-    @Argument(fullName = "input_prior", shortName = "inputPrior", doc = "Input prior for calls", optional = true)
+    @Argument(fullName = "input-prior",  doc = "Input prior for calls", optional = true)
     public List<Double> inputPrior = Collections.emptyList();
 
     /**
      *   Sample ploidy - equivalent to number of chromosomes per pool. In pooled experiments this should be = # of samples in pool * individual sample ploidy
      */
-    @Argument(shortName="ploidy", fullName="sample_ploidy", doc="Ploidy (number of chromosomes) per sample. For pooled data, set to (Number of samples in each pool * Sample Ploidy).", optional=true)
+    @Argument(shortName="ploidy", fullName="sample-ploidy", doc="Ploidy (number of chromosomes) per sample. For pooled data, set to (Number of samples in each pool * Sample Ploidy).", optional=true)
     public int samplePloidy = HomoSapiensConstants.DEFAULT_PLOIDY;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/StandardCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/StandardCallerArgumentCollection.java
@@ -46,13 +46,13 @@ public class StandardCallerArgumentCollection implements Serializable {
     @ArgumentCollection
     public GenotypeCalculationArgumentCollection genotypeArgs = new GenotypeCalculationArgumentCollection();
 
-    @Argument(fullName = "genotyping_mode", shortName = "gt_mode", doc = "Specifies how to determine the alternate alleles to use for genotyping", optional=true)
+    @Argument(fullName = "genotyping-mode", doc = "Specifies how to determine the alternate alleles to use for genotyping", optional=true)
     public GenotypingOutputMode genotypingOutputMode = GenotypingOutputMode.DISCOVERY;
 
     /**
      * When the caller is put into GENOTYPE_GIVEN_ALLELES mode it will genotype the samples using only the alleles provide in this rod binding
      */
-    @Argument(fullName="alleles", shortName = "alleles", doc="The set of alleles at which to genotype when --genotyping_mode is GENOTYPE_GIVEN_ALLELES", optional=true)
+    @Argument(fullName="alleles", doc="The set of alleles at which to genotype when --genotyping_mode is GENOTYPE_GIVEN_ALLELES", optional=true)
     public FeatureInput<VariantContext> alleles;
 
     /**
@@ -60,7 +60,7 @@ public class StandardCallerArgumentCollection implements Serializable {
      * Basically, it will ignore the contamination fraction of reads for each alternate allele.  So if the pileup contains N total bases, then we
      * will try to remove (N * contamination fraction) bases for each alternate allele.
      */
-    @Argument(fullName = "contamination_fraction_to_filter", shortName = "contamination", doc = "Fraction of contamination in sequencing data (for all samples) to aggressively remove", optional=true)
+    @Argument(fullName = "contamination-fraction-to-filter", shortName = "contamination", doc = "Fraction of contamination in sequencing data (for all samples) to aggressively remove", optional=true)
     public double CONTAMINATION_FRACTION = DEFAULT_CONTAMINATION_FRACTION;
     public static final double DEFAULT_CONTAMINATION_FRACTION = 0.0;
 
@@ -69,7 +69,7 @@ public class StandardCallerArgumentCollection implements Serializable {
      *  Samples that do not appear in this file will be processed with CONTAMINATION_FRACTION.
      **/
     @Advanced
-    @Argument(fullName = "contamination_fraction_per_sample_file", shortName = "contaminationFile", doc = "Tab-separated File containing fraction of contamination in sequencing data (per sample) to aggressively remove. Format should be \"<SampleID><TAB><Contamination>\" (Contamination is double) per line; No header.", optional = true)
+    @Argument(fullName = "contamination-fraction-per-sample-file", shortName = "contamination-file", doc = "Tab-separated File containing fraction of contamination in sequencing data (per sample) to aggressively remove. Format should be \"<SampleID><TAB><Contamination>\" (Contamination is double) per line; No header.", optional = true)
     public File CONTAMINATION_FRACTION_FILE = null;
 
     /**
@@ -109,14 +109,14 @@ public class StandardCallerArgumentCollection implements Serializable {
      * Controls the model used to calculate the probability that a site is variant plus the various sample genotypes in the data at a given locus.
      */
     @Hidden
-    @Argument(fullName = "p_nonref_model", shortName = "pnrm", doc = "Non-reference probability calculation model to employ", optional = true)
+    @Argument(fullName = "p-nonref-model", doc = "Non-reference probability calculation model to employ", optional = true)
     public AFCalculatorImplementation requestedAlleleFrequencyCalculationModel;
 
     @Hidden
-    @Argument(shortName = "logExactCalls", doc="x", optional=true)
+    @Argument(shortName = "log-exact-calls", optional=true)
     public File exactCallsLog = null;
 
-    @Argument(fullName = "output_mode", shortName = "out_mode", doc = "Specifies which type of calls we should output", optional = true)
+    @Argument(fullName = "output-mode", doc = "Specifies which type of calls we should output", optional = true)
     public OutputMode outputMode = OutputMode.EMIT_VARIANTS_ONLY;
 
     /**
@@ -128,6 +128,6 @@ public class StandardCallerArgumentCollection implements Serializable {
      * - An error will be emitted if EMIT_ALL_SITES is not set, or if anything other than diploid SNP model is used
      */
     @Advanced
-    @Argument(fullName = "allSitePLs", shortName = "allSitePLs", doc = "Annotate all sites with PLs", optional = true)
+    @Argument(fullName = "all-site-pls", doc = "Annotate all sites with PLs", optional = true)
     public boolean annotateAllSitesWithPLs = false;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
@@ -53,7 +53,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
     public boolean debug;
 
     @Advanced
-    @Argument(fullName="useFilteredReadsForAnnotations", shortName="useFilteredReadsForAnnotations", doc = "Use the contamination-filtered read maps for the purposes of annotating variants", optional=true)
+    @Argument(fullName="use-filtered-reads-for-annotations", doc = "Use the contamination-filtered read maps for the purposes of annotating variants", optional=true)
     public boolean USE_FILTERED_READ_MAP_FOR_ANNOTATIONS = false;
 
     /**
@@ -63,7 +63,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      * This requirement is a temporary workaround for an issue with index compression.
      */
     @Advanced
-    @Argument(fullName="emitRefConfidence", shortName="ERC", doc="Mode for emitting reference confidence scores", optional = true)
+    @Argument(fullName="emit-ref-confidence", shortName="ERC", doc="Mode for emitting reference confidence scores", optional = true)
     public ReferenceConfidenceMode emitReferenceConfidence = ReferenceConfidenceMode.NONE;
 
     /**
@@ -97,7 +97,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      *
      */
     @Advanced
-    @Argument(fullName="bamOutput", shortName="bamout", doc="File to which assembled haplotypes should be written", optional = true)
+    @Argument(fullName="bam-output", shortName="bamout", doc="File to which assembled haplotypes should be written", optional = true)
     public String bamOutputPath = null;
 
     /**
@@ -105,7 +105,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      * considered (top 128 max) or just the ones that were selected as alleles and assigned to samples.
      */
     @Advanced
-    @Argument(fullName="bamWriterType", shortName="bamWriterType", doc="Which haplotypes should be written to the BAM", optional = true)
+    @Argument(fullName="bam-writer-type", doc="Which haplotypes should be written to the BAM", optional = true)
     public HaplotypeBAMWriter.WriterType bamWriterType = HaplotypeBAMWriter.WriterType.CALLED_HAPLOTYPES;
 
     /**
@@ -115,7 +115,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      * reads in regions with no variations. Setting the -forceActive and -dontTrimActiveRegions flags may also be necessary.
      */
     @Advanced
-    @Argument(fullName = "disableOptimizations", shortName="disableOptimizations", doc="Don't skip calculations in ActiveRegions with no variants",
+    @Argument(fullName = "disable-optimizations", doc="Don't skip calculations in ActiveRegions with no variants",
             optional = true)
     public boolean disableOptimizations = false;
 
@@ -124,29 +124,29 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
     // -----------------------------------------------------------------------------------------------
 
     @Hidden
-    @Argument(fullName = "keepRG", shortName = "keepRG", doc = "Only use reads from this read group when making calls (but use all reads to build the assembly)", optional = true)
+    @Argument(fullName = "keep-rg", doc = "Only use reads from this read group when making calls (but use all reads to build the assembly)", optional = true)
     public String keepRG = null;
 
     /**
      * This argument is intended for benchmarking and scalability testing.
      */
     @Hidden
-    @Argument(fullName = "justDetermineActiveRegions", shortName = "justDetermineActiveRegions", doc = "Just determine ActiveRegions, don't perform assembly or calling", optional = true)
+    @Argument(fullName = "just-determine-active-regions", doc = "Just determine ActiveRegions, don't perform assembly or calling", optional = true)
     public boolean justDetermineActiveRegions = false;
 
     /**
      * This argument is intended for benchmarking and scalability testing.
      */
     @Hidden
-    @Argument(fullName = "dontGenotype", shortName = "dontGenotype", doc = "Perform assembly but do not genotype variants", optional = true)
+    @Argument(fullName = "dont-genotype", doc = "Perform assembly but do not genotype variants", optional = true)
     public boolean dontGenotype = false;
 
     @Advanced
-    @Argument(fullName = "dontUseSoftClippedBases", shortName = "dontUseSoftClippedBases", doc = "Do not analyze soft clipped bases in the reads", optional = true)
+    @Argument(fullName = "dont-use-soft-clipped-bases", doc = "Do not analyze soft clipped bases in the reads", optional = true)
     public boolean dontUseSoftClippedBases = false;
 
     @Hidden
-    @Argument(fullName = "captureAssemblyFailureBAM", shortName = "captureAssemblyFailureBAM", doc = "Write a BAM called assemblyFailure.bam capturing all of the reads that were in the active region when the assembler failed for any reason", optional = true)
+    @Argument(fullName = "capture-assembly-failure-bam", doc = "Write a BAM called assemblyFailure.bam capturing all of the reads that were in the active region when the assembler failed for any reason", optional = true)
     public boolean captureAssemblyFailureBAM = false;
 
     // Parameters to control read error correction
@@ -154,26 +154,26 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      * Enabling this argument may cause fundamental problems with the assembly graph itself.
      */
     @Hidden
-    @Argument(fullName = "errorCorrectReads", shortName = "errorCorrectReads", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
+    @Argument(fullName = "error-correct-reads", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
     public boolean errorCorrectReads = false;
 
     /**
      * As of GATK 3.3, HaplotypeCaller outputs physical (read-based) information (see version 3.3 release notes and documentation for details). This argument disables that behavior.
      */
     @Advanced
-    @Argument(fullName = "doNotRunPhysicalPhasing", shortName = "doNotRunPhysicalPhasing", doc = "Disable physical phasing", optional = true)
+    @Argument(fullName = "do-not-run-physical-phasing",  doc = "Disable physical phasing", optional = true)
     public boolean doNotRunPhysicalPhasing = false;
 
     /**
      * Bases with a quality below this threshold will not be used for calling.
      */
-    @Argument(fullName = "min_base_quality_score", shortName = "mbq", doc = "Minimum base quality required to consider a base for calling", optional = true)
+    @Argument(fullName = "min-base-quality-score", shortName = "mbq", doc = "Minimum base quality required to consider a base for calling", optional = true)
     public byte minBaseQualityScore = 10;
 
     //Annotations
 
     @Advanced
-    @Argument(fullName = "smithWaterman", shortName = "smithWaterman", doc = "Which Smith-Waterman implementation to use, generally FASTEST_AVAILABLE is the right choice", optional = true)
+    @Argument(fullName = "smith-waterman", doc = "Which Smith-Waterman implementation to use, generally FASTEST_AVAILABLE is the right choice", optional = true)
     public SmithWatermanAligner.Implementation smithWatermanImplementation = SmithWatermanAligner.Implementation.JAVA;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyRegionTrimmerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyRegionTrimmerArgumentCollection.java
@@ -8,28 +8,28 @@ public class AssemblyRegionTrimmerArgumentCollection {
     private static final long serialVersionUID = 1L;
 
     @Advanced
-    @Argument(fullName="dontTrimActiveRegions", shortName="dontTrimActiveRegions", doc="If specified, we will not trim down the active region from the full region (active + extension) to just the active interval for genotyping", optional = true)
+    @Argument(fullName="dont-trim-active-regions", doc="If specified, we will not trim down the active region from the full region (active + extension) to just the active interval for genotyping", optional = true)
     protected boolean dontTrimActiveRegions = false;
 
     /**
      * the maximum extent into the full active region extension that we're willing to go in genotyping our events
      */
     @Hidden
-    @Argument(fullName="maxDiscARExtension", shortName="maxDiscARExtension", doc = "the maximum extent into the full active region extension that we're willing to go in genotyping our events for discovery", optional = true)
+    @Argument(fullName="max-disc-ar-extension", doc = "the maximum extent into the full active region extension that we're willing to go in genotyping our events for discovery", optional = true)
     protected int discoverExtension = 25;
 
     @Hidden
-    @Argument(fullName="maxGGAARExtension", shortName="maxGGAARExtension", doc = "the maximum extent into the full active region extension that we're willing to go in genotyping our events for GGA mode", optional = true)
+    @Argument(fullName="max-gga-ar-extension", doc = "the maximum extent into the full active region extension that we're willing to go in genotyping our events for GGA mode", optional = true)
     protected int ggaExtension = 300;
 
     /**
      * Include at least this many bases around an event for calling it
      */
     @Hidden
-    @Argument(fullName="paddingAroundIndels", shortName="paddingAroundIndels", doc = "Include at least this many bases around an event for calling indels", optional = true)
+    @Argument(fullName="padding-around-indels", doc = "Include at least this many bases around an event for calling indels", optional = true)
     public int indelPadding = 150;
 
     @Hidden
-    @Argument(fullName="paddingAroundSNPs", shortName="paddingAroundSNPs", doc = "Include at least this many bases around an event for calling snps", optional = true)
+    @Argument(fullName="padding-around-snps", doc = "Include at least this many bases around an event for calling snps", optional = true)
     public int snpPadding = 20;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -85,18 +85,18 @@ import org.broadinstitute.hellbender.utils.io.IOUtils;
  * <h4>Single-sample GVCF calling (outputs intermediate GVCF)</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" HaplotypeCaller  \
- *   -R reference.fasta \
+ *   -R Homo_sapiens_assembly38.fasta \
  *   -I input.bam \
- *   -O output.g.vcf \
+ *   -O output.g.vcf.gz \
  *   -ERC GVCF
  * </pre>
  *
  * <h4>Single-sample GVCF calling with <a href='https://software.broadinstitute.org/gatk/documentation/article?id=9622'>allele-specific annotations</a></h4>
  * <pre>
  * gatk --java-options "-Xmx4g" HaplotypeCaller  \
- *   -R reference.fasta \
+ *   -R Homo_sapiens_assembly38.fasta \
  *   -I input.bam \
- *   -O output.g.vcf \
+ *   -O output.g.vcf.gz \
  *   -ERC GVCF \
  *   -G Standard \
  *   -G AS_Standard
@@ -105,9 +105,9 @@ import org.broadinstitute.hellbender.utils.io.IOUtils;
  * <h4>Variant calling with <a href='https://software.broadinstitute.org/gatk/documentation/article?id=5484'>bamout</a> to show realigned reads</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" HaplotypeCaller  \
- *   -R reference.fasta \
+ *   -R Homo_sapiens_assembly38.fasta \
  *   -I input.bam \
- *   -O output.vcf \
+ *   -O output.vcf.gz \
  *   -bamout bamout.bam
  * </pre>
  *
@@ -141,6 +141,7 @@ import org.broadinstitute.hellbender.utils.io.IOUtils;
 @BetaFeature
 public final class HaplotypeCaller extends AssemblyRegionWalker {
 
+    //NOTE: many of these settings are referenced by HaplotypeCallerSpark
     public static final int DEFAULT_MIN_ASSEMBLY_REGION_SIZE = 50;
     public static final int DEFAULT_MAX_ASSEMBLY_REGION_SIZE = 300;
     public static final int DEFAULT_ASSEMBLY_REGION_PADDING = 100;
@@ -159,7 +160,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
     private VariantContextWriter vcfWriter;
 
     private HaplotypeCallerEngine hcEngine;
-    
+
     @Override
     protected int defaultMinAssemblyRegionSize() { return DEFAULT_MIN_ASSEMBLY_REGION_SIZE; }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.VariantAnnotationArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.annotator.StandardAnnotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.StandardHCAnnotation;
@@ -35,7 +36,7 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      * is especially useful if your samples are all in the same file but you need to run them individually through HC
      * in -ERC GVC mode (which is the recommended usage). Note that the name is case-sensitive.
      */
-    @Argument(fullName = "sample_name", shortName = "sn", doc = "Name of single sample to use from a multi-sample bam", optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.SAMPLE_NAME_LONG_NAME, shortName = StandardArgumentDefinitions.SAMPLE_ALIAS_SHORT_NAME, doc = "Name of single sample to use from a multi-sample bam", optional = true)
     public String sampleNameToUse = null;
 
     // -----------------------------------------------------------------------------------------------
@@ -56,7 +57,7 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      * and end at 100 (exclusive).
      */
     @Advanced
-    @Argument(fullName = "GVCFGQBands", shortName = "GQB", doc= "Exclusive upper bounds for reference confidence GQ bands " +
+    @Argument(fullName = "gvcf-gq-bands", shortName = "GQB", doc= "Exclusive upper bounds for reference confidence GQ bands " +
             "(must be in [1, 100] and specified in increasing order)", optional = true)
     public List<Integer> GVCFGQBands = new ArrayList<>(70);
     {
@@ -74,11 +75,11 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      * position in the genome, given its alignment to the reference.
      */
     @Advanced
-    @Argument(fullName = "indelSizeToEliminateInRefModel", shortName = "ERCIS", doc = "The size of an indel to check for in the reference model", optional = true)
+    @Argument(fullName = "indel-size-to-eliminate-in-ref-model", doc = "The size of an indel to check for in the reference model", optional = true)
     public int indelSizeToEliminateInRefModel = 10;
 
 
     @Advanced
-    @Argument(fullName = "useAllelesTrigger", shortName = "allelesTrigger", doc = "Use additional trigger on variants found in an external alleles file", optional = true)
+    @Argument(fullName = "use-alleles-trigger", doc = "Use additional trigger on variants found in an external alleles file", optional = true)
     public boolean USE_ALLELES_TRIGGER = false;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
@@ -14,27 +14,28 @@ import java.io.Serializable;
  */
 public final class LikelihoodEngineArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
+
     @Hidden
     @Advanced
-    @Argument(fullName = "likelihoodCalculationEngine", shortName = "likelihoodEngine",
+    @Argument(fullName = "likelihood-calculation-engine",
             doc= "What likelihood calculation engine to use to calculate the relative likelihood of reads vs haplotypes", optional = true)
     public ReadLikelihoodCalculationEngine.Implementation likelihoodEngineImplementation = ReadLikelihoodCalculationEngine.Implementation.PairHMM;
 
     /**
      * Bases with a quality below this threshold will reduced to the minimum usable qualiy score (6).
      */
-    @Argument(fullName = "base_quality_score_threshold", shortName = "bqst", doc = "Base qualities below this threshold will be reduced to the minimum (" + QualityUtils.MIN_USABLE_Q_SCORE + ")", optional = true)
+    @Argument(fullName = "base-quality-score-threshold", doc = "Base qualities below this threshold will be reduced to the minimum (" + QualityUtils.MIN_USABLE_Q_SCORE + ")", optional = true)
     public byte BASE_QUALITY_SCORE_THRESHOLD = PairHMM.BASE_QUALITY_SCORE_THRESHOLD;
 
     @Advanced
-    @Argument(fullName="gcpHMM", shortName="gcpHMM", doc="Flat gap continuation penalty for use in the Pair HMM", optional = true)
+    @Argument(fullName="pair-hmm-gap-continuation-penalty", doc="Flat gap continuation penalty for use in the Pair HMM", optional = true)
     public int gcpHMM = 10;
 
     /**
      * The PairHMM implementation to use for genotype likelihood calculations. The various implementations balance a tradeoff of accuracy and runtime.
      */
     @Hidden
-    @Argument(fullName = "pair_hmm_implementation", shortName = "pairHMM", doc = "The PairHMM implementation to use for genotype likelihood calculations", optional = true)
+    @Argument(fullName = "pair-hmm-implementation", shortName = "pairHMM", doc = "The PairHMM implementation to use for genotype likelihood calculations", optional = true)
     public PairHMM.Implementation pairHMM = PairHMM.Implementation.FASTEST_AVAILABLE;
 
     /**
@@ -47,7 +48,7 @@ public final class LikelihoodEngineArgumentCollection implements Serializable {
      * definitely recommend setting this argument to NONE</b>.
      */
     @Advanced
-    @Argument(fullName = "pcr_indel_model", shortName = "pcrModel", doc = "The PCR indel model to use", optional = true)
+    @Argument(fullName = "pcr-indel-model", doc = "The PCR indel model to use", optional = true)
     public PairHMMLikelihoodCalculationEngine.PCRErrorModel pcrErrorModel = PairHMMLikelihoodCalculationEngine.PCRErrorModel.CONSERVATIVE;
 
 
@@ -64,7 +65,7 @@ public final class LikelihoodEngineArgumentCollection implements Serializable {
      * Set this term to any negative number to turn off the global mapping rate.
      */
     @Advanced
-    @Argument(fullName="phredScaledGlobalReadMismappingRate", shortName="globalMAPQ", doc="The global assumed mismapping rate for reads", optional = true)
+    @Argument(fullName="phred-scaled-global-read-mismapping-rate", doc="The global assumed mismapping rate for reads", optional = true)
     public int phredScaledGlobalReadMismappingRate = 45;
 
     @ArgumentCollection

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
@@ -8,10 +8,10 @@ import org.broadinstitute.barclay.argparser.Argument;
  */
 public class PairHMMNativeArgumentCollection {
 
-    @Argument(fullName = "nativePairHmmThreads", shortName = "threads", doc="How many threads should a native pairHMM implementation use", optional = true)
+    @Argument(fullName = "native-pair-hmm-threads", doc="How many threads should a native pairHMM implementation use", optional = true)
     private int pairHmmNativeThreads = 4;
 
-    @Argument(fullName = "useDoublePrecision", shortName = "useDoublePrecision", doc="use double precision in the native pairHmm. " +
+    @Argument(fullName = "native-pair-hmm-use-double-precision", doc="use double precision in the native pairHmm. " +
             "This is slower but matches the java implementation better", optional = true)
     private boolean useDoublePrecision = false;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * Multiple kmer sizes can be specified, using e.g. `-kmerSize 10 -kmerSize 25`.
      */
     @Advanced
-    @Argument(fullName="kmerSize", shortName="kmerSize", doc="Kmer size to use in the read threading assembler", optional = true)
+    @Argument(fullName="kmer-size", doc="Kmer size to use in the read threading assembler", optional = true)
     public List<Integer> kmerSizes = Lists.newArrayList(10,25);
 
     /**
@@ -30,7 +30,7 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * resolved. Disabling this behavior may cause the program to give up on assembling the ActiveRegion.
      */
     @Advanced
-    @Argument(fullName="dontIncreaseKmerSizesForCycles", shortName="dontIncreaseKmerSizesForCycles", doc="Disable iterating over kmer sizes when graph cycles are detected", optional = true)
+    @Argument(fullName="dont-increase-kmer-sizes-for-cycles", doc="Disable iterating over kmer sizes when graph cycles are detected", optional = true)
     public boolean dontIncreaseKmerSizesForCycles = false;
 
     /**
@@ -38,28 +38,28 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * this check may cause problems in the assembly graph.
      */
     @Advanced
-    @Argument(fullName="allowNonUniqueKmersInRef", shortName="allowNonUniqueKmersInRef", doc="Allow graphs that have non-unique kmers in the reference", optional = true)
+    @Argument(fullName="allow-non-unique-kmers-in-ref", doc="Allow graphs that have non-unique kmers in the reference", optional = true)
     public boolean allowNonUniqueKmersInRef = false;
 
     /**
      * If fewer samples than the specified number pass the minPruning threshold for a given path, that path will be eliminated from the graph.
      */
     @Advanced
-    @Argument(fullName="numPruningSamples", shortName="numPruningSamples", doc="Number of samples that must pass the minPruning threshold", optional = true)
+    @Argument(fullName="num-pruning-samples", doc="Number of samples that must pass the minPruning threshold", optional = true)
     public int numPruningSamples = 1;
 
     /**
      * As of version 3.3, this argument is no longer needed because dangling end recovery is now the default behavior. See GATK 3.3 release notes for more details.
      */
     @Deprecated
-    @Argument(fullName="recoverDanglingHeads", shortName="recoverDanglingHeads", doc="This argument is deprecated since version 3.3", optional = true)
+    @Argument(fullName="recover-dangling-heads", doc="This argument is deprecated since version 3.3", optional = true)
     public boolean DEPRECATED_RecoverDanglingHeads = false;
 
     /**
      * By default, the read threading assembler will attempt to recover dangling heads and tails. See the `minDanglingBranchLength` argument documentation for more details.
      */
     @Hidden
-    @Argument(fullName="doNotRecoverDanglingBranches", shortName="doNotRecoverDanglingBranches", doc="Disable dangling head and tail recovery", optional = true)
+    @Argument(fullName="do-not-recover-dangling-branches", doc="Disable dangling head and tail recovery", optional = true)
     public boolean doNotRecoverDanglingBranches = false;
 
     /**
@@ -68,7 +68,7 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * try to rescue it.  A smaller number here will lead to higher sensitivity to real variation but also to a higher number of false positives.
      */
     @Advanced
-    @Argument(fullName="minDanglingBranchLength", shortName="minDanglingBranchLength", doc="Minimum length of a dangling branch to attempt recovery", optional = true)
+    @Argument(fullName="min-dangling-branch-length", doc="Minimum length of a dangling branch to attempt recovery", optional = true)
     public int minDanglingBranchLength = 4;
 
     /**
@@ -76,7 +76,7 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * provided alleles to the assembly graph but will not forcibly genotype all of them.
      */
     @Advanced
-    @Argument(fullName="consensus", shortName="consensus", doc="1000G consensus mode", optional = true)
+    @Argument(fullName="consensus", doc="1000G consensus mode", optional = true)
     public boolean consensusMode = false;
 
     /**
@@ -88,14 +88,14 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * You can consider increasing this number when calling organisms with high heterozygosity.
      */
     @Advanced
-    @Argument(fullName="maxNumHaplotypesInPopulation", shortName="maxNumHaplotypesInPopulation", doc="Maximum number of haplotypes to consider for your population", optional = true)
+    @Argument(fullName="max-num-haplotypes-in-population", doc="Maximum number of haplotypes to consider for your population", optional = true)
     public int maxNumHaplotypesInPopulation = 128;
 
     /**
      * Enabling this argument may cause fundamental problems with the assembly graph itself.
      */
     @Hidden
-    @Argument(fullName="errorCorrectKmers", shortName="errorCorrectKmers", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
+    @Argument(fullName="error-correct-kmers", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
     public boolean errorCorrectKmers = false;
 
     /**
@@ -108,17 +108,17 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * depth to produce calls).
      */
     @Advanced
-    @Argument(fullName="minPruning", shortName="minPruning", doc = "Minimum support to not prune paths in the graph", optional = true)
+    @Argument(fullName="min-pruning", doc = "Minimum support to not prune paths in the graph", optional = true)
     public int minPruneFactor = 2;
 
     @Hidden
-    @Argument(fullName="debugGraphTransformations", shortName="debugGraphTransformations", doc="Write DOT formatted graph files out of the assembler for only this graph size", optional = true)
+    @Argument(fullName="debug-graph-transformations", doc="Write DOT formatted graph files out of the assembler for only this graph size", optional = true)
     public boolean debugGraphTransformations = false;
 
     /**
      * This argument is meant for debugging and is not immediately useful for normal analysis use.
      */
-    @Argument(fullName="graphOutput", shortName="graph", doc="Write debug assembly graph information to this file", optional = true)
+    @Argument(fullName="graph-output", shortName="graph", doc="Write debug assembly graph information to this file", optional = true)
     public String graphOutput = null;
 
     //---------------------------------------------------------------------------------------------------------------
@@ -131,10 +131,10 @@ public final class ReadThreadingAssemblerArgumentCollection implements Serializa
      * Enabling this argument may cause fundamental problems with the assembly graph itself.
      */
     @Hidden
-    @Argument(fullName="kmerLengthForReadErrorCorrection", shortName="kmerLengthForReadErrorCorrection", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
+    @Argument(fullName="kmer-length-for-read-error-correction", doc = "Use an exploratory algorithm to error correct the kmers used during assembly", optional = true)
     public int kmerLengthForReadErrorCorrection = 25;
 
     @Hidden
-    @Argument(fullName="minObservationsForKmerToBeSolid", shortName="minObservationsForKmerToBeSolid", doc = "A k-mer must be seen at least these times for it considered to be solid", optional = true)
+    @Argument(fullName="min-observations-for-kmer-to-be-solid", doc = "A k-mer must be seen at least these times for it considered to be solid", optional = true)
     public int minObservationsForKmerToBeSolid = 20;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounter.java
@@ -5,7 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.LocusWalker;
@@ -26,11 +26,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Calculate read counts per allele for allele-specific expression analysis
+ * Calculate read counts per allele for allele-specific expression analysis of RNAseq data
  * <p>
  * <p>
  * This tool calculates allele counts at a set of positions after applying filters that are tuned for enabling
- * allele-specific expression (ASE) analysis. The filters operate on mapping quality, base quality, depth of coverage,
+ * allele-specific expression (ASE) analysis of RNAseq data. The filters operate on mapping quality, base quality, depth of coverage,
  * overlapping paired reads and deletions overlapping the position. All thresholds and options are controlled by
  * command-line arguments.
  * </p>
@@ -46,6 +46,14 @@ import java.util.List;
  * A table of allele counts at the given sites. By default, it is formatted as a tab-delimited text file
  * that is readable by R and compatible with <a href="http://www.well.ox.ac.uk/~rivas/mamba/">Mamba</a>,
  * a downstream tool developed for allele-specific expression analysis.
+ * </p>
+ * <h3>Usage Example</h3>
+ * <p>
+ *     gatk ASEReadCounter \
+ *     -R Homo_sapiens_assembly38.fasta \
+ *     -I input.bam \
+ *     -V sites.vcf.gz \
+ *     -O output.table
  * </p>
  * <p>
  * <h3>Note</h3>
@@ -70,7 +78,7 @@ import java.util.List;
 @CommandLineProgramProperties(
         summary = "Counts filtered reads at het sites for allele specific expression estimate",
         oneLineSummary = "Generates table of filtered base counts at het sites for allele specific expression",
-        programGroup = ReadProgramGroup.class
+        programGroup = CoverageAnalysisProgramGroup.class
 )
 public class ASEReadCounter extends LocusWalker {
 
@@ -84,33 +92,33 @@ public class ASEReadCounter extends LocusWalker {
      * If this argument is enabled, loci with total depth lower than this threshold after all filters have been applied
      * will be skipped. This can be set to -1 by default to disable the evaluation and ignore this threshold.
      */
-    @Argument(fullName = "minDepthOfNonFilteredBase", shortName = "minDepth", doc = "Minimum number of bases that pass filters", optional = true)
+    @Argument(fullName = "min-depth-of-non-filtered-base", shortName = "min-depth", doc = "Minimum number of bases that pass filters", optional = true)
     public int minDepthOfNonFilteredBases = -1;
 
     /**
      * If this argument is enabled, reads with mapping quality values lower than this threshold will not be counted.
      * This can be set to -1 by default to disable the evaluation and ignore this threshold.
      */
-    @Argument(fullName = "minMappingQuality", shortName = "mmq", doc = "Minimum read mapping quality", optional = true)
+    @Argument(fullName = "min-mapping-quality", shortName = "mmq", doc = "Minimum read mapping quality", optional = true)
     public int minMappingQuality = 0;
 
     /**
      * If this argument is enabled, bases with quality scores lower than this threshold will not be counted.
      * This can be set to -1 by default to disable the evaluation and ignore this threshold.
      */
-    @Argument(fullName = "minBaseQuality", shortName = "mbq", doc = "Minimum base quality", optional = true)
+    @Argument(fullName = "min-base-quality", shortName = "mbq", doc = "Minimum base quality", optional = true)
     public byte minBaseQuality = 0;
 
     /**
      * These options modify how the tool deals with overlapping read pairs. The default value is COUNT_FRAGMENTS_REQUIRE_SAME_BASE.
      */
-    @Argument(fullName = "countOverlapReadsType", shortName = "overlap", doc = "Handling of overlapping reads from the same fragment", optional = true)
+    @Argument(fullName = "count-overlap-reads-handling", shortName = "overlap", doc = "Handling of overlapping reads from the same fragment", optional = true)
     public CountPileupType countType = CountPileupType.COUNT_FRAGMENTS_REQUIRE_SAME_BASE;
 
     /**
      * Available options are csv, table, rtable. By default, the format is rtable (an r-readable table).
      */
-    @Argument(fullName = "outputFormat", doc = "Format of the output file", optional = true)
+    @Argument(fullName = "output-format", doc = "Format of the output file", optional = true)
     public OUTPUT_FORMAT outputFormat = OUTPUT_FORMAT.RTABLE;
 
     public String separator = "\t";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.rnaseq;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
+import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
@@ -12,6 +13,7 @@ import org.broadinstitute.hellbender.engine.TwoPassReadWalker;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.transformers.MappingQualityReadTransformer;
 import org.broadinstitute.hellbender.transformers.NDNCigarReadTransformer;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
@@ -32,11 +34,30 @@ import static org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions.
 
 /**
  *
- * Splits reads that contain Ns in their cigar string (e.g. spanning splicing events).
+ * Splits reads that contain Ns in their cigar string (e.g. spanning splicing events in RNAseq data).
  *
  * Identifies all N cigar elements and creates k+1 new reads (where k is the number of N cigar elements).
  * The first read includes the bases that are to the left of the first N element, while the part of the read that is to the right of the N
- * (including the Ns) is hard clipped and so on for the rest of the new reads.
+ * (including the Ns) is hard clipped and so on for the rest of the new reads. Used for post-processing RNA reads aligned against the full reference.
+ *
+ * <h3>Input</h3>
+ *  <p>
+ *	    BAM file
+ *  </p>
+ *
+ *
+ * <h3>Output</h3>
+ *  <p>
+ *      BAM file with reads split at N CIGAR elements and CIGAR strings updated.
+ *  </p>
+ *
+ * <h3>Usage example</h3>
+ *  <pre>
+ *    gatk SplitNCigarReads \
+ *      -R Homo_sapiens_assembly38.fasta \
+ *      -I input.bam \
+ *      -o output.bam
+ *  </pre>
  */
 @DocumentedFeature
 @CommandLineProgramProperties(
@@ -52,23 +73,31 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
     static final String[] TAGS_TO_REMOVE = {"NM","MD","NH"};
     static final String MATE_CIGAR_TAG = "MC";
 
-    @Argument(fullName = OUTPUT_LONG_NAME, shortName = OUTPUT_SHORT_NAME, doc="Write output to this BAM filename instead of STDOUT")
+    @Argument(fullName = OUTPUT_LONG_NAME, shortName = OUTPUT_SHORT_NAME, doc="Write output to this BAM filename")
     File OUTPUT;
 
     /**
      * This flag tells GATK to refactor cigar string with NDN elements to one element. It intended primarily for use in
-     * a RNAseq pipeline since the problem might come up when using RNAseq aligner such as Tophat2 with provided transcriptoms.
+     * a RNAseq pipeline since the problem might come up when using RNAseq aligner such as Tophat2 with provided transcriptomes.
      * You should only use this if you know that your reads have that problem.
      */
-    @Argument(fullName = "refactor_NDN_cigar_string", shortName = "fixNDN", doc = "refactor cigar string with NDN elements to one element", optional = true)
+    @Argument(fullName = "refactor-cigar-string", shortName = "fixNDN", doc = "refactor cigar string with NDN elements to one element", optional = true)
     boolean REFACTOR_NDN_CIGAR_READS = false;
+
+    /**
+     * This flag turns off the mapping quality 255 -> 60 read transformer. The transformer is on by default to ensure that
+     * uniquely mapping reads assigned STAR's default 255 MQ aren't filtered out by HaplotypeCaller.
+     */
+    @Argument(fullName = "skip-mapping-quality-transform", shortName = "skip-mq-transform", doc = "skip the 255 -> 60 MQ read transform", optional = true)
+    boolean SKIP_MQ_TRANSFORM = false;
 
     /**
      * For expert users only!  To minimize memory consumption you can lower this number, but then the tool may skip
      * overhang fixing in regions with too much coverage.  Just make sure to give Java enough memory!  4Gb should be
      * enough with the default value.
      */
-    @Argument(fullName="maxReadsInMemory", shortName="maxInMemory", doc="max reads allowed to be kept in memory at a time by the BAM writer", optional=true)
+    @Advanced
+    @Argument(fullName="max-reads-in-memory", doc="max reads allowed to be kept in memory at a time by the BAM writer", optional=true)
     int MAX_RECORDS_IN_MEMORY = 150000;
 
     /**
@@ -76,19 +105,19 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
      * It is still possible in some cases that the overhang could get clipped if the number of mismatches do not exceed this
      * value, e.g. if most of the overhang mismatches.
      */
-    @Argument(fullName="maxMismatchesInOverhang", shortName="maxMismatches", doc="max number of mismatches allowed in the overhang", optional=true)
+    @Argument(fullName="max-mismatches-in-overhang", doc="max number of mismatches allowed in the overhang", optional=true)
     int MAX_MISMATCHES_IN_OVERHANG = 1;
 
     /**
      * If there are more than this many bases in the overhang, we won't try to hard-clip them out
      */
-    @Argument(fullName="maxBasesInOverhang", shortName="maxOverhang", doc="max number of bases allowed in the overhang", optional=true)
+    @Argument(fullName="max-bases-in-overhang", doc="max number of bases allowed in the overhang", optional=true)
     int MAX_BASES_TO_CLIP = 40;
 
-    @Argument(fullName="doNotFixOverhangs", shortName="doNotFixOverhangs", doc="do not have the walker soft-clip overhanging sections of the reads", optional=true)
+    @Argument(fullName="do-not-fix-overhangs", doc="do not have the walker soft-clip overhanging sections of the reads", optional=true)
     boolean doNotFixOverhangs = false;
 
-    @Argument(fullName="processSecondaryAlignments", shortName="processSecondaryAlignments", doc="have the walker split secondary alignments (will still repair MC tag without it)", optional=true)
+    @Argument(fullName="process-secondary-alignments", doc="have the walker split secondary alignments (will still repair MC tag without it)", optional=true)
     boolean processSecondaryAlignments = false;
 
     @Override
@@ -98,7 +127,6 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
 
     private SAMFileGATKReadWriter outputWriter;
     private OverhangFixingManager overhangManager;
-    ReadTransformer rnaReadTransform;
     private IndexedFastaSequenceFile referenceReader;
     SAMFileHeader header;
 
@@ -108,9 +136,33 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
     }
 
     @Override
+    public ReadTransformer makePreReadFilterTransformer(){
+        if (REFACTOR_NDN_CIGAR_READS) {
+            return new NDNCigarReadTransformer();
+        }
+        else {
+            return ReadTransformer.identity();
+        }
+    }
+
+    //FIXME: once the engine accepts read transformer arguments, remove these magic numbers?
+    private static final int FROM_QUALITY = 255;
+    private static final int TO_QUALITY = 60;
+
+
+    @Override
+    public ReadTransformer makePostReadFilterTransformer(){
+        if (SKIP_MQ_TRANSFORM) {
+            return ReadTransformer.identity();
+        }
+        else {
+            return new MappingQualityReadTransformer(FROM_QUALITY, TO_QUALITY);
+        }
+    }
+
+    @Override
     public void onTraversalStart() {
         header = getHeaderForSAMWriter();
-        rnaReadTransform = REFACTOR_NDN_CIGAR_READS ? new NDNCigarReadTransformer() : ReadTransformer.identity();
         try {
             referenceReader = new CachingIndexedFastaSequenceFile(referenceArguments.getReferencePath());
             GenomeLocParser genomeLocParser = new GenomeLocParser(getBestAvailableSequenceDictionary());
@@ -124,12 +176,12 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
 
     @Override
     protected void firstPassApply(GATKRead read, ReferenceContext bytes, FeatureContext featureContext) {
-        splitNCigarRead(rnaReadTransform.apply(read),overhangManager, true, header, processSecondaryAlignments);
+        splitNCigarRead(read,overhangManager, true, header, processSecondaryAlignments);
     }
 
     @Override
     protected void secondPassApply(GATKRead read, ReferenceContext bytes, FeatureContext featureContext) {
-        splitNCigarRead(rnaReadTransform.apply(read),overhangManager, true, header, processSecondaryAlignments);
+        splitNCigarRead(read,overhangManager, true, header, processSecondaryAlignments);
     }
 
     // Activates writing in the manager, which destinguishes each pass

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriors.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriors.java
@@ -86,23 +86,23 @@ import java.util.*;
  * <h4>Refine genotypes based on the discovered allele frequency in an input VCF containing many samples</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" CalculateGenotypePosteriors \
- *   -V multisample_input.vcf \
- *   -O output.vcf
+ *   -V multisample_input.vcf.gz \
+ *   -O output.vcf.gz
  * </pre>
  *
- * <h4>Inform the genotype assignment of a single sample using the 1000G_EUR European panel</h4>
+ * <h4>Inform the genotype assignment of a single sample using the 1000G phase 3 samples</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" CalculateGenotypePosteriors \
- *   -V sample_input.vcf \
- *   -O sample_output.1000G_EUR.vcf \
- *   -supporting 1000G_EUR.genotypes.vcf
+ *   -V sample_input.vcf.gz \
+ *   -O sample_output.1000G_PPs.vcf.gz \
+ *   -supporting 1000G.phase3.integrated.sites_only.no_MATCHED_REV.hg38.vcf.gz
  * </pre>
  *
  * <h4>Apply only family priors to a callset</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" CalculateGenotypePosteriors \
- *   -V input.vcf \
- *   -O output.vcf \
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
  *   -ped family.ped \
  *   --skipPopulationPriors
  * </pre>
@@ -111,19 +111,19 @@ import java.util.*;
  * in the allele frequency estimates</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" CalculateGenotypePosteriors \
- *   -V input.vcf \
- *   -O output.vcf \
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
  *   --ignoreInputSamples
  * </pre>
  *
  * <h4>Calculate the posterior genotypes of a callset, and impose that a variant *not seen* in the external panel
- * is tantamount to being AC=0, AN=100 within that panel</h4>
+ * is tantamount to being AC=0, AN=5008 within that panel</h4>
  * <pre>
  * gatk --java-options "-Xmx4g" CalculateGenotypePosteriors \
- *   -V input.vcf \
- *   -O output.vcf \
- *   -supporting external.panel.vcf \
- *   --numRefSamplesIfNoCall 100
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
+ *   -supporting 1000G.phase3.integrated.sites_only.no_MATCHED_REV.hg38.vcf.gz \
+ *   --num-reference-samples-if-no-call 2504
  * </pre>
  *
  * <h3>Caveat</h3>
@@ -146,7 +146,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * Supporting external panels. Allele counts from these panels (taken from AC,AN or MLEAC,AN or raw genotypes) will
      * be used to inform the frequency distribution underlying the genotype priors. These files must be VCF 4.2 spec or later.
      */
-    @Argument(fullName="supporting", shortName = "supporting", doc="Other callsets to use in generating genotype posteriors", optional=true)
+    @Argument(fullName="supporting-callsets", shortName = "supporting", doc="Other callsets to use in generating genotype posteriors", optional=true)
     public List<FeatureInput<VariantContext>> supportVariants = new ArrayList<>();
 
     @Argument(doc="File to which variants should be written", fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, optional = false)
@@ -158,7 +158,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * across alleles. The calculation for this parameter is (Effective population size) * (steady state mutation rate)
      *
      */
-     @Argument(fullName="globalPrior",shortName="G",doc="Global Dirichlet prior parameters for the allele frequency",optional=true)
+     @Argument(fullName="global-prior", doc="Global Dirichlet prior parameters for the allele frequency",optional=true)
      public double globalPrior = HomoSapiensConstants.SNP_HETEROZYGOSITY;
 
     /**
@@ -166,7 +166,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * mutations suggests a default value of 10^-6.
      *
      */
-    @Argument(fullName="deNovoPrior",shortName="DNP",doc="Prior for de novo mutations",optional=true)
+    @Argument(fullName="de-novo-prior", doc="Prior for de novo mutations",optional=true)
     public double deNovoPrior = 1e-6;
 
     /**
@@ -175,7 +175,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * AN=2000". This is applied across all external panels, so if numRefIsMissing = 10, and the variant is absent in
      * two panels, this confers evidence of AC=0,AN=20.
      */
-    @Argument(fullName="numRefSamplesIfNoCall",shortName="nrs",doc="Number of hom-refs sites to infer at sites not present in a panel",optional=true)
+    @Argument(fullName="num-reference-samples-if-no-call",doc="Number of hom-ref genotypes to infer at sites not present in a panel",optional=true)
     public int numRefIfMissing = 0;
 
     /**
@@ -183,7 +183,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * flag is set, the behavior is flipped and the tool looks first for the AC field and then fall back to MLEAC or
      * raw genotypes.
      */
-    @Argument(fullName="defaultToAC",shortName="useAC",doc="Use AC rather than MLEAC",optional=true)
+    @Argument(fullName="default-to-allele-count",doc="Use AC rather than MLEAC",optional=true)
     public boolean defaultToAC = false;
 
     /**
@@ -191,26 +191,26 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * will not use the discovered allele frequency in the callset whose posteriors are being calculated. Useful for
      * callsets containing related individuals.
      */
-    @Argument(fullName="ignoreInputSamples",shortName="ext",doc="Use external information only",optional=true)
+    @Argument(fullName="ignore-input-samples",doc="Use external information only",optional=true)
     public boolean ignoreInputSamples = false;
 
     /**
      * Calculate priors for missing external variants from sample data -- default behavior is to apply flat priors
      */
-    @Argument(fullName="discoveredACpriorsOff",shortName="useACoff",doc="Do not use discovered allele count in the input callset " +
+    @Argument(fullName="discovered-allele-count-priors-off",doc="Do not use discovered allele count in the input callset " +
             "for variants that do not appear in the external callset. ", optional=true)
     public boolean useACoff = false;
 
     /**
      * Skip application of population-based priors
      */
-    @Argument(fullName="skipPopulationPriors",shortName="skipPop",doc="Skip application of population-based priors", optional=true)
+    @Argument(fullName="skip-population-priors",doc="Skip application of population-based priors", optional=true)
     public boolean skipPopulationPriors = false;
 
     /**
      * Skip application of family-based priors. Note: if pedigree file is absent, family-based priors will always be skipped.
      */
-    @Argument(fullName="skipFamilyPriors",shortName="skipFam",doc="Skip application of family-based priors", optional=true)
+    @Argument(fullName="skip-family-priors",doc="Skip application of family-based priors", optional=true)
     public boolean skipFamilyPriors = false;
 
     /**
@@ -219,7 +219,7 @@ public final class CalculateGenotypePosteriors extends VariantWalker {
      * tell the GATK PED parser that the corresponding fields are missing from the ped file.
      *
      */
-    @Argument(fullName="pedigree", shortName="ped", doc="Pedigree file for samples", optional=true)
+    @Argument(fullName=StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME, shortName=StandardArgumentDefinitions.PEDIGREE_FILE_SHORT_NAME, doc="Pedigree file for samples", optional=true)
     private File pedigreeFile = null;
 
     private FamilyLikelihoods famUtils;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -84,15 +84,24 @@ import java.util.stream.Collectors;
  * A new VCF file containing the selected subset of variants.
  * </p>
  *
- * * <h3>Usage example</h3>
+ * * <h3>Usage examples</h3>
+ * <h4>Select SNPs</h4>
  * <pre>
  *     gatk SelectVariants \
- *     -R reference.fasta \
+ *     -R Homo_sapiens_assembly38.fasta \
  *     -V input.vcf \
  *     --select-type-to-include SNP \
  *     -O output.vcf
  * </pre>
  *
+ * <h4>Query Chromosome 20 Variants from a GenomicsDB</h4>
+ * <pre>
+ *     gatk SelectVariants \
+ *     -R Homo_sapiens_assembly38.fasta \
+ *     -V gendb://genomicsDB \
+ *     -L 20 \
+ *     -O output.chr20.vcf
+ * </pre>
  */
 @CommandLineProgramProperties(
         summary = "This tool makes it possible to select a subset of variants based on various criteria in order to facilitate certain " +
@@ -142,7 +151,7 @@ public final class SelectVariants extends VariantWalker {
      * expected file format is simply plain text with one sample name per line. Note that sample exclusion takes
      * precedence over inclusion, so that if a sample is in both lists it will be excluded.
      */
-    @Argument(fullName="sample-name", shortName="sn", doc="Include genotypes from this sample", optional=true)
+    @Argument(fullName=StandardArgumentDefinitions.SAMPLE_NAME_LONG_NAME, shortName=StandardArgumentDefinitions.SAMPLE_NAME_SHORT_NAME, doc="Include genotypes from this sample", optional=true)
     private Set<String> sampleNames = new LinkedHashSet<>(0);
 
     /**
@@ -159,7 +168,7 @@ public final class SelectVariants extends VariantWalker {
      * specify the name of one or more files containing sample names. File names must use the extension ".args",
      * and the expected file format is simply plain text with one sample name per line.
      */
-    @Argument(fullName="exclude-sample-name", shortName="xl_sn", doc="Exclude genotypes from this sample", optional=true)
+    @Argument(fullName="exclude-sample-name", shortName="xl-sn", doc="Exclude genotypes from this sample", optional=true)
     private Set<String> XLsampleNames = new LinkedHashSet<>(0);
 
     /**
@@ -188,14 +197,14 @@ public final class SelectVariants extends VariantWalker {
      * If this flag is enabled, sites that are found to be non-variant after the subsetting procedure (i.e. where none
      * of the selected samples display evidence of variation) will be excluded from the output.
      */
-    @Argument(fullName="exclude-non-variants", shortName="env", doc="Don't include non-variant sites", optional=true)
+    @Argument(fullName="exclude-non-variants", doc="Don't include non-variant sites", optional=true)
     private boolean XLnonVariants = false;
 
     /**
      * If this flag is enabled, sites that have been marked as filtered (i.e. have anything other than `.` or `PASS`
      * in the FILTER field) will be excluded from the output.
      */
-    @Argument(fullName="exclude-filtered", shortName="ef", doc="Don't include filtered sites", optional=true)
+    @Argument(fullName="exclude-filtered", doc="Don't include filtered sites", optional=true)
     private boolean XLfiltered = false;
 
     /**
@@ -203,7 +212,7 @@ public final class SelectVariants extends VariantWalker {
      * operations have been completed, leaving only their minimal representation. If this flag is enabled, the original
      * alleles will be preserved as recorded in the input VCF.
      */
-    @Argument(fullName="preserve-alleles", shortName="no-trim", doc="Preserve original alleles, do not trim", optional=true)
+    @Argument(fullName="preserve-alleles", doc="Preserve original alleles, do not trim", optional=true)
     private boolean preserveAlleles = false;
 
     /**
@@ -212,7 +221,7 @@ public final class SelectVariants extends VariantWalker {
      * removed and the record will contain a '.' in the ALT column. Note also that sites-only VCFs, by definition, do
      * not include the alternate allele in any genotype calls.
      */
-    @Argument(fullName="remove-unused-alternates", shortName="trim-alternates",
+    @Argument(fullName="remove-unused-alternates",
                     doc="Remove alternate alleles not present in any genotypes", optional=true)
     private boolean removeUnusedAlternates = false;
 
@@ -226,7 +235,7 @@ public final class SelectVariants extends VariantWalker {
      * will be included in that case, but would be excluded if `-restrict-alleles-to MULTIALLELIC` is used.
      * Valid options are ALL (default), MULTIALLELIC or BIALLELIC.
      */
-    @Argument(fullName="restrict-alleles-to", shortName="restrict-alleles-to",
+    @Argument(fullName="restrict-alleles-to",
                     doc="Select only variants of a particular allelicity", optional=true)
     private NumberAlleleRestriction alleleRestriction = NumberAlleleRestriction.ALL;
 
@@ -235,7 +244,7 @@ public final class SelectVariants extends VariantWalker {
      * subset. If this flag is enabled, the original values of those annotations will be stored in new annotations called
      * AC_Orig, AF_Orig, and AN_Orig.
      */
-    @Argument(fullName="keep-original-AC", shortName="keep-original-AC",
+    @Argument(fullName="keep-original-ac",
                     doc="Store the original AC, AF, and AN values after subsetting", optional=true)
     private boolean keepOriginalChrCounts = false;
 
@@ -244,7 +253,7 @@ public final class SelectVariants extends VariantWalker {
      * contents of the subset. If this flag is enabled, the original value of the DP annotation will be stored in
      * a new annotation called DP_Orig.
      */
-    @Argument(fullName="keep-original-DP", shortName="keep-original-DP",
+    @Argument(fullName="keep-original-dp",
                     doc="Store the original DP value after subsetting", optional=true)
     private boolean keepOriginalDepth = false;
 
@@ -253,7 +262,7 @@ public final class SelectVariants extends VariantWalker {
      * determined on the basis of family structure. Requires passing a pedigree file using the engine-level
      * `-ped` argument.
      */
-    @Argument(fullName="mendelian-violation", shortName="mv", doc="Output mendelian violation sites only", optional=true)
+    @Argument(fullName="mendelian-violation", doc="Output mendelian violation sites only", optional=true)
     private Boolean mendelianViolations = false;
 
     /**
@@ -261,7 +270,7 @@ public final class SelectVariants extends VariantWalker {
      * determined on the basis of family structure. Requires passing a pedigree file using the engine-level
      * `-ped` argument.
      */
-    @Argument(fullName="invert-mendelian-violation", shortName="inv-mv",
+    @Argument(fullName="invert-mendelian-violation",
                     doc="Output non-mendelian violation sites only", optional=true)
     private Boolean invertMendelianViolations = false;
 
@@ -270,11 +279,11 @@ public final class SelectVariants extends VariantWalker {
      * for a site to be accepted as a mendelian violation. Note that the `-mv` flag must be set for this argument
      * to have an effect.
      */
-    @Argument(fullName="mendelian-violation-qual-threshold", shortName="mvq",
+    @Argument(fullName="mendelian-violation-qual-threshold",
                     doc="Minimum GQ score for each trio member to accept a site as a violation", optional=true)
     private double mendelianViolationQualThreshold = 0;
 
-    @Argument(fullName="pedigree", shortName="ped", doc="Pedigree file", optional=true)
+    @Argument(fullName=StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME, shortName=StandardArgumentDefinitions.PEDIGREE_FILE_SHORT_NAME, doc="Pedigree file", optional=true)
     private File pedigreeFile = null;
 
     /**
@@ -291,7 +300,7 @@ public final class SelectVariants extends VariantWalker {
      * randomly selected from the input callset and set to no-call (./). Note that this is done using a probabilistic
      * function, so the final result is not guaranteed to carry the exact fraction requested. Can be used for large fractions.
      */
-    @Argument(fullName="remove-fraction-genotypes", shortName="fraction-genotypes",
+    @Argument(fullName="remove-fraction-genotypes",
                         doc="Select a fraction of genotypes at random from the input and sets them to no-call", optional=true)
     private double fractionGenotypes = 0;
 
@@ -318,7 +327,7 @@ public final class SelectVariants extends VariantWalker {
      * field is present in this list of IDs. The matching is done by exact string matching. If a file, the file
      * name must end in ".list", and the expected file format is simply plain text with one ID per line.
      */
-    @Argument(fullName="keep-IDs", shortName="IDs", doc="List of variant rsIDs to select", optional=true)
+    @Argument(fullName="keep-ids", shortName="ids", doc="List of variant rsIDs to select", optional=true)
     private Set<String> rsIDsToKeep = new HashSet<>();
 
     /**
@@ -326,7 +335,7 @@ public final class SelectVariants extends VariantWalker {
      * field is present in this list of IDs. The matching is done by exact string matching. If a file, the
      * file name must end in ".list", and the expected file format is simply plain text with one ID per line.
      */
-    @Argument(fullName="exclude-IDs", shortName="xl-IDs", doc="List of variant rsIDs to exclude", optional=true)
+    @Argument(fullName="exclude-ids", shortName="xl-ids", doc="List of variant rsIDs to exclude", optional=true)
     private Set<String> rsIDsToRemove = new HashSet<>();
 
     @Hidden
@@ -378,30 +387,30 @@ public final class SelectVariants extends VariantWalker {
     /**
      * If this argument is provided, select sites where at most the given number of samples have no-call genotypes.
      */
-    @Argument(fullName="max-no-call-number", optional=true,
+    @Argument(fullName="max-nocall-number", optional=true,
             doc="Maximum number of samples with no-call genotypes")
     private int maxNOCALLnumber = MAX_NOCALL_NUMBER_DEFAULT_VALUE;
 
     /**
      * If this argument is provided, select sites where at most the given fraction of samples have no-call genotypes.
      */
-    @Argument(fullName="max-no-call-fraction", optional=true,
+    @Argument(fullName="max-nocall-fraction", optional=true,
             doc="Maximum fraction of samples with no-call genotypes")
     private double maxNOCALLfraction = MAX_NOCALL_FRACTION_DEFAULT_VALUE;
 
     /**
      * If this argument is provided, set filtered genotypes to no-call (./.).
      */
-    @Argument(fullName="set-filtered-GT-to-no-call", optional=true, doc="Set filtered genotypes to no-call")
+    @Argument(fullName="set-filtered-gt-to-nocall", optional=true, doc="Set filtered genotypes to no-call")
     private boolean setFilteredGenotypesToNocall = false;
 
     @Hidden
-    @Argument(fullName="allow-non-overlapping-command-line-samples", optional=true,
+    @Argument(fullName="allow-nonoverlapping-command-line-samples", optional=true,
                     doc="Allow samples other than those in the VCF to be specified on the command line. These samples will be ignored.")
     private boolean allowNonOverlappingCommandLineSamples = false;
 
     @Hidden
-    @Argument(fullName="suppress-reference-path", shortName="sr", optional=true,
+    @Argument(fullName="suppress-reference-path", optional=true,
             doc="Suppress reference path in output for test result differencing")
     private boolean suppressReferencePath = false;
 
@@ -687,7 +696,7 @@ public final class SelectVariants extends VariantWalker {
                         "Samples entered on command line (through -sf or -sn) that are not present in the VCF.",
                         "A list of these samples:",
                         Utils.join(",", samplesNotInHeader),
-                        "To ignore these samples, run with --allow-non-overlapping-command-line-samples"));
+                        "To ignore these samples, run with --allow-nonoverlapping-command-line-samples"));
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSR.java
@@ -56,9 +56,9 @@ import java.util.regex.Pattern;
  * assigned a score and filter status.</p>
  *
  * <p>VQSR is probably the hardest part of the Best Practices to get right, so be sure to read the
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=39'>method documentation</a>,
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=1259'>parameter recommendations</a> and
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=2805'>tutorial</a> to really understand what these
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=39'>method documentation</a>,
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=1259'>parameter recommendations</a> and
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=2805'>tutorial</a> to really understand what these
  * tools do and how to use them for best results on your own data.</p>
  *
  * <h3>Inputs</h3>
@@ -76,28 +76,28 @@ import java.util.regex.Pattern;
  *
  * <h3>Usage examples</h3>
  *
- * <h4>Applying rcelibration/filtering to SNPs</h4>
+ * <h4>Applying recalibration/filtering to SNPs</h4>
  * <pre>
  * gatk ApplyVQSR \
- *   -R reference.fasta \
- *   -V input.vcf \
- *   -O output.vcf \
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
  *   --ts_filter_level 99.0 \
- *   -tranchesFile output.tranches \
- *   --recalFile output.recal \
+ *   --tranches-file output.tranches \
+ *   --recal-file output.recal \
  *   -mode SNP
  * </pre>
  *
  * <h4>Allele-specific version of the SNP filtering (beta)</h4>
  * <pre>
  * gatk ApplyVQSR \
- *   -R reference.fasta \
- *   -V input.vcf \
- *   -O output.vcf \
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V input.vcf.gz \
+ *   -O output.vcf.gz \
  *   -AS \
  *   --ts_filter_level 99.0 \
- *   -tranchesFile output.AS.tranches \
- *   --recalFile output.AS.recal \
+ *   --tranches-file output.AS.tranches \
+ *   --recal-file output.AS.recal \
  *   -mode SNP 
  * </pre>
  * <p>Note that the tranches and recalibration files must have been produced by an allele-specific run of
@@ -139,10 +139,10 @@ public class ApplyVQSR extends MultiVariantWalker {
     /////////////////////////////
     // Inputs
     /////////////////////////////
-    @Argument(fullName="recal_file", shortName="recalFile", doc="The input recal file used by ApplyRecalibration", optional=false)
+    @Argument(fullName="recal-file", doc="The input recal file used by ApplyRecalibration", optional=false)
     private FeatureInput<VariantContext> recal;
 
-    @Argument(fullName="tranches_file", shortName="tranchesFile", doc="The input tranches file describing where to cut the data", optional=true)
+    @Argument(fullName="tranches-file", doc="The input tranches file describing where to cut the data", optional=true)
     private File TRANCHES_FILE;
 
     /////////////////////////////
@@ -157,30 +157,30 @@ public class ApplyVQSR extends MultiVariantWalker {
     /////////////////////////////
     // Command Line Arguments
     /////////////////////////////
-    @Argument(fullName="ts_filter_level", shortName="ts_filter_level", doc="The truth sensitivity level at which to start filtering", optional=true)
+    @Argument(fullName="truth-sensitivity-filter-level", shortName="ts-filter-level", doc="The truth sensitivity level at which to start filtering", optional=true)
     private Double TS_FILTER_LEVEL = null;
 
     /**
      *  Filter the input file based on allele-specific recalibration data.  See tool docs for site-level and allele-level filtering details.
      *  Requires a .recal file produced using an allele-specific run of VariantRecalibrator.
      */
-    @Argument(fullName="useAlleleSpecificAnnotations", shortName="AS", doc="If specified, the tool will attempt to apply a filter to each allele based on the input tranches and allele-specific .recal file.", optional=true)
+    @Argument(fullName="use-allele-specific-annotations", shortName="AS", doc="If specified, the tool will attempt to apply a filter to each allele based on the input tranches and allele-specific .recal file.", optional=true)
     private boolean useASannotations = false;
 
     @Advanced
-    @Argument(fullName="lodCutoff", shortName="lodCutoff", doc="The VQSLOD score below which to start filtering", optional=true)
+    @Argument(fullName="lod-score-cutoff", doc="The VQSLOD score below which to start filtering", optional=true)
     protected Double VQSLOD_CUTOFF = null;
 
     /**
      * For this to work properly, the -ignoreFilter argument should also be applied to the VariantRecalibration command.
      */
-    @Argument(fullName="ignore_filter", shortName="ignoreFilter", doc="If specified, the recalibration will be applied to variants marked as filtered by the specified filter name in the input VCF file", optional=true)
+    @Argument(fullName="ignore-filter", doc="If specified, the recalibration will be applied to variants marked as filtered by the specified filter name in the input VCF file", optional=true)
     private List<String> IGNORE_INPUT_FILTERS = new ArrayList<>();
 
-    @Argument(fullName="ignore_all_filters", shortName="ignoreAllFilters", doc="If specified, the variant recalibrator will ignore all input filters. Useful to rerun the VQSR from a filtered output file.", optional=true)
+    @Argument(fullName="ignore-all-filters", doc="If specified, the variant recalibrator will ignore all input filters. Useful to rerun the VQSR from a filtered output file.", optional=true)
     private boolean IGNORE_ALL_FILTERS = false;
 
-    @Argument(fullName="excludeFiltered", shortName="ef", doc="Don't output filtered loci after applying the recalibration", optional=true)
+    @Argument(fullName="exclude-filtered", doc="Don't output filtered loci after applying the recalibration", optional=true)
     private boolean EXCLUDE_FILTERED = false;
 
     @Argument(fullName = "mode", shortName = "mode", doc = "Recalibration mode to employ: 1.) SNP for recalibrating only SNPs (emitting indels untouched in the output VCF); 2.) INDEL for indels; and 3.) BOTH for recalibrating both SNPs and indels simultaneously.", optional=true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranches.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/GatherTranches.java
@@ -2,7 +2,9 @@ package org.broadinstitute.hellbender.tools.walkers.vqsr;
 
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -21,7 +23,7 @@ import java.util.*;
         oneLineSummary = "Gathers scattered VQSLOD tranches into a single file",
         programGroup = VariantProgramGroup.class
 )
-@DocumentedFeature
+@BetaFeature
 public class GatherTranches extends CommandLineProgram {
     @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc="List of scattered tranches files")
@@ -32,7 +34,7 @@ public class GatherTranches extends CommandLineProgram {
      * which will result in 4 estimated tranches in the final call set: the full set of calls (100% sensitivity at the accessible
      * sites in the truth set), a 99.9% truth sensitivity tranche, along with progressively smaller tranches at 99% and 90%.
      */
-    @Argument(fullName="TStranche",
+    @Argument(fullName="truth-sensitivity-tranche",
             shortName="tranche",
             doc="The levels of truth sensitivity at which to slice the data. (in percent, that is 1.0 for 1 percent)",
             optional=true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
@@ -68,9 +68,9 @@ import java.util.*;
  * assigned a score and filter status.</p>
  *
  * <p>VQSR is probably the hardest part of the Best Practices to get right, so be sure to read the
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=39'>method documentation</a>,
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=1259'>parameter recommendations</a> and
- * <a href='https://www.broadinstitute.org/gatk/guide/article?id=2805'>tutorial</a> to really understand what these
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=39'>method documentation</a>,
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=1259'>parameter recommendations</a> and
+ * <a href='https://software.broadinstitute.org/gatk/guide/article?id=2805'>tutorial</a> to really understand what these
  * tools do and how to use them for best results on your own data.</p>
  *
  * <h3>Inputs</h3>
@@ -94,34 +94,34 @@ import java.util.*;
  * <h4>Recalibrating SNPs in exome data</h4>
  * <pre>
  * gatk VariantRecalibrator \
- *   -R reference.fasta \
- *   -V input.vcf \
- *   --resource hapmap,known=false,training=true,truth=true,prior=15.0 hapmap_3.3.b37.sites.vcf \
- *   --resource omni,known=false,training=true,truth=false,prior=12.0 1000G_omni2.5.b37.sites.vcf \
- *   --resource 1000G,known=false,training=true,truth=false,prior=10.0 1000G_phase1.snps.high_confidence.vcf \
- *   --resource dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_135.b37.vcf \
- *   -an QD -an MQ -an MQRankSum -an ReadPosRankSum -an FS -an SOR -an InbreedingCoeff \
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V input.vcf.gz \
+ *   --resource hapmap,known=false,training=true,truth=true,prior=15.0:hapmap_3.3.hg38.sites.vcf.gz \
+ *   --resource omni,known=false,training=true,truth=false,prior=12.0:1000G_omni2.5.hg38.sites.vcf.gz \
+ *   --resource 1000G,known=false,training=true,truth=false,prior=10.0:1000G_phase1.snps.high_confidence.hg38.vcf.gz \
+ *   --resource dbsnp,known=true,training=false,truth=false,prior=2.0:Homo_sapiens_assembly38.dbsnp138.vcf.gz \
+ *   -an QD -an MQ -an MQRankSum -an ReadPosRankSum -an FS -an SOR \
  *   -mode SNP \
- *   --recalFile output.recal \
- *   -tranchesFile output.tranches \
- *   --rscriptFile output.plots.R
+ *   --recal-file output.recal \
+ *   --tranches-file output.tranches \
+ *   --rscript-file output.plots.R
  * </pre>
  *
  * <h4>Allele-specific version of the SNP recalibration (beta)</h4>
  * <pre>
  * gatk VariantRecalibrator \
- *   -R reference.fasta \
- *   -V input.vcf \
+ *   -R Homo_sapiens_assembly38.fasta \
+ *   -V input.vcf.gz \
  *   -AS \
- *   --resource hapmap,known=false,training=true,truth=true,prior=15.0:hapmap_3.3.b37.sites.vcf \
- *   --resource omni,known=false,training=true,truth=false,prior=12.0:1000G_omni2.5.b37.sites.vcf \
- *   --resource 1000G,known=false,training=true,truth=false,prior=10.0:1000G_phase1.snps.high_confidence.vcf \
- *   --resource dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_135.b37.vcf \
- *   -an QD -an MQ -an MQRankSum -an ReadPosRankSum -an FS -an SOR -an InbreedingCoeff \
+ *   --resource hapmap,known=false,training=true,truth=true,prior=15.0:hapmap_3.3.hg38.sites.vcf.gz \
+ *   --resource omni,known=false,training=true,truth=false,prior=12.0:1000G_omni2.5.hg38.sites.vcf.gz \
+ *   --resource 1000G,known=false,training=true,truth=false,prior=10.0:1000G_phase1.snps.high_confidence.hg38.vcf.gz \
+ *   --resource dbsnp,known=true,training=false,truth=false,prior=2.0:Homo_sapiens_assembly38.dbsnp138.vcf.gz \
+ *   -an QD -an MQ -an MQRankSum -an ReadPosRankSum -an FS -an SOR \
  *   -mode SNP \
- *   --recalFile output.AS.recal \
- *   --tranchesFile output.AS.tranches \
- *   --rscriptFile output.plots.AS.R
+ *   --recal-file output.AS.recal \
+ *   --tranches-file output.AS.tranches \
+ *   --rscript-file output.plots.AS.R
  * </pre>
  * <p>Note that to use the allele-specific (AS) mode, the input VCF must have been produced using allele-specific
  * annotations in HaplotypeCaller. Note also that each allele will have a separate line in the output recalibration
@@ -134,7 +134,7 @@ import java.util.*;
  * They are not meant to be taken as specific recommendations of values to use in your own work, and they may be
  * different from the values cited elsewhere in our documentation. For the latest and greatest recommendations on
  * how to set parameter values for your own analyses, please read the Best Practices section of the documentation,
- * especially the <a href='https://www.broadinstitute.org/gatk/guide/article?id=1259'>FAQ document</a> on VQSR parameters.</li>
+ * especially the <a href='https://software.broadinstitute.org/gatk/guide/article?id=1259'>FAQ document</a> on VQSR parameters.</li>
  * <li>Whole genomes and exomes take slightly different parameters, so make sure you adapt your commands accordingly! See
  * the documents linked above for details.</li>
  * <li>If you work with small datasets (e.g. targeted capture experiments or small number of exomes), you will run into
@@ -203,7 +203,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
             doc="The output recal file used by ApplyRecalibration", optional=false)
     private String output;
 
-    @Argument(fullName="tranches_file", shortName="tranchesFile", doc="The output tranches file used by ApplyRecalibration", optional=false)
+    @Argument(fullName="tranches-file", doc="The output tranches file used by ApplyRecalibration", optional=false)
     private String TRANCHES_FILE;
 
     /////////////////////////////
@@ -212,11 +212,11 @@ public class VariantRecalibrator extends MultiVariantWalker {
     /**
      * The expected transition / transversion ratio of true novel variants in your targeted region (whole genome, exome, specific
      * genes), which varies greatly by the CpG and GC content of the region. See expected Ti/Tv ratios section of the GATK best
-     * practices documentation (http://www.broadinstitute.org/gatk/guide/best-practices) for more information.
+     * practices documentation (https://software.broadinstitute.org/gatk/guide/best-practices) for more information.
      * Normal values are 2.15 for human whole genome values and 3.2 for human whole exomes. Note
      * that this parameter is used for display purposes only and isn't used anywhere in the algorithm!
      */
-    @Argument(fullName="target_titv",
+    @Argument(fullName="target-titv",
             shortName="titv",
             doc="The expected novel Ti/Tv ratio to use when calculating FDR tranches and for display on the optimization curve output figures. (approx 2.15 for whole genome experiments). ONLY USED FOR PLOTTING PURPOSES!",
             optional=true)
@@ -225,7 +225,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
     /**
      * See the input VCF file's INFO field for a list of all available annotations.
      */
-    @Argument(fullName="use_annotation",
+    @Argument(fullName="use-annotation",
             shortName="an",
             doc="The names of the annotations which should used for calculations",
             optional=false)
@@ -236,7 +236,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
      * which will result in 4 estimated tranches in the final call set: the full set of calls (100% sensitivity at the accessible
      * sites in the truth set), a 99.9% truth sensitivity tranche, along with progressively smaller tranches at 99% and 90%.
      */
-    @Argument(fullName="TStranche",
+    @Argument(fullName="truth-sensitivity-tranche",
             shortName="tranche",
             doc="The levels of truth sensitivity at which to slice the data. (in percent, that is 1.0 for 1 percent)",
             optional=true)
@@ -245,19 +245,17 @@ public class VariantRecalibrator extends MultiVariantWalker {
     /**
      * For this to work properly, the -ignoreFilter argument should also be applied to the ApplyRecalibration command.
      */
-    @Argument(fullName="ignore_filter",
-            shortName="ignoreFilter",
+    @Argument(fullName="ignore-filter",
             doc="If specified, the variant recalibrator will also use variants marked as filtered by the specified filter name in the input VCF file",
             optional=true)
     private List<String> IGNORE_INPUT_FILTERS = new ArrayList<>();
 
-    @Argument(fullName="ignore_all_filters",
-            shortName="ignoreAllFilters",
+    @Argument(fullName="ignore-all-filters",
             doc="If specified, the variant recalibrator will ignore all input filters. Useful to rerun the VQSR from a filtered output file.",
             optional=true)
     private boolean IGNORE_ALL_FILTERS = false;
 
-    @Argument(fullName="rscript_file", shortName="rscriptFile", doc="The output rscript file generated by the VQSR to aid in visualization of the input data and learned model", optional=true)
+    @Argument(fullName="rscript-file",doc="The output rscript file generated by the VQSR to aid in visualization of the input data and learned model", optional=true)
     private String RSCRIPT_FILE = null;
 
     /**
@@ -267,18 +265,16 @@ public class VariantRecalibrator extends MultiVariantWalker {
      *  to help describe the normalization. The model fit report can be read in with our R gsalib package. Individual
      *  model Gaussians can be subset by the value in the "Gaussian" column if desired.
      */
-    @Argument(fullName="output_model",
-            shortName = "outputModel",
+    @Argument(fullName="output-model",
             doc="If specified, the variant recalibrator will output the VQSR model to this file path.",
             optional=true)
     private String outputModel = null;
 
     /**
      *  The filename for a VQSR model fit to use to recalibrate the input variants. This model should be generated using
-     *  a previous VariantRecalibration run with the --output_model argument.
+     *  a previous VariantRecalibration run with the --output-model argument.
      */
-    @Argument(fullName="input_model",
-            shortName = "inputModel",
+    @Argument(fullName="input-model",
             doc="If specified, the variant recalibrator will read the VQSR model from this file path.",
             optional=true)
     private String inputModel = null;
@@ -286,18 +282,19 @@ public class VariantRecalibrator extends MultiVariantWalker {
     /**
      * This argument is intended to be used in a more complicated VQSR scheme meant for very large WGS callsets that
      * require a prohibitive amount of memory for classic VQSR. Given that training data is downsampled once it exceeds
-     * --maxNumTrainingData, reading in additional data to build the model only serves to consume resources. However,
+     * --max-num-training-data, reading in additional data to build the model only serves to consume resources. However,
      * with this argument the output recal file will also be downsampled. The recommended VQSR procedure when using this
-     * argument is to run VariantRecalibrator once with sampling and designate an --output_model file. Then
+     * argument is to run VariantRecalibrator once with sampling and designate an --output-model file. Then
      * VariantRecalibrator can be run a second time scattered using the -scatterTranches argument and that file as an
-     * --input_model.  The scattered recal files can be gathered with the GatherVcfs tool and the scattered tranches can
+     * --input-model.  The scattered recal files can be gathered with the GatherVcfs tool and the scattered tranches can
      * be gathered with the GatherTranches tool.
      *
      */
-    @Argument(fullName="sample_every_Nth_variant",
-            shortName = "sampleEvery",
+    @Argument(fullName="sample-every-Nth-variant",
+            shortName = "sample-every",
             doc="If specified, the variant recalibrator will use (and output) only a subset of variants consisting of every Nth variant where N is specified by this argument; for use with -outputModel -- see argument details",
             optional=true)
+    @Hidden
     private int sampleMod = 1;
 
     /**
@@ -307,10 +304,10 @@ public class VariantRecalibrator extends MultiVariantWalker {
      *  scattered VariantRecalibrator.
      */
 
-    @Argument(fullName="output_tranches_for_scatter",
-            shortName = "scatterTranches",
+    @Argument(fullName="output-tranches-for-scatter",
             doc="Output tranches in a format appropriate to running VariantRecalibrator in scatter-gather",
             optional = true)
+    @Hidden
     private boolean scatterTranches = false;
 
     /**
@@ -321,8 +318,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
      * Alternative lists of tranche values should only be used for testing.
      */
     @Hidden
-    @Argument(fullName="VQSLODtranche",
-            shortName="VQSLODtranche",
+    @Argument(fullName="vqslod-tranche",
             doc="The levels of VQSLOD at which to slice the data.",
             optional=true)
     private List<Double> VQSLOD_TRANCHES = new ArrayList<>(1000);
@@ -357,8 +353,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
      * in order to generate a more robust model.
      */
     @Advanced
-    @Argument(fullName="max_attempts",
-            shortName = "max_attempts",
+    @Argument(fullName="max-attempts",
             doc="Number of attempts to build a model before failing",
             optional=true)
     @VisibleForTesting
@@ -368,8 +363,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
     // Debug Arguments
     /////////////////////////////
     @Advanced
-    @Argument(fullName = "trustAllPolymorphic",
-            shortName = "allPoly",
+    @Argument(fullName = "trust-all-polymorphic",
             doc = "Trust that all the input training sets' unfiltered records contain only polymorphic sites to drastically speed up the computation.",
             optional=true)
     private boolean TRUST_ALL_POLYMORPHIC = false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorArgumentCollection.java
@@ -26,7 +26,7 @@ final class VariantRecalibratorArgumentCollection {
      * Generate a VQSR model using per-allele data instead of the default per-site data, assuming that the input VCF contains allele-specific annotations.
      * Annotations should be specified using their full names with AS_ prefix. Non-allele-specific (scalar) annotations will be applied to all alleles.
      */
-    @Argument(fullName="useAlleleSpecificAnnotations",
+    @Argument(fullName="use-allele-specific-annotations",
             shortName="AS",
             doc="If specified, the variant recalibrator will attempt to use the allele-specific versions of the specified annotations.", optional=true)
     public boolean useASannotations = false;
@@ -36,7 +36,7 @@ final class VariantRecalibratorArgumentCollection {
      * using the variational Bayes algorithm.
      */
     @Advanced
-    @Argument(fullName = "maxGaussians", shortName = "mG", doc = "Max number of Gaussians for the positive model", optional = true)
+    @Argument(fullName = "max-gaussians", doc = "Max number of Gaussians for the positive model", optional = true)
     public int MAX_GAUSSIANS = 8;
 
     /**
@@ -46,7 +46,7 @@ final class VariantRecalibratorArgumentCollection {
      * be small (e.g. 4) to achieve the best results.
      */
     @Advanced
-    @Argument(fullName = "maxNegativeGaussians", shortName = "mNG", doc = "Max number of Gaussians for the negative model", optional = true)
+    @Argument(fullName = "max-negative-gaussians", doc = "Max number of Gaussians for the negative model", optional = true)
     public int MAX_GAUSSIANS_FOR_NEGATIVE_MODEL = 2;
 
     /**
@@ -54,7 +54,7 @@ final class VariantRecalibratorArgumentCollection {
      * The procedure will normally end when convergence is detected.
      */
     @Advanced
-    @Argument(fullName = "maxIterations", shortName = "mI", doc = "Maximum number of VBEM iterations", optional = true)
+    @Argument(fullName = "max-iterations", doc = "Maximum number of VBEM iterations", optional = true)
     public int MAX_ITERATIONS = 150;
 
     /**
@@ -62,7 +62,7 @@ final class VariantRecalibratorArgumentCollection {
      * the Gaussians in the Gaussian mixture model.
      */
     @Advanced
-    @Argument(fullName = "numKMeans", shortName = "nKM", doc = "Number of k-means iterations", optional = true)
+    @Argument(fullName = "k-means-iterations", doc = "Number of k-means iterations", optional = true)
     public int NUM_KMEANS_ITERATIONS = 100;
 
     /**
@@ -70,26 +70,26 @@ final class VariantRecalibratorArgumentCollection {
      * the Gaussian mixture model.
      */
     @Advanced
-    @Argument(fullName = "stdThreshold", shortName = "std", doc = "Annotation value divergence threshold (number of standard deviations from the means) ", optional = true)
+    @Argument(fullName = "standard-deviation-threshold", shortName = "std", doc = "Annotation value divergence threshold (number of standard deviations from the means) ", optional = true)
     public double STD_THRESHOLD = 10.0;
 
     @Advanced
-    @Argument(fullName = "shrinkage", shortName = "shrinkage", doc = "The shrinkage parameter in the variational Bayes algorithm.", optional = true)
+    @Argument(fullName = "shrinkage", doc = "The shrinkage parameter in the variational Bayes algorithm.", optional = true)
     public double SHRINKAGE = 1.0;
 
     @Advanced
-    @Argument(fullName = "dirichlet", shortName = "dirichlet", doc = "The dirichlet parameter in the variational Bayes algorithm.", optional = true)
+    @Argument(fullName = "dirichlet",doc = "The dirichlet parameter in the variational Bayes algorithm.", optional = true)
     public double DIRICHLET_PARAMETER = 0.001;
 
     @Advanced
-    @Argument(fullName = "priorCounts", shortName = "priorCounts", doc = "The number of prior counts to use in the variational Bayes algorithm.", optional = true)
+    @Argument(fullName = "prior-counts", doc = "The number of prior counts to use in the variational Bayes algorithm.", optional = true)
     public double PRIOR_COUNTS = 20.0;
 
     /**
      * The number of variants to use in building the Gaussian mixture model. Training sets larger than this will be randomly downsampled.
      */
     @Advanced
-    @Argument(fullName = "maxNumTrainingData", shortName = "maxNumTrainingData", doc = "Maximum number of training data", optional = true)
+    @Argument(fullName = "maximum-training-variants", doc = "Maximum number of training data", optional = true)
     protected int MAX_NUM_TRAINING_DATA = 2500000;
 
     /**
@@ -97,14 +97,14 @@ final class VariantRecalibratorArgumentCollection {
      * variants to use for building the Gaussian mixture model of bad variants.
      */
     @Advanced
-    @Argument(fullName = "minNumBadVariants", shortName = "minNumBad", doc = "Minimum number of bad variants", optional = true)
+    @Argument(fullName = "minimum-bad-variants", doc = "Minimum number of bad variants", optional = true)
     public int MIN_NUM_BAD_VARIANTS = 1000;
 
     /**
      * Variants scoring lower than this threshold will be used to build the Gaussian model of bad variants.
      */
     @Advanced
-    @Argument(fullName = "badLodCutoff", shortName = "badLodCutoff", doc = "LOD score cutoff for selecting bad variants", optional = true)
+    @Argument(fullName = "bad-lod-score-cutoff", shortName = "bad-lod-cutoff", doc = "LOD score cutoff for selecting bad variants", optional = true)
     public double BAD_LOD_CUTOFF = -5.0;
 
     /**
@@ -124,7 +124,7 @@ final class VariantRecalibratorArgumentCollection {
      * If this option is not used, or if MQCap is set to 0, MQ will not be transformed.
      */
     @Advanced
-    @Argument(fullName="MQCapForLogitJitterTransform", shortName = "MQCap", doc="Apply logit transform and jitter to MQ values", optional=true)
+    @Argument(fullName="mq-cap-for-logit-jitter-transform", shortName = "mq-cap", doc="Apply logit transform and jitter to MQ values", optional=true)
     public int MQ_CAP = 0;
 
     /**
@@ -134,12 +134,12 @@ final class VariantRecalibratorArgumentCollection {
 
     @Hidden
     @Advanced
-    @Argument(fullName = "no_MQ_logit", shortName = "NoMQLogit", doc="MQ is by default transformed to log[(MQ_cap + epsilon - MQ)/(MQ + epsilon)] to make it more Gaussian-like.  Use this flag to not do that.", optional = true)
+    @Argument(fullName = "no-mq-logit", doc="MQ is by default transformed to log[(MQ_cap + epsilon - MQ)/(MQ + epsilon)] to make it more Gaussian-like.  Use this flag to not do that.", optional = true)
     public boolean NO_MQ_LOGIT = false;
 
     @Hidden
     @Advanced
-    @Argument(fullName="MQ_jitter", shortName="MQJitt", doc="Amount of jitter (as a factor to a Normal(0,1) noise) to add to the MQ capped values", optional = true)
+    @Argument(fullName="mq-jitter", doc="Amount of jitter (as a factor to a Normal(0,1) noise) to add to the MQ capped values", optional = true)
     public double MQ_JITTER = 0.05;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/transformers/MappingQualityReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/MappingQualityReadTransformer.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.hellbender.transformers;
+
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+/**
+ * A read transformer to modify the mapping quality of reads with MQ=255 to reads with MQ=60
+ *
+ *
+ */
+public class MappingQualityReadTransformer implements ReadTransformer {
+    private static final long serialVersionUID = 1L;
+
+    private int fromQuality = 255;
+    private int toQuality = 60;
+
+    public MappingQualityReadTransformer(final int fromQuality, final int toQuality) {
+        this.fromQuality = fromQuality;
+        this.toQuality = toQuality;
+    }
+
+    @Override
+    public GATKRead apply(final GATKRead read) {
+        if (read.getMappingQuality() == fromQuality) {
+            read.setMappingQuality(toQuality);
+        }
+        return read;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/transformers/NDNCigarReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/NDNCigarReadTransformer.java
@@ -8,17 +8,13 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * A read transformer that refactor NDN cigar elements to one N element.
+ * A read transformer that refactors NDN cigar elements to one N element.
  *
  *  <p>
  *     This read transformer will refactor cigar strings that contain N-D-N elements to one N element (with total length of the three refactored elements).
  *     This is intended primarily for users of RNA-Seq data handling programs such as TopHat2.
  *     Currently we consider that the internal N-D-N motif is illegal and we error out when we encounter it. By refactoring the cigar string of
  *     those specific reads, users of TopHat and other tools can circumvent this problem without affecting the rest of their dataset.
- *
- *     NOTE: any walker that need that functionality should apply that read transformer in its map function, since it won't be activated by the GATK engine.
- *
- *     The engine parameter that activate this read transformer is --refactor_NDN_cigar_string or -fixNDN
  *  </p>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/HelpConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/HelpConstants.java
@@ -107,6 +107,9 @@ public final class HelpConstants {
     public final static String DOC_CAT_TEST = "Test Tools";
     public final static String DOC_CAT_TEST_SUMMARY = "Tools for internal test purposes";
 
+    public final static String DOC_CAT_RNA = "RNA-Specific Tools";
+    public final static String DOC_CAT_RNA_SUMMARY = "Tools intended to be used for processing RNA data.";
+
     /**
      * List of "supercategory" values used for doc purposes. Every doc group name can/should be put into
      * one of the following super-categories.

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/GenomicsDBTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/GenomicsDBTestUtils.java
@@ -52,7 +52,7 @@ public final class GenomicsDBTestUtils {
 
 
         final String workspace = new File(workspaceDir, "workspace").getAbsolutePath();
-        args.addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, workspace);
+        args.addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
         args.addArgument("L", IntervalUtils.locatableToString(interval));
         importer.runCommandLine(args);
         return new File(workspace);

--- a/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/IntelInflaterDeflaterIntegrationTest.java
@@ -92,8 +92,8 @@ public class IntelInflaterDeflaterIntegrationTest extends CommandLineProgramTest
         final ArrayList<String> args = new ArrayList<>();
         args.add("--input"); args.add(ORIG_BAM.getAbsolutePath());
         args.add("--output"); args.add(outFile.getAbsolutePath());
-        args.add("--use_jdk_inflater"); args.add(String.valueOf(use_jdk_inflater));
-        args.add("--use_jdk_deflater"); args.add(String.valueOf(use_jdk_deflater));
+        args.add("--use-jdk-inflater"); args.add(String.valueOf(use_jdk_inflater));
+        args.add("--use-jdk-deflater"); args.add(String.valueOf(use_jdk_deflater));
 
         // store current default factories, so they can be restored later
         InflaterFactory currentInflaterFactory = BlockGunzipper.getDefaultInflaterFactory();

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadWalkerIntegrationTest.java
@@ -26,8 +26,8 @@ public class ReadWalkerIntegrationTest extends CommandLineProgramTest {
         final String[] args = new String[] {
             "-I", BAM_PATH + "reads_data_source_test1.bam",
             "-I", BAM_PATH + "reads_data_source_test2.bam",
-            "--readIndex", INDEX_PATH + "reads_data_source_test1.bam.bai",
-            "--readIndex", INDEX_PATH + "reads_data_source_test2.bam.bai",
+            "--read-index", INDEX_PATH + "reads_data_source_test1.bam.bai",
+            "--read-index", INDEX_PATH + "reads_data_source_test2.bam.bai",
             "-O", outFile.getAbsolutePath()
         };
         runCommandLine(args);
@@ -43,7 +43,7 @@ public class ReadWalkerIntegrationTest extends CommandLineProgramTest {
         final String[] args = new String[] {
                 "-I", BAM_PATH + "reads_data_source_test1.bam",
                 "-I", BAM_PATH + "reads_data_source_test2.bam",
-                "--readIndex", INDEX_PATH + "reads_data_source_test1.bam.bai"
+                "--read-index", INDEX_PATH + "reads_data_source_test1.bam.bai"
         };
         runCommandLine(args);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrderingIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrderingIntegrationTest.java
@@ -136,12 +136,12 @@ public class FixCallSetSampleOrderingIntegrationTest extends CommandLineProgramT
         final File fixed = createTempFile("fixed_", ".vcf");
         args.addVCF(shuffled)
                 .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, sampleMap)
-                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
                 .addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(readerThreads))
+                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                 .addBooleanArgument(FixCallSetSampleOrdering.SKIP_PROMPT_LONG_NAME, true)
                 .addOutput(fixed);
         if ( gvcfToHeaderSampleMapFile != null ) {
-            args.addFileArgument("gvcfToHeaderSampleMapFile", gvcfToHeaderSampleMapFile);
+            args.addFileArgument("gvcf-to-header-sample-map-file", gvcfToHeaderSampleMapFile);
         }
         
         runCommandLine(args);
@@ -178,12 +178,12 @@ public class FixCallSetSampleOrderingIntegrationTest extends CommandLineProgramT
         final File fixed = createTempFile("fixed_", ".vcf");
         args.addVCF(shuffled)
                 .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, sampleMap)
-                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
                 .addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(readerThreads))
+                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                 .addBooleanArgument(FixCallSetSampleOrdering.SKIP_PROMPT_LONG_NAME, true)
                 .addOutput(fixed);
         if ( gvcfToHeaderSampleMapFile != null ) {
-            args.addFileArgument("gvcfToHeaderSampleMapFile", gvcfToHeaderSampleMapFile);
+            args.addFileArgument("gvcf-to-header-sample-map-file", gvcfToHeaderSampleMapFile);
         }
 
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -169,13 +169,13 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     private void writeToGenomicsDB(final List<String> vcfInputs, final SimpleInterval interval, final String workspace,
                                    final int batchSize, final Boolean useBufferSize, final int bufferSizePerSample, int threads) {
         final ArgumentsBuilder args = new ArgumentsBuilder();
-        args.addArgument("genomicsDBWorkspace", workspace);
+        args.addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
         args.addArgument("L", IntervalUtils.locatableToString(interval));
         vcfInputs.forEach(vcf -> args.addArgument("V", vcf));
-        args.addArgument("batchSize", String.valueOf(batchSize));
+        args.addArgument("batch-size", String.valueOf(batchSize));
         args.addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(threads));
         if (useBufferSize)
-            args.addArgument("genomicsDBVCFBufferSize", String.valueOf(bufferSizePerSample));
+            args.addArgument("genomicsdb-vcf-buffer-size", String.valueOf(bufferSizePerSample));
 
         runCommandLine(args);
     }
@@ -218,31 +218,31 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         for( final Integer batchSize: batchSizes){
             // -V in order
             results.add(new Object[] {new ArgumentsBuilder()
-                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                     .addVCF(new File(HG_00096))
                     .addVCF(new File(HG_00268))
                     .addVCF(new File(NA_19625))});
 
             // -V out of order
             results.add(new Object[] {new ArgumentsBuilder()
-                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                     .addVCF(new File(HG_00268))
                     .addVCF(new File(NA_19625))
                     .addVCF(new File(HG_00096))});
 
             //in order sample map
             results.add(new Object[] {new ArgumentsBuilder()
-                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                     .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, createInOrderSampleMap())});
 
             //out of order sample map
             results.add(new Object[] {new ArgumentsBuilder()
-                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                     .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, outOfOrderSampleMap)});
 
             //out of order sample map with multiple threads
             results.add(new Object[] {new ArgumentsBuilder()
-                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                    .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                     .addFileArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, outOfOrderSampleMap)
                     .addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, "2")});
         }
@@ -254,7 +254,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         final String workspace = createTempDir("gendbtest").getAbsolutePath() + "/workspace";
 
         args.addArgument("L", IntervalUtils.locatableToString(INTERVAL))
-            .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, workspace);
+            .addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
 
         runCommandLine(args);
         checkJSONFilesAreWritten(workspace);
@@ -342,9 +342,9 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         Files.delete(Paths.get(workspace));
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .addArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, sampleMapFile.getAbsolutePath())
-                .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, new File(workspace).getAbsolutePath())
+                .addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, new File(workspace).getAbsolutePath())
                 .addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(threads))
-                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_NAME, String.valueOf(batchSize))
+                .addArgument(GenomicsDBImport.BATCHSIZE_ARG_LONG_NAME, String.valueOf(batchSize))
                 .addArgument("L", IntervalUtils.locatableToString(INTERVAL));
 
         runCommandLine(args);
@@ -400,7 +400,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .addArgument(GenomicsDBImport.SAMPLE_NAME_MAP_LONG_NAME, createInOrderSampleMap().getAbsolutePath())
                 .addArgument(StandardArgumentDefinitions.VARIANT_LONG_NAME, HG_00096)
-                .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, createTempDir("workspace").getAbsolutePath())
+                .addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, createTempDir("workspace").getAbsolutePath())
                 .addArgument("L",  IntervalUtils.locatableToString(INTERVAL));
         runCommandLine(args);
     }
@@ -408,7 +408,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     @Test(expectedExceptions = CommandLineException.MissingArgument.class)
     public void testRequireOneOfVCFOrSampleNameFile(){
         final ArgumentsBuilder args = new ArgumentsBuilder()
-                .addArgument(GenomicsDBImport.WORKSPACE_ARG_NAME, createTempDir("workspace").getAbsolutePath())
+                .addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, createTempDir("workspace").getAbsolutePath())
                 .addArgument("L", "1:1-10");
 
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -40,7 +40,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
             return  " -R " + referenceURL +
                     " -I " + bam +
                     " " + args +
-                    (knownSites.isEmpty() ? "": " -knownSites " + knownSites) +
+                    (knownSites.isEmpty() ? "": " --known-sites " + knownSites) +
                     " -O %s";
         }
 
@@ -87,50 +87,50 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 // See RecalDatum for explanation of why the multiplier is needed.
 
                 // local input/computation/reference, SHUFFLE
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " + "--joinStrategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--joinStrategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy SHUFFLE --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " + "--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy SHUFFLE --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy SHUFFLE --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy SHUFFLE --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy SHUFFLE --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
                 // multiple known sites; output generated with GATK4 walker
-                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
-                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqCram_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqCram_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
                 // multiple known sites  with SHUFFLE; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE -knownSites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
+                {new BQSRTest(hg19Chr171Mb, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE -known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
 
                 // multiple known sites  with BROADCAST; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST -knownSites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
+                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST -known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
 
                 // local input/computation, 2Bit Reference, BROADCAST
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
                 // multiple known sites with 2bit BROADCAST; same output used for multiple known sites SHUFFLE test above
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
                 // Can't use 2 bit reference with a CRAM file: https://github.com/broadinstitute/gatk/issues/1443
-                //{new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqCram_20_21_100000, more20Sites, " -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.1m-1m100.recal.txt")},
+                //{new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqCram_20_21_100000, more20Sites, " -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.1m-1m100.recal.txt")},
 
                 //// //{new BQSRTest(b36Reference, origQualsBam, dbSNPb36, "-OQ", getResourceDir() + "expected.originalQuals.1kg.chr1.1-1K.1RG.dictFix.OQ.txt")},
 
                 // multiple known sites  with OVERLAPS_PARTITIONER; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --joinStrategy OVERLAPS_PARTITIONER -knownSites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
+                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indelBQSR -enableBAQ " +" --join-strategy OVERLAPS_PARTITIONER -known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
 
                 // local input/computation, 2Bit Reference, OVERLAPS_PARTITIONER
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--joinStrategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy OVERLAPS_PARTITIONER --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER --indels_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER --low_quality_tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER --quantizing_levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy OVERLAPS_PARTITIONER --mismatches_context_size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
                 // multiple known sites with 2bit OVERLAPS_PARTITIONER; same output used for multiple known sites SHUFFLE test above
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --joinStrategy OVERLAPS_PARTITIONER -knownSites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indelBQSR -enableBAQ " +" --join-strategy OVERLAPS_PARTITIONER -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
         };
     }
 
@@ -162,22 +162,22 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 // See RecalDatum for explanation of why the multiplier is needed.
 
                 // local input/computation, using the GA4GH reference API, SHUFFLE
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, " --joinStrategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE --indels_context_size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE --low_quality_tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE --quantizing_levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy SHUFFLE --mismatches_context_size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, " --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE --indels_context_size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE --low_quality_tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE --quantizing_levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy SHUFFLE --mismatches_context_size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
 
                 // local input/computation, using a 2bit reference file in a GCS bucket, BROADCAST
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, " --joinStrategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST --indels_context_size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST --low_quality_tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST --quantizing_levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --joinStrategy BROADCAST --mismatches_context_size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_1read, dbSNPb37_chr2021, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, " --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST --indels_context_size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST --low_quality_tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST --quantizing_levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +" --join-strategy BROADCAST --mismatches_context_size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
         };
     }
 
@@ -196,7 +196,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
         final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
-        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--joinStrategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
+        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
 
         ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
         IntegrationTestSpec spec = new IntegrationTestSpec(
@@ -217,10 +217,10 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
 
         return new Object[][]{
                 // input in cloud, computation local.
-                {new BQSRTest(GRCh37RefCloud, HiSeqBamCloud_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ "+" --joinStrategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, HiSeqBamCloud_chr20, dbSNPb37_chr20, " --joinStrategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, HiSeqBamCloud_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ "+" --joinStrategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, HiSeqBamCloud_chr20, dbSNPb37_chr20, " --joinStrategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, HiSeqBamCloud_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ "+" --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, HiSeqBamCloud_chr20, dbSNPb37_chr20, " --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, HiSeqBamCloud_chr20, dbSNPb37_chr20, "-indelBQSR -enableBAQ "+" --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(chr2021Reference2bit, HiSeqBamCloud_chr20, dbSNPb37_chr20, " --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
         };
     }
 
@@ -245,7 +245,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final File actualHiSeqBam_recalibrated = createTempFile("actual.recalibrated", ".bam");
 
         final String tablePre = createTempFile("gatk4.pre.cols", ".table").getAbsolutePath();
-        final String argPre = " -R " + ReferenceAPISource.URL_PREFIX + chr2021Reference2bit + "-indelBQSR -enableBAQ " +" -knownSites " + dbSNPb37_chr2021 + " -I " + HiSeqBam_chr20
+        final String argPre = " -R " + ReferenceAPISource.URL_PREFIX + chr2021Reference2bit + "-indelBQSR -enableBAQ " +" --known-sites " + dbSNPb37_chr2021 + " -I " + HiSeqBam_chr20
                 + " -O " + tablePre;
         new BaseRecalibratorSpark().instanceMain(Utils.escapeExpressions(argPre));
 
@@ -253,7 +253,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         new ApplyBQSRSpark().instanceMain(Utils.escapeExpressions(argApply));
 
         final File actualTablePost = createTempFile("gatk4.post.cols", ".table");
-        final String argsPost = " -R " + ReferenceAPISource.URL_PREFIX + chr2021Reference2bit + "-indelBQSR -enableBAQ " +" -knownSites " + dbSNPb37_chr2021 + " -I " + actualHiSeqBam_recalibrated.getAbsolutePath()
+        final String argsPost = " -R " + ReferenceAPISource.URL_PREFIX + chr2021Reference2bit + "-indelBQSR -enableBAQ " +" --known-sites " + dbSNPb37_chr2021 + " -I " + actualHiSeqBam_recalibrated.getAbsolutePath()
                 + " -O " + actualTablePost.getAbsolutePath();
         new BaseRecalibratorSpark().instanceMain(Utils.escapeExpressions(argsPost));
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -41,7 +41,7 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
             return  " -R " + referenceURL +
                     " -I " + bam +
                     " " + args +
-                    (knownSites.isEmpty() ? "": " --knownSites " + knownSites) +
+                    (knownSites.isEmpty() ? "": " --known-sites " + knownSites) +
                     " -O %s";
         }
 
@@ -84,19 +84,19 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
                 //        -O src/test/resources/org/broadinstitute/hellbender/tools/BQSR/expected.MultiSite.reads.pipeline.vcf \
                 //        -pairHMM AVX_LOGLESS_CACHING \
                 //        -stand_call_conf 30.0
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--joinStrategy BROADCAST", null, getResourceDir() + expectedSingleKnownSitesVcf)}, // don't write intermediate BAM
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--joinStrategy BROADCAST", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--joinStrategy OVERLAPS_PARTITIONER --readShardPadding 1000", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20_queryNameSorted, ".bam", dbSNPb37_20, "--joinStrategy BROADCAST", getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", null, getResourceDir() + expectedSingleKnownSitesVcf)}, // don't write intermediate BAM
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy OVERLAPS_PARTITIONER --read-shard-padding 1000", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20_queryNameSorted, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
 
                 // Output generated with GATK4
                 // CRAM test fails since can't use 2bit with CRAM, can only use 2bit with HC.
 //                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqCram_chr20, ".cram", dbSNPb37_20, "--joinStrategy BROADCAST --knownSites " + more20Sites, getResourceDir() + expectedMultipleKnownSitesCram, getResourceDir() + expectedMultipleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--joinStrategy BROADCAST --knownSites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--joinStrategy OVERLAPS_PARTITIONER --readShardPadding 1000 --knownSites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy OVERLAPS_PARTITIONER --read-shard-padding 1000 --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
 
                 // BWA-MEM
-                {new PipelineTest(GRCh37Ref2bit_chr2021, unalignedBam, ".bam", dbSNPb37_20, "--align --bwaMemIndexImage " + GRCh37Ref_2021_img + " --disable-sequence-dictionary-validation true --joinStrategy BROADCAST --knownSites " + more20Sites, null, largeFileTestDir + expectedMultipleKnownSitesFromUnalignedVcf)},
+                {new PipelineTest(GRCh37Ref2bit_chr2021, unalignedBam, ".bam", dbSNPb37_20, "--align --bwaMemIndexImage " + GRCh37Ref_2021_img + " --disable-sequence-dictionary-validation true --join-strategy BROADCAST --known-sites " + more20Sites, null, largeFileTestDir + expectedMultipleKnownSitesFromUnalignedVcf)},
         };
     }
 
@@ -111,7 +111,7 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
         args.add("-O");
         args.add(outFile.getAbsolutePath());
         if (params.expectedBamFileName != null) {
-            args.add("--outputBam");
+            args.add("--output-bam");
             args.add(outFileBam.getAbsolutePath());
         }
 
@@ -125,9 +125,9 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
         args.add("-enableBAQ");
         args.add("-pairHMM");
         args.add("AVX_LOGLESS_CACHING");
-        args.add("-stand_call_conf");
+        args.add("-stand-call-conf");
         args.add("30.0");
-        args.add("--knownSites");
+        args.add("--known-sites");
         args.add(params.knownSites);
         if (params.args != null) {
             Stream.of(params.args.trim().split(" ")).forEach(args::add);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/CombineGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/CombineGVCFsIntegrationTest.java
@@ -66,9 +66,9 @@ public class CombineGVCFsIntegrationTest extends CommandLineProgramTest {
                 // Interval Test
                 {new File[]{getTestFile("gvcfExample1.vcf"),getTestFile("gvcfExample2.vcf"),}, getTestFile("IntervalTest.vcf"), Arrays.asList(" -L ",  "20:69485-69791"), b37_reference_20_21},
                 // convert-to-base-pair-resolution argument test
-                {new File[]{getTestFile("gvcfExample1.vcf"),getTestFile("gvcfExample2.vcf"),}, getTestFile("convertToBasePairResolution.vcf"), Arrays.asList(" -L ",  "20:69485-69791", "--convert-to-base-pair-resolution"), b37_reference_20_21},
+                {new File[]{getTestFile("gvcfExample1.vcf"),getTestFile("gvcfExample2.vcf"),}, getTestFile("convertToBasePairResolution.vcf"), Arrays.asList(" -L ",  "20:69485-69791", "--" + CombineGVCFs.BP_RES_LONG_NAME), b37_reference_20_21},
                 // Testing the breakBands argument " -L 1:69485-69791 --break-bands-at-multiples-of 5"
-                {new File[]{getTestFile("gvcfExample1.vcf"),getTestFile("gvcfExample2.vcf"),}, getTestFile("testBreakBandsArgumet.vcf"), Arrays.asList(" -L ",  "20:69485-69791", "--break-bands-at-multiples-of", "5", "-A", "ClippingRankSumTest"), b37_reference_20_21},
+                {new File[]{getTestFile("gvcfExample1.vcf"),getTestFile("gvcfExample2.vcf"),}, getTestFile("testBreakBandsArgumet.vcf"), Arrays.asList(" -L ",  "20:69485-69791", "--" + CombineGVCFs.BREAK_BANDS_LONG_NAME, "5", "-A", "ClippingRankSumTest"), b37_reference_20_21},
                 // Testing mismatched reference bases
                 {new File[]{getTestFile("combine-gvcf-wrong-ref-input1.vcf"),getTestFile("combine-gvcf-wrong-ref-input2.vcf"),}, getTestFile("testWrongReferenceBaseBugFix.vcf"), Arrays.asList("-A", "ClippingRankSumTest"), b37_reference_20_21},
                 //Testing allele-specific annotations

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -79,9 +79,9 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
                 {getTestFile("gvcfExample1.vcf"), getTestFile( "gvcfExample1.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-L", "20"), b37_reference_20_21}, //single sample vcf with -L
                 {getTestFile("combined_genotype_gvcf_exception.original.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21}, //test that an input vcf with 0/0 already in GT field is overwritten
                 {getTestFile("combined_genotype_gvcf_exception.nocall.vcf"), getTestFile( "combined_genotype_gvcf_exception.gatk3.7_30_ga4f720357.output.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},  //same test as above but with ./.
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("ndaTest.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("-nda"), b37_reference_20_21},  //annotating with the number of alleles discovered option
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("maxAltAllelesTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-maxAltAlleles", "1"), b37_reference_20_21 }, //restricting the max number of alt alleles
-                {getTestFile(BASE_PAIR_GVCF), getTestFile("standardConfTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-stand_call_conf", "300"),b37_reference_20_21}, //set minimum calling threshold
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("ndaTest.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("--annotate-with-num-discovered-alleles"), b37_reference_20_21},  //annotating with the number of alleles discovered option
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("maxAltAllelesTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("--max-alternate-alleles", "1"), b37_reference_20_21 }, //restricting the max number of alt alleles
+                {getTestFile(BASE_PAIR_GVCF), getTestFile("standardConfTest.gatk3.7_30_ga4f720357.expected.vcf"), Arrays.asList("-stand-call-conf", "300"),b37_reference_20_21}, //set minimum calling threshold
                 {getTestFile("spanningDel.combined.g.vcf"), getTestFile( "spanningDel.combined.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},
                 {getTestFile("spanningDel.delOnly.g.vcf"), getTestFile( "spanningDel.delOnly.gatk3.7_30_ga4f720357.expected.vcf"), NO_EXTRA_ARGS, b37_reference_20_21},
                 {getTestFile("spanningDel.depr.delOnly.g.vcf"), getTestFile( "spanningDel.depr.delOnly.gatk3.7_30_ga4f720357.expected.vcf" ), NO_EXTRA_ARGS, b37_reference_20_21},
@@ -96,7 +96,7 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
                 {getTestFile( "multiSamples.g.vcf"), getTestFile( "multiSamples.GATK3expected.g.vcf"), Arrays.asList( "-A", "ClippingRankSumTest", "-G", "AS_StandardAnnotation", "-G", "StandardAnnotation"), b37_reference_20_21},
                 {getTestFile( "testAlleleSpecificAnnotations.CombineGVCF.output.g.vcf"), getTestFile( "testAlleleSpecificAnnotations.CombineGVCF.expected.g.vcf"), Arrays.asList( "-A", "ClippingRankSumTest", "-G", "AS_StandardAnnotation", "-G", "StandardAnnotation"), b37_reference_20_21},
                 //all sites not supported yet see https://github.com/broadinstitute/gatk-protected/issues/580 and  https://github.com/broadinstitute/gatk/issues/2429
-                //{getTestFile(basePairGVCF), getTestFile( "gvcf.basepairResolution.includeNonVariantSites.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("--includeNonVariantSites") //allsites not supported yet
+                //{getTestFile(basePairGVCF), getTestFile( "gvcf.basepairResolution.includeNonVariantSites.gatk3.7_30_ga4f720357.expected.vcf"), Collections.singletonList("--"+GenotypeGVCFs.ALL_SITES_LONG_NAME) //allsites not supported yet
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltrationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltrationIntegrationTest.java
@@ -30,7 +30,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testClusteredSnps() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-        baseTestString("vcfexample2.vcf", " -window 10 "),
+        baseTestString("vcfexample2.vcf", " -cluster-window-size 10 "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testClusteredSnps.vcf")
         );
 
@@ -42,14 +42,14 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
         return new String[][]{
                 {"foo", "--mask " + getToolTestDataDir() + "vcfexample2.vcf", "testVariantFiltration_testMask1.vcf"},
                 {"foo", "--mask VCF:" + getToolTestDataDir() + "vcfMask.vcf", "testVariantFiltration_testMask2.vcf"},
-                {"foo", "-maskExtend 10 --mask VCF:" + getToolTestDataDir() + "vcfMask.vcf", "testVariantFiltration_testMask3.vcf"},
+                {"foo", "--" + VariantFiltration.MASK_EXTENSION_LONG_NAME + " 10 --mask VCF:" + getToolTestDataDir() + "vcfMask.vcf", "testVariantFiltration_testMask3.vcf"},
         };
     }
 
     @Test(dataProvider = "masks")
     public void testMask(final String maskName, final String mask, final String expected) throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -maskName " + maskName + " " + mask),
+                baseTestString("vcfexample2.vcf", " -mask-name " + maskName + " " + mask),
                 Arrays.asList(getToolTestDataDir() + "expected/" + expected)
         );
 
@@ -59,7 +59,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testMaskReversed() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -maskName outsideGoodSites -filterNotInMask --mask BED:" + getToolTestDataDir() + "goodMask.bed"),
+                baseTestString("vcfexample2.vcf", " -mask-name outsideGoodSites -filter-not-in-mask --mask BED:" + getToolTestDataDir() + "goodMask.bed"),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testMaskReversed.vcf")
         );
 
@@ -69,7 +69,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testIllegalFilterName() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -filter 'DoC < 20 || FisherStrand > 20.0' -filterName 'foo < foo' "),
+                baseTestString("vcfexample2.vcf", " -filter 'DoC < 20 || FisherStrand > 20.0' -filter-name 'foo < foo' "),
                 1,
                 UserException.class
         );
@@ -80,7 +80,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilter1() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -filter 'DoC < 20 || FisherStrand > 20.0' -filterName foo "),
+                baseTestString("vcfexample2.vcf", " -filter 'DoC < 20 || FisherStrand > 20.0' -filter-name foo "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilter1.vcf")
         );
 
@@ -90,7 +90,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilter2() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -filter 'AlleleBalance < 70.0 && FisherStrand == 1.4' -filterName bar "),
+                baseTestString("vcfexample2.vcf", " -filter 'AlleleBalance < 70.0 && FisherStrand == 1.4' -filter-name bar "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilter2.vcf")
         );
 
@@ -100,7 +100,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilterWithSeparateNames() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " --filterName ABF -filter 'AlleleBalance < 0.7' --filterName FSF -filter 'FisherStrand == 1.4' "),
+                baseTestString("vcfexample2.vcf", " -filter-name ABF -filter 'AlleleBalance < 0.7' -filter-name FSF -filter 'FisherStrand == 1.4' "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilterWithSeparateNames.vcf")
         );
 
@@ -110,7 +110,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testInvertFilter() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " --filterName ABF -filter 'AlleleBalance < 0.7' --filterName FSF -filter 'FisherStrand == 1.4' --invertFilterExpression "),
+                baseTestString("vcfexample2.vcf", " -filter-name ABF -filter 'AlleleBalance < 0.7' -filter-name FSF -filter 'FisherStrand == 1.4' --" + VariantFiltration.INVERT_LONG_NAME + " "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testInvertFilter.vcf")
         );
 
@@ -122,7 +122,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
         //Note: the "invert" in the name refers to the logic being the opposite of testFilterWithSeparateNames (and same as testInvertFilter)
         //Note: Output differs from testInvertFilter because FILTER description uses the -genotypeFilterExpression argument
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " --filterName ABF -filter 'AlleleBalance >= 0.7' --filterName FSF -filter 'FisherStrand != 1.4' "),
+                baseTestString("vcfexample2.vcf", " -filter-name ABF -filter 'AlleleBalance >= 0.7' -filter-name FSF -filter 'FisherStrand != 1.4' "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testInvertJexlFilter.vcf")
         );
 
@@ -132,7 +132,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testGenotypeFilters1() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -G_filter 'GQ == 0.60' -G_filterName foo "),
+                baseTestString("vcfexample2.vcf", " -G-filter 'GQ == 0.60' -G-filter-name foo "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testGenotypeFilters1.vcf")
         );
 
@@ -142,7 +142,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testGenotypeFilters2() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("vcfexample2.vcf", " -G_filter 'isHomVar == 1' -G_filterName foo "),
+                baseTestString("vcfexample2.vcf", " -G-filter 'isHomVar == 1' -G-filter-name foo "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testGenotypeFilters2.vcf")
         );
 
@@ -152,7 +152,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testDeletions() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("twoDeletions.vcf", " --filterExpression 'QUAL < 100' --filterName foo "),
+                baseTestString("twoDeletions.vcf", " -filter 'QUAL < 100' -filter-name foo "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testDeletions.vcf")
         );
 
@@ -162,7 +162,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testUnfilteredBecomesFilteredAndPass() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("unfilteredForFiltering.vcf", " --filterExpression 'FS > 60.0' --filterName SNP_FS "),
+                baseTestString("unfilteredForFiltering.vcf", " -filter 'FS > 60.0' -filter-name SNP_FS "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testUnfilteredBecomesFilteredAndPass.vcf")
         );
 
@@ -172,7 +172,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilteringDPfromINFO() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringDepthInFormat.vcf", " --filterExpression 'DP < 8' --filterName lowDP "),
+                baseTestString("filteringDepthInFormat.vcf", " -filter 'DP < 8' -filter-name lowDP "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilteringDPfromINFO.vcf")
         );
 
@@ -182,7 +182,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilteringDPfromFORMAT() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringDepthInFormat.vcf", " -genotypeFilterExpression 'DP < 8' --genotypeFilterName lowDP "),
+                baseTestString("filteringDepthInFormat.vcf", " --" + VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME +" 'DP < 8' --" + VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " lowDP "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilteringDPfromFORMAT.vcf")
         );
 
@@ -192,7 +192,8 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testInvertGenotypeFilterExpression() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringDepthInFormat.vcf", " --genotypeFilterExpression 'DP < 8' --genotypeFilterName highDP --invertGenotypeFilterExpression "),
+                baseTestString("filteringDepthInFormat.vcf", " --" + VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME + " 'DP < 8' --"
+                        + VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " highDP --" + VariantFiltration.INVERT_GT_LONG_NAME),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testInvertGenotypeFilterExpression.vcf")
         );
 
@@ -204,7 +205,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
         //Note: the "invert" in the name refers to the logic being the opposite of testFilteringDPfromFORMAT (and same as testInvertGenotypeFilterExpression_
         //Note: Output differs from testInvertGenotypeFilterExpression because FILTER description uses the -genotypeFilterExpression argument
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringDepthInFormat.vcf", " --genotypeFilterExpression 'DP >= 8' --genotypeFilterName highDP "),
+                baseTestString("filteringDepthInFormat.vcf", " --" + VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME +" 'DP >= 8' --" + VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " highDP "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testInvertJexlGenotypeFilterExpression.vcf")
         );
 
@@ -214,7 +215,8 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testSetFilteredGtoNocall() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringDepthInFormat.vcf", " --genotypeFilterExpression 'DP < 8' --genotypeFilterName lowDP --setFilteredGtToNocall "),
+                baseTestString("filteringDepthInFormat.vcf", " --" + VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME +" 'DP < 8' --"
+                        + VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " lowDP --" + VariantFiltration.NO_CALL_GTS_LONG_NAME),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testSetFilteredGtoNocall.vcf")
         );
 
@@ -224,7 +226,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testSetFilteredGtoNocallUpdateInfo()  throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("variantFiltrationInfoField.vcf", " -G_filter 'GQ < 20' -G_filterName lowDP -G_filter 'DP < 10' -G_filterName lowGQ --setFilteredGtToNocall "),
+                baseTestString("variantFiltrationInfoField.vcf", " -G-filter 'GQ < 20' -G-filter-name lowDP -G-filter 'DP < 10' -G-filter-name lowGQ --" + VariantFiltration.NO_CALL_GTS_LONG_NAME + " "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testSetFilteredGtoNocallUpdateInfo.vcf")
         );
 
@@ -234,7 +236,7 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testSetVcfFilteredGtoNocall()  throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteredSamples.vcf", " --setFilteredGtToNocall "),
+                baseTestString("filteredSamples.vcf", " --" + VariantFiltration.NO_CALL_GTS_LONG_NAME + " "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testSetVcfFilteredGtoNocall.vcf")
         );
 
@@ -248,7 +250,9 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilteringZfromFORMATWithMissing() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringZInFormatWithMissing.vcf", " -genotypeFilterExpression 'Z < 10' --genotypeFilterName lowZ "),
+                baseTestString("filteringZInFormatWithMissing.vcf",
+                        " --" + VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME + " 'Z < 10'  --"
+                        + VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " lowZ "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilteringZfromFORMAT.vcf")
         );
 
@@ -259,7 +263,9 @@ public final class VariantFiltrationIntegrationTest extends CommandLineProgramTe
     @Test
     public void testFilteringZfromFORMATAndFailMissing() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString("filteringZInFormatWithMissing.vcf", " --missingValuesInExpressionsShouldEvaluateAsFailing --genotypeFilterExpression 'Z < 10' --genotypeFilterName lowZ "),
+                baseTestString("filteringZInFormatWithMissing.vcf", " --" + VariantFiltration.MISSING_VAL_LONG_NAME +
+                        " --" +VariantFiltration.GENOTYPE_FILTER_EXPRESSION_LONG_NAME + " 'Z < 10' --" +
+                                VariantFiltration.GENOTYPE_FILTER_NAME_LONG_NAME + " lowZ "),
                 Arrays.asList(getToolTestDataDir() + "expected/" + "testVariantFiltration_testFilteringZfromFORMATAndFailMissing.vcf")
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -294,7 +294,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false",
-                "--genotyping_mode", "GENOTYPE_GIVEN_ALLELES",
+                "--genotyping-mode", "GENOTYPE_GIVEN_ALLELES",
                 "--alleles", new File(TEST_FILES_DIR, "testGenotypeGivenAllelesMode_givenAlleles.vcf").getAbsolutePath()
         };
 
@@ -317,7 +317,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false",
-                "--genotyping_mode", "GENOTYPE_GIVEN_ALLELES",
+                "--genotyping-mode", "GENOTYPE_GIVEN_ALLELES",
                 "--alleles", new File(TEST_FILES_DIR, "testGenotypeGivenAllelesMode_givenAlleles.vcf").getAbsolutePath(),
                 "-ERC", "GVCF"
         };
@@ -436,7 +436,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:11363580-11363600",
                 "-O", output.getAbsolutePath(),
                 "-ploidy", "4",
-                "-maxGT", "15",
+                "--max-genotype-count", "15",
                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"
         };
         runCommandLine(args);
@@ -472,8 +472,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10003000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
-                "--assemblyRegionOut", assemblyRegionOut.getAbsolutePath(),
-                "--activityProfileOut", activityProfileOut.getAbsolutePath()
+                "--" + HaplotypeCaller.ASSEMBLY_REGION_OUT_LONG_NAME, assemblyRegionOut.getAbsolutePath(),
+                "--" + HaplotypeCaller.PROFILE_OUT_LONG_NAME, activityProfileOut.getAbsolutePath()
         };
 
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -70,7 +70,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-XL", mask.getAbsolutePath(),
                 "-O", unfilteredVcf.getAbsolutePath(),
                 "--downsampling-stride", "20",
-                "--maxReadsPerAlignmentStart", "4",
+                "--max-reads-per-alignment-start", "4",
                 "--max-suspicious-reads-per-alignment-start", "4"
         };
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounterIntegrationTest.java
@@ -65,7 +65,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterMinDepth70() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -minDepth 70",
+                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s -min-depth 70",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.MinDepth70.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -73,7 +73,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterFileFormat() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
+                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.SYNONYMOUS_CODING.vcf -mmq 60 -mbq 10 -O %s --output-format CSV",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.FileFormat.table"));
         spec.executeTest("test high mq with no read passing", this);
     }
@@ -129,7 +129,7 @@ public final class ASEReadCounterIntegrationTest extends CommandLineProgramTest 
     @Test
     public void testASEReadCounterImproperPairs() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.IMPROPER_PAIR.vcf -mmq 60 -mbq 10 -O %s --outputFormat CSV",
+                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam -V " + aseTestDir + "NA12878.chr20_2444518_2637800.RNAseq.IMPROPER_PAIR.vcf -mmq 60 -mbq 10 -O %s --output-format CSV",
                 Arrays.asList(aseTestDir + "expected.ASEReadCount.ImproperPair.table"));
         spec.executeTest("test improper pairs", this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -19,7 +19,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                "-R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --process-secondary-alignments",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.bam"));
         spec.executeTest("test splits with overhangs", this);
     }
@@ -27,7 +27,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangsNotClipping() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--doNotFixOverhangs -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                "--do-not-fix-overhangs -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --process-secondary-alignments",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.doNotFixOverhangs.bam"));
         spec.executeTest("test splits with overhangs not clipping", this);
     }
@@ -35,7 +35,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs0Mismatches() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--maxMismatchesInOverhang 0 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                "--max-mismatches-in-overhang 0 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --process-secondary-alignments",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxMismatchesInOverhang0.bam"));
         spec.executeTest("test splits with overhangs 0 mismatches", this);
     }
@@ -43,7 +43,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsWithOverhangs5BasesInOverhang()  throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "--maxBasesInOverhang 5 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --processSecondaryAlignments",
+                "--max-bases-in-overhang 5 -R " + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s --process-secondary-alignments",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.maxBasesInOverhang5.bam"));
         spec.executeTest("test splits with overhangs 5 bases in overhang", this);
     }
@@ -51,7 +51,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsFixNDN() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN --processSecondaryAlignments",
+                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN --process-secondary-alignments",
                 Arrays.asList(getTestDataDir() +"/" + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
         spec.executeTest("test fix NDN", this);
     }
@@ -59,7 +59,8 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test //regression test for https://github.com/broadinstitute/gatk/pull/1853
     public void testSplitsOfUnpairedAndUnmappedReads() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "K-562.duplicateMarked.chr20.bam -O %s --processSecondaryAlignments",
+                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "K-562.duplicateMarked.chr20.bam -O %s --process-secondary-alignments " +
+                        "-skip-mq-transform", //this is TopHat data so a 255 does actually mean the MQ is unavailable
                 Arrays.asList(largeFileTestDir + "expected.K-562.splitNCigarReads.chr20.bam"));
         spec.executeTest("regression test for unmapped and unpaired reads", this);
     }
@@ -67,7 +68,7 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test //regression test for https://github.com/broadinstitute/gatk/pull/1864
     public void testSplitsTargetRegionFunctionality() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s -L 20:2444518-2454410 --processSecondaryAlignments",
+                "-R" + b37_reference_20_21 + " -I " + largeFileTestDir + "NA12878.RNAseq.bam -O %s -L 20:2444518-2454410 --process-secondary-alignments",
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.subSequenceTest.bam"));
         spec.executeTest("regression test for unmapped and unpaired reads", this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriorsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/CalculateGenotypePosteriorsIntegrationTest.java
@@ -41,7 +41,7 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
     //only test the first 20 variants to save time
     public void testMissingPriors() throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                        "-useACoff" +
+                        "--discovered-allele-count-priors-off" +
                         " -O %s" +
                         " -R " + b37_reference_20_21 +    //NOTE: we need a reference for -L
                         " -L 20:10,000,000-10,001,432" +
@@ -55,12 +55,12 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
     @Test
     public void testInputINDELs() throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                        "-useACoff" +
+                        "--discovered-allele-count-priors-off" +
                         " -O %s" +
                         " -R " + b37_reference_20_21 +    //NOTE: we need a reference for -L
                         " -L 20:10,000,000-10,100,000" +
                         " -V " + dir + "NA12878.Jan2013.haplotypeCaller.subset.indels.vcf" +
-                        " -supporting " + largeDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf" +
+                        " --supporting-callsets " + largeDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf" +
                         " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Collections.singletonList(dir + "expectedCGP_testInputINDELs.vcf")
         );
@@ -70,11 +70,11 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
     @Test
     public void testFamilyPriors() throws IOException {
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                        "-useACoff" +
+                        "--discovered-allele-count-priors-off" +
                         " -O %s" +
                         " -ped " + CEUtrioFamilyFile +
                         " -V " + CEUtrioTest +
-                        " -supporting " + CEUtrioPopPriorsTest +
+                        " --supporting-callsets " + CEUtrioPopPriorsTest +
                         " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Collections.singletonList(dir + "expectedCGP_testFamilyPriors_chr1.vcf")
         );
@@ -87,7 +87,7 @@ public final class CalculateGenotypePosteriorsIntegrationTest extends CommandLin
                         " -O %s" +
                         " -ped " + threeMemberNonTrioFamilyFile +
                         " -V " + getThreeMemberNonTrioTest +
-                        " -skipPop" +
+                        " --skip-population-priors" +
                         " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Collections.singletonList(dir + "expectedCGP_testSingleParentFamily_chr1.vcf")
         );

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -31,7 +31,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                 " -R " + hg19MiniReference
                         + " --variant " + testFile
                         + " -sn NA11918 "
-                        + " -sr " // suppress reference file path in output for test differencing
+                        + " --suppress-reference-path " // suppress reference file path in output for test differencing
                         + " -O %s "
                         + " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleSelection.vcf")
@@ -48,7 +48,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                 " -R " + hg19MiniReference
                         + " --variant " + testFile
                         + " -select 'DP < 7' "
-                        + " -sr " // suppress reference file path in output for test differencing
+                        + " --suppress-reference-path " // suppress reference file path in output for test differencing
                         + " -O %s  --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleExpressionSelection.vcf")
         );
@@ -61,7 +61,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "test.dup.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn A -sn B -sn C -ef ", testFile),
+                baseTestString(" -sn A -sn B -sn C -exclude-filtered ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_RepeatedLineSelection.vcf")
         );
 
@@ -87,7 +87,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String samplesFile = getToolTestDataDir() + "samples.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --allow-non-overlapping-command-line-samples -select 'RMSMAPQ < 170.0' -sn Z -sn " // non existent samples on command line
+                baseTestString(" --allow-nonoverlapping-command-line-samples  -select 'RMSMAPQ < 170.0' -sn Z -sn " // non existent samples on command line
                         + samplesFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_ComplexSelectionWithNonExistingSamples.vcf")
         );
@@ -112,7 +112,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample2.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -env -select 'foo!=0 || RMSMAPQ < 170.0' ", testFile),
+                baseTestString(" --exclude-non-variants -select 'foo!=0 || RMSMAPQ < 170.0' ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_NonExistingSelection.vcf")
         );
 
@@ -128,7 +128,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String samplesFile = getToolTestDataDir() + "samples.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -xl_sn NA11894 -xl_sn " + samplesFile, testFile),
+                baseTestString(" -xl-sn NA11894 -xl-sn " + samplesFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SampleExclusionFromFileAndSeparateSample.vcf")
         );
 
@@ -144,7 +144,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String samplesFile = getToolTestDataDir() + "samples.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -xl_sn " + samplesFile, testFile),
+                baseTestString(" -xl-sn " + samplesFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SampleExclusionJustFromFile.vcf")
         );
 
@@ -234,7 +234,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -restrict-alleles-to MULTIALLELIC -select-type MIXED ",testFile),
+                baseTestString(" --restrict-alleles-to MULTIALLELIC --select-type-to-include MIXED ",testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_VariantTypeSelection.vcf")
         );
 
@@ -249,7 +249,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -select-type INDEL --max-indel-size 2 ", testFile),
+                baseTestString(" --select-type-to-include INDEL --max-indel-size 2 ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_MaxIndelLengthSelection.vcf")
         );
 
@@ -264,7 +264,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -select-type INDEL --min-indel-size 2 ", testFile),
+                baseTestString(" --select-type-to-include INDEL --min-indel-size 2 ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_MinIndelLengthSelection.vcf")
         );
 
@@ -288,7 +288,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.loseAlleleInSelection.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --keep-original-AC -sn NA12892 ", testFile),
+                baseTestString(" --keep-original-ac -sn NA12892 ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_KeepOriginalAC.vcf")
         );
 
@@ -300,7 +300,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.loseAlleleInSelection.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --keep-original-AC -sn NA12892 -env -trim-alternates ", testFile),
+                baseTestString(" --keep-original-ac -sn NA12892 --exclude-non-variants --remove-unused-alternates ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_KeepOriginalACAndENV.vcf")
         );
 
@@ -312,7 +312,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "CEUtrioTest.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --keep-original-DP -sn NA12892 ", testFile),
+                baseTestString(" --keep-original-dp -sn NA12892 ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_KeepOriginalDP.vcf")
         );
 
@@ -349,7 +349,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String samplesFile = getToolTestDataDir() + "GIH.samples.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn " + samplesFile + " --exclude-non-variants -trim-alternates", testFile),
+                baseTestString(" -sn " + samplesFile + " --exclude-non-variants --remove-unused-alternates", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_MultiAllelicExcludeNonVar.vcf")
         );
         spec.executeTest("test select from multi allelic with exclude-non-variants --" + testFile, this);
@@ -411,7 +411,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "forHardLeftAlignVariantsTest.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn NA12878 -env -trim-alternates ", testFile),
+                baseTestString(" -sn NA12878 --exclude-non-variants --remove-unused-alternates ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_AlleleTrimming.vcf"));
         spec.executeTest("testAlleleTrimming", this);
     }
@@ -422,7 +422,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         return new Object[][] {
                 {
                         getToolTestDataDir() + "forHardLeftAlignVariantsTest.vcf",
-                        "-trim-alternates",
+                        "--remove-unused-alternates",
                         expectedPath + "testSelectVariants_UnusedAlleleHardLeftTrim.vcf"
                 },
                 {
@@ -437,17 +437,17 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                 },
                 {
                         getToolTestDataDir() + "multi-allelic-ordering.vcf",
-                        "-sn SAMPLE-CC -sn SAMPLE-CT -env",
+                        "-sn SAMPLE-CC -sn SAMPLE-CT --exclude-non-variants",
                         expectedPath + "testSelectVariants_UnusedAlleleCCCTEnv.vcf"
                 },
                 {
                         getToolTestDataDir() + "multi-allelic-ordering.vcf",
-                        "-sn SAMPLE-CC -sn SAMPLE-CT -trim-alternates",
+                        "-sn SAMPLE-CC -sn SAMPLE-CT --remove-unused-alternates",
                         expectedPath + "testSelectVariants_UnusedAlleleCCCTTrim.vcf"
                 },
                 {
                         getToolTestDataDir() + "multi-allelic-ordering.vcf",
-                        "-sn SAMPLE-CC -sn SAMPLE-CT -env -trim-alternates",
+                        "-sn SAMPLE-CC -sn SAMPLE-CT --exclude-non-variants --remove-unused-alternates",
                         expectedPath + "testSelectVariants_UnusedAlleleCCCTTrimAltEnv.vcf"
                 }
         };
@@ -523,7 +523,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 baseTestString(" -sn NA11894 -sn " + samplesFile +
-                                    " -select 'RMSMAPQ < 170.0' -invert-select ", testFile),
+                                    " -select 'RMSMAPQ < 170.0' --invert-select ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_InvertSelection.vcf")
         );
 
@@ -556,7 +556,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String idFile = getToolTestDataDir() + "complexExample1.vcf.id.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -IDs " + idFile, testFile),
+                baseTestString(" -ids " + idFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_KeepSelectionID.vcf")
         );
 
@@ -571,7 +571,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -IDs testid1", testFile),
+                baseTestString(" -ids testid1", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_KeepSelectionID.vcf")
         );
 
@@ -587,7 +587,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String idFile = getToolTestDataDir() + "complexExample1.vcf.id.args";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -xl-IDs " + idFile, testFile),
+                baseTestString(" -xl-ids " + idFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_ExcludeSelectionID.vcf")
         );
 
@@ -602,7 +602,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -xl-IDs testid1", testFile),
+                baseTestString(" -xl-ids testid1", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_ExcludeSelectionID.vcf")
         );
 
@@ -617,7 +617,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "complexExample1.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -xl-select-type SNP ", testFile),
+                baseTestString(" --select-type-to-exclude SNP ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_ExcludeSelectionType.vcf")
         );
 
@@ -630,7 +630,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String pedFile = getToolTestDataDir() + "CEUtrio.ped";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -ped " + pedFile + " -mv -mvq 0 ", testFile),
+                baseTestString(" -ped " + pedFile + " --mendelian-violation --mendelian-violation-qual-threshold 0 ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_MendelianViolationSelection.vcf")
         );
 
@@ -643,7 +643,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String pedFile = getToolTestDataDir() + "CEUtrio.ped";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -mv -mvq 0 -inv-mv -ped " + pedFile, testFile),
+                baseTestString(" --mendelian-violation --mendelian-violation-qual-threshold 0 --invert-mendelian-violation -ped " + pedFile, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_InvertMendelianViolationSelection.vcf")
         );
 
@@ -703,7 +703,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "filteredSamples.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --set-filtered-GT-to-no-call ", testFile),
+                baseTestString(" --set-filtered-gt-to-nocall ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SetFilteredGtoNocall.vcf")
         );
 
@@ -715,7 +715,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.forNoCallFiltering.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --max-no-call-number 1", testFile),
+                baseTestString(" --max-nocall-number 1", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_maxNOCALLnumber1.vcf")
         );
 
@@ -727,7 +727,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.forNoCallFiltering.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --max-no-call-fraction 0.25", testFile),
+                baseTestString(" --max-nocall-fraction 0.25", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_maxNOCALLnumber1.vcf")
         );
 
@@ -739,7 +739,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.forNoCallFiltering.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --max-no-call-number 2", testFile),
+                baseTestString(" --max-nocall-number 2", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_maxNOCALLnumber2.vcf")
         );
 
@@ -751,7 +751,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "vcfexample.forNoCallFiltering.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --max-no-call-fraction 0.5", testFile),
+                baseTestString(" --max-nocall-fraction 0.5", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_maxNOCALLnumber2.vcf")
         );
 
@@ -763,7 +763,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "haploid-multisample.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn HG00610 -select 'DP > 7' -trim-alternates ", testFile),
+                baseTestString(" -sn HG00610 -select 'DP > 7' --remove-unused-alternates ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_Haploid.vcf")
         );
 
@@ -775,7 +775,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "tetraploid-multisample.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn NA18486 -select 'DP > 57' -trim-alternates ", testFile),
+                baseTestString(" -sn NA18486 -select 'DP > 57' --remove-unused-alternates ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_Tetraploid.vcf")
         );
 
@@ -787,7 +787,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "tetra-diploid.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn NA12878 -select 'DP > 48' -trim-alternates ", testFile),
+                baseTestString(" -sn NA12878 -select 'DP > 48' --remove-unused-alternates ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_TetraDiploid.vcf")
         );
 
@@ -799,7 +799,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "261_S01_raw_variants_gvcf.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -trim-alternates", testFile),
+                baseTestString(" --remove-unused-alternates", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleDiploid.vcf")
         );
 
@@ -811,7 +811,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "diploid-multisample-sac.g.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn NA12891 -trim-alternates", testFile),
+                baseTestString(" -sn NA12891 --remove-unused-alternates", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SACDiploid.vcf")
         );
 
@@ -823,7 +823,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "tetraploid-multisample-sac.g.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -sn NA12891 -trim-alternates", testFile),
+                baseTestString(" -sn NA12891 --remove-unused-alternates", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SACNonDiploid.vcf")
         );
 
@@ -835,7 +835,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "selectVariantsInfoField.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" --set-filtered-GT-to-no-call --remove-unused-alternates --exclude-non-variants", testFile),
+                baseTestString(" --set-filtered-gt-to-nocall --remove-unused-alternates --exclude-non-variants", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_SetFilteredGtoNocallUpdateInfo.vcf")
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSRIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/ApplyVQSRIntegrationTest.java
@@ -48,10 +48,10 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
                     " --lenient" +
                     " --output %s" +
                     " -mode SNP" +
-                    " -tranchesFile " + getLargeVQSRTestDataDir() + "expected/SNPTranches.txt" +
+                    " --tranches-file " + getLargeVQSRTestDataDir() + "expected/SNPTranches.txt" +
                     // pass in the tranche file to match GATK3; though without a TS_FILTER_LEVEL
                     // arg they aren't used
-                    " -recalFile " + getLargeVQSRTestDataDir() + "snpRecal.vcf" +
+                    " --recal-file " + getLargeVQSRTestDataDir() + "snpRecal.vcf" +
                     " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(getLargeVQSRTestDataDir() + "expected/snpApplyResult.vcf"));
         spec.executeTest("testApplyRecalibrationSNP", this);
@@ -69,8 +69,8 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
                     " --output %s" +
                     // pass in the tranche file to match GATK3; though without a TS_FILTER_LEVEL
                     // arg they aren't used
-                    " -tranchesFile " + getLargeVQSRTestDataDir() + "expected/indelTranches.txt" +
-                    " -recalFile " + getLargeVQSRTestDataDir() + "indelRecal.vcf" +
+                    " --tranches-file " + getLargeVQSRTestDataDir() + "expected/indelTranches.txt" +
+                    " --recal-file " + getLargeVQSRTestDataDir() + "indelRecal.vcf" +
                     " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(getLargeVQSRTestDataDir() + "expected/indelApplyResult.vcf"));
         spec.executeTest("testApplyRecalibrationIndel", this);
@@ -83,8 +83,8 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
                     " -mode BOTH" +
                     " --variant " + getToolTestDataDir() + "VQSR.mixedTest.input.vcf" +
                     " --output %s" +
-                    " -tranchesFile " + getToolTestDataDir() + "VQSR.mixedTest.tranches" +
-                    " -recalFile " + getToolTestDataDir() + "VQSR.mixedTest.recal.vcf" +
+                    " --tranches-file " + getToolTestDataDir() + "VQSR.mixedTest.tranches" +
+                    " --recal-file " + getToolTestDataDir() + "VQSR.mixedTest.recal.vcf" +
                     " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(getToolTestDataDir() + "expected/applySNPAndIndelResult.vcf"));
         spec.executeTest("testApplyRecalibrationSnpAndIndelTogether", this);
@@ -101,12 +101,12 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
         args.add("20:1000100-1000500");
         args.add("-mode");
         args.add("BOTH");
-        args.add("--excludeFiltered");
-        args.add("-ts_filter_level");
+        args.add("-exclude-filtered");
+        args.add("-truth-sensitivity-filter-level");
         args.add("90.0");
-        args.add("-tranchesFile ");
+        args.add("--tranches-file ");
         args.add(getToolTestDataDir() + "VQSR.mixedTest.tranches");
-        args.add("-recalFile");
+        args.add("--recal-file");
         args.add(getToolTestDataDir() + "VQSR.mixedTest.recal.vcf");
         args.addOutput(tempOut);
 
@@ -125,11 +125,11 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
         final String base =
                 " -L 3:113005755-195507036" +
                 " -mode SNP -AS" +
-                " -ts_filter_level 99.7" +
+                " -ts-filter-level 99.7" +
                 " --variant " + getToolTestDataDir() + "VQSR.AStest.input.vcf" +
                 " --output %s" +
-                " -tranchesFile " + getToolTestDataDir() + "VQSR.AStest.snps.tranches" +
-                " -recalFile " + getToolTestDataDir() + "VQSR.AStest.snps.recal.vcf" +
+                " --tranches-file " + getToolTestDataDir() + "VQSR.AStest.snps.tranches" +
+                " --recal-file " + getToolTestDataDir() + "VQSR.AStest.snps.recal.vcf" +
                 " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
@@ -143,11 +143,11 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
         final String base =
                 " -L 3:113005755-195507036" +
                 " -mode INDEL -AS" +
-                " -ts_filter_level 99.3" +
+                " -ts-filter-level 99.3" +
                 " --variant " + getToolTestDataDir() + "VQSR.AStest.postSNPinput.vcf" +
                 " --output %s" +
-                " -tranchesFile " + getToolTestDataDir() + "VQSR.AStest.indels.tranches" +
-                " -recalFile " + getToolTestDataDir() + "VQSR.AStest.indels.recal.vcf" +
+                " --tranches-file " + getToolTestDataDir() + "VQSR.AStest.indels.tranches" +
+                " --recal-file " + getToolTestDataDir() + "VQSR.AStest.indels.recal.vcf" +
                 " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
@@ -180,11 +180,11 @@ public class ApplyVQSRIntegrationTest extends CommandLineProgramTest {
         final String base =
                 " -L " +  queryInterval.toString() +
                         " -mode INDEL -AS" +
-                        " -ts_filter_level 99.3" +
+                        " -ts-filter-level 99.3" +
                         " --variant " + getToolTestDataDir() + "VQSR.AStest.postSNPinput.HACKEDhg38header.vcf.gz" +
                         " --output " + tempGZIPOut.getAbsolutePath() +
-                        " -tranchesFile " + getToolTestDataDir() + "VQSR.AStest.indels.tranches" +
-                        " -recalFile " + getToolTestDataDir() + "VQSR.AStest.indels.recal.vcf" +
+                        " --tranches-file " + getToolTestDataDir() + "VQSR.AStest.indels.tranches" +
+                        " --recal-file " + getToolTestDataDir() + "VQSR.AStest.indels.recal.vcf" +
                         " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(base, Collections.emptyList());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibratorIntegrationTest.java
@@ -61,7 +61,7 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
                     "--resource",
                     "truth_training2,training=true,truth=true,prior=12.0:" + getLargeVQSRTestDataDir() + "Omni25_sites_1525_samples.b37.20.1M-10M.vcf",
                     "-an", "QD", "-an", "HaplotypeScore", "-an", "HRun",
-                    "--trustAllPolymorphic", // for speed
+                    "--trust-all-polymorphic", // for speed
                     "-mode", "SNP",
                     "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"
                 }
@@ -144,7 +144,7 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
         File tranchesOut = createTempFile("testVarRecalMaxAttempts", ".txt");
         args.addAll(addTempFileArgs(recalOut, tranchesOut));
 
-        args.add("--max_attempts");
+        args.add("--max-attempts");
         args.add("4"); // it takes for for this test to wind up with enough training data
 
         runCommandLine(args);
@@ -157,7 +157,7 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
         List<java.lang.String> args = new ArrayList<>(2);
         args.add("--output");
         args.add(recalOutFile.getAbsolutePath());
-        args.add("--tranches_file");
+        args.add("--tranches-file");
         args.add(tranchesOutFile.getAbsolutePath());
         return args;
     }
@@ -174,10 +174,10 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
                 " --variant " + inputFile +
                 " -L 20:1,000,000-10,000,000" +
                 " -an QD -an ReadPosRankSum -an HaplotypeScore" +
-                " -mode INDEL -mG 3" +
-                " --trustAllPolymorphic" + // for speed
+                " -mode INDEL -max-gaussians 3" +
+                " --trust-all-polymorphic" + // for speed
                 " --output %s" +
-                " -tranchesFile %s" +
+                " -tranches-file %s" +
                 " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(
                         // the "expected" vcf is not in the expected dir because its used
@@ -202,12 +202,12 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
                 " --resource truth_training1,truth=true,training=true,prior=15.0:" + getLargeVQSRTestDataDir() + "sites_r27_nr.b37_fwd.20.1M-10M.vcf" +
                 " --resource truth_training2,training=true,truth=true,prior=12.0:" + getLargeVQSRTestDataDir() + "Omni25_sites_1525_samples.b37.20.1M-10M.vcf" +
                 " -an QD -an HaplotypeScore -an HRun" +
-                " --trustAllPolymorphic" + // for speed
+                " --trust-all-polymorphic" + // for speed
                 " --output %s" +
-                " -tranchesFile %s" +
-                " --output_model " + modelReportFilename +
-                " -mode SNP -mG 3" +  //reduce max gaussians so we have negative training data with the sampled input
-                " -sampleEvery 2" +
+                " -tranches-file %s" +
+                " --output-model " + modelReportFilename +
+                " -mode SNP --max-gaussians 3" +  //reduce max gaussians so we have negative training data with the sampled input
+                " -sample-every 2" +
                 " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(
                         modelReportRecal,
@@ -226,12 +226,12 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
                         " --resource truth_training1,truth=true,training=true,prior=15.0:" + getLargeVQSRTestDataDir() + "sites_r27_nr.b37_fwd.20.1M-10M.vcf" +
                         " --resource truth_training2,training=true,truth=true,prior=12.0:" + getLargeVQSRTestDataDir() + "Omni25_sites_1525_samples.b37.20.1M-10M.vcf" +
                         " -an QD -an HaplotypeScore -an HRun" +
-                        " --trustAllPolymorphic" + // for speed
+                        " --trust-all-polymorphic" + // for speed
                         " --output %s" +
-                        " -tranchesFile %s" +
-                        " --input_model " + modelReportFilename +
-                        " -mode SNP -mG 3" +  //reduce max gaussians so we have negative training data with the sampled input
-                        " -sampleEvery 2" +
+                        " -tranches-file %s" +
+                        " --input-model " + modelReportFilename +
+                        " -mode SNP -max-gaussians 3" +  //reduce max gaussians so we have negative training data with the sampled input
+                        " -sample-every 2" +
                         " --" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE +" false",
                 Arrays.asList(
                         modelReportRecal,
@@ -254,22 +254,22 @@ public class VariantRecalibratorIntegrationTest extends CommandLineProgramTest {
                                 "--resource",
                                 "truth_training2,training=true,truth=true,prior=12.0:" + getLargeVQSRTestDataDir() + "Omni25_sites_1525_samples.b37.20.1M-10M.vcf",
                                 "-an", "QD", "-an", "HaplotypeScore", "-an", "HRun",
-                                "--trustAllPolymorphic", // for speed
+                                "-trust-all-polymorphic", // for speed
                                 "-mode", "SNP",
                                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false",
-                                "-scatterTranches",
-                                "--VQSLODtranche", "10.0",
-                                "--VQSLODtranche", "8.0",
-                                "--VQSLODtranche", "6.0",
-                                "--VQSLODtranche", "4.0",
-                                "--VQSLODtranche", "2.0",
-                                "--VQSLODtranche", "0.0",
-                                "--VQSLODtranche", "-2.0",
-                                "--VQSLODtranche", "-4.0",
-                                "--VQSLODtranche", "-6.0",
-                                "--VQSLODtranche", "-8.0",
-                                "--VQSLODtranche", "-10.0",
-                                "--VQSLODtranche", "-12.0"
+                                "--output-tranches-for-scatter",
+                                "--vqslod-tranche", "10.0",
+                                "--vqslod-tranche", "8.0",
+                                "--vqslod-tranche", "6.0",
+                                "--vqslod-tranche", "4.0",
+                                "--vqslod-tranche", "2.0",
+                                "--vqslod-tranche", "0.0",
+                                "--vqslod-tranche", "-2.0",
+                                "--vqslod-tranche", "-4.0",
+                                "--vqslod-tranche", "-6.0",
+                                "--vqslod-tranche", "-8.0",
+                                "--vqslod-tranche", "-10.0",
+                                "--vqslod-tranche", "-12.0"
                         }
                 },
         };


### PR DESCRIPTION
Updated docs with usage examples and kebabed long args for:
- HaplotypeCaller
- HaplotypeCallerSpark
- CombineGVCFs
- GenomicsDBImport
- GenotypeGVCFs
- VariantFiltration
- ASEReadCounter
- SplitNCigarReads
- CalculateGenotypePosteriors
- VariantRecalibrator
- ApplyVQSR

Elaborated on/fixed docs for:
- InbreedingCoeff
- ExcessHet
- SampleList

Hid GatherTranches

Added a ReadTransformer to SplitNCigarReads to simplify the command from the old RNA best practices (https://software.broadinstitute.org/gatk/documentation/article.php?id=3891)  NOTE: this slightly changes the default behavior @vdauwera 

Unfortunately I squashed the SplitNCigarReads changes into the doc fixes.  :(  If that's a problem I can split into two commits.