### PR TITLE
Use BED files as a way to resolve ambiguous queries.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenomeLocParser.java
@@ -351,8 +351,10 @@ public final class GenomeLocParser {
         } else if (allResolvedIntervals.size() > 1) {
             throw new UserException.MalformedGenomeLoc(
                     String.format(
-                            "Query interval is ambiguous and has multiple valid interpretations: %s. Please report this as a GATK issue.",
-                            allResolvedIntervals.stream().map(f -> f.toString()).collect(Collectors.joining(" and "))
+                            "The query interval \"%s\" is ambiguous and can be interpreted as a query against more than one contig: \"%s\". " +
+                                    "The ambiguity can be resolved by providing the interval in a BED file (using zero-based, half-open coordinates).",
+                            intervalQueryString,
+                            allResolvedIntervals.stream().map(f -> f.getContig()).collect(Collectors.joining(" or "))
                     ));
         } else {
             return allResolvedIntervals.get(0);

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
@@ -255,7 +255,10 @@ public final class FeatureDataSourceUnitTest extends GATKBaseTest {
             sd = vcfReader.getFileHeader().getSequenceDictionary();
         }
 
-        // Test that we can execute an unambiguous query using any hg38 contig name against a VCF with an hg38 sequence dictionary.
+        // Test that we can execute a query using any hg38 contig name against a VCF with an hg38 sequence dictionary.
+        // Since the query is provided as a SimpleInterval, no interval query parsing or disambiguation is executed by
+        // this code path, but GenomeLocParserUnitTest IntervalUtilsUnitTest have corresponding tests that ensures that
+        // no hg38 query can be ambiguous.
         try (final FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>(testFile)) {
             sd.getSequences().stream().forEach(
                     hg38Contig -> featureSource.query(new SimpleInterval(hg38Contig.getSequenceName(), 1, hg38Contig.getSequenceLength())));


### PR DESCRIPTION
Add a test that validates than an ambiguous interval query can be disambiguated by the user by providing the interval in a bed file; changes the error message to recommend this alternative; fixes an issue where the error message was displaying the entire interval query multiple times, rather than the specific contigs which make the query ambiguous.