### PR TITLE
update apache commons-io 2.4->2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     compile 'org.apache.commons:commons-math3:3.5'
     compile 'org.apache.commons:commons-collections4:4.1'
     compile 'org.apache.commons:commons-vfs2:2.0'
-    compile 'commons-io:commons-io:2.4'
+    compile 'commons-io:commons-io:2.5'
     compile 'org.reflections:reflections:0.9.10'
     compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:0.4.150727'
     compile 'it.unimi.dsi:fastutil:7.0.6'

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -18,6 +18,8 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -117,7 +119,7 @@ public final class IOUtils {
     public static File writeTempFile(String content, String prefix, String suffix, File directory) {
         try {
             File tempFile = absolute(File.createTempFile(prefix, suffix, directory));
-            FileUtils.writeStringToFile(tempFile, content);
+            FileUtils.writeStringToFile(tempFile, content, StandardCharsets.UTF_8);
             return tempFile;
         } catch (IOException e) {
             throw new UserException.BadTmpDir(e.getMessage());

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
@@ -68,7 +69,7 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
         }
         Assert.assertTrue(md5File.exists(), md5File + " does not exist");
         final String expectedMD5 = Utils.calculateFileMD5(outFile);
-        final String actualMD5 = FileUtils.readFileToString(md5File);
+        final String actualMD5 = FileUtils.readFileToString(md5File, StandardCharsets.UTF_8);
         Assert.assertEquals(actualMD5, expectedMD5);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 public class PathSeqPipelineSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -76,8 +77,8 @@ public class PathSeqPipelineSparkIntegrationTest extends CommandLineProgramTest 
 
         SamAssertionUtils.assertEqualBamFiles(outputBamFile, expectedBamFile, true, ValidationStringency.STRICT);
 
-        String expectedScoreString = FileUtils.readFileToString(expectedScoresFile);
-        String actualScoresString = FileUtils.readFileToString(outputScoresFile);
+        String expectedScoreString = FileUtils.readFileToString(expectedScoresFile, StandardCharsets.UTF_8);
+        String actualScoresString = FileUtils.readFileToString(outputScoresFile, StandardCharsets.UTF_8);
         PathSeqScoreIntegrationTest.compareScoreTables(expectedScoreString, actualScoresString);
 
         Assert.assertTrue(MetricsFile.areMetricsEqual(outputFilterMetricsFile, expectedFilterMetricsFile));

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreIntegrationTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,8 +115,8 @@ public class PathSeqScoreIntegrationTest extends CommandLineProgramTest {
 
         this.runCommandLine(args.getArgsArray());
 
-        final String expectedScoresString = FileUtils.readFileToString(expectedScoresFile);
-        final String actualScoresString = FileUtils.readFileToString(outputScoresFile);
+        final String expectedScoresString = FileUtils.readFileToString(expectedScoresFile, StandardCharsets.UTF_8);
+        final String actualScoresString = FileUtils.readFileToString(outputScoresFile, StandardCharsets.UTF_8);
         compareScoreTables(expectedScoresString, actualScoresString);
 
         Assert.assertTrue(MetricsFile.areMetricsEqual(outputMetricsFile, expectedMetricsFile));

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSparkIntegrationTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 public final class CountBasesSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -39,7 +40,7 @@ public final class CountBasesSparkIntegrationTest extends CommandLineProgramTest
         }
         this.runCommandLine(args.getArgsArray());
 
-        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
+        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile(), StandardCharsets.UTF_8);
         Assert.assertEquals((int) Integer.valueOf(readIn), expectedCount);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -44,7 +45,7 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
             args.addReference(REF);
         }
         this.runCommandLine(args.getArgsArray());
-        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
+        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile(), StandardCharsets.UTF_8);
         Assert.assertEquals((long)Long.valueOf(readIn), expectedCount);
     }
 
@@ -57,7 +58,7 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
         args.addOutput(outputTxt);
         this.runCommandLine(args.getArgsArray());
 
-        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
+        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile(), StandardCharsets.UTF_8);
         Assert.assertEquals((int)Integer.valueOf(readIn), 8);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSparkIntegrationTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 public final class CountVariantsSparkIntegrationTest extends CommandLineProgramTest {
 
@@ -28,7 +29,7 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
         args.addOutput(outputTxt);
         this.runCommandLine(args.getArgsArray());
 
-        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
+        final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile(), StandardCharsets.UTF_8);
         Assert.assertEquals((int)Integer.valueOf(readIn), expected);
     }
 
@@ -78,7 +79,7 @@ public final class CountVariantsSparkIntegrationTest extends CommandLineProgramT
 
             this.runCommandLine(args.getArgsArray());
 
-            final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile());
+            final String readIn = FileUtils.readFileToString(outputTxt.getAbsoluteFile(), StandardCharsets.UTF_8);
             Assert.assertEquals((int)Integer.valueOf(readIn), expected);
             String errString = baosErr.toString();
             Assert.assertFalse(errString.contains("Warning: using GzipCodec, which is not splittable,"), errString);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -559,7 +560,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
         IntegrationTestSpec.assertEqualTextFiles(metricsFile, expectedMetrics, "#"); //this compares the values but not headers
 
         //Note: headers need to be compares not by exact values because they include times and class names
