### PR TITLE
Remove -SNAPSHOT from online doc name.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -548,7 +548,7 @@ task gatkDoc(type: Javadoc, dependsOn: classes) {
         options.addStringOption("output-file-extension", phpExtension)
         options.addStringOption("index-file-extension", phpExtension)
     }
-    options.addStringOption("absolute-version", getVersion())
+    options.addStringOption("absolute-version", gitVersion().replaceAll("-SNAPSHOT", "").replaceAll(".dirty", ""))
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
 }
 


### PR DESCRIPTION
This retains the commit hash and commit number delta part in the version.