### PR TITLE
update sv scripts to only copy a single bam file and index, and respect project parameter

### DIFF
--- a/scripts/sv/copy_sv_results.sh
+++ b/scripts/sv/copy_sv_results.sh
@@ -51,7 +51,7 @@ else
     # (may not be current date stamp if multiple jobs run on same cluster)
     MASTER="${CLUSTER_NAME}-m"
     RESULTS_DIR="$(dirname ${OUTPUT_DIR})"
-    RESULTS_DIR=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --command="hadoop fs -ls ${RESULTS_DIR} | tail -n 1")
+    RESULTS_DIR=$(gcloud compute ssh ${MASTER} --project ${PROJECT_NAME} --zone ${ZONE} --command="hadoop fs -ls ${RESULTS_DIR} | tail -n 1")
     RESULTS_DIR=$(echo "${RESULTS_DIR}" | awk '{print $NF}' | sed -e 's/^\///')
 fi
 
@@ -69,7 +69,7 @@ else
     # chose semi-optimal parallel args for distcp
     # 1) count number of files to copy
     COUNT_FILES_CMD="hadoop fs -count /${RESULTS_DIR}/ | tr -s ' ' | cut -d ' ' -f 3"
-    NUM_FILES=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --command="${COUNT_FILES_CMD}")
+    NUM_FILES=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --project ${PROJECT_NAME} --command="${COUNT_FILES_CMD}")
     # 2) get the number of instances
     NUM_INSTANCES=$(echo "${CLUSTER_INFO}" | cut -d' ' -f 2)
     # 3) choose number of maps as min of NUM_FILES or NUM_INSTANCES * MAPS_PER_INSTANCE
@@ -90,8 +90,8 @@ else
             ;;
     esac
     CPY_CMD="hadoop distcp ${DIST_CP_ARGS} -m ${NUM_MAPS} -strategy dynamic /${RESULTS_DIR}/* ${GCS_RESULTS_DIR}/"
-    echo "gcloud compute ssh ${MASTER} --zone ${ZONE} --command=\"${CPY_CMD}\" 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
-    gcloud compute ssh ${MASTER} --zone ${ZONE} --command="${CPY_CMD}" 2>&1 | tee -a ${LOCAL_LOG_FILE}
+    echo "gcloud compute ssh ${MASTER} --zone ${ZONE} --project ${PROJECT_NAME} --command=\"${CPY_CMD}\" 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+    gcloud compute ssh ${MASTER} --zone ${ZONE} --project ${PROJECT_NAME} --command="${CPY_CMD}" 2>&1 | tee -a ${LOCAL_LOG_FILE}
 fi
 
 # create file with command-line args. Always create (even if empty) so

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -12,7 +12,7 @@ if [[ "$#" -lt 8 ]]; then
     echo -e "  [4] maximum life time of cluster (required)"
     echo -e "  [5] maximum idling time before cluster self-termination begins (required)"
     echo -e "  [6] GCS directory containing the correct reference & indices (required)"
-    echo -e "  [7] GCS directory containing the BAM and its index (required), and"
+    echo -e "  [7] GCS directory containing the BAM and its index (required), or the GCS url of the BAM file, and"
     echo -e "either when a local initialization script is to be uploaded to a bucket:"
     echo -e "  [8] local initialization script"
     echo -e "  [9] GCS path to upload initialization script to (required as per Google)"
@@ -49,7 +49,7 @@ CLUSTER_NAME=$3
 MAX_LIFE_HOURS=$4
 MAX_IDLE_MINUTES=$5
 REF_DIR=$6
-SAMP_DIR=$7
+SAMP_INPUT=$7
 
 INIT_ACTION=""
 if [[ "$#" -eq 8 ]]; then
@@ -93,7 +93,7 @@ gcloud beta dataproc clusters create ${CLUSTER_NAME} \
     --num-preemptible-workers ${NUM_SV_PREEMPTIBLE_WORKERS} \
     --num-worker-local-ssds 1 \
     --metadata "reference=$REF_DIR" \
