### PR TITLE
Option to analyze contributions of different filters in Concordance

### DIFF
--- a/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
+++ b/scripts/mutect2_wdl/unsupported/hapmap_sensitivity.wdl
@@ -133,6 +133,7 @@ workflow HapmapSensitivity {
         Array[File] tpfn_idx = Concordance.tpfn_idx
         Array[File] ftnfn = Concordance.ftnfn
         Array[File] ftnfn_idx = Concordance.ftnfn_idx
+        Array[File] filter_analysis = Concordance.filter_analysis
     }
 } #end of workflow
 
@@ -381,6 +382,7 @@ task Concordance {
             -truth ${truth} -eval ${eval} \
             -tpfn "tpfn.vcf" \
             -ftnfn "ftnfn.vcf" \
+            --filter-analysis "filter-analysis.txt" \
             -summary summary.tsv
       }
 
@@ -394,6 +396,7 @@ task Concordance {
             File tpfn_idx = "tpfn.vcf.idx"
             File ftnfn = "ftnfn.vcf"
             File ftnfn_idx = "ftnfn.vcf.idx"
+            File filter_analysis = "filter-analysis.txt"
             File summary = "summary.tsv"
       }
 }

--- a/scripts/mutect2_wdl/unsupported/hapmap_sensitivity_all_plexes.wdl
+++ b/scripts/mutect2_wdl/unsupported/hapmap_sensitivity_all_plexes.wdl
@@ -148,6 +148,7 @@ workflow HapmapSensitivityAllPlexes {
       Array[File] tpfn_idx_5_plex = FivePlex.tpfn_idx
       Array[File] ftnfn_5_plex = FivePlex.ftnfn
       Array[File] ftnfn_idx_5_plex = FivePlex.ftnfn_idx
+      Array[File] filter_analysis_5_plex = FivePlex.filter_analysis
       File snp_table_10_plex = TenPlex.snp_table
       File snp_plot_10_plex = TenPlex.snp_plot
       File indel_table_10_plex = TenPlex.indel_table
@@ -159,6 +160,7 @@ workflow HapmapSensitivityAllPlexes {
       Array[File] tpfn_idx_10_plex = TenPlex.tpfn_idx
       Array[File] ftnfn_10_plex = TenPlex.ftnfn
       Array[File] ftnfn_idx_10_plex = TenPlex.ftnfn_idx
+      Array[File] filter_analysis_10_plex = TenPlex.filter_analysis
       File snp_table_20_plex = TwentyPlex.snp_table
       File snp_plot_20_plex = TwentyPlex.snp_plot
       File indel_table_20_plex = TwentyPlex.indel_table
@@ -170,6 +172,7 @@ workflow HapmapSensitivityAllPlexes {
       Array[File] tpfn_idx_20_plex = TwentyPlex.tpfn_idx
       Array[File] ftnfn_20_plex = TwentyPlex.ftnfn
       Array[File] ftnfn_idx_20_plex = TwentyPlex.ftnfn_idx
+      Array[File] filter_analysis_20_plex = TwentyPlex.filter_analysis
 
       File snp_table_all_plex = AllPlex.snp_table
       File snp_plot_all_plex = AllPlex.snp_plot

--- a/scripts/mutect2_wdl/unsupported/mutect2_multi_sample_concordance.wdl
+++ b/scripts/mutect2_wdl/unsupported/mutect2_multi_sample_concordance.wdl
@@ -77,6 +77,7 @@ c    }
         Array[File] tpfp_idx = Concordance.tpfp_idx
         Array[File] ftnfn = Concordance.ftnfn
         Array[File] ftnfn_idx = Concordance.ftnfn_idx
+        Array[File] filter_analysis = Concordance.filter_analysis
         Array[File] summary = Concordance.summary
     }
 }
@@ -104,6 +105,7 @@ task Concordance {
             -tpfn "tpfn.vcf" \
             -tpfp "tpfp.vcf" \
             -ftnfn "ftnfn.vcf" \
+            --filter-analysis "filter-analysis.txt" \
             -summary summary.tsv
     }
 
