### PR TITLE
Added documentation warnings about empty clipped reads from readClipper where they can occur

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -289,7 +289,7 @@ public final class AssemblyRegion implements Locatable {
         final List<GATKRead> trimmedReads = new ArrayList<>(myReads.size());
         for( final GATKRead read : myReads ) {
             final GATKRead clippedRead = ReadClipper.hardClipToRegion(read, resultExtendedLocStart, resultExtendedLocStop);
-            if( result.readOverlapsRegion(clippedRead) && clippedRead.getLength() > 0 ) {
+            if( result.readOverlapsRegion(clippedRead) && !clippedRead.isEmpty() ) {
                 trimmedReads.add(clippedRead);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.transforms.markduplicates;
 
+import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.apache.spark.Partitioner;
@@ -106,6 +107,8 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
 
         // Here we combine the original bam with the repartitioned unmarked readnames to produce our marked reads
         return sortedReadsForMarking.zipPartitions(repartitionedReadNames, (readsIter, readNamesIter)  -> {
+            System.out.println("system property says: " + System.getProperty("samjdk.compression_level"));
+            System.out.println("htsjdk says: " + Defaults.COMPRESSION_LEVEL);
             final Map<String,Integer> namesOfNonDuplicateReadsAndOpticalCounts = new HashMap<>();
             readNamesIter.forEachRemaining(tup -> { if (namesOfNonDuplicateReadsAndOpticalCounts.putIfAbsent(tup._1,tup._2)!=null) {
                 throw new GATKException(String.format("Detected multiple mark duplicate records objects corresponding to read with name '%s', this could be the result of the file sort order being incorrect or that a previous tool has let readnames span multiple partitions",tup._1()));

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -107,8 +107,6 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
 
         // Here we combine the original bam with the repartitioned unmarked readnames to produce our marked reads
         return sortedReadsForMarking.zipPartitions(repartitionedReadNames, (readsIter, readNamesIter)  -> {
-            System.out.println("system property says: " + System.getProperty("samjdk.compression_level"));
-            System.out.println("htsjdk says: " + Defaults.COMPRESSION_LEVEL);
             final Map<String,Integer> namesOfNonDuplicateReadsAndOpticalCounts = new HashMap<>();
             readNamesIter.forEachRemaining(tup -> { if (namesOfNonDuplicateReadsAndOpticalCounts.putIfAbsent(tup._1,tup._2)!=null) {
                 throw new GATKException(String.format("Detected multiple mark duplicate records objects corresponding to read with name '%s', this could be the result of the file sort order being incorrect or that a previous tool has let readnames span multiple partitions",tup._1()));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -390,11 +390,9 @@ public class OverhangFixingManager {
         }
 
         public void setRead(final GATKRead read) {
-            if ( ! read.isEmpty() ) {
-                this.read = read;
-                if ( ! read.isUnmapped() ) {
-                    unclippedLoc = genomeLocParser.createGenomeLoc(read.getContig(), read.getSoftStart(), read.getSoftEnd());
-                }
+            this.read = read;
+            if ( ! read.isUnmapped() ) {
+                unclippedLoc = genomeLocParser.createGenomeLoc(read.getContig(), read.getSoftStart(), read.getSoftEnd());
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
@@ -359,7 +359,7 @@ public final class ClippingOp {
      * @param read a non-null read
      * @param start a start >= 0 and < read.length
      * @param stop a stop >= 0 and < read.length.
-     * @return a cloned version of read that has been properly trimmed down
+     * @return a cloned version of read that has been properly trimmed down (Could be an empty, unmapped read)
      */
     private GATKRead applyHardClipBases(final GATKRead read, final int start, final int stop) {
         // If the read is unmapped there is no Cigar string and neither should we create a new cigar string

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
@@ -120,7 +120,7 @@ public class ReadClipper {
      * Clips a read according to ops and the chosen algorithm.
      *
      * @param algorithm What mode of clipping do you want to apply for the stacked operations.
-     * @return the read with the clipping applied.
+     * @return the read with the clipping applied (Could be an empty, unmapped read if the clip removed all bases)
      */
     public GATKRead clipRead(final ClippingRepresentation algorithm) {
         return clipRead(algorithm, true);
@@ -159,7 +159,7 @@ public class ReadClipper {
      * coordinates.
      *
      * @param refStop the last base to be hard clipped in the left tail of the read.
-     * @return a new read, without the left tail.
+     * @return a new read, without the left tail (Could be an empty, unmapped read if the clip removed all bases).
      */
     private GATKRead hardClipByReferenceCoordinatesLeftTail(final int refStop) {
         return clipByReferenceCoordinates(-1, refStop, ClippingRepresentation.HARDCLIP_BASES, true);
@@ -173,7 +173,7 @@ public class ReadClipper {
      * coordinates.
      *
      * @param refStart refStop the first base to be hard clipped in the right tail of the read.
-     * @return a new read, without the right tail.
+     * @return a new read, without the right tail (Could be an empty, unmapped read if the clip removed all bases).
      */
     private GATKRead hardClipByReferenceCoordinatesRightTail(final int refStart) {
         return clipByReferenceCoordinates(refStart, -1, ClippingRepresentation.HARDCLIP_BASES, true);
@@ -187,7 +187,7 @@ public class ReadClipper {
      *
      * @param start the first base to clip (inclusive)
      * @param stop the last base to clip (inclusive)
-     * @return a new read, without the clipped bases
+     * @return a new read, without the clipped bases (Could return an empty, unmapped read)
      */
     private GATKRead hardClipByReadCoordinates(final int start, final int stop) {
         if (read.isEmpty() || (start == 0 && stop == read.getLength() - 1)) {
@@ -210,7 +210,7 @@ public class ReadClipper {
      *
      * @param left the coordinate of the last base to be clipped in the left tail (inclusive)
      * @param right the coordinate of the first base to be clipped in the right tail (inclusive)
-     * @return a new read, without the clipped bases
+     * @return a new read, without the clipped bases (Could return an empty, unmapped read)
      */
     private GATKRead hardClipBothEndsByReferenceCoordinates(final int left, final int right) {
         if (read.isEmpty() || left == right) {
@@ -241,7 +241,7 @@ public class ReadClipper {
      *
      * @param algorithm the algorithm to use (HardClip, SoftClip, Write N's,...)
      * @param lowQual every base quality lower than or equal to this in the tail of the read will be hard clipped
-     * @return a new read without low quality tails
+     * @return a new read without low quality tails (Could be an empty, unmapped read if the clip removed all bases).
      */
     private GATKRead clipLowQualEnds(final ClippingRepresentation algorithm, final byte lowQual) {
         if (read.isEmpty()) {
@@ -289,7 +289,7 @@ public class ReadClipper {
     /**
      * Will hard clip every soft clipped bases in the read.
      *
-     * @return a new read without the soft clipped bases
+     * @return a new read without the soft clipped bases (Could be an empty, unmapped read if it was all soft and hard clips).
      */
     private GATKRead hardClipSoftClippedBases () {
         if (read.isEmpty()) {
@@ -339,7 +339,7 @@ public class ReadClipper {
      * @param read     the read to be clipped
      * @param refStart the beginning of the variant region (inclusive)
      * @param refStop  the end of the variant region (inclusive)
-     * @return the read hard clipped to the variant region
+     * @return the read hard clipped to the variant region (Could return an empty, unmapped read)
      */
     public static GATKRead hardClipToRegion( final GATKRead read, final int refStart, final int refStop ) {
         final int start = read.getStart();
@@ -353,7 +353,7 @@ public class ReadClipper {
      * @param read     the read to be clipped
      * @param refStart the beginning of the variant region (inclusive)
      * @param refStop  the end of the variant region (inclusive)
-     * @return the read hard clipped to the variant region
+     * @return the read hard clipped to the variant region (Could return an empty, unmapped read)
      */
     public static GATKRead hardClipToRegionIncludingClippedBases( final GATKRead read, final int refStart, final int refStop ) {
         final int start = read.getUnclippedStart();
@@ -383,7 +383,7 @@ public class ReadClipper {
      *
      * Note: To see how a read is checked for adaptor sequence see ReadUtils.getAdaptorBoundary()
      *
-     * @return a new read without adaptor sequence
+     * @return a new read without adaptor sequence (Could return an empty, unmapped read)
      */
     private GATKRead hardClipAdaptorSequence () {
         final int adaptorBoundary = read.getAdaptorBoundary();
@@ -401,7 +401,7 @@ public class ReadClipper {
     /**
      * Hard clips any leading insertions in the read. Only looks at the beginning of the read, not the end.
      *
-     * @return a new read without leading insertions
+     * @return a new read without leading insertions (Could return an empty, unmapped read)
      */
     private GATKRead hardClipLeadingInsertions() {
         if (read.isEmpty()) {
@@ -441,7 +441,7 @@ public class ReadClipper {
      * Reverts ALL soft-clipped bases
      *
      * @param read the read
-     * @return the read with all soft-clipped bases turned into matches
+     * @return the read with all soft-clipped bases turned into matches (May return empty, unclipped reads close to the beginning of a contig)
      */
     public static GATKRead revertSoftClippedBases(final GATKRead read) {
         return new ReadClipper(read).revertSoftClippedBases();
@@ -461,7 +461,7 @@ public class ReadClipper {
      * @param refStart  first base to clip (inclusive)
      * @param refStop last base to clip (inclusive)
      * @param clippingOp clipping operation to be performed
-     * @return a new read, without the clipped bases
+     * @return a new read, without the clipped bases (May return empty, unclipped reads)
      */
     protected GATKRead clipByReferenceCoordinates(final int refStart, final int refStop, ClippingRepresentation clippingOp, boolean runAsserts) {
         if (read.isEmpty()) {
@@ -515,7 +515,7 @@ public class ReadClipper {
      * @param read     the read to be clipped
      * @param refStart the beginning of the variant region (inclusive)
      * @param refStop  the end of the variant region (inclusive)
-     * @return the read soft clipped to the variant region
+     * @return the read soft clipped to the variant region (May return empty, unclipped reads)
      */
     public static GATKRead softClipToRegionIncludingClippedBases( final GATKRead read, final int refStart, final int refStop ) {
         final int start = read.getUnclippedStart();
@@ -544,7 +544,7 @@ public class ReadClipper {
      *
      * @param left the coordinate of the last base to be clipped in the left tail (inclusive)
      * @param right the coordinate of the first base to be clipped in the right tail (inclusive)
-     * @return a new read, without the clipped bases
+     * @return a new read, without the clipped bases (May return empty, unclipped reads)
      */
     private GATKRead softClipBothEndsByReferenceCoordinates(final int left, final int right) {
         if (read.isEmpty()) {
@@ -590,7 +590,7 @@ public class ReadClipper {
      *
      * @param start the first base to clip (inclusive)
      * @param stop the last base to clip (inclusive)
-     * @return a new read, without the clipped bases
+     * @return a new read, without the clipped bases (May return empty, unclipped reads)
      */
     private GATKRead softClipByReadCoordinates(final int start, final int stop) {
         if (read.isEmpty()) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
@@ -11,8 +11,10 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.clipping.ClippingRepresentation;
 import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
+import org.testng.annotations.Test;
 
 public final class ContextCovariate implements Covariate {
     private static final long serialVersionUID = 1L;
@@ -114,7 +116,7 @@ public final class ContextCovariate implements Covariate {
      * reverse-complementing for negative-strand reads.
      * @param read the read
      * @param lowQTail every base quality lower than or equal to this in the tail of the read will be replaced with N.
-     * @return bases of the read.
+     * @return bases of the read (Could be an empty array if all bases are below lowQTail).
      */
     @VisibleForTesting
     static byte[] getStrandedClippedBytes(final GATKRead read, final byte lowQTail) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
@@ -11,10 +11,8 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.clipping.ClippingRepresentation;
 import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
-import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
-import org.testng.annotations.Test;
 
 public final class ContextCovariate implements Covariate {
     private static final long serialVersionUID = 1L;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.testutils.ReadClipperTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -37,6 +38,21 @@ public final class SplitNCigarReadsUnitTest extends GATKBaseTest {
         public TestManager( final SAMFileHeader header , DummyTestWriter writer) {
             super(header, writer, hg19GenomeLocParser, hg19ReferenceReader, 10000, 1, 40, false, true);
         }
+    }
+
+    @Test
+    public void testEmptyReads() {
+        DummyTestWriter writer = new DummyTestWriter();
+        header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
+        TestManager manager = new TestManager(header, writer);
+        manager.activateWriting();
+
+        //Testing that bogus splits make it through unaffected
+        GATKRead read1 = ReadUtils.emptyRead(ReadClipperTestUtils.makeReadFromCigar("1S4N2S3N4H"));
+        SplitNCigarReads.splitNCigarRead(read1, manager, true, header, true);
+        manager.flush();
+        Assert.assertEquals(1, writer.writtenReads.size());
+        Assert.assertEquals("*", writer.writtenReads.get(0).getCigar().toString());
     }
 
     @Test


### PR DESCRIPTION
* Fixed an issue where OverhangFixingManger did not handle empty reads correctly resulting in an NPE
* Checked every codepath that could result in an empty read in readClipper and ensured that it handles empty reads.

Resolves: https://github.com/broadinstitute/gatk/issues/4204 