### PR TITLE
setting default compression level to 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ import javax.tools.ToolProvider
 mainClassName = "org.broadinstitute.hellbender.Main"
 
 //Note: the test suite must use the same defaults. If you change system properties in this list you must also update the one in the test task
-applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=1"]
+applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamjdk.use_async_io_write_samtools=true", "-Dsamjdk.use_async_io_write_tribble=false", "-Dsamjdk.compression_level=2"]
 
 //Delete the windows script - we never test on Windows so let's not pretend it works
 startScripts {
@@ -340,7 +340,7 @@ test {
     systemProperty "samjdk.use_async_io_read_samtools", "false"
     systemProperty "samjdk.use_async_io_write_samtools", "true"
     systemProperty "samjdk.use_async_io_write_tribble", "false"
-    systemProperty "samjdk.compression_level", "1"
+    systemProperty "samjdk.compression_level", "2"
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     environment "SPARK_LOCAL_IP","127.0.0.1"

--- a/gatk
+++ b/gatk
@@ -37,12 +37,12 @@ EXTRA_JAVA_OPTIONS_SPARK= "-DGATK_STACKTRACE_ON_USER_EXCEPTION=true " \
                    "-Dsamjdk.use_async_io_read_samtools=false " \
                    "-Dsamjdk.use_async_io_write_samtools=false " \
                    "-Dsamjdk.use_async_io_write_tribble=false " \
-                   "-Dsamjdk.compression_level=1 " 
+                   "-Dsamjdk.compression_level=2 "
 
 PACKAGED_LOCAL_JAR_OPTIONS= ["-Dsamjdk.use_async_io_read_samtools=false",
                   "-Dsamjdk.use_async_io_write_samtools=true",
                   "-Dsamjdk.use_async_io_write_tribble=false",
-                  "-Dsamjdk.compression_level=1"]
+                  "-Dsamjdk.compression_level=2"]
 
 DEFAULT_SPARK_ARGS_PREFIX = '--conf'
 DEFAULT_SPARK_ARGS = {

--- a/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
@@ -89,7 +89,7 @@ public interface GATKConfig extends Mutable, Accessible {
 
     @SystemProperty
     @Key("samjdk.compression_level")
-    @DefaultValue("1")
+    @DefaultValue("2")
     int samjdk_compression_level();
 
     // ----------------------------------------------------------

--- a/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
@@ -41,7 +41,7 @@ gatk_stacktrace_on_user_exception = false
 samjdk.use_async_io_read_samtools = false
 samjdk.use_async_io_write_samtools = true
 samjdk.use_async_io_write_tribble = false
-samjdk.compression_level = 1
+samjdk.compression_level = 2
 
 # ----------------------------------------------------------
 # Spark Options:


### PR DESCRIPTION
I'm honestly not sure which of the various settings take precedence, so I set them all...  We should remove the irrelevant ones.  I assume that that includes the ones in the `gatk` launch script as well as the defaults in build.gradle? 