### PR TITLE
Added missing fullName for sequence dictionary in PlotModeledSegments.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.java
@@ -137,6 +137,7 @@ public final class PlotModeledSegments extends CommandLineProgram {
 
     @Argument(
             doc = PlottingUtils.SEQUENCE_DICTIONARY_DOC_STRING,
+            fullName = StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME,
             shortName = StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME
     )
     private File inputSequenceDictionaryFile;


### PR DESCRIPTION
See #4049.
  