### PR TITLE
Sh sv cluster image ver upgrade and custom name

### DIFF
--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -94,7 +94,7 @@ gcloud beta dataproc clusters create ${CLUSTER_NAME} \
     --num-worker-local-ssds 1 \
     --metadata "reference=$REF_DIR" \
     --metadata "sample=$SAMP_DIR" \
-    --image-version 1.1 \
+    --image-version 1.2 \
     --project ${PROJECT} \
     --initialization-actions ${INIT_ACTION} \
     --initialization-action-timeout 10m \


### PR DESCRIPTION
does two small things:
1. bump the image version so that we don't get the annoying "org.bdgenomics.adam.serialization.ADAMKryoRegistrator: Did not find Spark internal class. This is expected for Spark 1." message
2. name of cluster created with manage_sv_pipeline.sh now post-fixed with "master" or "feature" depending on if running master or a feature branch.

@TedBrookings can you please review? 
