### PR TITLE
NIO output support for HaplotypeCaller

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -197,7 +197,7 @@ public final class AssemblyBasedCallerUtils {
                                                                final boolean createBamOutMD5,
                                                                final SAMFileHeader header) {
         return args.bamOutputPath != null ?
-                Optional.of(HaplotypeBAMWriter.create(args.bamWriterType, new File(args.bamOutputPath), createBamOutIndex, createBamOutMD5, header)) :
+                Optional.of(HaplotypeBAMWriter.create(args.bamWriterType, IOUtils.getPath(args.bamOutputPath), createBamOutIndex, createBamOutMD5, header)) :
                 Optional.empty();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMTag;
 
 import htsjdk.samtools.util.Locatable;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.utils.read.*;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
@@ -68,7 +69,7 @@ public abstract class HaplotypeBAMWriter implements AutoCloseable {
      * Create a new HaplotypeBAMWriter of type "type" for writing SAMRecords to an output file
      *
      * @param type the type of the writer we want to create, must not be null
-     * @param outputFile the destination, must not be null
+     * @param outputPath the destination, must not be null
      * @param createBamOutIndex true to create an index for the bamout
      * @param createBamOutMD5 true to create an MD5 file for the bamout
      * @param sourceHeader the header of the input BAMs used to make calls, must not be null.
@@ -76,15 +77,15 @@ public abstract class HaplotypeBAMWriter implements AutoCloseable {
      */
     public static HaplotypeBAMWriter create(
             final WriterType type,
-            final File outputFile,
+            final Path outputPath,
             final boolean createBamOutIndex,
             final boolean createBamOutMD5,
             final SAMFileHeader sourceHeader) {
         Utils.nonNull(type, "type cannot be null");
-        Utils.nonNull(outputFile, "outputFile cannot be null");
+        Utils.nonNull(outputPath, "outputPath cannot be null");
         Utils.nonNull(sourceHeader, "sourceHeader cannot be null");
 
-        return create(type, new SAMFileDestination(outputFile, createBamOutIndex, createBamOutMD5, sourceHeader, DEFAULT_HAPLOTYPE_READ_GROUP_ID));
+        return create(type, new SAMFileDestination(outputPath, createBamOutIndex, createBamOutMD5, sourceHeader, DEFAULT_HAPLOTYPE_READ_GROUP_ID));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.haplotype;
 
 import htsjdk.samtools.SAMFileHeader;
+import java.nio.file.Path;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -17,14 +18,14 @@ public final class SAMFileDestination extends HaplotypeBAMDestination {
     /**
      * Create a new file destination.
      *
-     * @param outFile file where output is written
+     * @param outPath path where output is written (doesn't have to be local)
      * @param createBamOutIndex true to create an index file for the bamout
      * @param createBamOutMD5 true to create an md5 file for the bamout
      * @param sourceHeader SAMFileHeader used to seed the output SAMFileHeader for this destination, must not be null
      * @param haplotypeReadGroupID  read group ID used when writing haplotypes as reads
      */
     public SAMFileDestination(
-            final File outFile,
+            final Path outPath,
             final boolean createBamOutIndex,
             final boolean createBamOutMD5,
             final SAMFileHeader sourceHeader,
@@ -32,7 +33,7 @@ public final class SAMFileDestination extends HaplotypeBAMDestination {
     {
         super(sourceHeader, haplotypeReadGroupID);
         samWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(
-                outFile,
+                outPath,
                 null,
                 getBAMOutputHeader(), // use the header derived from the source header by HaplotypeBAMDestination
                 false,


### PR DESCRIPTION
HaplotypeCaller's bamOutputPath is no longer internally converted to a File so "gs://" paths can now be passed for the optional "bam output" parameter.