### PR TITLE
Add new configuration entry for plugins

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
@@ -11,6 +11,8 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.PedigreeAnnotation;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.config.GATKConfig;
 
 import java.io.File;
 import java.lang.reflect.Modifier;
@@ -33,8 +35,17 @@ import java.util.stream.Stream;
  *       as no such annotations exist in the GATK.
  */
 public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor<Annotation> {
-    //TODO this should be a configurable option or otherwise exposed to the user when configurations are fully supported.
-    private static final String pluginPackageName = "org.broadinstitute.hellbender.tools.walkers.annotator";
+    /**
+     * At startup, set the plugin package name to the one(s) in the configuration file.
+     */
+    private static final List<String> PLUGIN_PACKAGE_NAMES;
+    static {
+
+        // Get our configuration:
+        final GATKConfig config = ConfigFactory.getInstance().getGATKConfig();
+        // Exclude abstract classes and interfaces from the list of discovered codec classes
+        PLUGIN_PACKAGE_NAMES = Collections.unmodifiableList(config.codec_packages());
+    }
     private static final Class<?> pluginBaseClass = org.broadinstitute.hellbender.tools.walkers.annotator.Annotation.class;
 
     protected transient Logger logger = LogManager.getLogger(this.getClass());
@@ -84,7 +95,7 @@ public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor
      */
     @Override
     public List<String> getPackageNames() {
-        return Collections.singletonList(pluginPackageName);
+        return PLUGIN_PACKAGE_NAMES;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -5,12 +5,15 @@ import htsjdk.samtools.SAMFileHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.ClassFinder;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.config.GATKConfig;
 
 import java.io.IOException;
 import java.util.*;
@@ -30,7 +33,18 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
         logger = LogManager.getLogger(this.getClass()); // Logger is not serializable (even by Kryo)
     }
 
-    private static final String pluginPackageName = "org.broadinstitute.hellbender.engine.filters";
+    /**
+     * At startup, set the plugin package name to the one(s) in the configuration file.
+     */
+    private static final List<String> PLUGIN_PACKAGE_NAMES;
+    static {
+
+        // Get our configuration:
+        final GATKConfig config = ConfigFactory.getInstance().getGATKConfig();
+        // Exclude abstract classes and interfaces from the list of discovered codec classes
+        PLUGIN_PACKAGE_NAMES = Collections.unmodifiableList(config.codec_packages());
+    }
+
     private static final Class<ReadFilter> pluginBaseClass = org.broadinstitute.hellbender.engine.filters.ReadFilter.class;
 
     // the purpose of this argument collection is to allow the caller to control the exposure of the command line arguments
@@ -103,7 +117,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      * @return
      */
     @Override
-    public List<String> getPackageNames() {return Collections.singletonList(pluginPackageName);}
+    public List<String> getPackageNames() {return PLUGIN_PACKAGE_NAMES;}
 
     @Override
     public boolean includePluginClass(Class<?> c) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
@@ -5,6 +5,7 @@ import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.argparser.ClassFinder;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.DefaultGATKVariantAnnotationArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKAnnotationArgumentCollection;
@@ -15,6 +16,8 @@ import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.Redu
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.ReducibleAnnotationData;
 import org.broadinstitute.hellbender.utils.ClassUtils;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.config.GATKConfig;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 import org.reflections.ReflectionUtils;
@@ -490,7 +493,15 @@ public final class VariantAnnotatorEngine {
         }
 
         private static List<InfoFieldAnnotation> makeAllInfoFieldAnnotations() {
-            return ClassUtils.makeInstancesOfSubclasses(InfoFieldAnnotation.class, Annotation.class.getPackage());
+            // Get our configuration:
+            final GATKConfig config = ConfigFactory.getInstance().getGATKConfig();
+
+            final ClassFinder finder = new ClassFinder();
+            for ( final String codecPackage : config.annotation_packages() ) {
+                finder.find(codecPackage, InfoFieldAnnotation.class);
+            }
+            return finder.getConcreteClasses().stream().map(c -> (InfoFieldAnnotation) ClassUtils.makeInstanceOf(c))
+                    .filter(Objects::isNull).collect(Collectors.toList());
         }
 
         public List<GenotypeAnnotation> createGenotypeAnnotations() {
@@ -499,7 +510,15 @@ public final class VariantAnnotatorEngine {
         }
 
         private static List<GenotypeAnnotation> makeAllGenotypeAnnotations() {
-            return ClassUtils.makeInstancesOfSubclasses(GenotypeAnnotation.class, Annotation.class.getPackage());
+            // Get our configuration:
+            final GATKConfig config = ConfigFactory.getInstance().getGATKConfig();
+
+            final ClassFinder finder = new ClassFinder();
+            for ( final String codecPackage : config.annotation_packages() ) {
+                finder.find(codecPackage, GenotypeAnnotation.class);
+            }
+            return finder.getConcreteClasses().stream().map(c -> (GenotypeAnnotation) ClassUtils.makeInstanceOf(c))
+                    .filter(Objects::isNull).collect(Collectors.toList());
         }
 
         /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/ClassUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/ClassUtils.java
@@ -49,15 +49,31 @@ public final class ClassUtils {
         final List<T> results = new ArrayList<>(classes.size());
 
         for (final Class<?> found: classes){
-            if (canMakeInstances(found)){
-                try {
-                    results.add((T)found.newInstance());
-                } catch (InstantiationException | IllegalAccessException e) {
-                    throw new GATKException("Problem making an instance of " + found + " Do check that the class has a non-arg constructor", e);
-                }
+            final T instance = (T) makeInstanceOf(found);
+            if (instance != null) {
+                results.add(instance);
             }
         }
         return results;
+    }
+
+    /**
+     * Create objects of a concrete class.
+     *
+     * The public no-arg constructor is called to create the objects.
+     *
+     * @param clazz class to be instantiated
+     * @return new object or {@code null} if cannot be instantiated.
+     */
+    public static <T> T makeInstanceOf(final Class<T> clazz) {
+        if (canMakeInstances(clazz)) {
+            try {
+                return clazz.newInstance();
+            } catch (final InstantiationException | IllegalAccessException e) {
+                throw new GATKException("Problem making an instance of " + clazz + " Do check that the class has a non-arg constructor", e);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
@@ -147,6 +147,9 @@ public interface GATKConfig extends Mutable, Accessible {
     @DefaultValue("org.broadinstitute.hellbender.engine.filters")
     List<String> read_filter_packages();
 
+    @DefaultValue("org.broadinstitute.hellbender.tools.walkers.annotator")
+    List<String> annotation_packages();
+
     // ----------------------------------------------------------
     // GATKTool Options:
     // ----------------------------------------------------------

--- a/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
@@ -144,6 +144,9 @@ public interface GATKConfig extends Mutable, Accessible {
     @DefaultValue("htsjdk.variant,htsjdk.tribble,org.broadinstitute.hellbender.utils.codecs")
     List<String> codec_packages();
 
+    @DefaultValue("org.broadinstitute.hellbender.engine.filters")
+    List<String> read_filter_packages();
+
     // ----------------------------------------------------------
     // GATKTool Options:
     // ----------------------------------------------------------

--- a/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
@@ -73,6 +73,7 @@ spark.executor.extraJavaOptions =
 # ---------------------------------------------------------------------------------
 
 codec_packages = htsjdk.variant, htsjdk.tribble, org.broadinstitute.hellbender.utils.codecs
+read_filter_packages = "org.broadinstitute.hellbender.engine.filters"
 
 # ---------------------------------------------------------------------------------
 # GATKTool Options:

--- a/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
@@ -74,6 +74,7 @@ spark.executor.extraJavaOptions =
 
 codec_packages = htsjdk.variant, htsjdk.tribble, org.broadinstitute.hellbender.utils.codecs
 read_filter_packages = "org.broadinstitute.hellbender.engine.filters"
+annotation_packages = "org.broadinstitute.hellbender.tools.walkers.annotator"
 
 # ---------------------------------------------------------------------------------
 # GATKTool Options:


### PR DESCRIPTION
Includes:

* Configuration for packages to search read filters
* Configuration for packages to search annotations

In addition, it changes the behavior of `VariantAnnotatorEngine` to use the annotation packages from the configuration, and mimic what the plugin is doing. This closes https://github.com/broadinstitute/gatk/issues/2155