### PR TITLE
Proposal: argument collection for CLP options

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/CLPConfigurationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/CLPConfigurationArgumentCollection.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import htsjdk.samtools.util.Log;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Arguments used to configure the {@link org.broadinstitute.hellbender.cmdline.CommandLineProgram}.
+ *
+ * <p>The purpose of this abstract class is to allow downstream projects to decide which configuration arguments they
+ * want to expose to the CLP.
+ *
+ * <p>In addition, this class might contain arguments for documentation-only (e.g., arguments from a wrapper script).
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface CLPConfigurationArgumentCollection extends Serializable {
+
+    /**
+     * Return a non-empty list of temp directories.
+     */
+    public abstract List<Path> getTmpDirectories();
+
+    public abstract Log.LogLevel getVerbosity();
+
+    public abstract boolean isQuiet();
+
+    public abstract boolean useJdkDeflater();
+
+    public abstract boolean useJdkInflater();
+
+    public abstract int getNioMaxReopens();
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDefaultCLPConfigurationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDefaultCLPConfigurationArgumentCollection.java
@@ -1,0 +1,102 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default arguments for GATK configuration.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class GATKDefaultCLPConfigurationArgumentCollection implements CLPConfigurationArgumentCollection {
+    private static final long serialVersionUID = 1L;
+
+    // TODO - TMP_DIR and QUIET are not in the standard kebab-case in the latest master
+    // TODO - it was changed in the previous version of this commit/PR
+    public static final String TMP_DIR_NAME = "TMP_DIR";
+    public static final String QUIET_NAME = "QUIET";
+    public static final String USE_JDK_DEFLATER_LONG_NAME = "use-jdk-deflater";
+    public static final String USE_JDK_DEFLATER_SHORT_NAME = "jdk-deflater";
+    public static final String USE_JDK_INFLATER_LONG_NAME = "use-jdk-inflater";
+    public static final String USE_JDK_INFLATER_SHORT_NAME = "jdk-inflater";
+    public static final String NIO_MAX_REOPENS_LONG_NAME = "gcs-max-retries";
+    public static final String NIO_MAX_REOPENS_SHORT_NAME = "gcs-retries";
+
+    @Argument(fullName = TMP_DIR_NAME, doc = "List of temp directories to use.", common=true, optional=true)
+    public List<String> tmpDir = new ArrayList<>();
+
+    @Argument(fullName = StandardArgumentDefinitions.VERBOSITY_NAME, shortName = StandardArgumentDefinitions.VERBOSITY_NAME, doc = "Control verbosity of logging.", common = true, optional = true)
+    public Log.LogLevel verbosity = Log.LogLevel.INFO;
+
+    @Argument(fullName = QUIET_NAME, doc = "Whether to suppress job-summary info on System.err.", common=true)
+    public Boolean quiet = false;
+
+    @Argument(fullName = USE_JDK_DEFLATER_LONG_NAME, shortName = USE_JDK_DEFLATER_SHORT_NAME, doc = "Whether to use the JdkDeflater (as opposed to IntelDeflater)", common=true)
+    public boolean useJdkDeflater = false;
+
+    @Argument(fullName = USE_JDK_INFLATER_LONG_NAME, shortName = USE_JDK_INFLATER_SHORT_NAME, doc = "Whether to use the JdkInflater (as opposed to IntelInflater)", common=true)
+    public boolean useJdkInflater = false;
+
+    @Argument(fullName = NIO_MAX_REOPENS_LONG_NAME, shortName = NIO_MAX_REOPENS_SHORT_NAME, doc = "If the GCS bucket channel errors out, how many times it will attempt to re-initiate the connection", optional = true)
+    public int nioMaxReopens = ConfigFactory.getInstance().getGATKConfig().gcsMaxRetries();
+
+    // This option is here for documentation completeness.
+    // This is actually parsed out in Main to initialize configuration files because
+    // we need to have the configuration completely set up before we create our CommandLinePrograms.
+    // (Some of the CommandLinePrograms have default values set to config values, and these are loaded
+    // at class load time as static initializers).
+    @Argument(fullName = StandardArgumentDefinitions.GATK_CONFIG_FILE_OPTION,
+            doc = "A configuration file to use with the GATK.",
+            common = true,
+            optional = true)
+    public String gatkConfigFile = null;
+
+    private final List<Path> resolvedTmpDirectories = new ArrayList<>();
+
+    @Override
+    public List<Path> getTmpDirectories() {
+        if (resolvedTmpDirectories.isEmpty()) {
+            // Provide one temp directory if the caller didn't
+            if (tmpDir == null || tmpDir.isEmpty()) {
+                resolvedTmpDirectories.add(IOUtil.getDefaultTmpDirPath());
+            } else {
+                tmpDir.forEach(s -> resolvedTmpDirectories.add(IOUtils.getPath(s)));
+            }
+        }
+        return Collections.unmodifiableList(resolvedTmpDirectories);
+    }
+
+    @Override
+    public Log.LogLevel getVerbosity() {
+        return verbosity;
+    }
+
+    @Override
+    public boolean isQuiet() {
+        return quiet;
+    }
+
+    @Override
+    public boolean useJdkDeflater() {
+        return useJdkDeflater;
+    }
+
+    @Override
+    public boolean useJdkInflater() {
+        return useJdkInflater;
+    }
+
+    @Override
+    public int getNioMaxReopens() {
+        return nioMaxReopens;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDefaultCLPConfigurationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDefaultCLPConfigurationArgumentCollection.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -67,7 +66,8 @@ public final class GATKDefaultCLPConfigurationArgumentCollection implements CLPC
         if (resolvedTmpDirectories.isEmpty()) {
             // Provide one temp directory if the caller didn't
             if (tmpDir == null || tmpDir.isEmpty()) {
-                resolvedTmpDirectories.add(IOUtil.getDefaultTmpDirPath());
+                // TODO - this should use the HTSJDK IOUtil.getDefaultTmpDirPath, which is somehow broken in the current HTSJDK version
+                resolvedTmpDirectories.add(IOUtils.getPath(System.getProperty("java.io.tmpdir")));
             } else {
                 tmpDir.forEach(s -> resolvedTmpDirectories.add(IOUtils.getPath(s)));
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/EstimateLibraryComplexityGATK.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/EstimateLibraryComplexityGATK.java
@@ -37,7 +37,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.lang.Math.pow;
 
@@ -303,7 +302,7 @@ public final class EstimateLibraryComplexityGATK extends AbstractOpticalDuplicat
                 new PairedReadCodec(),
                 new PairedReadComparator(),
                 MAX_RECORDS_IN_RAM,
-                TMP_DIR.stream().map(File::toPath).collect(Collectors.toList()));
+                configArgs.getTmpDirectories());
 
         // Loop through the input files and pick out the read sequences etc.
         final ProgressLogger progress = new ProgressLogger(logger, (int) 1e6, "Read");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATK.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATK.java
@@ -15,13 +15,12 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.read.markduplicates.*;
 import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
-import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * A better duplication marking algorithm that handles all cases including clipped
@@ -208,13 +207,13 @@ public final class MarkDuplicatesGATK extends AbstractMarkDuplicatesCommandLineP
                 new ReadEndsForMarkDuplicatesCodec(),
                 new ReadEndsMDComparator(),
                 maxInMemory,
-                TMP_DIR.stream().map(File::toPath).collect(Collectors.toList()));
+                configArgs.getTmpDirectories());
 
         this.fragSort = SortingCollection.newInstanceFromPaths(ReadEndsForMarkDuplicates.class,
                 new ReadEndsForMarkDuplicatesCodec(),
                 new ReadEndsMDComparator(),
                 maxInMemory,
-                TMP_DIR.stream().map(File::toPath).collect(Collectors.toList()));
+                configArgs.getTmpDirectories());
 
         try(final SamHeaderAndIterator headerAndIterator = openInputs()) {
             final SAMFileHeader header = headerAndIterator.header;
@@ -358,7 +357,7 @@ public final class MarkDuplicatesGATK extends AbstractMarkDuplicatesCommandLineP
         final int maxInMemory = (int) Math.min((Runtime.getRuntime().maxMemory() * 0.25) / SortingLongCollection.SIZEOF,
                 (double) (Integer.MAX_VALUE - 5));
         logger.info("Will retain up to " + maxInMemory + " duplicate indices before spilling to disk.");
-        this.duplicateIndexes = new SortingLongCollection(maxInMemory, TMP_DIR.toArray(new File[TMP_DIR.size()]));
+        this.duplicateIndexes = new SortingLongCollection(maxInMemory, configArgs.getTmpDirectories().toArray(new Path[configArgs.getTmpDirectories().size()]));
 
         ReadEndsForMarkDuplicates firstOfNextChunk = null;
         final List<ReadEndsForMarkDuplicates> nextChunk = new ArrayList<>(200);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATKIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATKIntegrationTest.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.GATKDefaultCLPConfigurationArgumentCollection;
 import org.broadinstitute.hellbender.utils.read.markduplicates.MarkDuplicatesTester;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.testers.AbstractMarkDuplicatesTester;
@@ -176,7 +177,7 @@ public final class MarkDuplicatesGATKIntegrationTest extends AbstractMarkDuplica
         }
         markDuplicatesGATK.OUTPUT = outputSam;
         markDuplicatesGATK.METRICS_FILE = metricsFile;
