### PR TITLE
GenomicsDBImport: Modifications in order to address GATK issue #3269

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.4.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+6d8f87d9e')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+ed318f7e815')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.4.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+d8f149eef716')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+b825ffa6eb47a')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.4.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+ed318f7e815')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+d8f149eef716')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+uuid-static')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.4.0')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+e071855938')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final hadoopBamVersion = System.getProperty('hadoopBam.version','7.10.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.4.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+e071855938')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','0.9.2-proto-3.0.0-beta-1+6d8f87d9e')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -24,6 +24,7 @@ import org.broadinstitute.hellbender.utils.nio.SeekableByteChannelPrefetcher;
 import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -412,23 +413,22 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
                         .setProduceGTWithMinPLValueForSpanningDeletions(false)
                         .setSitesOnlyQuery(false)
                         .setMaxDiploidAltAllelesThatCanBeGenotyped(GenotypeLikelihoods.MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED);
-        File arrayFolder = new File(Paths.get(workspace.getAbsolutePath(), GenomicsDBConstants.DEFAULT_ARRAY_NAME)
-                .toAbsolutePath().toString());
+        Path arrayFolder = Paths.get(workspace.getAbsolutePath(), GenomicsDBConstants.DEFAULT_ARRAY_NAME).toAbsolutePath();
 
-        //For the multi-interval support, we create multiple arrays (directories) in a single workspace -
-        //one per interval. So, if you wish to import intervals ("chr1", [ 1, 100M ]) and ("chr2", [ 1, 100M ]),
-        //you end up with 2 directories named chr1$1$100M and chr2$1$100M. So, the array names depend on the
-        //partition bounds.
+        // For the multi-interval support, we create multiple arrays (directories) in a single workspace -
+        // one per interval. So, if you wish to import intervals ("chr1", [ 1, 100M ]) and ("chr2", [ 1, 100M ]),
+        // you end up with 2 directories named chr1$1$100M and chr2$1$100M. So, the array names depend on the
+        // partition bounds.
 
-        //During the read phase, the user only supplies the workspace. The array names are obtained by scanning
-        //the entries in the workspace and reading the right arrays. For example, if you wish to read ("chr2",
-        //50, 50M), then only the second array is queried.
+        // During the read phase, the user only supplies the workspace. The array names are obtained by scanning
+        // the entries in the workspace and reading the right arrays. For example, if you wish to read ("chr2",
+        // 50, 50M), then only the second array is queried.
 
