### PR TITLE
Changed the key generation in MarkDuplicates to use a StringBuilder

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
@@ -26,12 +26,10 @@ public final class ReadsKey {
     private static String subkeyForFragment(final SAMFileHeader header, final GATKRead read) {
         final String library = ReadUtils.getLibrary(read, header);
 
-        return String.format(
-                "%s|%d|%d|%s",
-                library != null ? library : "-",
-                ReadUtils.getReferenceIndex(read, header),
-                ReadUtils.getStrandedUnclippedStart(read),
-                read.isReverseStrand() ? "r" : "f");
+        return (library != null ? library : "-") + "|" +
+                ReadUtils.getReferenceIndex(read, header) + "|" +
+                ReadUtils.getStrandedUnclippedStart(read) + "|" +
+                (read.isReverseStrand() ? "r" : "f");
     }
 
     /**
@@ -43,12 +41,10 @@ public final class ReadsKey {
             return PAIRED_ENDS_PREFIX + key;
         }
 
-        return String.format(
-                PAIRED_ENDS_PREFIX + "%s|%d|%d|%s",
-                key,
-                ReadUtils.getReferenceIndex(second, header),
-                ReadUtils.getStrandedUnclippedStart(second),
-                second.isReverseStrand() ? "r" : "f");
+        return PAIRED_ENDS_PREFIX + key + "|" +
+                ReadUtils.getReferenceIndex(second, header) + "|" +
+                ReadUtils.getStrandedUnclippedStart(second) + "|" +
+                (second.isReverseStrand() ? "r" : "f");
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
@@ -9,15 +9,17 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
  */
 public final class ReadsKey {
 
-    public static final String FRAGMENT_PREFIX = "f|";
+    public static final String FRAGMENT_PREFIX = "f";
 
-    private static final String PAIRED_ENDS_PREFIX = "p|";
+    public static final String DELIMETER = "|";
+
+    private static final String PAIRED_ENDS_PREFIX = "p";
 
     /**
      * Makes a unique key for the fragment.
      */
     public static String keyForFragment(final SAMFileHeader header, final GATKRead read) {
-        return FRAGMENT_PREFIX + subkeyForFragment(header, read);
+        return FRAGMENT_PREFIX + DELIMETER + subkeyForFragment(header, read);
     }
 
     /**
@@ -26,9 +28,9 @@ public final class ReadsKey {
     private static String subkeyForFragment(final SAMFileHeader header, final GATKRead read) {
         final String library = ReadUtils.getLibrary(read, header);
 
-        return new StringBuilder().append(library != null ? library : "-").append("|")
-                .append(ReadUtils.getReferenceIndex(read, header)).append("|")
-                .append(ReadUtils.getStrandedUnclippedStart(read)).append("|")
+        return new StringBuilder().append(library != null ? library : "-").append(DELIMETER)
+                .append(ReadUtils.getReferenceIndex(read, header)).append(DELIMETER)
+                .append(ReadUtils.getStrandedUnclippedStart(read)).append(DELIMETER)
                 .append(read.isReverseStrand() ? "r" : "f").toString();
     }
 
@@ -38,12 +40,12 @@ public final class ReadsKey {
     public static String keyForPairedEnds(final SAMFileHeader header, final GATKRead first, final GATKRead second) {
         final String key = subkeyForFragment(header, first);
         if (second == null) {
-            return PAIRED_ENDS_PREFIX + key;
+            return PAIRED_ENDS_PREFIX + DELIMETER + key;
         }
 
-        return new StringBuilder().append(PAIRED_ENDS_PREFIX).append(key).append("|")
-                .append(ReadUtils.getReferenceIndex(second, header)).append("|")
-                .append(ReadUtils.getStrandedUnclippedStart(second)).append("|")
+        return new StringBuilder().append(PAIRED_ENDS_PREFIX).append(key).append(DELIMETER)
+                .append(ReadUtils.getReferenceIndex(second, header)).append(DELIMETER)
+                .append(ReadUtils.getStrandedUnclippedStart(second)).append(DELIMETER)
                 .append(second.isReverseStrand() ? "r" : "f").toString();
     }
 
@@ -51,13 +53,13 @@ public final class ReadsKey {
      * Makes a unique key for the read.
      */
     public static String keyForRead(final SAMFileHeader header, final GATKRead read) {
-        return new StringBuilder().append(read.getReadGroup()).append("|").append(read.getName()).toString();
+        return new StringBuilder().append(read.getReadGroup()).append(DELIMETER).append(read.getName()).toString();
     }
 
     /**
      * Returns true if the key is a fragment key.
      */
     public static boolean isFragment(String key) {
-        return key.startsWith(FRAGMENT_PREFIX);
+        return key.charAt(0)=='f';
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
@@ -26,10 +26,10 @@ public final class ReadsKey {
     private static String subkeyForFragment(final SAMFileHeader header, final GATKRead read) {
         final String library = ReadUtils.getLibrary(read, header);
 
-        return (library != null ? library : "-") + "|" +
-                ReadUtils.getReferenceIndex(read, header) + "|" +
-                ReadUtils.getStrandedUnclippedStart(read) + "|" +
-                (read.isReverseStrand() ? "r" : "f");
+        return new StringBuilder().append(library != null ? library : "-").append("|")
+                .append(ReadUtils.getReferenceIndex(read, header)).append("|")
+                .append(ReadUtils.getStrandedUnclippedStart(read)).append("|")
+                .append(read.isReverseStrand() ? "r" : "f").toString();
     }
 
     /**
@@ -41,17 +41,17 @@ public final class ReadsKey {
             return PAIRED_ENDS_PREFIX + key;
         }
 
-        return PAIRED_ENDS_PREFIX + key + "|" +
-                ReadUtils.getReferenceIndex(second, header) + "|" +
-                ReadUtils.getStrandedUnclippedStart(second) + "|" +
-                (second.isReverseStrand() ? "r" : "f");
+        return new StringBuilder().append(PAIRED_ENDS_PREFIX).append(key).append("|")
+                .append(ReadUtils.getReferenceIndex(second, header)).append("|")
+                .append(ReadUtils.getStrandedUnclippedStart(second)).append("|")
+                .append(second.isReverseStrand() ? "r" : "f").toString();
     }
 
     /**
      * Makes a unique key for the read.
      */
     public static String keyForRead(final SAMFileHeader header, final GATKRead read) {
-        return  read.getReadGroup() + "|" + read.getName();
+        return new StringBuilder().append(read.getReadGroup()).append("|").append(read.getName()).toString();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKey.java
@@ -51,10 +51,7 @@ public final class ReadsKey {
      * Makes a unique key for the read.
      */
     public static String keyForRead(final SAMFileHeader header, final GATKRead read) {
-        return String.format(
-                "%s|%s",
-                read.getReadGroup(),
-                read.getName());
+        return  read.getReadGroup() + "|" + read.getName();
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKeyUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKeyUnitTest.java
@@ -1,0 +1,79 @@
+package org.broadinstitute.hellbender.utils.read.markduplicates;
+
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+public class ReadsKeyUnitTest {
+
+    @Test //(enabled = false)
+    // This test makes the argument that using a StringBuilder in ReadsKey is faster than an equivalent call to String.format()
+    /* an example of the results:
+        With Format:	13909867289
+        With Builder:	1130077051
+        With String +:	1155343164
+        With Joiner:	2013227121
+     */
+    public void testKeyForFragment() throws Exception {
+        Random rand = new Random();
+        int numTrials = 10000000;
+        for (int i = 0; i < numTrials; i++) {
+            rand.nextInt();
+        }
+
+        long startTime = System.nanoTime();
+        for (int i = 0; i < numTrials; i++) {
+            String s = String.format(
+                    "%s|%d|%d|%s",
+                    rand.nextBoolean() ? "SomeLongTestLibraryName-----x" : "-",
+                    rand.nextInt(30),
+                    rand.nextInt(100),
+                    rand.nextBoolean() ? "r" : "f");
+        }
+        long endTime = System.nanoTime();
+        System.out.println("With Format:\t" + (endTime - startTime));
+
+        startTime = System.nanoTime();
+        for (int i = 0; i < numTrials; i++) {
+            String s = new StringBuilder().append(rand.nextBoolean() ? "SomeLongTestLibraryName-----x" : "-")
+                    .append("|")
+                    .append(rand.nextInt(30))
+                    .append("|")
+                    .append(rand.nextInt(100))
+                    .append("|")
+                    .append( rand.nextBoolean() ? "r" : "f")
+                    .toString();
+
+        }
+        endTime = System.nanoTime();
+        System.out.println("With Builder:\t" + (endTime - startTime));
+
+        startTime = System.nanoTime();
+        for (int i = 0; i < numTrials; i++) {
+            String s = (rand.nextBoolean() ? "SomeLongTestLibraryName-----x" : "-") +
+                    "|" +
+                    rand.nextInt(30) +
+                    "|" +
+                    rand.nextInt(100) +
+                    "|" +
+                    (rand.nextBoolean() ? "r" : "f");
+
+        }
+        endTime = System.nanoTime();
+        System.out.println("With String +:\t" + (endTime - startTime));
+
+
+
+        startTime = System.nanoTime();
+        for (int i = 0; i < numTrials; i++) {
+            String s = String.join("|", rand.nextBoolean() ? "SomeLongTestLibraryName-----x" : "-",
+                    Integer.toString(rand.nextInt(30)),
+                    Integer.toString(rand.nextInt(100)),
+                    rand.nextBoolean() ? "r" : "f");
+
+        }
+        endTime = System.nanoTime();
+        System.out.println("With Joiner:\t" + (endTime - startTime));
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKeyUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/ReadsKeyUnitTest.java
@@ -6,7 +6,7 @@ import java.util.Random;
 
 public class ReadsKeyUnitTest {
 
-    @Test //(enabled = false)
+    @Test (enabled = false)
     // This test makes the argument that using a StringBuilder in ReadsKey is faster than an equivalent call to String.format()
     /* an example of the results:
         With Format:	13909867289
@@ -14,7 +14,7 @@ public class ReadsKeyUnitTest {
         With String +:	1155343164
         With Joiner:	2013227121
      */
-    public void testKeyForFragment() throws Exception {
+    public void testKeyForFragmentPerformanceEvidence() throws Exception {
         Random rand = new Random();
         int numTrials = 10000000;
         for (int i = 0; i < numTrials; i++) {
@@ -61,8 +61,6 @@ public class ReadsKeyUnitTest {
         }
         endTime = System.nanoTime();
         System.out.println("With String +:\t" + (endTime - startTime));
-
-
 
         startTime = System.nanoTime();
         for (int i = 0; i < numTrials; i++) {


### PR DESCRIPTION
This optimization came out of performance testing associated with https://github.com/broadinstitute/gatk/issues/3706 