### PR TITLE
CNV Tumor only WDL

### DIFF
--- a/scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_no-gc_tumor_only_workflow.json
+++ b/scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_no-gc_tumor_only_workflow.json
@@ -1,0 +1,11 @@
+{
+  "CNVSomaticPairWorkflow.common_sites": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/common_snps_sample-chr20.interval_list",
+  "CNVSomaticPairWorkflow.gatk_docker": "__GATK_DOCKER__",
+  "CNVSomaticPairWorkflow.intervals": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/ice_targets_sample-chr20.interval_list",
+  "CNVSomaticPairWorkflow.read_count_pon": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/wes-no-gc.pon.hdf5",
+  "CNVSomaticPairWorkflow.ref_fasta_dict": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.dict",
+  "CNVSomaticPairWorkflow.ref_fasta_fai": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.fasta.fai",
+  "CNVSomaticPairWorkflow.ref_fasta": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.fasta",
+  "CNVSomaticPairWorkflow.tumor_bam": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/SM-74P4M-v1-chr20-downsampled.deduplicated.bam",
+  "CNVSomaticPairWorkflow.tumor_bam_idx": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/SM-74P4M-v1-chr20-downsampled.deduplicated.bam.bai"
+}

--- a/scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wgs_do-gc_tumor_only_workflow.json
+++ b/scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wgs_do-gc_tumor_only_workflow.json
@@ -1,0 +1,12 @@
+{
+  "CNVSomaticPairWorkflow.common_sites": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/common_snps_sample-chr20.interval_list",
+  "CNVSomaticPairWorkflow.gatk_docker": "__GATK_DOCKER__",
+  "CNVSomaticPairWorkflow.intervals": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/chr20.interval_list",
+  "CNVSomaticPairWorkflow.bin_length": "10000",
+  "CNVSomaticPairWorkflow.read_count_pon": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/wgs-do-gc.pon.hdf5",
+  "CNVSomaticPairWorkflow.ref_fasta_dict": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.dict",
+  "CNVSomaticPairWorkflow.ref_fasta_fai": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.fasta.fai",
+  "CNVSomaticPairWorkflow.ref_fasta": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/human_g1k_v37.chr-20.truncated.fasta",
+  "CNVSomaticPairWorkflow.tumor_bam": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/HCC1143-t1-chr20-downsampled.deduplicated.bam",
+  "CNVSomaticPairWorkflow.tumor_bam_idx": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_somatic_workflows_test_files/HCC1143-t1-chr20-downsampled.deduplicated.bam.bai"
+}

--- a/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
+++ b/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
@@ -34,7 +34,7 @@ sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_T
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wgs_no-gc_workflow.json >cnv_somatic_pair_wgs_no-gc_workflow_mod.json
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wes_do-gc_workflow.json >cnv_somatic_pair_wes_do-gc_workflow_mod.json
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wgs_do-gc_workflow.json >cnv_somatic_pair_wgs_do-gc_workflow_mod.json
-
+sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wgs_do-gc_tumor_only_workflow.json > cnv_somatic_pair_wgs_do-gc_tumor_only_workflow_mod.json
 echo "Running ========"
 CROMWELL_JAR="cromwell-0.29.jar"
 
@@ -55,3 +55,6 @@ java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/c
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wes_do-gc_workflow_mod.json
 # Pair WGS w/ explicit GC correction
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wgs_do-gc_workflow_mod.json
+
+# Tumor only WGS w/ explicit GC correction
+java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wgs_do-gc_tumor_only_workflow_mod.json

--- a/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
+++ b/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
@@ -57,9 +57,7 @@ java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/c
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wes_do-gc_workflow_mod.json
 # Pair WGS w/ explicit GC correction
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wgs_do-gc_workflow_mod.json
-
 # Tumor only WGS w/ explicit GC correction
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wgs_do-gc_tumor_only_workflow_mod.json
-
 # Tumor only WES w/o explicit GC correction
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wes_no-gc_tumor_only_workflow_mod.json

