### PR TITLE
Fix #3894

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -271,8 +271,6 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
                 SvDiscoverFromLocalAssemblyContigAlignmentsSpark.preprocess(updatedSvDiscoveryInputData, nonCanonicalChromosomeNamesFile,true);
 
         SvDiscoverFromLocalAssemblyContigAlignmentsSpark.dispatchJobs(contigsByPossibleRawTypes, updatedSvDiscoveryInputData);
-
-        // TODO: 11/30/17 add EXTERNAL_CNV_CALLS annotation to the variants called here
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/AssemblyContigAlignmentSignatureClassifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/AssemblyContigAlignmentSignatureClassifier.java
@@ -98,25 +98,9 @@ public final class AssemblyContigAlignmentSignatureClassifier {
 
         final EnumMap<RawTypes, JavaRDD<AssemblyContigWithFineTunedAlignments>> contigsByRawTypes = new EnumMap<>(RawTypes.class);
 
-        // first remove overlap, if any
-        final JavaRDD<AssemblyContigWithFineTunedAlignments> preprocessedContigs = contigsWithOnlyOneBestConfigAnd2AI.map(
-                decoratedContig -> {
-                    final AlignedContig contig = decoratedContig.getSourceContig();
-                    final AlignmentInterval one = contig.alignmentIntervals.get(0),
-                                            two = contig.alignmentIntervals.get(1);
-                    final List<AlignmentInterval> deOverlappedAlignments =
-                            ContigAlignmentsModifier.removeOverlap(one, two, broadcastSequenceDictionary.getValue());
-
-                    final AlignedContig contigWithDeOverlappedAlignments =
-                            new AlignedContig(contig.contigName, contig.contigSequence, deOverlappedAlignments,
-                                    contig.hasEquallyGoodAlnConfigurations);
-                    return new AssemblyContigWithFineTunedAlignments(contigWithDeOverlappedAlignments);
-                }
-        );
-
         // split between the case where both alignments has unique ref span or not
         final Tuple2<JavaRDD<AssemblyContigWithFineTunedAlignments>, JavaRDD<AssemblyContigWithFineTunedAlignments>> hasFullyContainedRefSpanOrNot =
-                RDDUtils.split(preprocessedContigs, AssemblyContigWithFineTunedAlignments::hasIncompletePictureFromTwoAlignments, false);
+                RDDUtils.split(contigsWithOnlyOneBestConfigAnd2AI, AssemblyContigWithFineTunedAlignments::hasIncompletePictureFromTwoAlignments, false);
         contigsByRawTypes.put(RawTypes.Incomplete, hasFullyContainedRefSpanOrNot._1);
 
         // split between same chromosome mapping or not

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ChimericAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ChimericAlignment.java
@@ -483,10 +483,10 @@ public class ChimericAlignment {
         if (intervalOne.mapQual < mapQThresholdInclusive || intervalTwo.mapQual < mapQThresholdInclusive)
             return false;
 
-        final int overlap = AlignmentInterval.overlapOnContig(intervalOne, intervalTwo);
-
-        return Math.min(intervalOne.getSizeOnRead() - overlap, intervalTwo.getSizeOnRead() - overlap)
-                >= alignmentLengthThresholdInclusive;
+        // TODO: 2/2/18 improve annotation for alignment length: compared to #firstAlignmentIsTooShort(),
+        // we are not subtracting alignments' overlap on the read, i.e. we are not filtering alignments based on their unique read span size,
+        // but downstream analysis should have this information via an annotation, the current annotation is not up for this task
+        return Math.min(intervalOne.getSizeOnRead(), intervalTwo.getSizeOnRead()) >= alignmentLengthThresholdInclusive;
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/StructuralVariationDiscoveryPipelineSparkIntegrationTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -197,9 +198,9 @@ public class StructuralVariationDiscoveryPipelineSparkIntegrationTest extends Co
             final String experimentalInsDelVcf = onHDFS ? path.toUri().toString() : path.toString();
             actualVcs = extractActualVCs(experimentalInsDelVcf, onHDFS);
 
-            // TODO: 11/30/17 temporary solution to ignore these attributes before they can be brought back
+            // TODO: 1/28/18 see ticket #4228
             final List<String> moreAttributesToIgnoreForNow = new ArrayList<>(attributesToIgnore);
-            moreAttributesToIgnoreForNow.addAll(Arrays.asList("HOMSEQ", "HOMLEN", "EXTERNAL_CNV_CALLS"));
+            moreAttributesToIgnoreForNow.addAll(Collections.singletonList("EXTERNAL_CNV_CALLS"));
             GATKBaseTest.assertCondition(actualVcs, expectedVcs,
                     (a, e) -> VariantContextTestUtils.assertVariantContextsAreEqual(a, e, moreAttributesToIgnoreForNow));
         }


### PR DESCRIPTION
The stable version is not affected since this only changes the code path for the experimental tool.

The number of calls from the stable-versioned tool:

```
20:54:33.375 INFO  StructuralVariationDiscoveryPipelineSpark - Called 662 imprecise deletion variants
20:54:33.405 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 7234 variants.
20:54:33.421 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 184
20:54:33.421 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 4486
20:54:33.421 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 1170
20:54:33.421 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 1394
20:54:33.430 INFO  StructuralVariationDiscoveryPipelineSpark - BND_NOSS: 0
20:54:33.430 INFO  StructuralVariationDiscoveryPipelineSpark - DUP_INV: 0
20:54:33.430 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV33: 0
20:54:33.430 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV55: 0
20:54:33.430 INFO  StructuralVariationDiscoveryPipelineSpark - CPX: 0
```

The number of calls from the experimental tool without this fix:

```
18:24:37.263 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - Discovered 10831 variants.
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_NOSS: 4462
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_INV33: 184
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_INV55: 182
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DEL: 3741
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DUP: 935
18:24:37.278 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - INS: 1327
18:24:37.283 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - INV: 0
18:24:37.283 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DUP_INV: 0
18:24:37.283 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - CPX: 0
18:24:37.612 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - Discovered 612 variants.
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - CPX: 612
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - INV: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_NOSS: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DUP_INV: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_INV33: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - BND_INV55: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DEL: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - DUP: 0
18:24:37.613 INFO  SvDiscoverFromLocalAssemblyContigAlignmentsSpark - INS: 0
```

The number of calls from this PR:

```
20:55:47.247 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 10571 variants.
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - BND_NOSS: 4242
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV33: 178
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV55: 180
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 3744
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 900
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 1327
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 0
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - DUP_INV: 0
20:55:47.258 INFO  StructuralVariationDiscoveryPipelineSpark - CPX: 0
20:55:48.322 INFO  StructuralVariationDiscoveryPipelineSpark - Discovered 612 variants.
20:55:48.322 INFO  StructuralVariationDiscoveryPipelineSpark - CPX: 612
20:55:48.322 INFO  StructuralVariationDiscoveryPipelineSpark - INV: 0
20:55:48.322 INFO  StructuralVariationDiscoveryPipelineSpark - BND_NOSS: 0
20:55:48.322 INFO  StructuralVariationDiscoveryPipelineSpark - DUP_INV: 0
20:55:48.323 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV33: 0
20:55:48.323 INFO  StructuralVariationDiscoveryPipelineSpark - BND_INV55: 0
20:55:48.323 INFO  StructuralVariationDiscoveryPipelineSpark - DEL: 0
20:55:48.323 INFO  StructuralVariationDiscoveryPipelineSpark - DUP: 0
20:55:48.323 INFO  StructuralVariationDiscoveryPipelineSpark - INS: 0
```


A slight drop in number of DEL is due to this:
in the upfront deoverlapping step, we follow the left-aligning convention, this sometimes yield the homologuos sequence to a shorter alignment and take that away from a longer alignment; when it comes to a later filtering step that filters out alignments purely based on its unique read span, because of the deoverlapping step, those short alignment that received the homologuous sequence because of the left-aligning convention now survived, compared to if there were no upfront deoverlap.

The drop in number of DUP is due to a similar reason:
the upfront overlap removal made some contigs that would be classified as having incomplete picture unfairly now becomes a contig with complete picture (see [this](http://www.genomeribbon.com/?perma=AvOvbThN4z) for example).

IMO removal of the upfront deoverlapping step is good, because the number of calls would not be affected by which convention we follow (convention should only affect representation, not if a variant is real); on the other hand, the convention definitely  hurts some other small alignments.

-------

The drop in number of variants detected from stable-versioned tool to the experimental tool without this fix are mainly from the imprecise deletion calls that are not hooked up in the experiemental tool yet, and many deletion and duplications are now incoporated into CPX variants.

-------

Alternatively, we can turn off the filter based on unique alignment length all together, and annotate the calls with unique alignment length for later stage filter.

I did experiment with that, and as expected, the number of BND calls and deletion calls increased, whereas the numer of DUP calls dropped, when comparing only-turn-off-length-filter, turn-off-upfront-deoverlap-and-length-filter. The drop in number of DUP calls are due to the fact that without upfront deoverlap, more contigs are classified as having incomplete picture.

-------
Also proposing an "improvement" to the script by adding more checks in the pipeline bash script:
the problem it is trying to address is documented in the changes to the script.