### PR TITLE
Use Path for references instead of File

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
@@ -14,16 +14,6 @@ public final class OptionalReferenceInputArgumentCollection extends ReferenceInp
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence", optional = true)
     private String referenceFileName;
 
-    private File referenceFile = null;
-
-    @Override
-    public File getReferenceFile() {
-        if (null!=referenceFile) return referenceFile;
-        if (null==referenceFileName) return null;
-        referenceFile = new File(referenceFileName);
-        return referenceFile;
-    }
-
     @Override
     public String getReferenceFileName() {
         return referenceFileName;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
@@ -13,11 +13,6 @@ public abstract class ReferenceInputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Get the reference file specified at the command line, creating the File object first if necessary.
-     */
-    public abstract File getReferenceFile();
-
-    /**
      * Get the name of the reference file specified at the command line.
      */
     public abstract String getReferenceFileName();

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
@@ -14,17 +14,6 @@ public final class RequiredReferenceInputArgumentCollection extends ReferenceInp
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file", optional = false)
     private String referenceFileName;
 
-    private File referenceFile = null;
-
-    // Not thread-safe
-    @Override
-    public File getReferenceFile() {
-        if (null!=referenceFile) return referenceFile;
-        if (null==referenceFileName) return null;
-        referenceFile = new File(referenceFileName);
-        return referenceFile;
-    }
-
     @Override
     public String getReferenceFileName() {
         return referenceFileName;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.iterators.ByteArrayIterator;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -21,10 +22,10 @@ public interface ReferenceDataSource extends GATKDataSource<Byte>, AutoCloseable
      *
      * The provided fasta file must have companion .fai and .dict files.
      *
-     * @param fastaFile reference fasta file
+     * @param fastaPath reference fasta Path
      */
-    public static ReferenceDataSource of(final File fastaFile) {
-        return new ReferenceFileSource(fastaFile);
+    public static ReferenceDataSource of(final Path fastaPath) {
+        return new ReferenceFileSource(fastaPath);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceFileSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceFileSource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
@@ -30,11 +31,11 @@ public final class ReferenceFileSource implements ReferenceDataSource {
      *
      * The provided fasta file must have companion .fai and .dict files.
      *
-     * @param fastaFile reference fasta file
+     * @param fastaPath reference fasta file
      */
-    public ReferenceFileSource(final File fastaFile) {
+    public ReferenceFileSource(final Path fastaPath) {
         // Will throw a UserException if the .fai and/or .dict are missing
-        reference = CachingIndexedFastaSequenceFile.checkAndCreate(Utils.nonNull(fastaFile));
+        reference = CachingIndexedFastaSequenceFile.checkAndCreate(Utils.nonNull(fastaPath));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceFileSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/datasources/ReferenceFileSource.java
@@ -4,8 +4,13 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 
 import java.io.File;
@@ -15,33 +20,52 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Class to load a reference sequence from a local fasta file.
+ * Class to load a reference sequence from a fasta file.
  */
 public class ReferenceFileSource implements ReferenceSource, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final String referencePath;
+    private final URI referenceUri;
+    // ReferenceFileSource is serializable (for running across a cluster), so we re-make the path
+    // if necessary. Of course if you give us a Path to a RAM filesystem, don't expect
+    // it to survive serialization.
+    private transient Path referencePath;
 
     /**
-     * @param referencePath the local path to the reference file
+     * @param referenceUri the path to the reference file
      */
-    public ReferenceFileSource(final String referencePath) {
-        if (!new File(referencePath).exists()) {
+    public ReferenceFileSource(final String referenceUri) {
+        this(IOUtils.getPath(referenceUri));
+    }
+
+    /**
+     * @param referencePath the path to the reference file
+     */
+    public ReferenceFileSource(final Path referencePath) {
+        this.referencePath = referencePath;
+        this.referenceUri = referencePath.toUri();
+        if (!Files.exists(this.referencePath)) {
             throw new UserException.MissingReference("The specified fasta file (" + referencePath + ") does not exist.");
         }
-        this.referencePath = referencePath;
+    }
+
+    private synchronized Path getReferencePath() {
+        if (null == referencePath) {
+            this.referencePath = Paths.get(referenceUri);
+        }
+        return referencePath;
     }
 
     @Override
     public ReferenceBases getReferenceBases(final SimpleInterval interval) throws IOException {
-        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(new File(referencePath)) ) {
+        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(getReferencePath()) ) {
             ReferenceSequence sequence = referenceSequenceFile.getSubsequenceAt(interval.getContig(), interval.getStart(), interval.getEnd());
             return new ReferenceBases(sequence.getBases(), interval);
         }
     }
 
     public Map<String, ReferenceBases> getAllReferenceBases() throws IOException {
-        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(new File(referencePath)) ) {
+        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(getReferencePath()) ) {
             Map<String, ReferenceBases> bases = new LinkedHashMap<>();
             ReferenceSequence seq;
             while ( (seq = referenceSequenceFile.nextSequence()) != null ) {
@@ -54,7 +78,7 @@ public class ReferenceFileSource implements ReferenceSource, Serializable {
 
     @Override
     public SAMSequenceDictionary getReferenceSequenceDictionary(final SAMSequenceDictionary optReadSequenceDictionaryToMatch) throws IOException {
-        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(new File(referencePath)) ) {
+        try ( ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(getReferencePath()) ) {
             return referenceSequenceFile.getSequenceDictionary();
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -242,7 +242,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             if (hasCramInput() && !hasReference()){
                 throw new UserException.MissingReference("A reference file is required when using CRAM files.");
             }
-            final String refPath = hasReference() ?  referenceArguments.getReferenceFile().getAbsolutePath() : null;
+            final String refPath = hasReference() ?  referenceArguments.getReferenceFileName() : null;
             return readsSource.getParallelReads(readInput, refPath, traversalParameters, bamPartitionSplitSize);
         }
     }
@@ -267,7 +267,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
     public void writeReads(final JavaSparkContext ctx, final String outputFile, JavaRDD<GATKRead> reads, SAMFileHeader header) {
         try {
             ReadsSparkSink.writeReads(ctx, outputFile,
-                    hasReference() ? referenceArguments.getReferenceFile().getAbsolutePath() : null,
+                    hasReference() ? referenceArguments.getReferencePath().toFile().getAbsolutePath() : null,
                     reads, header, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                     getRecommendedNumReducers());
         } catch (IOException e) {
@@ -406,7 +406,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         readsSource = new ReadsSparkSource(sparkContext, readArguments.getReadValidationStringency());
         readsHeader = readsSource.getHeader(
                 readInput,
-                hasReference() ?  referenceArguments.getReferenceFile().getAbsolutePath() : null);
+                hasReference() ?  referenceArguments.getReferenceFileName() : null);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -227,24 +227,24 @@ public class UserException extends RuntimeException {
 
     public static class MissingReferenceFaiFile extends UserException {
         private static final long serialVersionUID = 0L;
-        public MissingReferenceFaiFile( final File indexFile, final File fastaFile ) {
+        public MissingReferenceFaiFile( final Path indexPath, final Path fastaPath ) {
             super(String.format("Fasta index file %s for reference %s does not exist. Please see %s for help creating it.",
-                    indexFile.getAbsolutePath(), fastaFile.getAbsolutePath(),
+                    indexPath.toUri(), fastaPath.toUri(),
                     HelpConstants.forumPost("discussion/1601/how-can-i-prepare-a-fasta-file-to-use-as-reference")));
         }
     }
 
     public static class MissingReferenceDictFile extends UserException {
         private static final long serialVersionUID = 0L;
-        public MissingReferenceDictFile( final File dictFile, final File fastaFile ) {
+        public MissingReferenceDictFile( final Path dictFile, final Path fastaFile ) {
             super(String.format("Fasta dict file %s for reference %s does not exist. Please see %s for help creating it.",
-                    dictFile.getAbsolutePath(), fastaFile.getAbsolutePath(),
+                    dictFile.toUri(), fastaFile.toUri(),
                     HelpConstants.forumPost("discussion/1601/how-can-i-prepare-a-fasta-file-to-use-as-reference")));
         }
 
-        public MissingReferenceDictFile( final String fastaFile ) {
+        public MissingReferenceDictFile( final String fastaFileName ) {
             super(String.format("Fasta dict file for reference %s does not exist. Please see %s for help creating it.",
-                    fastaFile,
+                    fastaFileName,
                     HelpConstants.forumPost("discussion/1601/how-can-i-prepare-a-fasta-file-to-use-as-reference")));
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/AnnotateIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/AnnotateIntervals.java
@@ -103,7 +103,7 @@ public final class AnnotateIntervals extends GATKTool {
         logger.info("Loading intervals for annotation...");
         sequenceDictionary = getBestAvailableSequenceDictionary();
         intervals = intervalArgumentCollection.getIntervals(sequenceDictionary);
-        reference = ReferenceDataSource.of(referenceArguments.getReferenceFile());  //the GATKTool ReferenceDataSource is package-protected, so we cannot access it directly
+        reference = ReferenceDataSource.of(referenceArguments.getReferencePath());  //the GATKTool ReferenceDataSource is package-protected, so we cannot access it directly
         logger.info("Annotating intervals...");
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
@@ -153,7 +153,7 @@ public final class PreprocessIntervals extends GATKTool {
         final IntervalList unfilteredBins = generateBins(paddedIntervalList, binLength, sequenceDictionary);
 
         logger.info("Filtering bins containing only Ns...");
-        final ReferenceDataSource reference = ReferenceDataSource.of(referenceArguments.getReferenceFile());
+        final ReferenceDataSource reference = ReferenceDataSource.of(referenceArguments.getReferencePath());
         final IntervalList bins = filterBinsContainingOnlyNs(unfilteredBins, reference);
 
         logger.info(String.format("Writing bins to %s...", outputFile));

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -495,7 +495,7 @@ public class Funcotator extends VariantWalker {
 
         // Create our gencode factory:
         final GencodeFuncotationFactory gencodeFuncotationFactory =
-            new GencodeFuncotationFactory(dataSourceFile.resolveSibling(fastaPath).toFile(),
+            new GencodeFuncotationFactory(dataSourceFile.resolveSibling(fastaPath),
                     version,
                     transcriptSelectionMode,
                     transcriptList,

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -21,10 +21,10 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.codecs.gencode.*;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
-import org.testng.collections.Sets;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.testng.collections.Sets;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -130,33 +130,33 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
     private final Set<String> userRequestedTranscripts;
 
     /**
-     * The {@link File} from which we will read the sequences for the coding regions in given transcripts.
+     * The {@link Path} from which we will read the sequences for the coding regions in given transcripts.
      */
-    private final File gencodeTranscriptFastaFile;
+    private final Path gencodeTranscriptFastaFile;
 
     //==================================================================================================================
     // Constructors:
 
-    public GencodeFuncotationFactory(final File gencodeTranscriptFastaFile, final String version) {
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile, final String version) {
         this(gencodeTranscriptFastaFile, version, FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE, new HashSet<>(), new LinkedHashMap<>());
     }
 
-    public GencodeFuncotationFactory(final File gencodeTranscriptFastaFile, final String version, final Set<String> userRequestedTranscripts) {
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile, final String version, final Set<String> userRequestedTranscripts) {
         this(gencodeTranscriptFastaFile, version, FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE, userRequestedTranscripts, new LinkedHashMap<>());
     }
 
-    public GencodeFuncotationFactory(final File gencodeTranscriptFastaFile, final String version,final FuncotatorArgumentDefinitions.TranscriptSelectionMode transcriptSelectionMode) {
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile, final String version,final FuncotatorArgumentDefinitions.TranscriptSelectionMode transcriptSelectionMode) {
         this(gencodeTranscriptFastaFile, version, transcriptSelectionMode, new HashSet<>(), new LinkedHashMap<>());
     }
 
-    public GencodeFuncotationFactory(final File gencodeTranscriptFastaFile,
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile,
                                      final String version,
                                      final FuncotatorArgumentDefinitions.TranscriptSelectionMode transcriptSelectionMode,
                                      final Set<String> userRequestedTranscripts) {
         this(gencodeTranscriptFastaFile, version, transcriptSelectionMode, userRequestedTranscripts, new LinkedHashMap<>());
     }
 
-    public GencodeFuncotationFactory(final File gencodeTranscriptFastaFile,
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile,
                                      final String version,
                                      final FuncotatorArgumentDefinitions.TranscriptSelectionMode transcriptSelectionMode,
                                      final Set<String> userRequestedTranscripts,
@@ -478,7 +478,7 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
                 // Make sure that we have the transcript in our list.
                 // If we don't, warn the user and do not add any funcotations:
                 if ( !transcriptIdMap.containsKey(transcript.getTranscriptId()) ) {
-                    logger.warn("Coding sequence for given transcript ID (" + transcript.getTranscriptId() + ") is missing in file(" + gencodeTranscriptFastaFile.toURI().toString() + "): Skipping.");
+                    logger.warn("Coding sequence for given transcript ID (" + transcript.getTranscriptId() + ") is missing in file(" + gencodeTranscriptFastaFile.toUri().toString() + "): Skipping.");
                     continue;
                 }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildReferenceTaxonomy.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildReferenceTaxonomy.java
@@ -69,7 +69,7 @@ public class PathSeqBuildReferenceTaxonomy extends CommandLineProgram {
         }
 
         logger.info("Parsing reference and files... (this may take a few minutes)");
-        final ReferenceDataSource reference = ReferenceDataSource.of(referenceArguments.getReferenceFile());
+        final ReferenceDataSource reference = ReferenceDataSource.of(referenceArguments.getReferencePath());
         if (reference.getSequenceDictionary() == null) {
             throw new UserException.BadInput("Reference sequence dictionary not found. Please build one using CreateSequenceDictionary.");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
@@ -12,16 +12,11 @@ import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDesc
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.PathSeqProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.pathseq.loggers.PSFilterEmptyLogger;
 import org.broadinstitute.hellbender.tools.spark.pathseq.loggers.PSFilterFileLogger;
 import org.broadinstitute.hellbender.tools.spark.pathseq.loggers.PSFilterLogger;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import scala.Tuple2;
-
-import java.io.IOException;
 
 /**
  * This Spark tool is the first step in the PathSeq pipeline.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
@@ -63,7 +63,7 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
             final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.cleanupTemporaryAttributes(markedReadsWithOD);
             try {
                 ReadsSparkSink.writeReads(ctx, output,
-                        referenceArguments.getReferenceFile().getAbsolutePath(),
+                        referenceArguments.getReferencePath().toFile().getAbsolutePath(),
                         markedReads, bwaEngine.getHeader(),
                         shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                         getRecommendedNumReducers());

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -138,7 +138,7 @@ public final class BaseRecalibrator extends ReadWalker {
 
         recalibrationEngine = new BaseRecalibrationEngine(recalArgs, getHeaderForReads());
         recalibrationEngine.logCovariatesUsed();
-        referenceDataSource = ReferenceDataSource.of(referenceArguments.getReferenceFile());
+        referenceDataSource = ReferenceDataSource.of(referenceArguments.getReferencePath());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -19,6 +19,7 @@ import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.genotyper.SampleList;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.haplotype.HaplotypeBAMWriter;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.*;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
@@ -148,9 +149,9 @@ public final class AssemblyBasedCallerUtils {
     public static CachingIndexedFastaSequenceFile createReferenceReader(final String reference) {
         try {
             // fasta reference reader to supplement the edges of the reference sequence
-            return new CachingIndexedFastaSequenceFile(new File(reference));
+            return new CachingIndexedFastaSequenceFile(IOUtils.getPath(reference));
         } catch( FileNotFoundException e ) {
-            throw new UserException.CouldNotReadInputFile(new File(reference), e);
+            throw new UserException.CouldNotReadInputFile(IOUtils.getPath(reference), e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import java.nio.file.Path;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.BetaFeature;
@@ -20,6 +21,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 
 /**
@@ -202,7 +204,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
 
     private static CachingIndexedFastaSequenceFile getReferenceReader(ReferenceInputArgumentCollection referenceArguments) {
         final CachingIndexedFastaSequenceFile referenceReader;
-        final File reference = new File(referenceArguments.getReferenceFileName());
+        final Path reference = IOUtils.getPath(referenceArguments.getReferenceFileName());
         try {
             referenceReader = new CachingIndexedFastaSequenceFile(reference);
         } catch (FileNotFoundException e) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReads.java
@@ -112,13 +112,13 @@ public final class SplitNCigarReads extends TwoPassReadWalker {
         header = getHeaderForSAMWriter();
         rnaReadTransform = REFACTOR_NDN_CIGAR_READS ? new NDNCigarReadTransformer() : ReadTransformer.identity();
         try {
-            referenceReader = new CachingIndexedFastaSequenceFile(referenceArguments.getReferenceFile());
+            referenceReader = new CachingIndexedFastaSequenceFile(referenceArguments.getReferencePath());
             GenomeLocParser genomeLocParser = new GenomeLocParser(getBestAvailableSequenceDictionary());
             outputWriter = createSAMWriter(OUTPUT, false);
             overhangManager = new OverhangFixingManager(header, outputWriter, genomeLocParser, referenceReader, MAX_RECORDS_IN_MEMORY, MAX_MISMATCHES_IN_OVERHANG, MAX_BASES_TO_CLIP, doNotFixOverhangs, processSecondaryAlignments);
 
         } catch (FileNotFoundException ex) {
-            throw new UserException.CouldNotReadInputFile(referenceArguments.getReferenceFile(), ex);
+            throw new UserException.CouldNotReadInputFile(referenceArguments.getReferencePath(), ex);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -16,6 +16,7 @@ import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
 import htsjdk.variant.vcf.VCFUtils;
 
+import java.nio.file.Path;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.Hidden;
@@ -485,9 +486,9 @@ public final class SelectVariants extends VariantWalker {
         Set<VCFHeaderLine> actualLines = null;
         SAMSequenceDictionary sequenceDictionary = null;
         if (hasReference()) {
-            File refFile = referenceArguments.getReferenceFile();
+            Path refPath = referenceArguments.getReferencePath();
             sequenceDictionary= this.getReferenceDictionary();
-            actualLines = VcfUtils.updateHeaderContigLines(headerLines, refFile, sequenceDictionary, suppressReferencePath);
+            actualLines = VcfUtils.updateHeaderContigLines(headerLines, refPath, sequenceDictionary, suppressReferencePath);
         }
         else {
             sequenceDictionary = getHeaderForVariants().getSequenceDictionary();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
@@ -473,7 +473,7 @@ public class VariantRecalibrator extends MultiVariantWalker {
         final SAMSequenceDictionary sequenceDictionary = getBestAvailableSequenceDictionary();
         if (hasReference()) {
             hInfo = VcfUtils.updateHeaderContigLines(
-                    hInfo, referenceArguments.getReferenceFile(), sequenceDictionary, true);
+                    hInfo, referenceArguments.getReferencePath(), sequenceDictionary, true);
         }
         else if (null != sequenceDictionary) {
             hInfo = VcfUtils.updateHeaderContigLines(hInfo, null, sequenceDictionary, true);

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -552,7 +552,7 @@ public final class IntervalUtils {
      * @param reference The reference for the intervals.
      * @return A map of contig names with their sizes.
      */
-    public static Map<String, Integer> getContigSizes(final File reference) {
+    public static Map<String, Integer> getContigSizes(final Path reference) {
         final ReferenceSequenceFile referenceSequenceFile = createReference(reference);
         final List<GenomeLoc> locs = GenomeLocSortedSet.createSetFromSequenceDictionary(referenceSequenceFile.getSequenceDictionary()).toList();
         final Map<String, Integer> lengths = new LinkedHashMap<>();
@@ -1000,8 +1000,8 @@ public final class IntervalUtils {
         return intervalGroups;
     }
 
-    private static ReferenceSequenceFile createReference(final File fastaFile) {
-            return CachingIndexedFastaSequenceFile.checkAndCreate(fastaFile);
+    private static ReferenceSequenceFile createReference(final Path fastaPath) {
+            return CachingIndexedFastaSequenceFile.checkAndCreate(fastaPath);
     }
 
     private static LinkedHashMap<String, List<GenomeLoc>> splitByContig(final List<GenomeLoc> sorted) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
@@ -5,8 +5,13 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.FastaSequenceIndex;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +22,7 @@ import org.broadinstitute.hellbender.utils.BaseUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Arrays;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 /**
  * A caching version of the IndexedFastaSequenceFile that avoids going to disk as often as the raw indexer.
@@ -73,7 +79,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * @param preserveCase If true, we will keep the case of the underlying bases in the FASTA, otherwise everything is converted to upper case
      * @param preserveIUPAC If true, we will keep the IUPAC bases in the FASTA, otherwise they are converted to Ns
      */
-    public CachingIndexedFastaSequenceFile(final File fasta, final FastaSequenceIndex index, final long cacheSize, final boolean preserveCase, final boolean preserveIUPAC) {
+    public CachingIndexedFastaSequenceFile(final Path fasta, final FastaSequenceIndex index, final long cacheSize, final boolean preserveCase, final boolean preserveIUPAC) {
         super(fasta, index);
         if ( cacheSize < 0 ) throw new IllegalArgumentException("cacheSize must be > 0");
         this.cacheSize = cacheSize;
@@ -92,7 +98,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * @param cacheSize the size of the cache to use in this CachingIndexedFastaReader, must be >= 0
      * @param preserveCase If true, we will keep the case of the underlying bases in the FASTA, otherwise everything is converted to upper case
      */
-    public CachingIndexedFastaSequenceFile(final File fasta, final long cacheSize, final boolean preserveCase, final boolean  preserveIUPAC) throws FileNotFoundException {
+    public CachingIndexedFastaSequenceFile(final Path fasta, final long cacheSize, final boolean preserveCase, final boolean  preserveIUPAC) throws FileNotFoundException {
         super(fasta);
         if ( cacheSize < 0 ) throw new IllegalArgumentException("cacheSize must be > 0");
         this.cacheSize = cacheSize;
@@ -110,7 +116,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * @param index the index of the fasta file, used for efficient random access
      * @param cacheSize the size in bp of the cache we will use for this reader
      */
-    public CachingIndexedFastaSequenceFile(final File fasta, final FastaSequenceIndex index, final long cacheSize) {
+    public CachingIndexedFastaSequenceFile(final Path fasta, final FastaSequenceIndex index, final long cacheSize) {
         this(fasta, index, cacheSize, false, false);
     }
 
@@ -122,7 +128,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      *
      * @param fasta The file to open.
      */
-    public CachingIndexedFastaSequenceFile(final File fasta) throws FileNotFoundException {
+    public CachingIndexedFastaSequenceFile(final Path fasta) throws FileNotFoundException {
         this(fasta, false);
     }
 
@@ -134,7 +140,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * @param fasta The file to open.
      * @param preserveCase If true, we will keep the case of the underlying bases in the FASTA, otherwise everything is converted to upper case
      */
-    public CachingIndexedFastaSequenceFile(final File fasta, final boolean preserveCase) throws FileNotFoundException {
+    public CachingIndexedFastaSequenceFile(final Path fasta, final boolean preserveCase) throws FileNotFoundException {
         this(fasta, DEFAULT_CACHE_SIZE, preserveCase, false);
     }
 
@@ -142,45 +148,43 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * Create reference data source from fasta file, after performing several preliminary checks on the file.
      * This static utility was refactored from the constructor of ReferenceDataSource.
      * Possibly may be better as an overloaded constructor.
-     * @param fastaFile Fasta file to be used as reference
+     * @param fastaPath Fasta file to be used as reference
      * @return A new instance of a CachingIndexedFastaSequenceFile.
      */
-    public static CachingIndexedFastaSequenceFile checkAndCreate(final File fastaFile) {
+    public static CachingIndexedFastaSequenceFile checkAndCreate(final Path fastaPath) {
         // does the fasta file exist? check that first...
-        if (!fastaFile.exists()) {
-            throw new UserException.MissingReference("The specified fasta file (" + fastaFile.getAbsolutePath() + ") does not exist.");
+        if (!Files.exists(fastaPath)) {
+            throw new UserException.MissingReference("The specified fasta file (" + fastaPath.toUri() + ") does not exist.");
         }
 
-        final boolean isGzipped = fastaFile.getAbsolutePath().endsWith(".gz");
+        final boolean isGzipped = fastaPath.toString().endsWith(".gz");
         if ( isGzipped ) {
             throw new UserException.CannotHandleGzippedRef();
         }
 
-        final File indexFile = new File(fastaFile.getAbsolutePath() + ".fai");
+        final Path indexPath = IOUtil.addExtension(fastaPath, ".fai");
 
         // determine the name for the dict file
-        // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
-        final String fastaExt = fastaFile.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
-        final File dictFile = new File(fastaFile.getAbsolutePath().replaceAll(fastaExt, IOUtil.DICT_FILE_EXTENSION));
+        final Path dictPath = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(fastaPath);
 
         // It's an error if either the fai or dict file does not exist. The user is now responsible
         // for creating these files.
-        if (!indexFile.exists()) {
-            throw new UserException.MissingReferenceFaiFile(indexFile, fastaFile);
+        if (!Files.exists(indexPath)) {
+            throw new UserException.MissingReferenceFaiFile(indexPath, fastaPath);
         }
-        if (!dictFile.exists()) {
-            throw new UserException.MissingReferenceDictFile(dictFile, fastaFile);
+        if (!Files.exists(dictPath)) {
+            throw new UserException.MissingReferenceDictFile(dictPath, fastaPath);
         }
 
         // Read reference data by creating an IndexedFastaSequenceFile.
         try {
-            return new CachingIndexedFastaSequenceFile(fastaFile);
+            return new CachingIndexedFastaSequenceFile(fastaPath);
         }
         catch (IllegalArgumentException e) {
-            throw new UserException.CouldNotReadInputFile(fastaFile, "Could not read reference sequence.  The FASTA must have either a .fasta or .fa extension", e);
+            throw new UserException.CouldNotReadInputFile(fastaPath, "Could not read reference sequence.  The FASTA must have either a .fasta or .fa extension", e);
         }
         catch (Exception e) {
-            throw new UserException.CouldNotReadInputFile(fastaFile, e);
+            throw new UserException.CouldNotReadInputFile(fastaPath, e);
         }
     }
 
@@ -193,7 +197,7 @@ public final class CachingIndexedFastaSequenceFile extends IndexedFastaSequenceF
      * @param fasta The file to open.
      * @param cacheSize the size of the cache to use in this CachingIndexedFastaReader, must be >= 0
      */
-    public CachingIndexedFastaSequenceFile(final File fasta, final long cacheSize ) throws FileNotFoundException {
+    public CachingIndexedFastaSequenceFile(final Path fasta, final long cacheSize ) throws FileNotFoundException {
         this(fasta, cacheSize, false, false);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ArgumentsBuilder.java
@@ -73,6 +73,7 @@ public final class ArgumentsBuilder {
         return this;
     }
 
+
     /**
      * add a vcf file argument using {@link StandardArgumentDefinitions#VARIANT_LONG_NAME}
      */

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VcfUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VcfUtils.java
@@ -7,6 +7,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -54,14 +55,14 @@ public final class VcfUtils {
      * Given a set of VCF header lines, update the set with contig
      * lines from the provided reference dictionary.
      * @param oldLines
-     * @param referenceFile
+     * @param referencePath
      * @param refDict
      * @param referenceNameOnly
      * @return Updated list of VCF header lines.
      */
     public static Set<VCFHeaderLine> updateHeaderContigLines(
             final Set<VCFHeaderLine> oldLines,
-            final File referenceFile,
+            final Path referencePath,
             final SAMSequenceDictionary refDict,
             final boolean referenceNameOnly) {
         final Set<VCFHeaderLine> lines = new LinkedHashSet<>(oldLines.size());
@@ -76,16 +77,16 @@ public final class VcfUtils {
             lines.add(line);
         }
 
-        lines.addAll(makeContigHeaderLines(refDict, referenceFile).stream().collect(Collectors.toList()));
+        lines.addAll(makeContigHeaderLines(refDict, referencePath).stream().collect(Collectors.toList()));
 
-        if (referenceFile != null) {
+        if (referencePath != null) {
             final String referenceValue;
             if (referenceNameOnly) {
-                final int extensionStart = referenceFile.getName().lastIndexOf(".");
-                referenceValue = extensionStart == -1 ? referenceFile.getName() : referenceFile.getName().substring(0, extensionStart);
+                final int extensionStart = referencePath.getFileName().toString().lastIndexOf(".");
+                referenceValue = extensionStart == -1 ? referencePath.getFileName().toString() : referencePath.getFileName().toString().substring(0, extensionStart);
             }
             else {
-                referenceValue = "file://" + referenceFile.getAbsolutePath();
+                referenceValue = referencePath.toUri().toString();
             }
             lines.add(new VCFHeaderLine(VCFHeader.REFERENCE_KEY, referenceValue));
         }
@@ -93,9 +94,9 @@ public final class VcfUtils {
     }
 
     private static List<VCFContigHeaderLine> makeContigHeaderLines(final SAMSequenceDictionary refDict,
-                                                                   final File referenceFile) {
+                                                                   final Path referencePath) {
         final List<VCFContigHeaderLine> lines = new ArrayList<>();
-        final String assembly = referenceFile != null ? referenceFile.getName() : null;
+        final String assembly = referencePath != null ? referencePath.getFileName().toString() : null;
         lines.addAll(refDict.getSequences().stream().map(contig -> makeContigHeaderLine(contig, assembly)).collect(Collectors.toList()));
         return lines;
     }

--- a/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.BeforeClass;
 
@@ -96,7 +97,7 @@ public abstract class GATKBaseTest extends BaseTest {
 
     @BeforeClass
     public void initGenomeLocParser() throws FileNotFoundException {
-        hg19ReferenceReader = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));
+        hg19ReferenceReader = new CachingIndexedFastaSequenceFile(IOUtils.getPath(hg19MiniReference));
         hg19Header = new SAMFileHeader();
         hg19Header.setSequenceDictionary(hg19ReferenceReader.getSequenceDictionary());
         hg19GenomeLocParser = new GenomeLocParser(hg19ReferenceReader);

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
@@ -38,22 +38,11 @@ public final class ReferenceInputArgumentCollectionTest {
         clp.parseArguments(System.out, args);
     }
 
-    @Test
-    public void testGetReferencePath(){
-       final ReferenceInputArgumentCollection nonNullPath = new ReferenceInputArgumentCollection(){
-            private static final long serialVersionUID = 0L;
-            @Override public File getReferenceFile() { return new File("someFilePath"); }
-            @Override public String getReferenceFileName() { return "someFilePath";}
-        };
-
-        Assert.assertEquals(nonNullPath.getReferencePath().toFile(), nonNullPath.getReferenceFile());
-    }
 
     @Test
     public void testGetNullPath(){
         final ReferenceInputArgumentCollection nullPath = new ReferenceInputArgumentCollection(){
             private static final long serialVersionUID = 0L;
-            @Override public File getReferenceFile() { return null; }
             @Override public String getReferenceFileName() { return null;}
         };
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
@@ -55,10 +55,10 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
     @Test(dataProvider = "testCorrectRegionsHaveCorrectReadsAndSizeData")
     public void testRegionsHaveCorrectReadsAndSize( final String reads, final String reference, final List<SimpleInterval> shardIntervals, final int minRegionSize, final int maxRegionSize, final int assemblyRegionPadding ) throws IOException {
         try ( final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(reads));
-              final ReferenceDataSource refSource = ReferenceDataSource.of(new File(reference)) ) {
+              final ReferenceDataSource refSource = ReferenceDataSource.of(IOUtils.getPath(reference)) ) {
             final SAMSequenceDictionary readsDictionary = readsSource.getSequenceDictionary();
             final MultiIntervalLocalReadShard readShard = new MultiIntervalLocalReadShard(shardIntervals, assemblyRegionPadding, readsSource);
-            final AssemblyRegionEvaluator evaluator = new HaplotypeCallerEngine(new HaplotypeCallerArgumentCollection(), false, false, readsSource.getHeader(), new CachingIndexedFastaSequenceFile(new File(b37_reference_20_21)));
+            final AssemblyRegionEvaluator evaluator = new HaplotypeCallerEngine(new HaplotypeCallerArgumentCollection(), false, false, readsSource.getHeader(), new CachingIndexedFastaSequenceFile(IOUtils.getPath(b37_reference_20_21)));
             final ReadCoordinateComparator readComparator = new ReadCoordinateComparator(readsSource.getHeader());
 
             final List<ReadFilter> readFilters = new ArrayList<>(2);
@@ -169,7 +169,7 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
     @Test(dataProvider = "testIncludeReadsWithDeletionsInIsActivePileupsData")
     public void testIncludeReadsWithDeletionsInIsActivePileups(final String reads, final String reference, final SimpleInterval deletionInterval, final boolean includeReadsWithDeletionsInIsActivePileups, final int expectedNumDeletions) {
         try ( final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(reads));
-              final ReferenceDataSource refSource = ReferenceDataSource.of(new File(reference)) ) {
+              final ReferenceDataSource refSource = ReferenceDataSource.of(IOUtils.getPath(reference)) ) {
             final SAMSequenceDictionary readsDictionary = readsSource.getSequenceDictionary();
             final SimpleInterval shardInterval = deletionInterval.expandWithinContig(50, readsDictionary);
             final MultiIntervalLocalReadShard readShard = new MultiIntervalLocalReadShard(Arrays.asList(shardInterval), 50, readsSource);

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionUnitTest.java
@@ -35,7 +35,7 @@ public final class AssemblyRegionUnitTest extends GATKBaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        seq = new CachingIndexedFastaSequenceFile(new File(hg19MiniReference));
+        seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(hg19MiniReference));
         contig = "1";
         contigLength = seq.getSequence(contig).length();
         header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
@@ -397,7 +397,7 @@ public final class AssemblyRegionUnitTest extends GATKBaseTest {
     @Test
     public void testCreateFromReadShard() {
         final Path testBam = IOUtils.getPath(NA12878_20_21_WGS_bam);
-        final File reference = new File(b37_reference_20_21);
+        final Path reference = IOUtils.getPath(b37_reference_20_21);
         final SimpleInterval shardInterval = new SimpleInterval("20", 10000000, 10001000);
         final SimpleInterval paddedShardInterval = new SimpleInterval(shardInterval.getContig(), shardInterval.getStart() - 100, shardInterval.getEnd() + 100);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceContextUnitTest.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.engine;
 
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -14,7 +16,7 @@ import java.util.List;
 
 public final class ReferenceContextUnitTest extends GATKBaseTest {
 
-    private static final File TEST_REFERENCE = new File(hg19MiniReference);
+    private static final Path TEST_REFERENCE = IOUtils.getPath(hg19MiniReference);
 
     @DataProvider(name = "EmptyReferenceContextDataProvider")
     public Object[][] getEmptyReferenceContextData() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
@@ -2,9 +2,11 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -17,26 +19,26 @@ import java.util.List;
 
 public final class ReferenceDataSourceUnitTest extends GATKBaseTest {
 
-    private static final File TEST_REFERENCE = new File(hg19MiniReference);
+    private static final Path TEST_REFERENCE = IOUtils.getPath(hg19MiniReference);
 
     @Test(expectedExceptions = UserException.class)
     public void testNonExistentReference() {
-        new ReferenceFileSource(GATKBaseTest.getSafeNonExistentFile("nonexistent.fasta"));
+        new ReferenceFileSource(GATKBaseTest.getSafeNonExistentPath("nonexistent.fasta"));
     }
 
     @Test(expectedExceptions = UserException.MissingReferenceFaiFile.class)
     public void testReferenceWithMissingFaiFile() {
-        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(publicTestDir + "fastaWithoutFai.fasta"));
+        ReferenceDataSource refDataSource = new ReferenceFileSource(IOUtils.getPath(publicTestDir + "fastaWithoutFai.fasta"));
     }
 
     @Test(expectedExceptions = UserException.MissingReferenceDictFile.class)
     public void testReferenceWithMissingDictFile() {
-        ReferenceDataSource refDataSource = new ReferenceFileSource(new File(publicTestDir + "fastaWithoutDict.fasta"));
+        ReferenceDataSource refDataSource = new ReferenceFileSource(IOUtils.getPath(publicTestDir + "fastaWithoutDict.fasta"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNullReference() {
-        ReferenceDataSource refDataSource = new ReferenceFileSource(null);
+        ReferenceDataSource refDataSource = new ReferenceFileSource((Path)null);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceFileSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceFileSourceUnitTest.java
@@ -1,6 +1,10 @@
 package org.broadinstitute.hellbender.engine;
 
-import org.broadinstitute.hellbender.engine.datasources.ReferenceFileSource;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.GATKBaseTest;
 
@@ -10,9 +14,42 @@ import java.io.IOException;
 
 public class ReferenceFileSourceUnitTest extends GATKBaseTest {
 
-    @Test(expectedExceptions = UserException.MissingReference.class)
-    public void testMissingReferenceFile() throws IOException {
-        new ReferenceFileSource(GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta").getAbsolutePath());
+    @Test(expectedExceptions = UserException.MissingReferenceFaiFile.class)
+    public void testReferenceInPathWithoutFai() throws IOException {
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path refPath = jimfs.getPath("reference.fasta");
+            Files.createFile(refPath);
+            final Path dictPath = jimfs.getPath("reference.dict");
+            Files.createFile(dictPath);
+
+            new ReferenceFileSource(refPath);
+        }
+    }
+
+    @Test(expectedExceptions = UserException.MissingReferenceDictFile.class)
+    public void testReferenceInPathWithoutDict() throws IOException {
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path refPath = jimfs.getPath("reference.fasta");
+            Files.createFile(refPath);
+            final Path faiFile = jimfs.getPath("reference.fasta.fai");
+            Files.createFile(faiFile);
+
+            new ReferenceFileSource(refPath);
+        }
+    }
+
+    @Test
+    public void testReferenceInPath() throws IOException {
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path refPath = jimfs.getPath("reference.fasta");
+            Files.createFile(refPath);
+            final Path faiFile = jimfs.getPath("reference.fasta.fai");
+            Files.createFile(faiFile);
+            final Path dictPath = jimfs.getPath("reference.dict");
+            Files.createFile(dictPath);
+
+            new ReferenceFileSource(refPath);
+        }
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/VariantWalkerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
 import org.broadinstitute.hellbender.engine.filters.ReadNameReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.examples.ExampleVariantWalker;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.testng.Assert;
@@ -105,7 +106,7 @@ public final class VariantWalkerIntegrationTest extends CommandLineProgramTest {
         final SAMSequenceDictionary toolDict = tool.getBestAvailableSequenceDictionary();
         Assert.assertFalse(toolDict.getSequences().stream().allMatch(seqRec -> seqRec.getSequenceLength() == 0));
 
-        SAMSequenceDictionary refDict = new ReferenceFileSource(new File(hg19MiniReference)).getSequenceDictionary();
+        SAMSequenceDictionary refDict = new ReferenceFileSource(IOUtils.getPath(hg19MiniReference)).getSequenceDictionary();
         toolDict.assertSameDictionary(refDict);
         refDict.assertSameDictionary(toolDict);
         Assert.assertEquals(toolDict, refDict);

--- a/src/test/java/org/broadinstitute/hellbender/engine/datasources/ReferenceFileSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/datasources/ReferenceFileSourceUnitTest.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.hellbender.engine.datasources;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.annotations.Test;
+
+public class ReferenceFileSourceUnitTest extends GATKBaseTest {
+
+    @Test(expectedExceptions = UserException.MissingReference.class)
+    public void testMissingReferenceFile() throws IOException {
+        new ReferenceFileSource(
+                GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta")
+                        .getAbsolutePath());
+    }
+
+    @Test
+    public void testDatasourcesReferenceInPath() throws IOException {
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path refPath = jimfs.getPath("reference.fasta");
+            Files.createFile(refPath);
+            final Path faiFile = jimfs.getPath("reference.fasta.fai");
+            Files.createFile(faiFile);
+            final Path dictPath = jimfs.getPath("reference.dict");
+            Files.createFile(dictPath);
+
+            new ReferenceFileSource(refPath);
+        }
+    }
+
+    @Test
+    public void testDatasourcesReferenceSerializes() throws IOException, ClassNotFoundException {
+        Path refPath = GATKBaseTest.createTempFile("reference", ".fasta").toPath();
+        GATKBaseTest.createTempFile("reference", ".fasta.fai");
+        GATKBaseTest.createTempFile("reference", ".dict");
+
+        final ReferenceFileSource referenceFileSource = new ReferenceFileSource(refPath);
+
+        // Can we serialize it?
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream os = new ObjectOutputStream(baos);
+        os.writeObject(referenceFileSource);
+
+        ObjectInputStream is = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        ReferenceFileSource otherSide = (ReferenceFileSource)is.readObject();
+        // After deserialization, will it crash?
+        otherSide.getReferenceSequenceDictionary(null);
+
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/AnnotateIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/AnnotateIntervalsIntegrationTest.java
@@ -13,11 +13,13 @@ import org.broadinstitute.hellbender.tools.copynumber.formats.records.Annotation
 import org.broadinstitute.hellbender.utils.IntervalMergingRule;
 import org.broadinstitute.hellbender.utils.IntervalSetRule;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 /**
@@ -30,7 +32,7 @@ public final class AnnotateIntervalsIntegrationTest extends CommandLineProgramTe
     private static final File INTERVALS_FILE = new File(TEST_SUB_DIR, "annotate-intervals-test.interval_list");
     private static final File REFERENCE_FILE = new File(b37_reference_20_21);
 
-    private static final SAMSequenceDictionary SEQUENCE_DICTIONARY = ReferenceDataSource.of(REFERENCE_FILE).getSequenceDictionary();
+    private static final SAMSequenceDictionary SEQUENCE_DICTIONARY = ReferenceDataSource.of(REFERENCE_FILE.toPath()).getSequenceDictionary();
     private static final LocatableMetadata LOCATABLE_METADATA = new SimpleLocatableMetadata(SEQUENCE_DICTIONARY);
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCountsIntegrationTest.java
@@ -31,7 +31,7 @@ public final class CollectAllelicCountsIntegrationTest extends CommandLineProgra
 
     private static final String NORMAL_SAMPLE_NAME_EXPECTED = "20";
     private static final String TUMOR_SAMPLE_NAME_EXPECTED = "20";
-    private static final SAMSequenceDictionary SEQUENCE_DICTIONARY = ReferenceDataSource.of(REFERENCE_FILE).getSequenceDictionary();
+    private static final SAMSequenceDictionary SEQUENCE_DICTIONARY = ReferenceDataSource.of(REFERENCE_FILE.toPath()).getSequenceDictionary();
     private static final SampleLocatableMetadata NORMAL_METADATA_EXPECTED = new SimpleSampleLocatableMetadata(
             NORMAL_SAMPLE_NAME_EXPECTED, SEQUENCE_DICTIONARY);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -10,12 +10,14 @@ import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +31,7 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
 
     //==================================================================================================================
     // Static Variables:
-    private static final File TEST_REFERENCE = new File(hg19MiniReference);
+    private static final Path TEST_REFERENCE = IOUtils.getPath(hg19MiniReference);
     private static final String TEST_REFERENCE_CONTIG = "1";
     private static final int TEST_REFERENCE_START = 12000;
     private static final int TEST_REFERENCE_END = 16000;
@@ -38,7 +40,7 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
 
     // Initialization of static variables:
     static {
-        refDataSourceHg19Ch3 = ReferenceDataSource.of(new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME));
+        refDataSourceHg19Ch3 = ReferenceDataSource.of(IOUtils.getPath(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME));
     }
 
     //==================================================================================================================
@@ -79,7 +81,7 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
      * @param start Start point in contig from which to print bases.
      * @param end End point in contig to which to print bases.
      */
-    private void printReferenceBases(final File refFile, final String contig, final int start, final int end) {
+    private void printReferenceBases(final Path refFile, final String contig, final int start, final int end) {
         final ReferenceContext ref = new ReferenceContext(new ReferenceFileSource(refFile), new SimpleInterval(contig, start, end));
 
         final int numReferenceRows = (int)Math.ceil(Math.log10( end - start ) + 1);

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactoryUnitTest.java
@@ -46,7 +46,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
     private static final VariantContext defaultVariantContext;
     private static final ReferenceContext defaultReferenceContext;
 
-    private static final ReferenceDataSource PIK3CA_REF_DATA_SOURCE = ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME) );
+    private static final ReferenceDataSource PIK3CA_REF_DATA_SOURCE = ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME).toPath() );
 
     static {
         final VariantContextBuilder variantContextBuilder = new VariantContextBuilder(

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -20,6 +20,7 @@ import org.broadinstitute.hellbender.tools.funcotator.FuncotatorTestConstants;
 import org.broadinstitute.hellbender.tools.funcotator.SequenceComparison;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.codecs.gencode.*;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -56,12 +57,12 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         muc16NonBasicFeatureReader = AbstractFeatureReader.getFeatureReader(FuncotatorTestConstants.MUC16_GENCODE_NON_BASIC_ANNOTATIONS_FILE_NAME, new GencodeGtfCodec() );
         muc16FeatureReader = AbstractFeatureReader.getFeatureReader(FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME, new GencodeGtfCodec() );
         pik3caFeatureReader = AbstractFeatureReader.getFeatureReader( FuncotatorTestConstants.PIK3CA_GENCODE_ANNOTATIONS_FILE_NAME, new GencodeGtfCodec() );
-        refDataSourceHg19Ch19 = ReferenceDataSource.of( new File (FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME) );
-        refDataSourceHg19Ch3 = ReferenceDataSource.of( new File (FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME) );
+        refDataSourceHg19Ch19 = ReferenceDataSource.of( IOUtils.getPath(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME) );
+        refDataSourceHg19Ch3 = ReferenceDataSource.of( IOUtils.getPath(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME) );
 
         // Gets cleaned up in `cleanupAfterTests()`
         // NOTE: This is initialized here to save time in testing.
-        testMuc16SnpCreateFuncotationsFuncotationFactory = new GencodeFuncotationFactory(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE), "VERSION");
+        testMuc16SnpCreateFuncotationsFuncotationFactory = new GencodeFuncotationFactory(IOUtils.getPath(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE), "VERSION");
     }
 
     //==================================================================================================================
@@ -885,7 +886,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
 
         final List<? extends Locatable> exonPositionList = GencodeFuncotationFactory.getSortedExonAndStartStopPositions(transcript);
 
-        final ReferenceDataSource muc16TranscriptDataSource = ReferenceDataSource.of(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE));
+        final ReferenceDataSource muc16TranscriptDataSource = ReferenceDataSource.of(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE).toPath());
         final Map<String, GencodeFuncotationFactory.MappedTranscriptIdInfo> muc16TranscriptIdMap = GencodeFuncotationFactory. createTranscriptIdMap(muc16TranscriptDataSource);
 
         final SequenceComparison seqComp =
@@ -951,7 +952,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         final Set<String> requestedTranscriptIds = getValidTranscriptsForGene("MUC16");
 
         // Create a factory for our funcotations:
-        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE), "VERSION", requestedTranscriptIds)) {
+        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE).toPath(), "VERSION", requestedTranscriptIds)) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1002,7 +1003,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         final ReferenceContext referenceContext = new ReferenceContext(refDataSourceHg19Ch19, variantInterval );
 
         // Create a factory for our funcotations:
-        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE), "VERSION")) {
+        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(new File(FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE).toPath(), "VERSION")) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1066,7 +1067,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         final Set<String> requestedTranscriptIds = getValidTranscriptsForGene(expectedGeneName);
 
         // Create a factory for our funcotations:
-        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(new File(transcriptFastaFile), "VERSION", requestedTranscriptIds)) {
+        try (final GencodeFuncotationFactory funcotationFactory = new GencodeFuncotationFactory(IOUtils.getPath(transcriptFastaFile), "VERSION", requestedTranscriptIds)) {
 
             final List<Feature> featureList = new ArrayList<>();
             featureList.add( gene );

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactoryUnitTest.java
@@ -38,8 +38,8 @@ public class LocatableXsvFuncotationFactoryUnitTest extends GATKBaseTest {
     static {
         referenceDataSourceMap = new HashMap<>(2);
 
-        referenceDataSourceMap.put(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME) ));
-        referenceDataSourceMap.put(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME, ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME) ));
+        referenceDataSourceMap.put(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME).toPath() ));
+        referenceDataSourceMap.put(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME, ReferenceDataSource.of( new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME).toPath() ));
     }
 
     //==================================================================================================================

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactoryUnitTest.java
@@ -71,7 +71,7 @@ public class SimpleKeyXsvFuncotationFactoryUnitTest extends GATKBaseTest {
         defaultVariantContext = variantContextBuilder.make();
 
         defaultReferenceContext = new ReferenceContext(
-                ReferenceDataSource.of( new File (FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME) ),
+                ReferenceDataSource.of( new File (FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME).toPath() ),
                 new SimpleInterval(defaultContig, defaultStart, defaultEnd)
         );
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.tools.walkers;
 
 import htsjdk.samtools.SAMSequenceRecord;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
@@ -21,7 +23,7 @@ import java.util.stream.Stream;
  */
 public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
 
-    private static final File REFERENCE = new File(b37_reference_20_21);
+    private static final Path REFERENCE = Paths.get(b37_reference_20_21);
     private static final GenomeLocParser GLP = new GenomeLocParser(ReferenceDataSource.of(REFERENCE).getSequenceDictionary());
 
     @Test
@@ -30,7 +32,7 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         final File outputDir = createTempDir("output");
         final String[] args = {
                 "-L", "20:1000000-2000000",
-                "-R", REFERENCE.getAbsolutePath(),
+                "-R", REFERENCE.toAbsolutePath().toString(),
                 "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
                 "-O", outputDir.getAbsolutePath()
         };
@@ -45,7 +47,7 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         final File outputDir = createTempDir("output");
         final String[] args = {
                 "-L", "20:1000000-2000000",
-                "-R", REFERENCE.getAbsolutePath(),
+                "-R", REFERENCE.toAbsolutePath().toString(),
                 "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
                 "-O", outputDir.getAbsolutePath()
         };
@@ -62,7 +64,7 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         final String[] args = {
                 "-L", "20:1000000-2000000",
                 "-L", "20:3000000-4000000",
-                "-R", REFERENCE.getAbsolutePath(),
+                "-R", REFERENCE.toAbsolutePath().toString(),
                 "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
                 "-O", outputDir.getAbsolutePath()
         };
@@ -77,7 +79,7 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         final int scatterCount = 5;
         final File outputDir = createTempDir("output");
         final String[] args = {
-                "-R", REFERENCE.getAbsolutePath(),
+                "-R", REFERENCE.toAbsolutePath().toString(),
                 "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
                 "-O", outputDir.getAbsolutePath()
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
@@ -3,11 +3,13 @@ package org.broadinstitute.hellbender.tools.walkers.annotator;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +23,7 @@ public class ReferenceBasesUnitTest extends GATKBaseTest {
 
     @Test
     public void test() {
-        final File refFasta = new File(b37_reference_20_21);
+        final Path refFasta = IOUtils.getPath(b37_reference_20_21);
 
         final ReferenceDataSource refDataSource = new ReferenceFileSource(refFasta);
         final ReferenceContext ref = new ReferenceContext(refDataSource, new SimpleInterval("20", 10_000_000, 10_000_200));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -25,7 +27,7 @@ public class HaplotypeCallerEngineUnitTest extends GATKBaseTest {
     @Test
     public void testIsActive() throws IOException {
         final File testBam = new File(NA12878_20_21_WGS_bam);
-        final File reference = new File(b37_reference_20_21);
+        final Path reference = Paths.get(b37_reference_20_21);
         final SimpleInterval shardInterval = new SimpleInterval("20", 10000000, 10001000);
         final SimpleInterval paddedShardInterval = new SimpleInterval(shardInterval.getContig(), shardInterval.getStart() - 100, shardInterval.getEnd() + 100);
         final HaplotypeCallerArgumentCollection hcArgs = new HaplotypeCallerArgumentCollection();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
+import java.nio.file.Paths;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResultSet;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KBestHaplotype;
@@ -40,7 +41,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
 
     @BeforeClass
     public void setup() throws FileNotFoundException {
-        seq = new CachingIndexedFastaSequenceFile(new File(hg19_chr1_1M_Reference));
+        seq = new CachingIndexedFastaSequenceFile(Paths.get(hg19_chr1_1M_Reference));
         header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocParserUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocParserUnitTest.java
@@ -12,6 +12,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -435,7 +436,7 @@ public final class GenomeLocParserUnitTest extends GATKBaseTest {
 
     @Test
     public void testcreateGenomeLocOnContig() throws FileNotFoundException {
-        final CachingIndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final CachingIndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(exampleReference));
         final SAMSequenceDictionary dict = seq.getSequenceDictionary();
         final GenomeLocParser genomeLocParser = new GenomeLocParser(dict);
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GenomeLocSortedSetUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
@@ -299,7 +300,8 @@ public final class GenomeLocSortedSetUnitTest extends GATKBaseTest {
 
     @DataProvider(name = "GetOverlapping")
     public Object[][] makeGetOverlappingTest() throws Exception {
-        final GenomeLocParser genomeLocParser = new GenomeLocParser(new CachingIndexedFastaSequenceFile(new File(exampleReference)));
+        final GenomeLocParser genomeLocParser = new GenomeLocParser(new CachingIndexedFastaSequenceFile(
+                IOUtils.getPath(exampleReference)));
 
         List<Object[]> tests = new ArrayList<>();
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.FileUtils;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -424,7 +425,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testGetContigLengths() {
-        Map<String, Integer> lengths = IntervalUtils.getContigSizes(new File(GATKBaseTest.exampleReference));
+        Map<String, Integer> lengths = IntervalUtils.getContigSizes(IOUtils.getPath(GATKBaseTest.exampleReference));
         Assert.assertEquals((long)lengths.get("1"), 16000);
         Assert.assertEquals((long)lengths.get("2"), 16000);
         Assert.assertEquals((long) lengths.get("3"), 16000);

--- a/src/test/java/org/broadinstitute/hellbender/utils/NGSPlatformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/NGSPlatformUnitTest.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -31,7 +32,7 @@ public final class NGSPlatformUnitTest extends GATKBaseTest {
     @BeforeClass
     public void setup() throws FileNotFoundException {
         // sequence
-        seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(exampleReference));
     }
 
     @DataProvider(name = "TestPrimary")

--- a/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileUnitTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -26,7 +27,7 @@ public class ActivityProfileUnitTest extends GATKBaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(b37_reference_20_21));
+        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(b37_reference_20_21));
         genomeLocParser = new GenomeLocParser(seq);
         startLoc = genomeLocParser.createGenomeLoc("20", 0, 1, 100);
         header = new SAMFileHeader();

--- a/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/BandPassActivityProfileUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/activityprofile/BandPassActivityProfileUnitTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -30,7 +31,7 @@ public class BandPassActivityProfileUnitTest extends GATKBaseTest {
     @BeforeClass
     public void init() throws FileNotFoundException {
         // sequence
-        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(b37_reference_20_21));
+        ReferenceSequenceFile seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(b37_reference_20_21));
         genomeLocParser = new GenomeLocParser(seq);
         header = new SAMFileHeader();
         seq.getSequenceDictionary().getSequences().forEach(sequence -> header.addSequence(sequence));

--- a/src/test/java/org/broadinstitute/hellbender/utils/baq/BAQUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/baq/BAQUnitTest.java
@@ -6,10 +6,12 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.util.Locatable;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.engine.ReferenceMemorySource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -174,8 +176,8 @@ public final class BAQUnitTest extends GATKBaseTest {
 
     @Test
     public void testBAQOverwritesExistingTagWithNull() {
-        final File referenceFile = new File(hg19_chr1_1M_Reference);
-        final ReferenceDataSource rds = new ReferenceFileSource(referenceFile);
+        final Path reference = IOUtils.getPath(hg19_chr1_1M_Reference);
+        final ReferenceDataSource rds = new ReferenceFileSource(reference);
 
         // create a read with a single base off the end of the contig, which cannot be BAQed
         final GATKRead read = ArtificialReadUtils.createArtificialRead(createHeader(), "foo", 0, rds.getSequenceDictionary().getSequence("1").getSequenceLength() + 1, 1);

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -40,6 +40,7 @@ import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.RandomDNA;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -226,7 +227,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test
     public void testReadWithNsRefIndexInDeletion() throws FileNotFoundException {
 
-        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(exampleReference));
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
         final int readLength = 76;
 
@@ -242,7 +243,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test
     public void testReadWithNsRefAfterDeletion() throws FileNotFoundException {
 
-        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(new File(exampleReference));
+        final IndexedFastaSequenceFile seq = new CachingIndexedFastaSequenceFile(IOUtils.getPath(exampleReference));
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(seq.getSequenceDictionary());
         final int readLength = 76;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/VcfUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/VcfUtilsUnitTest.java
@@ -5,7 +5,9 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderVersion;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -20,10 +22,10 @@ public class VcfUtilsUnitTest extends GATKBaseTest {
     @DataProvider(name = "testData")
     public Object[][] getInitialData() {
     return new Object[][] {
-            { createHeaderLines(), createSequenceDictonary(), new File(b37_reference_20_21), true,  "human_g1k_v37.20.21"},
+            { createHeaderLines(), createSequenceDictonary(), IOUtils.getPath(b37_reference_20_21), true,  "human_g1k_v37.20.21"},
             { createHeaderLines(), createSequenceDictonary(), null, true,  "human_g1k_v37.20.21"},
-            { createHeaderLines(), createSequenceDictonary(), new File(b37_reference_20_21), false,
-                    "file://" + new File(b37_reference_20_21).getAbsolutePath() }
+            { createHeaderLines(), createSequenceDictonary(), IOUtils.getPath(b37_reference_20_21), false,
+                    IOUtils.getPath(b37_reference_20_21).toUri().toString() }
         };
     }
 
@@ -31,15 +33,15 @@ public class VcfUtilsUnitTest extends GATKBaseTest {
     public void testUpdateContigsReferenceNameOnly(
             final Set<VCFHeaderLine> inHeaderLines,
             final SAMSequenceDictionary seqDict,
-            final File referenceFile,
+            final Path referencePath,
             final boolean refNameOnly,
             final String expectedRefName) {
 
         Set<VCFHeaderLine> resultLines = VcfUtils.updateHeaderContigLines(
-                inHeaderLines, referenceFile, seqDict, refNameOnly
+                inHeaderLines, referencePath, seqDict, refNameOnly
         );
 
-        Assert.assertEquals(resultLines.size(), referenceFile == null ? 2 : 3);
+        Assert.assertEquals(resultLines.size(), referencePath == null ? 2 : 3);
         for (VCFHeaderLine resultLine : resultLines) {
             if (resultLine instanceof VCFContigHeaderLine) {
                 VCFContigHeaderLine headerLine = (VCFContigHeaderLine) resultLine;
@@ -52,7 +54,7 @@ public class VcfUtilsUnitTest extends GATKBaseTest {
                     Assert.fail("Bad sequence name in header lines");
                 }
             } else {
-                if (referenceFile != null) {
+                if (referencePath != null) {
                     Assert.assertEquals(resultLine.getValue(), expectedRefName);
                 }
                 else {


### PR DESCRIPTION
Update multiple tools to use a Path instead of File.

Updated: FeatureWalker, ReadWalker, IntervalWalker, MultiVariantWalker, AnnotateIntervals, BaseRecalibrator, SelectVariants, SplitNCigarReads.

Some tools will need a change to ReferenceSequenceFileWalker in htsjdk, so I couldn't change those. Same for the writers.

Part of addressing issue #3709