### PR TITLE
fix 4649

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentation.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AnnotatedVariantProducer;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AlignmentInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AssemblyContigWithFineTunedAlignments;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.StrandSwitch;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import scala.Tuple2;
 
@@ -136,8 +137,9 @@ final class CpxVariantCanonicalRepresentation {
             checkBoundedBySharedSingleBase(cpxVariantInducingAssemblyContig);
         }
 
+        final Set<SimpleInterval> twoBaseBoundaries = cpxVariantInducingAssemblyContig.getTwoBaseBoundaries();
         affectedRefRegion = getAffectedReferenceRegion(segmentingLocations);
-        referenceSegments = extractRefSegments(basicInfo, segmentingLocations);
+        referenceSegments = extractRefSegments(basicInfo, segmentingLocations, twoBaseBoundaries);
         eventDescriptions = extractAltArrangements(basicInfo, contigAlignments, jumps, referenceSegments);
 
         altSeq = extractAltHaplotypeSeq(cpxVariantInducingAssemblyContig.getPreprocessedTig(), referenceSegments, basicInfo);
@@ -152,7 +154,8 @@ final class CpxVariantCanonicalRepresentation {
 
     @VisibleForTesting
     static List<SimpleInterval> extractRefSegments(final CpxVariantInducingAssemblyContig.BasicInfo basicInfo,
-                                                   final List<SimpleInterval> segmentingLocations) {
+                                                   final List<SimpleInterval> segmentingLocations,
+                                                   final Set<SimpleInterval> twoBaseBoundaries) {
 
         if (segmentingLocations.size() == 1) { // for case described in {@link checkBoundedBySharedSingleBase}
             return segmentingLocations;
@@ -168,8 +171,14 @@ final class CpxVariantCanonicalRepresentation {
             // there shouldn't be a segment constructed if two segmenting locations are adjacent to each other on the reference
             // this could happen when (in the simplest case), two alignments are separated by a mapped insertion (hence 3 total alignments),
             // and the two alignments' ref span are connected
+            // more generally: only segment when the two segmenting locations are boundaries of alignments that overlap each other (ref. span)
             if (rightBoundary.getStart() - leftBoundary.getEnd() > 1) {
                 segments.add(new SimpleInterval(eventPrimaryChromosome, leftBoundary.getStart(), rightBoundary.getStart()));
+            } else if (rightBoundary.getStart() - leftBoundary.getEnd() == 1) {
+                final SimpleInterval twoBaseSegment = new SimpleInterval(eventPrimaryChromosome, leftBoundary.getEnd(), rightBoundary.getStart());
+                if ( twoBaseBoundaries.contains(twoBaseSegment) ) {
+                    segments.add(twoBaseSegment);
+                }
             }
             leftBoundary = rightBoundary;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentation.java
@@ -335,7 +335,7 @@ final class CpxVariantCanonicalRepresentation {
                                                                                           : (head.referenceSpan.getStart() - firstSegment.getEnd() == 1);
             if ( ! firstSegmentNeighborsHeadAlignment )
                 throw new CpxVariantInterpreter.UnhandledCaseSeen("1st segment is not overlapping with head alignment but it is not immediately before/after the head alignment either\n"
-                        + tigWithInsMappings.toString());
+                        + tigWithInsMappings.toString() + "\nSegments:\t" + segments.toString());
             start = head.endInAssembledContig;
         } else {
             final SimpleInterval intersect = firstSegment.intersect(head.referenceSpan);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContig.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContig.java
@@ -429,7 +429,7 @@ final class CpxVariantInducingAssemblyContig {
                 default: throw new NoSuchElementException("seeing a strand switch that doesn't make sense");
             }
 
-            gapSize = Math.max(0, two.startInAssembledContig - one.endInAssembledContig - 2); // -2 because we want bases in-between
+            gapSize = Math.max(0, two.startInAssembledContig - one.endInAssembledContig - 1); // -1 because we want bases in-between
         }
 
         boolean isGapped() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxSVInferenceTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxSVInferenceTestUtils.java
@@ -11,10 +11,7 @@ import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.SVTestUtils;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.SimpleSVType;
-import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AlignedContig;
-import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AssemblyContigAlignmentsConfigPicker;
-import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AssemblyContigWithFineTunedAlignments;
-import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.StrandSwitch;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.*;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -104,10 +101,10 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         //////////
         final List<CpxVariantInducingAssemblyContig.Jump> manuallyCalculatedJumps =
                 Arrays.asList(
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 4452399, 4452399), new SimpleInterval("chr9", 34840477, 34840477), StrandSwitch.NO_SWITCH, 117),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr9", 34840411, 34840411), new SimpleInterval("chr6", 15853414, 15853414), StrandSwitch.NO_SWITCH, 114),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr6", 15853372, 15853372), new SimpleInterval("chr2", 4452357, 4452357), StrandSwitch.NO_SWITCH, 53),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 4452298, 4452298), new SimpleInterval("chr2", 4452406, 4452406), StrandSwitch.NO_SWITCH, 317)
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 4452399, 4452399), new SimpleInterval("chr9", 34840477, 34840477), StrandSwitch.NO_SWITCH, 118),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr9", 34840411, 34840411), new SimpleInterval("chr6", 15853414, 15853414), StrandSwitch.NO_SWITCH, 115),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr6", 15853372, 15853372), new SimpleInterval("chr2", 4452357, 4452357), StrandSwitch.NO_SWITCH, 54),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 4452298, 4452298), new SimpleInterval("chr2", 4452406, 4452406), StrandSwitch.NO_SWITCH, 318)
                 );
         final List<SimpleInterval> manuallyCalculatedEventPrimaryChromosomeSegmentingLocations =
                 Arrays.asList(
@@ -131,7 +128,7 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
                         new SimpleInterval("chr2", 4452357, 4452399),
                         new SimpleInterval("chr2", 4452399, 4452406));
         final List<String> manuallyCalculatedAltArrangementDescription =
