### PR TITLE
Option to emit (but still filter) all germline sites in Mutect2

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -22,6 +22,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final String PANEL_OF_NORMALS_LONG_NAME = "panel-of-normals";
     public static final String PANEL_OF_NORMALS_SHORT_NAME = "pon";
     public static final String GENOTYPE_PON_SITES_LONG_NAME = "genotype-pon-sites";
+    public static final String GENOTYPE_GERMLINE_SITES_LONG_NAME = "genotype-germline-sites";
     public static final String GERMLINE_RESOURCE_LONG_NAME = "germline-resource";
     public static final String DEFAULT_AF_LONG_NAME = "af-of-alleles-not-in-resource";
     public static final String DEFAULT_AF_SHORT_NAME = "default-af";
@@ -63,8 +64,15 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      * Usually we exclude sites in the panel of normals from active region determination, which saves time.  Setting this to true
      * causes Mutect to produce a variant call at these sites.  This call will still be filtered, but it shows up in the vcf.
      */
-    @Argument(fullName= GENOTYPE_PON_SITES_LONG_NAME, doc="Whether to call sites in the PoN even though they will ultimately be filtered.", optional = true)
+    @Argument(fullName= GENOTYPE_PON_SITES_LONG_NAME, doc="Call sites in the PoN even though they will ultimately be filtered.", optional = true)
     public boolean genotypePonSites = false;
+
+    /**
+     * Usually we exclude sites in the panel of normals from active region determination, which saves time.  Setting this to true
+     * causes Mutect to produce a variant call at these sites.  This call will still be filtered, but it shows up in the vcf.
+     */
+    @Argument(fullName= GENOTYPE_GERMLINE_SITES_LONG_NAME, doc="(EXPERIMENTAL) Call all apparent germline site even though they will ultimately be filtered.", optional = true)
+    public boolean genotypeGermlineSites = false;
 
     /**
      * A resource, such as gnomAD, containing population allele frequencies of common and rare variants.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
@@ -58,12 +58,8 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
     @Argument(fullName = NORMAL_ARTIFACT_LOD_LONG_NAME, optional = true, doc = "LOD threshold for calling normal artifacts")
     public double NORMAL_ARTIFACT_LOD_THRESHOLD = 0.0;
 
-    /**
-     * The default value of this argument was chosen to achieve roughly one false positive per covered megabase according
-     * to a back-of-the-envelope calculation assuming the neutral model of allele selection, with parameters estimated from ExAC.
-     */
     @Argument(fullName = MAX_GERMLINE_POSTERIOR_LONG_NAME, optional = true, doc = "Maximum posterior probability that an allele is a germline variant")
