### PR TITLE
restored explicit PASS (as opposed to empty) filter in Mutect2

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -255,6 +255,7 @@ public class Mutect2FilteringEngine {
 
     //TODO: building a list via repeated side effects is ugly
     public void applyFilters(final M2FiltersArgumentCollection MTFAC, final VariantContext vc, final VariantContextBuilder vcb) {
+        vcb.filters(new HashSet<>());
         applyInsufficientEvidenceFilter(MTFAC, vc, vcb);
         applyClusteredEventFilter(vc, vcb);
         applyDuplicatedAltReadFilter(MTFAC, vc, vcb);


### PR DESCRIPTION
Closes #4625.

@takutosato Could you review this?  It's a one-liner.