### PR TITLE
updating to use our google-cloud-nio build from central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     // Using the shaded version to avoid conflicts between its protobuf dependency
     // and that of Hadoop/Spark (either the one we reference explicitly, or the one
     // provided by dataproc).
-    compile 'com.google.cloud:google-cloud-nio:0.20.4-alpha-20171031.194208-5:shaded'
+    compile 'org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.4-alpha-GCS-RETRY-FIX:shaded'
 
     compile 'com.google.cloud.genomics:gatk-tools-java:1.1'
     // this comes built-in when running on Google Dataproc, but the library


### PR DESCRIPTION
`com.google.cloud:google-cloud-nio:0.20.4-alpha-20171031.194208-5:shaded` -> `org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.4-alpha-GCS-RETRY-FIX:shaded`
This artifact should be functionally identical to our previous artifact but it's hosted in maven central instead of our artifactory.

closes  #4008