### PR TITLE
Shl Update somatic short variants tool docs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
@@ -30,59 +30,75 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Additionally filter Mutect2 somatic variant calls for sequence context-dependent artifacts.
+ * <p>Additionally filter Mutect2 somatic variant calls for sequence context-dependent artifacts, e.g. OxoG or FFPE deamination.</p>
  *
  * <p>
- *     This tool is complementary to {@link FilterMutectCalls}.
- *     The tool requires the pre-adapter detailed metrics calculated by Picard {@link CollectSequencingArtifactMetrics}.
- *     Specify the base substitution to consider for orientation bias. For a given base substitution specified with
+ *     This tool is complementary to {@link FilterMutectCalls} and if run, should be run after FilterMutectCalls.
+ *     The tool requires the pre-adapter detailed metrics calculated by Picard {@link CollectSequencingArtifactMetrics} and specification
+ *     of the base substitution(s) to consider for orientation bias. For a given base substitution specified with
  *     the --artifact-modes argument, the tool considers both the forward and reverse complement for filtering.  That is, specifying
  *     {@code --artifact-modes 'G/T'} means the tool considers G to T <i>and</i> A to C artifacts for filtering.
  * </p>
- *
  * <p>
  *     The metrics from {@link CollectSequencingArtifactMetrics} give a global view across a sample's genome that empowers
- *     decision making in ways site-specific analyses cannot. {@link CollectSequencingArtifactMetrics} should be run for both
- *     the normal sample and the tumor sample, if the matched normal is available. The detailed metrics measure orientation
- *     bias for all 3-base contexts and help determine whether variant filtering for a sequence context is necessary.
+ *     decision making in ways site-specific analyses cannot. The detailed metrics measure orientation
+ *     bias for all three-base contexts and help determine whether variant filtering for a sequence context is necessary.
  * </p>
- *
  * <p>
  *     The most common artifact to consider for filtering is the OxoG (8-Oxoguanine) artifact. OxoG artifacts stem from oxidation of
- *     guanine to 8-oxoguanine, which results in G to T transversion mutations. If samples were derived from histological
+ *     guanine to 8-oxoguanine, which results in G to T transversions. If samples were derived from histological
  *     slides, then consider the FFPE (formalin-fixed paraffin-embedded) artifact. FFPE artifacts stem from formaldehyde
- *     deamination of cytosines, which results in C to T transition mutations.
+ *     deamination of cytosines, which results in C to T transitions.
+ * </p>
+ * <p>
+ *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
  * </p>
  *
- * <h3>Example</h3>
- * <h4>Step 1A: invoke Picard CollectSequencingArtifactMetrics using the GATK4 launch script</h4>
+ * <h3>Example workflow </h3>
+ * <h4>Step 1. Run CollectSequencingArtifactMetrics on sample BAM.</h4>
+ * <p>Either invoke CollectSequencingArtifactMetrics using the GATK4 launch script:</p>
  * <pre>
  * gatk CollectSequencingArtifactMetrics \
+ *   -R reference.fa \
  *   -I tumor.bam \
- *   -R ref.fasta \
- *   -O tumor_artifact \
- *   --FILE_EXTENSION ".txt"
+ *   --FILE_EXTENSION ".txt" \
+ *   -O tumor_artifact
  * </pre>
  *
- * <h4>Step 1 B: run Picard CollectSequencingArtifactMetrics from a Picard jar</h4>
+ * <p>Or run CollectSequencingArtifactMetrics from a standalone Picard jar:</p>
  * <pre>
  * java -jar picard.jar CollectSequencingArtifactMetrics \
+ *   R=reference.fa \
  *   I=tumor.bam \
- *   R=ref.fasta \
- *   O="tumor_artifact" \
- *   VALIDATION_STRINGENCY=LENIENT
+ *   --FILE_EXTENSION=.txt \
+ *   O=tumor_artifact
  *</pre>
+ * <p>This generates a number of metrics files, including 'tumor_artifact.pre_adapter_detail_metrics.txt'.</p>
  *
- * <h4>Step 2: run FilterByOrientationBias</h4>
- * For OxoG artifacts, specify G to T artifacts.
+ * <h4>Step 2. Run FilterByOrientationBias on Mutect2 calls that have been filtered by FilterMutectCalls.</h4>
+ * <p>Here we specify the G to T OxoG artifact and provide the pre_adapter_detail_metrics.</p>
  * <pre>
  * gatk FilterByOrientationBias \
