### PR TITLE
throw if GenomicsDBImport tries to import into existing directory

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.intel.genomicsdb.ChromosomeInterval;
-import com.intel.genomicsdb.GenomicsDBCallsetsMapProto;
-import com.intel.genomicsdb.GenomicsDBImportConfiguration;
-import com.intel.genomicsdb.GenomicsDBImporter;
+import com.intel.genomicsdb.*;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -629,18 +626,26 @@ public final class GenomicsDBImport extends GATKTool {
 
         if (!workspaceDir.exists()) {
             final int ret = GenomicsDBImporter.createTileDBWorkspace(workspaceDir.getAbsolutePath());
-
             if (ret > 0) {
                 checkIfValidWorkspace(workspaceDir);
                 logger.info("Importing data to GenomicsDB workspace: " + workspaceDir);
             } else if (ret < 0) {
-                throw new UserException("Error creating GenomicsDB workspace: " + workspaceDir);
+                throw new UnableToCreateGenomicsDBWorkspace("Error creating GenomicsDB workspace: " + workspaceDir);
             }
+            return workspaceDir;
         } else {
-            // Check whether its a valid workspace
-            checkIfValidWorkspace(workspaceDir);
+            throw new UnableToCreateGenomicsDBWorkspace("The workspace you're trying to create already exists. ( " + workspaceDir.getAbsolutePath() + " ) " +
+                                                  "Writing into an existing workspace can cause data corruption. " +
+                                                  "Please choose an output path that doesn't already exist. ");
         }
-        return workspaceDir;
+    }
+
+    static class UnableToCreateGenomicsDBWorkspace extends UserException {
+        private static final long serialVersionUID = 1L;
+
+        UnableToCreateGenomicsDBWorkspace(final String message){
+            super(message);
+        }
     }
 
     private static void checkIfValidWorkspace(final File workspaceDir) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -444,4 +444,11 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
                 null,
                 new BCF2Codec());
     }
+
+    @Test(expectedExceptions = GenomicsDBImport.UnableToCreateGenomicsDBWorkspace.class)
+    public void testYouCantWriteIntoAnExistingDirectory(){
+        // this actually creates the directory on disk, not just the file name.
+        final String workspace = createTempDir("workspace").getAbsolutePath();
+        writeToGenomicsDB(LOCAL_GVCFS, INTERVAL, workspace, 0, false, 0, 1);
+    }
 }


### PR DESCRIPTION
This should prevent the confusing case of accidentally corrupting an existing GenomicsDB.  The next genomicsDB update is supposed to make this unnecessary, but until it happens lets avoid this problem.