### PR TITLE
kabobifying MarkDuplicatesSpark arguments

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -70,6 +70,11 @@ public final class StandardArgumentDefinitions {
     public static final String BQSR_TABLE_SHORT_NAME = "bqsr";
     public static final String BQSR_TABLE_LONG_NAME = "bqsr-recal-file";
 
+    public static final String DUPLICATE_SCORING_STRATEGY_LONG_NAME = "duplicate-scoring-strategy";
+    public static final String DUPLICATE_SCORING_STRATEGY_SHORT_NAME = "DS";
+    public static final String METRICS_FILE_LONG_NAME = "metrics-file";
+    public static final String METRICS_FILE_SHORT_NAME = "M";
+
     /**
      * The option specifying a main configuration file.
      * This is used in {@link org.broadinstitute.hellbender.Main} to control which config file is loaded.

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/MarkDuplicatesSparkArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/MarkDuplicatesSparkArgumentCollection.java
@@ -1,9 +1,8 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.read.markduplicates.MarkDuplicatesScoringStrategy;
-import org.broadinstitute.hellbender.utils.read.markduplicates.OpticalDuplicateFinder;
 
 import java.io.Serializable;
 
@@ -15,9 +14,11 @@ import java.io.Serializable;
 public final class MarkDuplicatesSparkArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Argument(shortName = "DS", fullName = "DUPLICATE_SCORING_STRATEGY", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
+    public static final String DO_NOT_MARK_UNMAPPED_MATES_LONG_NAME = "do-not-mark-unmapped-mates";
+
+    @Argument(shortName = StandardArgumentDefinitions.DUPLICATE_SCORING_STRATEGY_SHORT_NAME, fullName = StandardArgumentDefinitions.DUPLICATE_SCORING_STRATEGY_LONG_NAME, doc = "The scoring strategy for choosing the non-duplicate among candidates.")
     public MarkDuplicatesScoringStrategy duplicatesScoringStrategy = MarkDuplicatesScoringStrategy.SUM_OF_BASE_QUALITIES;
 
-    @Argument(fullName = MarkDuplicatesSpark.DO_NOT_MARK_UNMAPPED_MATES, doc = "Enabling this option will mean unmapped mates of duplicate marked reads will not be marked as duplicates.")
+    @Argument(fullName = MarkDuplicatesSparkArgumentCollection.DO_NOT_MARK_UNMAPPED_MATES_LONG_NAME, doc = "Enabling this option will mean unmapped mates of duplicate marked reads will not be marked as duplicates.")
     public boolean dontMarkUnmappedMates = false;
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OpticalDuplicatesArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OpticalDuplicatesArgumentCollection.java
@@ -13,6 +13,9 @@ import java.io.Serializable;
 public final class OpticalDuplicatesArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    public static final String READ_NAME_REGEX_LONG_NAME = "read-name-regex";
+    public static final String OPTICAL_DUPLICATE_PIXEL_DISTANCE_LONG_NAME = "optical-duplicate-pixel-distance";
+
     @Argument(doc = "Regular expression that can be used to parse read names in the incoming SAM file. Read names are " +
              "parsed to extract three variables: tile/region, x coordinate and y coordinate. These values are used " +
              "to estimate the rate of optical duplication in order to give a more accurate estimated library size. " +
@@ -23,12 +26,14 @@ public final class OpticalDuplicatesArgumentCollection implements Serializable {
              " is split on colon character. " +
              "For 5 element names, the 3rd, 4th and 5th elements are assumed to be tile, x and y values. " +
              "For 7 element names (CASAVA 1.8), the 5th, 6th, and 7th elements are assumed to be tile, x and y values.",
+             fullName = READ_NAME_REGEX_LONG_NAME,
              optional = true)
     public String READ_NAME_REGEX = OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX;
 
     @Argument(doc = "The maximum offset between two duplicate clusters in order to consider them optical duplicates. This " +
              "should usually be set to some fairly small number (e.g. 5-10 pixels) unless using later versions of the " +
-        "Illumina pipeline that multiply pixel values by 10, in which case 50-100 is more normal.",
+             "Illumina pipeline that multiply pixel values by 10, in which case 50-100 is more normal.",
+              fullName = OPTICAL_DUPLICATE_PIXEL_DISTANCE_LONG_NAME,
               optional = true)
     public int OPTICAL_DUPLICATE_PIXEL_DISTANCE = OpticalDuplicateFinder.DEFAULT_OPTICAL_DUPLICATE_DISTANCE;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 @BetaFeature
 public final class MarkDuplicatesSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
-    public static final String DO_NOT_MARK_UNMAPPED_MATES = "do-not-mark-unmapped-mates";
 
     @Override
     public boolean requiresReads() { return true; }
@@ -50,7 +49,8 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
     protected String output;
 
     @Argument(doc = "Path to write duplication metrics to.", optional=true,
-            shortName = "M", fullName = "METRICS_FILE")
+            shortName = StandardArgumentDefinitions.METRICS_FILE_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.METRICS_FILE_LONG_NAME)
     protected String metricsFile;
 
     @ArgumentCollection

--- a/src/main/java/org/broadinstitute/hellbender/tools/validation/validate-reads-spark-pipeline.sh
+++ b/src/main/java/org/broadinstitute/hellbender/tools/validation/validate-reads-spark-pipeline.sh
@@ -88,7 +88,7 @@ echo "################################################"
 echo "############## Run GATK 4 tools ################"
 echo "################################################"
 # Run MarkDuplicates
-${GATK4_JAR} MarkDuplicatesSpark -I ${CLEAN_BAM} -O ${MARKED_BAM} --METRICS_FILE=tmp.metrics -DS SUM_OF_BASE_QUALITIES
+${GATK4_JAR} MarkDuplicatesSpark -I ${CLEAN_BAM} -O ${MARKED_BAM} --metrics-file=tmp.metrics -DS SUM_OF_BASE_QUALITIES
 
 # Run BQSR
 ${GATK4_JAR} BaseRecalibratorSpark -I ${MARKED_BAM} -R $3 -knownSites $4 -O ${RECAL_TABLE}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractMarkDuplicatesCommandLineProgram.java
@@ -30,7 +30,8 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
             doc = "The output file to write marked records to")
     public File OUTPUT;
 
-    @Argument(shortName = "M",
+    @Argument(shortName = StandardArgumentDefinitions.METRICS_FILE_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.METRICS_FILE_LONG_NAME,
             doc = "File to write duplication metrics to")
     public File METRICS_FILE;
 
@@ -67,7 +68,9 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
             doc = "If true, assume that the input file is coordinate sorted even if the header says otherwise.")
     public boolean ASSUME_SORTED = false;
 
-    @Argument(shortName = "DS", doc = "The scoring strategy for choosing the non-duplicate among candidates.")
+    @Argument(shortName = StandardArgumentDefinitions.DUPLICATE_SCORING_STRATEGY_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.DUPLICATE_SCORING_STRATEGY_LONG_NAME,
+            doc = "The scoring strategy for choosing the non-duplicate among candidates.")
     public DuplicateScoringStrategy.ScoringStrategy DUPLICATE_SCORING_STRATEGY = ScoringStrategy.TOTAL_MAPPED_REFERENCE_LENGTH;
 
     /** The program groups that have been seen during the course of examining the input records. */

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/OpticalDuplicateFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/OpticalDuplicateFinder.java
@@ -1,8 +1,9 @@
 package org.broadinstitute.hellbender.utils.read.markduplicates;
 
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicatesArgumentCollection;
 
- import java.io.Serializable;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -103,8 +104,8 @@ public final class OpticalDuplicateFinder implements Serializable {
             final int fields = getRapidDefaultReadNameRegexSplit(readName, ':', tmpLocationFields);
             if (!(fields == 5 || fields == 7)) {
                 if (null != log && !this.warnedAboutRegexNotMatching) {
-                    this.log.warn(String.format("Default READ_NAME_REGEX '%s' did not match read name '%s'.  " +
-                                    "You may need to specify a READ_NAME_REGEX in order to correctly identify optical duplicates.  " +
+                    this.log.warn(String.format("Default "+ OpticalDuplicatesArgumentCollection.READ_NAME_REGEX_LONG_NAME + " '%s' did not match read name '%s'.  " +
+                                    "You may need to specify a " + OpticalDuplicatesArgumentCollection.READ_NAME_REGEX_LONG_NAME + " in order to correctly identify optical duplicates.  " +
                                     "Note that this message will not be emitted again even if other read names do not match the regex.",
                             this.readNameRegex, readName));
                     this.warnedAboutRegexNotMatching = true;
@@ -130,7 +131,7 @@ public final class OpticalDuplicateFinder implements Serializable {
                 return true;
             } else {
                 if (null != log && !this.warnedAboutRegexNotMatching) {
-                    this.log.warn(String.format("READ_NAME_REGEX '%s' did not match read name '%s'.  Your regex may not be correct.  " +
+                    this.log.warn(String.format(OpticalDuplicatesArgumentCollection.READ_NAME_REGEX_LONG_NAME+ " '%s' did not match read name '%s'.  Your regex may not be correct.  " +
                                     "Note that this message will not be emitted again even if other read names do not match the regex.",
                             this.readNameRegex, readName));
                     warnedAboutRegexNotMatching = true;

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/testers/AbstractMarkDuplicatesTester.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/testers/AbstractMarkDuplicatesTester.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.FormatUtil;
 import htsjdk.samtools.util.TestUtil;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.read.markduplicates.DuplicationMetrics;
 import org.testng.Assert;
 
@@ -32,8 +33,8 @@ public abstract class AbstractMarkDuplicatesTester extends SamFileTester {
         expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES = 0;
 
         metricsFile = new File(getOutputDir(), "metrics.txt");
-        addArg("--METRICS_FILE", metricsFile.getAbsolutePath());
-        addArg("--DUPLICATE_SCORING_STRATEGY", duplicateScoringStrategy.name());
+        addArg("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME, metricsFile.getAbsolutePath());
+        addArg("--"+StandardArgumentDefinitions.DUPLICATE_SCORING_STRATEGY_LONG_NAME, duplicateScoringStrategy.name());
     }
 
     public AbstractMarkDuplicatesTester() {
@@ -43,7 +44,7 @@ public abstract class AbstractMarkDuplicatesTester extends SamFileTester {
         expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES = 0;
 
         metricsFile = new File(getOutputDir(), "metrics.txt");
-        addArg("--METRICS_FILE", metricsFile.getAbsolutePath());
+        addArg("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME, metricsFile.getAbsolutePath());
     }
 
     public File getMetricsFile() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaAndMarkDuplicatesPipelineSparkIntegrationTest.java
@@ -2,8 +2,8 @@ package org.broadinstitute.hellbender.tools.spark.bwa;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.pipelines.BwaAndMarkDuplicatesPipelineSpark;
-import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.SamAssertionUtils;
 import org.testng.Assert;
@@ -35,7 +35,7 @@ public final class BwaAndMarkDuplicatesPipelineSparkIntegrationTest extends Comm
         args.addInput(input);
         args.addOutput(output);
         args.addBooleanArgument(StandardArgumentDefinitions.DISABLE_SEQUENCE_DICT_VALIDATION_NAME, true);
-        args.add("--"+MarkDuplicatesSpark.DO_NOT_MARK_UNMAPPED_MATES);
+        args.add("--"+MarkDuplicatesSparkArgumentCollection.DO_NOT_MARK_UNMAPPED_MATES_LONG_NAME);
         this.runCommandLine(args.getArgsArray());
 
         SamAssertionUtils.assertSamsEqual(output, expectedSam);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
@@ -96,7 +96,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
         outputFile.delete();
         args.add(outputFile.getAbsolutePath());
 
-        args.add("--METRICS_FILE");
+        args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
         File metricsFile = createTempFile("markdups_metrics", ".txt");
         args.add(metricsFile.getAbsolutePath());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -2,8 +2,8 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSource;
-import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerIntegrationTest;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -122,7 +122,7 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
             args.add("-R");
             args.add(referenceFile.getAbsolutePath());
         }
-        args.add("--"+ MarkDuplicatesSpark.DO_NOT_MARK_UNMAPPED_MATES);
+        args.add("--"+ MarkDuplicatesSparkArgumentCollection.DO_NOT_MARK_UNMAPPED_MATES_LONG_NAME);
         args.add("-indels");
         args.add("--enable-baq");
         args.add("-pairHMM");

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -562,7 +562,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
         args.add(sam.getAbsolutePath());
         args.add("-O");
         args.add(outputSam.getAbsolutePath());
-        args.add("--METRICS_FILE");
+        args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
         args.add(metricsFile.getAbsolutePath());
         markDuplicates.instanceMain(args.getArgsArray());
         IntegrationTestSpec.assertEqualTextFiles(metricsFile, expectedMetrics, "#"); //this compares the values but not headers
@@ -615,7 +615,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
         args.add(input.getPath());
         args.add("-"+StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
         args.add(outputFile.getAbsolutePath());
-        args.add("--METRICS_FILE");
+        args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
         args.add(metricsFile.getAbsolutePath());
         args.add(extraArgs);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATKIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/MarkDuplicatesGATKIntegrationTest.java
@@ -72,7 +72,7 @@ public final class MarkDuplicatesGATKIntegrationTest extends AbstractMarkDuplica
             final File outputSam = new File(outputDir, TEST_BASE_NAME + ".sam");
             args.add("--output");
             args.add(outputSam.getAbsolutePath());
-            args.add("--METRICS_FILE");
+            args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
             args.add(new File(outputDir, TEST_BASE_NAME + ".duplicate_metrics").getAbsolutePath());
             if (suppressPg) {
                 args.add("--PROGRAM_RECORD_ID");
@@ -197,7 +197,7 @@ public final class MarkDuplicatesGATKIntegrationTest extends AbstractMarkDuplica
         outputFile.delete();
         args.add(outputFile.getAbsolutePath());
 
-        args.add("--METRICS_FILE");
+        args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
         File metricsFile = createTempFile("markdups_metrics", ".txt");
         args.add(metricsFile.getAbsolutePath());
 
@@ -220,7 +220,7 @@ public final class MarkDuplicatesGATKIntegrationTest extends AbstractMarkDuplica
         outputFile.delete();
         args.add(outputFile.getAbsolutePath());
 
-        args.add("--METRICS_FILE");
+        args.add("--"+StandardArgumentDefinitions.METRICS_FILE_LONG_NAME);
         File metricsFile = createTempFile("markdups_metrics", ".txt");
         args.add(metricsFile.getAbsolutePath());
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/MarkDuplicatesSparkTester.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/MarkDuplicatesSparkTester.java
@@ -1,13 +1,10 @@
 package org.broadinstitute.hellbender.utils.read.markduplicates;
 
-import com.google.common.collect.Lists;
 import htsjdk.samtools.DuplicateScoringStrategy;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
 import org.broadinstitute.hellbender.utils.test.testers.AbstractMarkDuplicatesTester;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * A tester class for {@link MarkDuplicatesSpark}.
@@ -30,7 +27,7 @@ public final class MarkDuplicatesSparkTester extends AbstractMarkDuplicatesTeste
     @Override
     protected void addArgs() {
         if (!markUnmappedReads) {
-            addArg("--" + MarkDuplicatesSpark.DO_NOT_MARK_UNMAPPED_MATES);
+            addArg("--" + MarkDuplicatesSparkArgumentCollection.DO_NOT_MARK_UNMAPPED_MATES_LONG_NAME);
         }
     }
 }


### PR DESCRIPTION
* some of the arguments to MarkDuplicatesSpark were still using Picard style uppercase names
* the following arguments in MarkDuplicatesGATK and MarkDuplicatesSpark have changed

  --METRICS_FILE -> --metrics-file
  --DUPLICATE_SCORING_STRATEGY -> --duplicate-scoring-strategy
  --READ_NAME_REGEX -> --read-name-regex
  --OPTICAL_DUPLICATE_PIXEL_DISTANCE -> --optical-duplicate-pixel-distance

* this fixes an accidental change to ReadsPipelineSpark which was introduced when we added MarkDuplicatesSparkArgumentCollection