### PR TITLE
Make the SV cluster creation scripts work with preemptible workers

### DIFF
--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -99,7 +99,8 @@ gcloud beta dataproc clusters create ${CLUSTER_NAME} \
     --initialization-actions ${INIT_ACTION} \
     --initialization-action-timeout 10m \
     --max-age ${MAX_LIFE_HOURS} \
-    --max-idle ${MAX_IDLE_MINUTES}
+    --max-idle ${MAX_IDLE_MINUTES} \
+    --properties yarn:yarn.resourcemanager.am.max-attempts=5,mapred:mapreduce.map.maxattempts=8,mapred:mapreduce.reduce.maxattempts=8,spark:spark.task.maxFailures=8,spark:spark.stage.maxConsecutiveAttempts=8
 
 MASTER_NODE="hdfs://""$CLUSTER_NAME""-m:8020"
 

--- a/scripts/sv/default_init.sh
+++ b/scripts/sv/default_init.sh
@@ -16,8 +16,9 @@ fi
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 if [[ ! "${ROLE}" == 'Master' ]]; then
     # the /mnt/1/ prefix is the default mounting location of the ssd if the cluster is created with a local ssd for the worker nodes
-    if [[ -d "/mnt/1/" ]]; then 
+    if [[ -d "/mnt/1/" ]]; then
         mkdir -p /mnt/1/reference && gsutil -m cp "$REFLOC"*.img /mnt/1/reference/
+        ln -s /mnt/1/reference /reference
     else
         mkdir -p /reference && gsutil -m cp "$REFLOC"*.img /reference/
     fi

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -231,7 +231,7 @@ export GATK_GCS_STAGING=${GATK_GCS_STAGING:-"gs://${PROJECT_NAME}/${GCS_USER}/st
 # paths on cluster (HDFS, except for reference image which must be regular FS)
 CLUSTER_BAM="/data/$(basename ${GCS_BAM})"
 CLUSTER_REFERENCE_2BIT="/reference/$(basename ${GCS_REFERENCE_2BIT})"
-CLUSTER_REFERENCE_IMAGE="/mnt/1/reference/$(basename ${GCS_REFERENCE_IMAGE})"
+CLUSTER_REFERENCE_IMAGE="/reference/$(basename ${GCS_REFERENCE_IMAGE})"
 
 ##############################################
 # store local run log in this file (NOTE: can override by defining SV_LOCAL_LOG_FILE)

--- a/scripts/sv/runWholePipeline.sh
+++ b/scripts/sv/runWholePipeline.sh
@@ -18,7 +18,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "      /test-sample \\"
     echo -e "      /data/NA12878_test.bam \\"
     echo -e "      /reference/Homo_sapiens_assembly38.2bit"
-    echo -e "      /mnt/1/reference/Homo_sapiens_assembly38.fasta.img (the /mnt/1/ prefix is the default mounting location of the ssd if the cluster is created with a local ssd for the worker nodes)"
+    echo -e "      /reference/Homo_sapiens_assembly38.fasta.img"
     exit 1
 fi
 


### PR DESCRIPTION
The current initialization action for dataproc workers puts the reference image in different places depending on whether or not an SSD is mounted. Preemptible dataproc workers don't have SSDs, so a mixed cluster will have references mounted on different paths depending on the worker. This change symlinks the SSD mount point onto the HDD so that paths can be consistent. 

Also increases several cluster configuration parameters relating to retries, which I saw recommended if using preemptible workers.