### PR TITLE
Upgrade Barclay, suppress file expansion for interval arguments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ repositories {
 
 final htsjdkVersion = System.getProperty('htsjdk.version','2.14.1')
 final picardVersion = System.getProperty('picard.version','2.17.2')
+final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.8.1-proto-3.0.0-beta-1+uuid-static')
@@ -78,6 +79,7 @@ configurations.all {
         force 'com.google.protobuf:protobuf-java:3.0.0-beta-1'
         // force testng dependency so we don't pick up a different version via GenomicsDB
         force 'org.testng:testng:' + testNGVersion
+        force 'org.broadinstitute:barclay:' + barclayVersion
     }
     all*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
     all*.exclude group: 'com.google.guava', module: 'guava-jdk5'
@@ -143,7 +145,7 @@ dependencies {
     compileOnly(javadocJDKFiles)
     testCompile(javadocJDKFiles)
 
-    compile 'org.broadinstitute:barclay:2.0.0'
+    compile 'org.broadinstitute:barclay:' + barclayVersion
     // Library for configuration:
     compile 'org.aeonbits.owner:owner:1.0.9'
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -24,6 +24,7 @@ public abstract class IntervalArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public static final String EXCLUDE_INTERVALS_LONG_NAME = "exclude-intervals";
+    public static final String EXCLUDE_INTERVALS_SHORT_NAME = "XL";
     public static final String INTERVAL_SET_RULE_LONG_NAME = "interval-set-rule";
     public static final String INTERVAL_PADDING_LONG_NAME = "interval-padding";
     public static final String INTERVAL_EXCLUSION_PADDING_LONG_NAME = "interval-exclusion-padding";
@@ -55,7 +56,10 @@ public abstract class IntervalArgumentCollection implements Serializable {
      * (e.g. -XL myFile.intervals).
      * @return strings gathered from the command line -XL argument to be parsed into intervals to exclude
      */
-    @Argument(fullName = EXCLUDE_INTERVALS_LONG_NAME, shortName = "XL", doc = "One or more genomic intervals to exclude from processing", optional = true, common = true)
+    // Interval list files such as Picard interval lists are structured and require specialized parsing that
+    // is handled by IntervalUtils, so use suppressFileExpansion to bypass command line parser auto-expansion.
+    @Argument(fullName = EXCLUDE_INTERVALS_LONG_NAME, shortName = EXCLUDE_INTERVALS_SHORT_NAME, doc = "One or more genomic intervals to exclude from processing",
+            suppressFileExpansion = true, optional = true, common = true)
     protected final List<String> excludeIntervalStrings = new ArrayList<>();
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalIntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalIntervalArgumentCollection.java
@@ -14,8 +14,10 @@ import java.util.List;
 public final class OptionalIntervalArgumentCollection extends IntervalArgumentCollection {
     private static final long serialVersionUID = 1L;
 
+    // Interval list files such as Picard interval lists are structured and require specialized parsing that
+    // is handled by IntervalUtils, so use suppressFileExpansion to bypass command line parser auto-expansion.
     @Argument(fullName = StandardArgumentDefinitions.INTERVALS_LONG_NAME, shortName = StandardArgumentDefinitions.INTERVALS_SHORT_NAME,
-            doc = "One or more genomic intervals over which to operate", optional = true)
+            suppressFileExpansion = true, doc = "One or more genomic intervals over which to operate", optional = true)
     protected final List<String> intervalStrings = new ArrayList<>();
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredIntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredIntervalArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.ArrayList;
@@ -14,7 +15,9 @@ import java.util.List;
 public final class RequiredIntervalArgumentCollection extends IntervalArgumentCollection {
     private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = "intervals", shortName = "L", doc = "One or more genomic intervals over which to operate", optional = false)
+    // Interval list files such as Picard interval lists are structured and require specialized parsing that
+    // is handled by IntervalUtils, so use suppressFileExpansion to bypass command line parser auto-expansion.
+    @Argument(fullName = StandardArgumentDefinitions.INTERVALS_LONG_NAME, shortName = StandardArgumentDefinitions.INTERVALS_SHORT_NAME, suppressFileExpansion = true, doc = "One or more genomic intervals over which to operate", optional = false)
     protected final List<String> intervalStrings = new ArrayList<>();
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
@@ -33,11 +33,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Iterator;
+import java.util.*;
 import java.io.IOException;
-import java.util.List;
-import java.util.Set;
 
 public final class GATKToolUnitTest extends GATKBaseTest {
 
@@ -349,7 +346,7 @@ public final class GATKToolUnitTest extends GATKBaseTest {
         tool.doWork();
 
         // ensure that the raw interval argument has not been expanded by Barclay, and that the post-merged
-        // intervals list contains 3 itervals (there are 4 in the file; 2 get merged)
+        // intervals list contains 3 intervals (there are 4 in the file; 2 get merged)
         Assert.assertEquals(tool.getIntervals().size(), 3);
 
         tool.onShutdown();


### PR DESCRIPTION
This is currently using a Barclay snapshot, and should not be merged until the released version is up.