### PR TITLE
Compressed vcf output and Funcotator options in Mutect2 wdl

### DIFF
--- a/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
+++ b/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
@@ -9,6 +9,7 @@
   "Mutect2_Multi.scatter_count": 2,
   "Mutect2_Multi.run_orientation_bias_filter": true,
   "Mutect2_Multi.run_oncotator": true,
+  "Mutect2_Multi.run_funcotator": false,
   "Mutect2_Multi.preemptible_attempts": 2,
   "Mutect2_Multi.artifact_modes": ["G/T", "C/T"],
   "Mutect2_Multi.compress_vcfs": false,

--- a/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
+++ b/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
@@ -7,11 +7,10 @@
   "Mutect2_Multi.ref_dict": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/human_g1k_v37.20.21.dict",
   "Mutect2_Multi.pair_list": "/home/travis/build/broadinstitute/gatk/scripts/m2_cromwell_tests/pair_list",
   "Mutect2_Multi.scatter_count": 2,
-  "Mutect2_Multi.dbsnp": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/dbsnp_138.b37.20.21.vcf",
-  "Mutect2_Multi.dbsnp_index": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/dbsnp_138.b37.20.21.vcf.idx",
-  "Mutect2_Multi.is_run_orientation_bias_filter": true,
-  "Mutect2_Multi.is_run_oncotator": true,
+  "Mutect2_Multi.run_orientation_bias_filter": true,
+  "Mutect2_Multi.run_oncotator": true,
   "Mutect2_Multi.preemptible_attempts": 2,
   "Mutect2_Multi.artifact_modes": ["G/T", "C/T"],
+  "Mutect2_Multi.compress_vcfs": false,
   "Mutect2_Multi.onco_ds_local_db_dir": "/root/"
 }

--- a/scripts/mutect2_wdl/mutect2_multi_sample.wdl
+++ b/scripts/mutect2_wdl/mutect2_multi_sample.wdl
@@ -38,6 +38,7 @@ workflow Mutect2_Multi {
 	Array[String]? artifact_modes
 	String? m2_extra_args
     String? m2_extra_filtering_args
+    Boolean? compress_vcfs
     Boolean? make_bamout
 
     # Oncotator inputs
@@ -91,6 +92,7 @@ workflow Mutect2_Multi {
                 sequence_source = sequence_source,
                 default_config_file = default_config_file,
                 make_bamout = make_bamout,
+                compress_vcfs = compress_vcfs,
                 gatk_override = gatk_override,
                 gatk_docker = gatk_docker,
                 oncotator_docker = oncotator_docker,

--- a/scripts/mutect2_wdl/mutect2_multi_sample.wdl
+++ b/scripts/mutect2_wdl/mutect2_multi_sample.wdl
@@ -49,6 +49,15 @@ workflow Mutect2_Multi {
     String? sequence_source
     File? default_config_file
 
+    # funcotator inputs
+    Boolean? run_funcotator
+    String? reference_version
+    String? data_sources_tar_gz
+    String? transcript_selection_mode
+    Array[String]? transcript_selection_list
+    Array[String]? annotation_defaults
+    Array[String]? annotation_overrides
+
     File? gatk_override
 
     # runtime
@@ -91,6 +100,13 @@ workflow Mutect2_Multi {
                 sequencing_center = sequencing_center,
                 sequence_source = sequence_source,
                 default_config_file = default_config_file,
+                run_funcotator = run_funcotator,
+                reference_version = reference_version,
+                data_sources_tar_gz = data_sources_tar_gz,
+                transcript_selection_mode = transcript_selection_mode,
+                transcript_selection_list = transcript_selection_list,
+                annotation_defaults = annotation_defaults,
+                annotation_overrides = annotation_overrides,
                 make_bamout = make_bamout,
                 compress_vcfs = compress_vcfs,
                 gatk_override = gatk_override,


### PR DESCRIPTION
Closes #4188.

@sooheelee This wraps up the wish list in #4188.

@takutosato Although funcotator is off in the Travis test, I *did* test it locally. Also, I have tested with and without compressed vcf output.  The funcotator command is simply copied from @jonn-smith's funcotator.wdl.  Subworkflows are a pain in Firecloud, which is why I don't `import` it.