### PR TITLE
Fixes PairedStrandedIntervalTree

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/PairedStrandedIntervalTree.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/PairedStrandedIntervalTree.java
@@ -311,9 +311,25 @@ public class PairedStrandedIntervalTree<V> implements Iterable<Tuple2<PairedStra
         }
     }
 
+    private void serialize(final Kryo kryo, final Output output) {
+        kryo.writeClassAndObject(output, this);
+    }
+
+    @DefaultSerializer(PairedStrandedIntervalTree.LeftEndEntry.Serializer.class)
     static final class LeftEndEntry<V> {
-        final SVIntervalTree<RightEndEntry<V>> posStrandEntries = new SVIntervalTree<>();
-        final SVIntervalTree<RightEndEntry<V>> negStrandEntries = new SVIntervalTree<>();
+        final SVIntervalTree<RightEndEntry<V>> posStrandEntries;
+        final SVIntervalTree<RightEndEntry<V>> negStrandEntries;
+
+        public LeftEndEntry() {
+            posStrandEntries = new SVIntervalTree<>();
+            negStrandEntries = new SVIntervalTree<>();
+        }
+
+        @SuppressWarnings("unchecked")
+        public LeftEndEntry(final Kryo kryo, final Input input) {
+            posStrandEntries = (SVIntervalTree<RightEndEntry<V>>) kryo.readClassAndObject(input);
+            negStrandEntries = (SVIntervalTree<RightEndEntry<V>>) kryo.readClassAndObject(input);
+        }
 
         public SVIntervalTree<RightEndEntry<V>> getPosStrandEntries() {
             return posStrandEntries;
@@ -322,11 +338,38 @@ public class PairedStrandedIntervalTree<V> implements Iterable<Tuple2<PairedStra
         public SVIntervalTree<RightEndEntry<V>> getNegStrandEntries() {
             return negStrandEntries;
         }
+
+        public static final class Serializer<V> extends com.esotericsoftware.kryo.Serializer<PairedStrandedIntervalTree.LeftEndEntry<V>> {
+            @Override
+            public void write(final Kryo kryo, final Output output, final LeftEndEntry<V> entry) {
+                entry.serialize(kryo, output);
+            }
+
+            @Override
+            public LeftEndEntry<V> read(final Kryo kryo, final Input input, final Class<LeftEndEntry<V>> type) {
+                return new LeftEndEntry<>(kryo, input);
+            }
+        }
+
+        private void serialize(final Kryo kryo, final Output output) {
+            kryo.writeClassAndObject(output, posStrandEntries);
+            kryo.writeClassAndObject(output, negStrandEntries);
+        }
     }
 
+    @DefaultSerializer(PairedStrandedIntervalTree.RightEndEntry.Serializer.class)
     static final class RightEndEntry<V> {
         V posStrandValue;
         V negStrandValue;
+
+        public RightEndEntry() {
+        }
+
+        @SuppressWarnings("unchecked")
+        public RightEndEntry(final Kryo kryo, final Input input) {
+            posStrandValue = (V) kryo.readClassAndObject(input);
+            negStrandValue = (V) kryo.readClassAndObject(input);
+        }
 
         public V getPosStrandValue() {
             return posStrandValue;
@@ -347,9 +390,23 @@ public class PairedStrandedIntervalTree<V> implements Iterable<Tuple2<PairedStra
         public boolean isEmpty() {
             return posStrandValue == null && negStrandValue == null;
         }
+
+        public static final class Serializer<V> extends com.esotericsoftware.kryo.Serializer<PairedStrandedIntervalTree.RightEndEntry<V>> {
+            @Override
+            public void write(final Kryo kryo, final Output output, final RightEndEntry<V> entry) {
+                entry.serialize(kryo, output);
+            }
+
+            @Override
+            public RightEndEntry<V> read(final Kryo kryo, final Input input, final Class<RightEndEntry<V>> type) {
+                return new RightEndEntry<>(kryo, input);
+            }
+        }
+
+        private void serialize(final Kryo kryo, final Output output) {
+            kryo.writeClassAndObject(output, posStrandValue);
+            kryo.writeClassAndObject(output, negStrandValue);
+        }
     }
 
-    private void serialize(final Kryo kryo, final Output output) {
-        kryo.writeClassAndObject(output, this);
-    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/PairedStrandedIntervalTreeTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/PairedStrandedIntervalTreeTest.java
@@ -41,9 +41,13 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
                         new StrandedInterval(new SVInterval(1, 550, 650),
                         true));
 
+        Assert.assertEquals(psiTree.size(), 0);
         psiTree.put(v1, 1);
+        Assert.assertEquals(psiTree.size(), 1);
         psiTree.put(v2, 2);
+        Assert.assertEquals(psiTree.size(), 2);
         psiTree.put(v3, 3);
+        Assert.assertEquals(psiTree.size(), 3);
 
         Iterator<Tuple2<PairedStrandedIntervals, Integer>> overlappers = psiTree.overlappers(query);
         Assert.assertFalse(overlappers.hasNext());
@@ -62,6 +66,7 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
         Assert.assertEquals(next._1(), v1);
         Assert.assertEquals(next._2().intValue(), 1);
         overlappers.remove();
+        Assert.assertEquals(psiTree.size(), 2);
 
         Assert.assertTrue(overlappers.hasNext());
         next = overlappers.next();
@@ -106,12 +111,12 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
         Iterator<Tuple2<PairedStrandedIntervals, Integer>> iterator = psiTree.iterator();
         Assert.assertTrue(iterator.hasNext());
         Tuple2<PairedStrandedIntervals, Integer> out1 = iterator.next();
-        Assert.assertEquals(v2, out1._1());
-        Assert.assertEquals(2, out1._2().intValue());
+        Assert.assertEquals(out1._1(), v2);
+        Assert.assertEquals(out1._2().intValue(), 2);
         Assert.assertTrue(iterator.hasNext());
         Tuple2<PairedStrandedIntervals, Integer> out2 = iterator.next();
-        Assert.assertEquals(v1, out2._1());
-        Assert.assertEquals(1, out2._2().intValue());
+        Assert.assertEquals(out2._1(), v1);
+        Assert.assertEquals(out2._2().intValue(), 1);
 
     }
 
@@ -134,7 +139,9 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
                         true));
 
         psiTree.put(v1, 1);