-                Arrays.asList("1", "2", "3", "UINS-317", "1", "UINS-53", "chr6:15853372-15853414", "UINS-114", "chr9:34840411-34840477", "UINS-117", "3");
+                Arrays.asList("1", "2", "3", "UINS-318", "1", "UINS-54", "chr6:15853372-15853414", "UINS-115", "chr9:34840411-34840477", "UINS-118", "3");
         final byte[] manuallyCalculatedAltSeq = Arrays.copyOfRange(analysisReadyContig.getContigSequence(), 247, 1139);
         SequenceUtil.reverseComplement(manuallyCalculatedAltSeq);
         final CpxVariantCanonicalRepresentation manuallyCalculatedCpxVariantCanonicalRepresentation =
@@ -179,9 +176,9 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         //////////
         final List<CpxVariantInducingAssemblyContig.Jump> manuallyCalculatedJumps =
                 Arrays.asList(
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16225125, 16225125), new SimpleInterval("chr2", 16226720, 16226720), StrandSwitch.NO_SWITCH, 6),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16226497, 16226497), new SimpleInterval("chr2", 16225125, 16225125), StrandSwitch.REVERSE_TO_FORWARD, 27),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16225237, 16225237), new SimpleInterval("chr2", 16225142, 16225142), StrandSwitch.FORWARD_TO_REVERSE, 1)
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16225125, 16225125), new SimpleInterval("chr2", 16226720, 16226720), StrandSwitch.NO_SWITCH, 7),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16226497, 16226497), new SimpleInterval("chr2", 16225125, 16225125), StrandSwitch.REVERSE_TO_FORWARD, 28),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr2", 16225237, 16225237), new SimpleInterval("chr2", 16225142, 16225142), StrandSwitch.FORWARD_TO_REVERSE, 2)
                 );
         final List<SimpleInterval> manuallyCalculatedEventPrimaryChromosomeSegmentingLocations =
                 Arrays.asList(
@@ -203,7 +200,7 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
                         new SimpleInterval("chr2", 16225125, 16225142),
                         new SimpleInterval("chr2", 16225142, 16225237));
         final List<String> manuallyCalculatedAltArrangementDescription =
-                Arrays.asList("1", "UINS-1", "-2", "-1", "UINS-27", "chr2:16226497-16226720", "UINS-6", "1", "2");
+                Arrays.asList("1", "UINS-2", "-2", "-1", "UINS-28", "chr2:16226497-16226720", "UINS-7", "1", "2");
         final byte[] manuallyCalculatedAltSeq = Arrays.copyOfRange(analysisReadyContig.getContigSequence(), 147, 652);
         SequenceUtil.reverseComplement(manuallyCalculatedAltSeq);
         final CpxVariantCanonicalRepresentation manuallyCalculatedCpxVariantCanonicalRepresentation =
@@ -250,12 +247,12 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         //////////
         final List<CpxVariantInducingAssemblyContig.Jump> manuallyCalculatedJumps =
                 Arrays.asList(
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30793441, 30793441), new SimpleInterval("chrX", 30793442, 30793442), StrandSwitch.NO_SWITCH, 77),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30794753, 30794753), new SimpleInterval("chrX", 30794754, 30794754), StrandSwitch.NO_SWITCH, 95),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30793441, 30793441), new SimpleInterval("chrX", 30793442, 30793442), StrandSwitch.NO_SWITCH, 78),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30794753, 30794753), new SimpleInterval("chrX", 30794754, 30794754), StrandSwitch.NO_SWITCH, 96),
                         new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30795363, 30795363), new SimpleInterval("chrX", 30795415, 30795415), StrandSwitch.NO_SWITCH, 0),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30795543, 30795543), new SimpleInterval("chrX", 30794688, 30794688), StrandSwitch.NO_SWITCH, 228),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30794787, 30794787), new SimpleInterval("chrX", 30789491, 30789491), StrandSwitch.NO_SWITCH, 80),
