### PR TITLE
Updated R requirement in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ releases of the toolkit.
       To activate the environment once it has been created, run the command ```source activate gatk```. See the
       [Conda](https://conda.io/docs/user-guide/tasks/manage-environments.html) documentation for
       additional information about using and managing Conda environments.
-    * R 3.1.3 (needed for producing plots in certain tools, and for running the test suite)
+    * R 3.2.5 (needed for producing plots in certain tools, and for running the test suite)
     * [git-lfs](https://git-lfs.github.com/) 1.1.0 or greater (needed to download large files for the complete test suite).
       Run `git lfs install` after downloading, followed by `git lfs pull` from the root of your git clone to download the large files. The download is several hundred megabytes.
 
@@ -264,7 +264,7 @@ You can download and run pre-built versions of GATK4 from the following places:
 * Note: Some GATK Spark tools by default require the reference file to be in 2bit format (notably `BaseRecalibratorSpark`,`BQSRPipelineSpark` and `ReadsPipelineSpark`). You can convert your fasta to 2bit by using the `faToTwoBit` utility from [UCSC](http://hgdownload.soe.ucsc.edu/admin/exe/) - see also the [documentation for `faToTwoBit`](https://genome.ucsc.edu/goldenpath/help/blatSpec.html#faToTwoBitUsage).
 
 #### <a name="R">Using R to generate plots</a>
-Certain GATK tools may optionally generate plots if R is installed.  We recommend **R v3.1.3** if you want to produce plots.  If you are uninterested in plotting, R is still required by several of the unit tests.  Plotting is currently untested and should be viewed as a convenience rather than a primary output.
+Certain GATK tools may optionally generate plots if R is installed.  We recommend **R v3.2.5** if you want to produce plots.  If you are uninterested in plotting, R is still required by several of the unit tests.  Plotting is currently untested and should be viewed as a convenience rather than a primary output.
 
 R installation is not part of the gradle build.  See http://cran.r-project.org/ for general information on installing R for your system.
 * for ubuntu see these [ubuntu specific instructions](http://cran.r-project.org/bin/linux/ubuntu/README)


### PR DESCRIPTION
Matches what is in the docker image, now.  Also, 3.1.3 (previous version) is actually incompatible with the docker image (and probably some tools).