### PR TITLE
Support g.vcf.gz, g.bcf and g.bcf.gz files in Spark.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ final picardVersion = System.getProperty('picard.version','2.18.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
-final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
+final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -5,8 +5,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -136,13 +134,6 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        //TODO remove me when https://github.com/broadinstitute/gatk/issues/4274 and https://github.com/broadinstitute/gatk/issues/4303 are fixed
-        if(hcArgs.emitReferenceConfidence == ReferenceConfidenceMode.GVCF
-                && (AbstractFeatureReader.hasBlockCompressedExtension(output) || output.endsWith(IOUtil.BCF_FILE_EXTENSION))) {
-            throw new UserException.UnimplementedFeature("It is currently not possible to write a compressed g.vcf or g.bcf from HaplotypeCallerSpark.  " +
-                                            "See https://github.com/broadinstitute/gatk/issues/4274 and https://github.com/broadinstitute/gatk/issues/4303 for more details.");
-        }
-
         logger.info("********************************************************************************");
         logger.info("The output of this tool DOES NOT match the output of HaplotypeCaller. ");
         logger.info("It is under development and should not be used for production work. ");

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -134,6 +135,10 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
+        //TODO remove me when https://github.com/broadinstitute/gatk/issues/4303 are fixed
+        if (output.endsWith(IOUtil.BCF_FILE_EXTENSION) || output.endsWith(IOUtil.BCF_FILE_EXTENSION + ".gz")) {
+            throw new UserException.UnimplementedFeature("It is currently not possible to write a BCF file on spark.  See https://github.com/broadinstitute/gatk/issues/4303 for more details .");
+        }
         logger.info("********************************************************************************");
         logger.info("The output of this tool DOES NOT match the output of HaplotypeCaller. ");
         logger.info("It is under development and should not be used for production work. ");

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -92,23 +92,6 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         assertSingleShardedWritingWorks(vcf, outputUrl);
     }
 
-
-    @DataProvider
-    public static Object[][] brokenGVCFCases() {
-        return new Object[][]{
-                {"g.vcf.gz"},
-                {"g.bcf"},
-                {"g.bcf.gz"}
-        };
-    }
-
-    @Test(dataProvider = "brokenGVCFCases", expectedExceptions = UserException.UnimplementedFeature.class)
-    public void testBrokenGVCFCasesAreDisallowed(String extension) throws IOException {
-        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
-        VariantsSparkSink.writeVariants(ctx, createTempFile("test", extension).toString(), null,
-                                        new VCFHeader(), true, Arrays.asList(1, 2, 4, 5), 2, 1 );
-    }
-
     @DataProvider
     public Object[][] gvcfCases(){
         return new Object[][]{
@@ -117,9 +100,9 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
                 {false, ".vcf.gz"},
                 {false, ".bcf"},
                 {false, ".bcf.gz"},
-                //  {true, "g.vcf.gz"},  TODO enable this when https://github.com/broadinstitute/gatk/issues/4274 is resolved
-                //  {true, ".g.bcf"},    TODO enable these when https://github.com/broadinstitute/gatk/issues/4303 is resolved
-                //  {true, ".g.bcf.gz"}
+                {true, ".g.vcf.gz"},
+                {true, ".g.bcf"},
+                {true, ".g.bcf.gz"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -67,20 +67,20 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         };
     }
 
-    //@Test(dataProvider = "loadVariants", groups = "spark")
+    @Test(dataProvider = "loadVariants", groups = "spark")
     public void variantsSinkTest(String vcf, String outputFileExtension) throws IOException {
         final File outputFile = createTempFile(outputFileName, outputFileExtension);
         assertSingleShardedWritingWorks(vcf, outputFile.getAbsolutePath());
     }
 
-    //@Test(dataProvider = "loadVariants", groups = "spark")
+    @Test(dataProvider = "loadVariants", groups = "spark")
     public void variantsSinkHDFSTest(String vcf, String outputFileExtension) throws IOException {
         final String outputHDFSPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension).toString();
         Assert.assertTrue(BucketUtils.isHadoopUrl(outputHDFSPath));
         assertSingleShardedWritingWorks(vcf, outputHDFSPath);
     }
 
