### PR TITLE
fixed M2 wdl bamout bug on scatters with overlapping assembly regions

### DIFF
--- a/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
+++ b/scripts/m2_cromwell_tests/test_m2_wdl_multi.json
@@ -13,5 +13,6 @@
   "Mutect2_Multi.preemptible_attempts": 2,
   "Mutect2_Multi.artifact_modes": ["G/T", "C/T"],
   "Mutect2_Multi.compress_vcfs": false,
+  "Mutect2_Multi.make_bamout": true,
   "Mutect2_Multi.onco_ds_local_db_dir": "/root/"
 }


### PR DESCRIPTION
Closes #4606.
@takutosato Another little one for you.  This works on SGE and in Travis.