### PR TITLE
Add registry for deprecated tools and annotations.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -4,6 +4,7 @@ import com.google.cloud.storage.StorageException;
 import htsjdk.samtools.util.StringUtil;
 import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.DeprecatedToolsRegistry;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgramExecutor;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.PicardNonZeroExitException;
@@ -465,6 +466,28 @@ public class Main {
     }
 
     /**
+     * Get deprecation message for a tool
+     * @param toolName command specified by the user
+     * @return deprecation message string, or null if none
+     */
+    public String getToolDeprecationMessage(final String toolName) {
+        return DeprecatedToolsRegistry.getToolDeprecationInfo(toolName);
+    }
+
+    /**
+     * When a command does not match any known command, searches for a deprecation message, if any, or for similar
+     * commands.
+     * @return returns an error message including the closes match if relevant.
+     */
+    public String getUnknownCommandMessage(final Set<Class<?>> classes, final String command) {
+        final String deprecationMessage = getToolDeprecationMessage(command);
+        if (deprecationMessage != null) {
+            return deprecationMessage;
+        }
+        return getSuggestedAlternateCommand(classes, command);
+    }
+
+    /**
      * similarity floor for matching in getUnknownCommandMessage *
      */
     private static final int HELP_SIMILARITY_FLOOR = 7;
@@ -474,7 +497,7 @@ public class Main {
      * When a command does not match any known command, searches for similar commands, using the same method as GIT *
      * @return returns an error message including the closes match if relevant.
      */
-    public static String getUnknownCommandMessage(final Set<Class<?>> classes, final String command) {
+    public String getSuggestedAlternateCommand(final Set<Class<?>> classes, final String command) {
         final Map<Class<?>, Integer> distances = new LinkedHashMap<>();
 
         int bestDistance = Integer.MAX_VALUE;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URL;
 import java.text.DecimalFormat;
-import java.lang.Thread;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistry.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistry.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.hellbender.cmdline;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * When a tool is removed from GATK (after having been @Deprecated for a suitable period), an entry should
+ * be added to this list to issue a message when the user tries to run that tool.
+ *
+ * NOTE: Picard tools should be listed here as well, since by definition such tools will not be found in
+ * the Picard jar.
+ */
+public class DeprecatedToolsRegistry {
+
+    // Mapping from tool name to string describing the major version number where the tool first disappeared and
+    // optional recommended alternatives
+    private static Map<String, Pair<String, String>> deprecatedTools = new HashMap<>();
+
+    static {
+        // Indicate version in which the tool disappeared, and recommended replacement in parentheses if applicable
+        deprecatedTools.put("IndelRealigner", Pair.of("4.0.0.0", "Please use GATK3 to run this tool"));
+        deprecatedTools.put("RealignerTargetCreator", Pair.of("4.0.0.0", "Please use GATK3 to run this tool"));
+    }
+
+    /**
+     * Utility method to pull up the version number at which a tool was deprecated and the suggested replacement, if any
+     *
+     * @param toolName   the tool class name (not the full package) to check
+     */
+    public static String getToolDeprecationInfo(final String toolName) {
+        return deprecatedTools.containsKey(toolName) ?
+                String.format("%s is no longer included in GATK as of version %s. %s",
+                        toolName,
+                        deprecatedTools.get(toolName).getLeft(),
+                        deprecatedTools.get(toolName).getRight()
+                ) :
+                null;
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistryTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistryTest.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.cmdline;
+
+import org.broadinstitute.hellbender.Main;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+public class DeprecatedToolsRegistryTest {
+
+    @Test
+    public void testRunMissingDeprecatedTool() {
+        final String missingTool = "IndelRealigner";
+
+        final UserException e = Assert.expectThrows(
+                UserException.class,
+                () -> new Main().instanceMain( new String[] {missingTool} )
+        );
+        Assert.assertTrue(e.getMessage().contains(DeprecatedToolsRegistry.getToolDeprecationInfo(missingTool)));
+    }
+
+    @Test
+    public void testRunMissingButNotRegisteredTool() {
+        final String missingButNotRegisteredTool = "MadeUpToolNotInTheRegistry";
+
+        Assert.assertNull(DeprecatedToolsRegistry.getToolDeprecationInfo(missingButNotRegisteredTool));
+
+        final Main main = new Main();
+        final UserException e = Assert.expectThrows(
+                UserException.class,
+                () -> main.instanceMain( new String[] {missingButNotRegisteredTool} )
+        );
+        Assert.assertTrue(e.getMessage().contains(main.getUnknownCommandMessage(Collections.emptySet(), missingButNotRegisteredTool)));
+    }
+
+}


### PR DESCRIPTION
We should be able to use this single implementation to satisfy both https://github.com/broadinstitute/gatk/issues/4347 and https://github.com/broadinstitute/gatk/issues/4351.

Questions: @vdauwera What other tools that were dropped from GATK3 should be added to the list now? GATK3 also has a deprecated annotations list, which is included here, but is empty. Are there any annotations that should be listed ? I can't really implement/test that part unless I populate it with something.

Also, trying to run a missing tool is currently handled as an error, and surfaces in the context of a usage message. Perhaps that hides it too much:

<img width="918" alt="screen shot 2018-03-07 at 11 25 40 am" src="https://user-images.githubusercontent.com/10062863/37104403-a15635ae-21fa-11e8-985a-94ff0e203cf8.png">
