### PR TITLE
Use Picard-style doc summaries when generating doc for Picard tools.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.help;
 
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
 import org.broadinstitute.barclay.help.DocWorkUnit;
 
@@ -36,4 +37,25 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      */
     @Override
     public String getTemplateName(final DocWorkUnit workUnit) { return GATK_FREEMARKER_TEMPLATE_NAME; }
+
+
+    /**
+     * Add any custom freemarker bindings discovered via custom javadoc tags. Subclasses can override this to
+     * provide additional custom bindings.
+     *
+     * @param currentWorkUnit the work unit for the feature being documented
+     */
+    @Override
+    protected void addCustomBindings(final DocWorkUnit currentWorkUnit) {
+        super.addCustomBindings(currentWorkUnit);
+
+        // Picard tools use the summary line for the long overview section, so extract that
+        // from Picard tools only, and put it in the freemarker map.
+        Class<?> toolClass = currentWorkUnit.getClazz();
+        if (picard.cmdline.CommandLineProgram.class.isAssignableFrom(toolClass)) {
+            final CommandLineProgramProperties clpProperties = currentWorkUnit.getCommandLineProperties();
+            currentWorkUnit.setProperty("picardsummary", clpProperties.summary());
+        }
+    }
+
 }

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -112,7 +112,11 @@
 			<h1>${name}</h1>
 		</#if>
 
-		<p class="lead">${summary}</p>
+		<#if picardsummary??>
+			<p>${picardsummary}</p>
+		<#else>
+			<p>${summary}</p>
+		</#if>
 
 		<#if group?? >
 			<h3>Category

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/DocumentationGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/DocumentationGenerationIntegrationTest.java
@@ -32,6 +32,8 @@ public class DocumentationGenerationIntegrationTest extends CommandLineProgramTe
             "org.broadinstitute.hellbender.tools.walkers.bqsr",
             "org.broadinstitute.hellbender.tools.walkers.vqsr",
             "org.broadinstitute.hellbender.tools.walkers.variantutils",
+            "picard.fingerprint",
+            "picard.analysis"
     };
 
     @Test


### PR DESCRIPTION
GATK tools use the tool javadoc for the summary details, but Picard tools rely on the summary line, so special-case Picard tools so the details aren't stranded.