### PR TITLE
upgrading to spark 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ repositories {
 final htsjdkVersion = System.getProperty('htsjdk.version','2.14.1')
 final picardVersion = System.getProperty('picard.version','2.17.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
-final sparkVersion = System.getProperty('spark.version', '2.0.2')
+final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
 final testNGVersion = '6.11'

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ final htsjdkVersion = System.getProperty('htsjdk.version','2.14.1')
 final picardVersion = System.getProperty('picard.version','2.17.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
+final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
 final testNGVersion = '6.11'
@@ -208,13 +209,13 @@ dependencies {
 
     compile 'org.jgrapht:jgrapht-core:0.9.1'
     compile 'org.testng:testng:' + testNGVersion //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
-    compile 'org.apache.hadoop:hadoop-minicluster:2.7.2' //the version of minicluster should match the version of hadoop
+    compile 'org.apache.hadoop:hadoop-minicluster:' + hadoopVersion
 
     compile('org.seqdoop:hadoop-bam:' + hadoopBamVersion) {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
     }
-    compile('org.apache.hadoop:hadoop-client:2.7.2') // should be a 'provided' dependency
+    compile('org.apache.hadoop:hadoop-client:' + hadoopVersion) // should be a 'provided' dependency
     compile('com.github.jsr203hadoop:jsr203hadoop:1.0.3')
 
     compile('de.javakaffee:kryo-serializers:0.41') {

--- a/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportColumn.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportColumn.java
@@ -66,7 +66,7 @@ public final class GATKReportColumn {
      * @return true if the value is a right alignable
      */
     protected static boolean isRightAlign(final String value) {
-        return value == null || RIGHT_ALIGN_STRINGS.contains(value) || NumberUtils.isNumber(value.trim());
+        return value == null || RIGHT_ALIGN_STRINGS.contains(value) || NumberUtils.isCreatable(value.trim());
     }
 
     /**


### PR DESCRIPTION
This bumped some transitive dependencies which required a minor update in unrelated classes

We shouldn't merge this until we get a 👍 from the SV team as well as running the jenkins spark tests.

I think the SV team is already using 2.2.0 since they've gone to dataproc image 1.2.

This will prevent the annoying adam log spam, closes #4186 
closes #2555 