### PR TITLE
fixes and refactoring methods in SparkUtils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
@@ -26,6 +26,7 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadToBDGAlignmentRecordConverter;
+import org.broadinstitute.hellbender.utils.read.HeaderlessSAMRecordCoordinateComparator;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
 import org.seqdoop.hadoop_bam.*;
@@ -34,6 +35,7 @@ import scala.Tuple2;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 
 /**
  * ReadsSparkSink writes GATKReads to a file. This code lifts from the HadoopGenomics/Hadoop-BAM
@@ -42,6 +44,36 @@ import java.io.IOException;
 public final class ReadsSparkSink {
 
     private final static Logger logger = LogManager.getLogger(ReadsSparkSink.class);
+
+    /**
+     * Sorts the given reads according to the sort order in the header.
+     * @param reads the reads to sort
+     * @param header the header specifying the sort order,
+     *               if the header specifies {@link SAMFileHeader.SortOrder#unsorted} or {@link SAMFileHeader.SortOrder#unknown}
+     *               then no sort will be performed
+     * @param numReducers the number of reducers to use; a value of 0 means use the default number of reducers
+     * @return a sorted RDD of reads
+     */
+    public static JavaRDD<SAMRecord> sortSamRecordsToMatchHeader(final JavaRDD<SAMRecord> reads, final SAMFileHeader header, final int numReducers) {
+        final Comparator<SAMRecord> comparator = getSAMRecordComparator(header);
+        if ( comparator == null ) {
+            return reads;
+        } else {
+            return SparkUtils.sortUsingElementsAsKeys(reads, comparator, numReducers);
+        }
+    }
+
+    //Returns the comparator to use or null if no sorting is required.
+    private static Comparator<SAMRecord> getSAMRecordComparator(final SAMFileHeader header) {
+        switch (header.getSortOrder()){
+            case coordinate: return new HeaderlessSAMRecordCoordinateComparator(header);
+            //duplicate isn't supported because it doesn't work right on headerless SAMRecords
+            case duplicate: throw new UserException.UnimplementedFeature("The sort order \"duplicate\" is not supported in Spark.");
+            case queryname:
+            case unsorted:   return header.getSortOrder().getComparatorInstance();
+            default:         return null; //NOTE: javac warns if you have this (useless) default BUT it errors out if you remove this default.
+        }
+    }
 
     // Output format class for writing BAM files through saveAsNewAPIHadoopFile. Must be public.
     public static class SparkBAMOutputFormat extends KeyIgnoringBAMOutputFormat<NullWritable> {
@@ -284,7 +316,7 @@ public final class ReadsSparkSink {
             final JavaSparkContext ctx, final String outputFile, final String referenceFile, final SAMFormat samOutputFormat, final JavaRDD<SAMRecord> reads,
             final SAMFileHeader header, final int numReducers, final String outputPartsDir) throws IOException {
 
-        final JavaRDD<SAMRecord> sortedReads = SparkUtils.sortSamRecordsToMatchHeader(reads, header, numReducers);
+        final JavaRDD<SAMRecord> sortedReads = sortSamRecordsToMatchHeader(reads, header, numReducers);
         final String outputPartsDirectory = (outputPartsDir == null)? getDefaultPartsDirectory(outputFile)  : outputPartsDir;
         saveAsShardedHadoopFiles(ctx, outputPartsDirectory, referenceFile, samOutputFormat, sortedReads,  header, false);
         logger.info("Finished sorting the bam file and dumping read shards to disk, proceeding to merge the shards into a single file using the master thread");

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
@@ -22,12 +22,10 @@ import org.bdgenomics.adam.models.SequenceDictionary;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadToBDGAlignmentRecordConverter;
-import org.broadinstitute.hellbender.utils.read.HeaderlessSAMRecordCoordinateComparator;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
 import org.seqdoop.hadoop_bam.*;
@@ -36,7 +34,6 @@ import scala.Tuple2;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Comparator;
 
 /**
  * ReadsSparkSink writes GATKReads to a file. This code lifts from the HadoopGenomics/Hadoop-BAM
@@ -287,7 +284,7 @@ public final class ReadsSparkSink {
             final JavaSparkContext ctx, final String outputFile, final String referenceFile, final SAMFormat samOutputFormat, final JavaRDD<SAMRecord> reads,
             final SAMFileHeader header, final int numReducers, final String outputPartsDir) throws IOException {
 
-        final JavaRDD<SAMRecord> sortedReads = SparkUtils.sortReads(reads, header, numReducers);
+        final JavaRDD<SAMRecord> sortedReads = SparkUtils.sortSamRecordsToMatchHeader(reads, header, numReducers);
         final String outputPartsDirectory = (outputPartsDir == null)? getDefaultPartsDirectory(outputFile)  : outputPartsDir;
         saveAsShardedHadoopFiles(ctx, outputPartsDirectory, referenceFile, samOutputFormat, sortedReads,  header, false);
         logger.info("Finished sorting the bam file and dumping read shards to disk, proceeding to merge the shards into a single file using the master thread");

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -182,7 +182,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         // Reads must be coordinate sorted to use the overlaps partitioner
         final SAMFileHeader readsHeader = header.clone();
         readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-        final JavaRDD<GATKRead> coordinateSortedReads = SparkUtils.coordinateSortReads(reads, readsHeader, numReducers);
+        final JavaRDD<GATKRead> coordinateSortedReads = SparkUtils.sortReadsAccordingToHeader(reads, readsHeader, numReducers);
 
         final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, false, false, readsHeader, new ReferenceMultiSourceAdapter(reference));
         final JavaRDD<VariantContext> variants = callVariantsWithHaplotypeCaller(ctx, coordinateSortedReads, readsHeader, reference, intervals, hcArgs, shardingArgs);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -181,7 +181,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
             // the overlaps partitioner requires that reads are coordinate-sorted
             final SAMFileHeader readsHeader = header.clone();
             readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-            markedFilteredReadsForBQSR = SparkUtils.coordinateSortReads(markedFilteredReadsForBQSR, readsHeader, numReducers);
+            markedFilteredReadsForBQSR = SparkUtils.sortReadsAccordingToHeader(markedFilteredReadsForBQSR, readsHeader, numReducers);
         }
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -90,13 +90,12 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
                                          final MarkDuplicatesScoringStrategy scoringStrategy,
                                          final OpticalDuplicateFinder opticalDuplicateFinder,
                                          final int numReducers, final boolean dontMarkUnmappedMates) {
-        JavaRDD<GATKRead> sortedReadsForMarking;
         SAMFileHeader headerForTool = header.clone();
 
         // If the input isn't queryname sorted, sort it before duplicate marking
-        sortedReadsForMarking = querynameSortReadsIfNecessary(reads, numReducers, headerForTool);
+        final JavaRDD<GATKRead> sortedReadsForMarking = querynameSortReadsIfNecessary(reads, numReducers, headerForTool);
 
-        JavaPairRDD<MarkDuplicatesSparkUtils.IndexPair<String>, Integer> namesOfNonDuplicates = MarkDuplicatesSparkUtils.transformToDuplicateNames(headerForTool, scoringStrategy, opticalDuplicateFinder, sortedReadsForMarking, numReducers);
+        final JavaPairRDD<MarkDuplicatesSparkUtils.IndexPair<String>, Integer> namesOfNonDuplicates = MarkDuplicatesSparkUtils.transformToDuplicateNames(headerForTool, scoringStrategy, opticalDuplicateFinder, sortedReadsForMarking, numReducers);
 
         // Here we explicitly repartition the read names of the unmarked reads to match the partitioning of the original bam
         final JavaRDD<Tuple2<String,Integer>> repartitionedReadNames = namesOfNonDuplicates
@@ -139,7 +138,7 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
             sortedReadsForMarking = reads;
         } else {
             headerForTool.setSortOrder(SAMFileHeader.SortOrder.queryname);
-            sortedReadsForMarking = SparkUtils.querynameSortReads(reads, headerForTool, numReducers);
+            sortedReadsForMarking = SparkUtils.sortReadsAccordingToHeader(reads, headerForTool, numReducers);
         }
         return sortedReadsForMarking;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -133,14 +133,13 @@ public final class MarkDuplicatesSpark extends GATKSparkTool {
     /**
      * Sort reads into queryname order if they are not already sorted
      */
-    protected static JavaRDD<GATKRead> querynameSortReadsIfNecessary(JavaRDD<GATKRead> reads, int numReducers, SAMFileHeader headerForTool) {
+    private static JavaRDD<GATKRead> querynameSortReadsIfNecessary(JavaRDD<GATKRead> reads, int numReducers, SAMFileHeader headerForTool) {
         JavaRDD<GATKRead> sortedReadsForMarking;
         if (ReadUtils.isReadNameGroupedBam(headerForTool)) {
             sortedReadsForMarking = reads;
         } else {
             headerForTool.setSortOrder(SAMFileHeader.SortOrder.queryname);
-            JavaRDD<GATKRead> sortedReads = SparkUtils.querynameSortReads(reads, numReducers);
-            sortedReadsForMarking = ReadsSparkSource.putPairsInSamePartition(headerForTool, sortedReads, JavaSparkContext.fromSparkContext(reads.context()));
+            sortedReadsForMarking = SparkUtils.querynameSortReads(reads, headerForTool, numReducers);
         }
         return sortedReadsForMarking;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -400,6 +400,28 @@ public abstract class BaseTest {
     }
 
     /**
+     * assert that the iterable is sorted according to the comparator
+     */
+    public static <T> void assertSorted(Iterable<T> iterable, Comparator<T> comparator){
+        final Iterator<T> iter = iterable.iterator();
+        assertSorted(iter, comparator);
+    }
+
+    /**
+     * assert that the iterator is sorted according to the comparator
+     */
+    public static <T> void assertSorted(Iterator<T> iterator, Comparator<T> comparator){
+        T previous = null;
+        while(iterator.hasNext()){
+            T current = iterator.next();
+            if( previous != null) {
+                Assert.assertTrue(comparator.compare(previous, current) <= 0, "Expected " + previous + " to be <= " + current);
+            }
+            previous = current;
+        }
+    }
+
+    /**
      * Get a FileSystem that uses the explicit credentials instead of the default
      * credentials.
      *

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -18,6 +18,7 @@ import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.test.ReadTestUtils;
 import org.seqdoop.hadoop_bam.SplittingBAMIndexer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -25,13 +26,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 
 public class ReadsSparkSinkUnitTest extends GATKBaseTest {

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -1,26 +1,41 @@
 package org.broadinstitute.hellbender.utils.spark;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import htsjdk.samtools.*;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.Partition;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
+import org.broadinstitute.hellbender.utils.read.ReadQueryNameComparator;
 import org.broadinstitute.hellbender.utils.test.MiniClusterUtils;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.assertEquals;
 
 public class SparkUtilsUnitTest extends GATKBaseTest {
 
     @Test
-    public void testConvertHeaderlessHadoopBamShardToBam() throws Exception {
+    public void testConvertHeaderlessHadoopBamShardToBam() {
         final File bamShard = new File(publicTestDir + "org/broadinstitute/hellbender/utils/spark/reads_data_source_test1.bam.headerless.part-r-00000");
         final File output = createTempFile("testConvertHadoopBamShardToBam", ".bam");
         final File headerSource = new File(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam");
@@ -69,6 +84,157 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
             fs.deleteOnExit(tempPath);
             Assert.assertTrue(SparkUtils.pathExists(ctx, tempPath));
         });
+    }
 
+    @DataProvider(name="readPairsAndPartitions")
+    public Object[][] readPairsAndPartitions() {
+        return new Object[][] {
+                // number of pairs, number of partitions, number of reads per pair,  expected reads per partition
+                { 1, 1, 2, new int[] {2} },
+                { 2, 2, 2, new int[] {4, 0} },
+                { 3, 2, 2, new int[] {4, 2} },
+                { 3, 3, 2, new int[] {4, 2, 0} },
+                { 6, 2, 2, new int[] {8, 4} },
+                { 6, 3, 2, new int[] {6, 4, 2} },
+                { 6, 4, 2, new int[] {4, 4, 2, 2} },
+                { 2, 2, 3, new int[] {6, 0} },
+                { 3, 2, 10, new int[] {20, 10} },
+                { 6, 4, 3, new int[] {6, 6, 3, 3} },
+                { 20, 7, 5, new int[] {15, 15, 15, 15, 15, 15, 10} },
+        };
+    }
+
+    @Test(dataProvider = "readPairsAndPartitions")
+    public void testPutReadsWithSameNameInSamePartition(int numPairs, int numPartitions, int numReadsInPair, int[] expectedReadsPerPartition) {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        JavaRDD<GATKRead> reads =  ctx.parallelize(createPairedReads(header, numPairs, numReadsInPair), numPartitions);
+        JavaRDD<GATKRead> pairedReads = SparkUtils.putReadsWithTheSameNameInTheSamePartition(header, reads, ctx);
+        List<List<GATKRead>> partitions = pairedReads.mapPartitions((FlatMapFunction<Iterator<GATKRead>, List<GATKRead>>) it ->
+                Iterators.singletonIterator(Lists.newArrayList(it))).collect();
+        assertEquals(partitions.size(), numPartitions);
+        for (int i = 0; i < numPartitions; i++) {
+            assertEquals(partitions.get(i).size(), expectedReadsPerPartition[i]);
+        }
+        assertEquals(Arrays.stream(expectedReadsPerPartition).sum(), numPairs * numReadsInPair);
+    }
+
+    private static List<GATKRead> createPairedReads(SAMFileHeader header, int numPairs, int numReadsInPair) {
+        final int readSize = 151;
+        final int fragmentLen = 400;
+        final String templateName = "readpair";
+        int leftStart = 10000;
+        List<GATKRead> reads = new ArrayList<>();
+        for (int i = 0; i < numPairs;i++) {
+            leftStart += readSize * 2;
+            int rightStart = leftStart + fragmentLen - readSize;
+            reads.addAll(ArtificialReadUtils.createPair(header, templateName + i, readSize, leftStart, rightStart, true, false));
+            // Copying a secondary alignment for the second read to fill out the read group
+            GATKRead readToCopy = reads.get(reads.size()-1).copy();
+            readToCopy.setIsSecondaryAlignment(true);
+            for (int j = 2; j < numReadsInPair; j++) {
+                reads.add(readToCopy.copy());
+            }
+        }
+        return reads;
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testReadsPairsSpanningMultiplePartitionsCrash() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        List<GATKRead> reads = createPairedReads(header, 40, 2);
+        // Creating one group in the middle that should cause problems
+        reads.addAll(40, createPairedReads(header, 1, 30));
+
+        JavaRDD<GATKRead> problemReads = ctx.parallelize(reads,5 );
+        SparkUtils.putReadsWithTheSameNameInTheSamePartition(header, problemReads, ctx);
+    }
+
+    @Test
+    public void testReadsMustBeQueryGroupedToFixPartitions(){
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        List<GATKRead> reads = createPairedReads(header, 40, 2);
+        final JavaRDD<GATKRead> readsRDD = ctx.parallelize(reads, 5);
+        Assert.assertThrows(IllegalArgumentException.class, () -> SparkUtils.putReadsWithTheSameNameInTheSamePartition(header, readsRDD, ctx));
+    }
+
+    @Test
+    public void testSortCoordinateSort() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        List<GATKRead> reads = new ArrayList<>();
+        for(int i = 0; i < 2000; i++){
+            //create reads with alternating contigs and  decreasing start position
+            reads.add(ArtificialReadUtils.createArtificialRead(header, "READ"+i, i % header.getSequenceDictionary().size() , 3000 - i, 100));
+        }
+        final JavaRDD<GATKRead> readsRDD = ctx.parallelize(reads);
+        final List<GATKRead> coordinateSorted = SparkUtils.coordinateSortReads(readsRDD, header, 0).collect();
+        assertSorted(coordinateSorted, new ReadCoordinateComparator(header));
+        assertSorted(coordinateSorted.stream().map(read -> read.convertToSAMRecord(header)).collect(Collectors.toList()), new SAMRecordCoordinateComparator());
+    }
+
+    @Test
+    public void testSortQuerynameSort() {
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        List<GATKRead> reads = new ArrayList<>();
+        final int numReads = 2000;
+        for(int i = 0; i < numReads; i++) {
+
+            //create reads with non-lexicographically ordered names
+            //names are created in lexicographically decreasing order, with 2 repetitions to create "pairs"
+            reads.add(ArtificialReadUtils.createArtificialRead(header, "READ" + (numReads - i) % (numReads / 2),
+                                                               i % header.getSequenceDictionary().size(),
+                                                               3000 - i,
+                                                               100));
+        }
+        header.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        final JavaRDD<GATKRead> readsRDD = ctx.parallelize(reads);
+        final List<GATKRead> querynameSorted = SparkUtils.querynameSortReads(readsRDD, header, 31).collect();
+        assertSorted(querynameSorted, new ReadQueryNameComparator());
+        assertSorted(querynameSorted.stream().map(read -> read.convertToSAMRecord(header)).collect(Collectors.toList()), new SAMRecordQueryNameComparator());
+    }
+
+    @Test
+    public void testSortQuerynameFixesPartitionBoundaries(){
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        final int numReadsWithSameName = 4;
+        final List<GATKRead> pairedReads = createPairedReads(header, 100, numReadsWithSameName);
+        final int numPartitions = 7;
+        final JavaRDD<GATKRead> reads = ctx.parallelize(pairedReads, numPartitions);
+
+        //assert that the grouping is not correct before sorting
+        final List<GATKRead>[] partitions = reads.collectPartitions(IntStream.range(0, reads.getNumPartitions()).toArray());
+        Assert.assertTrue(
+                Arrays.stream(partitions)
+                        //look through each partition and count the number of each read name seen
+                        .flatMap( readsInPartition -> readsInPartition.stream()
+                            .collect(Collectors.groupingBy(GATKRead::getName))
+                            .values()
+                            .stream()
+                            .map(List::size)
+                        )
+                        //check that at least one partition was not correctly distributed
+                .anyMatch(size -> size != numReadsWithSameName), "The partitioning was correct before sorting so the test is meaningless.");
+
+        final JavaRDD<GATKRead> sorted = SparkUtils.querynameSortReads(reads, header, numPartitions);
+
+        //assert that the grouping is fixed after sorting
+        final List<GATKRead>[] sortedPartitions = sorted.collectPartitions(IntStream.range(0, sorted.getNumPartitions()).toArray());
+        Assert.assertTrue(Arrays.stream(sortedPartitions)
+                .flatMap( readsInPartition -> readsInPartition.stream()
+                        .collect(Collectors.groupingBy(GATKRead::getName))
+                        .values()
+                        .stream()
+                        .map(List::size)
+                )
+                .allMatch(size -> size == numReadsWithSameName), "Some reads names were split between multiple partitions");
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/ReadTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/ReadTestUtils.java
@@ -1,15 +1,8 @@
 package org.broadinstitute.hellbender.utils.test;
 
-import htsjdk.samtools.Cigar;
-import htsjdk.samtools.CigarElement;
-import htsjdk.samtools.CigarOperator;
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.*;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.util.SequenceUtil;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 


### PR DESCRIPTION
* fix partitioning bug by moving edge fixing from coordinateSortReads -> querynameSortReads
* refactor methods to reduce code duplication
* renaming and moving some methods
* disallow duplicate sort order on spark because it doesn't work with headerless reads