### PR TITLE
Remove min crazy zish score for template size evidence

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -182,8 +182,9 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         public static final int CHIMERIC_ALIGNMENTS_HIGHMQ_THRESHOLD = 60;
         public static final int DEFAULT_MIN_ALIGNMENT_LENGTH = 50; // Minimum flanking alignment length filters used when going through contig alignments.
         public static final int DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY = 100;
-        public static final int DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD = 7;
+        public static final int DEFAULT_IMPRECISE_VARIANT_EVIDENCE_THRESHOLD = 7;
         public static final int DEFAULT_TRUTH_INTERVAL_PADDING = 50;
+        public static final int DEFAULT_MAX_CALLABLE_IMPRECISE_DELETION_SIZE = 15000;
 
         @Argument(doc = "Minimum flanking alignment length", fullName = "min-align-length")
         public Integer minAlignLength = DEFAULT_MIN_ALIGNMENT_LENGTH;
@@ -198,8 +199,8 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         public int assemblyImpreciseEvidenceOverlapUncertainty = DEFAULT_ASSEMBLED_IMPRECISE_EVIDENCE_OVERLAP_UNCERTAINTY;
 
         @Argument(doc = "Number of pieces of imprecise evidence necessary to call a variant in the absence of an assembled breakpoint.",
-                fullName = "imprecise-evidence-variant-calling-threshold")
-        public int impreciseEvidenceVariantCallingThreshold = DEFAULT_IMPRECISE_EVIDENCE_VARIANT_CALLING_THRESHOLD;
+                fullName = "imprecise-variant-evidence-threshold")
+        public int impreciseVariantEvidenceThreshold = DEFAULT_IMPRECISE_VARIANT_EVIDENCE_THRESHOLD;
 
         @Argument(doc = "External CNV calls file. Should be single sample VCF, and contain only confident autosomal non-reference CNV calls (for now).",
                 fullName = "cnv-calls", optional = true)
@@ -208,6 +209,10 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
         @Argument(doc = "Breakpoint padding for evaluation against truth data.",
                 fullName = "truth-interval-padding", optional = true)
         public int truthIntervalPadding = DEFAULT_TRUTH_INTERVAL_PADDING;
+
+        @Argument(doc = "Maximum size deletion to call based on imprecise evidence without corroborating read depth evidence",
+                fullName = "max-callable-imprecise-deletion-size", optional=true)
+        public int maxCallableImpreciseVariantDeletionSize = DEFAULT_MAX_CALLABLE_IMPRECISE_DELETION_SIZE;
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -222,7 +222,9 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
             // then also imprecise deletion
             final List<VariantContext> impreciseVariants = ImpreciseVariantDetector.
                     callImpreciseDeletionFromEvidenceLinks(evidenceTargetLinks, metadata, reference,
-                            discoverStageArgs.impreciseEvidenceVariantCallingThreshold, toolLogger);
+                            discoverStageArgs.impreciseVariantEvidenceThreshold,
+                            discoverStageArgs.maxCallableImpreciseVariantDeletionSize,
+                            toolLogger);
 
             annotatedVariants.addAll(impreciseVariants);
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
@@ -108,9 +108,22 @@ public final class EvidenceTargetLink {
         return new PairedStrandedIntervals(source, target);
     }
 