+        Assert.assertEquals(psiTree.size(), 1);
         psiTree.put(v2, 2);
+        Assert.assertEquals(psiTree.size(), 2);
 
         Iterator<Tuple2<PairedStrandedIntervals, Integer>> iterator = psiTree.iterator();
         Assert.assertTrue(iterator.hasNext());
@@ -143,6 +150,7 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
         Assert.assertEquals(2, out1._2().intValue());
 
         iterator.remove();
+        Assert.assertEquals(psiTree.size(), 1);
 
         Assert.assertTrue(iterator.hasNext());
         Tuple2<PairedStrandedIntervals, Integer> out2 = iterator.next();
@@ -157,10 +165,65 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
 
         iterator.remove();
         Assert.assertFalse(iterator.hasNext());
+        Assert.assertEquals(psiTree.size(), 0);
 
         iterator = psiTree.iterator();
         Assert.assertFalse(iterator.hasNext());
 
+
+    }
+
+    @Test(groups = "sv")
+    public void testIteratorRemove_sharedLeftIntervals() {
+        final PairedStrandedIntervalTree<Integer> psiTree = new PairedStrandedIntervalTree<>();
+
+        final PairedStrandedIntervals v1 =
+                new PairedStrandedIntervals(
+                        new StrandedInterval(new SVInterval(1, 100, 200),
+                                true),
+                        new StrandedInterval(new SVInterval(1, 500, 600),
+                                false));
+
+        final PairedStrandedIntervals v2 =
+                new PairedStrandedIntervals(
+                        new StrandedInterval(new SVInterval(1, 100, 200),
+                                false),
+                        new StrandedInterval(new SVInterval(1, 800, 900),
+                                true));
+
+        final PairedStrandedIntervals v3 =
+                new PairedStrandedIntervals(
+                        new StrandedInterval(new SVInterval(1, 400, 500),
+                                false),
+                        new StrandedInterval(new SVInterval(1, 800, 900),
+                                true));
+
+        psiTree.put(v1, 1);
+        Assert.assertEquals(psiTree.size(), 1);
+        psiTree.put(v2, 2);
+        Assert.assertEquals(psiTree.size(), 2);
+
+        psiTree.put(v3, 3);
+        Assert.assertEquals(psiTree.size(), 3);
+
+        Iterator<Tuple2<PairedStrandedIntervals, Integer>> iterator = psiTree.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        Tuple2<PairedStrandedIntervals, Integer> out1 = iterator.next();
+        Assert.assertEquals(v1, out1._1());
+        Assert.assertEquals(1, out1._2().intValue());
+
+        Assert.assertTrue(iterator.hasNext());
+        Tuple2<PairedStrandedIntervals, Integer> out2 = iterator.next();
+        Assert.assertEquals(v2, out2._1());
+        Assert.assertEquals(2, out2._2().intValue());
+
+        iterator.remove();
+        Assert.assertEquals(psiTree.size(), 2);
+        Assert.assertTrue(iterator.hasNext());
+
+        Tuple2<PairedStrandedIntervals, Integer> out3 = iterator.next();
+        Assert.assertEquals(v3, out3._1());
+        Assert.assertEquals(3, out3._2().intValue());
 
     }
 
@@ -185,6 +248,20 @@ public class PairedStrandedIntervalTreeTest extends GATKBaseTest {
                         true));
 
         Assert.assertFalse(psiTree.contains(query2));
+
+        PairedStrandedIntervals query3 =
+                new PairedStrandedIntervals(
+                        new StrandedInterval(new SVInterval(1, 100, 200),
+                                false),
+                        new StrandedInterval(new SVInterval(1, 500, 600),
+                                true));
+
+        Assert.assertFalse(psiTree.contains(query3));
+
+        Assert.assertEquals( psiTree.put(query3, 3), null);
+        Assert.assertTrue(psiTree.contains(query3));
+        Assert.assertTrue(psiTree.contains(query));
+
     }
 
 }


### PR DESCRIPTION
The current implementation of `PairedStrandedIntervalTree` contains a few bugs and a few inefficiencies. The most important bug is the fact that it could not store two different entries with the same left interval but different left strands. This PR attempts to fix that. Unfortunately fixing that issue required a near-total re-write of the class. The rewritten version also introduces several efficiency improvements such as not calling `contains()` whenever `put()` is called (which essentially did two lookups) and tracking the size of the data structure instead of re-computing it each time.