### PR TITLE
GenomicsDB Allele-specific Annotation Support and Bug Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ final htsjdkVersion = System.getProperty('htsjdk.version','2.14.1')
 final picardVersion = System.getProperty('picard.version','2.17.2')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.1-proto-3.0.0-beta-1+uuid-static')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
 final testNGVersion = '6.11'
 
 final baseJarName = 'gatk'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ final htsjdkVersion = System.getProperty('htsjdk.version','2.14.1')
 final picardVersion = System.getProperty('picard.version','2.17.2')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.8.1-proto-3.0.0-beta-1+uuid-static')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.1-proto-3.0.0-beta-1+uuid-static')
 final testNGVersion = '6.11'
 
 final baseJarName = 'gatk'

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -43,6 +43,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     private static final String HG_00096 = largeFileTestDir + "gvcfs/HG00096.g.vcf.gz";
     private static final String HG_00268 = largeFileTestDir + "gvcfs/HG00268.g.vcf.gz";
     private static final String NA_19625 = largeFileTestDir + "gvcfs/NA19625.g.vcf.gz";
+    private static final String NA_24385 = largeFileTestDir + "NA24385.vcf.gz";
     private static final String NA_12878_PHASED = largeFileTestDir + "NA12878.phasedData.Chr20.vcf"; //NOTE: this is not phased according to the vcf spec but it reflects phasing currently produced by haplotype caller
     private static final String MULTIPLOID_DATA_HG37 = largeFileTestDir + "gvcfs/HapMap5plex.ploidy10.b37.g.vcf";
     private static final String NA12878_HG37 = " src/test/resources/org/broadinstitute/hellbender/tools/haplotypecaller/expected.testGVCFMode.gatk4.g.vcf";
@@ -53,6 +54,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     private static final String COMBINED = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
     private static final SimpleInterval INTERVAL = new SimpleInterval("chr20", 17960187, 17981445);
+    private static final SimpleInterval INTERVAL_3736 = new SimpleInterval("chr6",130365070,146544250);
     private static final SimpleInterval INTERVAL_NONDIPLOID = new SimpleInterval("20", 10000000, 10100000);
     private static final VCFHeader VCF_HEADER = VariantContextTestUtils.getCompleteHeader();
 
@@ -507,6 +509,22 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
                 .addArgument("L", "1:1-10");
 
         runCommandLine(args);
+    }
+
+    @Test
+    public void testGenomicsDBImportWithoutDBField() throws IOException {
+	//Test for https://github.com/broadinstitute/gatk/issues/3736
+	final List<String> vcfInputs = Arrays.asList(NA_24385);
+        final String workspace = createTempDir("genomicsdb-tests").getAbsolutePath() + "/workspace";
+	writeToGenomicsDB(vcfInputs, INTERVAL_3736, workspace, 0, false, 0, 1);
+    }
+    
+    @Test
+    public void testLongWorkspacePath() throws IOException {
+	//Test for https://github.com/broadinstitute/gatk/issues/4160
+        final List<String> vcfInputs = LOCAL_GVCFS;
+        final String workspace = createTempDir("long_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_genomicsdb").getAbsolutePath() + "/should_not_fail_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        writeToGenomicsDB(vcfInputs, INTERVAL, workspace, 0, false, 0, 1);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -151,7 +151,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         checkGenomicsDBAgainstExpected(workspace2.getAbsolutePath() + "/workspace", INTERVAL, COMBINED, b38_reference_20_21, true);
     }
 
-    @Test (enabled = false)
+    @Test (enabled = true)
     public void testGenomicsDBAlleleSpecificAnnotations() throws IOException {
         testGenomicsDBAgainstCombineGVCFs(Arrays.asList(COMBINEGVCFS_TEST_DIR+"NA12878.AS.chr20snippet.g.vcf", COMBINEGVCFS_TEST_DIR+"NA12892.AS.chr20snippet.g.vcf"),
                 new SimpleInterval("20", 10433000, 10700000),

--- a/src/test/resources/large/NA24385.vcf.gz
+++ b/src/test/resources/large/NA24385.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3326d552a86197e1d8fbfee2941f6b8684f7b31bfab9730f953401566066e2b
+size 2176154

--- a/src/test/resources/large/NA24385.vcf.gz.tbi
+++ b/src/test/resources/large/NA24385.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99d8fb13100405e872f6bdb68314e1eac29780918c4081e8786bfccb2d25485e
+size 4808


### PR DESCRIPTION
This PR adds:
- Allele Annotation Support #3707 (w/ changes requested in [4047](https://github.com/broadinstitute/gatk/pull/4047))

and fixes:
- [4160](https://github.com/broadinstitute/gatk/issues/4160)
- [4106](https://github.com/broadinstitute/gatk/issues/4106)
- [3736](https://github.com/broadinstitute/gatk/issues/3736)
- [3745](https://github.com/broadinstitute/gatk/issues/3745)
- Bug fix - Resize LUTs when dealing with spanning deletions