### PR TITLE
removing unecessary test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,11 +252,7 @@ dependencies {
     // Required for COSMIC Funcotator data source:
     compile 'org.xerial:sqlite-jdbc:3.20.1'
 
-    //needed for DataflowAssert
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:2.10.0"
-
     testCompile "com.google.jimfs:jimfs:1.1"
 }
 


### PR DESCRIPTION
removing hamcrest and junit test dependencies
these were necessary for dataflow tests but are no longer used