@@ -121,6 +123,7 @@ task Concordance {
         File tpfp_idx = "tpfp.vcf.idx"
         File ftnfn = "ftnfn.vcf"
         File ftnfn_idx = "ftnfn.vcf.idx"
+        File filter_analysis = "filter-analysis.txt"
         File summary = "summary.tsv"
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/FilterAnalysisRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/FilterAnalysisRecord.java
@@ -1,0 +1,114 @@
+package org.broadinstitute.hellbender.tools.walkers.validation;
+
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.tsv.DataLine;
+import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
+import org.broadinstitute.hellbender.utils.tsv.TableReader;
+import org.broadinstitute.hellbender.utils.tsv.TableWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+public class FilterAnalysisRecord {
+    private final String filter;
+    private int trueNegativeCount;
+    private int falseNegativeCount;
+    private int uniqueTrueNegativeCount;
+    private int uniqueFalseNegativeCount;
+
+    public FilterAnalysisRecord(final String filter, final int trueNegativeCount, final int falseNegativeCount, final int uniqueTrueNegativeCount, final int uniqueFalseNegativeCount) {
+        this.filter = filter;
+        this.trueNegativeCount = trueNegativeCount;
+        this.falseNegativeCount = falseNegativeCount;
+        this.uniqueTrueNegativeCount = uniqueTrueNegativeCount;
+        this.uniqueFalseNegativeCount = uniqueFalseNegativeCount;
+    }
+
+    public String getFilter() { return filter; }
+
+    public int getTrueNegativeCount() { return trueNegativeCount; }
+
+    public int getFalseNegativeCount() { return falseNegativeCount; }
+
+    public int getUniqueTrueNegativeCount() { return uniqueTrueNegativeCount; }
+
+    public int getUniqueFalseNegativeCount() { return uniqueFalseNegativeCount; }
+
+    public void incrementTrueNegative() { trueNegativeCount++; }
+    public void incrementFalseNegative() { falseNegativeCount++; }
+    public void incrementUniqueTrueNegative() { uniqueTrueNegativeCount++; }
+    public void incrementUniqueFalseNegative() { uniqueFalseNegativeCount++; }
+
+    //----- The following two public static methods read and write contamination files
+    public static void writeToFile(final Collection<FilterAnalysisRecord> records, final File outputTable) {
+        try ( FilterAnalysisTableWriter writer = new FilterAnalysisTableWriter(outputTable) ) {
+            writer.writeAllRecords(records);
+        } catch (IOException e){
+            throw new UserException(String.format("Encountered an IO exception while writing to %s.", outputTable));
+        }
+    }
+
+    public static List<FilterAnalysisRecord> readFromFile(final File tableFile) {
+        try( FilterAnalysisTableReader reader = new FilterAnalysisTableReader(tableFile) ) {
+            return reader.toList();
+        } catch (IOException e){
+            throw new UserException(String.format("Encountered an IO exception while reading from %s.", tableFile));
+        }
+    }
+
+    //-------- The following methods are boilerplate for reading and writing contamination tables
+    private static class FilterAnalysisTableWriter extends TableWriter<FilterAnalysisRecord> {
+        private FilterAnalysisTableWriter(final File output) throws IOException {
+            super(output, FilterAnalysisTableColumn.COLUMNS);
+        }
+
+        @Override
+        protected void composeLine(final FilterAnalysisRecord record, final DataLine dataLine) {
+            dataLine.set(FilterAnalysisTableColumn.FILTER.toString(), record.getFilter())
+                    .set(FilterAnalysisTableColumn.TRUE_NEGATIVES.toString(), record.getTrueNegativeCount())
+                    .set(FilterAnalysisTableColumn.FALSE_NEGATIVES.toString(), record.getFalseNegativeCount())
+                    .set(FilterAnalysisTableColumn.UNIQUE_TRUE_NEGATIVES.toString(), record.getUniqueTrueNegativeCount())
+                    .set(FilterAnalysisTableColumn.UNIQUE_FALSE_NEGATIVES.toString(), record.getUniqueFalseNegativeCount());
+        }
+    }
+
+    private static class FilterAnalysisTableReader extends TableReader<FilterAnalysisRecord> {
+        public FilterAnalysisTableReader(final File file) throws IOException {
+            super(file);
+        }
+
+        @Override
+        protected FilterAnalysisRecord createRecord(final DataLine dataLine) {
+            final String filter = dataLine.get(FilterAnalysisTableColumn.FILTER);
+            final int trueNegatives = dataLine.getInt(FilterAnalysisTableColumn.TRUE_NEGATIVES);
+            final int falseNegatives = dataLine.getInt(FilterAnalysisTableColumn.FALSE_NEGATIVES);
+            final int uniqueTrueNegatives = dataLine.getInt(FilterAnalysisTableColumn.UNIQUE_TRUE_NEGATIVES);
+            final int uniqueFalseNegatives = dataLine.getInt(FilterAnalysisTableColumn.UNIQUE_FALSE_NEGATIVES);
+            return new FilterAnalysisRecord(filter, trueNegatives, falseNegatives, uniqueTrueNegatives, uniqueFalseNegatives);
+        }
+    }
+
+    private enum FilterAnalysisTableColumn {
+        FILTER("filter"),
+        TRUE_NEGATIVES("tn"),
+        FALSE_NEGATIVES("fn"),
+        UNIQUE_TRUE_NEGATIVES("uniq_tn"),
+        UNIQUE_FALSE_NEGATIVES("uniq_fn");
+
+        private final String columnName;
+
+        FilterAnalysisTableColumn(final String columnName) {
+            this.columnName = Utils.nonNull(columnName);
+        }
+
+        @Override
+        public String toString() {
+            return columnName;
+        }
+
+        public static final TableColumnCollection COLUMNS = new TableColumnCollection(FILTER, TRUE_NEGATIVES, FALSE_NEGATIVES, UNIQUE_TRUE_NEGATIVES, UNIQUE_FALSE_NEGATIVES);
+    }
+}

--- a/src/test/resources/org/broadinstitute/hellbender/tools/concordance/filter-analysis-eval.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/concordance/filter-analysis-eval.vcf
@@ -1,0 +1,51 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=bad_filter,Description="This filter is always wrong">
+##FILTER=<ID=good_filter,Description="This filter is always right">
+##FILTER=<ID=average_filter,Description="This filter is sometimes right and sometimes wrong">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##SAMPLE=<ID=NORMAL,SampleName=SM-612V6>
+##contig=<ID=1,length=249250621,assembly=GRCh37>
+##contig=<ID=2,length=243199373,assembly=GRCh37>
+##contig=<ID=3,length=198022430,assembly=GRCh37>
+##contig=<ID=4,length=191154276,assembly=GRCh37>
+##contig=<ID=5,length=180915260,assembly=GRCh37>
+##contig=<ID=6,length=171115067,assembly=GRCh37>
+##contig=<ID=7,length=159138663,assembly=GRCh37>
+##contig=<ID=8,length=146364022,assembly=GRCh37>
+##contig=<ID=9,length=141213431,assembly=GRCh37>
+##contig=<ID=10,length=135534747,assembly=GRCh37>
+##contig=<ID=11,length=135006516,assembly=GRCh37>
+##contig=<ID=12,length=133851895,assembly=GRCh37>
+##contig=<ID=13,length=115169878,assembly=GRCh37>
+##contig=<ID=14,length=107349540,assembly=GRCh37>
+##contig=<ID=15,length=102531392,assembly=GRCh37>
+##contig=<ID=16,length=90354753,assembly=GRCh37>
+##contig=<ID=17,length=81195210,assembly=GRCh37>
+##contig=<ID=18,length=78077248,assembly=GRCh37>
+##contig=<ID=19,length=59128983,assembly=GRCh37>
+##contig=<ID=20,length=63025520,assembly=GRCh37>
+##contig=<ID=21,length=48129895,assembly=GRCh37>
+##contig=<ID=22,length=51304566,assembly=GRCh37>
+##contig=<ID=X,length=155270560,assembly=GRCh37>
+##contig=<ID=Y,length=59373566,assembly=GRCh37>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+20	100	.	G	A	.	bad_filter	AC=1
+20	200	.	ACAG	A	.	PASS	AC=1
+20	300	.	TAA	T	.	bad_filter	AC=1
+20	400	.	CT	C	.	PASS	AC=1
+20	500	.	TGCC	T	.	PASS	AC=1
+20	600	.	GGTT	G	.	bad_filter;average_filter	AC=1
+20	700	.	G	C	.	PASS	AC=1
+20	800	.	GAGC	G	.	PASS	AC=1
+20	900	.	GTGC	G	.	bad_filter	AC=1
+20	9100	.	G	A	.	PASS	AC=1
+20	9200	.	ACAG	A	.	PASS	AC=1
+20	9300	.	TAA	T	.	good_filter;average_filter	AC=1
+20	9400	.	CT	C	.	PASS	AC=1
+20	9500	.	TGCC	T	.	good_filter	AC=1
+20	9600	.	GGTT	G	.	good_filter	AC=1
+20	9700	.	G	C	.	average_filter	AC=1
+20	9800	.	GAGC	G	.	good_filter	AC=1
+20	9900	.	GTGC	G	.	good_filter	AC=1

--- a/src/test/resources/org/broadinstitute/hellbender/tools/concordance/filter-analysis-truth.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/concordance/filter-analysis-truth.vcf
@@ -1,0 +1,42 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=bad_filter,Description="This filter is always wrong">
+##FILTER=<ID=good_filter,Description="This filter is always right">
+##FILTER=<ID=average_filter,Description="This filter is sometimes right and sometimes wrong">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##SAMPLE=<ID=NORMAL,SampleName=SM-612V6>
+##contig=<ID=1,length=249250621,assembly=GRCh37>
+##contig=<ID=2,length=243199373,assembly=GRCh37>
+##contig=<ID=3,length=198022430,assembly=GRCh37>
+##contig=<ID=4,length=191154276,assembly=GRCh37>
+##contig=<ID=5,length=180915260,assembly=GRCh37>
+##contig=<ID=6,length=171115067,assembly=GRCh37>
+##contig=<ID=7,length=159138663,assembly=GRCh37>
+##contig=<ID=8,length=146364022,assembly=GRCh37>
+##contig=<ID=9,length=141213431,assembly=GRCh37>
+##contig=<ID=10,length=135534747,assembly=GRCh37>
+##contig=<ID=11,length=135006516,assembly=GRCh37>
+##contig=<ID=12,length=133851895,assembly=GRCh37>
+##contig=<ID=13,length=115169878,assembly=GRCh37>
+##contig=<ID=14,length=107349540,assembly=GRCh37>
+##contig=<ID=15,length=102531392,assembly=GRCh37>
+##contig=<ID=16,length=90354753,assembly=GRCh37>
+##contig=<ID=17,length=81195210,assembly=GRCh37>
+##contig=<ID=18,length=78077248,assembly=GRCh37>
+##contig=<ID=19,length=59128983,assembly=GRCh37>
+##contig=<ID=20,length=63025520,assembly=GRCh37>
+##contig=<ID=21,length=48129895,assembly=GRCh37>
+##contig=<ID=22,length=51304566,assembly=GRCh37>
+##contig=<ID=X,length=155270560,assembly=GRCh37>
+##contig=<ID=Y,length=59373566,assembly=GRCh37>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+20	100	.	G	A	.	PASS	AC=1
+20	200	.	ACAG	A	.	PASS	AC=1
+20	300	.	TAA	T	.	PASS	AC=1
+20	400	.	CT	C	.	PASS	AC=1
+20	500	.	TGCC	T	.	PASS	AC=1
+20	600	.	GGTT	G	.	PASS	AC=1
+20	700	.	G	C	.	PASS	AC=1
+20	800	.	GAGC	G	.	PASS	AC=1
+20	900	.	GTGC	G	.	PASS	AC=1


### PR DESCRIPTION
@takutosato This adds an option to report counts of false negatives, true negatives, and false/true negatives not flagged by any other filter for each filter.  Gives a rough picture of how valuable (or harmful) each filter is.