+ *   -V filtered.vcf.gz \
  *   --artifact-modes 'G/T' \
- *   -V mutect_calls.vcf.gz \
- *   -P tumor.pre_adapter_detail_metrics \
+ *   -P tumor_artifact.pre_adapter_detail_metrics.txt \
  *   -O oxog_filtered.vcf.gz
  * </pre>
  *
+ * <p>This produces variant calls filtered with the 'orientation_bias' filter and a summary 'oxog_filtered.vcf.gz.summary' file.
+ * The summary tallies the number of calls for the sequence context(s) and the number of those that the tool filters.</p>
+ *
+ * <h3>Further points of interest</h3>
+ * <ul>
+ *     <li>The tool only considers passing calls and relies on the presence of sample-level F1R2 and F2R1 annotations.</li>
+ *     <li>If a site is multiallelic, only the first alternate allele is considered in filtering. If a sample call is triallelic, it may not be considered for filtering.
+ *     The implication is that FilterByOrientationBias is only recommended for use with Mutect2 callsets from originally diploid and non-pooled samples.</li>
+ *     <li>For calls that the tool filters, the FILTER and sample fields are each annotated with the 'orientation_bias' label.</li>
+ * </ul>
  */
 
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/FilterByOrientationBias.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * <p>Additionally filter Mutect2 somatic variant calls for sequence context-dependent artifacts, e.g. OxoG or FFPE deamination.</p>
  *
  * <p>
- *     This tool is complementary to {@link FilterMutectCalls} and if run, should be run after FilterMutectCalls.
+ *     This tool is complementary to {@link FilterMutectCalls} and if run, should be run <i>after</i> FilterMutectCalls.
  *     The tool requires the pre-adapter detailed metrics calculated by Picard {@link CollectSequencingArtifactMetrics} and specification
  *     of the base substitution(s) to consider for orientation bias. For a given base substitution specified with
  *     the --artifact-modes argument, the tool considers both the forward and reverse complement for filtering.  That is, specifying
@@ -77,10 +77,10 @@ import java.util.stream.Collectors;
  *   --FILE_EXTENSION=.txt \
  *   O=tumor_artifact
  *</pre>
- * <p>This generates a number of metrics files, including 'tumor_artifact.pre_adapter_detail_metrics.txt'.</p>
+ * <p>This generates a number of metrics files, including tumor_artifact.pre_adapter_detail_metrics.txt.</p>
  *
  * <h4>Step 2. Run FilterByOrientationBias on Mutect2 calls that have been filtered by FilterMutectCalls.</h4>
- * <p>Here we specify the G to T OxoG artifact and provide the pre_adapter_detail_metrics.</p>
+ * <p>Here we specify the G to T OxoG artifact and provide the pre_adapter_detail_metrics from step 1.</p>
  * <pre>
  * gatk FilterByOrientationBias \
  *   -V filtered.vcf.gz \
@@ -89,8 +89,8 @@ import java.util.stream.Collectors;
  *   -O oxog_filtered.vcf.gz
  * </pre>
  *
- * <p>This produces variant calls filtered with the 'orientation_bias' filter and a summary 'oxog_filtered.vcf.gz.summary' file.
- * The summary tallies the number of calls for the sequence context(s) and the number of those that the tool filters.</p>
+ * <p>This produces variant calls filtered with the orientation_bias filter and a summary oxog_filtered.vcf.gz.summary file.
+ * The summary tallies the number of calls for the sequence context(s) and the number of those that the tool filtered.</p>
  *
  * <h3>Further points of interest</h3>
  * <ul>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
@@ -30,13 +30,19 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * Given pileup data from {@link GetPileupSummaries}, calculates the fraction of reads coming from cross-sample contamination.
- *
  * <p>
+ *     Given pileup data from {@link GetPileupSummaries}, calculates the fraction of reads coming from cross-sample contamination.
  *     The resulting contamination table is used with {@link FilterMutectCalls}.
  * </p>
+ * <p>
+ *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
+ * </p>
  *
