### PR TITLE
Revert "Bump to ADAM 0.23.0 release. (#4044)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,13 +197,13 @@ dependencies {
         exclude module: 'servlet-api'
     }
 
-    compile('org.bdgenomics.adam:adam-core-spark2_2.11:0.23.0') {
+    compile 'org.bdgenomics.bdg-formats:bdg-formats:0.5.0'
+    compile('org.bdgenomics.adam:adam-core-spark2_2.11:0.20.0') {
         exclude group: 'org.slf4j'
         exclude group: 'org.apache.hadoop'
         exclude group: 'org.scala-lang'
         exclude module: 'kryo'
         exclude module: 'hadoop-bam'
-        exclude module: 'commons-math3'
     }
 
     compile 'org.jgrapht:jgrapht-core:0.9.1'


### PR DESCRIPTION
This reverts commit 8a366c7ba570c61338f7109b86c3284b80d5cf47.

We noticed a major performance regression in `BaseRecalibratorSpark` and `HaplotypeCallerSpark` after we upgraded our ADAM dependency (see https://github.com/broadinstitute/gatk/issues/4376). This PR reverts that upgrade for now until we understand the underlying cause.