### PR TITLE
Added a new WEX test bam to src/test/resources/large, with a companion target interval list

### DIFF
--- a/src/test/resources/large/NexPond-377866.NA12878.WEX.20.21.with.unmapped.bam
+++ b/src/test/resources/large/NexPond-377866.NA12878.WEX.20.21.with.unmapped.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ff6daa8910f163f39044b63f718695146181afaa80e1af0bf0be3530983e2ae
+size 134998122

--- a/src/test/resources/large/NexPond-377866.NA12878.WEX.20.21.with.unmapped.bam.bai
+++ b/src/test/resources/large/NexPond-377866.NA12878.WEX.20.21.with.unmapped.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:549aa8d55a06f6e9cba9d4db821d74dd3a0f0e4f22581d15bdfaed21322985cd
+size 150176

--- a/src/test/resources/large/whole_exome_illumina_coding_v1.Homo_sapiens_assembly19.targets.interval_list
+++ b/src/test/resources/large/whole_exome_illumina_coding_v1.Homo_sapiens_assembly19.targets.interval_list
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1de903367e7335a203ec2ae5c2371c5c22718f653d74dec4118484311d57114d
+size 11046999


### PR DESCRIPTION
This is a ~130 MB snippet of the NexPond-377866 NA12878 bam from
https://github.com/broadinstitute/palantir/wiki/Gold-Standard-Datasets
with:

-all reads from chromosomes 20 and 21
-50,000 unmapped reads added to the end

It can be used with the existing human_g1k_v37.20.21.fasta reference in
src/test/resources/large

Tests that use this new file will be coming in a future branch.