--- a/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
+++ b/scripts/cnv_cromwell_tests/somatic/run_cnv_somatic_workflows.sh
@@ -35,6 +35,8 @@ sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_T
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wes_do-gc_workflow.json >cnv_somatic_pair_wes_do-gc_workflow_mod.json
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wgs_do-gc_workflow.json >cnv_somatic_pair_wgs_do-gc_workflow_mod.json
 sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wgs_do-gc_tumor_only_workflow.json > cnv_somatic_pair_wgs_do-gc_tumor_only_workflow_mod.json
+sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" ${CNV_CROMWELL_TEST_DIR}/cnv_somatic_pair_wes_no-gc_tumor_only_workflow.json > cnv_somatic_pair_wes_no-gc_tumor_only_workflow_mod.json
+
 echo "Running ========"
 CROMWELL_JAR="cromwell-0.29.jar"
 
@@ -58,3 +60,6 @@ java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/c
 
 # Tumor only WGS w/ explicit GC correction
 java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wgs_do-gc_tumor_only_workflow_mod.json
+
+# Tumor only WES w/o explicit GC correction
+java -jar ~/${CROMWELL_JAR} run /home/travis/build/broadinstitute/gatk/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl -i cnv_somatic_pair_wes_no-gc_tumor_only_workflow_mod.json

--- a/scripts/cnv_wdl/somatic/README.md
+++ b/scripts/cnv_wdl/somatic/README.md
@@ -24,10 +24,10 @@ The reference used must be the same between PoN and case samples.
 - ``CNVSomaticPanelWorkflow.ref_fasta_fai`` -- Path to reference fasta fai file.
 - ``CNVSomaticPanelWorkflow.ref_fasta`` -- Path to reference fasta file.
 
-In additional, there are optional workflow-level and task-level parameters that may be set by advanced users; for example:
+Additionally, there are optional workflow-level and task-level parameters that may be set by advanced users; for example:
 
 - ``CNVSomaticPanelWorkflow.do_explicit_gc_correction`` -- (optional) If true, perform explicit GC-bias correction when creating PoN and in subsequent denoising of case samples.  If false, rely on PCA-based denoising to correct for GC bias.
-- ``CNVSomaticPanelWorkflow.PreprocessIntervals.bin_length`` -- Size of bins (in bp) for coverage collection.  *This must be the same value used for all case samples.*
+- ``CNVSomaticPanelWorkflow.PreprocessIntervals.bin_length`` -- Size of bins (in bp) for coverage collection.  Typically, this is set to `0` for capture samples.  *This must be the same value used for all case samples.*
 - ``CNVSomaticPanelWorkflow.PreprocessIntervals.padding`` -- Amount of padding (in bp) to add to both sides of targets for WES coverage collection.  *This must be the same value used for all case samples.*
 
 Further explanation of other task-level parameters may be found by invoking the ``--help`` documentation available in the gatk.jar for each tool.
@@ -39,8 +39,8 @@ The reference and bins (if specified) must be the same between PoN and case samp
 - ``CNVSomaticPairWorkflow.common_sites`` -- Picard or GATK-style interval list of common sites to use for collecting allelic counts.
 - ``CNVSomaticPairWorkflow.gatk_docker`` -- GATK Docker image (e.g., ``broadinstitute/gatk:latest``).
 - ``CNVSomaticPairWorkflow.intervals`` -- Picard or GATK-style interval list.  For WGS, this should typically only include the autosomal chromosomes.