-    //@Test(dataProvider = "loadVariants", groups = "spark")
+    @Test(dataProvider = "loadVariants", groups = "spark")
     public void testWritingToAnExistingFileHDFS(String vcf, String outputFileExtension) throws IOException {
         final Path outputPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension);
         final FileSystem fs = outputPath.getFileSystem(new Configuration());
@@ -89,7 +89,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         assertSingleShardedWritingWorks(vcf, outputPath.toString());
     }
 
-    //@Test(dataProvider = "loadVariants", groups = "spark")
+    @Test(dataProvider = "loadVariants", groups = "spark")
     public void testWritingToFileURL(String vcf, String outputFileExtension) throws IOException {
         String outputUrl = "file://" + createTempFile(outputFileName, outputFileExtension).getAbsolutePath();
         assertSingleShardedWritingWorks(vcf, outputUrl);

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -3,8 +3,11 @@ package org.broadinstitute.hellbender.engine.spark.datasources;
 import com.google.common.io.Files;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamStreams;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeBuilder;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -20,11 +23,13 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
 import org.broadinstitute.hellbender.utils.test.VariantContextTestUtils;
+import org.seqdoop.hadoop_bam.VCFFormat;
 import org.seqdoop.hadoop_bam.util.VCFHeaderReader;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -32,11 +37,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.net.URI;
 import java.util.*;
-
-import static org.testng.Assert.assertEquals;
 
 public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
     private static final String SAMPLE = "sample";
@@ -64,20 +67,20 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         };
     }
 
-    @Test(dataProvider = "loadVariants", groups = "spark")
+    //@Test(dataProvider = "loadVariants", groups = "spark")
     public void variantsSinkTest(String vcf, String outputFileExtension) throws IOException {
         final File outputFile = createTempFile(outputFileName, outputFileExtension);
         assertSingleShardedWritingWorks(vcf, outputFile.getAbsolutePath());
     }
 
-    @Test(dataProvider = "loadVariants", groups = "spark")
+    //@Test(dataProvider = "loadVariants", groups = "spark")
     public void variantsSinkHDFSTest(String vcf, String outputFileExtension) throws IOException {
         final String outputHDFSPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension).toString();
         Assert.assertTrue(BucketUtils.isHadoopUrl(outputHDFSPath));
         assertSingleShardedWritingWorks(vcf, outputHDFSPath);
     }
 
-    @Test(dataProvider = "loadVariants", groups = "spark")
+    //@Test(dataProvider = "loadVariants", groups = "spark")
     public void testWritingToAnExistingFileHDFS(String vcf, String outputFileExtension) throws IOException {
         final Path outputPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension);
         final FileSystem fs = outputPath.getFileSystem(new Configuration());
@@ -86,23 +89,36 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         assertSingleShardedWritingWorks(vcf, outputPath.toString());
     }
 
-    @Test(dataProvider = "loadVariants", groups = "spark")
+    //@Test(dataProvider = "loadVariants", groups = "spark")
     public void testWritingToFileURL(String vcf, String outputFileExtension) throws IOException {
         String outputUrl = "file://" + createTempFile(outputFileName, outputFileExtension).getAbsolutePath();
         assertSingleShardedWritingWorks(vcf, outputUrl);
     }
 
     @DataProvider
