### PR TITLE
add warning message to install_R_scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using OpenJDK 8
-FROM broadinstitute/gatk:gatkbase-1.2.2
+FROM broadinstitute/gatk:gatkbase-1.2.3
 ARG DRELEASE
 
 ADD . /gatk

--- a/scripts/docker/gatkbase/build_docker_base.sh
+++ b/scripts/docker/gatkbase/build_docker_base.sh
@@ -6,7 +6,7 @@ set -e
 
 REPO=broadinstitute
 PROJECT=gatk
-VERSION=1.2.2
+VERSION=1.2.3
 FULL_PATH=${REPO}/${PROJECT}:gatkbase-${VERSION}
 
 #################################################

--- a/scripts/docker/gatkbase/install_R_packages.R
+++ b/scripts/docker/gatkbase/install_R_packages.R
@@ -1,3 +1,11 @@
+###############################################################################
+# If you edit this file you MUST release a new version of the gatkbase docker #
+# built with the updated r dependencies                                       #
+#                                                                             #
+# you MUST also manually clear the travis cache for master before running the #
+# pull request tests in order to make sure it's still working                 #
+###############################################################################
+
 #Make sure to use http not https as this will give an "unsupported URL scheme" error
 getoptUrl="http://cran.r-project.org/src/contrib/Archive/getopt/getopt_1.20.0.tar.gz"
 if (!("getopt" %in% rownames(installed.packages()))) {


### PR DESCRIPTION
Adding a note to developers that if they change the install_R_scripts script they must rebuild gatkbase and test with clean caches.