-        //In the previous version of the tool, the array name was a constant - genomicsdb_array. The new version
-        //will be backward compatible with respect to reads. Hence, if a directory named genomicsdb_array is found,
-        //the array name is passed to the GenomicsDBFeatureReader otherwise the array names are generated from the
-        //directory entries.
-        if (arrayFolder.exists()) {
+        // In the previous version of the tool, the array name was a constant - genomicsdb_array. The new version
+        // will be backward compatible with respect to reads. Hence, if a directory named genomicsdb_array is found,
+        // the array name is passed to the GenomicsDBFeatureReader otherwise the array names are generated from the
+        // directory entries.
+        if (Files.exists(arrayFolder)) {
             exportConfigurationBuilder.setArrayName(GenomicsDBConstants.DEFAULT_ARRAY_NAME);
         } else {
             exportConfigurationBuilder.setGenerateArrayNameFromPartitionBounds(true);

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -406,10 +406,26 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
                         .setReferenceGenome(reference.getAbsolutePath())
                         .setVidMappingFile(vidmapJson.getAbsolutePath())
                         .setCallsetMappingFile(callsetJson.getAbsolutePath())
-                        .setVcfHeaderFilename(vcfHeader.getAbsolutePath());
+                        .setVcfHeaderFilename(vcfHeader.getAbsolutePath())
+                        .setProduceGTField(false)
+                        .setProduceGTWithMinPLValueForSpanningDeletions(false)
+                        .setSitesOnlyQuery(false);
         File arrayFolder = new File(Paths.get(workspace.getAbsolutePath(), GenomicsDBConstants.DEFAULT_ARRAY_NAME)
                 .toAbsolutePath().toString());
 
+        //For the multi-interval support, we create multiple arrays (directories) in a single workspace -
+        //one per interval. So, if you wish to import intervals ("chr1", [ 1, 100M ]) and ("chr2", [ 1, 100M ]),
+        //you end up with 2 directories named chr1$1$100M and chr2$1$100M. So, the array names depend on the
+        //partition bounds.
+
+        //During the read phase, the user only supplies the workspace. The array names are obtained by scanning
+        //the entries in the workspace and reading the right arrays. For example, if you wish to read ("chr2",
+        //50, 50M), then only the second array is queried.
+
+        //In the previous version of the tool, the array name was a constant - genomicsdb_array. The new version
+        //will be backward compatible with respect to reads. Hence, if a directory named genomicsdb_array is found,
+        //the array name is passed to the GenomicsDBFeatureReader otherwise the array names are generated from the
+        //directory entries.
         if (arrayFolder.exists()) {
             exportConfigurationBuilder.setArrayName(GenomicsDBConstants.DEFAULT_ARRAY_NAME);
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.tribble.*;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.GenotypeLikelihoods;
 import htsjdk.variant.vcf.VCFHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -409,7 +410,8 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
                         .setVcfHeaderFilename(vcfHeader.getAbsolutePath())
                         .setProduceGTField(false)
                         .setProduceGTWithMinPLValueForSpanningDeletions(false)
-                        .setSitesOnlyQuery(false);
+                        .setSitesOnlyQuery(false)
+                        .setMaxDiploidAltAllelesThatCanBeGenotyped(GenotypeLikelihoods.MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED);
         File arrayFolder = new File(Paths.get(workspace.getAbsolutePath(), GenomicsDBConstants.DEFAULT_ARRAY_NAME)
                 .toAbsolutePath().toString());
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -387,6 +387,19 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
                     GenomicsDBConstants.DEFAULT_VCFHEADER_FILE_NAME + ") could not be read from GenomicsDB workspace " + workspace.getAbsolutePath(), e);
         }
 
+        final GenomicsDBExportConfiguration.ExportConfiguration exportConfigurationBuilder =
+                createExportConfiguration(reference, workspace, callsetJson, vidmapJson, vcfHeader);
+
+        try {
+            return new GenomicsDBFeatureReader<>(exportConfigurationBuilder, new BCF2Codec(), Optional.empty());
+        } catch (final IOException e) {
+            throw new UserException("Couldn't create GenomicsDBFeatureReader", e);
+        }
+    }
+
+    private static GenomicsDBExportConfiguration.ExportConfiguration createExportConfiguration(final File reference, final File workspace,
+                                                                                               final File callsetJson, final File vidmapJson,
+                                                                                               final File vcfHeader) {
         GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder =
                 GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
                         .setWorkspace(workspace.getAbsolutePath())
@@ -403,11 +416,7 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
             exportConfigurationBuilder.setGenerateArrayNameFromPartitionBounds(true);
         }
 
