### PR TITLE
Support several libraries in LibraryReadFilter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
@@ -34,6 +34,6 @@ public final class LibraryReadFilter extends ReadFilter implements Serializable 
             return false;
         }
 
-        return libraryToKeep.stream().anyMatch(library::equals);
+        return libraryToKeep.contains(library);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/LibraryReadFilter.java
@@ -8,6 +8,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
 import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Keep only reads from the specified library.
@@ -17,7 +19,7 @@ public final class LibraryReadFilter extends ReadFilter implements Serializable 
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = "library", shortName = "library", doc="Name of the library to keep", optional=false)
-    public String libraryToKeep = null;
+    public Set<String> libraryToKeep = new LinkedHashSet<>();
 
     // Command line parser requires a no-arg constructor
     public LibraryReadFilter() { }
@@ -28,6 +30,10 @@ public final class LibraryReadFilter extends ReadFilter implements Serializable 
     @Override
     public boolean test( final GATKRead read ) {
         final String library = ReadUtils.getLibrary(read, samHeader);
-        return library != null && library.equals(libraryToKeep);
+        if (library == null) {
+            return false;
+        }
+
+        return libraryToKeep.stream().anyMatch(library::equals);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibraryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibraryUnitTest.java
@@ -399,8 +399,12 @@ public final class ReadFilterLibraryUnitTest {
         header.getReadGroup(read.getReadGroup()).setLibrary(foo);
 
         Assert.assertFalse(f.test(read), read.toString());//fail
-        f.libraryToKeep = foo;
+        f.libraryToKeep = Collections.singleton(foo);
         Assert.assertTrue(f.test(read), read.toString());//pass
+        f.libraryToKeep = new HashSet<>(Arrays.asList("A", "B"));
+        Assert.assertFalse(f.test(read), read.toString());
+        f.libraryToKeep.add(foo);
+        Assert.assertTrue(f.test(read), read.toString());
     }
 
     @Test


### PR DESCRIPTION
Part of https://github.com/broadinstitute/gatk/issues/3144, maintaining the usage as before but allowing multiple `--library` arguments to provide more than one library...