### PR TITLE
Added pedigree file support for InbreedingCoeff and ExcessHet

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -4,24 +4,23 @@ import com.google.common.annotations.VisibleForTesting;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
-import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.GenotypeCounts;
 import org.broadinstitute.hellbender.utils.GenotypeUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.samples.PedigreeValidationType;
+import org.broadinstitute.hellbender.utils.samples.SampleDBBuilder;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
-import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.io.File;
+import java.util.*;
 
 
 /**
@@ -41,20 +40,22 @@ import java.util.Set;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Likelihood-based test for the consanguinity among samples (InbreedingCoeff)")
-public final class InbreedingCoeff extends InfoFieldAnnotation implements StandardAnnotation {
+public final class InbreedingCoeff extends PedigreeAnnotation implements StandardAnnotation {
 
     private static final Logger logger = LogManager.getLogger(InbreedingCoeff.class);
     private static final int MIN_SAMPLES = 10;
     private static final boolean ROUND_GENOTYPE_COUNTS = false;
-    private final Set<String> founderIds;
 
     public InbreedingCoeff(){
-        this(null);
+        super((Set<String>) null);
     }
 
     public InbreedingCoeff(final Set<String> founderIds){
-        //If available, get the founder IDs and cache them. the IC will only be computed on founders then.
-        this.founderIds = founderIds;
+        super(founderIds);
+    }
+
+    public InbreedingCoeff(final File pedigreeFile){
+        super(pedigreeFile);
     }
 
     @Override
@@ -62,7 +63,7 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
                                         final VariantContext vc,
                                         final ReadLikelihoods<Allele> likelihoods) {
         Utils.nonNull(vc);
-        final GenotypesContext genotypes = (founderIds == null || founderIds.isEmpty()) ? vc.getGenotypes() : vc.getGenotypes(founderIds);
+        final GenotypesContext genotypes = getFounderGenotypes(vc);
         if (genotypes == null || genotypes.size() < MIN_SAMPLES || !vc.isVariant()) {
             return Collections.emptyMap();
         }
@@ -96,5 +97,4 @@ public final class InbreedingCoeff extends InfoFieldAnnotation implements Standa
 
     @Override
     public List<String> getKeyNames() { return Collections.singletonList(GATKVCFConstants.INBREEDING_COEFFICIENT_KEY); }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PedigreeAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PedigreeAnnotation.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator;
+
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.utils.samples.PedigreeValidationType;
+import org.broadinstitute.hellbender.utils.samples.SampleDBBuilder;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * A common interface for handling annotations that require pedigree file information either in the form of explicitly
+ * selected founderIDs or in the form of an imported pedigreeFile.
+ *
+ * In order to use the the behavior, simply extend Pedigree annotation and access its constructors, then call
+ * getFounderGenotypes() to extract only the genotypes corresponding to requested founder samples or that appear as founders
+ * in the provided pedigree file. If no founderIDs or pedigreeFiles are present, then it defaults to returning all genotypes.
+ */
+public abstract class PedigreeAnnotation extends InfoFieldAnnotation {
+    private final Collection<String> founderIds;
+    private File pedigreeFile = null;
+    private boolean hasAddedPedigreeFounders = false;
+
+    protected GenotypesContext getFounderGenotypes(VariantContext vc) {
+        if ((pedigreeFile!= null) && (!hasAddedPedigreeFounders)) {
+            founderIds.addAll(initializeSampleDB(pedigreeFile));
+            hasAddedPedigreeFounders=true;
+        }
+        return (founderIds == null || founderIds.isEmpty()) ? vc.getGenotypes() : vc.getGenotypes(new HashSet<>(founderIds));
+    }
+
+    public PedigreeAnnotation(final Set<String> founderIds){
+        //If available, get the founder IDs and cache them. the IC will only be computed on founders then.
+        this.founderIds = founderIds == null? new ArrayList<>() : new ArrayList<>(founderIds);
+    }
+
+    public PedigreeAnnotation(final File pedigreeFile){
+        //If available, get the founder IDs and cache them. the IC will only be computed on founders then.
+        this.pedigreeFile = pedigreeFile;
+        founderIds = initializeSampleDB(pedigreeFile);
+        hasAddedPedigreeFounders = true;
+    }
+
+    /**
+     * Entry-point function to initialize the samples database from input data
+     */
+    private Set<String> initializeSampleDB(File pedigreeFile) {
+        final SampleDBBuilder sampleDBBuilder = new SampleDBBuilder(PedigreeValidationType.STRICT);
+        sampleDBBuilder.addSamplesFromPedigreeFiles(Collections.singletonList(pedigreeFile));
+        return sampleDBBuilder.getFinalSampleDB().getFounderIds();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeffUnitTest.java
@@ -183,6 +183,40 @@ public final class InbreedingCoeffUnitTest extends GATKBaseTest {
     }
 
     @Test
+    public void testInbreedingCoeffForMultiallelicVC_usingPedigreeFile() {
+        //make sure that compound hets (with no ref) don't add to het count
+        VariantContext vc = makeVC("1", Arrays.asList(Aref, T, C),
+                makeG("s1", Aref, T, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s2", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s3", T, C, 7099, 2530, 7099, 3056, 0, 14931),
+                makeG("s4", Aref, T, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s5", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s6", Aref, T, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s7", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s8", Aref, T, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s9", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s10", Aref, T, 2530, 0, 7099, 366, 3056, 14931),
+
+                //add a bunch of hom samples that will be ignored if we use s1..s10 as founders
+                makeG("s11", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s12", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s13", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s14", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s15", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s16", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931),
+                makeG("s17", T, T, 7099, 2530, 0, 7099, 366, 3056, 14931)
+        );
+
+        final Map<String, Object> foundersOnly = new InbreedingCoeff(getTestFile("testtrio.ped")).annotate(null, vc, null);
+        final double ICresultFoundersOnly = Double.valueOf((String) foundersOnly.get(GATKVCFConstants.INBREEDING_COEFFICIENT_KEY));
+        Assert.assertEquals(ICresultFoundersOnly, -0.3333333, DELTA_PRECISION, "ICresultFoundersOnly");
+
+        final Map<String, Object> all = new InbreedingCoeff().annotate(null, vc, null);
+        final double ICresult = Double.valueOf((String) all.get(GATKVCFConstants.INBREEDING_COEFFICIENT_KEY));
+        Assert.assertEquals(ICresult, -0.1724, DELTA_PRECISION, "ICresult");
+    }
+
+    @Test
     public void testInbreedingCoeffForMultiallelicVC_refAltFlip() {
         //make sure that compound hets (with no ref) don't add to het count
         VariantContext test1 = makeVC("1", Arrays.asList(Aref, T, C),

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff/testtrio.ped
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff/testtrio.ped
@@ -1,0 +1,17 @@
+fam001 s1 0 0 2 2
+fam001 s2 0 0 1 1
+fam001 s3 0 0 2 2
+fam001 s4 0 0 1 2
+fam001 s5 0 0 2 2
+fam001 s6 0 0 1 2
+fam001 s7 0 0 2 2
+fam001 s8 0 0 1 2
+fam001 s9 0 0 2 2
+fam001 s10 0 0 1 2
+fam001 s11 s1 s2 1 2
+fam001 s12 s3 s4 1 2
+fam001 s13 s5 s6 1 2
+fam001 s14 s7 s8 1 2
+fam001 s15 s9 s10 1 2
+fam001 s16 s1 s2 1 2
+fam001 s17 s3 s4 1 2

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/annotator/testPedigree.ped
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/annotator/testPedigree.ped
@@ -1,0 +1,10 @@
+fam001 s1 0 0 2 2
+fam001 s2 0 0 1 1
+fam001 s3 0 0 2 2
+fam001 s4 0 0 1 2
+fam001 s5 0 0 2 2
+fam001 s6 s1 s2 1 2
+fam001 s7 s3 s4 2 2
+fam001 s8 s2 s5 1 2
+fam001 s9 s1 s2 2 2
+fam001 s10 s3 s4 1 2


### PR DESCRIPTION
Currently there is no way to supply the pedigree file, but that is dependent on #3287 but this is a first step to implementing the pedigree annotations. 

The current plan is still to have the pedigree file be an argument on the tool but to reconcile them using the pluginDescriptor since there is currently one tool which takes a ped file that doesn't have annotations.

Fixes #3939 
Fixes #2542 