### PR TITLE
VariantContextTestUtils: add a utility method to slurp an entire VCF into a collection

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -137,6 +137,17 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
     }
 
     /**
+     * Creates a FeatureDataSource backed by the provided path. The data source will have an automatically
+     * generated name, and will look ahead the default number of bases ({@link #DEFAULT_QUERY_LOOKAHEAD_BASES})
+     * during queries that produce cache misses.
+     *
+     * @param featurePath path or URI to source of Features
+     */
+    public FeatureDataSource(final String featurePath) {
+        this(featurePath, null, DEFAULT_QUERY_LOOKAHEAD_BASES, null);
+    }
+
+    /**
      * Creates a FeatureDataSource backed by the provided File and assigns this data source the specified logical
      * name. We will look ahead the default number of bases ({@link #DEFAULT_QUERY_LOOKAHEAD_BASES}) during queries
      * that produce cache misses.

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureDataSourceUnitTest.java
@@ -26,7 +26,7 @@ public final class FeatureDataSourceUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleNullFile() {
-        FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>(null);
+        FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>((File)null);
     }
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)


### PR DESCRIPTION
This method is for unit/integration testing purposes only, and should not be called from tools.