### PR TITLE
adding missing registrations in kryo

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -21,7 +21,6 @@ public class GATKRegistrator implements KryoRegistrator {
 
     public GATKRegistrator() {}
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public void registerClasses(Kryo kryo) {
 
@@ -53,6 +52,7 @@ public class GATKRegistrator implements KryoRegistrator {
         registerGATKClasses(kryo);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private void registerGATKClasses(Kryo kryo) {
         //relatively inefficient serialization of Collections created with Collections.nCopies(), without this
         //any Collection created with Collections.nCopies fails to serialize at run time

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.engine.spark;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
-import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.*;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
@@ -17,7 +17,7 @@ import java.util.Collections;
  */
 public class GATKRegistrator implements KryoRegistrator {
 
-    private ADAMKryoRegistrator ADAMregistrator;
+    private final ADAMKryoRegistrator ADAMregistrator;
 
     public GATKRegistrator() {
         this.ADAMregistrator = new ADAMKryoRegistrator();
@@ -43,6 +43,13 @@ public class GATKRegistrator implements KryoRegistrator {
         kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
 
         kryo.register(SAMRecord.class, new SAMRecordSerializer());
+        kryo.register(BAMRecord.class, new SAMRecordSerializer());
+
+        kryo.register(SAMFileHeader.class);
+        kryo.register(SAMFileHeader.GroupOrder.class);
+        kryo.register(SAMFileHeader.SortOrder.class);
+        kryo.register(SAMProgramRecord.class);
+        kryo.register(SAMReadGroupRecord.class);
 
         //register to avoid writing the full name of this class over and over
         kryo.register(PairedEnds.class, new FieldSerializer<>(kryo, PairedEnds.class));

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -17,16 +17,43 @@ import java.util.Collections;
  */
 public class GATKRegistrator implements KryoRegistrator {
 
-    private final ADAMKryoRegistrator ADAMregistrator;
+    private final ADAMKryoRegistrator ADAMregistrator = new ADAMKryoRegistrator();
 
-    public GATKRegistrator() {
-        this.ADAMregistrator = new ADAMKryoRegistrator();
-    }
+    public GATKRegistrator() {}
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public void registerClasses(Kryo kryo) {
 
+        registerGATKClasses(kryo);
+
+
+        // register the ADAM data types using Avro serialization, including:
+        //     AlignmentRecord
+        //     Genotype
+        //     Variant
+        //     DatabaseVariantAnnotation
+        //     NucleotideContigFragment
+        //     Contig
+        //     StructuralVariant
+        //     VariantCallingAnnotations
+        //     VariantEffect
+        //     DatabaseVariantAnnotation
+        //     Dbxref
+        //     Feature
+        //     ReferencePosition
+        //     ReferencePositionPair
+        //     SingleReadBucket
+        //     IndelRealignmentTarget
+        //     TargetSet
+        //     ZippedTargetSet
+        ADAMregistrator.registerClasses(kryo);
+
+        //do this before and after ADAM to try and force our registrations to win out
+        registerGATKClasses(kryo);
+    }
+
+    private void registerGATKClasses(Kryo kryo) {
         //relatively inefficient serialization of Collections created with Collections.nCopies(), without this
         //any Collection created with Collections.nCopies fails to serialize at run time
         kryo.register(Collections.nCopies(2, "").getClass(), new FieldSerializer<>(kryo, Collections.nCopies(2, "").getClass()));
@@ -53,26 +80,5 @@ public class GATKRegistrator implements KryoRegistrator {
 
         //register to avoid writing the full name of this class over and over
         kryo.register(PairedEnds.class, new FieldSerializer<>(kryo, PairedEnds.class));
-
-        // register the ADAM data types using Avro serialization, including:
-        //     AlignmentRecord
-        //     Genotype
-        //     Variant
-        //     DatabaseVariantAnnotation
-        //     NucleotideContigFragment
-        //     Contig
-        //     StructuralVariant
-        //     VariantCallingAnnotations
-        //     VariantEffect
-        //     DatabaseVariantAnnotation
-        //     Dbxref
-        //     Feature
-        //     ReferencePosition
-        //     ReferencePositionPair
-        //     SingleReadBucket
-        //     IndelRealignmentTarget
-        //     TargetSet
-        //     ZippedTargetSet
-        ADAMregistrator.registerClasses(kryo);
     }
 }


### PR DESCRIPTION
* some classes were missing registration in kryo which causes less efficient serialization
* adding registrations for a number of classes that MarkDuplicatesSpark needs that weren't registered yet

* notably, BAMRecord wasn't registered to use the correct serializer which could cause major inefficiencies
* it's not clear what circumstances we're serializing BAMRecord instead of SAMRecordToGATKReadAdapter so how much this will help is not obvious