-    public double maxGermlinePosterior = 0.025;
+    public double maxGermlinePosterior = 0.1;
 
     @Argument(fullName = MAX_ALT_ALLELE_COUNT_LONG_NAME, optional = true, doc = "filter variants with too many alt alleles")
     public int numAltAllelesThreshold = 1;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -303,7 +303,7 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
 
         if (tumorLog10Odds < MTAC.initialTumorLodThreshold) {
             return new ActivityProfileState(refInterval, 0.0);
-        } else if (hasNormal()) {
+        } else if (hasNormal() && !MTAC.genotypeGermlineSites) {
             final ReadPileup normalPileup = pileup.getPileupForSample(normalSampleName, header);
             final Pair<Integer, Double> normalAltCountAndQualSum = altCountAndQualSum(normalPileup, refBase);
             final int normalAltCount = normalAltCountAndQualSum.getFirst();
@@ -311,7 +311,7 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
             if (normalAltCount > normalPileup.size() * MAX_ALT_FRACTION_IN_NORMAL && normalQualSum > MAX_NORMAL_QUAL_SUM) {
                 return new ActivityProfileState(refInterval, 0.0);
             }
-        } else {
+        } else if (!MTAC.genotypeGermlineSites) {
             final List<VariantContext> germline = featureContext.getValues(MTAC.germlineResource, refInterval);
             if (!germline.isEmpty() && germline.get(0).getAttributeAsDoubleList(VCFConstants.ALLELE_FREQUENCY_KEY, 0.0).get(0) > MTAC.maxPopulationAlleleFrequency) {
                 return new ActivityProfileState(refInterval, 0.0);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -222,7 +222,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
 
     public static double[] getEffectiveCounts(final LikelihoodMatrix<Allele> log10LikelihoodMatrix) {
         if (log10LikelihoodMatrix.numberOfReads() == 0) {
-            return new double[log10LikelihoodMatrix.numberOfAlleles()]; // zero couns for each allele
+            return new double[log10LikelihoodMatrix.numberOfAlleles()]; // zero counts for each allele
         }
         final RealMatrix log10Likelihoods = getAsRealMatrix(log10LikelihoodMatrix);
         return MathUtils.sumArrayFunction(0, log10Likelihoods.getColumnDimension(),

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticLikelihoodsEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticLikelihoodsEngine.java
@@ -1,12 +1,15 @@
 package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import com.google.common.annotations.VisibleForTesting;
+import htsjdk.variant.variantcontext.Allele;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.special.Gamma;
 import org.apache.commons.math3.util.MathArrays;
 import org.broadinstitute.hellbender.utils.*;
+import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Created by David Benjamin on 3/9/17.
@@ -58,12 +61,6 @@ public class SomaticLikelihoodsEngine {
         final double[] effectiveLog10Weights = new Dirichlet(dirichletPrior).effectiveLog10MultinomialWeights();
         return MathUtils.sumArrayFunction(0, log10Likelihoods.getColumnDimension(),
                 read -> MathUtils.posteriors(effectiveLog10Weights, log10Likelihoods.getColumn(read)));
-    }
-
-    // same but with flat prior
-    public static double[] getEffectiveCounts(RealMatrix log10Likelihoods) {
-        return MathUtils.sumArrayFunction(0, log10Likelihoods.getColumnDimension(),
-                read -> MathUtils.normalizeFromLog10ToLinearSpace(log10Likelihoods.getColumn(read)));
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -117,7 +117,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
 
         // run Concordance
         final File concordanceSummary = createTempFile("concordance", ".txt");
-        new Main().instanceMain(makeCommandLineArgs(Arrays.asList("-truth", truthVcf.getAbsolutePath(), "-eval", unfilteredVcf.getAbsolutePath(), "-L", "20", "-XL", mask.getAbsolutePath(), "-summary", concordanceSummary.getAbsolutePath()), "Concordance"));
+        new Main().instanceMain(makeCommandLineArgs(Arrays.asList("-truth", truthVcf.getAbsolutePath(), "-eval", filteredVcf.getAbsolutePath(), "-L", "20", "-XL", mask.getAbsolutePath(), "-summary", concordanceSummary.getAbsolutePath()), "Concordance"));
 
         final List<ConcordanceSummaryRecord> summaryRecords = new ConcordanceSummaryRecord.Reader(concordanceSummary).toList();
         summaryRecords.forEach(rec -> {
@@ -453,7 +453,6 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 {new File(DREAM_BAMS_DIR, "tumor_3.bam"), "IS3.snv.indel.sv", new File(DREAM_BAMS_DIR, "normal_3.bam"), "G15512.prenormal.sorted", new File(DREAM_VCFS_DIR, "sample_3.vcf"), new File(DREAM_MASKS_DIR, "mask3.list"), 0.90, false},
                 {new File(DREAM_BAMS_DIR, "tumor_4.bam"), "synthetic.challenge.set4.tumour", new File(DREAM_BAMS_DIR, "normal_4.bam"), "synthetic.challenge.set4.normal", new File(DREAM_VCFS_DIR, "sample_4.vcf"), new File(DREAM_MASKS_DIR, "mask4.list"), 0.65, false},
                 {new File(DREAM_BAMS_DIR, "tumor_4.bam"), "synthetic.challenge.set4.tumour", new File(DREAM_BAMS_DIR, "normal_4.bam"), "synthetic.challenge.set4.normal", new File(DREAM_VCFS_DIR, "sample_4.vcf"), new File(DREAM_MASKS_DIR, "mask4.list"), 0.65, true}
-
 
         };
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -64,8 +64,6 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
     public void testDreamTumorNormal(final File tumorBam, final String tumorSample, final File normalBam, final String normalSample,
                                      final File truthVcf, final File mask, final double requiredSensitivity, final boolean tumorOnly) throws Exception {
         Utils.resetRandomGenerator();
-        int N = 120000;
-        double x = 0.55;
         final File unfilteredVcf = createTempFile("unfiltered", ".vcf");
         final File filteredVcf = createTempFile("filtered", ".vcf");
 


### PR DESCRIPTION
@takutosato I made sure that when the new option is turned off, as it is by default, nothing changes.  Also, the new option surprisingly only added 30% or so to runtime because M2 already calls so many 
 false active regions.

@chandrans @sooheelee This is the feature we have been discussing.