-                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30789573, 30789573), new SimpleInterval("chrX", 30796147, 30796147), StrandSwitch.NO_SWITCH, 39),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30795543, 30795543), new SimpleInterval("chrX", 30794688, 30794688), StrandSwitch.NO_SWITCH, 229),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30794787, 30794787), new SimpleInterval("chrX", 30789491, 30789491), StrandSwitch.NO_SWITCH, 81),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30789573, 30789573), new SimpleInterval("chrX", 30796147, 30796147), StrandSwitch.NO_SWITCH, 40),
                         new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chrX", 30796247, 30796247), new SimpleInterval("chrX", 30795360, 30795360), StrandSwitch.NO_SWITCH, 0)
                 );
         final List<SimpleInterval> manuallyCalculatedEventPrimaryChromosomeSegmentingLocations =
@@ -294,7 +291,7 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
                         new SimpleInterval("chrX", 30795543, 30796147),
                         new SimpleInterval("chrX", 30796147, 30796247));
         final List<String> manuallyCalculatedAltArrangementDescription =
-                Arrays.asList("UINS-77", "1", "2", "UINS-95", "3", "4", "5", "7", "UINS-228", "2", "3", "UINS-80", "chrX:30789491-30789573", "UINS-39", "9", "5", "6", "7", "8", "9");
+                Arrays.asList("UINS-78", "1", "2", "UINS-96", "3", "4", "5", "7", "UINS-229", "2", "3", "UINS-81", "chrX:30789491-30789573", "UINS-40", "9", "5", "6", "7", "8", "9");
         final byte[] manuallyCalculatedAltSeq = Arrays.copyOfRange(analysisReadyContig.getContigSequence(), 790, 4538);
         final CpxVariantCanonicalRepresentation manuallyCalculatedCpxVariantCanonicalRepresentation =
                 new CpxVariantCanonicalRepresentation(
@@ -333,12 +330,21 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
                                                                                  final SAMSequenceDictionary refSeqDict) {
         final AlignedContig alignedContig =
                 SVTestUtils.fromPrimarySAMRecordString(primarySAMRecord, true);
-        final AssemblyContigWithFineTunedAlignments toBeDeOverlapped =
+        final AssemblyContigWithFineTunedAlignments intermediate =
                 AssemblyContigAlignmentsConfigPicker.reConstructContigFromPickedConfiguration(
                         new Tuple2<>(new Tuple2<>(alignedContig.getContigName(), alignedContig.getContigSequence()),
                                 AssemblyContigAlignmentsConfigPicker.pickBestConfigurations(alignedContig, canonicalChromosomes,
                                                                             0.0)))
                         .next();
-        return CpxVariantInterpreter.furtherPreprocess(toBeDeOverlapped, refSeqDict);
+
+        final AssemblyContigAlignmentsConfigPicker.GoodAndBadMappings goodAndBadMappings =
+                AssemblyContigAlignmentSignatureClassifier.removeNonUniqueMappings(
+                        intermediate.getAlignments(),
+                        AssemblyContigAlignmentSignatureClassifier.ALIGNMENT_MAPQUAL_THREHOLD,
+                        AssemblyContigAlignmentSignatureClassifier.ALIGNMENT_READSPAN_THRESHOLD);
+        final AssemblyContigWithFineTunedAlignments result = new AssemblyContigWithFineTunedAlignments(
+                new AlignedContig(intermediate.getContigName(), intermediate.getContigSequence(), goodAndBadMappings.getGoodMappings()),
+                goodAndBadMappings.getBadMappingsAsCompactStrings(), false, (AlignmentInterval) null);
+        return CpxVariantInterpreter.furtherPreprocess(result, refSeqDict);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxSVInferenceTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxSVInferenceTestUtils.java
@@ -44,14 +44,18 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         final VariantContext expectedVariantContext;
         final byte[] assumedReferenceSequence; // reference sequence used in constructed the expected results that can be used in real tests
 
-        private PreprocessedAndAnalysisReadyContigWithExpectedResults(final CpxVariantInducingAssemblyContig expectedCpxVariantInducingAssemblyContig,
-                                                                      final CpxVariantCanonicalRepresentation expectedCpxVariantCanonicalRepresentation,
-                                                                      final VariantContext expectedVariantContext,
-                                                                      final byte[] assumedReferenceSequence) {
+        final Set<SimpleInterval> expectedTwoBaseBoundaries;
+
+        PreprocessedAndAnalysisReadyContigWithExpectedResults(final CpxVariantInducingAssemblyContig expectedCpxVariantInducingAssemblyContig,
+                                                              final CpxVariantCanonicalRepresentation expectedCpxVariantCanonicalRepresentation,
+                                                              final VariantContext expectedVariantContext,
+                                                              final byte[] assumedReferenceSequence,
+                                                              final Set<SimpleInterval> expectedTwoBaseBoundaries) {
             this.expectedCpxVariantInducingAssemblyContig = expectedCpxVariantInducingAssemblyContig;
             this.expectedCpxVariantCanonicalRepresentation = expectedCpxVariantCanonicalRepresentation;
             this.expectedVariantContext = expectedVariantContext;
             this.assumedReferenceSequence = assumedReferenceSequence;
+            this.expectedTwoBaseBoundaries = expectedTwoBaseBoundaries;
         }
     }
 
@@ -84,6 +88,7 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS.add(buildForContig_2428_0(hg38CanonicalChromosomes, bareBoneHg38SAMSeqDict));
         PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS.add(buildForContig_2548_1(hg38CanonicalChromosomes, bareBoneHg38SAMSeqDict));
         PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS.add(buildForContig_30077_1(hg38CanonicalChromosomes, bareBoneHg38SAMSeqDict));
+        PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS.add(buildForContig_22672_4(hg38CanonicalChromosomes, bareBoneHg38SAMSeqDict));
     }
 
     // =================================================================================================================
