### PR TITLE
Add a scan for intervals of high depth and excludes reads from those regions from evidence

### DIFF
--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -65,6 +65,7 @@ case ${GATK_SV_TOOL} in
             --kmers-to-ignore ${KMER_KILL_LIST} \
             --cross-contigs-to-ignore ${ALTS_KILL_LIST} \
             --breakpoint-intervals ${PROJECT_OUTPUT_DIR}/intervals \
+            --high-coverage-intervals "${PROJECT_OUTPUT_DIR}/highCoverageIntervals.bed" \
             --fastq-dir ${PROJECT_OUTPUT_DIR}/fastq \
             --contig-sam-file ${PROJECT_OUTPUT_DIR}/assemblies.sam \
             --target-link-file ${PROJECT_OUTPUT_DIR}/target_links.bedpe \
@@ -80,6 +81,7 @@ case ${GATK_SV_TOOL} in
             --kmers-to-ignore ${KMER_KILL_LIST} \
             --cross-contigs-to-ignore ${ALTS_KILL_LIST} \
             --breakpoint-intervals ${PROJECT_OUTPUT_DIR}/intervals \
+            --high-coverage-intervals "${PROJECT_OUTPUT_DIR}/highCoverageIntervals.bed" \
             --fastq-dir ${PROJECT_OUTPUT_DIR}/fastq \
             --target-link-file ${PROJECT_OUTPUT_DIR}/target_links.bedpe"
         ;;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryArgumentCollection.java
@@ -42,10 +42,15 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
                 "fragment size statistics.", fullName = "max-tracked-fragment-length")
         public int maxTrackedFragmentLength = 2000;
 
-        @Argument(doc = "Intervals with more than this much coverage are filtered out, because the reads mapped to "+
-                "that interval are clearly not exclusively local to the interval.",
-                fullName = "max-interval-coverage")
-        public int maxIntervalCoverage = 1000;
+        @Argument(doc = "We filter out contiguous regions of the genome that have coverage of at least high-depth-coverage-factor * avg-coverage and a " +
+                "peak coverage of high-depth-coverage-peak-factor * avg-coverage, because the reads mapped to those regions tend to be non-local and high depth prevents accurate assembly.",
+                fullName = "high-depth-coverage-peak-factor")
+        public int highDepthCoveragePeakFactor = 7;
+
+        @Argument(doc = "We filter out contiguous regions of the genome that have coverage of at least high-depth-coverage-factor * avg-coverage and a " +
+                "peak coverage of high-depth-coverage-peak-factor * avg-coverage, because the reads mapped to those regions tend to be non-local and high depth prevents accurate assembly.",
+                fullName = "high-depth-coverage-factor")
+        public int highDepthCoverageFactor = 3;
 
         @Argument(doc = "Minimum weight of the corroborating read evidence to validate some single piece of evidence.",
                 fullName = "min-evidence-count")
@@ -122,6 +127,9 @@ public class StructuralVariationDiscoveryArgumentCollection implements Serializa
 
         @Argument(doc = "file for breakpoint intervals output", fullName = "breakpoint-intervals", optional = true)
         public String intervalFile;
+
+        @Argument(doc = "file for high-coverage intervals output", fullName = "high-coverage-intervals", optional = true)
+        public String highCoverageIntervalsFile;
 
         @Argument(doc = "file for mapped qname intervals output", fullName = "qname-intervals-mapped", optional = true)
         public String qNamesMappedFile;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/IntervalCoverageFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/IntervalCoverageFinder.java
@@ -1,9 +1,16 @@
 package org.broadinstitute.hellbender.tools.spark.sv.evidence;
 
+import com.esotericsoftware.kryo.DefaultSerializer;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.annotations.VisibleForTesting;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import scala.Tuple2;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -11,21 +18,22 @@ import java.util.stream.IntStream;
 /**
  * Class to find the coverage of the intervals.
  */