-- ``CNVSomaticPairWorkflow.normal_bam`` -- Path to normal BAM file.
-- ``CNVSomaticPairWorkflow.normal_bam_idx`` -- Path to normal BAM file index.
+- ``CNVSomaticPairWorkflow.normal_bam`` -- (optional, but recommended) Path to normal BAM file.  Do not specify in order to run the tumor sample without a matched normal.
+- ``CNVSomaticPairWorkflow.normal_bam_idx`` -- (optional, but recommended) Path to normal BAM file index.  Do not specify in order to run the tumor sample without a matched normal.
 - ``CNVSomaticPairWorkflow.read_count_pon`` -- Path to read-count PoN created by the panel workflow. 
 - ``CNVSomaticPairWorkflow.ref_fasta_dict`` -- Path to reference dict file.
 - ``CNVSomaticPairWorkflow.ref_fasta_fai`` -- Path to reference fasta fai file.
@@ -48,7 +48,7 @@ The reference and bins (if specified) must be the same between PoN and case samp
 - ``CNVSomaticPairWorkflow.tumor_bam`` -- Path to tumor BAM file.
 - ``CNVSomaticPairWorkflow.tumor_bam_idx`` -- Path to tumor BAM file index.
 
-In additional, there are several task-level parameters that may be set by advanced users as above.
+Additionally, there are several task-level parameters that may be set by advanced users as above.
 
 To invoke Oncotator on the called tumor copy-ratio segments:
 