-        markDuplicatesGATK.TMP_DIR = CollectionUtil.makeList(outputDir);
+        ((GATKDefaultCLPConfigurationArgumentCollection) markDuplicatesGATK.configArgs).tmpDir = CollectionUtil.makeList(outputDir.toString());
         // Needed to suppress calling CommandLineProgram.getVersion(), which doesn't work for code not in a jar
         markDuplicatesGATK.PROGRAM_RECORD_ID = null;
         Assert.assertEquals(markDuplicatesGATK.doWork(), null);
@@ -252,7 +253,7 @@ public final class MarkDuplicatesGATKIntegrationTest extends AbstractMarkDuplica
         markDuplicatesGATK.INPUT = CollectionUtil.makeList(sam);
         markDuplicatesGATK.OUTPUT = outputSam;
         markDuplicatesGATK.METRICS_FILE = metricsFile;
-        markDuplicatesGATK.TMP_DIR = CollectionUtil.makeList(outputDir);
+        ((GATKDefaultCLPConfigurationArgumentCollection) markDuplicatesGATK.configArgs).tmpDir = CollectionUtil.makeList(outputDir.toString());
         // Needed to suppress calling CommandLineProgram.getVersion(), which doesn't work for code not in a jar
         markDuplicatesGATK.PROGRAM_RECORD_ID = null;
         Assert.assertEquals(markDuplicatesGATK.doWork(), null);


### PR DESCRIPTION
I have three main reasons to propose to move the arguments in CLP to an argument collection that is configurable by downstream tools/projects:

1. Support hiding some arguments for downstream projects. For example, I do not want to support a config file by the user, but rather decide the settings for the framework and expose only some configuration.
1. Set custom defaults for some downstream tools (including GATK). For example, a concrete tool might want to force the temp directory to be specified to avoid failures due to no space (and specify that in the documentation).
1. Support old-style arguments (not kebab-case) for downstream projects that rely on the current argument definitions. I am specially affected by this one, because updating GATK to the 4.0.0 release of January will be a breaking change that will cause some nightmares for my users - and I don't want to do a major version bump yet (I have to re-work a bit my own framework before it)

Thus, the first commit of this PR holds the proposal for the new argument collection. As I know that the team is also trying to normalize arguments and documentation, I included two more commits to help with the task (they can be removed if you think that it is better after the argument collection):
* Use `java.nio.Path` for temp directories (to support temp directories in HDFS, for example)
* Change arguments moved to the collection to kebab-case (to help with #3853)