### PR TITLE
Fix two instances of immutable collections being used to initialize List arguments

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -158,7 +158,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      */
     @Advanced
     @Argument(fullName = "input-prior",  doc = "Input prior for calls", optional = true)
-    public List<Double> inputPrior = Collections.emptyList();
+    public List<Double> inputPrior = new ArrayList<>();
 
     /**
      *   Sample ploidy - equivalent to number of chromosomes per pool. In pooled experiments this should be = # of samples in pool * individual sample ploidy

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -62,7 +62,7 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      */
     @Advanced
     @Argument(fullName = "comp", shortName = "comp", doc = "Comparison VCF file(s)", optional = true)
-    public List<FeatureInput<VariantContext>> comps = Collections.emptyList();
+    public List<FeatureInput<VariantContext>> comps = new ArrayList<>();
 
     /**
      * The reference confidence mode makes it possible to emit a per-bp or summarized confidence estimate for a site being strictly homozygous-reference.


### PR DESCRIPTION
Barclay can't currently handle immutable collections in `@Argument` values due to
https://github.com/broadinstitute/gatk/issues/4702

Tests for these arguments are coming in a separate, larger branch, but I
wanted to get the fixes in first since it's such a simple fix.