### PR TITLE
Create a conda-based Python environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TEST_TYPE=cloud UPLOAD=true
   - TEST_TYPE=integration TEST_DOCKER=true TEST_VERBOSITY=minimal
   - TEST_TYPE=unit TEST_DOCKER=true TEST_VERBOSITY=minimal
+  - TEST_TYPE=python TEST_DOCKER=true TEST_VERBOSITY=minimal
   - RUN_CNV_SOMATIC_LEGACY_WDL=true
   - RUN_M2_WDL=true
   global:
@@ -145,7 +146,7 @@ script:
     echo ${TEST_TYPE};
     sudo mkdir -p build/reports/;
     sudo chmod -R a+w build/reports/;
-    sudo docker run -v $(pwd)/src/test/resources:/testdata -v $(pwd)/build/reports/:/gatk/build/reports/ --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${DOCKER_TAG} bash /root/run_unit_tests.sh;
+    sudo docker run -v $(pwd)/src/test/resources:/testdata -v $(pwd)/build/reports/:/gatk/build/reports/ --rm -e "TEST_VERBOSITY=minimal" -e "TEST_TYPE=${TEST_TYPE}" -t broadinstitute/gatk:${DOCKER_TAG} bash --init-file /gatk/gatkenv.rc /root/run_unit_tests.sh;
   else
     ./gatk-launch PrintReads -I src/test/resources/NA12878.chr17_69k_70k.dictFix.bam -O output.bam;
     travis_wait 50 ./gradlew jacocoTestReport;

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,31 @@ RUN ln -s /testdata src/test/resources
 
 # Create a simple unit test runner
 ENV CI true
-RUN echo "cd /gatk/ && ./gradlew jacocoTestReport" >/root/run_unit_tests.sh
+RUN echo "source activate gatk" > /root/run_unit_tests.sh && \
+    echo "cd /gatk/ && ./gradlew jacocoTestReport" >> /root/run_unit_tests.sh
 
 WORKDIR /root
 RUN cp -r /root/run_unit_tests.sh /gatk
 RUN cp -r gatk.jar /gatk
 RUN cp -r install_R_packages.R /gatk
+
+# Start GATK Python environment
+
+ENV DOWNLOAD_DIR /downloads
+ENV CONDA_URL https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh
+ENV CONDA_MD5 = "0b80a152332a4ce5250f3c09589c7a81"
+ENV CONDA_PATH /opt/miniconda
+RUN mkdir $DOWNLOAD_DIR && \
+    wget -nv -O $DOWNLOAD_DIR/miniconda.sh $CONDA_URL && \
+    test "`md5sum $DOWNLOAD_DIR/miniconda.sh | awk -v FS='  ' '{print $1}'` = $CONDA_MD5" && \
+    bash $DOWNLOAD_DIR/miniconda.sh -p $CONDA_PATH -b && \
+    rm $DOWNLOAD_DIR/miniconda.sh
+ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
+RUN conda env create -n gatk -f /gatk/scripts/gatkcondaenv.yml && \
+    echo "source activate gatk" >> /gatk/gatkenv.rc
+
+CMD ["bash", "--init-file", "/gatk/gatkenv.rc"]
+
+# End GATK Python environment
 
 WORKDIR /gatk

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ releases of the toolkit.
     * Gradle 3.1 or greater, needed for building the GATK. We recommend using the `./gradlew` script which will
       download and use an appropriate gradle version automatically (see examples below).
     * Python 2.6 or greater (needed for running the `gatk-launch` frontend script)
