### PR TITLE
switch away from calling hashCode directly on enums

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/AlignmentInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/AlignmentInterval.java
@@ -472,7 +472,7 @@ public final class AlignmentInterval {
         result = 31 * result + mapQual;
         result = 31 * result + mismatches;
         result = 31 * result + alnScore;
-        result = 31 * result + alnModType.hashCode();
+        result = 31 * result + Objects.hashCode(alnModType.ordinal());
         return result;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ChimericAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ChimericAlignment.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Holds information about a split alignment of a contig, which may represent an SV breakpoint. Each ChimericAlignment
@@ -463,7 +464,7 @@ public class ChimericAlignment {
         int result = sourceContigName.hashCode();
         result = 31 * result + regionWithLowerCoordOnContig.hashCode();
         result = 31 * result + regionWithHigherCoordOnContig.hashCode();
-        result = 31 * result + strandSwitch.hashCode();
+        result = 31 * result + Objects.hashCode(strandSwitch.ordinal());
         result = 31 * result + (isForwardStrandRepresentation ? 1 : 0);
         result = 31 * result + insertionMappings.hashCode();
         return result;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContig.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContig.java
@@ -16,10 +16,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -500,7 +497,7 @@ final class CpxVariantInducingAssemblyContig {
         public int hashCode() {
             int result = start.hashCode();
             result = 31 * result + landing.hashCode();
-            result = 31 * result + strandSwitch.hashCode();
+            result = 31 * result + Objects.hashCode(strandSwitch.ordinal());
             result = 31 * result + gapSize;
             return result;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/NovelAdjacencyAndAltHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/NovelAdjacencyAndAltHaplotype.java
@@ -17,6 +17,7 @@ import scala.Tuple2;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class represents a pair of inferred genomic locations on the reference whose novel adjacency is generated
@@ -124,7 +125,7 @@ public class NovelAdjacencyAndAltHaplotype {
     public int hashCode() {
         int result = leftJustifiedLeftRefLoc.hashCode();
         result = 31 * result + leftJustifiedRightRefLoc.hashCode();
-        result = 31 * result + strandSwitch.hashCode();
+        result = 31 * result + Objects.hashCode(strandSwitch.ordinal());
         result = 31 * result + complication.hashCode();
         result = 31 * result + Arrays.hashCode(altHaplotypeSequence);
         return result;


### PR DESCRIPTION
Calling `hashCode` directly on an instance of a Java enum produces a value that depends on the object's memory location and is therefore not stable across machines in a distributed environment. This causes issues when using these objects (or objects that contain them) as keys in Spark RDDs, which by default use `HashPartitioner` to parition by hash code. See this blog post for a summary:

http://dev.bizo.com/2014/02/beware-enums-in-spark.html

This PR modifies all places within the sv tools where we call `hashCode` on an enum, instead computing the hash of the ordinal of the enum value.

For @SHuang-Broad 