### PR TITLE
GenomicsDB unit test fix

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -535,17 +535,17 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testGenomicsDBImportWithoutDBField() throws IOException {
-	//Test for https://github.com/broadinstitute/gatk/issues/3736
-	final List<String> vcfInputs = Arrays.asList(NA_24385);
+        //Test for https://github.com/broadinstitute/gatk/issues/3736
+        final List<String> vcfInputs = Arrays.asList(NA_24385);
         final String workspace = createTempDir("genomicsdb-tests").getAbsolutePath() + "/workspace";
 	writeToGenomicsDB(vcfInputs, INTERVAL_3736, workspace, 0, false, 0, 1);
     }
-    
+
     @Test
     public void testLongWorkspacePath() throws IOException {
-	//Test for https://github.com/broadinstitute/gatk/issues/4160
+        //Test for https://github.com/broadinstitute/gatk/issues/4160
         final List<String> vcfInputs = LOCAL_GVCFS;
-        final String workspace = createTempDir("long_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_genomicsdb").getAbsolutePath() + "/should_not_fail_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        final String workspace = createTempDir("long_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_genomicsdb").getAbsolutePath() + "/should_not_fail_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         writeToGenomicsDB(vcfInputs, INTERVAL, workspace, 0, false, 0, 1);
     }
 


### PR DESCRIPTION
This PR:
- Increases workspace to 256+ character path for `GenomicsDBImportIntegrationTest.testLongWorkspacePath()`
- Fixes whitespace inconsistency introduced in previous PR

@droazen I can also confirm that the two unit tests introduced in the last PR - `GenomicsDBImportIntegrationTest.testLongWorkspacePath()` and `GenomicsDBImportIntegrationTest.testGenomicsDBImportWithoutDBField()` pass with the latest version of GenomicsDB (0.9.2-\*) and fail with the previous version (0.8.1-\*) as expected