### PR TITLE
build_docker.sh: don't rebuild the image when tagging latest

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -138,7 +138,7 @@ if [ -n "${IS_PUSH}" ]; then
 
 	if [ -z "${IS_NOT_LATEST}" ] && [ -z "${IS_HASH}" ] ; then
 		echo "Updating latest tag in ${REPO_PRJ}"
-		docker build -t ${REPO_PRJ}:latest .
+		docker tag ${REPO_PRJ}:${GITHUB_TAG} ${REPO_PRJ}:latest
 		docker push ${REPO_PRJ}:latest
 		
 		echo "Updating latest tag in ${GCR_REPO}"


### PR DESCRIPTION
This fixes an issue in build_docker.sh where the script was
rebuilding the image from scratch when creating the "latest"
tag.