### PR TITLE
fix MarkDuplicatesSpark serialization crash

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -2,7 +2,9 @@ package org.broadinstitute.hellbender.engine.spark;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.google.common.collect.ImmutableMap;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
+import de.javakaffee.kryoserializers.guava.ImmutableMapSerializer;
 import htsjdk.samtools.*;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
@@ -67,6 +69,10 @@ public class GATKRegistrator implements KryoRegistrator {
         kryo.register(Collections.unmodifiableMap(Collections.EMPTY_MAP).getClass(), new UnmodifiableCollectionsSerializer());
 
         kryo.register(Collections.unmodifiableList(Collections.EMPTY_LIST).getClass(), new UnmodifiableCollectionsSerializer());
+
+        kryo.register(ImmutableMap.of().getClass(), new ImmutableMapSerializer());
+        kryo.register(ImmutableMap.of("one","element").getClass(), new ImmutableMapSerializer());
+        kryo.register(ImmutableMap.of("map","with","multiple","elements").getClass(), new ImmutableMapSerializer());
 
         kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -7,7 +7,6 @@ import com.google.common.collect.*;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.metrics.MetricsFile;
-import org.apache.parquet.Ints;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
@@ -104,7 +104,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
     }
 
     //test that MarkDuplicatesSpark doesn't explode on a tiny file
-    @Test
+    @Test(groups = {"cloud", "bucket"})
     public void markDuplicatesSparkOnDataproc() throws IOException {
         final String gcsInputPath = getGCPTestInputPath() + "large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam";
         final String bamOut = BucketUtils.getTempFilePath(getGCPTestStaging(), ".bam");

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.hellbender.engine.spark;
 
+import com.google.common.collect.Iterators;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintReadsSpark;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintVariantsSpark;
+import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -99,5 +101,31 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
         Files.delete(output);
         Files.copy(input, output);
         return output.toFile();
+    }
+
+    //test that MarkDuplicatesSpark doesn't explode on a tiny file
+    @Test
+    public void markDuplicatesSparkOnDataproc() throws IOException {
+        final String gcsInputPath = getGCPTestInputPath() + "large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam";
+        final String bamOut = BucketUtils.getTempFilePath(getGCPTestStaging(), ".bam");
+        final String metricsOut = BucketUtils.getTempFilePath(getGCPTestStaging(), ".metrics");
+
+        final ArgumentsBuilder argBuilder = new ArgumentsBuilder();
+        argBuilder.addArgument("I", gcsInputPath)
+                .addArgument("O", bamOut)
+                .addArgument("M", metricsOut);
+
+        DataprocTestUtils.launchGatkTool(MarkDuplicatesSpark.class.getSimpleName(), argBuilder.getArgsList(), clusterName);
+        final File actual = copyLocally(bamOut, "actual");
+
+        //assert that the output has the right number of reads and they're ordered correctly
+        assertReadsAreInCoordinatishOrder(actual);
+        try( ReadsDataSource reader = new ReadsDataSource(actual.toPath())){
+            Assert.assertEquals(Iterators.size(reader.iterator()), 1838);
+        }
+
+        //and that the metrics file is not empty
+        Assert.assertTrue( Files.size(IOUtils.getPath(metricsOut)) > 0);
+
     }
 }


### PR DESCRIPTION
* register the variants of ImmutableMap that we use in MarkDuplicatesSpark with appropriate serializers
* fixes #4775