### PR TITLE
Display a warning message for Beta and Exerimental tools.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -174,7 +174,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
             printStartupMessage(startDateTime);
         }
 
-        printProductionWarning();
+        warnOnToolStatus();
 
         try {
             return runTool();
@@ -285,7 +285,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
      * @param useTerminalColor true if the message should include highlighting terminal colorization
      * @return a warning message if the tool is Beta or Experimental, otherwise null
      */
-    protected String getProductionWarning(final boolean useTerminalColor) {
+    protected String getToolStatusWarning(final boolean useTerminalColor) {
         final String KNRM = "\u001B[0m"; // reset
         final String BOLDRED = "\u001B[1m\u001B[31m";
         final int BORDER_LENGTH = 60;
@@ -317,8 +317,8 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
     /**
      * If a tool is either Experimental or Beta, log a warning against use in production a environment.
      */
-    protected void printProductionWarning() {
-        final String warningMessage = getProductionWarning(!(System.console() == null));
+    protected void warnOnToolStatus() {
+        final String warningMessage = getToolStatusWarning(true);
         if (warningMessage != null) {
             logger.warn(warningMessage);
         }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -14,7 +14,6 @@ import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.*;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.config.ConfigFactory;
@@ -281,49 +280,47 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
     }
 
     /**
-     * If a tool is either Experimental or Beta, return a warning message advising against use in production environment.
+     * If this tool is either Experimental or Beta, return a warning message advising against use in production
+     * environment.
+     * @param useTerminalColor true if the message should include highlighting terminal colorization
      * @return a warning message if the tool is Beta or Experimental, otherwise null
      */
-    protected String getProductionWarning() {
+    protected String getProductionWarning(final boolean useTerminalColor) {
         final String KNRM = "\u001B[0m"; // reset
         final String BOLDRED = "\u001B[1m\u001B[31m";
+        final int BORDER_LENGTH = 60;
 
         String warningMessage = null;
         if (isBetaFeature()) {
             warningMessage = String.format(
                     "\n\n%s   %s\n\n   Warning: %s is a BETA tool and is not yet ready for use in production\n\n   %s%s\n\n",
-                    BOLDRED,
-                    Utils.dupChar('!', 60),
+                    useTerminalColor ? BOLDRED : "",
+                    Utils.dupChar('!', BORDER_LENGTH),
                     this.getClass().getSimpleName(),
-                    Utils.dupChar('!', 60),
-                    KNRM
+                    Utils.dupChar('!', BORDER_LENGTH),
+                    useTerminalColor ? KNRM : ""
             );
         }
         else if (isExperimentalFeature()) {
             warningMessage = String.format(
                     "\n\n%s   %s\n\n   Warning: %s is an EXPERIMENTAL tool and should not be used for production\n\n   %s%s\n\n",
-                    BOLDRED,
-                    Utils.dupChar('!', 60),
+                    useTerminalColor ? BOLDRED : "",
+                    Utils.dupChar('!', BORDER_LENGTH),
                     this.getClass().getSimpleName(),
-                    Utils.dupChar('!', 60),
-                    KNRM
+                    Utils.dupChar('!', BORDER_LENGTH),
+                    useTerminalColor ? KNRM : ""
             );
         }
         return warningMessage;
     }
 
     /**
-     * If a tool is either Experimental or Beta, log a warning against use in production environment.
+     * If a tool is either Experimental or Beta, log a warning against use in production a environment.
      */
     protected void printProductionWarning() {
-        final String warningMessage = getProductionWarning();
+        final String warningMessage = getProductionWarning(!(System.console() == null));
         if (warningMessage != null) {
             logger.warn(warningMessage);
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                throw new GATKException("Interrupted during warning message pause", e);
-            }
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -204,9 +204,9 @@ public class CommandLineProgramUnitTest extends GATKBaseTest {
         Assert.assertEquals(clp.isBetaFeature(), isBeta);
         Assert.assertEquals(clp.isExperimentalFeature(), isExperimental);
         if (warningSentinel == null) {
-            Assert.assertEquals(clp.getProductionWarning(true), null);
+            Assert.assertEquals(clp.getToolStatusWarning(true), null);
         } else {
-            Assert.assertTrue(clp.getProductionWarning(true).contains(warningSentinel));
+            Assert.assertTrue(clp.getToolStatusWarning(true).contains(warningSentinel));
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -204,9 +204,9 @@ public class CommandLineProgramUnitTest extends GATKBaseTest {
         Assert.assertEquals(clp.isBetaFeature(), isBeta);
         Assert.assertEquals(clp.isExperimentalFeature(), isExperimental);
         if (warningSentinel == null) {
-            Assert.assertEquals(clp.getProductionWarning(), null);
+            Assert.assertEquals(clp.getProductionWarning(true), null);
         } else {
-            Assert.assertTrue(clp.getProductionWarning().contains(warningSentinel));
+            Assert.assertTrue(clp.getProductionWarning(true).contains(warningSentinel));
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -145,4 +145,69 @@ public class CommandLineProgramUnitTest extends GATKBaseTest {
         }
         return tempFile;
     }
+
+    @CommandLineProgramProperties(
+            summary = "ExperimentalTool",
+            oneLineSummary = "ExperimentalTool",
+            programGroup = TestProgramGroup.class
+    )
+    @ExperimentalFeature
+    private static class TestExperimentalTool extends CommandLineProgram {
+
+        @Override
+        protected Object doWork() {
+            return null;
+        }
+    }
+
+    @CommandLineProgramProperties(
+            summary = "BetaTool",
+            oneLineSummary = "BetaTool",
+            programGroup = TestProgramGroup.class
+    )
+    @BetaFeature
+    private static class TestBetaTool extends CommandLineProgram {
+        @Override
+        protected Object doWork() {
+            return null;
+        }
+    }
+
+    @CommandLineProgramProperties(
+            summary = "ProductionTool",
+            oneLineSummary = "ProductionTool",
+            programGroup = TestProgramGroup.class
+    )
+    private static class TestProductionTool extends CommandLineProgram {
+        @Override
+        protected Object doWork() {
+            return null;
+        }
+    }
+
+    @DataProvider(name = "toolMaturityLevels")
+    public Object[][] getToolMaturityLevels() {
+        return new Object[][]{
+                {new TestExperimentalTool(), true, false, "EXPERIMENTAL"},
+                {new TestBetaTool(), false, true, "BETA"},
+                {new TestProductionTool(), false, false, null}
+        };
+    }
+
+    @Test(dataProvider = "toolMaturityLevels")
+    public void testToolMaturityLevel(
+            final CommandLineProgram clp,
+            final boolean isExperimental,
+            final boolean isBeta,
+            final String warningSentinel)
+    {
+        Assert.assertEquals(clp.isBetaFeature(), isBeta);
+        Assert.assertEquals(clp.isExperimentalFeature(), isExperimental);
+        if (warningSentinel == null) {
+            Assert.assertEquals(clp.getProductionWarning(), null);
+        } else {
+            Assert.assertTrue(clp.getProductionWarning().contains(warningSentinel));
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/4367. Includes a sleep for 5 seconds; not sure thats a good idea, although the warning message scrolls off the screen pretty quickly, especially with Spark apps. This will need to be replicated in Picard as well.

Experimental:

<img width="679" alt="screen shot 2018-02-20 at 3 37 06 pm" src="https://user-images.githubusercontent.com/10062863/36447994-16fe058c-1654-11e8-94e7-efc6e90b8f3e.png">

Beta:

<img width="653" alt="screen shot 2018-02-20 at 3 37 22 pm" src="https://user-images.githubusercontent.com/10062863/36447984-13245560-1654-11e8-8776-9345319e37ae.png">

