### PR TITLE
Add DocOnlyArgumentCollection for better downstream toolkit extensibility

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -14,6 +14,8 @@ import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.*;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.DocOnlyArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.GATKDocOnlyArgumentCollection;
 import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.config.ConfigFactory;
@@ -82,16 +84,8 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
     @Argument(fullName = StandardArgumentDefinitions.NIO_MAX_REOPENS_LONG_NAME, shortName = StandardArgumentDefinitions.NIO_MAX_REOPENS_SHORT_NAME, doc = "If the GCS bucket channel errors out, how many times it will attempt to re-initiate the connection", optional = true)
     public int NIO_MAX_REOPENS = ConfigFactory.getInstance().getGATKConfig().gcsMaxRetries();
 
-    // This option is here for documentation completeness.
-    // This is actually parsed out in Main to initialize configuration files because
-    // we need to have the configuration completely set up before we create our CommandLinePrograms.
-    // (Some of the CommandLinePrograms have default values set to config values, and these are loaded
-    // at class load time as static initializers).
-    @Argument(fullName = StandardArgumentDefinitions.GATK_CONFIG_FILE_OPTION,
-              doc = "A configuration file to use with the GATK.",
-                common = true,
-                optional = true)
-    public String GATK_CONFIG_FILE = null;
+    @ArgumentCollection(doc = "Special documentation-only arguments.")
+    public DocOnlyArgumentCollection documentationArgumentsCollection = getDocOnlyArguments();
 
     private CommandLineParser commandLineParser;
 
@@ -102,6 +96,18 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
      * and debugging.
      */
     private String commandLine;
+
+    /**
+     * Returns documentation-only arguments.
+     *
+     * <p>Default behavior returns {@link GATKDocOnlyArgumentCollection}. Subclasses can override to extend/hide
+     * documentation arguments that are unused for other purposes.
+     *
+     * @return documentation-only argument collection.
+     */
+    protected DocOnlyArgumentCollection getDocOnlyArguments() {
+        return new GATKDocOnlyArgumentCollection();
+    }
 
     /**
      * Perform initialization/setup after command-line argument parsing but before doWork() is invoked.

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DocOnlyArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/DocOnlyArgumentCollection.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+/**
+ * Marker interface for documentation-only arguments.
+
+ * <p>Some arguments might be exposed on tools only for documentation, even if they are parsed in Main. Possible use
+ * cases include:
+ *
+ * <ul>
+ *     <li>Wrapper script arguments that might appear in the command line but are unused.</li>
+ *      <li>Arguments that should be parsed on Main to initialize custom configurations (e.g., defaults loaded
+ *          as static initializers.</li>
+ * </ul>
+ *
+ * <p>This interface allows to override documentation-only arguments to allow downstream projects to expose/hide
+ * specific documentation arguments of GATK or include custom ones.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ * @see GATKDocOnlyArgumentCollection for an example implementation.
+ */
+public interface DocOnlyArgumentCollection {
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDocOnlyArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/GATKDocOnlyArgumentCollection.java
@@ -1,0 +1,26 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+
+/**
+ * Documentation-only arguments for GATK.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ * @implNote this class is not final to allow downstream projects to extend documentation-only arguments, but keep GATK
+ * ones.
+ */
+public class GATKDocOnlyArgumentCollection implements DocOnlyArgumentCollection {
+
+    // This option is here for documentation completeness.
+    // This is actually parsed out in Main to initialize configuration files because
+    // we need to have the configuration completely set up before we create our CommandLinePrograms.
+    // (Some of the CommandLinePrograms have default values set to config values, and these are loaded
+    // at class load time as static initializers).
+    @Argument(fullName = StandardArgumentDefinitions.GATK_CONFIG_FILE_OPTION,
+            doc = "A configuration file to use with the GATK.",
+            common = true,
+            optional = true)
+    public String GATK_CONFIG_FILE = null;
+
+}


### PR DESCRIPTION
Can you review this one @droazen - this is the last part of the temporary solution for #3998 (mentioned on ##4468). I think that in this case, because the interface is just a marker, it is easier to just modify `GATKDocOnlyArgumentCollection` for doc-only top level arguments and does not modify the API. Thanks!