### PR TITLE
Update GCS connector from 1.6.1 to 1.6.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     // this comes built-in when running on Google Dataproc, but the library
     // allows us to read from GCS also when testing locally (or on non-Dataproc clusters,
     // should we want to)
-    compile 'com.google.cloud.bigdataoss:gcs-connector:1.6.1-hadoop2'
+    compile 'com.google.cloud.bigdataoss:gcs-connector:1.6.3-hadoop2'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
     compile 'org.apache.commons:commons-lang3:3.4'


### PR DESCRIPTION
This changes the GCS batch request endpoint to the new per-api endpoint
(https://github.com/GoogleCloudPlatform/bigdata-interop/blob/branch-1.6.x/gcs/CHANGES.txt),
as the old endpoint is being deprecated
(https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html).