### PR TITLE
Better default AF for M2 tumor-normal mode; improved M2 STR filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -37,6 +37,10 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final String MAX_SUSPICIOUS_READS_PER_ALIGNMENT_START_LONG_NAME = "max-suspicious-reads-per-alignment-start";
     public static final String NORMAL_LOD_LONG_NAME = "normal-lod";
 
+
+    public static final double DEFAULT_AF_FOR_TUMOR_ONLY_CALLING = 5e-8;
+    public static final double DEFAULT_AF_FOR_TUMOR_NORMAL_CALLING = 1e-5;
+
     //TODO: HACK ALERT HACK ALERT HACK ALERT
     //TODO: GATK4 does not yet have a way to tag inputs, eg -I:tumor tumor.bam -I:normal normal.bam,
     //TODO: so for now we require the user to specify bams *both* as inputs, with -I tumor.bam -I normal.bam
@@ -86,7 +90,12 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     @Argument(fullName= DEFAULT_AF_LONG_NAME, shortName = DEFAULT_AF_SHORT_NAME,
             doc="Population allele fraction assigned to alleles not found in germline resource.  Please see docs/mutect/mutect2.pdf for" +
                     "a derivation of the default value.", optional = true)
-    public double afOfAllelesNotInGermlineResource = 5e-8;
+    public double afOfAllelesNotInGermlineResource = -1;
+
+    public double getDefaultAlleleFrequency() {
+        return afOfAllelesNotInGermlineResource >= 0 ? afOfAllelesNotInGermlineResource :
+                (normalSampleName == null ? DEFAULT_AF_FOR_TUMOR_ONLY_CALLING : DEFAULT_AF_FOR_TUMOR_NORMAL_CALLING);
+    }
 
     /**
      * Only variants with tumor LODs exceeding this threshold will be written to the VCF, regardless of filter status.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
@@ -12,6 +12,9 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
     public static final String NORMAL_ARTIFACT_LOD_LONG_NAME = "normal-artifact-lod";
     public static final String MAX_GERMLINE_POSTERIOR_LONG_NAME = "max-germline-posterior";
     public static final String MAX_ALT_ALLELE_COUNT_LONG_NAME = "max-alt-allele-count";
+    public static final String MIN_BASES_TO_SUSPECT_PCR_SLIPPAGE_LONG_NAME = "min-pcr-slippage-size";
+    public static final String PCR_SLIPPAGE_RATE_LONG_NAME = "pcr-slippage-rate";
+    public static final String PCR_SLIPPAGE_P_VALUE_LONG_NAME = "pcr-slippage-p-value";
     public static final String MIN_MEDIAN_MAPPING_QUALITY_LONG_NAME = "min-median-mapping-quality";
     public static final String MIN_MEDIAN_BASE_QUALITY_LONG_NAME = "min-median-base-quality";
     public static final String MAX_MEDIAN_FRAGMENT_LENGTH_DIFFERENCE_LONG_NAME = "max-median-fragment-length-difference";
@@ -63,6 +66,15 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
 
     @Argument(fullName = MAX_ALT_ALLELE_COUNT_LONG_NAME, optional = true, doc = "filter variants with too many alt alleles")
     public int numAltAllelesThreshold = 1;
+
+    @Argument(fullName = MIN_BASES_TO_SUSPECT_PCR_SLIPPAGE_LONG_NAME, optional = true, doc = "Minimum number of reference bases in an STR to suspect PCR slippage")
+    public int minPcrSlippageBases = 8;
+
+    @Argument(fullName = PCR_SLIPPAGE_RATE_LONG_NAME, optional = true, doc = "In contexts where PCR slippage is suspected, the rough fraction of reads in which slippage occurs")
+    public double pcrSlippageRate = 0.1;
+
+    @Argument(fullName = PCR_SLIPPAGE_P_VALUE_LONG_NAME, optional = true, doc = "P-value threshold for PCR slippage")
+    public double pcrSlippagePValueThreshold = 0.001;
 
     @Argument(fullName = MIN_MEDIAN_MAPPING_QUALITY_LONG_NAME, optional = true, doc="filter variants for which alt reads' median mapping quality is too low.")
     public int minMedianMappingQuality = 30;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -151,7 +151,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
             final Optional<LikelihoodMatrix<Allele>> subsettedLog10NormalMatrix =
                     getForNormal(() -> new SubsettedLikelihoodMatrix<>(log10NormalMatrix.get(), allSomaticAlleles));
 
-            final Map<String, Object> populationAlleleFreqeuncyAnnotation = GermlineProbabilityCalculator.getPopulationAlleleFrequencyAnnotation(featureContext.getValues(MTAC.germlineResource, loc), somaticAltAlleles, MTAC.afOfAllelesNotInGermlineResource);
+            final Map<String, Object> populationAlleleFreqeuncyAnnotation = GermlineProbabilityCalculator.getPopulationAlleleFrequencyAnnotation(featureContext.getValues(MTAC.germlineResource, loc), somaticAltAlleles, MTAC.getDefaultAlleleFrequency());
 
             final VariantContextBuilder callVcb = new VariantContextBuilder(mergedVC)
                     .alleles(allSomaticAlleles)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -91,9 +91,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
 
         // tumor-only calling with gnomAD
         if (!tumorOnly) {
-            args.addAll(Arrays.asList("-I", normalBam.getAbsolutePath(),
-                    "-" + M2ArgumentCollection.NORMAL_SAMPLE_SHORT_NAME, normal,
-                    "-" + M2ArgumentCollection.DEFAULT_AF_SHORT_NAME, "0.000003"));
+            args.addAll(Arrays.asList("-I", normalBam.getAbsolutePath(), "-" + M2ArgumentCollection.NORMAL_SAMPLE_SHORT_NAME, normal));
         };
 
         runCommandLine(args);


### PR DESCRIPTION
@takutosato The first commit gives tumor-normal the old default AF.  The second commit is a more intelligent STR contraction filter that improves both sensitivity and precision.