- * <p>This tool and GetPileupSummaries together replace GATK3's ContEst.  Like ContEst, this tool estimates contamination based on the signal
+ * <p>This tool and GetPileupSummaries together replace GATK3's ContEst. Like ContEst, this tool estimates contamination based on the signal
  * from ref reads at hom alt sites.  However, ContEst uses a probabilistic model that assumes a diploid genotype with no copy number
  * variation and independent contaminating reads.  That is, ContEst assumes that each contaminating read is drawn randomly and
  * independently from a different human.  This tool uses a simpler estimate of contamination that relaxes these assumptions.  In particular,
@@ -44,12 +50,9 @@ import java.util.stream.IntStream;
  * is designed to work well with no matched normal data.  However, one can run {@link GetPileupSummaries} on a matched normal bam file
  * and input the result to this tool.</p>
  *
- * <p>
- *     The resulting table provides the fraction contamination, one line per sample, e.g. SampleID--TAB--Contamination.
- *     The file has no header.
- * </p>
+ * <h3>Usage examples</h3>
  *
- * <h3>Example: tumor-only mode</h3>
+ * <h4>Tumor-only mode</h4>
  *
  * <pre>
  * gatk CalculateContamination \
@@ -57,7 +60,7 @@ import java.util.stream.IntStream;
  *   -O contamination.table
  * </pre>
  *
- * <h3>Example: matched normal mode</h3>
+ * <h4>Matched normal mode</h4>
  *
  * <pre>
  * gatk CalculateContamination \
@@ -65,6 +68,10 @@ import java.util.stream.IntStream;
  *   -matched normal-pileups.table \
  *   -O contamination.table
  * </pre>
