### PR TITLE
Fix bug in sv copy script

### DIFF
--- a/scripts/sv/copy_sv_results.sh
+++ b/scripts/sv/copy_sv_results.sh
@@ -40,8 +40,8 @@ SV_ARGS=${*:-${SV_ARGS:-""}}
 
 # get appropriate ZONE for cluster
 echo "CLUSTER_INFO=\$(gcloud dataproc clusters list --project=${PROJECT_NAME} --filter='clusterName=${CLUSTER_NAME}')"
-CLUSTER_INFO=$(gcloud dataproc clusters list --project=${PROJECT_NAME} --filter="clusterName=${CLUSTER_NAME}")
-ZONE=$(echo "${CLUSTER_INFO}" | awk 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } } { print $(f["ZONE"]) }' | tail -1)
+CLUSTER_INFO=$(gcloud dataproc clusters list --project=${PROJECT_NAME} --filter="clusterName=${CLUSTER_NAME}" --format="csv(NAME, WORKER_COUNT, PREEMPTIBLE_WORKER_COUNT, STATUS, ZONE)")
+ZONE=$(echo "${CLUSTER_INFO}" | tail -1 | cut -d"," -f 5)
 echo "Zone = $ZONE"
 if [ -z "${ZONE}" ]; then
     # cluster is down.
@@ -72,7 +72,9 @@ else
     COUNT_FILES_CMD="hadoop fs -count /${RESULTS_DIR}/ | tr -s ' ' | cut -d ' ' -f 3"
     NUM_FILES=$(gcloud compute ssh ${MASTER} --zone ${ZONE} --project ${PROJECT_NAME} --command="${COUNT_FILES_CMD}")
     # 2) get the number of instances
-    NUM_INSTANCES=$(echo "${CLUSTER_INFO}" | awk 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } } { print $(f["WORKER_COUNT"]) + $(f["PREEMPTIBLE_WORKER_COUNT"]) }' | tail -1)
+    NUM_WORKERS=$(echo "${CLUSTER_INFO}" | tail -1 | cut -d"," -f 2)
+    NUM_PREEMPTIBLE_WORKERS=$(echo "${CLUSTER_INFO}" | tail -1 | cut -d"," -f 3)
+    NUM_INSTANCES=`echo "${NUM_WORKERS} + ${NUM_PREEMPTIBLE_WORKERS:-0}" | bc`
     echo "Num Instances: $NUM_INSTANCES"
     # 3) choose number of maps as min of NUM_FILES or NUM_INSTANCES * MAPS_PER_INSTANCE
     MAPS_PER_INSTANCE=10


### PR DESCRIPTION
The SV copy results script has to figure out the total number of workers including standard and preemptibles. The current version of the script had an error in parsing the `gcloud compute dataproc clusters list` command, which left a blank field when no preemptibles were used that couldn't be parsed because it was displayed in fixed-width format. This switches to the CSV format option for the cluster list command, making it easier to parse.