### PR TITLE
Use "stability ensured" trusty image on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: required
 dist: trusty
+group: travis_lts
 git:
   depth: 9999999
   lfs_skip_smudge: true


### PR DESCRIPTION
Travis [updated](https://docs.travis-ci.com/user/build-environment-updates/2017-12-12/) the trusty images last night (seems to be ok so far). They also added a new update schedule and a new [group](https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images) declaration. The default appears to be "stability ensured", but this adds an explicit declaration for that.