@@ -155,11 +160,21 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         final VariantContext manuallyCalculatedVariantContext = variantContextBuilder.make();
 
         //////////
+        final Set<SimpleInterval> manuallyCalculatedTwoBaseBoundaries = new HashSet<>();
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4452399, 4452400));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4452640, 4452641));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4452298, 4452299));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4452356, 4452357));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4450935, 4450936));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 4452405, 4452406));
+
+        //////////
         return new PreprocessedAndAnalysisReadyContigWithExpectedResults(
                 manuallyCalculatedCpxVariantInducingAssemblyContig,
                 manuallyCalculatedCpxVariantCanonicalRepresentation,
                 manuallyCalculatedVariantContext,
-                dummyRefSequence);
+                dummyRefSequence,
+                manuallyCalculatedTwoBaseBoundaries);
     }
 
 
@@ -227,11 +242,20 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         final VariantContext manuallyCalculatedVariantContext = variantContextBuilder.make();
 
         //////////
+        final Set<SimpleInterval> manuallyCalculatedTwoBaseBoundaries = new HashSet<>();
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 16225125, 16225126));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 16225383, 16225384));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 16225236, 16225237));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 16224630, 16224631));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr2", 16225141, 16225142));
+
+        //////////
         return new PreprocessedAndAnalysisReadyContigWithExpectedResults(
                 manuallyCalculatedCpxVariantInducingAssemblyContig,
                 manuallyCalculatedCpxVariantCanonicalRepresentation,
                 manuallyCalculatedVariantContext,
-                dummyRefSequence);
+                dummyRefSequence,
+                manuallyCalculatedTwoBaseBoundaries);
     }
 
     private static PreprocessedAndAnalysisReadyContigWithExpectedResults buildForContig_30077_1(final Set<String> canonicalChromosomes,
@@ -317,13 +341,117 @@ public final class CpxSVInferenceTestUtils extends GATKBaseTest {
         final VariantContext manuallyCalculatedVariantContext = variantContextBuilder.make();
 
         //////////
+        final Set<SimpleInterval> manuallyCalculatedTwoBaseBoundaries = new HashSet<>();
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30792651, 30792652));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30793440, 30793441));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30793442, 30793443));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30794752, 30794753));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30794754, 30794755));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30795362, 30795363));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30795415, 30795416));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30795542, 30795543));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30794688, 30794689));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30794786, 30794787));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30796147, 30796148));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30796246, 30796247));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30795360, 30795361));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chrX", 30796526, 30796527));
+
+        //////////
         return new PreprocessedAndAnalysisReadyContigWithExpectedResults(
                 manuallyCalculatedCpxVariantInducingAssemblyContig,
                 manuallyCalculatedCpxVariantCanonicalRepresentation,
                 manuallyCalculatedVariantContext,
-                dummyRefSequence);
+                dummyRefSequence,
+                manuallyCalculatedTwoBaseBoundaries);
     }
 
