### PR TITLE
minor improvements to code in IOUtils and UserException.BadTmpDir

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -2,8 +2,8 @@ package org.broadinstitute.hellbender.exceptions;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.tribble.Feature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.ValidateVariants;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -11,7 +11,6 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 
 /**
  * <p/>
@@ -186,8 +185,13 @@ public class UserException extends RuntimeException {
     public static class BadTmpDir extends UserException {
         private static final long serialVersionUID = 0L;
 
+        private static final String MESSAGE_FORMAT_STRING = "Failure working with the tmp directory %s. Try changing the tmp dir with with --" + StandardArgumentDefinitions.TMP_DIR_NAME + " on the command line.  Exact error was %s";
         public BadTmpDir(String message) {
-            super(String.format("Failure working with the tmp directory %s. Override with -Djava.io.tmpdir=X on the command line to a bigger/better file system.  Exact error was %s", System.getProperties().get("java.io.tmpdir"), message));
+            super(String.format(MESSAGE_FORMAT_STRING, System.getProperties().get("java.io.tmpdir"), message));
+        }
+
+        public BadTmpDir(String message, Throwable cause) {
+            super(String.format(MESSAGE_FORMAT_STRING, System.getProperties().get("java.io.tmpdir"), message), cause);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -182,15 +182,15 @@ public class UserException extends RuntimeException {
     }
 
 
-    public static class BadTmpDir extends UserException {
+    public static class BadTempDir extends UserException {
         private static final long serialVersionUID = 0L;
 
         private static final String MESSAGE_FORMAT_STRING = "Failure working with the tmp directory %s. Try changing the tmp dir with with --" + StandardArgumentDefinitions.TMP_DIR_NAME + " on the command line.  Exact error was %s";
-        public BadTmpDir(String message) {
+        public BadTempDir(String message) {
             super(String.format(MESSAGE_FORMAT_STRING, System.getProperties().get("java.io.tmpdir"), message));
         }
 
-        public BadTmpDir(String message, Throwable cause) {
+        public BadTempDir(String message, Throwable cause) {
             super(String.format(MESSAGE_FORMAT_STRING, System.getProperties().get("java.io.tmpdir"), message), cause);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PostprocessGermlineCNVCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PostprocessGermlineCNVCalls.java
@@ -432,7 +432,7 @@ public final class PostprocessGermlineCNVCalls extends GATKTool {
             logger.info("Generating segments VCF file...");
 
             /* perform segmentation */