-public final class IntervalCoverageFinder implements Iterable<Tuple2<Integer, Integer>> {
-    private final int[] basesInInterval;
+public final class IntervalCoverageFinder implements Iterable<Tuple2<Integer, int[]>> {
+    private final int[][] intervalCoverage;
 
     public IntervalCoverageFinder( final ReadMetadata metadata,
                                    final List<SVInterval> intervals,
                                    final Iterator<GATKRead> unfilteredReadItr,
                                    final SVReadFilter filter ) {
-        basesInInterval = new int[intervals.size()];
+        intervalCoverage = new int[intervals.size()][];
+
         int intervalsIndex = 0;
+        final int intervalsSize = intervals.size();
         final Iterator<GATKRead> readItr = filter.applyFilter(unfilteredReadItr, SVReadFilter::isMapped);
         while ( readItr.hasNext() ) {
             final GATKRead read = readItr.next();
             final int readContigId = metadata.getContigID(read.getContig());
-            final int readStart = read.getUnclippedStart();
-            final int intervalsSize = intervals.size();
+            final int readStart = read.getStart();
             while ( intervalsIndex < intervalsSize ) {
                 final SVInterval interval = intervals.get(intervalsIndex);
                 if ( interval.getContig() > readContigId ) break;
@@ -33,18 +41,113 @@ public final class IntervalCoverageFinder implements Iterable<Tuple2<Integer, In
                 intervalsIndex += 1;
             }
             if ( intervalsIndex >= intervalsSize ) break;
-            final SVInterval indexedInterval = intervals.get(intervalsIndex);
-            final SVInterval readInterval = new SVInterval(readContigId, readStart, read.getUnclippedEnd()+1);
-            basesInInterval[intervalsIndex] += indexedInterval.overlapLen(readInterval);
+            final SVInterval readInterval = new SVInterval(readContigId, readStart, read.getEnd()+1);
+
+            int intervalsContainingReadIndex = intervalsIndex;
+            SVInterval indexedInterval = intervals.get(intervalsContainingReadIndex);
+
+            while (intervalsContainingReadIndex < intervals.size() && indexedInterval.overlaps(readInterval)) {
+                final SVInterval overlapInterval = readInterval.intersect(indexedInterval);
+                if (overlapInterval == null) throw new GATKException.ShouldNeverReachHereException("read was supposed to intersect interval but overlap is null");
+                if (intervalCoverage[intervalsContainingReadIndex] == null) {
+                    intervalCoverage[intervalsContainingReadIndex] = new int[indexedInterval.getLength()];
+                }
+                for (int i = overlapInterval.getStart(); i < overlapInterval.getEnd(); i++) {
+                    intervalCoverage[intervalsContainingReadIndex][i - indexedInterval.getStart()] += 1;
+                }
+                intervalsContainingReadIndex++;
+                if (intervalsContainingReadIndex < intervals.size()) {
+                    indexedInterval = intervals.get(intervalsContainingReadIndex);
+                }
+            }
         }
     }
 
+    static Iterator<CandidateCoverageInterval> getHighCoverageIntervalsInWindow(final int minHighCoverageValue, final int maxHighCoverageValue, final SVInterval interval, final int[] coverageArray) {
+        boolean inRegion = false;
+        int regionStart = -1;
+        boolean foundHighRegion = false;
+        final List<CandidateCoverageInterval> highCovIntervals = new ArrayList<>(2);
+        for (int i = 0; i < coverageArray.length; i++) {
+            if (coverageArray[i] >= minHighCoverageValue) {
+                if (! inRegion) {
+                    inRegion = true;
+                    foundHighRegion = false;
+                    regionStart = i;
+                }
+                if (coverageArray[i] >= maxHighCoverageValue) {
+                    foundHighRegion = true;
+                }
+            } else {
+                if (inRegion) {
+                    if (foundHighRegion || regionStart == 0) {
+                        final SVInterval highCovInterval = new SVInterval(interval.getContig(),
+                                interval.getStart() + regionStart,
+                                interval.getStart() + i);
+                        highCovIntervals.add(new CandidateCoverageInterval(highCovInterval, foundHighRegion));
+                    }
+                }
+                inRegion = false;
+            }
+        }
+        if (inRegion) {
+            final SVInterval highCovInterval = new SVInterval(interval.getContig(),
+                    interval.getStart() + regionStart,
+                    interval.getEnd());
+            highCovIntervals.add(new CandidateCoverageInterval(highCovInterval, foundHighRegion));
+        }
+        return highCovIntervals.iterator();
+    }
+
     @Override
-    public Iterator<Tuple2<Integer, Integer>> iterator() {
+    public Iterator<Tuple2<Integer, int[]>> iterator() {
         return IntStream
-                .range(0, basesInInterval.length)
-                .filter(idx -> basesInInterval[idx] > 0)
-                .mapToObj(idx -> new Tuple2<>(idx, basesInInterval[idx]))
+                .range(0, intervalCoverage.length)
+                .filter(idx -> intervalCoverage[idx] != null)
+                .mapToObj(idx -> new Tuple2<>(idx, intervalCoverage[idx]))
                 .iterator();
+    }
+
+    @DefaultSerializer(CandidateCoverageInterval.Serializer.class)
+    static class CandidateCoverageInterval {
+        private static final SVInterval.Serializer intervalSerializer = new SVInterval.Serializer();
+        private boolean containsMaxCoveragePeak;
+        private SVInterval interval;
+
+        public CandidateCoverageInterval(final SVInterval interval, final boolean containsMaxCoveragePeak) {
+            this.containsMaxCoveragePeak = containsMaxCoveragePeak;
+            this.interval = interval;
+        }
+
+        public CandidateCoverageInterval(final Kryo kryo, final Input input) {
+            this.interval = intervalSerializer.read(kryo, input, SVInterval.class);
+            this.containsMaxCoveragePeak = input.readBoolean();
+        }
+
+        public boolean containsMaxCoveragePeak() {
+            return containsMaxCoveragePeak;
+        }
+
+        public SVInterval getInterval() {
+            return interval;
+        }
+
+        protected void serialize( final Kryo kryo, final Output output ) {
+            intervalSerializer.write(kryo, output, interval);
+            output.writeBoolean(containsMaxCoveragePeak);
+        }
+
+        public static final class Serializer extends com.esotericsoftware.kryo.Serializer<CandidateCoverageInterval> {
+            @Override
+            public void write(final Kryo kryo, final Output output, final CandidateCoverageInterval candidateCoverageInterval ) {
+                candidateCoverageInterval.serialize(kryo, output);
+            }
+
+            @Override
+            public CandidateCoverageInterval read(final Kryo kryo, final Input input, final Class<CandidateCoverageInterval> klass ) {
+                return new CandidateCoverageInterval(kryo, input);
+            }
+        }
+
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinder.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.sv.evidence;
 
 import org.apache.commons.collections4.iterators.SingletonIterator;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Collections;
@@ -17,14 +18,17 @@ public final class QNameFinder implements Function<GATKRead, Iterator<QNameAndIn
     private final List<SVInterval> intervals;
     private final SVReadFilter filter;
     private static final Iterator<QNameAndInterval> noName = Collections.emptyIterator();
+    private final SVIntervalTree<SVInterval> highCoverageSubIntervals;
     private int intervalsIndex = 0;
 
-    public QNameFinder( final ReadMetadata metadata,
-                        final List<SVInterval> intervals,
-                        final SVReadFilter filter ) {
+    public QNameFinder(final ReadMetadata metadata,
+                       final List<SVInterval> intervals,
+                       final SVReadFilter filter,
+                       final SVIntervalTree<SVInterval> highCoverageSubIntervals) {
         this.metadata = metadata;
         this.intervals = intervals;
         this.filter = filter;
+        this.highCoverageSubIntervals = highCoverageSubIntervals;
     }
 
     @Override
@@ -32,7 +36,6 @@ public final class QNameFinder implements Function<GATKRead, Iterator<QNameAndIn
         if ( !filter.isMapped(read) ) return Collections.emptyIterator();
 
         final int readContigId = metadata.getContigID(read.getContig());
-        final int readStart = read.getUnclippedStart();
         final int intervalsSize = intervals.size();
         while ( intervalsIndex < intervalsSize ) {
             final SVInterval interval = intervals.get(intervalsIndex);
@@ -42,8 +45,11 @@ public final class QNameFinder implements Function<GATKRead, Iterator<QNameAndIn
         }
         if ( intervalsIndex >= intervalsSize ) return noName;
         final SVInterval indexedInterval = intervals.get(intervalsIndex);
-        final SVInterval readInterval = new SVInterval(readContigId, readStart, read.getUnclippedEnd()+1);
-        if ( indexedInterval.isDisjointFrom(readInterval) ) return noName;
+        final SVInterval unclippedReadInterval = new SVInterval(readContigId, read.getUnclippedStart(), read.getUnclippedEnd());
+        final SVInterval clippedReadInterval = new SVInterval(readContigId, read.getStart(), read.getEnd());
+        if ( indexedInterval.isDisjointFrom(unclippedReadInterval) ) return noName;
+        if (filter.containedInRegionToIgnore(clippedReadInterval, highCoverageSubIntervals)) return noName;
         return new SingletonIterator<>(new QNameAndInterval(read.getName(), intervalsIndex));
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinder.java
@@ -46,8 +46,8 @@ public final class QNameFinder implements Function<GATKRead, Iterator<QNameAndIn
         if ( intervalsIndex >= intervalsSize ) return noName;
         final SVInterval indexedInterval = intervals.get(intervalsIndex);
         final SVInterval unclippedReadInterval = new SVInterval(readContigId, read.getUnclippedStart(), read.getUnclippedEnd());
-        final SVInterval clippedReadInterval = new SVInterval(readContigId, read.getStart(), read.getEnd());
         if ( indexedInterval.isDisjointFrom(unclippedReadInterval) ) return noName;
+        final SVInterval clippedReadInterval = new SVInterval(readContigId, read.getStart(), read.getEnd());
         if (filter.containedInRegionToIgnore(clippedReadInterval, highCoverageSubIntervals)) return noName;
         return new SingletonIterator<>(new QNameAndInterval(read.getName(), intervalsIndex));
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifier.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.tools.spark.sv.evidence;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.*;
@@ -22,15 +24,18 @@ public class ReadClassifier implements Function<GATKRead, Iterator<BreakpointEvi
     private final int allowedShortFragmentOverhang;
     private final SVReadFilter filter;
     private final KSWindowFinder smallIndelFinder;
+    private final SVIntervalTree<SVInterval> regionsToIgnore;
 
-    public ReadClassifier( final ReadMetadata readMetadata,
-                           GATKRead sentinel,
-                           final int allowedShortFragmentOverhang,
-                           SVReadFilter filter ) {
+    public ReadClassifier(final ReadMetadata readMetadata,
+                          GATKRead sentinel,
+                          final int allowedShortFragmentOverhang,
+                          SVReadFilter filter,
+                          final SVIntervalTree<SVInterval> regionsToIgnore) {
         this.readMetadata = readMetadata;
         this.sentinel = sentinel;
         this.allowedShortFragmentOverhang = allowedShortFragmentOverhang;
         this.filter = filter;
+        this.regionsToIgnore = regionsToIgnore;
         smallIndelFinder = new KSWindowFinder(readMetadata, filter);
     }
 
@@ -42,7 +47,15 @@ public class ReadClassifier implements Function<GATKRead, Iterator<BreakpointEvi
             return evidenceList.iterator();
         }
 
+        if ( !filter.isMappedToPrimaryContig(read, readMetadata)) return Collections.emptyIterator();
         if ( !filter.isEvidence(read) ) return Collections.emptyIterator();
+        if (regionsToIgnore != null) {
+            final int readContigId = readMetadata.getContigID(read.getContig());
+            final SVInterval clippedReadInterval = new SVInterval(readContigId, read.getStart(), read.getEnd());
+            if (filter.containedInRegionToIgnore(clippedReadInterval, regionsToIgnore)) {
+                return Collections.emptyIterator();
+            }
+        }
 
         final List<BreakpointEvidence> evidenceList = new ArrayList<>();
         checkForSplitRead(read, evidenceList);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/SVReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/SVReadFilter.java
@@ -67,13 +67,11 @@ public class SVReadFilter implements Serializable {
     }
 
     public boolean containedInRegionToIgnore(final SVInterval interval, final SVIntervalTree<SVInterval> regionsToIgnore) {
-        if (regionsToIgnore.hasOverlapper(interval)) {
-            final Iterator<SVIntervalTree.Entry<SVInterval>> overlappers = regionsToIgnore.overlappers(interval);
-            while (overlappers.hasNext()) {
-                SVIntervalTree.Entry<SVInterval> depthFilteredInterval = overlappers.next();
-                if (depthFilteredInterval.getInterval().overlapLen(interval) == interval.getLength()) {
-                    return true;
-                }
+        final Iterator<SVIntervalTree.Entry<SVInterval>> overlappers = regionsToIgnore.overlappers(interval);
+        while (overlappers.hasNext()) {
+            SVIntervalTree.Entry<SVInterval> depthFilteredInterval = overlappers.next();
+            if (depthFilteredInterval.getInterval().overlapLen(interval) == interval.getLength()) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/SVReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/SVReadFilter.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.sv.evidence;
 
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -16,11 +18,15 @@ public class SVReadFilter implements Serializable {
     private final int minEvidenceMapQ;
     private final int minEvidenceMatchLength;
     private final int allowedShortFragmentOverhang;
+    private final int maxDUSTScore;
+    private final int kSize;
 
     public SVReadFilter( final FindBreakpointEvidenceSparkArgumentCollection params ) {
         minEvidenceMapQ = params.minEvidenceMapQ;
         minEvidenceMatchLength = params.minEvidenceMatchLength;
         allowedShortFragmentOverhang = params.allowedShortFragmentOverhang;
+        maxDUSTScore = params.maxDUSTScore;
+        kSize = params.kSize;
     }
 
     public boolean notJunk( final GATKRead read ) {
@@ -39,9 +45,16 @@ public class SVReadFilter implements Serializable {
         return isMapped(read) && isPrimaryLine(read);
     }
 
-    public boolean isEvidence( final GATKRead read ) {
-        return isMapped(read) && read.getMappingQuality() >= minEvidenceMapQ &&
+    public boolean isEvidence(final GATKRead read) {
+        return isMapped(read) &&
+                read.getMappingQuality() >= minEvidenceMapQ &&
                 CigarUtils.countAlignedBases(read.getCigar()) >= minEvidenceMatchLength && ! read.isSecondaryAlignment();
+    }
+
+    public boolean isMappedToPrimaryContig(final GATKRead read, final ReadMetadata readMetadata) {
+        if (! isMapped(read)) return false;
+        final int contigID = readMetadata.getContigID(read.getContig());
+        return ( ! readMetadata.getCrossContigIgnoreSet().contains(contigID));
     }
 
     public boolean isTemplateLenTestable( final GATKRead read ) {
@@ -51,6 +64,19 @@ public class SVReadFilter implements Serializable {
                 read.mateIsReverseStrand() &&
                 read.getContig().equals(read.getMateContig()) &&
                 read.getStart() - allowedShortFragmentOverhang <= read.getMateStart();
+    }
+
+    public boolean containedInRegionToIgnore(final SVInterval interval, final SVIntervalTree<SVInterval> regionsToIgnore) {
+        if (regionsToIgnore.hasOverlapper(interval)) {
+            final Iterator<SVIntervalTree.Entry<SVInterval>> overlappers = regionsToIgnore.overlappers(interval);
+            while (overlappers.hasNext()) {
+                SVIntervalTree.Entry<SVInterval> depthFilteredInterval = overlappers.next();
+                if (depthFilteredInterval.getInterval().overlapLen(interval) == interval.getLength()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public Iterator<GATKRead> applyFilter( final Iterator<GATKRead> readItr, final BiPredicate<SVReadFilter, GATKRead> predicate ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVInterval.java
@@ -6,6 +6,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.ReadMetadata;
 
 /**
  * Naturally collating, simple interval.
@@ -101,6 +102,10 @@ public final class SVInterval implements Comparable<SVInterval> {
             if ( result == 0 ) result = Integer.compare(this.end, that.end);
         }
         return result;
+    }
+
+    public String toBedString(final ReadMetadata metadata) {
+        return metadata.getContigName(this.contig)+"\t"+(start-1)+"\t"+end;
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBreakpointEvidenceSparkUnitTest.java
@@ -50,6 +50,7 @@ public final class FindBreakpointEvidenceSparkUnitTest extends GATKBaseTest {
                         { new ReadMetadata.PartitionBounds(0, 1, 1, 10000, 9999)},
                     100, 10, 30);
     private final Broadcast<ReadMetadata> broadcastMetadata = ctx.broadcast(readMetadataExpected);
+    private final Broadcast<SVIntervalTree<SVInterval>> broadcastRegionsToIgnore = ctx.broadcast(new SVIntervalTree<>());
     private final List<List<BreakpointEvidence>> externalEvidence =
             FindBreakpointEvidenceSpark.readExternalEvidence(null, readMetadataExpected,
                                                     params.externalEvidenceWeight, params.externalEvidenceUncertainty);
@@ -62,14 +63,14 @@ public final class FindBreakpointEvidenceSparkUnitTest extends GATKBaseTest {
     public void getIntervalsTest() {
         final List<SVInterval> actualIntervals =
                 FindBreakpointEvidenceSpark.getIntervalsAndEvidenceTargetLinks(params,broadcastMetadata,
-                        broadcastExternalEvidence,header,reads,filter,logger)._1();
+                        broadcastExternalEvidence,header,reads,filter,logger, broadcastRegionsToIgnore)._1();
         Assert.assertEquals(actualIntervals, expectedIntervalList);
     }
 
     @Test(groups = "sv")
     public void getQNamesTest() {
         final Set<String> actualQNames = new HashSet<>();
-        FindBreakpointEvidenceSpark.getQNames(params, ctx, broadcastMetadata, expectedIntervalList, reads, filter)
+        FindBreakpointEvidenceSpark.getQNames(params, ctx, broadcastMetadata, expectedIntervalList, reads, filter, broadcastRegionsToIgnore)
                 .stream()
                 .map(QNameAndInterval::getKey)
                 .forEach(actualQNames::add);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/IntervalCoverageFinderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/IntervalCoverageFinderUnitTest.java
@@ -1,0 +1,132 @@
+package org.broadinstitute.hellbender.tools.spark.sv.evidence;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.utils.IntHistogramTest;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import scala.Tuple2;
+
+import java.util.*;
+
+public class IntervalCoverageFinderUnitTest extends GATKBaseTest {
+    private final static LibraryStatistics LIBRARY_STATISTICS =
+            new LibraryStatistics(IntHistogramTest.genLogNormalSample(400, 175, 10000).getCDF(),
+                    60000000000L, 600000000L, 1200000000000L, 3000000000L);
+
+
+    @Test
+    public void testIntervalCoverageFinder() throws Exception {
+        final StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection params = new StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection();
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeaderWithGroups(3, 1, 10000000, 1);
+        final Set<Integer> crossContigIgnoreSet = new HashSet<>();
+        final ReadMetadata readMetadata = new ReadMetadata(crossContigIgnoreSet, header, LIBRARY_STATISTICS, null, 2L, 2L, 1);
+        final ArrayList<SVInterval> intervals = new ArrayList<>(2);
+        final SVInterval interval1 = new SVInterval(0, 1000, 1100);
+        intervals.add(interval1);
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "read1", 0, 1050, 100);
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "read1", 0, 1090, 100);
+        final ArrayList<GATKRead> reads = new ArrayList<>();
+        reads.add(read1);
+        reads.add(read2);
+
+        IntervalCoverageFinder intervalCoverageFinder = new IntervalCoverageFinder(readMetadata, intervals, reads.iterator(), new SVReadFilter(params));
+
+        Iterator<Tuple2<Integer, int[]>> iterator = intervalCoverageFinder.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        Tuple2<Integer, int[]> next = iterator.next();
+        Assert.assertEquals(next._1.intValue(), 0);
+        int[] expected = new int[100];
+        for (int i = 50; i < 90; i++) {
+            expected[i] = 1;
+        }
+        for (int i = 90; i < 100; i++) {
+            expected[i] = 2;
+        }
+
+        Assert.assertTrue(Arrays.equals(next._2, expected));
+
+        final SVInterval interval2 = new SVInterval(0, 1100, 1200);
+        intervals.add(interval2);
+
+        Assert.assertTrue(! interval1.overlaps(interval2));
+
+        intervalCoverageFinder = new IntervalCoverageFinder(readMetadata, intervals, reads.iterator(), new SVReadFilter(params));
+
+        iterator = intervalCoverageFinder.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        next = iterator.next();
+        Assert.assertEquals(next._1.intValue(), 0);
+        expected = new int[100];
+        for (int i = 50; i < 90; i++) {
+            expected[i] = 1;
+        }
+        for (int i = 90; i < 100; i++) {
+            expected[i] = 2;
+        }
+
+        Assert.assertTrue(iterator.hasNext());
+        next = iterator.next();
+        Assert.assertEquals(next._1.intValue(), 1);
+        expected = new int[100];
+        for (int i = 0; i < 50; i++) {
+            expected[i] = 2;
+        }
+        for (int i = 50; i < 90; i++) {
+            expected[i] = 1;
+        }
+
+        Assert.assertTrue(Arrays.equals(next._2, expected));
+    }
+
+
+    @Test(groups="sv")
+    public void testGetHighCoverageIntervals() throws Exception {
+        final SVInterval interval = new SVInterval(0, 100, 200);
+        final int[] coverageArray = new int[interval.getLength()];
+        for (int i = 10; i < 20; i++) {
+            coverageArray[i] = 101;
+        }
+        coverageArray[15] = 401;
+
+        for (int i = 60; i < 80; i++) {
+            coverageArray[i] = 101;
+        }
+
+        for (int i = 90; i < 100; i++) {
+            coverageArray[i] = 101;
+        }
+
+        final Iterator<IntervalCoverageFinder.CandidateCoverageInterval> highCoverageIntervals =
+                IntervalCoverageFinder.getHighCoverageIntervalsInWindow(100, 400, interval, coverageArray);
+        Assert.assertTrue(highCoverageIntervals.hasNext());
+        IntervalCoverageFinder.CandidateCoverageInterval next = highCoverageIntervals.next();
+        Assert.assertEquals(next.getInterval(), new SVInterval(0, 110, 120));
+
+        Assert.assertTrue(highCoverageIntervals.hasNext());
+        next = highCoverageIntervals.next();
+        Assert.assertEquals(next.getInterval(), new SVInterval(0, 190, 200));
+        Assert.assertFalse(next.containsMaxCoveragePeak());
+
+        Assert.assertFalse(highCoverageIntervals.hasNext());
+    }
+
+    @Test(groups="sv")
+    public void testGetHighCoverageIntervalsEntireInterval() throws Exception {
+        final SVInterval interval = new SVInterval(0, 100, 200);
+        final int[] coverageArray = new int[interval.getLength()];
+        for (int i = 0; i < coverageArray.length; i++) {
+            coverageArray[i] = 401;
+        }
+        final Iterator<IntervalCoverageFinder.CandidateCoverageInterval> highCoverageIntervals =
+                IntervalCoverageFinder.getHighCoverageIntervalsInWindow(100, 400, interval, coverageArray);
+        Assert.assertTrue(highCoverageIntervals.hasNext());
+        final SVInterval next = highCoverageIntervals.next().getInterval();
+        Assert.assertEquals(next, interval);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinderTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/QNameFinderTest.java
@@ -1,0 +1,62 @@
+package org.broadinstitute.hellbender.tools.spark.sv.evidence;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.utils.IntHistogramTest;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public class QNameFinderTest extends GATKBaseTest {
+    private final static LibraryStatistics LIBRARY_STATISTICS =
+            new LibraryStatistics(IntHistogramTest.genLogNormalSample(400, 175, 10000).getCDF(),
+                    60000000000L, 600000000L, 1200000000000L, 3000000000L);
+
+    @Test
+    public void testHighDepthRegionFiltering() throws Exception {
+        final StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection params = new StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection();
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeaderWithGroups(3, 1, 10000000, 1);
+        final Set<Integer> crossContigIgnoreSet = new HashSet<>();
+        final ReadMetadata readMetadata = new ReadMetadata(crossContigIgnoreSet, header, LIBRARY_STATISTICS, null, 2L, 2L, 1);
+        final ArrayList<SVInterval> intervals = new ArrayList<>(2);
+        SVInterval interval1 = new SVInterval(0, 10378, 12002);
+        SVInterval interval2 = new SVInterval(0, 115732072, 115733072);
+        intervals.add(interval1);
+        intervals.add(interval2);
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead(header, "read1", 0, 11074,
+                ArtificialReadUtils.createRandomReadBases(151, false),
+                ArtificialReadUtils.createRandomReadQuals(151),
+                "151M");
+        read1.setIsReverseStrand(true);
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead(header, "read2", 0, 11063,
+                ArtificialReadUtils.createRandomReadBases(151, false),
+                ArtificialReadUtils.createRandomReadQuals(151),
+                "99M52S");
+
+        final SVIntervalTree<SVInterval> highDepthIntervals = new SVIntervalTree<>();
+        final SVInterval highDepthInterval1 = new SVInterval(0, 11010, 11590);
+        final SVInterval highDepthInterval2 = new SVInterval(0, 115732072, 115733072);
+        highDepthIntervals.put(highDepthInterval1, highDepthInterval1);
+        highDepthIntervals.put(highDepthInterval2, highDepthInterval2);
+
+        final QNameFinder qNameFinder = new QNameFinder(readMetadata, intervals, new SVReadFilter(params), highDepthIntervals);
+
+        Iterator<QNameAndInterval> read1Result = qNameFinder.apply(read1);
+        Assert.assertTrue(! read1Result.hasNext());
+
+        Iterator<QNameAndInterval> read2Result = qNameFinder.apply(read2);
+        Assert.assertTrue(! read2Result.hasNext());
+
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifierTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/ReadClassifierTest.java
@@ -35,7 +35,7 @@ public class ReadClassifierTest extends GATKBaseTest {
         read.setReadGroup(groupName);
         read.setMappingQuality(60);
         final SVReadFilter filter = new SVReadFilter(params);
-        final ReadClassifier classifier = new ReadClassifier(readMetadata, null, params.allowedShortFragmentOverhang, filter);
+        final ReadClassifier classifier = new ReadClassifier(readMetadata, null, params.allowedShortFragmentOverhang, filter, null);
         checkClassification(classifier, read, Collections.emptyList());
         read.setCigar(ReadClassifier.MIN_SOFT_CLIP_LEN+"S"+(readSize-ReadClassifier.MIN_SOFT_CLIP_LEN)+"M");
         checkClassification(classifier, read, Collections.singletonList(new BreakpointEvidence.SplitRead(read, readMetadata, true)));

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUnitTest.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SVIntervalUnitTest extends GATKBaseTest {
+    @Test(groups = "sv")
+    public void testOverlapLen() {
+        SVInterval container = new SVInterval(1, 1000, 2000);
+        SVInterval containee = new SVInterval(1, 1100, 1200);
+        Assert.assertTrue(container.overlaps(containee));
+        Assert.assertTrue(container.overlapLen(containee) == containee.getLength());
+
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVKmerLongUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVKmerLongUnitTest.java
@@ -190,5 +190,12 @@ public class SVKmerLongUnitTest extends GATKBaseTest {
                 "GGATCACAGGTCTATCACCCTATTAACCACTCACGGGAGCTCTCCATGCAT"
         ).map(str -> SVKmerizer.toKmer(str,kmer)).collect(Collectors.toList());
         Assert.assertEquals(kmers,expectedKmers);
+
+        final byte[] seq2 = "CTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCCCACCCCTAACCCTAACCCAAACCCTAACCCTAACCCAAACCCTAACCCTAACCCTAACCCCAACCCCAACCCTCACCCTAACCC".getBytes();
+        final List<SVKmer> kmers2 =
+                SVDUSTFilteredKmerizer.stream(seq2, KMER_SIZE, MAX_DUST_SCORE, kmer)
+                        .collect(SVUtils.arrayListCollector(seq.length - KMER_SIZE+1));
+
+        Assert.assertTrue(kmers2.isEmpty());
     }
 }


### PR DESCRIPTION
This PR attempts to eliminate long-running, useless assemblies that significantly extend runtime on some samples:

- Conducts a scan over the genome to find intervals of excessive depth, defined as an interval where coverage is greater than a lower factor times the average coverage of the sample and containing a coverage peak greater than an upper factor times the average coverage.
- Nearby high-coverage regions within one read-length of each other are merged together.
- Excludes reads that map exclusively inside high coverage regions from evidence gathering.
- Excludes reads that map exclusively inside high coverage regions from QName finding for seeding assemblies.

In addition, after observing that many long-running assemblies occur on non-primary reference contigs, we also exclude reads that map to non-primary contigs (as defined by the "cross-contig to ignore set") from evidence gathering.

Runtime on the CHM mix sample with this change is approximately 38 minutes, and our NA19238 snapshot now takes only 22 minutes, a significant drop in runtime. There are a few changes in the resulting call set but they appear to be minimal.