-    public Object[][] gvcfCases(){
+    public static Object[][] brokenCases() {
         return new Object[][]{
-                {true, ".g.vcf"},
-                {false, ".vcf"},
-                {false, ".vcf.gz"},
                 {false, ".bcf"},
                 {false, ".bcf.gz"},
-                {true, ".g.vcf.gz"},
                 {true, ".g.bcf"},
                 {true, ".g.bcf.gz"}
+        };
+    }
+
+    @Test(dataProvider = "brokenCases", expectedExceptions = UserException.UnimplementedFeature.class)
+    public void testBrokenGVCFCasesAreDisallowed(boolean writeGvcf, String extension) throws IOException {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        VariantsSparkSink.writeVariants(ctx, createTempFile("test", extension).toString(), null,
+                new VCFHeader(), writeGvcf, Arrays.asList(1, 2, 4, 5), 2, 1 );
+    }
+
+    @DataProvider
+    public Object[][] gvcfCases(){
+        return new Object[][]{
+                {false, ".vcf"},
+                {false, ".vcf.gz"},
+                {true, ".g.vcf"},
+                {true, ".g.vcf.gz"}
         };
     }
 
@@ -121,6 +137,8 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
         final File output = createTempFile(outputFileName, extension);
         VariantsSparkSink.writeVariants(ctx, output.toString(), ctx.parallelize(vcs), getHeader(), writeGvcf, Arrays.asList(100), 2, 1 );
+
+        checkFileExtensionConsistentWithContents(output.toString());
 
         new CommandLineProgramTest(){
             @Override
@@ -162,6 +180,8 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
 
         VariantsSparkSink.writeVariants(ctx, outputPath, variants, header);
 
+        checkFileExtensionConsistentWithContents(outputPath);
+
         JavaRDD<VariantContext> variants2 = variantsSparkSource.getParallelVariantContexts(outputPath, null);
         final List<VariantContext> writtenVariants = variants2.collect();
 
@@ -188,5 +208,59 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
             actualVcf = new File(vcf);
         }
         return VariantsSparkSourceUnitTest.getSerialVariantContexts(actualVcf.getAbsolutePath());
+    }
+
+    private void checkFileExtensionConsistentWithContents(String outputPath) throws IOException {
+        String outputFile;
+        if (BucketUtils.isFileUrl(outputPath)) {
+            outputFile = new File(URI.create(outputPath)).getAbsolutePath();
+        } else {
+            outputFile = outputPath;
+        }
+        boolean blockCompressed = isBlockCompressed(outputFile);
+        VCFFormat vcfFormat = getVcfFormat(outputFile);
+        if (outputFile.endsWith(".vcf")) {
+            Assert.assertTrue(vcfFormat == VCFFormat.VCF);
+            Assert.assertFalse(blockCompressed);
+        } else if (outputFile.endsWith(".vcf.gz") || outputFile.endsWith(".vcf.bgz")) {
+            Assert.assertTrue(vcfFormat == VCFFormat.VCF);
+            Assert.assertTrue(blockCompressed);
+        } else if (outputFile.endsWith(".bcf")) {
+            Assert.assertTrue(vcfFormat == VCFFormat.BCF);
+            Assert.assertFalse(blockCompressed);
+        } else if (outputFile.endsWith(".bcf.gz")) {
+            Assert.assertTrue(vcfFormat == VCFFormat.BCF);
+            Assert.assertTrue(blockCompressed);
+        }
+    }
+
+    private static VCFFormat getVcfFormat(String outputFile) throws IOException {
+        try (InputStream in = openFile(outputFile)) {
+            return VCFFormat.inferFromData(in);
+        }
+    }
+
+    private static boolean isBlockCompressed(String outputFile) throws IOException {
+        try (InputStream in = new BufferedInputStream(openFile(outputFile))) {
+            System.out.println("testing " + outputFile);
+            return BlockCompressedInputStream.isValidFile(in);
+        }
+    }
+
+    // Like BucketUtils.openFile, but doesn't unzip
+    private static InputStream openFile(String path) throws IOException {
+        Utils.nonNull(path);
+        InputStream inputStream;
+        if (BucketUtils.isCloudStorageUrl(path)) {
+            java.nio.file.Path p = BucketUtils.getPathOnGcs(path);
+            inputStream = java.nio.file.Files.newInputStream(p);
+        } else if (BucketUtils.isHadoopUrl(path)) {
+            Path file = new org.apache.hadoop.fs.Path(path);
+            FileSystem fs = file.getFileSystem(new Configuration());
+            inputStream = fs.open(file);
+        } else {
+            inputStream = new FileInputStream(path);
+        }
+        return inputStream;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -129,30 +129,19 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
     }
 
     @DataProvider
