### PR TITLE
Exposed maximum chunk size in CNV panel of normals.

### DIFF
--- a/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
@@ -68,6 +68,7 @@ workflow CNVSomaticPanelWorkflow {
     Boolean? do_impute_zeros
     Float? extreme_outlier_truncation_percentile
     Int? number_of_eigensamples
+    Int? maximum_chunk_size
     Int? mem_gb_for_create_read_count_pon
 
     Array[Pair[String, String]] normal_bams_and_bais = zip(normal_bams, normal_bais)
@@ -128,6 +129,7 @@ workflow CNVSomaticPanelWorkflow {
             do_impute_zeros = do_impute_zeros,
             extreme_outlier_truncation_percentile = extreme_outlier_truncation_percentile,
             number_of_eigensamples = number_of_eigensamples,
+            maximum_chunk_size = maximum_chunk_size,
             annotated_intervals = AnnotateIntervals.annotated_intervals,
             gatk4_jar_override = gatk4_jar_override,
             gatk_docker = gatk_docker,
@@ -153,6 +155,7 @@ task CreateReadCountPanelOfNormals {
     Boolean? do_impute_zeros
     Float? extreme_outlier_truncation_percentile
     Int? number_of_eigensamples
+    Int? maximum_chunk_size
     File? annotated_intervals   #do not perform explicit GC correction by default
     File? gatk4_jar_override
 
@@ -180,6 +183,7 @@ task CreateReadCountPanelOfNormals {
             --do-impute-zeros ${default="true" do_impute_zeros} \
             --extreme-outlier-truncation-percentile ${default="0.1" extreme_outlier_truncation_percentile} \
             --number-of-eigensamples ${default="20" number_of_eigensamples} \
+            --maximum-chunk-size ${default="16777216" maximum_chunk_size} \
             ${"--annotated-intervals " + annotated_intervals} \
             --output ${pon_entity_id}.pon.hdf5
     >>>

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/HDF5SVDReadCountPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/denoising/HDF5SVDReadCountPanelOfNormals.java
@@ -21,6 +21,7 @@ import org.broadinstitute.hellbender.tools.copynumber.utils.HDF5Utils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.spark.SparkConverter;
 
 import java.io.File;
@@ -237,6 +238,7 @@ public final class HDF5SVDReadCountPanelOfNormals implements SVDReadCountPanelOf
                               final boolean doImputeZeros,
                               final double extremeOutlierTruncationPercentile,
                               final int numEigensamplesRequested,
+                              final int maximumChunkSize,
                               final JavaSparkContext ctx) {
         try (final HDF5File file = new HDF5File(outFile, HDF5File.OpenMode.CREATE)) {
             logger.info("Creating " + outFile.getAbsolutePath() + "...");
@@ -253,7 +255,7 @@ public final class HDF5SVDReadCountPanelOfNormals implements SVDReadCountPanelOf
 
             logger.info(String.format("Writing original read counts (%d x %d)...",
                     originalReadCounts.getColumnDimension(), originalReadCounts.getRowDimension()));
-            pon.writeOriginalReadCountsPath(originalReadCounts);
+            pon.writeOriginalReadCountsPath(originalReadCounts, maximumChunkSize);
 
             logger.info(String.format("Writing original sample filenames (%d)...", originalSampleFilenames.size()));
             pon.writeOriginalSampleFilenames(originalSampleFilenames);
@@ -332,7 +334,7 @@ public final class HDF5SVDReadCountPanelOfNormals implements SVDReadCountPanelOf
             pon.writeSingularValues(singularValues);
 
             logger.info(String.format("Writing eigensample vectors (transposed to %d x %d)...", eigensampleVectors[0].length, eigensampleVectors.length));
-            pon.writeEigensampleVectors(eigensampleVectors);
+            pon.writeEigensampleVectors(eigensampleVectors, maximumChunkSize);
         } catch (final RuntimeException exception) {
             //if any exceptions encountered, delete partial output and rethrow
             logger.warn(String.format("Exception encountered during creation of panel of normals (%s).  Attempting to delete partial output in %s...",
@@ -361,8 +363,9 @@ public final class HDF5SVDReadCountPanelOfNormals implements SVDReadCountPanelOf
         file.makeStringArray(SEQUENCE_DICTIONARY_PATH, stringWriter.toString());
     }
 
-    private void writeOriginalReadCountsPath(final RealMatrix originalReadCounts) {
-        HDF5Utils.writeChunkedDoubleMatrix(file, ORIGINAL_READ_COUNTS_PATH, originalReadCounts.getData(), CHUNK_DIVISOR);
+    private void writeOriginalReadCountsPath(final RealMatrix originalReadCounts,
+                                             final int maximumChunkSize) {
+        HDF5Utils.writeChunkedDoubleMatrix(file, ORIGINAL_READ_COUNTS_PATH, originalReadCounts.getData(), maximumChunkSize);
     }
 
     private void writeOriginalSampleFilenames(final List<String> originalSampleFilenames) {
@@ -393,9 +396,9 @@ public final class HDF5SVDReadCountPanelOfNormals implements SVDReadCountPanelOf
         file.makeDoubleArray(PANEL_SINGULAR_VALUES_PATH, singularValues);
     }
 
-    private void writeEigensampleVectors(final double[][] eigensampleVectors) {
+    private void writeEigensampleVectors(final double[][] eigensampleVectors,
+                                         final int maximumChunkSize) {
         HDF5Utils.writeChunkedDoubleMatrix(file, PANEL_EIGENSAMPLE_VECTORS_PATH,
-                new Array2DRowRealMatrix(eigensampleVectors, false).transpose().getData(),
-                CHUNK_DIVISOR);
+                new Array2DRowRealMatrix(eigensampleVectors, false).transpose().getData(), maximumChunkSize);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/utils/HDF5UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/utils/HDF5UtilsUnitTest.java
@@ -19,13 +19,14 @@ import java.io.File;
 public final class HDF5UtilsUnitTest extends GATKBaseTest {
     private static final double DOUBLE_MATRIX_TOLERANCE = 1E-4;
     private static final int CHUNK_DIVISOR = 256;
+    private static final int MAX_CHUNK_SIZE = HDF5Utils.MAX_NUMBER_OF_VALUES_PER_HDF5_MATRIX / CHUNK_DIVISOR;
 
     @DataProvider(name = "testCreateLargeMatrixData")
     public Object[][] dataProvider() {
         return new Object[][] {
                 new Object[] {100, 100000},
-                new Object[] {CHUNK_DIVISOR + 16, (Integer.MAX_VALUE / Byte.SIZE) / CHUNK_DIVISOR},
-                new Object[] {(Integer.MAX_VALUE / Byte.SIZE) / CHUNK_DIVISOR, CHUNK_DIVISOR + 16}
+                new Object[] {CHUNK_DIVISOR + 16, MAX_CHUNK_SIZE},
+                new Object[] {MAX_CHUNK_SIZE, CHUNK_DIVISOR + 16}
         };
     }
 
@@ -40,7 +41,7 @@ public final class HDF5UtilsUnitTest extends GATKBaseTest {
         final RealMatrix largeMatrix = createMatrixOfGaussianValues(numRows, numColumns, mean, sigma);
         final File tempOutputHD5 = IOUtils.createTempFile("large-matrix-", ".hd5");
         try (final HDF5File hdf5File = new HDF5File(tempOutputHD5, HDF5File.OpenMode.CREATE)) {
-            HDF5Utils.writeChunkedDoubleMatrix(hdf5File, matrixPath, largeMatrix.getData(), CHUNK_DIVISOR);
+            HDF5Utils.writeChunkedDoubleMatrix(hdf5File, matrixPath, largeMatrix.getData(), MAX_CHUNK_SIZE);
         }
 
         try (final HDF5File hdf5FileForReading = new HDF5File(tempOutputHD5, HDF5File.OpenMode.READ_ONLY)) {


### PR DESCRIPTION
This enables PoNs to be built with a number of intervals greater than 16777216, which lets us push down to bin sizes <175bp if really necessary.  At some point, it is better to scatter and build a separate PoN for each contig so we don't run into memory issues.  However, the official WDL is not set up to do the scatter, so one would have to write a custom WDL.

@mwalker174 Do you mind taking a look?

Closes #4365.