### PR TITLE
Addressing issue #4712

### DIFF
--- a/scripts/funcotator/data_sources/getGencode.sh
+++ b/scripts/funcotator/data_sources/getGencode.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+################################################################################
+
+# Creates a set of files that allows for creating annotations based off dbSNP
+# Pulled directly from the ncbi FTP site.
+
+################################################################################
+
+#Setup variables for the script:
+SCRIPTDIR="$( cd -P "$( dirname "$0" )" && pwd )"
+SCRIPTNAME=$( echo $0 | sed 's#.*/##g' )
+MINARGS=0
+MAXARGS=0
+
+# Latest release numbers for our references.
+# Update these numbers when a new Gencode is released.
+LATEST_HG19_RELEASE=19
+LATEST_HG38_RELEASE=28
+
+DATA_SOURCE_NAME="Gencode"
+OUT_DIR_NAME='gencode'
+
+# Check if we have samtools installed so we can index our fasta files:
+HAS_SAMTOOLS=false
+which samtools &> /dev/null
+r=$?
+[[ $r -eq 0 ]] && HAS_SAMTOOLS=true
+
+################################################################################
+
+set -e
+
+################################################################################
+
+function simpleUsage()
+{
+  echo -e "Usage: $SCRIPTNAME [OPTIONS] ..."
+  echo -e "Creates the data sources folder for gencode for the GATK Funcotator tool."
+}
+
+#Define a usage function:
+function usage()
+{
+  simpleUsage
+  echo -e ""
+  echo -e "Will download all data sources directly from the Gencode website:"
+  echo -e "    https://www.gencodegenes.org"
+  echo -e ""
+  echo -e "Return values:"
+  echo -e "  0  NORMAL"
+  echo -e "  1  TOO MANY ARGUMENTS"
+  echo -e "  2  TOO FEW ARGUMENTS"
+  echo -e "  3  UNKNOWN ARGUMENT"
+  echo -e "  4  BAD CHECKSUM"
+  echo -e "  5  OUTPUT DIRECTORY ALREADY EXISTS"
+  echo -e ""
+}
+
+#Display a message to std error:
+function error()
+{
+  echo "$1" 2>&1
+}
+
+TMPFILELIST=''
+function makeTemp()
+{
+  local f
+  f=$( mktemp )
+  TMPFILELIST="${TMPFILELIST} $f"
+  echo $f
+}
+
+function cleanTempVars()
+{
+  rm -f ${TMPFILELIST}
+}
+
+function at_exit()
+{
+  cleanTempVars
+}
+
+################################################################################
+
+
+function createConfigFile() {
+
+    local dataSourceName=$1
+    local version=$2
+    local srcFile=$3
+    local originLocation=$4
+    local fastaPath=$5
+
+    echo "name = ${dataSourceName}"
+    echo "version = ${version}"
+    echo "src_file = ${srcFile}"
+    echo "origin_location = ${originLocation}"
+    echo "preprocessing_script = ${SCRIPTNAME} , fixGencodeOrdering.py"
+    echo ""
+    echo "# Supported types:"
+    echo "# simpleXSV    -- Arbitrary separated value table (e.g. CSV), keyed off Gene Name OR Transcript ID"
+    echo "# locatableXSV -- Arbitrary separated value table (e.g. CSV), keyed off a genome location"
+    echo "# gencode      -- Custom datasource class for GENCODE"
+    echo "# cosmic       -- Custom datasource class for COSMIC"
+    echo "# vcf          -- Custom datasource class for Variant Call Format (VCF) files"
+    echo "type = gencode"
+    echo ""
+    echo "# Required field for GENCODE files."
+    echo "# Path to the FASTA file from which to load the sequences for GENCODE transcripts:"
+    echo "gencode_fasta_path = ${fastaPath}"
+    echo ""
+    echo "# Required field for simpleXSV files."
+    echo "# Valid values:"
+    echo "#     GENE_NAME"
+    echo "#     TRANSCRIPT_ID"
+    echo "xsv_key ="
+    echo ""
+    echo "# Required field for simpleXSV files."
+    echo "# The 0-based index of the column containing the key on which to match"
+    echo "xsv_key_column ="
+    echo ""
+    echo "# Required field for simpleXSV AND locatableXSV files."
+    echo "# The delimiter by which to split the XSV file into columns."
+    echo "xsv_delimiter ="
+    echo ""
+    echo "# Required field for simpleXSV files."
+    echo "# Whether to permissively match the number of columns in the header and data rows"
+    echo "# Valid values:"
+    echo "#     true"
+    echo "#     false"
+    echo "xsv_permissive_cols ="
+    echo ""
+    echo "# Required field for locatableXSV files."
+    echo "# The 0-based index of the column containing the contig for each row"
+    echo "contig_column ="
+    echo ""
+    echo "# Required field for locatableXSV files."
+    echo "# The 0-based index of the column containing the start position for each row"
+    echo "start_column ="
+    echo ""
+    echo "# Required field for locatableXSV files."
+    echo "# The 0-based index of the column containing the end position for each row"
+    echo "end_column ="
+    echo ""
+
+}
+
+function getGencodeFiles()
+{
+    local version=$1
+    local refVersion=$2
+
+    echo "##################################################################################"
+    echo "Processing ${refVersion} - Gencode ${version} ..."
+    echo "===================================="
+
+    mkdir -p ${OUT_DIR_NAME}/${refVersion}
+    pushd ${OUT_DIR_NAME}/${refVersion} &> /dev/null
+    wget ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_${version}/gencode.v${version}.annotation.gtf.gz
+    wget ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_${version}/gencode.v${version}.pc_transcripts.fa.gz
+
+    gunzip gencode.v${version}.annotation.gtf.gz
+    gunzip gencode.v${version}.pc_transcripts.fa.gz
+
+    # We must fix the information in the gencode gtf file:
+    echo "Reordering Gencode GTF data ..."
+    ${SCRIPTDIR}/fixGencodeOrdering.py gencode.v${version}.annotation.gtf > gencode.v${version}.annotation.REORDERED.gtf
+
+    # Clean up original file:
+    rm gencode.v${version}.annotation.gtf
+
+    echo "Creating config file ..."
+    createConfigFile "${DATA_SOURCE_NAME}" "${version}" "gencode.v${version}.annotation.REORDERED.gtf" "ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_${version}/gencode.v${version}.annotation.gtf.gz" "gencode.v${version}.pc_transcripts.fa" > gencode.config
+
+    if $HAS_SAMTOOLS ; then
+        echo "Indexing Fasta File: gencode.v${version}.pc_transcripts.fa"
+        samtools faidx gencode.v${version}.pc_transcripts.fa
+    fi
+
+    echo
+    popd > /dev/null
+}
+
+################################################################################
+
+trap at_exit EXIT
+
+################################################################################
+
+#Check given arguments:
+if [[ $# -gt $MAXARGS ]] ; then
+  usage
+  exit 1
+elif [[ $# -lt $MINARGS ]] ; then
+  usage
+  exit 2
+fi
+
+################################################################################
+
+#Read args:
+while [ $# -gt 0 ] ; do
+
+  case "$1" in
+    -h|--h|--help|-help|help)
+      usage;
+      exit 0;
+      ;;
+    *)
+      error "${SCRIPTNAME}: invalid option: $1"
+      simpleUsage
+      echo "Try \`$SCRIPTNAME --help' for more information."
+      exit 3;
+    ;;
+  esac
+
+  #Get next argument in $1:
+  shift
+done
+
+################################################################################
+# Do the work here:
+
+# Make sure we don't have anything in our out folder already:
+if [[ -d ${OUT_DIR_NAME} ]] ; then
+    error "Output directory already exists: ${OUT_DIR_NAME} - aborting!"
+    exit 5
+fi
+
+# Get the link for HG19:
+getGencodeFiles $LATEST_HG19_RELEASE hg19
+
+# Get the link for HG38:
+getGencodeFiles $LATEST_HG38_RELEASE hg38
+
+if ! $HAS_SAMTOOLS ; then
+    echo -e "\033[1;33;40m##################################################################################\033[0;0m"
+    echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+    echo -e "\033[1;33;40m# \033[1;5;37;41mWARNING\033[0;0m: You \033[4;37;40mMUST\033[0;0m index both Gencode Fasta files before using this data source \033[1;33;40m#\033[0;0m"
+    echo -e "\033[1;33;40m#             Use samtools faidx <FASTA_FILE>                                    #\033[0;0m"
+    echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+    echo -e "\033[1;33;40m##################################################################################\033[0;0m"
+fi
+
+
+echo -e "\033[1;33;40m##################################################################################\033[0;0m"
+echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+echo -e "\033[1;33;40m# \033[1;5;37;41mWARNING\033[0;0m: You \033[4;37;40mMUST\033[0;0m create sequence dictionaries for both Gencode Fasta files #\033[0;0m"
+echo -e "\033[1;33;40m#             before using this data source.                                     #\033[0;0m"
+echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+echo -e "\033[1;33;40m#             Use gatk CreateSequenceDictionary <FASTA_FILE>                     #\033[0;0m"
+echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+echo -e "\033[1;33;40m# \033[1;5;37;41mWARNING\033[0;0m: You \033[4;37;40mMUST\033[0;0m ALSO index the Gencode GTF files for both HG19 and HG38 #\033[0;0m"
+echo -e "\033[1;33;40m#             before using this data source.                                     #\033[0;0m"
+echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+echo -e "\033[1;33;40m#             Use gatk IndexFeatureFile <GTF_FILE>                               #\033[0;0m"
+echo -e "\033[1;33;40m#                                                                                #\033[0;0m"
+echo -e "\033[1;33;40m##################################################################################\033[0;0m"
+
+exit 0
+

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
@@ -589,12 +589,15 @@ final public class DataSourceUtils {
             return false;
         }
 
-        if ( month < MIN_MONTH_RELEASED ) {
-            return false;
-        }
-
-        if ( day < MIN_DAY_RELEASED ) {
-            return false;
+        else if ( year == MIN_YEAR_RELEASED ) {
+            if ( month < MIN_MONTH_RELEASED ) {
+                return false;
+            }
+            else if ( month == MIN_MONTH_RELEASED ) {
+                if ( day < MIN_DAY_RELEASED ) {
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gencode/GencodeGtfCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gencode/GencodeGtfCodec.java
@@ -63,7 +63,7 @@ final public class GencodeGtfCodec extends AbstractFeatureCodec<GencodeGtfFeatur
     static final Logger logger = LogManager.getLogger(GencodeGtfCodec.class);
 
     public static final int GENCODE_GTF_MIN_VERSION_NUM_INCLUSIVE = 19;
-    public static final int GENCODE_GTF_MAX_VERSION_NUM_INCLUSIVE = 27;
+    public static final int GENCODE_GTF_MAX_VERSION_NUM_INCLUSIVE = 28;
 
     public static final String GENCODE_GTF_FILE_EXTENSION = "gtf";
     public static final String GENCODE_GTF_FILE_PREFIX = "gencode";
@@ -610,7 +610,8 @@ final public class GencodeGtfCodec extends AbstractFeatureCodec<GencodeGtfFeatur
             }
         }
 
-        if ( !header.get(2).endsWith("@sanger.ac.uk") ) {
+        if ( !header.get(2).endsWith("@sanger.ac.uk") &&
+             !header.get(2).endsWith("@ebi.ac.uk") ) {
             if ( throwIfInvalid ) {
                 throw new UserException.MalformedFile(
                         "GENCODE GTF Header line 2 does not contain expected contact email address (" +

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -181,24 +181,24 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
     @DataProvider
     public Object[][] provideForLargeDataValidationTest() {
         return new Object[][] {
-//                {
-//                        "M2_01115161-TA1-filtered.vcf",
-//                        "Homo_sapiens_assembly19.fasta",
-//                        true,
-//                        FuncotatorTestConstants.REFERENCE_VERSION_HG19,
-//                },
-//                {
-//                        "C828.TCGA-D3-A2JP-06A-11D-A19A-08.3-filtered.PASS.vcf",
-//                        "Homo_sapiens_assembly19.fasta",
-//                        true,
-//                        FuncotatorTestConstants.REFERENCE_VERSION_HG19
-//                },
-//                {
-//                        "hg38_test_variants.vcf",
-//                        "Homo_sapiens_assembly38.fasta",
-//                        false,
-//                        FuncotatorTestConstants.REFERENCE_VERSION_HG38
-//                },
+                {
+                        "M2_01115161-TA1-filtered.vcf",
+                        "Homo_sapiens_assembly19.fasta",
+                        true,
+                        FuncotatorTestConstants.REFERENCE_VERSION_HG19,
+                },
+                {
+                        "C828.TCGA-D3-A2JP-06A-11D-A19A-08.3-filtered.PASS.vcf",
+                        "Homo_sapiens_assembly19.fasta",
+                        true,
+                        FuncotatorTestConstants.REFERENCE_VERSION_HG19
+                },
+                {
+                        "hg38_test_variants.vcf",
+                        "Homo_sapiens_assembly38.fasta",
+                        false,
+                        FuncotatorTestConstants.REFERENCE_VERSION_HG38
+                },
                 {
                         "sample21.trimmed.vcf",
                         "Homo_sapiens_assembly38.fasta",

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -29,7 +29,7 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
 
     // Whether to do debug output (i.e. leave output around).
     // This should always be false when checked in.
-    private static final boolean doDebugTests           = false;
+    private static final boolean doDebugTests             = false;
     private static final String  LARGE_DATASOURCES_FOLDER = "funcotator_dataSources_latest";
 
     static {
@@ -181,20 +181,26 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
     @DataProvider
     public Object[][] provideForLargeDataValidationTest() {
         return new Object[][] {
+//                {
+//                        "M2_01115161-TA1-filtered.vcf",
+//                        "Homo_sapiens_assembly19.fasta",
+//                        true,
+//                        FuncotatorTestConstants.REFERENCE_VERSION_HG19,
+//                },
+//                {
+//                        "C828.TCGA-D3-A2JP-06A-11D-A19A-08.3-filtered.PASS.vcf",
+//                        "Homo_sapiens_assembly19.fasta",
+//                        true,
+//                        FuncotatorTestConstants.REFERENCE_VERSION_HG19
+//                },
+//                {
+//                        "hg38_test_variants.vcf",
+//                        "Homo_sapiens_assembly38.fasta",
+//                        false,
+//                        FuncotatorTestConstants.REFERENCE_VERSION_HG38
+//                },
                 {
-                        "M2_01115161-TA1-filtered.vcf",
-                        "Homo_sapiens_assembly19.fasta",
-                        true,
-                        FuncotatorTestConstants.REFERENCE_VERSION_HG19,
-                },
-                {
-                        "C828.TCGA-D3-A2JP-06A-11D-A19A-08.3-filtered.PASS.vcf",
-                        "Homo_sapiens_assembly19.fasta",
-                        true,
-                        FuncotatorTestConstants.REFERENCE_VERSION_HG19
-                },
-                {
-                        "hg38_test_variants.vcf",
+                        "sample21.trimmed.vcf",
                         "Homo_sapiens_assembly38.fasta",
                         false,
                         FuncotatorTestConstants.REFERENCE_VERSION_HG38

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/DataProviderForMuc16IndelData.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/DataProviderForMuc16IndelData.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A class to hold Indel data for MUC16 tests.
+ * Created by jonn on 5/15/18.
+ */
+public class DataProviderForMuc16IndelData {
+
+    static List<Object[]> provideIndelDataForMuc16() {
+        return Arrays.asList(
+                // These exercise a test case for issue 4712 (https://github.com/broadinstitute/gatk/issues/4712):
+                new Object[]{ "MUC16", 19, 9091890, 9091890, GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, GencodeFuncotation.VariantType.INS, "T", "ATTCG", "g.chr19:9091890_9091891insATTCG", "-", null, null, null },
+                new Object[]{ "MUC16", 19, 9091890, 9091890, GencodeFuncotation.VariantClassification.DE_NOVO_START_OUT_FRAME, GencodeFuncotation.VariantType.INS, "T", "CGCAT", "g.chr19:9091890_9091891insCGCA", "-", null, null, null },
+                new Object[]{ "MUC16", 19, 9091890, 9091890, GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, GencodeFuncotation.VariantType.INS, "T", "GCATC", "g.chr19:9091890_9091891insGCATC", "-", null, null, null }
+        );
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -358,13 +358,16 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
     Object[][] provideDataForCreateFuncotations() {
         final List<Object[]> outList = new ArrayList<>();
 
-        // MUC13 SNPs / DNPs:
+        // MUC16 SNPs / DNPs:
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_1(),       FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_2(),       FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_3(),       FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_4(),       FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_5(),       FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideEdgeCasesForMUC16Data_1(), FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+
+        // MUC16 INDELs:
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16IndelData.provideIndelDataForMuc16(), FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME, muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
 
         // PIK3CA SNPs / DNPs:
         outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caMnpData(), FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME, pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE ) );


### PR DESCRIPTION
Added in a script to pull down the latest Gencode data source.
Fixed an issue in 5' UTR processing that would cause variant alleles with length > 1 to throw an exception (issue 4712).
Added three test cases to prevent regression of issue 4712.
Updated Gencode codec to be compatible with latest Gencode release (v28).
Fixed a bug in the version detection for Funcotator data sources that would prevent newer data source versions from being detected as compatible (date comparison error).