### PR TITLE
Validation of sequence dictionaries from multiple BAMs now throws warning instead of exception in CNV workflows.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
@@ -318,11 +318,11 @@ public final class DetermineGermlineContigPloidy extends CommandLineProgram {
             logger.info(String.format("Aggregating read-count file %s (%d / %d)",
                     inputReadCountFile, sampleIndex + 1, numSamples));
             final SimpleCountCollection readCounts = SimpleCountCollection.read(inputReadCountFile);
-            Utils.validateArg(CopyNumberArgumentValidationUtils.isSameDictionary(
-                    readCounts.getMetadata().getSequenceDictionary(),
-                    metadata.getSequenceDictionary()),
-                    String.format("Sequence dictionary for read-count file %s does not match those " +
-                            "in other read-count files.", inputReadCountFile));
+            if (!CopyNumberArgumentValidationUtils.isSameDictionary(
+                    readCounts.getMetadata().getSequenceDictionary(), metadata.getSequenceDictionary())) {
+                logger.warn("Sequence dictionary for read-count file %s does not match that " +
+                        "in other read-count files.", inputReadCountFile);
+            }
             Utils.validateArg(readCounts.getIntervals().equals(intervals),
                     String.format("Intervals for read-count file %s do not match those in other " +
                             "read-count files.", inputReadCountFile));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
@@ -389,11 +389,11 @@ public final class GermlineCNVCaller extends CommandLineProgram {
             logger.info(String.format("Aggregating read-count file %s (%d / %d)",
                     inputReadCountFile, sampleIndex + 1, numSamples));
             final SimpleCountCollection readCounts = SimpleCountCollection.read(inputReadCountFile);
-            Utils.validateArg(CopyNumberArgumentValidationUtils.isSameDictionary(
-                    readCounts.getMetadata().getSequenceDictionary(),
-                    specifiedIntervals.getMetadata().getSequenceDictionary()),
-                    String.format("Sequence dictionary for read-count file %s does not match those in " +
-                            "other read-count files.", inputReadCountFile));
+            if (!CopyNumberArgumentValidationUtils.isSameDictionary(
+                    readCounts.getMetadata().getSequenceDictionary(), specifiedIntervals.getMetadata().getSequenceDictionary())) {
+                logger.warn("Sequence dictionary for read-count file %s does not match that " +
+                        "in other read-count files.", inputReadCountFile);
+            }
             Utils.validateArg(new HashSet<>(readCounts.getIntervals()).containsAll(intervalSubset),
                     String.format("Intervals for read-count file %s do not contain all specified intervals.",
                             inputReadCountFile));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
@@ -634,10 +634,11 @@ public final class ModelSegments extends CommandLineProgram {
                         "Run CollectAllelicCounts using the same interval list of sites for both samples.");
             }
             final SampleLocatableMetadata normalMetadata = normalAllelicCounts.getMetadata();
-            Utils.validateArg(CopyNumberArgumentValidationUtils.isSameDictionary(
+            if (!CopyNumberArgumentValidationUtils.isSameDictionary(
                     normalMetadata.getSequenceDictionary(),
-                    metadata.getSequenceDictionary()),
-                    "Sequence dictionaries in allelic-count files do not match.");
+                    metadata.getSequenceDictionary())) {
+                logger.warn("Sequence dictionaries in allelic-count files do not match.");
+            }
 
             //filter on total count in matched normal
             logger.info(String.format("Filtering allelic counts in matched normal with total count less than %d...", minTotalAlleleCount));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/arguments/CopyNumberArgumentValidationUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/arguments/CopyNumberArgumentValidationUtils.java
@@ -115,8 +115,9 @@ public final class CopyNumberArgumentValidationUtils {
         logger.info("Reading and validating GC-content annotations for intervals...");
         final AnnotatedIntervalCollection annotatedIntervals = new AnnotatedIntervalCollection(annotatedIntervalsFile);
         final SAMSequenceDictionary sequenceDictionary = locatableCollection.getMetadata().getSequenceDictionary();
-        Utils.validateArg(annotatedIntervals.getMetadata().getSequenceDictionary().isSameDictionary(sequenceDictionary),
-                "Annotated-intervals file contains incorrect sequence dictionary.");
+        if (!CopyNumberArgumentValidationUtils.isSameDictionary(annotatedIntervals.getMetadata().getSequenceDictionary(), sequenceDictionary)) {
+            logger.warn("Sequence dictionary in annotated-intervals file does not match the master sequence dictionary.");
+        }
         Utils.validateArg(annotatedIntervals.getIntervals().equals(locatableCollection.getIntervals()),
                 "Annotated intervals do not match provided intervals.");
         return annotatedIntervals;
@@ -140,8 +141,9 @@ public final class CopyNumberArgumentValidationUtils {
         IOUtils.canReadFile(annotatedIntervalsFile);
         final AnnotatedIntervalCollection annotatedIntervals = new AnnotatedIntervalCollection(annotatedIntervalsFile);
         final SAMSequenceDictionary sequenceDictionary = locatableCollection.getMetadata().getSequenceDictionary();
-        Utils.validateArg(annotatedIntervals.getMetadata().getSequenceDictionary().isSameDictionary(sequenceDictionary),
-                "Annotated-intervals file contains incorrect sequence dictionary.");
+        if (!CopyNumberArgumentValidationUtils.isSameDictionary(annotatedIntervals.getMetadata().getSequenceDictionary(), sequenceDictionary)) {
+            logger.warn("Sequence dictionary in annotated-intervals file does not match the master sequence dictionary.");
+        }
         final Set<SimpleInterval> intervalsSubset = new HashSet<>(locatableCollection.getIntervals());
         Utils.validateArg(annotatedIntervals.getIntervals().containsAll(intervalsSubset),
                 "Annotated intervals do not contain all specified intervals.");

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegmentsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegmentsIntegrationTest.java
@@ -170,18 +170,6 @@ public final class ModelSegmentsIntegrationTest extends CommandLineProgramTest {
         runCommandLine(argsBuilder);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testSequenceDictionaryMismatch() {
-        final File outputDir = createTempDir("testDir");
-        final String outputPrefix = "test";
-        final ArgumentsBuilder argsBuilder = new ArgumentsBuilder()
-                .addArgument(CopyNumberStandardArgument.ALLELIC_COUNTS_FILE_LONG_NAME, TUMOR_ALLELIC_COUNTS_FILE.getAbsolutePath())
-                .addArgument(CopyNumberStandardArgument.NORMAL_ALLELIC_COUNTS_FILE_LONG_NAME, NORMAL_ALLELIC_COUNTS_FILE_WITH_SEQUENCE_DICTIONARY_MISMATCH.getAbsolutePath())
-                .addOutput(outputDir)
-                .addArgument(CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, outputPrefix);
-        runCommandLine(argsBuilder);
-    }
-
     @Test(expectedExceptions = UserException.class)
     public void testOutputDirExists() {
         final String outputPrefix = "test";


### PR DESCRIPTION
Unfortunately, projects like TCGA with BAMs from different sequencing centers do not use the exact same sequence dictionary across them.  I've relaxed validation in cases where dictionaries are checked across different BAMs so that only a warning is thrown; however, cases where dictionaries should arise from the same BAM still throw an exception.