### PR TITLE
Sites-only query and GT field support in GenomicsDB (DO NOT MERGE)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ final picardVersion = System.getProperty('picard.version','2.17.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+3e2aa')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+023fbf70')
 final testNGVersion = '6.11'
 
 final baseJarName = 'gatk'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ final picardVersion = System.getProperty('picard.version','2.17.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.0.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.9.1')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+3e2aa')
 final testNGVersion = '6.11'
 
 final baseJarName = 'gatk'

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -386,13 +386,23 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
         }
 
         try {
+            //GT field is populated from TileDB/GenomicsDB rather than set to missing
+            final boolean produceGT = false;
+            //Sites only query - https://github.com/broadinstitute/gatk/issues/3688
+            final boolean sitesOnlyQuery = false;
+            //https://github.com/Intel-HLS/GenomicsDB/issues/161
+            final boolean produceGTWithMinPLVvalueForSpanningDeletions = false;
             return new GenomicsDBFeatureReader<>(vidmapJson.getAbsolutePath(),
                                                  callsetJson.getAbsolutePath(),
                                                  workspace.getAbsolutePath(),
                                                  GenomicsDBConstants.DEFAULT_ARRAY_NAME,
                                                  reference.getAbsolutePath(),
                                                  vcfHeader.getAbsolutePath(),
-                                                 new BCF2Codec());
+                                                 new BCF2Codec(),
+                                                 produceGT,
+                                                 sitesOnlyQuery,
+                                                 produceGTWithMinPLVvalueForSpanningDeletions
+                                                 );
         } catch (final IOException e) {
             throw new UserException("Couldn't create GenomicsDBFeatureReader", e);
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import com.intel.genomicsdb.GenomicsDBUtils;
+import com.intel.genomicsdb.GenomicsDBImporter;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
@@ -30,7 +30,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
     @Test
     public void testGenomicsDBInClassPath(){
         final String path = "/"+System.mapLibraryName("tiledbgenomicsdb");
-        Assert.assertNotNull(GenomicsDBUtils.class.getResource(path), "Could not find the genomicsdb binary at " + path);
+        Assert.assertNotNull(GenomicsDBImporter.class.getResource(path), "Could not find the genomicsdb binary at " + path);
     }
 
     @Test


### PR DESCRIPTION
* Shows the flags needed for sites only query and for producing GT fields
  * https://github.com/broadinstitute/gatk/issues/3688
  * https://github.com/Intel-HLS/GenomicsDB/issues/161
* Currently, hard coded - need to discuss how these flags will be passed in.
* FYI after https://github.com/Intel-HLS/GenomicsDB/pull/165 is merged in, we will not need to have long argument lists for GenomicsDB. A Protobuf object will be the input parameter and can be configured as needed.