### PR TITLE
prevent log message from triggering incorrectly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -474,10 +474,11 @@ task bundle(type: Zip) {
 task createPythonPackageArchive(type: Zip) {
 
     doFirst {
+        logger.lifecycle("Creating GATK Python package archive...")
         assert file("src/main/python/org/broadinstitute/hellbender/").exists()
     }
 
-    logger.lifecycle("Creating GATK Python package archive...")
+
     destinationDir file("$buildDir")
     archiveName "gatkPythonPackageArchive.zip"
     from("src/main/python/org/broadinstitute/hellbender/")


### PR DESCRIPTION
* moved a log message about creating the python bundle during build so it only triggers when the python bundle is actually being built
* previously it was emitted on every build