### PR TITLE
updating picard to 2.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ repositories {
 
 final requiredJavaVersion = "8"
 final htsjdkVersion = System.getProperty('htsjdk.version','2.14.3')
-final picardVersion = System.getProperty('picard.version','2.18.1')
+final picardVersion = System.getProperty('picard.version','2.18.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')


### PR DESCRIPTION
upgrading picard dependency from 2.18.1 -> 2.18.2

this way we'll be on the latest release when we start doing MarkDuplicates tieout