### PR TITLE
Mutect downsampler that recognizes and skips bad mapping regions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.activityprofile.ActivityProfileState;
 import org.broadinstitute.hellbender.utils.downsampling.PositionalDownsampler;
+import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.io.File;
@@ -279,6 +280,10 @@ public abstract class AssemblyRegionWalker extends GATKTool {
         return defaultFilters;
     }
 
+    protected ReadsDownsampler createDownsampler() {
+        return maxReadsPerAlignmentStart > 0 ? new PositionalDownsampler(maxReadsPerAlignmentStart, getHeaderForReads()) : null;
+    }
+
     @Override
     public final void traverse() {
 
@@ -293,7 +298,7 @@ public abstract class AssemblyRegionWalker extends GATKTool {
             // instead of filtering the reads directly here
             readShard.setPreReadFilterTransformer(makePreReadFilterTransformer());
             readShard.setReadFilter(countedFilter);
-            readShard.setDownsampler(maxReadsPerAlignmentStart > 0 ? new PositionalDownsampler(maxReadsPerAlignmentStart, getHeaderForReads()) : null);
+            readShard.setDownsampler(createDownsampler());
             readShard.setPostReadFilterTransformer(makePostReadFilterTransformer());
             currentReadShard = readShard;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.VariantAnnotationArgumentCollection;
@@ -90,6 +91,19 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      */
     @Argument(fullName = "max-population-af", shortName = "max-af", optional = true, doc = "Maximum population allele frequency in tumor-only mode.")
     public double maxPopulationAlleleFrequency = 0.01;
+
+    /**
+     * Downsample a pool of reads starting within a range of one or more bases.
+     */
+    @Argument(fullName = "downsampling-stride", shortName = "stride", optional = true, doc = "Downsample a pool of reads starting within a range of one or more bases.")
+    public int downsamplingStride = 1;
+
+    /**
+     * Maximum number of suspicious reads (mediocre mapping quality or too many substitutions) allowed in a downsampling stride.
+     */
+    @Advanced
+    @Argument(fullName = "max-suspicious-reads-per-alignment-start", optional = true, doc = "Maximum number of suspicious reads (mediocre mapping quality or too many substitutions) allowed in a downsampling stride.  Set to 0 to disable.")
+    public int maxSuspiciousReadsPerAlignmentStart = 0;
 
     /**
      * This is a measure of the minimum evidence to support that a variant observed in the tumor is not also present in the normal.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.variant.variantcontext.VariantContext;
-import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
@@ -13,11 +11,13 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.broadinstitute.hellbender.tools.walkers.contamination.GetPileupSummaries;
+import org.broadinstitute.hellbender.tools.exome.FilterByOrientationBias;
+import org.broadinstitute.hellbender.tools.walkers.contamination.CalculateContamination;
+import org.broadinstitute.hellbender.utils.downsampling.MutectDownsampler;
+import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -45,7 +45,7 @@ import java.util.List;
  *     <dd>(iv) Instead of using a maximum likelihood estimate, GATK4 Mutect2 marginalizes over allele fractions. 
  *     GATK3 MuTect2 directly uses allele depths (AD) to estimate allele fractions and calculate likelihoods. In contrast, GATK4 Mutect2
  *     factors for the statistical error inherent in allele depths by marginalizing over allele fractions when calculating likelihoods.</dd>
- *     <dd>(v) GATK4 Mutect2 recommends including contamination estimates with the -contaminationFile option from {@link CalculateContamination}, 
+ *     <dd>(v) GATK4 Mutect2 recommends including contamination estimates with the -contaminationFile option from {@link CalculateContamination},
  *     which in turn relies on the results of {@link GetPileupSummaries}.</dd>
  * </dl>
  *
@@ -225,6 +225,11 @@ public final class Mutect2 extends AssemblyRegionWalker {
     @Override
     public List<ReadFilter> getDefaultReadFilters() {
         return Mutect2Engine.makeStandardMutect2ReadFilters();
+    }
+
+    @Override
+    protected ReadsDownsampler createDownsampler() {
+        return new MutectDownsampler(maxReadsPerAlignmentStart, MTAC.maxSuspiciousReadsPerAlignmentStart, MTAC.downsamplingStride);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
@@ -1,0 +1,156 @@
+package org.broadinstitute.hellbender.utils.downsampling;
+
+import org.apache.commons.lang.mutable.MutableInt;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+import java.util.*;
+
+
+public final class MutectDownsampler extends ReadsDownsampler {
+    private static final int SUSPICIOUS_MAPPING_QUALITY = 50;
+    private final MutableInt suspiciousReadCount;
+    private final int maxSuspiciousReadsPerStride;
+    private boolean rejectAllReadsInStride;
+
+    private final int stride;
+    private final int maxCoverage;
+    private final List<GATKRead> pendingReads;
+    private List<GATKRead> finalizedReads;
+
+    private GATKRead firstReadInStride;
+
+
+    /**
+     * @param maxReadsPerAlignmentStart Maximum number of reads per alignment start position. Must be > 0
+     * @param stride Length in bases constituting a single pool of reads to downsample
+     */
+    public MutectDownsampler(final int maxReadsPerAlignmentStart,
+                             final int maxSuspiciousReadsPerAlignmentStart,
+                             final int stride) {
+        // convert coverage per base to coverage per stride
+        maxCoverage = maxReadsPerAlignmentStart <= 0 ? Integer.MAX_VALUE : (maxReadsPerAlignmentStart * stride);
+        this.stride = ParamUtils.isPositive(stride, "stride must be > 0");
+        maxSuspiciousReadsPerStride = maxSuspiciousReadsPerAlignmentStart <= 0 ? Integer.MAX_VALUE : stride * ParamUtils.isPositive(maxSuspiciousReadsPerAlignmentStart, "maxSuspiciousReadsPerAlignmentStart must be > 0");
+
+        pendingReads = new ArrayList<>();
+        finalizedReads = new ArrayList<>();
+        rejectAllReadsInStride = false;
+        suspiciousReadCount = new MutableInt(0);
+
+        clearItems();
+        resetStats();
+    }
+
+    @Override
+    public void submit( final GATKRead newRead ) {
+        Utils.nonNull(newRead);
+        if (ReadUtils.readHasNoAssignedPosition(newRead)) {
+            finalizedReads.add(newRead);
+            return;
+        } else {
+            handlePositionalChange(newRead);
+
+            if (rejectAllReadsInStride) {
+                return;
+            }
+
+            if (newRead.getMappingQuality() <= SUSPICIOUS_MAPPING_QUALITY) {
+                suspiciousReadCount.increment();
+            }
+
+            rejectAllReadsInStride |= suspiciousReadCount.intValue() >= maxSuspiciousReadsPerStride;
+
+            pendingReads.add(newRead);
+        }
+    }
+
+    private void handlePositionalChange( final GATKRead newRead ) {
+        if (ReadUtils.readHasNoAssignedPosition(newRead)) {
+            return;
+        } else if (firstReadInStride == null) {
+            firstReadInStride = newRead;
+        } else {
+            final boolean newContig = !newRead.getAssignedContig().equals(firstReadInStride.getAssignedContig());
+            final boolean newStride = newContig || newRead.getAssignedStart() >= firstReadInStride.getAssignedStart() + stride;
+            if (newStride) {
+                finalizePendingReads();
+                firstReadInStride = newRead;
+                rejectAllReadsInStride = false;
+                suspiciousReadCount.setValue(0);
+            }
+        }
+    }
+
+    private void finalizePendingReads() {
+        if (!rejectAllReadsInStride) {
+            // most common case: no downsampling necessary
+            if (pendingReads.size() <= maxCoverage) {
+                finalizedReads.addAll(pendingReads);
+            } else {
+                // if we exceed the max coverage, just use well-mapped reads.  Maybe the number of such reads won't reach
+                // the desired coverage, but if the region is decently mappable the shortfall will be minor.
+                final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage, false);
+                pendingReads.stream().filter(read -> read.getMappingQuality() > SUSPICIOUS_MAPPING_QUALITY).forEach(wellMappedDownsampler::submit);
+                final List<GATKRead> readsToFinalize = wellMappedDownsampler.consumeFinalizedItems();
+                if (stride > 1) {
+                    Collections.sort(readsToFinalize, Comparator.comparingInt(GATKRead::getAssignedStart));
+                }
+                finalizedReads.addAll(readsToFinalize);
+            }
+        }
+        pendingReads.clear();
+
+    }
+
+    @Override
+    public boolean hasFinalizedItems() {
+        return ! finalizedReads.isEmpty();
+    }
+
+    @Override
+    public boolean hasPendingItems() { return !pendingReads.isEmpty(); }
+
+    @Override
+    public GATKRead peekFinalized() { return finalizedReads.isEmpty() ? null : finalizedReads.get(0); }
+
+    @Override
+    public GATKRead peekPending() { return pendingReads.isEmpty() ? null : pendingReads.get(0); }
+
+    @Override
+    public List<GATKRead> consumeFinalizedItems() {
+        Collections.sort(finalizedReads, Comparator.comparingInt(GATKRead::getAssignedStart));
+        final List<GATKRead> toReturn = finalizedReads;
+        finalizedReads = new ArrayList<>();
+        return toReturn;
+    }
+
+    @Override
+    public int size() { return finalizedReads.size() + pendingReads.size(); }
+
+    @Override
+    public void signalEndOfInput() {
+        finalizePendingReads();
+    }
+
+    @Override
+    public void clearItems() {
+        pendingReads.clear();
+        finalizedReads.clear();
+        firstReadInStride = null;
+        rejectAllReadsInStride = false;
+        suspiciousReadCount.setValue(0);
+    }
+
+    @Override
+    public boolean requiresCoordinateSortOrder() {
+        return true;
+    }
+
+    @Override
+    public void signalNoMoreReadsBefore( final GATKRead read ) {
+        handlePositionalChange(read);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -68,7 +68,10 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-L", "20",
                 "-germline-resource", GNOMAD.getAbsolutePath(),
                 "-XL", mask.getAbsolutePath(),
-                "-O", unfilteredVcf.getAbsolutePath()
+                "-O", unfilteredVcf.getAbsolutePath(),
+                "--downsampling-stride", "20",
+                "--maxReadsPerAlignmentStart", "4",
+                "--max-suspicious-reads-per-alignment-start", "4"
         };
 
         runCommandLine(args);
@@ -198,7 +201,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         new Main().instanceMain(makeCommandLineArgs(Arrays.asList("-V", unfilteredVcf.getAbsolutePath(), "-O", filteredVcf.getAbsolutePath()), "FilterMutectCalls"));
 
 
-        final long numVariantsBeforeFiltering = StreamSupport.stream(new FeatureDataSource<VariantContext>(filteredVcf).spliterator(), false).count();
+        final long numVariantsBeforeFiltering = StreamSupport.stream(new FeatureDataSource<VariantContext>(unfilteredVcf).spliterator(), false).count();
 
         final long numVariantsPassingFilters = StreamSupport.stream(new FeatureDataSource<VariantContext>(filteredVcf).spliterator(), false)
                 .filter(vc -> vc.getFilters().isEmpty()).count();
@@ -311,6 +314,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 {new File(DREAM_BAMS_DIR, "tumor_2.bam"), "background.synth.challenge2.snvs.svs.tumorbackground", new File(DREAM_BAMS_DIR, "normal_2.bam"), "synthetic.challenge.set2.normal", new File(DREAM_VCFS_DIR, "sample_2.vcf"), new File(DREAM_MASKS_DIR, "mask2.list"), 0.95},
                 {new File(DREAM_BAMS_DIR, "tumor_3.bam"), "IS3.snv.indel.sv", new File(DREAM_BAMS_DIR, "normal_3.bam"), "G15512.prenormal.sorted", new File(DREAM_VCFS_DIR, "sample_3.vcf"), new File(DREAM_MASKS_DIR, "mask3.list"), 0.90},
                 {new File(DREAM_BAMS_DIR, "tumor_4.bam"), "synthetic.challenge.set4.tumour", new File(DREAM_BAMS_DIR, "normal_4.bam"), "synthetic.challenge.set4.normal", new File(DREAM_VCFS_DIR, "sample_4.vcf"), new File(DREAM_MASKS_DIR, "mask4.list"), 0.65}
+
         };
     }
 


### PR DESCRIPTION
This greatly reduces wall clock time in M2 scatters without affecting sensitivity.  It is decoupled from HaplotypeCaller's downsampling.