### PR TITLE
Change conda environment creation to work with release distribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ releases of the toolkit.
       with this environment pre-configured. In order to establish an environment suitable to run these tools
       outside of the Docker image, the conda [gatkcondaenv.yml](https://github.com/broadinstitute/gatk/blob/master/scripts/gatkcondaenv.yml)
       file is provided. To establish the conda environment locally, [Conda](https://conda.io/docs/index.html) must first
-      be installed. Then, create the gatk environment by running the command ```conda env create -n gatk -f gatkcondaenv.yml```.
+      be installed. Then, create the gatk environment by running the command ```conda env create -n gatk -f gatkcondaenv.yml```
+      (developers should run ```./gradlew createPythonPackageArchive```, followed by
+      ```conda env create -n gatk -f scripts/gatkcondaenv.yml``` from within the root of the repository clone).
       To activate the environment once it has been created, run the command ```source activate gatk```. See the
       [Conda](https://conda.io/docs/user-guide/tasks/manage-environments.html) documentation for
       additional information about using and managing Conda environments.

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ final testNGVersion = '6.11'
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'
 
+final pythonPackageArchiveName = 'gatkPythonPackageArchive.zip'
+
 configurations.all {
     resolutionStrategy {
         // the snapshot folder contains a dev version of guava, we don't want to use that.
@@ -408,8 +410,6 @@ tasks.withType(ShadowJar) {
     }
 }
 
-
-
 shadowJar {
     configurations = [project.configurations.runtime]
     classifier = 'local'
@@ -455,9 +455,12 @@ task bundle(type: Zip) {
     from("gatk")
     from("README.md")
     from("build/docs/tabCompletion/gatk-completion.sh")
-    from("scripts/gatkcondaenv.yml")
-    from("$buildDir/gatkPythonPackageArchive.zip")
-
+    from("${buildDir}/${pythonPackageArchiveName}")
+    // When including gatkcondaenv.yml file in the release bundle, strip off the
+    // 'build/' prefix used for the location of the Python package archive.
+    from("scripts/gatkcondaenv.yml", {
+        filter { line -> line.replace("build/${pythonPackageArchiveName}", pythonPackageArchiveName) }
+    })
     into(baseName)
 
     doLast {
@@ -472,9 +475,8 @@ task createPythonPackageArchive(type: Zip) {
         assert file("src/main/python/org/broadinstitute/hellbender/").exists()
     }
 
-
     destinationDir file("$buildDir")
-    archiveName "gatkPythonPackageArchive.zip"
+    archiveName pythonPackageArchiveName
     from("src/main/python/org/broadinstitute/hellbender/")
     into("/")
 


### PR DESCRIPTION
Fixes the Python part of https://github.com/broadinstitute/gatk/issues/4209. Also updated the README with more specific instructions based on previous feedback from another user. This was tested manually.