### PR TITLE
Changed CNV PoN to filter on equality to interval median percentile.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormals.java
@@ -164,7 +164,7 @@ public final class CreateReadCountPanelOfNormals extends SparkCommandLineProgram
 
     @Argument(
             doc = "Genomic intervals with a median (across samples) of fractional coverage (optionally corrected for GC bias) " +
-                    "below this percentile are filtered out.  " +
+                    "less than or equal to this percentile are filtered out.  " +
                     "(This is the first filter applied.)",
             fullName = MINIMUM_INTERVAL_MEDIAN_PERCENTILE_LONG_NAME,
             minValue = 0.,

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/SVDDenoisingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/SVDDenoisingUtils.java
@@ -208,12 +208,12 @@ public final class SVDDenoisingUtils {
             logger.info(String.format("A value of 0 was provided for argument %s, so the corresponding filtering step will be skipped...",
                     CreateReadCountPanelOfNormals.MINIMUM_INTERVAL_MEDIAN_PERCENTILE_LONG_NAME));
         } else {
-            logger.info(String.format("Filtering intervals with median (across samples) below the %.2f percentile...", minimumIntervalMedianPercentile));
+            logger.info(String.format("Filtering intervals with median (across samples) less than or equal to the %.2f percentile...", minimumIntervalMedianPercentile));
             //calculate percentile
             final double minimumIntervalMedianThreshold = new Percentile(minimumIntervalMedianPercentile).evaluate(originalIntervalMedians);
             //filter intervals
             IntStream.range(0, numOriginalIntervals)
-                    .filter(intervalIndex -> originalIntervalMedians[intervalIndex] < minimumIntervalMedianThreshold)
+                    .filter(intervalIndex -> originalIntervalMedians[intervalIndex] <= minimumIntervalMedianThreshold)
                     .forEach(intervalIndex -> filterIntervals[intervalIndex] = true);
             logger.info(String.format("After filtering, %d out of %d intervals remain...", countNumberPassingFilter(filterIntervals), numOriginalIntervals));
         }


### PR DESCRIPTION
This will require less tuning of `minimum-interval-median-percentile` to filter out completely uncovered intervals, which will avoid e.g. https://gatkforums.broadinstitute.org/gatk/discussion/11461/gatk-4-0-1-2-no-non-zero-singular-values-were-found-in-creating-a-panel-of-normals-for-somatic-cnv

For example, currently if 10% of my intervals are completely uncovered and I set the relevant parameter to 5%, the 5th percentile is then equal to zero.  However, because no intervals are strictly less than zero, none are filtered.  Changing this to filter on equality then gets rid of all 10% of the intervals as one would want to do in practice.