-    public static boolean isImpreciseDeletion(EvidenceTargetLink e) {
-        return e.getPairedStrandedIntervals().getLeft().getInterval().getContig() == e.getPairedStrandedIntervals().getRight().getInterval().getContig()
-                && e.getPairedStrandedIntervals().getLeft().getStrand() && !e.getPairedStrandedIntervals().getRight().getStrand();
+    public boolean isImpreciseDeletion() {
+        return getPairedStrandedIntervals().getLeft().getInterval().getContig() == getPairedStrandedIntervals().getRight().getInterval().getContig()
+                && getPairedStrandedIntervals().getLeft().getStrand() && !getPairedStrandedIntervals().getRight().getStrand();
+    }
+
+    /**
+     * Distance between the two intervals. Defined to be -1 if the intervals are on different contigs. Otherwise, returns the
+     * inner distance: the distance between the right boundary of the left interval and the left boundary of the right interval
+     */
+    public int getDistance() {
+        if (getPairedStrandedIntervals().getLeft().getInterval().getContig() != getPairedStrandedIntervals().getRight().getInterval().getContig()) {
+            return -1;
+        } else {
+            return getPairedStrandedIntervals().getRight().getInterval().getStart() - getPairedStrandedIntervals().getLeft().getInterval().getEnd();
+        }
+
     }
 
     public static final class Serializer extends com.esotericsoftware.kryo.Serializer<EvidenceTargetLink> {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifier.java
@@ -16,8 +16,7 @@ public class ReadClassifier implements Function<GATKRead, Iterator<BreakpointEvi
     @VisibleForTesting static final int MIN_INDEL_LEN = 40; // minimum length of an interesting indel
     private static final byte MIN_QUALITY = 15; // minimum acceptable quality in a soft-clip window
     private static final int MAX_LOW_QUALITY_SCORES = 3; // maximum # of low quality base calls in soft-clip window
-    private static final float MAX_ZISH_SCORE = 6.f; // maximum fragment-length "z" score for a normal fragment
-    private static final float MIN_CRAZY_ZISH_SCORE = 100.f; // "z" score that's probably associated with a mapping error
+    private static final float MAX_NON_OUTLIER_ZISH_SCORE = 6.f; // maximum fragment-length "z" score for a normal fragment
     private final ReadMetadata readMetadata;
     private final GATKRead sentinel;
     private final int allowedShortFragmentOverhang;
@@ -146,7 +145,7 @@ public class ReadClassifier implements Function<GATKRead, Iterator<BreakpointEvi
                     evidenceList.add(new BreakpointEvidence.OutiesPair(read, readMetadata));
                 } else {
                     final float zIshScore = readMetadata.getZishScore(read.getReadGroup(), Math.abs(read.getFragmentLength()));
-                    if ( zIshScore > MAX_ZISH_SCORE && zIshScore < MIN_CRAZY_ZISH_SCORE ) {
+                    if ( zIshScore > MAX_NON_OUTLIER_ZISH_SCORE) {
                         evidenceList.add(new BreakpointEvidence.WeirdTemplateSize(read, readMetadata));
                     }
                 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ImpreciseVariantDetectorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ImpreciseVariantDetectorUnitTest.java
@@ -68,7 +68,10 @@ public class ImpreciseVariantDetectorUnitTest extends GATKBaseTest {
     public void testProcessEvidenceTargetLinks(final List<EvidenceTargetLink> etls,
                                                final List<VariantContext> expectedVariants) {
         final int impreciseEvidenceVariantCallingThreshold =
-                new StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection().impreciseEvidenceVariantCallingThreshold;
+                new StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection().impreciseVariantEvidenceThreshold;
+
+        final int maxCallableImpreciseVariantDeletionSize =
+                new StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigsAlignmentsSparkArgumentCollection().maxCallableImpreciseVariantDeletionSize;
 
         final ReferenceMultiSource referenceMultiSource = new ReferenceMultiSource(twoBitRefURL, ReferenceWindowFunctions.IDENTITY_FUNCTION);
 
@@ -80,8 +83,12 @@ public class ImpreciseVariantDetectorUnitTest extends GATKBaseTest {
         etls.forEach(e -> evidenceTree.put(e.getPairedStrandedIntervals(), e));
 
         final List<VariantContext> impreciseVariants =
-                ImpreciseVariantDetector.callImpreciseDeletionFromEvidenceLinks(evidenceTree, metadata,
-                        referenceMultiSource, impreciseEvidenceVariantCallingThreshold, localLogger);
+                ImpreciseVariantDetector.callImpreciseDeletionFromEvidenceLinks(evidenceTree,
+                        metadata,
+                        referenceMultiSource,
+                        impreciseEvidenceVariantCallingThreshold,
+                        maxCallableImpreciseVariantDeletionSize,
+                        localLogger);
 
         VariantContextTestUtils.assertEqualVariants(impreciseVariants, expectedVariants);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifierTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifierTest.java
@@ -18,7 +18,7 @@ public class ReadClassifierTest extends GATKBaseTest {
                     60000000000L, 600000000L, 1200000000000L, 3000000000L);
 
     @Test(groups = "sv")
-    void restOfFragmentSizeTest() {
+    public void restOfFragmentSizeTest() {
         final FindBreakpointEvidenceSparkArgumentCollection params = new FindBreakpointEvidenceSparkArgumentCollection();
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeaderWithGroups(3, 1, 10000000, 1);
         final String groupName = header.getReadGroups().get(0).getReadGroupId();
@@ -78,6 +78,16 @@ public class ReadClassifierTest extends GATKBaseTest {
         read.setMateIsReverseStrand(true);
         read.setMatePosition(header.getSequenceDictionary().getSequence(2).getSequenceName(), read.getStart() - fragmentLen);
         checkClassification(classifier, read, Collections.emptyList());
+
+
+        read.setMatePosition(read.getContig(), read.getEnd() + 2000);
+        read.setFragmentLength(2000);
+        checkClassification(classifier, read, Collections.singletonList(new BreakpointEvidence.WeirdTemplateSize(read, readMetadata)));
+
+        read.setMatePosition(read.getContig(), read.getEnd() + 50000);
+        read.setFragmentLength(50000);
+        checkClassification(classifier, read, Collections.singletonList(new BreakpointEvidence.WeirdTemplateSize(read, readMetadata)));
+
     }
 
     private void checkClassification( final ReadClassifier classifier, final GATKRead read, final List<BreakpointEvidence> expectedEvidence ) {


### PR DESCRIPTION
This PR removes the cap on insert size for calling an 'innie' read pair SV evidence. Previously this was set to a max Z score of 100, which worked out to be around 10kb for some libraries. This was causing us to not gather read-pair based evidence around deletions of over 10kb. The motivation for this limit was to exclude very long read pairs as evidence since they are predominantly mapping errors. I believe that a) this limit was set too low, causing us to miss real events and b) the reads with very long insert sizes likely cover many instances of real variation, even if the actual mappings locations are incorrect, and that the assembly process, variant filters, and correlation with coverage data should be able to filter out assemblies triggered by reads with long mappings. 

Removing the limit on insert size does cause the imprecise deletion-calling code to produce many more spurious calls. In practice, I think that we should still evaluate this evidence but not make a call unless it is supported by coverage information, and a long deletion event should be very visible from depth-based calling. Therefore, I've added a limit on the size of imprecise deletions that will be called right now, with the expectation that this hard limit will be removed in favor of depth and other filtering in the future.

Manual evaluation of the results shows a small increase in incorrect imprecise variants (mostly in centromeric regions) that were just small enough to slip under the hard threshold, a very small number of incorrect small insertions caused by assembling messy regions, and a number of real 10-25kb deletions that we now assemble and either call an imprecise or precise deletion variant at, so I think this is a small net gain in callset quality.