### PR TITLE
re-add GenomicsDBImport test that was deleted

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -351,7 +351,7 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
         final File workspace = new File(noheader);
         final File callsetJson = new File(noheader, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME);
         final File vidmapJson = new File(noheader, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME);
-	final File vcfHeader = new File(noheader, GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME);
+        final File vcfHeader = new File(noheader, GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME);
 
         if ( ! workspace.exists() || ! workspace.canRead() || ! workspace.isDirectory() ) {
             throw new UserException("GenomicsDB workspace " + workspace.getAbsolutePath() + " does not exist, " +
@@ -361,7 +361,7 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
         try {
             IOUtils.canReadFile(callsetJson);
             IOUtils.canReadFile(vidmapJson);
-	    IOUtils.canReadFile(vcfHeader);
+            IOUtils.canReadFile(vcfHeader);
         }
         catch ( UserException.CouldNotReadInputFile e ) {
             throw new UserException("Couldn't connect to GenomicsDB because the vidmap, callset JSON files, or gVCF Header (" +

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -339,12 +339,12 @@ public final class GenomicsDBImport extends GATKTool {
             sampleNameToVcfPath = loadSampleNameMapFileInSortedOrder(IOUtils.getPath(sampleNameMapFile));
             final Path firstHeaderPath = sampleNameToVcfPath.entrySet().iterator().next().getValue();
             final VCFHeader header = getHeaderFromPath(firstHeaderPath);
-	    //getMetaDataInInputOrder() returns an ImmutableSet - LinkedHashSet is mutable and preserves ordering
+            //getMetaDataInInputOrder() returns an ImmutableSet - LinkedHashSet is mutable and preserves ordering
             mergedHeaderLines = new LinkedHashSet<VCFHeaderLine>(header.getMetaDataInInputOrder());
             mergedHeaderSequenceDictionary = header.getSequenceDictionary();
         }
 
-	mergedHeaderLines.addAll(getDefaultToolVCFHeaderLines());
+        mergedHeaderLines.addAll(getDefaultToolVCFHeaderLines());
 
         if ( mergedHeaderSequenceDictionary == null) {
             throw new UserException("The merged vcf header has no sequence dictionary. Please provide a header that contains a sequence dictionary.");
@@ -449,11 +449,11 @@ public final class GenomicsDBImport extends GATKTool {
 
         vidMapJSONFile = new File(workspaceDir + "/" + GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME);
         callsetMapJSONFile = new File(workspaceDir + "/" + GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME);
-	vcfHeaderFile = new File(workspaceDir + "/" + GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME);
+        vcfHeaderFile = new File(workspaceDir + "/" + GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME);
 
         logger.info("Vid Map JSON file will be written to " + vidMapJSONFile);
         logger.info("Callset Map JSON file will be written to " + callsetMapJSONFile);
-	logger.info("Complete VCF Header will be written to " + vcfHeaderFile);
+        logger.info("Complete VCF Header will be written to " + vcfHeaderFile);
         logger.info("Importing to array - " + workspace + "/" + GenomicsDBConstants.DEFAULT_ARRAY_NAME);
 
         //Pass in true here to use the given ordering, since sampleNameToVcfPath is already sorted
@@ -499,8 +499,8 @@ public final class GenomicsDBImport extends GATKTool {
             final long variantContextBufferSize = vcfBufferSizePerSample * sampleToReaderMap.size();
             final GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
                     createImportConfiguration(workspace, GenomicsDBConstants.DEFAULT_ARRAY_NAME,
-                            GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME,variantContextBufferSize, segmentSize,
-                            i, (i+updatedBatchSize-1));
+                                              variantContextBufferSize, segmentSize,
+                                              i, (i+updatedBatchSize-1));
 
             try {
                 importer = new GenomicsDBImporter(sampleToReaderMap, mergedHeaderLines, intervals.get(0), validateSampleToReaderMap, importConfiguration);
@@ -539,7 +539,7 @@ public final class GenomicsDBImport extends GATKTool {
         } catch (final FileNotFoundException fe) {
             throw new UserException("Unable to write callset map JSON file " + callsetMapJSONFile.getAbsolutePath(), fe);
         }
-	try {
+        try {
             GenomicsDBImporter.writeVcfHeaderFile(vcfHeaderFile.getAbsolutePath(), mergedHeaderLines);
         } catch (final FileNotFoundException fe) {
             throw new UserException("Unable to write VCF Header file " + vcfHeaderFile.getAbsolutePath(), fe);
@@ -633,13 +633,12 @@ public final class GenomicsDBImport extends GATKTool {
      * @return  GenomicsDB import configuration object
      */
     private static GenomicsDBImportConfiguration.ImportConfiguration createImportConfiguration(
-        final String workspace,
-        final String arrayName,
-	final String vcfHeaderName,
-        final long variantContextBufferSize,
-        final long segmentSize,
-        final long lbSampleIndex,
-        final long ubSampleIndex) {
+            final String workspace,
+            final String arrayName,
+            final long variantContextBufferSize,
+            final long segmentSize,
+            final long lbSampleIndex,
+            final long ubSampleIndex) {
 
         final GenomicsDBImportConfiguration.Partition.Builder pBuilder =
             GenomicsDBImportConfiguration.Partition.newBuilder();

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -262,7 +262,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     private static void checkJSONFilesAreWritten(final String workspace) {
         Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_VIDMAP_FILE_NAME).exists());
         Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_CALLSETMAP_FILE_NAME).exists());
-	Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME).exists());
+        Assert.assertTrue(new File(workspace, GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME).exists());
     }
 
     private static void checkGenomicsDBAgainstExpected(final String workspace, final SimpleInterval interval, final String expectedCombinedVCF, final String referenceFile, final boolean testAll) throws IOException {
@@ -516,7 +516,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
         writeToGenomicsDB(vcfInputs, INTERVAL, workspace, 0, false, 0, 1);
         try(final GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
-	        getGenomicsDBFeatureReader(workspace, b38_reference_20_21))
+                    getGenomicsDBFeatureReader(workspace, b38_reference_20_21))
         {
             final VCFHeader header = (VCFHeader) genomicsDBFeatureReader.getHeader();
             final Optional<VCFHeaderLine> commandLineHeaderLine = header.getMetaDataInSortedOrder().stream()
@@ -537,7 +537,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
                           new SimpleInterval("chr20", 17959479, 17959479), workspace, 0, false, 0, 1);
 
         try ( final GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> genomicsDBFeatureReader =
-	        getGenomicsDBFeatureReader(workspace, b38_reference_20_21);
+                      getGenomicsDBFeatureReader(workspace, b38_reference_20_21);
 
              final AbstractFeatureReader<VariantContext, LineIterator> inputGVCFReader =
                       AbstractFeatureReader.getFeatureReader(GENOMICSDB_TEST_DIR + "testHeaderContigLineSorting1.g.vcf", new VCFCodec(), true);
@@ -597,5 +597,12 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     private static GenomicsDBFeatureReader<VariantContext, PositionalBufferedStream> getGenomicsDBFeatureReader(final String workspace, final String reference) throws IOException {
         return getGenomicsDBFeatureReader(workspace, reference, false);
+    }
+
+    @Test(expectedExceptions = GenomicsDBImport.UnableToCreateGenomicsDBWorkspace.class)
+    public void testYouCantWriteIntoAnExistingDirectory(){
+        // this actually creates the directory on disk, not just the file name.
+        final String workspace = createTempDir("workspace").getAbsolutePath();
+        writeToGenomicsDB(LOCAL_GVCFS, INTERVAL, workspace, 0, false, 0, 1);
     }
 }


### PR DESCRIPTION
* adding back GenomicDBImportIntegrationTest.testYouCantWriteIntoAnExistingDirectory that was accidentally deleted
* fixing spacing issues introduced in the same pr
* removing unused parameter from internal method