### PR TITLE
Install GATK Python packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DRELEASE
 ADD . /gatk
 
 WORKDIR /gatk
-RUN /gatk/gradlew clean compileTestJava installAll localJar -Drelease=$DRELEASE
+RUN /gatk/gradlew clean compileTestJava installAll localJar createPythonPackageArchive -Drelease=$DRELEASE
 
 WORKDIR /root
 
@@ -40,6 +40,7 @@ RUN mkdir $DOWNLOAD_DIR && \
     bash $DOWNLOAD_DIR/miniconda.sh -p $CONDA_PATH -b && \
     rm $DOWNLOAD_DIR/miniconda.sh
 ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
+WORKDIR /gatk
 RUN conda env create -n gatk -f /gatk/scripts/gatkcondaenv.yml && \
     echo "source activate gatk" >> /gatk/gatkenv.rc
 

--- a/build.gradle
+++ b/build.gradle
@@ -466,6 +466,23 @@ task bundle(type: Zip) {
     }
 }
 
+task createPythonPackageArchive(type: Zip) {
+
+    doFirst {
+        assert file("src/main/python/org/broadinstitute/hellbender/").exists()
+    }
+
+    logger.lifecycle("Creating GATK Python package archive...")
+    destinationDir file("$buildDir")
+    archiveName "gatkPythonPackageArchive" + ".zip"
+    from("src/main/python/org/broadinstitute/hellbender/")
+    into("/")
+
+    doLast {
+        logger.lifecycle("Created GATK Python package archive in ${destinationDir}/${archiveName}")
+    }
+}
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from 'build/docs/javadoc'

--- a/scripts/gatkcondaenv.yml
+++ b/scripts/gatkcondaenv.yml
@@ -34,4 +34,5 @@ dependencies:
   - tensorflow-tensorboard==0.4.0rc3
   - theano==0.9.0
   - werkzeug==0.12.2
+  - build/gatkPythonPackageArchive.zip
 

--- a/src/main/python/org/broadinstitute/hellbender/gatkpython/__init__.py
+++ b/src/main/python/org/broadinstitute/hellbender/gatkpython/__init__.py
@@ -1,0 +1,3 @@
+def dosomething():
+    return ('gatk package is installed')
+

--- a/src/main/python/org/broadinstitute/hellbender/setup.py
+++ b/src/main/python/org/broadinstitute/hellbender/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(name='gatkpython',
+      version='0.1',
+      description='Testing install from archive',
+      author='GATK Team',
+      packages=['gatkpython'],
+      zip_safe=False)
+

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
@@ -25,6 +25,7 @@ public class PythonEnvironmentIntegrationTest {
                 { "keras" },
                 { "pymc3" },
                 { "argparse" },
+                { "gatkpython" }, // termporary test of the install-from-archive option
         };
     }
 


### PR DESCRIPTION
We need a way to install GATK Python modules onto the docker image, from repo source, in a way that doesn't assume a repo clone is present on the docker image (there currently is one, but we want to remove it to recover space), and that also doesn't make the conda environment dependent on a repo clone.

This PR adds a build task that creates a zip archive of the GATK Python source; propagates that to the docker image, and then pip installs the contents of the archive into the conda environment on the docker. Since we don't have an actual python module in the repo at the moment, there is a second, temporary, commit that contains a dummy python module used only to trigger and test that the installation works.