+    * Python 3.6.2, along with a set of additional Python packages, are required to run some tools and workflows.
+      GATK uses the [Conda](https://conda.io/docs/index.html) package manager to
+      establish and manage the environment and dependencies required by these tools. The GATK Docker image comes
+      with this environment pre-configured. In order to establish an environment suitable to run these tools
+      outside of the Docker image, the conda [gatkcondaenv.yml](https://github.com/broadinstitute/gatk/blob/master/scripts/gatkcondaenv.yml)
+      file is provided. To establish the conda environment locally, [Conda](https://conda.io/docs/index.html) must first
+      be installed. Then, create the gatk environment by running the command ```conda env -n gatk -f gatkcondaenv.yml```.
+      To activate the environment once its been created, run the command ```source activate gatk```. See the
+      [Conda](https://conda.io/docs/user-guide/tasks/manage-environments.html) documentation for
+      additional information about using and managing Conda environments.
     * R 3.1.3 (needed for producing plots in certain tools, and for running the test suite)
     * [git-lfs](https://git-lfs.github.com/) 1.1.0 or greater (needed to download large files for the complete test suite).
       Run `git lfs install` after downloading, followed by `git lfs pull` from the root of your git clone to download the large files. The download is several hundred megabytes.

--- a/build.gradle
+++ b/build.gradle
@@ -315,17 +315,19 @@ test {
             includeGroups 'cloud', 'bucket'
         } else if (TEST_TYPE == "integration"){
             include "**/*IntegrationTest.class"
-            excludeGroups "cloud", "bucket"
+            excludeGroups "cloud", "bucket", "python"
         } else if (TEST_TYPE == "unit") {
             exclude "**/*IntegrationTest.class"
-            excludeGroups "cloud", "bucket"
+            excludeGroups "cloud", "bucket", "python"
         } else if (TEST_TYPE == "spark") {
             includeGroups "spark"
-            excludeGroups "cloud", "bucket"
+            excludeGroups "cloud", "bucket", "python"
+        } else if (TEST_TYPE == "python") {
+            includeGroups "python"
         } else if (TEST_TYPE == "all"){
             //include everything
         } else {
-            excludeGroups "cloud", "bucket"
+            excludeGroups "cloud", "bucket", "python"
         }
     }
 

--- a/scripts/gatkcondaenv.yml
+++ b/scripts/gatkcondaenv.yml
@@ -1,0 +1,37 @@
+# Conda environment for GATK Python Tools
+#
+name: gatk
+channels:
+- defaults
+dependencies:
+- certifi=2016.2.28=py36_0
+- openssl=1.0.2l=0
+- pip=9.0.1=py36_1
+- python=3.6.2=0
+- readline=6.2=2
+- setuptools=36.4.0=py36_1
+- sqlite=3.13.0=0
+- tqdm=4.15.0
+- tk=8.5.18=0
+- wheel=0.29.0=py36_0
+- xz=5.2.3=0
+- zlib=1.2.11=0
+- pip:
+  - argparse
+  - bleach==1.5.0
+  - enum34==1.1.6
+  - h5py==2.7.1
+  - html5lib==0.9999999
+  - keras==2.1.1
+  - markdown==2.6.9
+  - numpy==1.13.3
+  - pymc3==3.1
+  - protobuf==3.5.0.post1
+  - pyyaml==3.12
+  - scipy==1.0.0
+  - six==1.11.0
+  - tensorflow==1.4.0
+  - tensorflow-tensorboard==0.4.0rc3
+  - theano==0.9.0
+  - werkzeug==0.12.2
+

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.hellbender.utils.python;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+// Tests to nominally validate that the GATK conda environment is activated, and that it's
+// dependencies are accessible.
+//
+// We could validate the version numbers of the dependencies, but that would require
+// changes every time we change the gatkcondaenv.yml file.
+//
+public class PythonEnvironmentIntegrationTest {
+    private final static String NL = String.format("%n");
+
+    @DataProvider(name="supportedPythonPackages")
+    public Object[][] getSupportedPythonPackages() {
+        return new Object[][] {
+                // names of base packages that we should be able to import from within the GATK conda environment
+                // this list isn't exhaustive
+                { "numpy"},
+                { "scipy"},
+                { "tensorflow"},
+                { "theano" },
+                { "keras" },
+                { "pymc3" },
+                { "argparse" },
+        };
+    }
+
+    @Test(groups = {"python"}, dataProvider="supportedPythonPackages")
+    public void testGATKPythonEnvironmentPackagePresent(final String packageName) {
+        // Do a basic sanity check of the GATK Python conda environment. This test should only be run on
+        // the GATK docker image, or if the conda environment has been activated manually.
+
+        // We use the default python executable name ("python"), which in the activated gatk conda env should be Python 3.6.1
+        final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
+        Assert.assertTrue(pythonExecutor.executeCommand(String.format("import %s", packageName) + NL,null,null));
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonScriptExecutorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonScriptExecutorUnitTest.java
@@ -14,9 +14,9 @@ import java.util.Collections;
 import java.util.List;
 
 public class PythonScriptExecutorUnitTest extends GATKBaseTest {
-    final String HELLO_WORLD_SCRIPT = "print \"hello, world\"";
+    final String HELLO_WORLD_SCRIPT = "print (\"hello, world\")";
 
-    @Test(groups = {"PYTHON"})
+    @Test(groups = {"python"})
     public void testPythonExists() {
         Assert.assertTrue(
                 new PythonScriptExecutor(true).externalExecutableExists(),
@@ -24,7 +24,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         );
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsCommand() {
         final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
         final boolean ret = pythonExecutor.executeCommand(HELLO_WORLD_SCRIPT, null, null);
@@ -32,7 +32,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsModule() {
         // use builtin module "random"
         final PythonScriptExecutor executor = new PythonScriptExecutor(true);
@@ -41,7 +41,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsScript() {
         final File scriptFile = writeTemporaryScriptFile(HELLO_WORLD_SCRIPT, PythonScriptExecutor.PYTHON_EXTENSION);
 
@@ -51,7 +51,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsRawArgs() {
         final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
         final boolean ret = pythonExecutor.executeArgs(new ArrayList<String>(Arrays.asList("-c", HELLO_WORLD_SCRIPT)));
@@ -59,7 +59,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsRawArgsSerial() {
         final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
         final List<String> args = new ArrayList<>(Arrays.asList("-c", HELLO_WORLD_SCRIPT));
@@ -68,7 +68,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(pythonExecutor.executeArgs(args), "Second Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsRawArgsWithPythonArguments() {
         final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
         final boolean ret = pythonExecutor.executeArgs(new ArrayList<>(Arrays.asList("-v", "-c", HELLO_WORLD_SCRIPT )));
@@ -76,7 +76,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
         Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testExecuteAsScriptWithScriptArguments() {
         final String SCRIPT_WITH_ARGUMENTS =
                 "import fileinput\n" +
@@ -92,7 +92,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
        Assert.assertTrue(ret, "Python exec failed");
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists", expectedExceptions = PythonScriptExecutorException.class)
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists", expectedExceptions = PythonScriptExecutorException.class)
     public void testNonExistentScriptException() throws IOException {
         final PythonScriptExecutor executor = new PythonScriptExecutor(true);
         executor.executeScript(
@@ -101,7 +101,7 @@ public class PythonScriptExecutorUnitTest extends GATKBaseTest {
                 null);
     }
 
-    @Test(groups = {"PYTHON"}, dependsOnMethods = "testPythonExists")
+    @Test(groups = {"python"}, dependsOnMethods = "testPythonExists")
     public void testNonExistentScriptNoException() {
         final PythonScriptExecutor executor = new PythonScriptExecutor(true);
         executor.setIgnoreExceptions(true);


### PR DESCRIPTION
- Adds the “gatk” conda environment, with dependencies defined by the file scripts/gatkcondaenv.yml.
- Updates the docker image to include the activated conda environment.
- Adds a new entry to the travis test matrix for running tests that depend on Python and the conda environment.
- Adds a “python” test group. Any tests for tools or functionality that are dependent on Python should be put into this group. Tests in this group will be executed in a docker container on travis in the python build matrix entry only.
- The existing WDL tests are unchanged; so although they execute in the context of the docker container and conda environment, there are no tests (yet) that are actually dependent on the conda environment and run through cromwell.