### PR TITLE
Add large runtime resource directory to lfs, and expose it to the Docker build.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/test/resources/large/** filter=lfs diff=lfs merge=lfs -text
+src/main/resources/large/** filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -50,28 +50,38 @@ releases of the toolkit.
 * [License](#license)
 
 ## <a name="requirements">Requirements</a>
-* Java 8
-* Git 2.5 or greater
-* Optional, but recommended:
-    * Gradle 3.1 or greater, needed for building the GATK. We recommend using the `./gradlew` script which will
-      download and use an appropriate gradle version automatically (see examples below).
-    * Python 2.6 or greater (needed for running the `gatk` frontend script)
-    * Python 3.6.2, along with a set of additional Python packages, are required to run some tools and workflows.
-      GATK uses the [Conda](https://conda.io/docs/index.html) package manager to
-      establish and manage the environment and dependencies required by these tools. The GATK Docker image comes
-      with this environment pre-configured. In order to establish an environment suitable to run these tools
-      outside of the Docker image, the conda [gatkcondaenv.yml](https://github.com/broadinstitute/gatk/blob/master/scripts/gatkcondaenv.yml)
-      file is provided. To establish the conda environment locally, [Conda](https://conda.io/docs/index.html) must first
+* To run GATK:
+    * Java 8
+    * Python 2.6 or greater (required to run the `gatk` frontend script)
+    * Python 3.6.2, along with a set of additional Python packages, is required to run some tools and workflows.
+      GATK uses the [Conda](https://conda.io/docs/index.html) package manager to establish and manage the
+      environment and dependencies required by these tools. The GATK Docker image comes with this environment
+      pre-configured. In order to establish an environment suitable to run these tools outside of the Docker image, the
+      conda [gatkcondaenv.yml](https://github.com/broadinstitute/gatk/blob/master/scripts/gatkcondaenv.yml) file is
+      provided. To establish the conda environment locally, [Conda](https://conda.io/docs/index.html) must first
       be installed. Then, create the gatk environment by running the command ```conda env create -n gatk -f gatkcondaenv.yml```
       (developers should run ```./gradlew createPythonPackageArchive```, followed by
       ```conda env create -n gatk -f scripts/gatkcondaenv.yml``` from within the root of the repository clone).
       To activate the environment once it has been created, run the command ```source activate gatk```. See the
       [Conda](https://conda.io/docs/user-guide/tasks/manage-environments.html) documentation for
       additional information about using and managing Conda environments.
-    * R 3.2.5 (needed for producing plots in certain tools, and for running the test suite)
-    * [git-lfs](https://git-lfs.github.com/) 1.1.0 or greater (needed to download large files for the complete test suite).
-      Run `git lfs install` after downloading, followed by `git lfs pull` from the root of your git clone to download the large files. The download is several hundred megabytes.
-* Alternatively, pre-packaged images with all needed dependencies installed can be found on [our dockerhub repository](https://hub.docker.com/r/broadinstitute/gatk/). This requires a recent version of the docker client, which can be found on the [docker website](https://www.docker.com/get-docker).
+    * R 3.2.5 (needed for producing plots in certain tools)
+* To build GATK:
+    * A Java 8 JDK
+    * Git 2.5 or greater
+    * [git-lfs](https://git-lfs.github.com/) 1.1.0 or greater. Required to download the large files used to build GATK, and
+      test files required to run the test suite. Run `git lfs install` after downloading, followed by `git lfs pull` from
+      the root of your git clone to download all of the large files, including those required to run the test suite. The
+      full download is approximately 2 gigabytes. Alternatively, if you are just building GATK and not running the test
+      suite, you can skip this step since the build itself will use git-lfs to download the minimal set of large `lfs`
+      resource files required to complete the build. The test resources will not be downloaded, but this greatly reduces
+      the size of the download.
+    * Gradle 3.1 or greater. We recommend using the `./gradlew` script which will
+      download and use an appropriate gradle version automatically (see examples below).
+    * R 3.2.5 (needed for running the test suite)
+* Pre-packaged Docker images with all needed dependencies installed can be found on
+  [our dockerhub repository](https://hub.docker.com/r/broadinstitute/gatk/). This requires a recent version of the
+   docker client, which can be found on the [docker website](https://www.docker.com/get-docker).
 
 ## <a name="quickstart">Quick Start Guide</a>
 
@@ -102,7 +112,7 @@ You can download and run pre-built versions of GATK4 from the following places:
         
     * This creates a zip archive in the `build/` directory with a name like `gatk-VERSION.zip` containing a complete standalone GATK distribution, including our launcher `gatk`, both the local and spark jars, and this README.    
     * You can also run GATK commands directly from the root of your git clone after running this command.
-    * Note that you *must* have a full git clone in order to build GATK. The zipped source code alone is not buildable.
+    * Note that you *must* have a full git clone in order to build GATK, including the git-lfs files in src/main/resources. The zipped source code alone is not buildable.
 
 * **Other ways to build:**
     * `./gradlew installDist`  

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ repositories {
     mavenLocal()
 }
 
+final requiredJavaVersion = "8"
 final htsjdkVersion = System.getProperty('htsjdk.version','2.14.3')
 final picardVersion = System.getProperty('picard.version','2.17.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
@@ -69,6 +70,72 @@ final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'
 final docBuildDir = "$buildDir/docs"
 final pythonPackageArchiveName = 'gatkPythonPackageArchive.zip'
+final largeResourcesFolder = "src/main/resources/large"
+final buildPrerequisitesMessage = "See https://github.com/broadinstitute/gatk#building for information on how to build GATK."
+
+// Returns true if any files in the target folder are git-lfs stub files.
+def checkForLFSStubFiles(targetFolder) {
+    final lfsStubFileHeader = "version https://git-lfs.github.com/spec/v1"  // first line of a git-lfs stub file
+    def readBytesFromFile = { largeFile, n ->
+        final byte[] bytes = new byte[n]
+        largeFile.withInputStream { stream -> stream.read(bytes, 0, bytes.length) }
+        return bytes
+    }
+    def targetFiles = fileTree(dir: targetFolder)
+    return targetFiles.any() { f ->
+        final byte[] actualBytes = readBytesFromFile(f, lfsStubFileHeader.length());
+        return new String(actualBytes, "UTF-8") == lfsStubFileHeader
+    }
+}
+
+// if any of the large resources are lfs stub files, download them
+def resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessage) {
+    def execGitLFSCommand = { gitLFSExecCommand ->
+        println "Executing: $gitLFSExecCommand"
+        try {
+            def retCode = gitLFSExecCommand.execute().waitFor()
+            if (retCode.intValue() != 0) {
+                throw new GradleException("Execution of \"$gitLFSExecCommand\" failed with exit code: $retCode");
+            }
+            return retCode
+        } catch (IOException e) {
+            throw new GradleException(
+                    "An IOException occurred while attempting to execute the command $gitLFSExecCommand."
+                    + " git-lfs is required to build GATK but may not be installed. $buildPrerequisitesMessage", e)
+        }
+    }
+
+    // check for stub files, try to pull once if there are any, then check again
+    if (checkForLFSStubFiles(largeResourcesFolder)) {
+        final gitLFSPullLargeResources = "git lfs pull --include $largeResourcesFolder"
+        execGitLFSCommand(gitLFSPullLargeResources)
+        if (checkForLFSStubFiles(largeResourcesFolder)) {
+            throw new GradleException("$largeResourcesFolder contains one or more git-lfs stub files."
+                    + " The resource files in $largeResourcesFolder must be downloaded by running the git-lfs"
+                    + " command \"$gitLFSPullLargeResources\". $buildPrerequisitesMessage")
+        }
+    }
+}
+
+// Ensure that we have the right JDK version, a clone of the git repository, and resolve any required git-lfs
+// resource files that are needed to run the build but are still lfs stub files.
+def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage) {
+    // Make sure we can get a ToolProvider class loader. If not we may have just a JRE, or a JDK from the future.
+    if (ToolProvider.getSystemToolClassLoader() == null) {
+        throw new GradleException(
+                "The ClassLoader obtained from the Java ToolProvider is null. "
+                + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
+    }
+    if (!file(".git").isDirectory()) {
+        throw new GradleException("The GATK Github repository must be cloned using \"git clone\" to run the build. "
+                + "$buildPrerequisitesMessage")
+    }
+    // Large runtime resource files must be present at build time to be compiled into the jar, so
+    // try to resolve them to real files if any of them are stubs.
+    resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessage)
+}
+
+ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage)
 
 configurations.all {
     resolutionStrategy {
@@ -264,6 +331,8 @@ processResources {
 processTestResources {
     //Don't waste time packaging unnecessary test data into the test resources:
     include "org/broadinstitute/hellbender/utils/config/*"
+    //Required for IOUtils resource tests
+    include "org/broadinstitute/hellbender/utils/io/*"
 }
 
 sourceCompatibility = 1.8

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -98,6 +98,13 @@ if [ -n "$STAGING_DIR" ]; then
     GIT_CHECKOUT_COMMAND="git checkout ${GITHUB_DIR}${GITHUB_TAG}"
     echo "${GIT_CHECKOUT_COMMAND}"
     ${GIT_CHECKOUT_COMMAND}
+    # Since the large runtime resources are compiled into the jar, they have to be available to
+    # the build when it's done as part of the Docker build. Although the build itself will pull
+    # them from the lfs server if they're not present, the Docker doesn't have git-lfs installed
+    # so that would fail. So pull them into the staging areas so they'll be copied directly.
+    GIT_PULL_LARGE_COMMAND="git lfs pull --include src/main/resources/large/"
+    echo ${GIT_PULL_LARGE_COMMAND}
+    ${GIT_PULL_LARGE_COMMAND}
 fi
 
 # Build

--- a/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/NativeUtils.java
@@ -58,7 +58,7 @@ public final class NativeUtils {
         Utils.validateArg(libraryPathInJar.startsWith("/"), "library path in jar must be absolute");
 
         try {
-            final File extractedLibrary = IOUtils.writeTempResource(new Resource(libraryPathInJar, NativeUtils.class));
+            final File extractedLibrary = IOUtils.writeTempResourceFromPath(libraryPathInJar, NativeUtils.class);
             extractedLibrary.deleteOnExit();
             System.load(extractedLibrary.getAbsolutePath());
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptLibrary.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptLibrary.java
@@ -30,7 +30,7 @@ public enum RScriptLibrary {
      * @return The path to the library source code. The caller must delete the code when done.
      */
     public File writeTemp() {
-        return IOUtils.writeTempResource(new Resource(getResourcePath(), RScriptLibrary.class));
+        return IOUtils.writeTempResourceFromPath(getResourcePath(), RScriptLibrary.class);
     }
 
     public File writeLibrary(File tempDir) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -204,7 +204,7 @@ public final class IOUtils {
     }
 
     /**
-     * Writes the an embedded resource to a temp file.
+     * Writes an embedded resource to a temp file.
      * File is not scheduled for deletion and must be cleaned up by the caller.
      * @param resource Embedded resource.
      * @return Path to the temp file with the contents of the resource.
@@ -218,6 +218,20 @@ public final class IOUtils {
         }
         writeResource(resource, temp);
         return temp;
+    }
+
+    /**
+     * Create a resource from a path and a relative class, and write it to a temporary file.
+     * If the relative class is null then the system classloader will be used and the path must be absolute.
+     * @param resourcePath Relative or absolute path to the class.
+     * @param relativeClass Relative class to use as a class loader and for a relative package.
+     * @return a temporary file containing the contents of the resource. the File is not automatically scheduled
+     * for deletion and must be cleaned up by the caller.
+     */
+    public static File writeTempResourceFromPath(final String resourcePath, final Class<?> relativeClass) {
+        Utils.nonNull(resourcePath, "A resource path must be provided");
+        final Resource resource = new Resource(resourcePath, relativeClass);
+        return writeTempResource(resource);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
@@ -11,6 +11,11 @@ public final class Resource {
     private final Class<?> relativeClass;
 
     /**
+     * Path to the directory for large runtime system resources
+     */
+    public final static String LARGE_RUNTIME_RESOURCES_PATH = "large";
+
+    /**
      * Create a resource with a path and a relative class.
      * @param path Relative or absolute path to the class.
      * @param relativeClass Relative class to use as a class loader and for a relative package.

--- a/src/main/resources/large/testResourceFile.txt
+++ b/src/main/resources/large/testResourceFile.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e69a86f301ab9ab0d507ad7659abb4ad3732382ccbeb714db497e51eb3cf87b
+size 29

--- a/src/test/resources/org/broadinstitute/hellbender/utils/io/testResourceFile.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/utils/io/testResourceFile.txt
@@ -1,0 +1,1 @@
+this is a test resource file


### PR DESCRIPTION
This adds a new folder for large runtime resources to git-lfs. Unlike the large test resources, which are only accessed via a volume mount when tests are run on the Docker image, the runtime resources need to be accessible to the GATK build during the Docker build process, since they're included in the jar. AFAICT there is no `docker build` equivalent to `docker run -v`. So for now the runtime resources are git pulled into the Docker staging area, and thus onto the Docker image. We need this for @lucidtronix 's CNN branch (and possibly for @TedBrookings) if we're going to load models for resources, but longer term, we need a better solution.