### PR TITLE
replacing inappropriate overrides of makeReadFilter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSpark.java
@@ -29,6 +29,7 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVVCFWriter;
 import scala.Tuple2;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -115,8 +116,8 @@ public final class DiscoverVariantsFromContigAlignmentsSAMSpark extends GATKSpar
     }
 
     @Override
-    public ReadFilter makeReadFilter() {
-        return ReadFilterLibrary.MAPPED;
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.MAPPED);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
@@ -124,8 +124,8 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
     }
 
     @Override
-    public ReadFilter makeReadFilter() {
-        return ReadFilterLibrary.MAPPED;
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.MAPPED);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/FilterLongReadAlignmentsSAMSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/FilterLongReadAlignmentsSAMSpark.java
@@ -98,8 +98,8 @@ public final class FilterLongReadAlignmentsSAMSpark extends GATKSparkTool {
     }
 
     @Override
-    public ReadFilter makeReadFilter() {
-        return ReadFilterLibrary.MAPPED;
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.MAPPED);
     }
 
     @Override


### PR DESCRIPTION
replacing overrides of `makeReadFilter` with `getDefaultReadFilters`
This way they these tools will obey read filter command line options correctly.

@SHuang-Broad I think you accidentally used the wrong method here, which is very reasonable because it's super confusing.  I think this is an improvement, but feel free to reject this is you disagree, I may be misunderstanding.