-    --metadata "sample=$SAMP_DIR" \
+    --metadata "sample=$SAMP_INPUT" \
     --image-version 1.2 \
     --project ${PROJECT} \
     --initialization-actions ${INIT_ACTION} \
@@ -114,6 +114,15 @@ ${GATK_DIR}/gatk ParallelCopyGCSDirectoryIntoHDFSSpark \
     -- \
     --spark-runner GCS \
     --cluster "$CLUSTER_NAME" \
+    --project $PROJECT
+
+if [[ $SAMP_INPUT =~ .+\.bam$ ]]; then
+    SAMP_DIR=`dirname $SAMP_INPUT`
+    SAMP_GLOB_ARG="--input-file-glob `basename $SAMP_INPUT`*"
+else
+    SAMP_DIR=$SAMP_INPUT
+    SAMP_GLOB_ARG=""
+fi
 
 if [[ ! $SAMP_DIR =~ .+/$ ]]; then
     SAMP_DIR+="/"
@@ -121,7 +130,9 @@ fi
 
 ${GATK_DIR}/gatk ParallelCopyGCSDirectoryIntoHDFSSpark \
     --input-gcs-path "$SAMP_DIR" \
+    $SAMP_GLOB_ARG \
     --output-hdfs-directory "$MASTER_NODE"/data \
     -- \
     --spark-runner GCS \
     --cluster "$CLUSTER_NAME" \
+    --project $PROJECT

--- a/scripts/sv/create_cluster.sh
+++ b/scripts/sv/create_cluster.sh
@@ -128,6 +128,7 @@ if [[ ! $SAMP_DIR =~ .+/$ ]]; then
     SAMP_DIR+="/"
 fi
 
+set -f
 ${GATK_DIR}/gatk ParallelCopyGCSDirectoryIntoHDFSSpark \
     --input-gcs-path "$SAMP_DIR" \
     $SAMP_GLOB_ARG \

--- a/scripts/sv/delete_cluster.sh
+++ b/scripts/sv/delete_cluster.sh
@@ -3,11 +3,12 @@
 # This script deletes a Google Dataproc cluster used for running the GATK-SV pipeline.
 
 set -eu
-if [ "$#" -ne 1 ]; then
-    echo "Please provide name of cluster to be shutdown"
+if [ "$#" -ne 2 ]; then
+    echo "Usage: delete_cluster.sh <CLUSTER_NAME> <PROJECT>"
     exit 1
 fi
 
 CLUSTER_NAME=$1
+PROJECT=$2
 
-gcloud dataproc clusters delete "$CLUSTER_NAME" --async
+gcloud dataproc clusters delete --project $PROJECT "$CLUSTER_NAME" --async

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -269,8 +269,8 @@ while true; do
                     INIT_ARGS="${INIT_SCRIPT} gs://${GCS_SAVE_PATH}/init/"
                 fi
 
-                echo "create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${CLUSTER_MAX_LIFE_HOURS} ${CLUSTER_MAX_IDLE_MINUTES} ${GCS_REFERENCE_DIR} ${GCS_BAM_DIR} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
-                create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${CLUSTER_MAX_LIFE_HOURS} ${CLUSTER_MAX_IDLE_MINUTES} ${GCS_REFERENCE_DIR} ${GCS_BAM_DIR} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
+                echo "create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${CLUSTER_MAX_LIFE_HOURS} ${CLUSTER_MAX_IDLE_MINUTES} ${GCS_REFERENCE_DIR} ${GCS_BAM} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+                create_cluster.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${CLUSTER_MAX_LIFE_HOURS} ${CLUSTER_MAX_IDLE_MINUTES} ${GCS_REFERENCE_DIR} ${GCS_BAM} ${INIT_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
                 break
                 ;;
         [Nn]*)  break
@@ -285,7 +285,7 @@ done
 ########################################################################################################################
 # call runWholePipeline
 # set output directory to datetime-git branch-git hash stamped folder
