### PR TITLE
Fixed the Docker build to run using the jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DRELEASE
 ADD . /gatk
 
 WORKDIR /gatk
-RUN /gatk/gradlew clean compileTestJava installAll localJar createPythonPackageArchive -Drelease=$DRELEASE
+RUN /gatk/gradlew clean compileTestJava sparkJar localJar createPythonPackageArchive -Drelease=$DRELEASE
 
 WORKDIR /root
 


### PR DESCRIPTION
There is currently an issue with spark stderr output if running through the wrapper script, this is a workaround to that. 