--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -128,6 +128,9 @@ workflow CNVSomaticPairWorkflow {
     # This is added to every task as padding, should increase if systematically you need more disk for every call
     Int disk_pad = 20 + ceil(size(intervals, "GB")) + ceil(size(common_sites, "GB")) + gatk4_override_size + select_first([emergency_extra_disk,0])
 
+    File final_normal_bam = select_first([normal_bam, "null"])
+    File final_normal_bam_idx = select_first([normal_bam_idx, "null"])
+
     Int preprocess_intervals_disk = ref_size + disk_pad
     call CNVTasks.PreprocessIntervals {
         input:
@@ -166,8 +169,8 @@ workflow CNVSomaticPairWorkflow {
         call CNVTasks.CollectCounts as CollectCountsNormal {
             input:
                 intervals = PreprocessIntervals.preprocessed_intervals,
-                bam = normal_bam,
-                bam_idx = normal_bam_idx,
+                bam = final_normal_bam,
+                bam_idx = final_normal_bam_idx,
                 ref_fasta = ref_fasta,
                 ref_fasta_fai = ref_fasta_fai,
                 ref_fasta_dict = ref_fasta_dict,
@@ -202,8 +205,8 @@ workflow CNVSomaticPairWorkflow {
         call CNVTasks.CollectAllelicCounts as CollectAllelicCountsNormal {
             input:
                 common_sites = common_sites,
-                bam = normal_bam,
-                bam_idx = normal_bam_idx,
+                bam = final_normal_bam,
+                bam_idx = final_normal_bam_idx,
                 ref_fasta = ref_fasta,
                 ref_fasta_dict = ref_fasta_dict,
                 ref_fasta_fai = ref_fasta_fai,

--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -30,8 +30,8 @@ workflow CNVSomaticPairWorkflow {
     File intervals
     File tumor_bam
     File tumor_bam_idx
-    File normal_bam
-    File normal_bam_idx
+    File? normal_bam
+    File? normal_bam_idx
     File read_count_pon
     File ref_fasta_dict
     File ref_fasta_fai
@@ -122,7 +122,7 @@ workflow CNVSomaticPairWorkflow {
     Int ref_size = ceil(size(ref_fasta, "GB") + size(ref_fasta_dict, "GB") + size(ref_fasta_fai, "GB"))
     Int read_count_pon_size = ceil(size(read_count_pon, "GB"))
     Int tumor_bam_size = ceil(size(tumor_bam, "GB") + size(tumor_bam_idx, "GB"))
-    Int normal_bam_size = ceil(size(normal_bam, "GB") + size(normal_bam_idx, "GB"))
+    Int normal_bam_size = if defined(normal_bam) then ceil(size(normal_bam, "GB") + size(normal_bam_idx, "GB")) else 0
 
     Int gatk4_override_size = if defined(gatk4_jar_override) then ceil(size(gatk4_jar_override, "GB")) else 0
     # This is added to every task as padding, should increase if systematically you need more disk for every call
@@ -162,20 +162,22 @@ workflow CNVSomaticPairWorkflow {
     }
 
     Int collect_counts_normal_disk = normal_bam_size + ceil(size(PreprocessIntervals.preprocessed_intervals, "GB")) + disk_pad
-    call CNVTasks.CollectCounts as CollectCountsNormal {
-        input:
-            intervals = PreprocessIntervals.preprocessed_intervals,
-            bam = normal_bam,
-            bam_idx = normal_bam_idx,
-            ref_fasta = ref_fasta,
-            ref_fasta_fai = ref_fasta_fai,
-            ref_fasta_dict = ref_fasta_dict,
-            format = format,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_collect_counts,
-            disk_space_gb = collect_counts_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        call CNVTasks.CollectCounts as CollectCountsNormal {
+            input:
+                intervals = PreprocessIntervals.preprocessed_intervals,
+                bam = normal_bam,
+                bam_idx = normal_bam_idx,
+                ref_fasta = ref_fasta,
+                ref_fasta_fai = ref_fasta_fai,
+                ref_fasta_dict = ref_fasta_dict,
+                format = format,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_collect_counts,
+                disk_space_gb = collect_counts_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     Int collect_allelic_counts_tumor_disk = tumor_bam_size + ref_size + disk_pad
@@ -195,21 +197,23 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    Int collect_allelic_counts_normal_disk = normal_bam_size + ref_size + disk_pad
-    call CNVTasks.CollectAllelicCounts as CollectAllelicCountsNormal {
-        input:
-            common_sites = common_sites,
-            bam = normal_bam,
-            bam_idx = normal_bam_idx,
-            ref_fasta = ref_fasta,
-            ref_fasta_dict = ref_fasta_dict,
-            ref_fasta_fai = ref_fasta_fai,
-            minimum_base_quality =  minimum_base_quality,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_collect_allelic_counts,
-            disk_space_gb = collect_allelic_counts_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        Int collect_allelic_counts_normal_disk = normal_bam_size + ref_size + disk_pad
+        call CNVTasks.CollectAllelicCounts as CollectAllelicCountsNormal {
+            input:
+                common_sites = common_sites,
+                bam = normal_bam,
+                bam_idx = normal_bam_idx,
+                ref_fasta = ref_fasta,
+                ref_fasta_dict = ref_fasta_dict,
+                ref_fasta_fai = ref_fasta_fai,
+                minimum_base_quality =  minimum_base_quality,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_collect_allelic_counts,
+                disk_space_gb = collect_allelic_counts_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     Int denoise_read_counts_tumor_disk = read_count_pon_size + ceil(size(CollectCountsTumor.counts, "GB")) + disk_pad
@@ -226,21 +230,24 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    Int denoise_read_counts_normal_disk = read_count_pon_size + ceil(size(CollectCountsNormal.counts, "GB")) + disk_pad
-    call DenoiseReadCounts as DenoiseReadCountsNormal {
-        input:
-            entity_id = CollectCountsNormal.entity_id,
-            read_counts = CollectCountsNormal.counts,
-            read_count_pon = read_count_pon,
-            number_of_eigensamples = number_of_eigensamples,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_denoise_read_counts,
-            disk_space_gb = denoise_read_counts_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        Int denoise_read_counts_normal_disk = read_count_pon_size + ceil(size(CollectCountsNormal.counts, "GB")) + disk_pad
+        call DenoiseReadCounts as DenoiseReadCountsNormal {
+            input:
+                entity_id = CollectCountsNormal.entity_id,
+                read_counts = CollectCountsNormal.counts,
+                read_count_pon = read_count_pon,
+                number_of_eigensamples = number_of_eigensamples,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_denoise_read_counts,
+                disk_space_gb = denoise_read_counts_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
-    Int model_segments_disk = ceil(size(DenoiseReadCountsTumor.denoised_copy_ratios, "GB")) + ceil(size(CollectAllelicCountsTumor.allelic_counts, "GB")) + ceil(size(CollectAllelicCountsNormal.allelic_counts, "GB")) + disk_pad
+    Int model_segments_normal_portion = if defined(normal_bam) then ceil(size(CollectAllelicCountsNormal.allelic_counts, "GB")) else 0
+    Int model_segments_disk = ceil(size(DenoiseReadCountsTumor.denoised_copy_ratios, "GB")) + ceil(size(CollectAllelicCountsTumor.allelic_counts, "GB")) + model_segments_normal_portion + disk_pad
     call ModelSegments as ModelSegmentsTumor {
         input:
             entity_id = CollectCountsTumor.entity_id,
@@ -273,35 +280,37 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    call ModelSegments as ModelSegmentsNormal {
-        input:
-            entity_id = CollectCountsNormal.entity_id,
-            denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
-            allelic_counts = CollectAllelicCountsNormal.allelic_counts,
-            max_num_segments_per_chromosome = max_num_segments_per_chromosome,
-            min_total_allele_count = min_total_allele_count,
-            genotyping_homozygous_log_ratio_threshold = genotyping_homozygous_log_ratio_threshold,
-            genotyping_base_error_rate = genotyping_base_error_rate,
-            kernel_variance_copy_ratio = kernel_variance_copy_ratio,
-            kernel_variance_allele_fraction = kernel_variance_allele_fraction,
-            kernel_scaling_allele_fraction = kernel_scaling_allele_fraction,
-            kernel_approximation_dimension = kernel_approximation_dimension,
-            window_sizes = window_sizes,
-            num_changepoints_penalty_factor = num_changepoints_penalty_factor,
-            minor_allele_fraction_prior_alpha = minor_allele_fraction_prior_alpha,
-            num_samples_copy_ratio = num_samples_copy_ratio,
-            num_burn_in_copy_ratio = num_burn_in_copy_ratio,
-            num_samples_allele_fraction = num_samples_allele_fraction,
-            num_burn_in_allele_fraction = num_burn_in_allele_fraction,
-            smoothing_threshold_copy_ratio = smoothing_threshold_copy_ratio,
-            smoothing_threshold_allele_fraction = smoothing_threshold_allele_fraction,
-            max_num_smoothing_iterations = max_num_smoothing_iterations,
-            num_smoothing_iterations_per_fit = num_smoothing_iterations_per_fit,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_model_segments,
-            disk_space_gb = model_segments_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        call ModelSegments as ModelSegmentsNormal {
+            input:
+                entity_id = CollectCountsNormal.entity_id,
+                denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
+                allelic_counts = CollectAllelicCountsNormal.allelic_counts,
+                max_num_segments_per_chromosome = max_num_segments_per_chromosome,
+                min_total_allele_count = min_total_allele_count,
+                genotyping_homozygous_log_ratio_threshold = genotyping_homozygous_log_ratio_threshold,
+                genotyping_base_error_rate = genotyping_base_error_rate,
+                kernel_variance_copy_ratio = kernel_variance_copy_ratio,
+                kernel_variance_allele_fraction = kernel_variance_allele_fraction,
+                kernel_scaling_allele_fraction = kernel_scaling_allele_fraction,
+                kernel_approximation_dimension = kernel_approximation_dimension,
+                window_sizes = window_sizes,
+                num_changepoints_penalty_factor = num_changepoints_penalty_factor,
+                minor_allele_fraction_prior_alpha = minor_allele_fraction_prior_alpha,
+                num_samples_copy_ratio = num_samples_copy_ratio,
+                num_burn_in_copy_ratio = num_burn_in_copy_ratio,
+                num_samples_allele_fraction = num_samples_allele_fraction,
+                num_burn_in_allele_fraction = num_burn_in_allele_fraction,
+                smoothing_threshold_copy_ratio = smoothing_threshold_copy_ratio,
+                smoothing_threshold_allele_fraction = smoothing_threshold_allele_fraction,
+                max_num_smoothing_iterations = max_num_smoothing_iterations,
+                num_smoothing_iterations_per_fit = num_smoothing_iterations_per_fit,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_model_segments,
+                disk_space_gb = model_segments_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     Int copy_ratio_segments_tumor_disk = ceil(size(DenoiseReadCountsTumor.denoised_copy_ratios, "GB")) + ceil(size(ModelSegmentsTumor.copy_ratio_only_segments, "GB")) + disk_pad
@@ -320,20 +329,22 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    Int copy_ratio_segments_normal_disk = ceil(size(DenoiseReadCountsNormal.denoised_copy_ratios, "GB")) + ceil(size(ModelSegmentsNormal.copy_ratio_only_segments, "GB")) + disk_pad
-    call CallCopyRatioSegments as CallCopyRatioSegmentsNormal {
-        input:
-            entity_id = CollectCountsNormal.entity_id,
-            copy_ratio_segments = ModelSegmentsNormal.copy_ratio_only_segments,
-            neutral_segment_copy_ratio_lower_bound = neutral_segment_copy_ratio_lower_bound,
-            neutral_segment_copy_ratio_upper_bound = neutral_segment_copy_ratio_upper_bound,
-            outlier_neutral_segment_copy_ratio_z_score_threshold = outlier_neutral_segment_copy_ratio_z_score_threshold,
-            calling_copy_ratio_z_score_threshold = calling_copy_ratio_z_score_threshold,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_call_copy_ratio_segments,
-            disk_space_gb = copy_ratio_segments_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        Int copy_ratio_segments_normal_disk = ceil(size(DenoiseReadCountsNormal.denoised_copy_ratios, "GB")) + ceil(size(ModelSegmentsNormal.copy_ratio_only_segments, "GB")) + disk_pad
+        call CallCopyRatioSegments as CallCopyRatioSegmentsNormal {
+            input:
+                entity_id = CollectCountsNormal.entity_id,
+                copy_ratio_segments = ModelSegmentsNormal.copy_ratio_only_segments,
+                neutral_segment_copy_ratio_lower_bound = neutral_segment_copy_ratio_lower_bound,
+                neutral_segment_copy_ratio_upper_bound = neutral_segment_copy_ratio_upper_bound,
+                outlier_neutral_segment_copy_ratio_z_score_threshold = outlier_neutral_segment_copy_ratio_z_score_threshold,
+                calling_copy_ratio_z_score_threshold = calling_copy_ratio_z_score_threshold,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_call_copy_ratio_segments,
+                disk_space_gb = copy_ratio_segments_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     # The F=files from other tasks are small enough to just combine into one disk variable and pass to the tumor plotting tasks
@@ -352,20 +363,22 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    # The files from other tasks are small enough to just combine into one disk variable and pass to the normal plotting tasks
-    Int plot_normal_disk = ref_size + ceil(size(DenoiseReadCountsNormal.standardized_copy_ratios, "GB")) + ceil(size(DenoiseReadCountsNormal.denoised_copy_ratios, "GB")) + ceil(size(ModelSegmentsNormal.het_allelic_counts, "GB")) + ceil(size(ModelSegmentsNormal.modeled_segments, "GB")) + disk_pad
-    call PlotDenoisedCopyRatios as PlotDenoisedCopyRatiosNormal {
-        input:
-            entity_id = CollectCountsNormal.entity_id,
-            standardized_copy_ratios = DenoiseReadCountsNormal.standardized_copy_ratios,
-            denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
-            ref_fasta_dict = ref_fasta_dict,
-            minimum_contig_length = minimum_contig_length,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_plotting,
-            disk_space_gb = plot_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        # The files from other tasks are small enough to just combine into one disk variable and pass to the normal plotting tasks
+        Int plot_normal_disk = ref_size + ceil(size(DenoiseReadCountsNormal.standardized_copy_ratios, "GB")) + ceil(size(DenoiseReadCountsNormal.denoised_copy_ratios, "GB")) + ceil(size(ModelSegmentsNormal.het_allelic_counts, "GB")) + ceil(size(ModelSegmentsNormal.modeled_segments, "GB")) + disk_pad
+        call PlotDenoisedCopyRatios as PlotDenoisedCopyRatiosNormal {
+            input:
+                entity_id = CollectCountsNormal.entity_id,
+                standardized_copy_ratios = DenoiseReadCountsNormal.standardized_copy_ratios,
+                denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
+                ref_fasta_dict = ref_fasta_dict,
+                minimum_contig_length = minimum_contig_length,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_plotting,
+                disk_space_gb = plot_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     call PlotModeledSegments as PlotModeledSegmentsTumor {
@@ -383,19 +396,21 @@ workflow CNVSomaticPairWorkflow {
             preemptible_attempts = preemptible_attempts
     }
 
-    call PlotModeledSegments as PlotModeledSegmentsNormal {
-        input:
-            entity_id = CollectCountsNormal.entity_id,
-            denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
-            het_allelic_counts = ModelSegmentsNormal.het_allelic_counts,
-            modeled_segments = ModelSegmentsNormal.modeled_segments,
-            ref_fasta_dict = ref_fasta_dict,
-            minimum_contig_length = minimum_contig_length,
-            gatk4_jar_override = gatk4_jar_override,
-            gatk_docker = gatk_docker,
-            mem_gb = mem_gb_for_plotting,
-            disk_space_gb = plot_normal_disk,
-            preemptible_attempts = preemptible_attempts
+    if (defined(normal_bam)) {
+        call PlotModeledSegments as PlotModeledSegmentsNormal {
+            input:
+                entity_id = CollectCountsNormal.entity_id,
+                denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
+                het_allelic_counts = ModelSegmentsNormal.het_allelic_counts,
+                modeled_segments = ModelSegmentsNormal.modeled_segments,
+                ref_fasta_dict = ref_fasta_dict,
+                minimum_contig_length = minimum_contig_length,
+                gatk4_jar_override = gatk4_jar_override,
+                gatk_docker = gatk_docker,
+                mem_gb = mem_gb_for_plotting,
+                disk_space_gb = plot_normal_disk,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     if (select_first([is_run_oncotator, false])) {
@@ -436,29 +451,29 @@ workflow CNVSomaticPairWorkflow {
         File scaled_delta_MAD_tumor = PlotDenoisedCopyRatiosTumor.scaled_delta_MAD
         File modeled_segments_plot_tumor = PlotModeledSegmentsTumor.modeled_segments_plot
 
-        File read_counts_entity_id_normal = CollectCountsNormal.entity_id
-        File read_counts_normal = CollectCountsNormal.counts
-        File allelic_counts_entity_id_normal = CollectAllelicCountsNormal.entity_id
-        File allelic_counts_normal = CollectAllelicCountsNormal.allelic_counts
-        File denoised_copy_ratios_normal = DenoiseReadCountsNormal.denoised_copy_ratios
-        File standardized_copy_ratios_normal = DenoiseReadCountsNormal.standardized_copy_ratios
-        File het_allelic_counts_normal = ModelSegmentsNormal.het_allelic_counts
-        File normal_het_allelic_counts_normal = ModelSegmentsNormal.normal_het_allelic_counts
-        File copy_ratio_only_segments_normal = ModelSegmentsNormal.copy_ratio_only_segments
-        File modeled_segments_begin_normal = ModelSegmentsNormal.modeled_segments_begin
-        File copy_ratio_parameters_begin_normal = ModelSegmentsNormal.copy_ratio_parameters_begin
-        File allele_fraction_parameters_begin_normal = ModelSegmentsNormal.allele_fraction_parameters_begin
-        File modeled_segments_normal = ModelSegmentsNormal.modeled_segments
-        File copy_ratio_parameters_normal = ModelSegmentsNormal.copy_ratio_parameters
-        File allele_fraction_parameters_normal = ModelSegmentsNormal.allele_fraction_parameters
-        File called_copy_ratio_segments_normal = CallCopyRatioSegmentsNormal.called_copy_ratio_segments
-        File denoised_copy_ratios_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_plot
-        File denoised_copy_ratios_lim_4_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_lim_4_plot
-        File standardized_MAD_normal = PlotDenoisedCopyRatiosNormal.standardized_MAD
-        File denoised_MAD_normal = PlotDenoisedCopyRatiosNormal.denoised_MAD
-        File delta_MAD_normal = PlotDenoisedCopyRatiosNormal.delta_MAD
-        File scaled_delta_MAD_normal = PlotDenoisedCopyRatiosNormal.scaled_delta_MAD
-        File modeled_segments_plot_normal = PlotModeledSegmentsNormal.modeled_segments_plot
+        File? read_counts_entity_id_normal = CollectCountsNormal.entity_id
+        File? read_counts_normal = CollectCountsNormal.counts
+        File? allelic_counts_entity_id_normal = CollectAllelicCountsNormal.entity_id
+        File? allelic_counts_normal = CollectAllelicCountsNormal.allelic_counts
+        File? denoised_copy_ratios_normal = DenoiseReadCountsNormal.denoised_copy_ratios
+        File? standardized_copy_ratios_normal = DenoiseReadCountsNormal.standardized_copy_ratios
+        File? het_allelic_counts_normal = ModelSegmentsNormal.het_allelic_counts
+        File? normal_het_allelic_counts_normal = ModelSegmentsNormal.normal_het_allelic_counts
+        File? copy_ratio_only_segments_normal = ModelSegmentsNormal.copy_ratio_only_segments
+        File? modeled_segments_begin_normal = ModelSegmentsNormal.modeled_segments_begin
+        File? copy_ratio_parameters_begin_normal = ModelSegmentsNormal.copy_ratio_parameters_begin
+        File? allele_fraction_parameters_begin_normal = ModelSegmentsNormal.allele_fraction_parameters_begin
+        File? modeled_segments_normal = ModelSegmentsNormal.modeled_segments
+        File? copy_ratio_parameters_normal = ModelSegmentsNormal.copy_ratio_parameters
+        File? allele_fraction_parameters_normal = ModelSegmentsNormal.allele_fraction_parameters
+        File? called_copy_ratio_segments_normal = CallCopyRatioSegmentsNormal.called_copy_ratio_segments
+        File? denoised_copy_ratios_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_plot
+        File? denoised_copy_ratios_lim_4_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_lim_4_plot
+        File? standardized_MAD_normal = PlotDenoisedCopyRatiosNormal.standardized_MAD
+        File? denoised_MAD_normal = PlotDenoisedCopyRatiosNormal.denoised_MAD
+        File? delta_MAD_normal = PlotDenoisedCopyRatiosNormal.delta_MAD
+        File? scaled_delta_MAD_normal = PlotDenoisedCopyRatiosNormal.scaled_delta_MAD
+        File? modeled_segments_plot_normal = PlotModeledSegmentsNormal.modeled_segments_plot
 
         File oncotated_called_file_tumor = select_first([CNVOncotatorWorkflow.oncotated_called_file, "null"])
         File oncotated_called_gene_list_file_tumor = select_first([CNVOncotatorWorkflow.oncotated_called_gene_list_file, "null"])


### PR DESCRIPTION
Fixes #3983 

- Added two tumor-only tests to the CNV WDL test.  I did not add all four possible combinations, since I did not see the value.  I just wanted to make sure that the WGS and WES cases were covered.