### PR TITLE
Adding in new, better documentation for Funcotator.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceContext.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.engine;
 
+import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.ReferenceSequence;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -347,6 +349,12 @@ public final class ReferenceContext implements Iterable<Byte> {
      * @return The end, potentially trimmed to the contig's length
      */
     private int trimToContigLength(final String contig, final int end){
+
+        final SAMSequenceRecord sequence = dataSource.getSequenceDictionary().getSequence(contig);
+        if ( sequence == null ) {
+            throw new UserException("Given reference file does not have data at the requested contig(" + contig + ")!");
+        }
+
         final int sequenceLength = dataSource.getSequenceDictionary().getSequence(contig).getSequenceLength();
         return Math.min(end, sequenceLength);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -6,7 +6,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -201,7 +201,7 @@ import java.util.stream.Collectors;
         programGroup = VariantProgramGroup.class
 )
 @DocumentedFeature
-@ExperimentalFeature
+@BetaFeature
 public class Funcotator extends VariantWalker {
     private static final Logger logger = LogManager.getLogger(Funcotator.class);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -32,15 +32,170 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Funcotator (FUNCtional annOTATOR) performs functional analysis on given variants
- * and reports output in a specified output file.
+ * Funcotator (FUNCtional annOTATOR) analyzes given variants for their function (as retrieved from a set of data sources) and produces the analysis in a specified output file.
  *
- * This tool is the GATK analog of the Oncotator.
+ * <p>
+ *     This tool is a functional annotation tool that allows a user to add annotations to called variants based on a set of data sources, each with its own matching criteria.
+ *     Data sources are expected to be in folders that are specified as input arguments.  While multiple data source folders can be specified, <b>no two data sources can have the same name</b>.
+ * </p>
+ * <h3>Data Source Folders</h3>
+ * <p>
+ *     In each main data source folder, there should be sub-directories for each individual data source, with further sub-directories for a specific reference (i.e. <i>hg19</i> or <i>hg38</i>).
+ *     In the reference-specific data source directory, there is a configuration file detailing information about the data source and how to match it to a variant.  This configuration file is required.
+ * </p>
+ * <p>
+ *     An example of a data source directory is the following:
  *
- * Created by jonn on 8/22/17.
+ *     <pre>
+ *         dataSourcesFolder/
+ *              Data_Source_1/
+ *                  hg19
+ *                      data_source_1.config
+ *                      data_source_1.data.file.one
+ *                      data_source_1.data.file.two
+ *                      data_source_1.data.file.three
+ *                      ...
+ *                   hg38
+ *                      data_source_1.config
+ *                      data_source_1.data.file.one
+ *                      data_source_1.data.file.two
+ *                      data_source_1.data.file.three
+ *                      ...
+ *              Data_Source_2/
+ *                  hg19
+ *                      data_source_2.config
+ *                      data_source_2.data.file.one
+ *                      data_source_2.data.file.two
+ *                      data_source_2.data.file.three
+ *                      ...
+ *                   hg38
+ *                      data_source_2.config
+ *                      data_source_2.data.file.one
+ *                      data_source_2.data.file.two
+ *                      data_source_2.data.file.three
+ *                      ...
+ *               ...
+ *     </pre>
+ *     <b>A gzip of data source files is provided here: <a href="ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/funcotator/">ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/funcotator/</a>.</b>
+ * </p>
+ * <h4>User-Defined Data Sources</h4>
+ * <p>
+ *     Users can define their own data sources by creating a new correctly-formatted data source sub-directory in the main data sources folder.  In this sub-directory, the user must create an additional folder for the reference for which the data source is valid.  If the data source is valid for multiple references, then multiple reference folders should be created.
+ *     Inside each reference folder, the user should place the file(s) containing the data for the data source.  Additionally the user <b>must</b> create a configuration file containing metadata about the data source.
+ * </p>
+ * <p>
+ *     There are several formats allowed for data sources, however the two most useful are arbitrarily separated value (XSV) files, such as comma-separated value (CSV), tab-separated value (TSV).  These files contain a table of data that can be matched to a variant by <i>gene name</i>, <i>transcript ID</i>, or <i>genome position</i>.
+ *     In the case of <i>gene name</i> and <i>transcript ID</i>, one column must contain the <i>gene name</i> or <i>transcript ID</i> for each row's data.
+ *     <ul>
+ *         <li>For <i>gene name</i>, when a variant is annotated with a gene name that <i>exactly matches</i> an entry in the gene name column for a row, that row's other fields will be added as annotations to the variant.</li>
+ *         <li>For <i>transcript ID</i>, when a variant is annotated with a transcript ID that <i>exactly matches</i> an entry in the transcript ID column for a row, that row's other fields will be added as annotations to the variant.</li>
+ *         <li>For <i>genome position</i>, one column must contain the contig ID, another column must contain the start position (1-based, inclusive), and a column must contain the stop position (1-based, inclusive).  The start and stop columns may be the same column.  When a variant is annotated with a genome position that <i>overlaps</i> an entry in the three genome position columns for a row, that row's other fields will be added as annotations to the variant.</li>
+ *     </ul>
+ * </p>
+ * <h4>Configuration File Format</h4>
+ * <p>
+ *     The configuration file is a standard Java properties-style configuration file with key-value pairs.  This file name <b>must end in .config</b>.
+ * </p>
+ * <p>
+ *     The following is an example of a genome position XSV configuration file (for the ORegAnno data source):
+ *     <pre>
+ *         name = Oreganno
+ *         version = 20160119
+ *         src_file = oreganno.tsv
+ *         origin_location = http://www.oreganno.org/dump/ORegAnno_Combined_2016.01.19.tsv
+ *         preprocessing_script = getOreganno.py
+ *
+ *         # Supported types:
+ *         # simpleXSV    -- Arbitrary separated value table (e.g. CSV), keyed off Gene Name OR Transcript ID
+ *         # locatableXSV -- Arbitrary separated value table (e.g. CSV), keyed off a genome location
+ *         # gencode      -- Custom datasource class for GENCODE
+ *         # cosmic       -- Custom datasource class for COSMIC
+ *         type = locatableXSV
+ *
+ *         # Required field for GENCODE files.
+ *         # Path to the FASTA file from which to load the sequences for GENCODE transcripts:
+ *         gencode_fasta_path =
+ *
+ *         # Required field for simpleXSV files.
+ *         # Valid values:
+ *         #     GENE_NAME
+ *         #     TRANSCRIPT_ID
+ *         xsv_key =
+ *
+ *         # Required field for simpleXSV files.
+ *         # The 0-based index of the column containing the key on which to match
+ *         xsv_key_column =
+ *
+ *         # Required field for simpleXSV AND locatableXSV files.
+ *         # The delimiter by which to split the XSV file into columns.
+ *         xsv_delimiter = \t
+ *
+ *         # Required field for simpleXSV files.
+ *         # Whether to permissively match the number of columns in the header and data rows
+ *         # Valid values:
+ *         #     true
+ *         #     false
+ *         xsv_permissive_cols = true
+ *
+ *         # Required field for locatableXSV files.
+ *         # The 0-based index of the column containing the contig for each row
+ *         contig_column = 1
+ *
+ *         # Required field for locatableXSV files.
+ *         # The 0-based index of the column containing the start position for each row
+ *         start_column = 2
+ *
+ *         # Required field for locatableXSV files.
+ *         # The 0-based index of the column containing the end position for each row
+ *         end_column = 3
+ *     </pre>
+ * </p>
+ *
+ * <h3>Inputs</h3>
+ * <ul>
+ *     <li>A reference genome sequence.</li>
+ *     <li>The version of the reference genome sequence being used (either <i>hg19</i> or <i>hg38</i>).</li>
+ *     <li>A VCF of variant calls to annotate.</li>
+ *     <li>The path to a folder of data sources formatted for use by Funcotator.</li>
+ * </ul>
+ *
+ * <h3>Output</h3>
+ * <ul>
+ *     <li>A VCF containing all variants from the input file with added annotation columns corresponding to annotations from each data source that matched a given variant according to that data source's matching criteria.</li>
+ * </ul>
+ *
+ * <h3>Usage example</h3>
+ * <pre>
+ *   ./gatk Funcotator \
+ *   -R reference.fasta \
+ *   -V input.vcf \
+ *   -O output.vcf \
+ *   --data-sources-path dataSourcesFolder/ \
+ *   --ref-version hg19
+ * </pre>
+ *
+ * <h3>Notes</h3>
+ * <ul>
+ *     <li>This is a beta tool, and as such may generate errors or warnings.</li>
+ *     <li>This tool is the GATK analog of <a href="http://portals.broadinstitute.org/oncotator/">Oncotator</a>.</li>
+ * </ul>
+ *
+ * <h3>Known Issues</h3>
+ * <p>A complete list of known open issues can be found on <a href="https://github.com/broadinstitute/gatk/issues?q=is%3Aopen+is%3Aissue+label%3AFuncotator">the GATK github entry for funcotator here.</a></p>
+ *
+ * <h4>Notable Issues as of 2018 Jan 3</h4>
+ * <ul>
+ *     <li>Only supports VCF for inputs and outputs (<a href="https://github.com/broadinstitute/gatk/issues/3922">Issue 3922</a>).</li>
+ *     <li>Only supports a single GENCODE data source (<a href="https://github.com/broadinstitute/gatk/issues/3956">Issue 3956</a>).</li>
+ *     <li>Non-GENCODE annotations on multiallelic variants are only rendered properly for the last allele (<a href="https://github.com/broadinstitute/gatk/issues/3896">Issue 3896</a>).</li>
+ *     <li>The "other transcripts" annotation is missing for IGR variants (<a href="https://github.com/broadinstitute/gatk/issues/3849">Issue 3849</a>).</li>
+ *     <li>Only the "Format" field of input VCF files is preserved in the output VCF file (<a href="https://github.com/broadinstitute/gatk/issues/3895">Issue 3895</a>).</li>
+ *     <li>Codon Change and Protein Change for indels spanning splice sites are not properly rendered (<a href="https://github.com/broadinstitute/gatk/issues/3749">Issue 3749</a>).</li>
+ * </ul>
+ *
  */
 @CommandLineProgramProperties(
-        summary = "Create functional annotations on given variants cross-referenced by a given database.\n" +
+        summary = "Create functional annotations on given variants cross-referenced by a given set of data sources.\n" +
                 "A GATK version of the Oncotator.",
         oneLineSummary = "Functional Annotator",
         programGroup = VariantProgramGroup.class
@@ -62,18 +217,18 @@ public class Funcotator extends VariantWalker {
     @Argument(
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName  = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
-            doc = "Output VCF File.")
+            doc = "Output VCF file to which annotated variants should be written.")
     protected File outputFile;
 
     @Argument(
             fullName =  FuncotatorArgumentDefinitions.REFERENCE_VERSION_LONG_NAME,
-            doc = "The version of the Human Genome reference to use (hg19 or Hhg38)."
+            doc = "The version of the Human Genome reference to use (either hg19 or hg38)."
     )
     protected FuncotatorArgumentDefinitions.ReferenceVersionType referenceVersion;
 
     @Argument(
             fullName =  FuncotatorArgumentDefinitions.DATA_SOURCES_PATH_LONG_NAME,
-            doc = "The paths to any datasource directories for Funcotator."
+            doc = "The path to a data source folder for Funcotator.  May be specified more than once to handle multiple data source folders."
     )
     protected List<String> dataSourceDirectories;
 
@@ -83,28 +238,28 @@ public class Funcotator extends VariantWalker {
     @Argument(
             fullName  = FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_LONG_NAME,
             optional = true,
-            doc = "Method of detailed transcript selection."
+            doc = "Method of detailed transcript selection.  This will select the transcript for detailed annotation (CANONICAL or BEST_EFFECT)."
     )
     protected FuncotatorArgumentDefinitions.TranscriptSelectionMode transcriptSelectionMode = FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE;
 
     @Argument(
             fullName  = FuncotatorArgumentDefinitions.TRANSCRIPT_LIST_LONG_NAME,
             optional = true,
-            doc = "List of transcripts to use for annotation to override selected transcript."
+            doc = "Set of transcripts to use for annotation to override selected transcript."
     )
     protected Set<String> transcriptList = FuncotatorArgumentDefinitions.TRANSCRIPT_LIST_DEFAULT_VALUE;
 
     @Argument(
             fullName  = FuncotatorArgumentDefinitions.ANNOTATION_DEFAULTS_LONG_NAME,
             optional = true,
-            doc = "Default values for annotations that are not added (in the format <ANNOTATION>:<VALUE>)"
+            doc = "Annotations to include in all annotated variants if the annotation is not specified in the data sources (in the format <ANNOTATION>:<VALUE>).  This will add the specified annotation to every annotated variant if it is not already present."
     )
     protected List<String> annotationDefaults = FuncotatorArgumentDefinitions.ANNOTATION_DEFAULTS_DEFAULT_VALUE;
 
     @Argument(
             fullName  = FuncotatorArgumentDefinitions.ANNOTATION_OVERRIDES_LONG_NAME,
             optional = true,
-            doc = "Override values for annotations.  Replaces existing matchihng annotations with given values (in the format <ANNOTATION>:<VALUE>)"
+            doc = "Override values for annotations (in the format <ANNOTATION>:<VALUE>).  Replaces existing annotations of the given name with given values."
     )
     protected List<String> annotationOverrides = FuncotatorArgumentDefinitions.ANNOTATION_OVERRIDES_DEFAULT_VALUE;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -191,6 +191,7 @@ import java.util.stream.Collectors;
  *     <li>The "other transcripts" annotation is missing for IGR variants (<a href="https://github.com/broadinstitute/gatk/issues/3849">Issue 3849</a>).</li>
  *     <li>Only the "Format" field of input VCF files is preserved in the output VCF file (<a href="https://github.com/broadinstitute/gatk/issues/3895">Issue 3895</a>).</li>
  *     <li>Codon Change and Protein Change for indels spanning splice sites are not properly rendered (<a href="https://github.com/broadinstitute/gatk/issues/3749">Issue 3749</a>).</li>
+ *     <li>Does not support Structural Variants (<a href="https://github.com/broadinstitute/gatk/issues/4083">Issue 4083</a>).</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -196,7 +196,7 @@ import java.util.stream.Collectors;
  */
 @CommandLineProgramProperties(
         summary = "Create functional annotations on given variants cross-referenced by a given set of data sources.\n" +
-                "A GATK version of the Oncotator.",
+                "A GATK functional annotation tool (similar functionality to Oncotator).",
         oneLineSummary = "Functional Annotator",
         programGroup = VariantProgramGroup.class
 )

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -16,14 +16,14 @@ public class FuncotatorArgumentDefinitions {
     // ------------------------------------------------------------
     // Definitions for required arguments:
 
-    public static final String REFERENCE_VERSION_LONG_NAME = "refVersion";
+    public static final String REFERENCE_VERSION_LONG_NAME = "ref-version";
 
-    public static final String DATA_SOURCES_PATH_LONG_NAME = "dataSourcesPath";
+    public static final String DATA_SOURCES_PATH_LONG_NAME = "data-sources-path";
 
     // ------------------------------------------------------------
     // Definitions for optional arguments:
 
-    public static final String TRANSCRIPT_SELECTION_MODE_LONG_NAME = "transcriptSelectionMode";
+    public static final String TRANSCRIPT_SELECTION_MODE_LONG_NAME = "transcript-selection-mode";
     public static final TranscriptSelectionMode TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE = TranscriptSelectionMode.CANONICAL;
 
     public static final String TRANSCRIPT_LIST_LONG_NAME = "transcript-list";
@@ -46,6 +46,9 @@ public class FuncotatorArgumentDefinitions {
 
         /**
          * BEST_EFFECT
+         *
+         * Select a transcript to be reported with details with priority on effect according to the folowing list of selection criteria:
+         *
          * Choose the transcript that is on the custom list specified by the user. If no list was specified, treat as if no transcripts were on the list (tie).
          * In case of tie, choose the transcript that yields the variant classification highest on the variant classification rank list (see below).
          * If still a tie, choose the transcript with highest level of curation. Note that this means lower number is better for level (see below).
@@ -115,6 +118,9 @@ public class FuncotatorArgumentDefinitions {
 
         /**
          * CANONICAL
+         *
+         * Select a transcript to be reported with details with priority on canonical order according to the folowing list of selection criteria:
+         *
          * Choose the transcript that is on the custom list specified by the user. If no list was specified, treat as if all transcripts were on the list (tie).
          * In case of tie, choose the transcript with highest level of curation. Note that this means lower number is better for level (see below).
          * If still a tie, choose the transcript that yields the variant classification highest on the variant classification rank list (see below).

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -1571,6 +1571,7 @@ public final class FuncotatorUtils {
      * @param strand The {@link Strand} from which the exons are to be read.  Must not be {@code null}.  Must not be {@link Strand#NONE}.
      * @return A string of bases for the given {@code exonList} concatenated together.
      */
+    @Deprecated // Deprecated until fixed!
     public static String getCodingSequence(final ReferenceContext reference, final List<? extends Locatable> exonList, final Strand strand) {
 
         // TODO: Fix this - it's broken (and re-enable the tests).

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -928,12 +928,12 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
             final List<Locatable> activeRegions = Collections.singletonList(utr);
 
             final String referenceCodingSequence;
-            if ( transcriptFastaReferenceDataSource != null ) {
+            //if ( transcriptFastaReferenceDataSource != null ) {
                 referenceCodingSequence = getCodingSequenceFromTranscriptFasta( transcript.getTranscriptId(), transcriptIdMap, transcriptFastaReferenceDataSource);
-            }
-            else {
-                referenceCodingSequence = FuncotatorUtils.getCodingSequence(reference, activeRegions, strand);
-            }
+            //}
+            //else {
+            //    referenceCodingSequence = FuncotatorUtils.getCodingSequence(reference, activeRegions, strand);
+            //}
 
             final int codingStartPos = FuncotatorUtils.getStartPositionInTranscript(variant, activeRegions, strand);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -927,13 +927,8 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
             // Get our coding sequence for this region:
             final List<Locatable> activeRegions = Collections.singletonList(utr);
 
-            final String referenceCodingSequence;
-            //if ( transcriptFastaReferenceDataSource != null ) {
-                referenceCodingSequence = getCodingSequenceFromTranscriptFasta( transcript.getTranscriptId(), transcriptIdMap, transcriptFastaReferenceDataSource);
-            //}
-            //else {
-            //    referenceCodingSequence = FuncotatorUtils.getCodingSequence(reference, activeRegions, strand);
-            //}
+            final String referenceCodingSequence =
+                    getCodingSequenceFromTranscriptFasta( transcript.getTranscriptId(), transcriptIdMap, transcriptFastaReferenceDataSource);
 
             final int codingStartPos = FuncotatorUtils.getStartPositionInTranscript(variant, activeRegions, strand);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -63,6 +63,28 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
         runCommandLine(arguments);
     }
 
+//    @Test()
+//    public void spotCheck() throws IOException {
+//
+//        final File outputFile = createTempFile("funcotator_tmp_out", ".vcf");
+//        final List<String> arguments = new ArrayList<>();
+//
+//        arguments.add("-" + StandardArgumentDefinitions.VARIANT_SHORT_NAME);
+//        arguments.add("/Users/jonn/Development/oncotator_testing/BENCHMARK_INPUT.funcotator.vcf");
+//
+//        arguments.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME);
+//        arguments.add("/Users/jonn/Development/references/GRCh37.p13.genome.fasta");
+//
+//        arguments.add("--" + FuncotatorArgumentDefinitions.DATA_SOURCES_PATH_LONG_NAME);
+//        arguments.add(FuncotatorTestConstants.FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER);
+//        arguments.add("--" + FuncotatorArgumentDefinitions.REFERENCE_VERSION_LONG_NAME);
+//        arguments.add(FuncotatorArgumentDefinitions.ReferenceVersionType.hg19.toString());
+//        arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
+//        arguments.add(outputFile.getAbsolutePath());
+//
+//        runCommandLine(arguments);
+//    }
+
     @Test(dataProvider = "provideForIntegrationTest")
     public void exhaustiveArgumentTest(final String dataSourcesPath,
                                        final FuncotatorArgumentDefinitions.ReferenceVersionType refVer,

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -63,27 +63,27 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
         runCommandLine(arguments);
     }
 
-//    @Test()
-//    public void spotCheck() throws IOException {
-//
-//        final File outputFile = createTempFile("funcotator_tmp_out", ".vcf");
-//        final List<String> arguments = new ArrayList<>();
-//
-//        arguments.add("-" + StandardArgumentDefinitions.VARIANT_SHORT_NAME);
-//        arguments.add("/Users/jonn/Development/oncotator_testing/BENCHMARK_INPUT.funcotator.vcf");
-//
-//        arguments.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME);
-//        arguments.add("/Users/jonn/Development/references/GRCh37.p13.genome.fasta");
-//
-//        arguments.add("--" + FuncotatorArgumentDefinitions.DATA_SOURCES_PATH_LONG_NAME);
-//        arguments.add(FuncotatorTestConstants.FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER);
-//        arguments.add("--" + FuncotatorArgumentDefinitions.REFERENCE_VERSION_LONG_NAME);
-//        arguments.add(FuncotatorArgumentDefinitions.ReferenceVersionType.hg19.toString());
-//        arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
-//        arguments.add(outputFile.getAbsolutePath());
-//
-//        runCommandLine(arguments);
-//    }
+    @Test(enabled = false)
+    public void spotCheck() throws IOException {
+
+        final File outputFile = createTempFile("funcotator_tmp_out", ".vcf");
+        final List<String> arguments = new ArrayList<>();
+
+        arguments.add("-" + StandardArgumentDefinitions.VARIANT_SHORT_NAME);
+        arguments.add("/Users/jonn/Development/oncotator_testing/BENCHMARK_INPUT.funcotator.vcf");
+
+        arguments.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME);
+        arguments.add("/Users/jonn/Development/references/GRCh37.p13.genome.fasta");
+
+        arguments.add("--" + FuncotatorArgumentDefinitions.DATA_SOURCES_PATH_LONG_NAME);
+        arguments.add(FuncotatorTestConstants.FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER);
+        arguments.add("--" + FuncotatorArgumentDefinitions.REFERENCE_VERSION_LONG_NAME);
+        arguments.add(FuncotatorArgumentDefinitions.ReferenceVersionType.hg19.toString());
+        arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
+        arguments.add(outputFile.getAbsolutePath());
+
+        runCommandLine(arguments);
+    }
 
     @Test(dataProvider = "provideForIntegrationTest")
     public void exhaustiveArgumentTest(final String dataSourcesPath,


### PR DESCRIPTION
- Deprecated FuncotatorUtils.getCodingSequence (until its fixed).
- Added a more descriptive error message when the reference does not contain sequence information for a given position.
- Fixed all args to be kabob case.
- Fixed high-level Funcotator documentation.

Fixes #4021 
  