-            final File pythonScriptOutputPath = IOUtils.createTmpDir("gcnv-segmented-calls");
+            final File pythonScriptOutputPath = IOUtils.createTempDir("gcnv-segmented-calls");
             final boolean pythonScriptSucceeded = executeSegmentGermlineCNVCallsPythonScript(
                     sampleIndex, contigPloidyCallsPath, sortedCallsShardPaths, sortedModelShardPaths,
                     pythonScriptOutputPath);

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PostprocessGermlineCNVCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PostprocessGermlineCNVCalls.java
@@ -432,7 +432,7 @@ public final class PostprocessGermlineCNVCalls extends GATKTool {
             logger.info("Generating segments VCF file...");
 
             /* perform segmentation */
-            final File pythonScriptOutputPath = IOUtils.tempDir("gcnv-segmented-calls", "");
+            final File pythonScriptOutputPath = IOUtils.createTmpDir("gcnv-segmented-calls");
             final boolean pythonScriptSucceeded = executeSegmentGermlineCNVCallsPythonScript(
                     sampleIndex, contigPloidyCallsPath, sortedCallsShardPaths, sortedModelShardPaths,
                     pythonScriptOutputPath);

--- a/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
@@ -83,8 +83,8 @@ public final class RScriptExecutor extends ScriptExecutor {
     public boolean exec() {
         List<File> tempFiles = new ArrayList<>();
         try {
-            File tempLibSourceDir  = IOUtils.tempDir("RlibSources.", "");
-            File tempLibInstallationDir = IOUtils.tempDir("Rlib.", "");
+            File tempLibSourceDir  = IOUtils.createTmpDir("RlibSources.");
+            File tempLibInstallationDir = IOUtils.createTmpDir("Rlib.");
             tempFiles.add(tempLibSourceDir);
             tempFiles.add(tempLibInstallationDir);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
@@ -83,8 +83,8 @@ public final class RScriptExecutor extends ScriptExecutor {
     public boolean exec() {
         List<File> tempFiles = new ArrayList<>();
         try {
-            File tempLibSourceDir  = IOUtils.createTmpDir("RlibSources.");
-            File tempLibInstallationDir = IOUtils.createTmpDir("Rlib.");
+            File tempLibSourceDir  = IOUtils.createTempDir("RlibSources.");
+            File tempLibInstallationDir = IOUtils.createTempDir("Rlib.");
             tempFiles.add(tempLibSourceDir);
             tempFiles.add(tempLibInstallationDir);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -93,7 +93,7 @@ public final class IOUtils {
                 throw new UserException.BadTmpDir("Could not create sub directory: " + temp.getAbsolutePath());
             return absolute(temp);
         } catch (IOException e) {
-            throw new UserException.BadTmpDir(e.getMessage());
+            throw new UserException.BadTmpDir(e.getMessage(), e);
         }
     }
 
@@ -124,7 +124,7 @@ public final class IOUtils {
             FileUtils.writeStringToFile(tempFile, content, StandardCharsets.UTF_8);
             return tempFile;
         } catch (IOException e) {
-            throw new UserException.BadTmpDir(e.getMessage());
+            throw new UserException.BadTmpDir(e.getMessage(), e);
         }
     }
 
@@ -214,7 +214,7 @@ public final class IOUtils {
         try {
             temp = File.createTempFile(FilenameUtils.getBaseName(resource.getPath()) + ".", "." + FilenameUtils.getExtension(resource.getPath()));
         } catch (IOException e) {
-            throw new UserException.BadTmpDir(e.getMessage());
+            throw new UserException.BadTmpDir(e.getMessage(), e);
         }
         writeResource(resource, temp);
         return temp;

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -271,9 +271,7 @@ public abstract class BaseTest {
      * @return an empty directory starting with prefix which will be deleted after the program exits
      */
     public static File createTempDir(final String prefix){
-        final File dir = IOUtils.tempDir(prefix, "");
-        IOUtils.deleteRecursivelyOnExit(dir);
-        return dir;
+        return IOUtils.createTmpDir(prefix);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -271,7 +271,7 @@ public abstract class BaseTest {
      * @return an empty directory starting with prefix which will be deleted after the program exits
      */
     public static File createTempDir(final String prefix){
-        return IOUtils.createTmpDir(prefix);
+        return IOUtils.createTempDir(prefix);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
@@ -21,7 +21,7 @@ public final class IOUtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testTempDir() {
-        File tempDir = IOUtils.tempDir("Q-Unit-Test", "", new File("queueTempDirToDelete"));
+        File tempDir = IOUtils.createTmpDir("Q-Unit-Test");
         Assert.assertTrue(tempDir.exists());
         Assert.assertFalse(tempDir.isFile());
         Assert.assertTrue(tempDir.isDirectory());

--- a/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/io/IOUtilsUnitTest.java
@@ -21,40 +21,13 @@ public final class IOUtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testTempDir() {
-        File tempDir = IOUtils.createTmpDir("Q-Unit-Test");
+        File tempDir = IOUtils.createTempDir("Q-Unit-Test");
         Assert.assertTrue(tempDir.exists());
         Assert.assertFalse(tempDir.isFile());
         Assert.assertTrue(tempDir.isDirectory());
         boolean deleted = IOUtils.tryDelete(tempDir);
         Assert.assertTrue(deleted);
         Assert.assertFalse(tempDir.exists());
-    }
-
-    @Test
-    public void testAbsolute() {
-        File dir = IOUtils.absolute(new File("/path/./to/./directory/."));
-        Assert.assertEquals(dir, new File("/path/to/directory"));
-
-        dir = IOUtils.absolute(new File("/"));
-        Assert.assertEquals(dir, new File("/"));
-
-        dir = IOUtils.absolute(new File("/."));
-        Assert.assertEquals(dir, new File("/"));
-
-        dir = IOUtils.absolute(new File("/././."));
-        Assert.assertEquals(dir, new File("/"));
-
-        dir = IOUtils.absolute(new File("/./directory/."));
-        Assert.assertEquals(dir, new File("/directory"));
-
-        dir = IOUtils.absolute(new File("/./directory/./"));
-        Assert.assertEquals(dir, new File("/directory"));
-
-        dir = IOUtils.absolute(new File("/./directory./"));
-        Assert.assertEquals(dir, new File("/directory."));
-
-        dir = IOUtils.absolute(new File("/./.directory/"));
-        Assert.assertEquals(dir, new File("/.directory"));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
@@ -415,7 +415,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
             FileUtils.writeStringToFile(file, contents, StandardCharsets.UTF_8);
             return file;
         } catch (IOException e) {
-            throw new UserException.BadTmpDir(e.getMessage());
+            throw new UserException.BadTmpDir(e.getMessage(), e);
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
@@ -415,7 +415,7 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
             FileUtils.writeStringToFile(file, contents, StandardCharsets.UTF_8);
             return file;
         } catch (IOException e) {
-            throw new UserException.BadTmpDir(e.getMessage(), e);
+            throw new UserException.BadTempDir(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Two commits here:

- The first is to fix a no longer accurate message in `UserException.BadTmpDir`
- The second is a few improvements to IOUtils.  
  1.  Rename and simplify `tmpDir` -> `createTempDir` and make it automatically scheduled for deletion
  2. Add documentation to the confusing `absolute` method so that I stop wondering what it's for
