### PR TITLE
Lots of updates to the Mutect2 wdl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,6 @@ before_install:
 - if [[ $RUN_CNV_GERMLINE_WDL == true || $RUN_CNV_SOMATIC_WDL == true || $RUN_M2_WDL == true ]]; then
     wget -O ~/cromwell-0.29.jar https://github.com/broadinstitute/cromwell/releases/download/29/cromwell-29.jar;
   fi
-# Download Picard jar
-- if [[ $RUN_M2_WDL == true ]]; then
-    wget -O ~/picard.jar https://github.com/broadinstitute/picard/releases/download/2.9.0/picard.jar;
-  fi
 # Download git lfs files
 - git lfs version
 - git lfs install

--- a/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
+++ b/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
@@ -1,5 +1,4 @@
 {
-  "Mutect2_Multi.picard": "/home/travis/picard.jar",
   "Mutect2_Multi.gatk_docker": "__GATK_DOCKER__",
   "Mutect2_Multi.oncotator_docker": "broadinstitute/oncotator:1.9.6.1",
   "Mutect2_Multi.intervals": "/home/travis/build/broadinstitute/gatk/scripts/m2_cromwell_tests/interval_list.interval_list",

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -260,7 +260,7 @@ workflow Mutect2 {
         File unfiltered_vcf_index = MergeVCFs.output_vcf_index
         File filtered_vcf = select_first([FilterByOrientationBias.filtered_vcf, Filter.filtered_vcf])
         File filtered_vcf_index = select_first([FilterByOrientationBias.filtered_vcf_index, Filter.filtered_vcf_index])
-        File contamination_table = CalculateContamination.contamination_table
+        File? contamination_table = CalculateContamination.contamination_table
 
         # select_first() fails if nothing resolves to non-null, so putting in "null" for now.
         File? oncotated_m2_maf = select_first([oncotate_m2.oncotated_m2_maf, "null"])

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -9,7 +9,7 @@
 ## Description of inputs:
 ##
 ## ** Runtime ** 
-## gatk_docker, oncotator_docker: docker images to use for GATK4 Mutect2 and for Oncotator
+## gatk_docker, oncotator_docker: docker images to use for GATK 4 Mutect2 and for Oncotator
 ## preemptible_attempts: how many preemptions to tolerate before switching to a non-preemptible machine (on Google)
 ## gatk_override: (optional) local file or Google bucket path to a GATK 4 java jar file to be used instead of the GATK 4 jar
 ##                in the docker image.  This must be supplied when running in an environment that does not support docker
@@ -33,7 +33,7 @@
 ## ** Primary resources ** (optional but strongly recommended)
 ## pon, pon_index: optional panel of normals in VCF format containing probable technical artifacts (false positves)
 ## gnomad, gnomad_index: optional database of known germline variants (see http://gnomad.broadinstitute.org/downloads)
-## variants_for_contamination, variants_for_contamination_index: VCF of common variants with allele frequencies fo calculating contamination
+## variants_for_contamination, variants_for_contamination_index: VCF of common variants with allele frequencies for calculating contamination
 ##
 ## ** Secondary resources ** (for optional tasks)
 ## onco_ds_tar_gz, default_config_file: Oncotator datasources and config file

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -658,14 +658,10 @@ task FilterByOrientationBias {
 
         export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk_override}
 
-        # Convert to GATK format
-        sed -r "s/picard\.analysis\.artifacts\.SequencingArtifactMetrics\\\$PreAdapterDetailMetrics/org\.broadinstitute\.hellbender\.tools\.picard\.analysis\.artifacts\.SequencingArtifactMetrics\$PreAdapterDetailMetrics/g" \
-            "${pre_adapter_metrics}" > "gatk.pre_adapter_detail_metrics"
-
         gatk --java-options "-Xmx${command_mem}m" FilterByOrientationBias \
             -V ${input_vcf} \
             -AM ${sep=" -AM " artifact_modes} \
-            -P gatk.pre_adapter_detail_metrics \
+            -P ${pre_adapter_metrics} \
             -O ${filtered_vcf_name}
     }
 

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -502,7 +502,7 @@ task CollectSequencingArtifactMetrics {
         set -e
         export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk_override}
         gatk --java-options "-Xmx${command_mem}m" CollectSequencingArtifactMetrics \
-            -I ${tumor_bam} -O "gatk" R=${ref_fasta} -VALIDATION_STRINGENCY LENIENT
+            -I ${tumor_bam} -O "gatk" -R ${ref_fasta} -VALIDATION_STRINGENCY LENIENT
     }
 
     runtime {

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -248,7 +248,7 @@ task SplitIntervals {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -329,7 +329,7 @@ task M2 {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -371,7 +371,7 @@ task MergeVCFs {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -416,7 +416,7 @@ task MergeBamOuts {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -457,7 +457,7 @@ task CollectSequencingArtifactMetrics {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -560,7 +560,7 @@ task Filter {
         docker: gatk_docker
         memory: machine_mem + " GB"
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 
@@ -687,7 +687,7 @@ task oncotate_m2 {
         memory: machine_mem + " GB"
         bootDiskSizeGb: 12
         disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
-        preemptible: select_first([preemptible_attempts, 3])
+        preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
     }
 

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -83,11 +83,11 @@ workflow Mutect2 {
     # These are multipliers to multipler inputs by to make sure we have enough disk to accommodate for possible output sizes
     # Large is for Bams/WGS vcfs
     # Small is for metrics/other vcfs
-    Float large_input_to_output_mulitplier = 2.25
-    Float small_input_to_output_mulitplier = 2.0
+    Float large_input_to_output_multiplier = 2.25
+    Float small_input_to_output_multiplier = 2.0
 
 
-    Int split_interval_size = ref_size + ceil(size(intervals, "GB") * small_input_to_output_mulitplier) + disk_pad
+    Int split_interval_size = ref_size + ceil(size(intervals, "GB") * small_input_to_output_multiplier) + disk_pad
     call SplitIntervals {
         input:
             intervals = intervals,
@@ -138,7 +138,7 @@ workflow Mutect2 {
             preemptible_attempts = preemptible_attempts
     }
 
-    Int merge_vcf_size = ceil(SumSubVcfs.total_size * large_input_to_output_mulitplier) + disk_pad
+    Int merge_vcf_size = ceil(SumSubVcfs.total_size * large_input_to_output_multiplier) + disk_pad
     call MergeVCFs {
         input:
             input_vcfs = M2.output_vcf,
@@ -156,7 +156,7 @@ workflow Mutect2 {
                 preemptible_attempts = preemptible_attempts,
         }
 
-        Int merge_bamout_size = ceil(SumSubBamouts.total_size * large_input_to_output_mulitplier) + disk_pad
+        Int merge_bamout_size = ceil(SumSubBamouts.total_size * large_input_to_output_multiplier) + disk_pad
 
         call MergeBamOuts {
             input:
@@ -187,7 +187,7 @@ workflow Mutect2 {
     }
 
     if (defined(variants_for_contamination)) {
-        Int calculate_contamination_size = tumor_bam_size + ceil(size(variants_for_contamination, "GB") * small_input_to_output_mulitplier) + disk_pad
+        Int calculate_contamination_size = tumor_bam_size + ceil(size(variants_for_contamination, "GB") * small_input_to_output_multiplier) + disk_pad
         call CalculateContamination {
             input:
                 gatk_override = gatk_override,
@@ -203,7 +203,7 @@ workflow Mutect2 {
         }
     }
 
-    Int filter_size = ceil(size(MergeVCFs.output_vcf, "GB") * small_input_to_output_mulitplier) + disk_pad
+    Int filter_size = ceil(size(MergeVCFs.output_vcf, "GB") * small_input_to_output_multiplier) + disk_pad
     call Filter {
         input:
             gatk_override = gatk_override,
@@ -221,7 +221,7 @@ workflow Mutect2 {
         # Get the metrics either from the workflow input or CollectSequencingArtifactMetrics if no workflow input is provided
         File input_artifact_metrics = select_first([tumor_sequencing_artifact_metrics, CollectSequencingArtifactMetrics.pre_adapter_metrics])
 
-        Int filter_by_orientation_bias_size = ceil(size(Filter.filtered_vcf, "GB") * small_input_to_output_mulitplier) + ceil(size(input_artifact_metrics, "GB")) + disk_pad
+        Int filter_by_orientation_bias_size = ceil(size(Filter.filtered_vcf, "GB") * small_input_to_output_multiplier) + ceil(size(input_artifact_metrics, "GB")) + disk_pad
         call FilterByOrientationBias {
             input:
                 gatk_override = gatk_override,
@@ -238,7 +238,7 @@ workflow Mutect2 {
 
     if (is_run_oncotator) {
         File oncotate_vcf_input = select_first([FilterByOrientationBias.filtered_vcf, Filter.filtered_vcf])
-        Int oncotate_size = ceil(size(oncotate_vcf_input, "GB") * large_input_to_output_mulitplier) + onco_tar_size + disk_pad
+        Int oncotate_size = ceil(size(oncotate_vcf_input, "GB") * large_input_to_output_multiplier) + onco_tar_size + disk_pad
         call oncotate_m2 {
             input:
                 m2_vcf = oncotate_vcf_input,

--- a/scripts/mutect2_wdl/mutect2_multi_sample.wdl
+++ b/scripts/mutect2_wdl/mutect2_multi_sample.wdl
@@ -36,7 +36,6 @@ workflow Mutect2_Multi {
 	Boolean is_run_orientation_bias_filter
 	Int scatter_count
 	Array[String] artifact_modes
-    File picard
 	String? m2_extra_args
     String? m2_extra_filtering_args
     Boolean? is_bamOut
@@ -83,7 +82,6 @@ workflow Mutect2_Multi {
                 variants_for_contamination_index = variants_for_contamination_index,
                 is_run_orientation_bias_filter = is_run_orientation_bias_filter,
                 artifact_modes = artifact_modes,
-                picard = picard,
                 m2_extra_args = m2_extra_args,
                 m2_extra_filtering_args = m2_extra_filtering_args,
                 is_run_oncotator = is_run_oncotator,

--- a/scripts/mutect2_wdl/mutect2_multi_sample.wdl
+++ b/scripts/mutect2_wdl/mutect2_multi_sample.wdl
@@ -103,7 +103,7 @@ workflow Mutect2_Multi {
         Array[File] unfiltered_vcf_idx = Mutect2.unfiltered_vcf_index
         Array[File] filtered_vcf = Mutect2.filtered_vcf
         Array[File] filtered_vcf_idx = Mutect2.filtered_vcf_index
-        Array[File] contamination_tables = Mutect2.contamination_table
+        Array[File?] contamination_tables = Mutect2.contamination_table
 
         Array[File?] oncotated_m2_mafs = Mutect2.oncotated_m2_maf
         Array[File?] m2_bamout = Mutect2.bamout

--- a/scripts/mutect2_wdl/mutect2_pon.wdl
+++ b/scripts/mutect2_wdl/mutect2_pon.wdl
@@ -2,7 +2,6 @@
 #
 #  Description of inputs
 #  gatk: java jar file containing gatk 4
-#  picard: java jar file containing picard
 #  intervals: genomic intervals
 #  ref_fasta, ref_fai, ref_dict: reference genome, index, and dictionary
 #  normal_bams, normal_bais: arrays of normal bams and bam indices
@@ -19,7 +18,6 @@ import "mutect2.wdl" as m2
 
 workflow Mutect2_Panel {
     # inputs
-    File picard
 	File? intervals
 	File ref_fasta
 	File ref_fai
@@ -55,7 +53,6 @@ workflow Mutect2_Panel {
                 m2_extra_args = m2_extra_args,
                 is_run_orientation_bias_filter = false,
                 is_run_oncotator = false,
-                picard = picard,
                 oncotator_docker = gatk_docker,
                 artifact_modes = [""],
                 gatk_override = gatk_override,

--- a/scripts/mutect2_wdl/mutect2_template.json
+++ b/scripts/mutect2_wdl/mutect2_template.json
@@ -1,6 +1,4 @@
 {
-  "Mutect2.gatk": "/root/gatk.jar",
-  "Mutect2.picard": "$__picard_jar__",
   "Mutect2.gatk_docker": "broadinstitute/gatk:4.beta.5",
   "Mutect2.oncotator_docker": "broadinstitute/oncotator:1.9.6.1",
   "Mutect2.intervals": "$__intervals__",

--- a/scripts/mutect2_wdl/unsupported/README.md
+++ b/scripts/mutect2_wdl/unsupported/README.md
@@ -23,7 +23,6 @@ The following resources:
 * Three preprocessed Hapmap vcfs -- one each for the 5-plex, 10-plex and 20-plex mixtures.  These are produced by preprocess_hapmap.wdl but as long as the sample composition of the mixtures remains the same they do not need to be generated again.  That is, the proportions need not be the same, but the same 5, 10, and 20 Hapmap samples must be present.
 * A reference .fasta file, along with accompanying .fasta.fai and .dict files.
 * A gatk4 java .jar file.
-* A Picard java .jar file.
 * Three lists of .bam files -- one each for 5-plex, 10-plex and 20-plex replicates -- where each row has the format <bam_file.bam></TAB><bam_index.bai>
 * A list of .bam files of the specificity validation's replicates, where each row has the format <replicate_i.bam></TAB><replicate_i.bai></TAB><replicate_j.bam></TAB><replicate_j.bai>, with one row for each *ordered* pair i, j eg (1,2), (1,3), (2,1), (2,3), (3,1), (3,2) if there are three replicates.
 * An intervals file.
@@ -36,7 +35,6 @@ In the same directory as your wdl scripts, fill in a file called sensitivity.jso
 ```
 {
   "HapmapSensitivityAllPlexes.gatk_override": "[Path to a gatk jar file.  Omitting this line uses the gatk jar in the docker image.]",
-  "HapmapSensitivityAllPlexes.picard": "[path to Picard .jar file]",
   "HapmapSensitivityAllPlexes.gatk_docker": "[gatk docker image eg broadinstitute/gatk:4.beta.3 -- this is not used in SGE but you still have to fill it in.]",
   "HapmapSensitivityAllPlexes.intervals": "[path to intervals file]",
   "HapmapSensitivityAllPlexes.ref_fasta": "[path to reference .fasta file]",
@@ -69,7 +67,6 @@ In the same directory as your wdl scripts, fill in a file called specificity.jso
 {
   "Mutect2ReplicateValidation.gatk_override": "[Path to a gatk jar file.  Omitting this line uses the gatk jar in the docker image.]",
   "Mutect2ReplicateValidation.gatk_docker": "[gatk docker image eg broadinstitute/gatk:4.beta.3 -- this is not used in SGE but you still have to fill it in.]",
-  "Mutect2ReplicateValidation.picard": "[path to Picard .jar file]",
   "Mutect2ReplicateValidation.ref_fasta": "[path to reference .fasta file]",
   "Mutect2ReplicateValidation.ref_fai": "[path to reference .fasta.fai file]",
   "Mutect2ReplicateValidation.ref_dict": "[path to reference .dict file]",

--- a/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
+++ b/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
@@ -21,7 +21,6 @@
 import "mutect2.wdl" as MutectSingleSample
 
 workflow HapmapSensitivity {
-    File picard
     File? intervals
   	File ref_fasta
   	File ref_fai
@@ -68,7 +67,6 @@ workflow HapmapSensitivity {
         call MutectSingleSample.Mutect2 {
             input:
                 gatk_override = gatk_override,
-                picard = picard,
                 gatk_docker = gatk_docker,
                 oncotator_docker = "ubuntu:16.04",
                 intervals = intervals,

--- a/scripts/mutect2_wdl/unsupported/hapmap_sensitivity_all_plexes.wdl
+++ b/scripts/mutect2_wdl/unsupported/hapmap_sensitivity_all_plexes.wdl
@@ -20,7 +20,6 @@
 import "hapmap_sensitivity.wdl" as single_plex
 
 workflow HapmapSensitivityAllPlexes {
-    File picard
     File? intervals
   	File ref_fasta
   	File ref_fai
@@ -55,7 +54,6 @@ workflow HapmapSensitivityAllPlexes {
   call single_plex.HapmapSensitivity as FivePlex {
       input:
           gatk_override = gatk_override,
-          picard = picard,
           gatk_docker = gatk_docker,
           intervals = intervals,
           ref_fasta = ref_fasta,
@@ -79,7 +77,6 @@ workflow HapmapSensitivityAllPlexes {
   call single_plex.HapmapSensitivity as TenPlex {
       input:
           gatk_override = gatk_override,
-          picard = picard,
           gatk_docker = gatk_docker,
           intervals = intervals,
           ref_fasta = ref_fasta,
@@ -103,7 +100,6 @@ workflow HapmapSensitivityAllPlexes {
   call single_plex.HapmapSensitivity as TwentyPlex {
       input:
           gatk_override = gatk_override,
-          picard = picard,
           gatk_docker = gatk_docker,
           intervals = intervals,
           ref_fasta = ref_fasta,

--- a/scripts/mutect2_wdl/unsupported/m2_basic_validation.wdl
+++ b/scripts/mutect2_wdl/unsupported/m2_basic_validation.wdl
@@ -42,7 +42,6 @@ workflow m2_validation {
     File? onco_ds_tar_gz
     String? onco_ds_local_db_dir
     Array[String] artifact_modes
-    File picard
     String? m2_extra_args
     String? m2_extra_filtering_args
     String? sequencing_center
@@ -97,7 +96,6 @@ workflow m2_validation {
         call m2.Mutect2 as m2_tn {
             input:
                 gatk_override = gatk_override,
-                picard = picard,
                 gatk_docker = gatk_docker,
                 basic_bash_docker = basic_bash_docker,
                 oncotator_docker = oncotator_docker,
@@ -129,7 +127,6 @@ workflow m2_validation {
         call m2.Mutect2 as m2_validation_bamout {
             input:
                 gatk_override = gatk_override,
-                picard = picard,
                 gatk_docker = gatk_docker,
                 basic_bash_docker = basic_bash_docker,
                 oncotator_docker = oncotator_docker,
@@ -190,7 +187,6 @@ workflow m2_validation {
 
         call m2.CollectSequencingArtifactMetrics as validation_normal_CollectSequencingArtifactMetrics {
             input:
-                picard = picard,
                 gatk_docker = gatk_docker,
                 ref_fasta = ref_fasta,
                 ref_fai = ref_fai,

--- a/scripts/mutect2_wdl/unsupported/mutect2-replicate-validation.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2-replicate-validation.wdl
@@ -4,7 +4,6 @@
 import "mutect2.wdl" as m2
 
 workflow Mutect2ReplicateValidation {
-	File picard
 	File? intervals
 	File ref_fasta
 	File ref_fai
@@ -44,7 +43,6 @@ workflow Mutect2ReplicateValidation {
 				scatter_count = scatter_count,
 				gnomad = gnomad,
 				gnomad_index = gnomad_index,
-				picard = picard,
                 is_run_orientation_bias_filter = is_run_orientation_bias_filter,
                 is_run_oncotator = false,
                 preemptible_attempts = preemptible_attempts,

--- a/scripts/mutect2_wdl/unsupported/mutect2_compare_tumors.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2_compare_tumors.wdl
@@ -8,7 +8,6 @@
 import "mutect2.wdl" as m2
 
 workflow Mutect2Trio {
-	File picard
 	File? intervals
 	File ref_fasta
 	File ref_fai
@@ -34,7 +33,6 @@ workflow Mutect2Trio {
 	scatter(trio in trios) {
 		call m2.Mutect2 as GoodTumor {
 			input:
-				picard = picard,
 				intervals = intervals,
 				ref_fasta = ref_fasta,
 				ref_fai = ref_fai,
@@ -59,7 +57,6 @@ workflow Mutect2Trio {
 
 		call m2.Mutect2 as BadTumor {
             input:
-        	    picard  =  picard,
         		intervals = intervals,
         		ref_fasta = ref_fasta,
        			ref_fai = ref_fai,

--- a/scripts/mutect2_wdl/unsupported/mutect2_multi_sample_concordance.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2_multi_sample_concordance.wdl
@@ -8,7 +8,6 @@ import "mutect2_multi_sample.wdl" as m2_multi
 
 workflow Mutect2_Multi_Concordance {
     # inputs
-	File picard
 	File? intervals
     File ref_fasta
     File ref_fai
@@ -36,7 +35,6 @@ workflow Mutect2_Multi_Concordance {
 
     call m2_multi.Mutect2_Multi {
         input:
-            picard = picard,
             ref_fasta = ref_fasta,
             ref_fai = ref_fai,
             ref_dict = ref_dict,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -30,8 +30,6 @@ public class Mutect2FilteringEngine {
         final Genotype tumorGenotype = vc.getGenotype(tumorSample);
         final double[] alleleFractions = GATKProtectedVariantContextUtils.getAttributeAsDoubleArray(tumorGenotype, VCFConstants.ALLELE_FREQUENCY_KEY,
                 () -> new double[] {1.0}, 1.0);
-        final int maxIndex = MathUtils.maxElementIndex(alleleFractions);
-        //final int depth = GATKProtectedVariantContextUtils.getAttribute
         final double maxFraction = MathUtils.arrayMax(alleleFractions);
         if (maxFraction < contamination) {
             filters.add(GATKVCFConstants.CONTAMINATION_FILTER_NAME);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -30,6 +30,8 @@ public class Mutect2FilteringEngine {
         final Genotype tumorGenotype = vc.getGenotype(tumorSample);
         final double[] alleleFractions = GATKProtectedVariantContextUtils.getAttributeAsDoubleArray(tumorGenotype, VCFConstants.ALLELE_FREQUENCY_KEY,
                 () -> new double[] {1.0}, 1.0);
+        final int maxIndex = MathUtils.maxElementIndex(alleleFractions);
+        //final int depth = GATKProtectedVariantContextUtils.getAttribute
         final double maxFraction = MathUtils.arrayMax(alleleFractions);
         if (maxFraction < contamination) {
             filters.add(GATKVCFConstants.CONTAMINATION_FILTER_NAME);


### PR DESCRIPTION
Closes #2962 (clean M2 wdl)
Closes #2949 (hardcoded memory)
Closes #2970 (optional user-supplied sequencing artifact metrics)
Closes #3341 (comments from FC wdl)
Closes #3270 (smarter disk requirements)
Closes #3625 (remove picard jar)
Closes #4142 (merge improvements from mutect2_opt wdl)

@takutosato This ought to be the last significant change to the M2 wdl for a while.  I hope.