+    private static PreprocessedAndAnalysisReadyContigWithExpectedResults buildForContig_22672_4(final Set<String> canonicalChromosomes,
+                                                                                                final SAMSequenceDictionary refSeqDict) {
+        final AssemblyContigWithFineTunedAlignments
+                analysisReadyContig = makeContigAnalysisReady("asm022672:tig00004\t16\tchr9\t130954964\t60\t1631S192M60I99M24I54M156I1430M\t*\t0\t0\tTCATCCAGGTTGGAGTGCAGTGGTGCTATCTCAGCTCACTGCAGCCTCCACCCCTGGATTGAATCGATTCTCCTGCCTCAGCCTCCTGAGTAGCTGGGATTACAGGAGTGCACCACCACGCCCGGCTCATGTTTGTGTTTTTAGTAGAGACAGGGTTTCACCACATTGGCCAGGCTGGTCTCAAACTCCTGACCTCAAGTGATCTGGCTGCCTTGGCCTCCCAAAGTGCTGGGATTATAGGTGTGAGCCACCACACCCAGCCAGAGTGGGTAGTTTTTAAAACCACCACAATTGCCCGCCAGGGGCACAAAGAGGACTCATGGGGATGGGTCTGATAAGTGCTGAGCCCAGTGCTGGGCACCTGCAGGCACTCAGTAGGTGGTGGACACTTGTTTTATTATGATTATCCAGCACCTAGCACCCAGTCTACCCCAAATAGCACCATCAACATATCTTCCTGAATCCTGCCTCCCTCATTTCAGCCTTTGCTCTCAGGCAGCCAGGGGTTCCCCATTTTCAACAAGAAAAAGCCCAAACCCTTTTGCTTGGCAGTCAACCCCACCCCATCCAAACCAATCCCTCCTTTCTCTGCTGAATGTTTCCCCTGTGCCAGCCACTTCCTTCCCACCACCACACCCTTAGCCAGGCTATCACCCACCAAGAATCCTGCCCCATCTTGAGCCTCTGCCTTCATTTGAAGCCTATCATCCCCTGTGCCTCAGTATTTTCCTTCAGCTCTAGATTCTTGCAGTGCTCTAGCCATTTACACAGCCATCAAATTCCAGGCCTCTTCTGTCACTCACCGGTTCACCTCTGTCATCTTGTCTCCTGCCCAAGACTGCATCTCCTCTTGTCCCTTCTCTGAGAGGCCTGTGGTTGAGCACAGGGATGAATGAGAAAGAAACCCAGCCTGTCCTCAAGAAGTTGACAATGTGTCCCTCAAAGACTGGGCTCATTGCTGCTACCTCTGGGAGTCCCAATGTGGAGGAGAGCTCTCAGTGGGTGTGCAGAAAATCTTGTCAGAAGTTACTGTCCCTGGGCAGGGCTAATACCACCAGTATCACCATTATCATCATCACCACTATCGTCATCATCACCACCATCACCATCATTACCACCATCATCACCATCAATATCGACACCATCCTCATCATCATCATCACCACCATCATCAGCATCATCATCAGCAGCAGCACCACCATTACCATCATTATCCCTACCATCTTCATCACCACCATCACCATCACCATCACCATCATCATCACCACCATCACCATCATCACCACCACCATCATCATCACCACCATCACCACCATCATCACCATCATCATCACCATCATCACCACCATCATCACCATCATCATCATCAGCACCACCACCACTATTACCATCATTATCACTACCATCCTCATCACCACCATCACTATCACCATCACCATCATCATCACCATCATCACCATCATCATCACCATCACCATCATCACCATCACCATCACCATCATCACCATCATCATCATCACCATCACCATCATCATCACCATCATCACCACCATCATCACCATCATCATCATCAGCACCACCACCACTATTACCATCATTATCCCTACCATCTTCATCACCACCATCACCATCACCATCACCATCATCATCACCACCATCACCATCACCATCACCATCATCATCACCATCATCACCACCATCATCACCATCATCATCATCAGCACCACCACCACTATTACCATCATTATCCCTACCATCCTCATCACCACCATCACCATCACCATCACCATCATCATCACCATCACCATCATCACCATCACCATCATCAACATCACCATCACCATCATCACCATCATCATCATCACCATCACCATCATCATCACCATCATCACCACCATCATCACCATCATCAGCAGCAGCAGCACCACCACCACTATTACCATCATTATCCCTACCATCCTCATCACCACCATCACCATCACCATCATCACCATCACCATCACCATCATCACCATCACCATCATCATCATCACCACCATCATCACCATCATCATCAGCAGCAGCACCACCACCACTATTACCATCATTATTCCTACCATCCTCATCACCACCCTCACCATCACCATCATCATCATGACCATCATCATCAGCACCACCGTTATCATCATTATCCCCACCGTCCTCATCACCATCATCACCATCACCATCATCATTGTCACCATCACCATGATCATCGTCACCATCTTTATCCCCACCATCCTCATCACCATCATCACTACCATCAGCACCATCACCATCATCACCATTACCACCATTATCACCACCATCATCATCACCAACACCATCCTCAGCACTACCACCACCATCACATTCTCATTCATCCCTGTGCTCAACCACAGGCCTCTCAGAGAAGGGACAAGAGGAGATGCAGTCTTGGGCAGGAGACCACTTTTGGGGGCAAAAGCAGCTCCTGAAACCACACCCCAAAGCAGGCTCCACTCCATTCCATCAGACCCTGCAGTCAGGAAGGGCCGTGGGGTGTCCTGGCCTTCATCTGTGAGAACTGCCTTACCCATGCTGATTTCCACCCACATGGCATCAGAGGACTCCGTGCCCTGACACTACAATCCTTGTCCCCTTGTGTAGCCACCTCAGGGTCCAGCACCAACTGTCCTGTCTACCTGGAGCATAACACCATGAGGTCCCCAGCTCCTGGCTCTCCCCTGGGGGCTTGCCATGACCCGTTGGCCTGAGCTTTGGGGTGTCAGAAGCCCCCATGGAATGCACTGCTAAGACAAGCCCATCCTGCCAGCCTTCCTACCTCTCATAGCTGACCCTGCTGGGTTCTATGTTACAAATTCCCCTGCCCCAGCACCACTCTGTGACCTGCAGTGAGCGCAGCTGTCACTCCCCTCAAGGGTGCCCAGGCAATAGGGAGATGTGAGGACTGTGGGGGCATAAGAGTTGTCTCAGGGCTGTGCAGAGGAAGCCAGGGCCCCCCTAAATATCTCCAGCTCATCGCACCAGCTCCATTCTGCCCGGAGCCCCATGTCTGAGCCCTCAGCTCAGAGCAGACAACCGTGCTAATCCTGTCCCAGGCTGGTGGCCGCCCCCACTGAGGAGGGGGAGCAAGCTGCCCAGAAAGCTGGTGTGGAGTGCCCGTTAGCTGTGGATGGCATCGTGGTGCCACCGGGAGATTATCCACACGCAGCTAGTTCCCAGCAGCCGACCCCAGTGCCCCAAAAGAAGGCAGCTAGCTATTAAGGAGATTCATGGGCAGGGGTGAGGCGAGGAGGAAGGCTAATCAAGCTGTCCTGATTGTAATTGTCCGAAGGTGCTGGCCTCTCTCGTAAACATGCCAACTGCAGGCCCTGCTTCTGCGTCTCAGCAGGACTTCTCCCTGCTGGGACCGTGCTGGGGAATGTTCTTTCAACATAACTCTATTTAAATTCACATTTCCATCATCCCCCAGAGGAGCCGAGAGAGCTGAGCTGCGTGGTATAAGCCGGGAAAGGATTAGATGGGGTGGGTGTTATTTTTTTTCCTTTTATTTTCCCTTAGTGATGGAGATGGGGTTGTGGGGGGTGGGCCATTCTAGAATTCTGCAGTATTGGAACTGGAAGAGCTGTTACAAACCATCCAGCTC\t*\tSA:Z:chr9,130953867,-,1274M42I167M2163H,60,55,1318;chr9,130955093,-,1469H33M3I179M1962H,19,14,138;\tMD:Z:15T1C5T11A0T3G0A2C4C3T8T5C5T2G8G5G2G6C24T45T2C23T5C14T46T33T5C32T1433\tRG:Z:GATKSVContigAlignments\tNM:i:268\tAS:i:1347\tXS:i:176",
+                canonicalChromosomes, refSeqDict);
+
+        final CpxVariantInducingAssemblyContig.BasicInfo manuallyCalculatedBasicInfo =
+                new CpxVariantInducingAssemblyContig.BasicInfo("chr9", false,
+                        new SimpleInterval("chr9", 130953867, 130953867), new SimpleInterval("chr9", 130956738, 130956738));
+
+        //////////
+        final List<CpxVariantInducingAssemblyContig.Jump> manuallyCalculatedJumps =
+                Arrays.asList(
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr9", 130955309, 130955309), new SimpleInterval("chr9", 130955308, 130955308), StrandSwitch.NO_SWITCH, 156),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr9", 130955156, 130955156), new SimpleInterval("chr9", 130955155, 130955155), StrandSwitch.NO_SWITCH, 60),
+                        new CpxVariantInducingAssemblyContig.Jump(new SimpleInterval("chr9", 130954964, 130954964), new SimpleInterval("chr9", 130955307, 130955307), StrandSwitch.NO_SWITCH, 148)
+                );
+        final List<SimpleInterval> manuallyCalculatedEventPrimaryChromosomeSegmentingLocations =
+                Arrays.asList(
+                        new SimpleInterval("chr9", 130954964, 130954964),
+                        new SimpleInterval("chr9", 130955155, 130955155),
+                        new SimpleInterval("chr9", 130955156, 130955156),
+                        new SimpleInterval("chr9", 130955307, 130955307),
+                        new SimpleInterval("chr9", 130955308, 130955308),
+                        new SimpleInterval("chr9", 130955309, 130955309)
+                );
+        final CpxVariantInducingAssemblyContig manuallyCalculatedCpxVariantInducingAssemblyContig =
+                new CpxVariantInducingAssemblyContig(analysisReadyContig,
+                        manuallyCalculatedBasicInfo,
+                        manuallyCalculatedJumps,
+                        manuallyCalculatedEventPrimaryChromosomeSegmentingLocations);
+
+        //////////
+        final SimpleInterval manuallyCalculatedAffectedRefRegion =
+                new SimpleInterval("chr9", 130954964, 130955309);
+        final List<SimpleInterval> manuallyCalculatedSegments =
+                Arrays.asList(
+                        new SimpleInterval("chr9", 130954964, 130955155),
+                        new SimpleInterval("chr9", 130955156, 130955307),
+                        new SimpleInterval("chr9", 130955307, 130955308));
+        final List<String> manuallyCalculatedAltArrangementDescription =
+                Arrays.asList("1", "2", "UINS-148", "1", "UINS-60", "2", "3", "UINS-156");
+        final byte[] manuallyCalculatedAltSeq = Arrays.copyOfRange(analysisReadyContig.getContigSequence(), 1429, 2549);
+        SequenceUtil.reverseComplement(manuallyCalculatedAltSeq);
+        final CpxVariantCanonicalRepresentation manuallyCalculatedCpxVariantCanonicalRepresentation =
+                new CpxVariantCanonicalRepresentation(
+                        manuallyCalculatedAffectedRefRegion,
+                        manuallyCalculatedSegments,
+                        manuallyCalculatedAltArrangementDescription,
+                        manuallyCalculatedAltSeq);
+
+        //////////
+        final byte[] dummyRefSequence = "TCGA".getBytes();
+        final VariantContextBuilder variantContextBuilder = new VariantContextBuilder()
+                .chr("chr9").start(130954964).stop(130955309)
+                .alleles(Arrays.asList(Allele.create(dummyRefSequence, true), Allele.create(SimpleSVType.createBracketedSymbAlleleString(CPX_SV_SYB_ALT_ALLELE_STR), false)))
+                .id("CPX_chr9:130954964-130955309")
+                .attribute(VCFConstants.END_KEY, 130955309)
+                .attribute(SVTYPE, GATKSVVCFConstants.CPX_SV_SYB_ALT_ALLELE_STR)
+                .attribute(SVLEN, 346)
+                .attribute(SEQ_ALT_HAPLOTYPE, new String(manuallyCalculatedAltSeq));
+        variantContextBuilder.attribute(CPX_EVENT_ALT_ARRANGEMENTS,
+                String.join(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR, manuallyCalculatedAltArrangementDescription));
+        variantContextBuilder.attribute(CPX_SV_REF_SEGMENTS,
+                String.join(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR, manuallyCalculatedSegments.stream().map(SimpleInterval::toString).collect(Collectors.toList())));
+        final VariantContext manuallyCalculatedVariantContext = variantContextBuilder.make();
+
+        //////////
+        final Set<SimpleInterval> manuallyCalculatedTwoBaseBoundaries = new HashSet<>();
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130955309, 130955310));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130956737, 130956738));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130955156, 130955157));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130955307, 130955308));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130954964, 130954965));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130955154, 130955155));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130953867, 130953868));
+        manuallyCalculatedTwoBaseBoundaries.add(new SimpleInterval("chr9", 130955306, 130955307));
+
+        //////////
+        return new PreprocessedAndAnalysisReadyContigWithExpectedResults(
+                manuallyCalculatedCpxVariantInducingAssemblyContig,
+                manuallyCalculatedCpxVariantCanonicalRepresentation,
+                manuallyCalculatedVariantContext,
+                dummyRefSequence,
+                manuallyCalculatedTwoBaseBoundaries);
+    }
 
     private static AssemblyContigWithFineTunedAlignments makeContigAnalysisReady(final String primarySAMRecord,
                                                                                  final Set<String> canonicalChromosomes,

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentationUnitTest.java
@@ -67,7 +67,7 @@ public class CpxVariantCanonicalRepresentationUnitTest extends GATKBaseTest {
         final CpxVariantInducingAssemblyContig analysisReadyContig = new CpxVariantInducingAssemblyContig(preprocessedTig, CpxSVInferenceTestUtils.bareBoneHg38SAMSeqDict);
         final SimpleInterval manuallyCalculatedAffectedRefRegion = new SimpleInterval("chr1", 14492666, 14492666);
         final byte[] manuallyCalculatedAltSeq = Arrays.copyOfRange(alignedContig.getContigSequence(), 1275, 1685);
-        final List<String> manuallyCalculatedAltArrangements = Arrays.asList("1", "UINS-61", "-chr4:8687087-8687132", "UINS-299", "1");
+        final List<String> manuallyCalculatedAltArrangements = Arrays.asList("1", "UINS-62", "-chr4:8687087-8687132", "UINS-300", "1");
         final List<SimpleInterval> manuallyCalculatedSegments = Collections.singletonList(manuallyCalculatedAffectedRefRegion);
 
         final CpxVariantCanonicalRepresentation cpxVariantCanonicalRepresentation = new CpxVariantCanonicalRepresentation(analysisReadyContig);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantCanonicalRepresentationUnitTest.java
@@ -22,10 +22,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.*;
@@ -123,7 +120,8 @@ public class CpxVariantCanonicalRepresentationUnitTest extends GATKBaseTest {
         for (final CpxSVInferenceTestUtils.PreprocessedAndAnalysisReadyContigWithExpectedResults x : CpxSVInferenceTestUtils.PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS) {
             data.add(new Object[]{x.expectedCpxVariantInducingAssemblyContig.getBasicInfo(),
                                   x.expectedCpxVariantInducingAssemblyContig.getEventPrimaryChromosomeSegmentingLocations(),
-                                  x.expectedCpxVariantCanonicalRepresentation.getReferenceSegments()
+                                  x.expectedCpxVariantCanonicalRepresentation.getReferenceSegments(),
+                                  x.expectedCpxVariantInducingAssemblyContig.getTwoBaseBoundaries()
             });
         }
         return data.toArray(new Object[data.size()][]);
@@ -132,8 +130,9 @@ public class CpxVariantCanonicalRepresentationUnitTest extends GATKBaseTest {
     @Test(groups = "sv", dataProvider = "forExtractRefSegments")
     public void testExtractRefSegments(final CpxVariantInducingAssemblyContig.BasicInfo basicInfo,
                                        final List<SimpleInterval> segmentingLocations,
-                                       final List<SimpleInterval> expectedResult) {
-        Assert.assertEquals(CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, segmentingLocations), expectedResult);
+                                       final List<SimpleInterval> expectedResult,
+                                       final Set<SimpleInterval> twoBaseBoundaries) {
+        Assert.assertEquals(CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, segmentingLocations, twoBaseBoundaries), expectedResult);
     }
 
     @DataProvider(name = "forExtractAltArrangements")
@@ -143,7 +142,7 @@ public class CpxVariantCanonicalRepresentationUnitTest extends GATKBaseTest {
             final CpxVariantInducingAssemblyContig cpxVariantInducingAssemblyContig = x.expectedCpxVariantInducingAssemblyContig;
             final CpxVariantInducingAssemblyContig.BasicInfo basicInfo = cpxVariantInducingAssemblyContig.getBasicInfo();
             final List<SimpleInterval> eventPrimaryChromosomeSegmentingLocations = cpxVariantInducingAssemblyContig.getEventPrimaryChromosomeSegmentingLocations();
-            final List<SimpleInterval> segments = CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, eventPrimaryChromosomeSegmentingLocations);
+            final List<SimpleInterval> segments = CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, eventPrimaryChromosomeSegmentingLocations, cpxVariantInducingAssemblyContig.getTwoBaseBoundaries());
             data.add(new Object[]{basicInfo,
                                   cpxVariantInducingAssemblyContig.getPreprocessedTig().getAlignments(),
                                   cpxVariantInducingAssemblyContig.getJumps(),
@@ -171,7 +170,7 @@ public class CpxVariantCanonicalRepresentationUnitTest extends GATKBaseTest {
             final CpxVariantInducingAssemblyContig cpxVariantInducingAssemblyContig = x.expectedCpxVariantInducingAssemblyContig;
             final CpxVariantInducingAssemblyContig.BasicInfo basicInfo = cpxVariantInducingAssemblyContig.getBasicInfo();
             final List<SimpleInterval> eventPrimaryChromosomeSegmentingLocations = cpxVariantInducingAssemblyContig.getEventPrimaryChromosomeSegmentingLocations();
-            final List<SimpleInterval> segments = CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, eventPrimaryChromosomeSegmentingLocations);
+            final List<SimpleInterval> segments = CpxVariantCanonicalRepresentation.extractRefSegments(basicInfo, eventPrimaryChromosomeSegmentingLocations, cpxVariantInducingAssemblyContig.getTwoBaseBoundaries());
 
             data.add(new Object[]{cpxVariantInducingAssemblyContig.getPreprocessedTig(),
                                   segments,

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContigUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantInducingAssemblyContigUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.spark.sv.discovery.inference;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.SVTestUtils;
@@ -15,9 +16,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.broadinstitute.hellbender.tools.spark.sv.discovery.inference.CpxSVInferenceTestUtils.bareBoneHg38SAMSeqDict;
 
@@ -159,5 +158,24 @@ public class CpxVariantInducingAssemblyContigUnitTest extends GATKBaseTest {
                 CpxVariantInducingAssemblyContig.extractSegmentingRefLocationsOnEventPrimaryChromosome(jumps, basicInfo,
                         bareBoneHg38SAMSeqDict);
         Assert.assertEquals(result, expectedResults);
+    }
+
+    // =================================================================================================================
+    @DataProvider(name = "forGetAlignmentsBoundedBySegmentingLocations")
+    private Object[][] forGetAlignmentsBoundedBySegmentingLocations() {
+        final List<Object[]> data = new ArrayList<>(20);
+        for (final CpxSVInferenceTestUtils.PreprocessedAndAnalysisReadyContigWithExpectedResults x : CpxSVInferenceTestUtils.PREPROCESSED_AND_ANALYSIS_READY_CONTIGS_AND_EXPECTED_RESULTS) {
+            final CpxVariantInducingAssemblyContig expectedCpxVariantInducingAssemblyContig = x.expectedCpxVariantInducingAssemblyContig;
+            final Set<SimpleInterval> expectedTwoBaseBoundaries = x.expectedTwoBaseBoundaries;
+            data.add(new Object[]{expectedCpxVariantInducingAssemblyContig, expectedTwoBaseBoundaries});
+        }
+        return data.toArray(new Object[data.size()][]);
+    }
+
+    @Test(groups = "sv", dataProvider = "forGetAlignmentsBoundedBySegmentingLocations")
+    public void testGetAlignmentsBoundedBySegmentingLocations(final CpxVariantInducingAssemblyContig cpxVariantInducingAssemblyContig,
+                                                              final Set<SimpleInterval> expectedAlignmentsBoundedBySegmentingLocations) {
+        Assert.assertTrue(CollectionUtils.isEqualCollection(cpxVariantInducingAssemblyContig.getTwoBaseBoundaries(),
+                                                            expectedAlignmentsBoundedBySegmentingLocations));
     }
 }


### PR DESCRIPTION
fix #4649 

The cause of the exception is a new edge case that was not imagined when the reference region segmenting logic was initially written.
It is now covered, with updated tests.