### PR TITLE
updating some of our libraries to 1.0+ versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
     compile 'org.nd4j:nd4j-native-platform:0.5.0'
     compile 'org.nd4j:nd4j-kryo_2.11:0.5.0'
-    compile 'org.broadinstitute:gatk-native-bindings:0.1.0-rc-1'
+    compile 'org.broadinstitute:gatk-native-bindings:1.0.0'
 
     compile 'org.ojalgo:ojalgo:44.0.0'
     compile ('org.ojalgo:ojalgo-commons-math3:1.0.0') {
@@ -243,8 +243,8 @@ dependencies {
         exclude module: 'htsjdk'
     }
 
-    compile 'org.broadinstitute:gatk-bwamem-jni:1.0.3'
-    compile 'org.broadinstitute:gatk-fermilite-jni:1.0.0-rc6'
+    compile 'org.broadinstitute:gatk-bwamem-jni:1.0.4'
+    compile 'org.broadinstitute:gatk-fermilite-jni:1.1.0'
 
     // Required for COSMIC Funcotator data source:
     compile 'org.xerial:sqlite-jdbc:3.20.1'


### PR DESCRIPTION
* gatk-native-bindings
	0.1.0-rc1 -> 1.0.0
	these versions are identical
* gatk-bwamem-jni
	1.0.3 -> 1.0.4
	this includes a new method to get the name of the default image	file
* gatk-fermilite-jni
	1.0.0-rc6 -> 1.1.0
	these versions should be identical, the rc6 tag is missing from the repo so it's hard to be perfectly sure though
	it's going to 1.1.0 because we already have a 1.0.0 version ofmysterious provenance in central

closes #4030