### PR TITLE
Exposed bounds for copy-neutral segments in CallCopyRatioSegments.

### DIFF
--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -442,7 +442,8 @@ task ModelSegments {
 task CallCopyRatioSegments {
     String entity_id
     File copy_ratio_segments
-    Float? neutral_segment_copy_ratio_threshold
+    Float? neutral_segment_copy_ratio_lower_bound
+    Float? neutral_segment_copy_ratio_upper_bound
     Float? outlier_neutral_segment_copy_ratio_z_score_threshold
     Float? calling_copy_ratio_z_score_threshold
     File? gatk4_jar_override
@@ -462,7 +463,8 @@ task CallCopyRatioSegments {
 
         gatk --java-options "-Xmx${command_mem_mb}m" CallCopyRatioSegments \
             --input ${copy_ratio_segments} \
-            --neutral-segment-copy-ratio-threshold ${default="0.1" neutral_segment_copy_ratio_threshold} \
+            --neutral-segment-copy-ratio-lower-bound ${default="0.9" neutral_segment_copy_ratio_lower_bound} \
+            --neutral-segment-copy-ratio-upper-bound ${default="1.1" neutral_segment_copy_ratio_upper_bound} \
             --outlier-neutral-segment-copy-ratio-z-score-threshold ${default="2.0" outlier_neutral_segment_copy_ratio_z_score_threshold} \
             --calling-copy-ratio-z-score-threshold ${default="2.0" calling_copy_ratio_z_score_threshold} \
             --output ${entity_id}.called.seg

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/records/AlleleFractionSegment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/records/AlleleFractionSegment.java
@@ -50,7 +50,6 @@ public class AlleleFractionSegment implements Locatable {
         return numPoints;
     }
 
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.java
@@ -204,5 +204,4 @@ public final class PlotDenoisedCopyRatios extends CommandLineProgram {
                 "--output_prefix=" + outputPrefix);
         executor.exec();
     }
-
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/caller/SimpleCopyRatioCallerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/caller/SimpleCopyRatioCallerUnitTest.java
@@ -27,7 +27,8 @@ import java.util.stream.IntStream;
 import static org.broadinstitute.hellbender.tools.copynumber.formats.records.CalledCopyRatioSegment.Call.*;
 
 public final class SimpleCopyRatioCallerUnitTest extends GATKBaseTest {
-    private static final double NEUTRAL_SEGMENT_COPY_RATIO_THRESHOLD = 0.1;
+    private static final double NEUTRAL_SEGMENT_COPY_RATIO_LOWER_BOUND = 0.9;
+    private static final double NEUTRAL_SEGMENT_COPY_RATIO_UPPER_BOUND = 1.1;
     private static final double OUTLIER_NEUTRAL_SEGMENT_COPY_RATIO_Z_SCORE_THRESHOLD = 2.;
     private static final double CALLING_COPY_RATIO_Z_SCORE_THRESHOLD = 2.;
 
@@ -67,7 +68,8 @@ public final class SimpleCopyRatioCallerUnitTest extends GATKBaseTest {
 
         final CalledCopyRatioSegmentCollection calledCopyRatioSegments =
                 new SimpleCopyRatioCaller(copyRatioSegments,
-                        NEUTRAL_SEGMENT_COPY_RATIO_THRESHOLD, OUTLIER_NEUTRAL_SEGMENT_COPY_RATIO_Z_SCORE_THRESHOLD, CALLING_COPY_RATIO_Z_SCORE_THRESHOLD)
+                        NEUTRAL_SEGMENT_COPY_RATIO_LOWER_BOUND, NEUTRAL_SEGMENT_COPY_RATIO_UPPER_BOUND,
+                        OUTLIER_NEUTRAL_SEGMENT_COPY_RATIO_Z_SCORE_THRESHOLD, CALLING_COPY_RATIO_Z_SCORE_THRESHOLD)
                         .makeCalls();
 
         Assert.assertEquals(copyRatioSegments.getMetadata(), calledCopyRatioSegments.getMetadata());


### PR DESCRIPTION
Although identification of the copy-neutral state is still relatively manual, this will at least make the tool usable for samples with high ploidy until @MartonKN finishes up the new caller.