-OUTPUT_DIR="/results/$(date "+%Y-%m-%d_%H.%M.%S")-${GIT_BRANCH}-${GATK_JAR_HASH}${UNTRACKED_COMMIT}"
+OUTPUT_DIR="/results/$(date "+%Y-%m-%d_%H.%M.%S")-${CLUSTER_NAME}-${GIT_BRANCH}-${GATK_JAR_HASH}${UNTRACKED_COMMIT}"
 while true; do
     echo "#############################################################" 2>&1 | tee -a ${LOCAL_LOG_FILE}
     if [ "${QUIET}" == "Y" ]; then
@@ -295,8 +295,8 @@ while true; do
     fi
     case $yn in
         [Yy]*)  SECONDS=0
-                echo "GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
-                GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
+                echo "GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+                GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
                 printf 'Pipeline completed in %02dh:%02dm:%02ds\n' $((${SECONDS}/3600)) $((${SECONDS}%3600/60)) $((${SECONDS}%60))
                 break
                 ;;

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -296,8 +296,8 @@ while true; do
     fi
     case $yn in
         [Yy]*)  SECONDS=0
-                echo "GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
-                GATK_SV_TOOL=${GATK_SV_TOOL} runWholePipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
+                echo "GATK_SV_TOOL=${GATK_SV_TOOL} run_whole_pipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}" | tee -a ${LOCAL_LOG_FILE}
+                GATK_SV_TOOL=${GATK_SV_TOOL} run_whole_pipeline.sh ${GATK_DIR} ${PROJECT_NAME} ${CLUSTER_NAME} ${OUTPUT_DIR} ${CLUSTER_BAM} ${CLUSTER_REFERENCE_2BIT} ${CLUSTER_REFERENCE_IMAGE} ${SV_ARGS} 2>&1 | tee -a ${LOCAL_LOG_FILE}
                 printf 'Pipeline completed in %02dh:%02dm:%02ds\n' $((${SECONDS}/3600)) $((${SECONDS}%3600/60)) $((${SECONDS}%60))
                 break
                 ;;

--- a/scripts/sv/manage_sv_pipeline.sh
+++ b/scripts/sv/manage_sv_pipeline.sh
@@ -285,7 +285,8 @@ done
 ########################################################################################################################
 # call runWholePipeline
 # set output directory to datetime-git branch-git hash stamped folder
-OUTPUT_DIR="/results/$(date "+%Y-%m-%d_%H.%M.%S")-${CLUSTER_NAME}-${GIT_BRANCH}-${GATK_JAR_HASH}${UNTRACKED_COMMIT}"
+OUTPUT_DIR="/results/${SV_OUTPUT_DIR:-"$(date "+%Y-%m-%d_%H.%M.%S")-${SANITIZED_BAM}-${GIT_BRANCH}-${GATK_JAR_HASH}${UNTRACKED_COMMIT}"}"
+
 while true; do
     echo "#############################################################" 2>&1 | tee -a ${LOCAL_LOG_FILE}
     if [ "${QUIET}" == "Y" ]; then

--- a/scripts/sv/run_whole_pipeline.sh
+++ b/scripts/sv/run_whole_pipeline.sh
@@ -13,7 +13,7 @@ if [[ "$#" -lt 6 ]]; then
     echo -e "  [7] absolute path to the reference index image on each worker node's local file system (required)"
     echo -e "  [*] extra command-line arguments to StructuralVariationDiscoveryPipelineSpark"
     echo -e "Example:"
-    echo -e " bash runWholePipeline.sh \\"
+    echo -e " bash run_whole_pipeline.sh \\"
     echo -e "      ~/GATK/gatk \\"
     echo -e "      my-project \\"
     echo -e "      my-test-cluster \\"


### PR DESCRIPTION
This PR makes four changes to the SV pipeline management scripts:  First it uses the new glob argument for copying data into HDFS to only copy the requested BAM file and its index, rather than everything in the GCS bucket directory (this is useful when the bucket directory contains multiple samples, as is the case with our HGSV trios). Second, the scripts now respect the project argument at each phase of the pipeline. Third, the output directory will include the name of the cluster so that if multiple samples are being processed by the same branch in parallel it's easier to figure out which results directory contains which sample and the results won't collide if two runs happen to start at the same timestamp. Finally, if the user requests not to copy the FASTQ files from the main management script, the script will not direct the SV discovery tool to write them to disk.