### PR TITLE
Rename SortReadFileSpark to SortSamSpark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSpark.java
@@ -24,7 +24,7 @@ import java.util.List;
         oneLineSummary = "SortSam on Spark (works on SAM/BAM/CRAM)",
         programGroup = ReadDataManipulationProgramGroup.class)
 @BetaFeature
-public final class SortReadFileSpark extends GATKSparkTool {
+public final class SortSamSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-public final class SortReadFileSparkIntegrationTest extends CommandLineProgramTest {
+public final class SortSamSparkIntegrationTest extends CommandLineProgramTest {
     @DataProvider(name="sortbams")
     public Object[][] sortBAMData() {
         return new Object[][] {


### PR DESCRIPTION
For consistency with the non-Spark version of this tool.