+ * <p>
+ *     The resulting table provides the fraction contamination, one line per sample, e.g. SampleID--TAB--Contamination.
+ *     The file has no header.
+ * </p>
  *
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/CalculateContamination.java
@@ -31,7 +31,7 @@ import java.util.stream.IntStream;
 
 /**
  * <p>
- *     Given pileup data from {@link GetPileupSummaries}, calculates the fraction of reads coming from cross-sample contamination.
+ *     Calculates the fraction of reads coming from cross-sample contamination, given results from {@link GetPileupSummaries}.
  *     The resulting contamination table is used with {@link FilterMutectCalls}.
  * </p>
  * <p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
@@ -25,16 +25,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Summarizes counts of reads that support reference, alternate and other alleles for given sites. Results can be used with {@link CalculateContamination}.
+ * <p>Summarizes counts of reads that support reference, alternate and other alleles for given sites. Results can be used with {@link CalculateContamination}.</p>
  *
  * <p>
- * The tool requires a <i>common</i> germline variant sites VCF, e.g. the gnomAD resource, with population allele frequencies (AF) in the INFO field.
+ * The tool requires a <i>common</i> germline variant sites VCF, e.g. derived from the gnomAD resource, with population allele frequencies (AF) in the INFO field.
  * This resource must contain only biallelic SNPs and can be an eight-column sites-only VCF.
  * The tool ignores the filter status of the sites.
- * See the GATK Resource Bundle for an example human file.
- * The GATK repository provides a script to prepare the resource at <a href=https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl/mutect_resources.wdl>
- *     https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl/mutect_resources.wdl</a>.
- * An example excerpt is shown.
+ * </p>
+ * <p>
+ *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
+ *     In particular, the mutect_resources.wdl script prepares a suitable resource from a larger dataset. An example excerpt is shown.
  * </p>
  *
  * <pre>
@@ -43,6 +47,23 @@ import java.util.List;
  * chr6	29942517	.	C	A	2975860	VQSRTrancheSNP99.80to99.90	AF=0.062
  * chr6	29942525	.	G	C	2975600	VQSRTrancheSNP99.60to99.80	AF=0.063
  * chr6	29942547	rs114945359	G	C	15667700	PASS	AF=0.077
+ * </pre>
+ *
+ * <h3>Usage examples</h3>
+ *
+ * <pre>
+ * gatk GetPileupSummaries \
+ *   -I tumor.bam \
+ *   -V common_biallelic.vcf.gz \
+ *   -O pileups.table
+ * </pre>
+ *
+ * <pre>
+ * gatk GetPileupSummaries \
+ *   -I normal.bam \
+ *   -V common_biallelic.vcf.gz \
+ *   -L chr1 \
+ *   -O pileups.table
  * </pre>
  *
  * <p>
@@ -65,24 +86,6 @@ import java.util.List;
  * or {@code -min-af}) is set to 0.01, which limits the sites the tool considers to those in the variants resource
  * file that have AF of 0.01 or more.
  * </p>
- *
- *
- * <h3>Usage examples</h3>
- *
- * <pre>
- * gatk GetPileupSummaries \
- *   -I tumor.bam \
- *   -V common_biallelic.vcf.gz \
- *   -O pileups.table
- * </pre>
- *
- * <pre>
- * gatk GetPileupSummaries \
- *   -I normal.bam \
- *   -V common_biallelic.vcf.gz \
- *   -L chr1 \
- *   -O pileups.table
- * </pre>
  *
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p>
  * The tool requires a <i>common</i> germline variant sites VCF, e.g. derived from the gnomAD resource, with population allele frequencies (AF) in the INFO field.
  * This resource must contain only biallelic SNPs and can be an eight-column sites-only VCF.
- * The tool ignores the filter status of the sites.
+ * The tool ignores the filter status of the variant calls in this germline resource.
  * </p>
  * <p>
  *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
@@ -31,8 +31,8 @@ import java.util.*;
  * Create a panel of normals (PoN) containing germline and artifactual sites for use with Mutect2.
  *
  * <p>
- *     The tool takes multiple normal sample callsets produced by {@link Mutect2}'s tumor-only mode and collates them into a single
- *     variant call format (VCF) file of false positive calls. The PoN captures common artifactual and germline variant sites.
+ *     The tool takes multiple normal sample callsets produced by {@link Mutect2}'s tumor-only mode and collates sites present in two or more samples
+ *     into a sites-only VCF. The PoN captures common artifactual and germline variant sites.
  *     Mutect2 then uses the PoN to filter variants at the site-level.
  * </p>
  * <p>
@@ -81,8 +81,9 @@ import java.util.*;
  *   -O pon.vcf.gz
  * </pre>
  *
- * <p>The resulting VCF will be an eight-column sites-only VCF without any annotations.
- * By default the tool fails if multiple vcfs have the same sample name, but the --duplicate-sample-strategy argument can be changed to
+ * <p>The resulting VCF will be an eight-column sites-only VCF lacking annotations.</p>
+ *
+ * <p>By default the tool fails if multiple vcfs have the same sample name, but the --duplicate-sample-strategy argument can be changed to
  *  ALLOW_ALL to allow duplicates or CHOOSE_FIRST to use only the first vcf with a given sample name.</p>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
@@ -54,8 +54,8 @@ import java.util.*;
  *   -O normal1_for_pon.vcf.gz
  * </pre>
  *
- * <h4>Step 2. Create a file ending with .args extension with the paths to the VCFs from step 1, one per line.</h4>
- * <p>This approach is optional.  It will fail if a file with an extension other than .args is used. </p>
+ * <h4>Step 2. Create a file ending with .args or .list extension with the paths to the VCFs from step 1, one per line.</h4>
+ * <p>This approach is optional. Other extensions will error the run. </p>
  *
  * <pre>
  *     normal1_for_pon.vcf.gz

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
@@ -35,26 +35,27 @@ import java.util.*;
  *     variant call format (VCF) file of false positive calls. The PoN captures common artifactual and germline variant sites.
  *     Mutect2 then uses the PoN to filter variants at the site-level.
  * </p>
- *
  * <p>
- *     This contrasts with the GATK3 workflow, which uses CombineVariants to retain variant sites called in at least
- *     two samples and then uses Picard MakeSitesOnlyVcf to simplify the callset for use as a PoN.
+ *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
  * </p>
+ * <h3>Example workflow</h3>
  *
- * <h3>Examples</h3>
- *
- * <p>Step 1. Run Mutect2 in tumor-only mode for each normal sample.</p>
+ * <h4>Step 1. Run Mutect2 in tumor-only mode for each normal sample.</h4>
  * <pre>
  * gatk Mutect2 \
- *   -R ref_fasta.fa \
+ *   -R reference.fa \
  *   -I normal1.bam \
  *   -tumor normal1_sample_name \
  *   --germline-resource af-only-gnomad.vcf.gz \
  *   -O normal1_for_pon.vcf.gz
  * </pre>
  *
- * <p>Step 2. Create a file ending with .args extension with the paths to the VCFs from step 1, one per line.
- * This approach is optional.  It will fail if a file with an extension other than .args is used. </p>
+ * <h4>Step 2. Create a file ending with .args extension with the paths to the VCFs from step 1, one per line.</h4>
+ * <p>This approach is optional.  It will fail if a file with an extension other than .args is used. </p>
  *
  * <pre>
  *     normal1_for_pon.vcf.gz
@@ -62,7 +63,7 @@ import java.util.*;
  *     normal3_for_pon.vcf.gz
  * </pre>
  *
- * <p>Step 3. Combine the normal calls using CreateSomaticPanelOfNormals.</p>
+ * <h4>Step 3. Combine the normal calls using CreateSomaticPanelOfNormals.</h4>
  *
  * <pre>
  * gatk CreateSomaticPanelOfNormals \
@@ -70,7 +71,8 @@ import java.util.*;
  *   -O pon.vcf.gz
  * </pre>
  *
- * <p>Alternatively, provide each normal's VCF as separate arguments.</p>
+ * <p>The tool also accepts multiple .args files. Pass each in with the -vcfs option.
+ * Alternatively, provide each normal's VCF as separate arguments.</p>
  * <pre>
  * gatk CreateSomaticPanelOfNormals \
  *   -vcfs normal1_for_pon_vcf.gz \
@@ -79,12 +81,9 @@ import java.util.*;
  *   -O pon.vcf.gz
  * </pre>
  *
- *  <p>The tool also accepts multiple .args files. Pass each in with the -vcfs option.</p>
- *
- *  <p>By default the tool fails if multiple vcfs have the same sample name, but the --duplicate-sample-strategy argument can be changed to
+ * <p>The resulting VCF will be an eight-column sites-only VCF without any annotations.
+ * By default the tool fails if multiple vcfs have the same sample name, but the --duplicate-sample-strategy argument can be changed to
  *  ALLOW_ALL to allow duplicates or CHOOSE_FIRST to use only the first vcf with a given sample name.</p>
- *
- *  <p>See {@link Mutect2} documentation for usage examples.</p>
  *
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
@@ -26,44 +26,40 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Filter SNVs and indels from a Mutect2 callset.
+ * <p>Filter variants in a Mutect2 VCF callset.</p>
  *
  * <p>
  *     FilterMutectCalls encapsulates GATK3 MuTect2's filtering functionality and adds additional filters.
  *     GATK4 Mutect2 retains variant calling and some prefiltering.
- *     Thresholds for filters are contained in {@link M2FiltersArgumentCollection} and described in <a href='https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf' target='_blank'>https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf</a>.
+ *     Thresholds for filters are contained in {@link M2FiltersArgumentCollection} and described in
+ *     <a href='https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf' target='_blank'>https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf</a>.
  *     Separating calling and filtering into two tools better enables an iterative filtering process
  *     that allows for context-specific optimizations. To filter further based on sequence context artifacts,
  *     additionally use {@link FilterByOrientationBias}.
  * </p>
- *
  * <p>
  *     Filtering thresholds for both normal-artifact-lod (default threshold 0.0) and tumor-lod (default threshold 5.3) can be set in this tool.
  *     If the normal artifact log odds is larger than the threshold, then FilterMutectCalls applies the artifact-in-normal filter.
  *     For matched normal analyses with tumor contamination in the normal, consider increasing the normal-artifact-lod threshold.
  *     If the tumor log odds is smaller than the threshold, then FilterMutectCalls filters the variant.
  * </p>
- *
  * <p>
  *     If given a --contamination-table file, e.g. results from
  *     {@link CalculateContamination}, the tool will additionally
- *     filter on contamination fractions. Alternatively, provide a numerical fraction to filter with --contamination.
+ *     filter on contamination fractions. Alternatively, provide a numerical fraction to filter with the --contamination argument.
  * </p>
- *
- * <h3>Input</h3>
  * <p>
- * VCF of unfiltered Mutect2 SNV and indel calls.
+ *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
  * </p>
  *
- * <h3>Output</h3>
- * <p>
- * A VCF of filtered SNV and indel calls.
- * </p>
- *
- * <h3>Example</h3>
+ * <h3>Usage example</h3>
  * <pre>
  * gatk FilterMutectCalls \
- *   -V unfiltered.vcf.gz \
+ *   -V somatic.vcf.gz \
  *   -contamination-table contamination.table \
  *   -O filtered.vcf.gz
  * </pre>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  *     FilterMutectCalls encapsulates GATK3 MuTect2's filtering functionality and adds additional filters.
  *     Thresholds for filters are contained in {@link M2FiltersArgumentCollection} and described in
  *     <a href='https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf' target='_blank'>https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf</a>.
- *     To filter further based on sequence context artifacts, additionally use {@link FilterByOrientationBias}.
+ *     To filter based on sequence context artifacts, see {@link FilterByOrientationBias}.
  * </p>
  * <p>
  *     Filtering thresholds for both normal-artifact-lod (default threshold 0.0) and tumor-lod (default threshold 5.3) can be set in this tool.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/FilterMutectCalls.java
@@ -30,12 +30,9 @@ import java.util.stream.Collectors;
  *
  * <p>
  *     FilterMutectCalls encapsulates GATK3 MuTect2's filtering functionality and adds additional filters.
- *     GATK4 Mutect2 retains variant calling and some prefiltering.
  *     Thresholds for filters are contained in {@link M2FiltersArgumentCollection} and described in
  *     <a href='https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf' target='_blank'>https://github.com/broadinstitute/gatk/tree/master/docs/mutect/mutect.pdf</a>.
- *     Separating calling and filtering into two tools better enables an iterative filtering process
- *     that allows for context-specific optimizations. To filter further based on sequence context artifacts,
- *     additionally use {@link FilterByOrientationBias}.
+ *     To filter further based on sequence context artifacts, additionally use {@link FilterByOrientationBias}.
  * </p>
  * <p>
  *     Filtering thresholds for both normal-artifact-lod (default threshold 0.0) and tumor-lod (default threshold 5.3) can be set in this tool.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -34,7 +34,7 @@ import java.util.List;
  * </p>
  *
  * <h3>Usage examples</h3>
- * <p>Example commands show how to run Mutect2 for typical scenerios. The two modes are (i) <i>somatic mode</i> where a tumor sample is matched with a normal sample in analysis and
+ * <p>Example commands show how to run Mutect2 for typical scenarios. The two modes are (i) <i>somatic mode</i> where a tumor sample is matched with a normal sample in analysis and
  * (ii) <i>tumor-only mode</i> where a single sample's alignment data undergoes analysis. </p>
  *
  * <h4>(i) Tumor with matched normal</h4>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -20,14 +20,12 @@ import java.util.List;
 /**
  * <p>Call somatic short variants via local assembly of haplotypes.
  * Short variants include single nucleotide (SNV) and insertion and deletion (indel) variants.
+ * The caller combines the DREAM challenge-winning somatic genotyping engine of the original MuTect
+ * (<a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>) with the
+ * assembly-based machinery of <a href="https://www.broadinstitute.org/gatk/documentation/tooldocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.
  * </p>
  * <p>
- *     The caller combines the DREAM challenge-winning somatic genotyping engine of the original MuTect
- *     (<a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>) with the
- *     assembly-based machinery of <a href="https://www.broadinstitute.org/gatk/documentation/tooldocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.
- * </p>
- * <p>
- *     This tool is featured in the Somatic Short Mutation calling Best Practice Workflow.
+ *     This tool is featured in the <i>Somatic Short Mutation calling Best Practice Workflow</i>.
  *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
  *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
  *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
@@ -36,10 +34,10 @@ import java.util.List;
  * </p>
  *
  * <h3>Usage examples</h3>
- * <p>Example commands show how to run Mutect2 for typical scenerios. The two modes are (i) somatic mode where a tumor sample is matched with a normal sample in analysis and
- * (ii) tumor-only mode where a single sample is provided for analysis. </p>
+ * <p>Example commands show how to run Mutect2 for typical scenerios. The two modes are (i) <i>somatic mode</i> where a tumor sample is matched with a normal sample in analysis and
+ * (ii) <i>tumor-only mode</i> where a single sample's alignment data undergoes analysis. </p>
  *
- * <h4>Tumor with matched normal</h4>
+ * <h4>(i) Tumor with matched normal</h4>
  * <p>
  *     Given a matched normal, Mutect2 is designed to call somatic variants only. The tool includes logic to skip
  *     emitting variants that are clearly present in the germline based on provided evidence, e.g. in the matched normal.
@@ -61,26 +59,23 @@ import java.util.List;
  * </pre>
  *
  * <p>The --af-of-alleles-not-in-resource argument value should match expectations for alleles not found in the provided germline resource.
- * Note the tool does not require a germline resource nor a panel of normals to run.</p>
+ * Note the tool does not require a germline resource nor a panel of normals (PoN) to run.
+ * The tool prefilters sites for the matched normal and the PoN. For the germline resource, the tool prefilters on the allele.</p>
  *
- * <h4>Tumor-only mode</h4>
+ * <h4>(ii) Tumor-only mode</h4>
  * <p>This mode runs on a single sample, e.g. single tumor or single normal sample.
- * To create a panel of normals (PoN), call on each normal sample in this mode, then use {@link CreateSomaticPanelOfNormals} to generate the PoN. </p>
+ * To create a PoN, call on each normal sample in this mode, then use {@link CreateSomaticPanelOfNormals} to generate the PoN. </p>
  *
  * <pre>
  *  gatk Mutect2 \
  *   -R reference.fa \
  *   -I sample.bam \
  *   -tumor sample_name \
- *   --germline-resource af-only-gnomad.vcf.gz \
  *   -O single_sample.vcf.gz
  * </pre>
  *
- * <p>If analyzing a tumor sample in tumor-only mode, then consider adding a PoN to the calling with the --panel-of-normals argument.</p>
  *
  * <h4>Excerpt of a known variants resource with population allele frequencies</h4>
- * <p>Multiallelic sites require corresponding multiple AF annotations.</p>
- *
  * <pre>
  *     #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
  *      1       10067   .       T       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCC      30.35   PASS    AC=3;AF=7.384E-5
@@ -103,9 +98,9 @@ import java.util.List;
  * </p>
  *
  * <dl>
- *     <dd>If the normal artifact log odds becomes large, then FilterMutectCalls applies the artifact-in-normal filter.
+ *     <dd>- If the normal artifact log odds becomes large, then FilterMutectCalls applies the artifact-in-normal filter.
  *     For matched normal samples with tumor contamination, consider increasing the normal-artifact-lod threshold.</dd>
- *     <dd>The tumor log odds, which is calculated independently of any matched normal, determines whether to filter a tumor
+ *     <dd>- The tumor log odds, which is calculated independently of any matched normal, determines whether to filter a tumor
  *     variant. Variants with tumor LODs exceeding the threshold pass filtering.</dd>
  * </dl>
  *

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -60,7 +60,20 @@ import java.util.List;
  *
  * <p>The --af-of-alleles-not-in-resource argument value should match expectations for alleles not found in the provided germline resource.
  * Note the tool does not require a germline resource nor a panel of normals (PoN) to run.
- * The tool prefilters sites for the matched normal and the PoN. For the germline resource, the tool prefilters on the allele.</p>
+ * The tool prefilters sites for the matched normal and the PoN. For the germline resource, the tool prefilters on the allele.
+ * Below is an excerpt of a known variants resource with population allele frequencies</p>
+ * <pre>
+ *     #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
+ *      1       10067   .       T       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCC      30.35   PASS    AC=3;AF=7.384E-5
+ *      1       10108   .       CAACCCT C       46514.32        PASS    AC=6;AF=1.525E-4
+ *      1       10109   .       AACCCTAACCCT    AAACCCT,*       89837.27        PASS    AC=48,5;AF=0.001223,1.273E-4
+ *      1       10114   .       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA  *,CAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA,T      36728.97        PASS    AC=55,9,1;AF=0.001373,2.246E-4,2.496E-5
+ *      1       10119   .       CT      C,*     251.23  PASS    AC=5,1;AF=1.249E-4,2.498E-5
+ *      1       10120   .       TA      CA,*    14928.74        PASS    AC=10,6;AF=2.5E-4,1.5E-4
+ *      1       10128   .       ACCCTAACCCTAACCCTAAC    A,*     285.71  PASS    AC=3,1;AF=7.58E-5,2.527E-5
+ *      1       10131   .       CT      C,*     378.93  PASS    AC=7,5;AF=1.765E-4,1.261E-4
+ *      1       10132   .       TAACCC  *,T     18025.11        PASS    AC=12,2;AF=3.03E-4,5.049E-5
+ * </pre>
  *
  * <h4>(ii) Tumor-only mode</h4>
  * <p>This mode runs on a single sample, e.g. single tumor or single normal sample.
@@ -74,20 +87,6 @@ import java.util.List;
  *   -O single_sample.vcf.gz
  * </pre>
  *
- *
- * <h4>Excerpt of a known variants resource with population allele frequencies</h4>
- * <pre>
- *     #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
- *      1       10067   .       T       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCC      30.35   PASS    AC=3;AF=7.384E-5
- *      1       10108   .       CAACCCT C       46514.32        PASS    AC=6;AF=1.525E-4
- *      1       10109   .       AACCCTAACCCT    AAACCCT,*       89837.27        PASS    AC=48,5;AF=0.001223,1.273E-4
- *      1       10114   .       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA  *,CAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAACCCTAACCCTAACCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCTAACCCTAACCCTAAACCCTA,T      36728.97        PASS    AC=55,9,1;AF=0.001373,2.246E-4,2.496E-5
- *      1       10119   .       CT      C,*     251.23  PASS    AC=5,1;AF=1.249E-4,2.498E-5
- *      1       10120   .       TA      CA,*    14928.74        PASS    AC=10,6;AF=2.5E-4,1.5E-4
- *      1       10128   .       ACCCTAACCCTAACCCTAAC    A,*     285.71  PASS    AC=3,1;AF=7.58E-5,2.527E-5
- *      1       10131   .       CT      C,*     378.93  PASS    AC=7,5;AF=1.765E-4,1.261E-4
- *      1       10132   .       TAACCC  *,T     18025.11        PASS    AC=12,2;AF=3.03E-4,5.049E-5
- * </pre>
  *
  * <h3>Further points of interest</h3>
  * <p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
@@ -39,7 +39,7 @@ import java.util.Set;
  *
  * <p>The tool assumes all records in the --truth VCF are passing truth variants. For the -eval VCF, the tool uses only unfiltered passing calls.</p>
  *
- * <p>Optionally, the tool also produces VCFs of the following variant records, annotated with each variant's concordance status:</p>
+ * <p>Optionally, the tool can be set to produce VCFs of the following variant records, annotated with each variant's concordance status:</p>
  * <ul>
  *     <li>True positives and false negatives (i.e. all variants in the truth VCF): useful for calculating sensitivity</li>
  *     <li>True positives and false positives (i.e. all variants in the eval VCF): useful for obtaining a training data

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/Concordance.java
@@ -27,11 +27,17 @@ import java.util.EnumMap;
 import java.util.Set;
 
 /**
- * Evaluate concordance of an input VCF against a validated truth VCF
+ * Evaluate site-level concordance of an input VCF against a truth VCF.
  *
- * <p>This tool evaluates an input VCF against a VCF that has been validated and is considered to represent ground truth.
- * The summary statistics (# true positives, # false positives, # false negatives, sensitivity, precision) are reported
- * in a TSV file (--summary). Note that this tool assumes that the truth VCF only contains PASS variants.</p>
+ * <p>This tool evaluates two variant callsets against each other and produces a six-column summary metrics table. The summary:</p>
+ *
+ * <ul>
+ *     <li>stratifies SNP and INDEL calls,</li>
+ *     <li>tallies true-positive, false-positive and false-negative calls,</li>
+ *     <li>and calculates sensitivity and precision.</li>
+ * </ul>
+ *
+ * <p>The tool assumes all records in the --truth VCF are passing truth variants. For the -eval VCF, the tool uses only unfiltered passing calls.</p>
  *
  * <p>Optionally, the tool also produces VCFs of the following variant records, annotated with each variant's concordance status:</p>
  * <ul>
@@ -43,11 +49,11 @@ import java.util.Set;
  * <p>These output VCFs can be passed to {@link VariantsToTable} to produce a TSV file for statistical analysis in R
  * or Python.</p>
  *
- * <h3>Usage examples</h3>
+ * <h3>Usage example</h3>
  *
  * <pre>
- * gatk --java-options "-Xmx4g" Concordance \
- *   -R reference.fasta \
+ * gatk Concordance \
+ *   -R reference.fa \
  *   -eval eval.vcf \
  *   --truth truth.vcf \
  *   --summary summary.tsv    


### PR DESCRIPTION
Tools touched:

 Mutect2
 CreateSomaticPanelOfNormals
 GetPileupSummaries
 CalculateContamination
 FilterMutectCalls
 Picard CollectSequencingArtifactMetrics
 FilterByOrientationBias
 Concordance 

The Mutect2 (How to) tutorial and various supporting documents are now public and so I've cleaned up now redundant information we temporarily placed in the tool docs. I also made a pass at unifying this set of tool docs in terms of presentation elements.