### PR TITLE
Added check for non-finite copy ratios in ModelSegments pipeline.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/SVDDenoisingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/SVDDenoisingUtils.java
@@ -473,6 +473,11 @@ public final class SVDDenoisingUtils {
     private static void divideBySampleMedianAndTransformToLog2(final RealMatrix matrix) {
         logger.info("Dividing by sample medians and transforming to log2 space...");
         final double[] sampleMedians = MatrixSummaryUtils.getRowMedians(matrix);
+        IntStream.range(0, sampleMedians.length).forEach(sampleIndex ->
+                ParamUtils.isPositive(sampleMedians[sampleIndex],
+                        sampleMedians.length == 1
+                                ? "Sample does not have a non-negative sample median."
+                                : String.format("Sample at index %s does not have a non-negative sample median.", sampleIndex)));
         matrix.walkInOptimizedOrder(new DefaultRealMatrixChangingVisitor() {
             @Override
             public double visit(int sampleIndex, int intervalIndex, double value) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/records/CopyRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/records/CopyRatio.java
@@ -11,6 +11,8 @@ public class CopyRatio implements Locatable {
     public CopyRatio(final SimpleInterval interval,
                      final double log2CopyRatioValue) {
         Utils.nonNull(interval);
+        Utils.validateArg(Double.isFinite(log2CopyRatioValue),
+                String.format("Non-finite log2 copy ratio at %s is not allowed.", interval));
         this.interval = interval;
         this.log2CopyRatioValue = log2CopyRatioValue;
     }


### PR DESCRIPTION
@LeeTL1220 This should fail earlier in situations like the one you ran into with the low coverage test data.  I don't *think* there should be any unintended side effects.  I'm fine if this doesn't make it in before the point release if you want to run some sanity checks on real data with it (since users should be able to figure out what is going on relatively quickly if they run into the issue), but I'll leave it up to you.