-    public static Object[][] brokenGVCFCases() {
+    public static Object[][] gvcfCases() {
         return new Object[][]{
-                {"g.vcf.gz"},
-                {"g.bcf"},
-                {"g.bcf.gz"}
+                {".g.vcf"},
+                {".g.vcf.gz"},
+                {".g.bcf"},
+                {".g.bcf.gz"}
         };
     }
-    
-    @Test(dataProvider = "brokenGVCFCases", expectedExceptions = UserException.UnimplementedFeature.class)
-    public void testBrokenGVCFConfigurationsAreDisallowed(String extension) {
-        final String[] args = {
-                "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
-                "-O", createTempFile("testGVCF_GZ_throw_exception", extension).getAbsolutePath(),
-                "-ERC", "GVCF",
-        };
 
-        runCommandLine(args);
-    }
-
-    @Test
-    public void testGVCFModeIsConcordantWithGATK3_8AlelleSpecificResults() throws Exception {
+    @Test(dataProvider = "gvcfCases")
+    public void testGVCFModeIsConcordantWithGATK3_8AlelleSpecificResults(String extension) throws Exception {
         Utils.resetRandomGenerator();
-        final File output = createTempFile("testGVCFModeIsConcordantWithGATK3_8AlelleSpecificResults", ".g.vcf");
+        final File output = createTempFile("testGVCFModeIsConcordantWithGATK3_8AlelleSpecificResults", extension);
 
         //Created by running:
         // java -jar gatk.3.8-4-g7b0250253f.jar -T HaplotypeCaller \

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -129,12 +129,30 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
     }
 
     @DataProvider
+    public static Object[][] brokenGVCFCases() {
+        return new Object[][]{
+                {".g.bcf"},
+                {".g.bcf.gz"}
+        };
+    }
+
+    @Test(dataProvider = "brokenGVCFCases", expectedExceptions = UserException.UnimplementedFeature.class)
+    public void testBrokenGVCFConfigurationsAreDisallowed(String extension) {
+        final String[] args = {
+                "-I", NA12878_20_21_WGS_bam,
+                "-R", b37_2bit_reference_20_21,
+                "-O", createTempFile("testGVCF_GZ_throw_exception", extension).getAbsolutePath(),
+                "-ERC", "GVCF",
+        };
+
+        runCommandLine(args);
+    }
+
+    @DataProvider
     public static Object[][] gvcfCases() {
         return new Object[][]{
                 {".g.vcf"},
-                {".g.vcf.gz"},
-                {".g.bcf"},
-                {".g.bcf.gz"}
+                {".g.vcf.gz"}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -19,6 +19,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.AlleleSubsettingUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.IntegrationTestSpec;
@@ -909,7 +910,9 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         int concordant = 0;
         int discordant = 0;
 
-        try ( final FeatureDataSource<VariantContext> actualSource = new FeatureDataSource<>(actual);
+        // unzip to avoid https://github.com/broadinstitute/gatk/issues/4224
+        File actualUnzipped = IOUtils.gunzipToTempIfNeeded(actual);
+        try ( final FeatureDataSource<VariantContext> actualSource = new FeatureDataSource<>(actualUnzipped);
               final FeatureDataSource<VariantContext> expectedSource = new FeatureDataSource<>(expected) ) {
 
             for ( final VariantContext vc : actualSource ) {


### PR DESCRIPTION
Fixes #4274 and #4303. Relies on https://github.com/HadoopGenomics/Hadoop-BAM/pull/194, so this won't pass (and shouldn't be merged) until a new release of Hadoop-BAM is available.