-        final List<String> lines = FileUtils.readLines(metricsFile);
+        final List<String> lines = FileUtils.readLines(metricsFile, StandardCharsets.UTF_8);
         Assert.assertTrue(lines.get(0).startsWith("##"), lines.get(0));
         Assert.assertTrue(lines.get(1).startsWith("#"), lines.get(1));
         Assert.assertTrue(lines.get(1).toLowerCase().contains("--input"), lines.get(1));  //Note: lowercase because picard uses INPUT and GATK uses input for full name

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -15,6 +15,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -349,7 +350,7 @@ public final class UtilsUnitTest extends GATKBaseTest {
         final byte[] sourceBytes = IOUtils.readFileIntoByteArray(source);
         Assert.assertEquals(Utils.calcMD5(sourceBytes), sourceMD5);
 
-        final String sourceString = FileUtils.readFileToString(source);
+        final String sourceString = FileUtils.readFileToString(source, StandardCharsets.UTF_8);
         Assert.assertEquals(Utils.calcMD5(sourceString), sourceMD5);
 
         Assert.assertEquals(Utils.calculateFileMD5(source), sourceMD5);

--- a/src/test/java/org/broadinstitute/hellbender/utils/mcmc/GibbsSamplerCopyRatioUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/mcmc/GibbsSamplerCopyRatioUnitTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -92,7 +93,7 @@ public final class GibbsSamplerCopyRatioUnitTest extends GATKBaseTest {
     //Loads test data from file
     private static <T> List<T> loadList(final File file, final Function<String, T> parse) {
         try {
-            return FileUtils.readLines(file).stream().map(parse).collect(Collectors.toList());
+            return FileUtils.readLines(file, StandardCharsets.UTF_8).stream().map(parse).collect(Collectors.toList());
         } catch (final IOException e) {
             throw new UserException.CouldNotReadInputFile(file, e);
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -159,7 +160,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
             String fileString, bufferString;
 
-            fileString = FileUtils.readFileToString(outFile);
+            fileString = FileUtils.readFileToString(outFile, StandardCharsets.UTF_8);
             Assert.assertTrue(fileString.length() > 0, "Out file was length 0");
 
             bufferString = result.getStdout().getBufferString();
@@ -168,7 +169,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
             Assert.assertFalse(result.getStdout().isBufferTruncated(), "Out buffer was truncated");
             Assert.assertEquals(bufferString.length(), fileString.length(), "Out buffer length did not match file length");
 
-            fileString = FileUtils.readFileToString(errFile);
+            fileString = FileUtils.readFileToString(errFile, StandardCharsets.UTF_8);
             Assert.assertEquals(fileString, "", "Unexpected output to err file");
 
             bufferString = result.getStderr().getBufferString();
@@ -201,7 +202,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
             String fileString, bufferString;
 
-            fileString = FileUtils.readFileToString(errFile);
+            fileString = FileUtils.readFileToString(errFile, StandardCharsets.UTF_8);
             Assert.assertTrue(fileString.length() > 0, "Err file was length 0");
 
             bufferString = result.getStderr().getBufferString();
@@ -210,7 +211,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
             Assert.assertFalse(result.getStderr().isBufferTruncated(), "Err buffer was truncated");
             Assert.assertEquals(bufferString.length(), fileString.length(), "Err buffer length did not match file length");
 
-            fileString = FileUtils.readFileToString(outFile);
+            fileString = FileUtils.readFileToString(outFile, StandardCharsets.UTF_8);
             Assert.assertEquals(fileString, "", "Unexpected output to out file");
 
             bufferString = result.getStdout().getBufferString();
@@ -310,7 +311,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
             if (script.output != null) {
 
-                String fileString = FileUtils.readFileToString(outputFile);
+                String fileString = FileUtils.readFileToString(outputFile, StandardCharsets.UTF_8);
                 Assert.assertEquals(fileString, script.output,
                         String.format("Output file didn't match (%d vs %d): %s",
                                 fileString.length(), script.output.length(), script));
@@ -378,7 +379,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
             if (script.output != null) {
 
-                String fileString = FileUtils.readFileToString(outputFile);
+                String fileString = FileUtils.readFileToString(outputFile, StandardCharsets.UTF_8);
                 Assert.assertEquals(fileString, script.output,
                         String.format("Output file didn't match (%d vs %d): %s",
                                 fileString.length(), script.output.length(), script));
@@ -411,7 +412,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
     private static File writeScript(String contents) {
         try {
             File file = GATKBaseTest.createTempFile("temp", "");
-            FileUtils.writeStringToFile(file, contents);
+            FileUtils.writeStringToFile(file, contents, StandardCharsets.UTF_8);
             return file;
         } catch (IOException e) {
             throw new UserException.BadTmpDir(e.getMessage());


### PR DESCRIPTION
this bring our version of commons-io from 2.4 -> 2.5 and removes use of
deprecated functions

it unblocks updating the adam version which relies on commons 2.5
unblocks #4044 