-        try {
-            return new GenomicsDBFeatureReader<>(exportConfigurationBuilder.build(), new BCF2Codec(), Optional.empty());
-        } catch (final IOException e) {
-            throw new UserException("Couldn't create GenomicsDBFeatureReader", e);
-        }
+        return exportConfigurationBuilder.build();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBConstants.java
@@ -9,7 +9,6 @@ public final class GenomicsDBConstants {
     public static final String DEFAULT_CALLSETMAP_FILE_NAME = "callset.json";
     public static final String DEFAULT_VCFHEADER_FILE_NAME = "vcfheader.vcf";
 
-
     /**
      * Don't instantiate a utility class
      */

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -486,7 +486,7 @@ public final class GenomicsDBImport extends GATKTool {
 
     private Map<String, FeatureReader<VariantContext>> createSampleToReaderMap(
             final Map<String, Path> sampleNameToVcfPath, final int batchSize, final int index) {
-        //TODO: fix casting since it's really ugly
+        // TODO: fix casting since it's really ugly
         return inputPreloadExecutorService != null ?
                 getFeatureReadersInParallel((SortedMap<String, Path>) sampleNameToVcfPath, batchSize, index)
                 : getFeatureReadersSerially(sampleNameToVcfPath, batchSize, index);
@@ -548,7 +548,6 @@ public final class GenomicsDBImport extends GATKTool {
 
         final int sampleCount = sampleNameToVcfPath.size();
         final int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleCount : batchSize;
-//        final int totalBatchCount = (sampleCount/updatedBatchSize) + (sampleCount%updatedBatchSize==0 ? 0 : 1);
         final ImportConfig importConfig = createImportConfig(updatedBatchSize);
 
         GenomicsDBImporter importer;

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -113,8 +113,7 @@ import java.util.stream.Collectors;
  * <h3>Caveats</h3>
  * <ul>
  *     <li>IMPORTANT: The -Xmx value the tool is run with should be less than the total amount of physical memory available by at least a few GB, as the native TileDB library requires additional memory on top of the Java memory. Failure to leave enough memory for the native code can result in confusing error messages!</li>
- *     <li>A single interval must be provided. This means each import is limited to a maximum of one contig</li>
- *     <li>Currently, only supports diploid data</li>
+ *     <li>At least one interval must be provided</li>
  *     <li>Input GVCFs cannot contain multiple entries for a single genomic position</li>
  *     <li>The --genomicsdb-workspace-path must point to a non-existent or empty directory.</li>
  * </ul>
@@ -479,8 +478,8 @@ public final class GenomicsDBImport extends GATKTool {
                 : getFeatureReadersSerially(sampleNameToVcfPath, batchSize, index);
     }
 
-    private List<GenomicsDBImportConfiguration.Partition> generatePartitionListFromIntervals(List<ChromosomeInterval> chromosomeIntevals) {
-        return chromosomeIntevals.stream().map(interval -> {
+    private List<GenomicsDBImportConfiguration.Partition> generatePartitionListFromIntervals(List<ChromosomeInterval> chromosomeIntervals) {
+        return chromosomeIntervals.stream().map(interval -> {
             GenomicsDBImportConfiguration.Partition.Builder partitionBuilder = GenomicsDBImportConfiguration.Partition.newBuilder();
             Coordinates.ContigPosition.Builder contigPositionBuilder = Coordinates.ContigPosition.newBuilder();
             Coordinates.GenomicsDBColumn.Builder columnBuilder = Coordinates.GenomicsDBColumn.newBuilder();
@@ -529,11 +528,7 @@ public final class GenomicsDBImport extends GATKTool {
         final int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleCount : batchSize;
 //        final int totalBatchCount = (sampleCount/updatedBatchSize) + (sampleCount%updatedBatchSize==0 ? 0 : 1);
         final ImportConfig importConfig = createImportConfig(updatedBatchSize);
-        //TODO: Fix this.
-//        BiConsumer<Map<String, FeatureReader<VariantContext>>, Integer> closeReaders = (readers, batchCount) -> {
-//            progressMeter.update(intervals.get(0));
-//            logger.info("Done importing batch " + batchCount + "/" + totalBatchCount);
-//        };
+
         GenomicsDBImporter importer;
         try {
             importer = new GenomicsDBImporter(importConfig);

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -678,26 +678,17 @@ public final class GenomicsDBImport extends GATKTool {
      */
     private void initializeIntervals() {
         if (intervalArgumentCollection.intervalsSpecified()) {
-
             final SAMSequenceDictionary intervalDictionary = getBestAvailableSequenceDictionary();
+
             if (intervalDictionary == null) {
                 throw new UserException("We require at least one input source that " +
                     "has a sequence dictionary (reference or reads) when intervals are specified");
             }
 
             intervals = new ArrayList<>();
-
-            final List<SimpleInterval> simpleIntervalList =
-                intervalArgumentCollection.getIntervals(intervalDictionary);
-
-            if (simpleIntervalList.size() > 1) {
-                throw new UserException("More than one interval specified. The tool takes only one");
-            }
-
-            for (final SimpleInterval simpleInterval : simpleIntervalList) {
-                intervals.add(new ChromosomeInterval(simpleInterval.getContig(),
-                  simpleInterval.getStart(), simpleInterval.getEnd()));
-            }
+            final List<SimpleInterval> simpleIntervalList = intervalArgumentCollection.getIntervals(intervalDictionary);
+            simpleIntervalList.forEach(interval -> intervals.add(new ChromosomeInterval(interval.getContig(),
+                    interval.getStart(), interval.getEnd())));
         } else {
             throw new UserException("No intervals specified");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -238,8 +238,8 @@ public final class GenomicsDBImport extends GATKTool {
     @Advanced
     @Argument(fullName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
             shortName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
-            doc = "Max number of intervals to import in parallel; higher values may improve performance, but require more"+
-            +" memory and a higher number of file descriptors open at the same time",
+            doc = "Max number of intervals to import in parallel; higher values may improve performance, but require more" +
+                  " memory and a higher number of file descriptors open at the same time",
             optional = true,
             minValue = 1)
     private int maxNumIntervalsToImportInParallel = 1;

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -144,6 +144,7 @@ public final class GenomicsDBImport extends GATKTool {
     public static final String SAMPLE_NAME_MAP_LONG_NAME = "sample-name-map";
     public static final String VALIDATE_SAMPLE_MAP_LONG_NAME = "validate-sample-name-map";
     public static final String VCF_INITIALIZER_THREADS_LONG_NAME = "reader-threads";
+    public static final String MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL = "max-num-intervals-to-import-in-parallel";
 
     @Argument(fullName = WORKSPACE_ARG_LONG_NAME,
               doc = "Workspace for GenomicsDB. Must be a POSIX file system path, but can be a relative path." +
@@ -232,6 +233,14 @@ public final class GenomicsDBImport extends GATKTool {
             optional = true,
             minValue = 1)
     private int vcfInitializerThreads = 1;
+
+    @Advanced
+    @Argument(fullName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
+            shortName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
+            doc = "Max number of intervals to import in parallel; higher values may improve performance",
+            optional = true,
+            minValue = 1)
+    private int maxNumIntervalsToImportInParallel = 1;
 
     //executor service used when vcfInitializerThreads > 1
     private ExecutorService inputPreloadExecutorService;
@@ -532,13 +541,11 @@ public final class GenomicsDBImport extends GATKTool {
         GenomicsDBImporter importer;
         try {
             importer = new GenomicsDBImporter(importConfig);
-            importer.executeImport();
+            importer.executeImport(maxNumIntervalsToImportInParallel);
         } catch (final IOException e) {
             throw new UserException("Error initializing GenomicsDBImporter", e);
         } catch (final IllegalArgumentException iae) {
             throw new GATKException("Null feature reader found in sampleNameMap file: " + sampleNameMapFile, iae);
-        } catch (final InterruptedException ie) {
-            throw new GATKException("Error while executing a parallel import in GenomicsDBImporter", ie);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -238,7 +238,8 @@ public final class GenomicsDBImport extends GATKTool {
     @Advanced
     @Argument(fullName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
             shortName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
-            doc = "Max number of intervals to import in parallel; higher values may improve performance",
+            doc = "Max number of intervals to import in parallel; higher values may improve performance, but require more"+
+            +" memory and a higher number of file descriptors open at the same time",
             optional = true,
             minValue = 1)
     private int maxNumIntervalsToImportInParallel = 1;

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
-import com.intel.genomicsdb.GenomicsDBUtils;
+import com.intel.genomicsdb.GenomicsDBLibLoader;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
@@ -30,7 +30,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
     @Test
     public void testGenomicsDBInClassPath(){
         final String path = "/"+System.mapLibraryName("tiledbgenomicsdb");
-        Assert.assertNotNull(GenomicsDBUtils.class.getResource(path), "Could not find the genomicsdb binary at " + path);
+        Assert.assertNotNull(GenomicsDBLibLoader.class.getResource(path), "Could not find the genomicsdb binary at " + path);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -74,6 +74,12 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         new SimpleInterval("chr20", 17970001, 17980000),
         new SimpleInterval("chr20", 17980001, 17981445)
     ));
+    private static final ArrayList<SimpleInterval> MULTIPLE_INTERVALS_THAT_WORK_WITH_COMBINE_GVCFS =
+        new ArrayList<SimpleInterval>(Arrays.asList(
+            new SimpleInterval("chr20", 17960187, 17969999),
+            new SimpleInterval("chr20", 17970000, 17980000),
+            new SimpleInterval("chr20", 17980001, 17981445)
+    ));
     private static final ArrayList<SimpleInterval> INTERVAL_3736 =
             new ArrayList<SimpleInterval>(Arrays.asList(new SimpleInterval("chr6",130365070,146544250)));
     private static final ArrayList<SimpleInterval> INTERVAL_NONDIPLOID =
@@ -117,7 +123,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testGenomicsDBImportFileInputsAgainstCombineGVCFWithMultipleIntervals() throws IOException {
-        testGenomicsDBAgainstCombineGVCFs(LOCAL_GVCFS, MULTIPLE_INTERVALS, b38_reference_20_21, new String[0]);
+        testGenomicsDBAgainstCombineGVCFs(LOCAL_GVCFS, MULTIPLE_INTERVALS_THAT_WORK_WITH_COMBINE_GVCFS, b38_reference_20_21, new String[0]);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -52,6 +52,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     private static final String GENOMICSDB_TEST_DIR = toolsTestDir + "GenomicsDBImport/";
     private static final String COMBINEGVCFS_TEST_DIR = toolsTestDir + "walkers/CombineGVCFs/";
     private static final String COMBINED = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+    private static final String COMBINED_MULTI_INTERVAL = largeFileTestDir + "gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz";
     private static final String COMBINED_WITHSPACES = largeFileTestDir + "gvcfs/combined.gatk3.7.smaller_interval.g.vcf";
     private static final ArrayList<SimpleInterval> INTERVAL =
             new ArrayList<SimpleInterval>(Arrays.asList(new SimpleInterval("chr20", 17960187, 17981445)));
@@ -93,7 +94,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testGenomicsDBImportFileInputsWithMultipleIntervals() throws IOException {
-        testGenomicsDBImporter(LOCAL_GVCFS, MULTIPLE_INTERVALS, COMBINED, b38_reference_20_21, true);
+        testGenomicsDBImporter(LOCAL_GVCFS, MULTIPLE_INTERVALS, COMBINED_MULTI_INTERVAL, b38_reference_20_21, true);
     }
 
     @Test
@@ -212,7 +213,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     @Test(dataProvider = "batchSizes")
     public void testGenomicsDBImportFileInputsInBatchesWithMultipleIntervals(final int batchSize) throws IOException {
-        testGenomicsDBImporterWithBatchSize(LOCAL_GVCFS, MULTIPLE_INTERVALS, COMBINED, batchSize);
+        testGenomicsDBImporterWithBatchSize(LOCAL_GVCFS, MULTIPLE_INTERVALS, COMBINED_MULTI_INTERVAL, batchSize);
     }
 
     @Test(groups = {"bucket"}, dataProvider = "batchSizes")

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -80,6 +80,11 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
             new SimpleInterval("chr20", 17970000, 17980000),
             new SimpleInterval("chr20", 17980001, 17981445)
     ));
+    private static final ArrayList<SimpleInterval> MULTIPLE_NON_ADJACENT_INTERVALS_THAT_WORK_WITH_COMBINE_GVCFS =
+        new ArrayList<SimpleInterval>(Arrays.asList(
+            new SimpleInterval("chr20", 17960187, 17969999),
+            new SimpleInterval("chr20", 17980001, 17981445)
+    ));
     private static final ArrayList<SimpleInterval> INTERVAL_3736 =
             new ArrayList<SimpleInterval>(Arrays.asList(new SimpleInterval("chr6",130365070,146544250)));
     private static final ArrayList<SimpleInterval> INTERVAL_NONDIPLOID =
@@ -124,6 +129,12 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     @Test
     public void testGenomicsDBImportFileInputsAgainstCombineGVCFWithMultipleIntervals() throws IOException {
         testGenomicsDBAgainstCombineGVCFs(LOCAL_GVCFS, MULTIPLE_INTERVALS_THAT_WORK_WITH_COMBINE_GVCFS, b38_reference_20_21, new String[0]);
+    }
+
+    @Test
+    public void testGenomicsDBImportFileInputsAgainstCombineGVCFWithMultipleNonAdjacentIntervals() throws IOException {
+        testGenomicsDBAgainstCombineGVCFs(LOCAL_GVCFS, MULTIPLE_NON_ADJACENT_INTERVALS_THAT_WORK_WITH_COMBINE_GVCFS,
+            b38_reference_20_21, new String[0]);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -52,6 +52,19 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     private static final String GENOMICSDB_TEST_DIR = toolsTestDir + "GenomicsDBImport/";
     private static final String COMBINEGVCFS_TEST_DIR = toolsTestDir + "walkers/CombineGVCFs/";
     private static final String COMBINED = largeFileTestDir + "gvcfs/combined.gatk3.7.g.vcf.gz";
+    //Consider a gVCF with a REF block chr20:50-150. Importing this data into GenomicsDB using multiple intervals
+    //-L chr20:1-100 and -L chr20:101-200 will cause the REF block to be imported into both the arrays
+    //Now, when reading data from the workspace (assume full scan) - the data is split into 2 REF block intervals chr20:50-100
+    //and chr20:101-150 one from each array
+    //The following COMBINED_MULTI_INTERVAL gvcf is identical to the gVCF in the previous line except at the partition break
+    //position
+    //The previous file has the following line:
+    //chr20   17970000        .       G       <NON_REF>       .       .       END=17970001
+    //
+    //while this file has:
+    //chr20   17970000        .       G       <NON_REF>       .       .       .
+    //chr20   17970001        .       G       <NON_REF>       .       .       .
+    //
     private static final String COMBINED_MULTI_INTERVAL = largeFileTestDir + "gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz";
     private static final String COMBINED_WITHSPACES = largeFileTestDir + "gvcfs/combined.gatk3.7.smaller_interval.g.vcf";
     private static final ArrayList<SimpleInterval> INTERVAL =

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
-import com.intel.genomicsdb.GenomicsDBImporter;
+import com.intel.genomicsdb.importer.GenomicsDBImporter;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -100,12 +100,5 @@ public class GenomicsDBImportUnitTest extends GATKBaseTest {
         final Map<String, Path> actual = GenomicsDBImport.loadSampleNameMapFileInSortedOrder(sampleFile.toPath());
         Assert.assertEquals(actual, expected);
         Assert.assertEquals(actual.keySet().iterator().next(), "Sample1");
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNullFeatureReadersToFail() {
-        final Map<String, FeatureReader<VariantContext>> sampleToReaderMap = new LinkedHashMap<>();
-        sampleToReaderMap.put("Sample1", null);
-        GenomicsDBImporter.generateSortedCallSetMap(sampleToReaderMap, true, true, 0L);
     }
 }

--- a/src/test/resources/large/gvcfs/.gitattributes
+++ b/src/test/resources/large/gvcfs/.gitattributes
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c509b2455521516a9c780ad1014592101e735bf8151b8691160de4576aaac804
-size 158

--- a/src/test/resources/large/gvcfs/.gitattributes
+++ b/src/test/resources/large/gvcfs/.gitattributes
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c509b2455521516a9c780ad1014592101e735bf8151b8691160de4576aaac804
+size 158

--- a/src/test/resources/large/gvcfs/HG00096_after_combine_gvcfs.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/HG00096_after_combine_gvcfs.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ecd33f3c80e8568f52ed8ed45ecdcab74bf3d0c1317a6cb833199556173f80f
+size 6086978

--- a/src/test/resources/large/gvcfs/HG00096_after_combine_gvcfs.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/HG00096_after_combine_gvcfs.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:517931164c1057c3846cde0ae891d1c852078d040d02f4fc82486fa3adc687cb
+size 5955

--- a/src/test/resources/large/gvcfs/HG00268_after_combine_gvcfs.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/HG00268_after_combine_gvcfs.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa34cade7d948d70059fe356763e9769d27a6cc543e06c5e5d723ff4b56f75b6
+size 4979805

--- a/src/test/resources/large/gvcfs/HG00268_after_combine_gvcfs.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/HG00268_after_combine_gvcfs.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:359e1d97343d6f0de7fa89d2a3d1991b0861e564b3991d7fff5bb472dce75835
+size 5838

--- a/src/test/resources/large/gvcfs/NA19625_after_combine_gvcfs.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/NA19625_after_combine_gvcfs.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f63abaa3efd43fe0f777b4f3d2cc5d51c8a8fb9ef9f02a5880c2ceca381ffec
+size 19666052

--- a/src/test/resources/large/gvcfs/NA19625_after_combine_gvcfs.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/NA19625_after_combine_gvcfs.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f49e647fdd014766fcacade906835efa96f36aa8224cb3bb0dac85e8e30349a
+size 6092

--- a/src/test/resources/large/gvcfs/combined.gatk3.7_sites_only.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/combined.gatk3.7_sites_only.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a25a984f07aae0707b3ab7792b580b2feb6d9579c7f5e5de120fbc408aad17ce
+size 7716766

--- a/src/test/resources/large/gvcfs/combined.gatk3.7_sites_only.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/combined.gatk3.7_sites_only.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc73c8d14ca6a9cfdcaec649f1680a76c0361a0db8f2e66af00fe8ed2876fb9a
+size 2644

--- a/src/test/resources/large/gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63cd5b9ce2552bb6b9fb2afb447ab168d4ea3b3684c8f7d224f1048e8bfb8cc6
+size 21583684

--- a/src/test/resources/large/gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/combined_multi_interval.gatk3.7.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:740245ac4c18fa72e3ef88484a2a91543530afb8a4f2b40c2aafc9c7797bc92c
+size 4035

--- a/src/test/resources/large/gvcfs/combined_with_genotypes.g.vcf.gz
+++ b/src/test/resources/large/gvcfs/combined_with_genotypes.g.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e73fd6716aaf12f9ec8007bdb197fe187d826a4444dc180749969a0f4042173f
+size 13135087

--- a/src/test/resources/large/gvcfs/combined_with_genotypes.g.vcf.gz.tbi
+++ b/src/test/resources/large/gvcfs/combined_with_genotypes.g.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9894e9c08e621a9a6dc531b978113b976dc6de466e6897ba893ae960f3e68ccc
+size 2692


### PR DESCRIPTION
This PR addresses required changes in order to use latest version of GenomicsDB which exposes new functionality such as:
- [Multi interval import and query support](https://github.com/broadinstitute/gatk/issues/3269):
  - We create multiple arrays (directories) in a single workspace - one per interval. So, if you wish to import intervals ("chr1", [ 1, 100M ]) and ("chr2", [ 1, 100M ]), you end up with 2 directories/arrays in the workspace with names chr1$1$100M and chr2$1$100M. The array names depend on the     partition bounds.
  - During the read phase, the user only supplies the workspace. The array names are obtained by scanning the entries in the workspace and reading the right arrays. For example, if you wish to read ("chr2", [ 50, 50M] ), then only the second array is queried.
  - In the previous version of the tool, the array name was a constant - _genomicsdb_array_. The new version will be backward compatible with respect to reads. Hence, if a directory named _genomicsdb_array_ is found in the workspace directory, it's passed as the array for the _GenomicsDBFeatureReader_ otherwise the array names are generated from the directory entry names.
  - Parallel import based on chromosome intervals. The number of threads to use can be specified as an integer argument to the [executeImport call](https://github.com/francares/gatk/blob/fmc_GenomicsDB_parallel_import/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java#L535). If no argument is specified, the number of threads is determined by Java's ForkJoinPool (typically equal to the \#cores in the system). 
    - The max number of intervals to import in parallel can be controlled by the command line argument --max-num-intervals-to-import-in-parallel (default 1)
    - Note that increasing parallelism increases the number of FeatureReaders opened to feed data to the importer. So, if you are using _N_ threads and your batch size is _B_, you will have _N*B_ feature readers open.
- Protobuf based API for import and read
  - [Import](https://github.com/francares/gatk/blob/fmc_GenomicsDB_parallel_import/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java#L522)
  - [Read](https://github.com/francares/gatk/blob/fmc_GenomicsDB_parallel_import/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java#L405)
    - #3688 
    - Option to produce GT field
    - [Option to produce GT for spanning deletion based on min PL value](https://github.com/Intel-HLS/GenomicsDB/issues/161)
    - https://github.com/broadinstitute/gatk/issues/2687
    - Doesn't support #4541 or #3689 yet - next version
- Bug fixes
  - #4716 
  - More error messages