### PR TITLE
Inversion breakpoint linking (no merge yet)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/StructuralVariationDiscoveryPipelineSpark.java
@@ -18,8 +18,8 @@ import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariantDisc
 import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection.DiscoverVariantsFromContigAlignmentsSparkArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.AnnotatedVariantProducer;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.SvDiscoverFromLocalAssemblyContigAlignmentsSpark;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.SvDiscoveryInputMetaData;
@@ -231,7 +231,7 @@ public class StructuralVariationDiscoveryPipelineSpark extends GATKSparkTool {
                 outputPrefixWithSampleName,
                 assembledEvidenceResults.getReadMetadata(), assembledEvidenceResults.getAssembledIntervals(),
                 makeEvidenceLinkTree(assembledEvidenceResults.getEvidenceTargetLinks()),
-                cnvCallsBroadcast, getHeaderForReads(), getReference(), localLogger);
+                cnvCallsBroadcast, evidenceAndAssemblyArgs.fastqDir, getHeaderForReads(), getReference(), localLogger);
     }
 
     public static Broadcast<SVIntervalTree<VariantContext>> broadcastCNVCalls(final JavaSparkContext ctx,

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromContigAlignmentsSAMSpark.java
@@ -131,7 +131,7 @@ public final class DiscoverVariantsFromContigAlignmentsSAMSpark extends GATKSpar
         final SvDiscoveryInputMetaData svDiscoveryInputMetaData =
                 new SvDiscoveryInputMetaData(ctx, discoverStageArgs, null, vcfOutputPath,
                         null, null, null,
-                        cnvCallsBroadcast,
+                        cnvCallsBroadcast, null,
                         getHeaderForReads(), getReference(), localLogger);
 
         final JavaRDD<AlignedContig> parsedContigAlignments =

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoverFromLocalAssemblyContigAlignmentsSpark.java
@@ -175,6 +175,12 @@ public final class SvDiscoverFromLocalAssemblyContigAlignmentsSpark extends GATK
 
     private void validateParams() {
         discoverStageArgs.validate();
+
+        if (nonCanonicalChromosomeNamesFile!=null)
+            IOUtils.assertFileIsReadable(IOUtils.getPath(nonCanonicalChromosomeNamesFile));
+
+        if ( fastqDir != null && Files.notExists(IOUtils.getPath(fastqDir)) )
+            throw new UserException("Provided fastq dir: " + fastqDir + " doesn't exist");
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoveryInputMetaData.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SvDiscoveryInputMetaData.java
@@ -71,18 +71,22 @@ public final class SvDiscoveryInputMetaData {
     public static final class SampleSpecificData {
         private final String sampleId;
 
+        private final String pathToAssemblyFastqDir;
+
         private final ReadMetadata readMetadata;
         private final Broadcast<SAMFileHeader> headerBroadcast;
         private final Broadcast<SVIntervalTree<VariantContext>> cnvCallsBroadcast;
         private final PairedStrandedIntervalTree<EvidenceTargetLink> evidenceTargetLinks;
         private final List<SVInterval> assembledIntervals;
 
-        public SampleSpecificData(final String sampleId, final Broadcast<SVIntervalTree<VariantContext>> cnvCallsBroadcast,
+        public SampleSpecificData(final String sampleId, final String pathToAssemblyFastqDir,
+                                  final Broadcast<SVIntervalTree<VariantContext>> cnvCallsBroadcast,
                                   final List<SVInterval> assembledIntervals,
                                   final PairedStrandedIntervalTree<EvidenceTargetLink> evidenceTargetLinks,
                                   final ReadMetadata readMetadata,
                                   final Broadcast<SAMFileHeader> headerBroadcast) {
             this.sampleId = sampleId;
+            this.pathToAssemblyFastqDir = pathToAssemblyFastqDir;
             this.cnvCallsBroadcast = cnvCallsBroadcast;
             this.assembledIntervals = assembledIntervals;
             this.evidenceTargetLinks = evidenceTargetLinks;
@@ -92,6 +96,10 @@ public final class SvDiscoveryInputMetaData {
 
         public String getSampleId() {
             return sampleId;
+        }
+
+        public String getPathToAssemblyFastqDir() {
+            return pathToAssemblyFastqDir;
         }
 
         public ReadMetadata getReadMetadata() {
@@ -133,6 +141,7 @@ public final class SvDiscoveryInputMetaData {
                                     final List<SVInterval> assembledIntervals,
                                     final PairedStrandedIntervalTree<EvidenceTargetLink> evidenceTargetLinks,
                                     final Broadcast<SVIntervalTree<VariantContext>> cnvCallsBroadcast,
+                                    final String pathToAssemblyFastqDir,
                                     final SAMFileHeader headerForReads,
                                     final ReferenceMultiSource reference,
                                     final Logger toolLogger) {
@@ -143,7 +152,7 @@ public final class SvDiscoveryInputMetaData {
         final String sampleId = SVUtils.getSampleId(headerForReads);
 
         this.referenceData = new ReferenceData(canonicalChromosomesBroadcast, ctx.broadcast(reference), ctx.broadcast(sequenceDictionary));
-        this.sampleSpecificData = new SampleSpecificData(sampleId, cnvCallsBroadcast, assembledIntervals, evidenceTargetLinks, readMetadata, ctx.broadcast(headerForReads));
+        this.sampleSpecificData = new SampleSpecificData(sampleId, pathToAssemblyFastqDir, cnvCallsBroadcast, assembledIntervals, evidenceTargetLinks, readMetadata, ctx.broadcast(headerForReads));
         this.discoverStageArgs = discoverStageArgs;
         this.outputPath = outputPath;
         this.toolLogger = toolLogger;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantReInterpreterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/CpxVariantReInterpreterSpark.java
@@ -85,7 +85,7 @@ public class CpxVariantReInterpreterSpark extends GATKSparkTool {
         final SvDiscoveryInputMetaData svDiscoveryInputMetaData =
                 new SvDiscoveryInputMetaData(ctx, discoverStageArgs, nonCanonicalChromosomeNamesFile,
                         derivedSimpleVCFPrefix,
-                        null, null, null, null,
+                        null, null, null, null, null,
                         headerForReads, getReference(), localLogger);
 
         final JavaRDD<VariantContext> complexVariants = new VariantsSparkSource(ctx)

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/InversionBreakendInterpreterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/InversionBreakendInterpreterSpark.java
@@ -1,0 +1,167 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.inference;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariantDiscoveryProgramGroup;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
+import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVLocalContext;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVVCFWriter;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
+
+import java.util.List;
+
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.SVLocalContext.InvBreakEndContext;
+
+/**
+ * (Internal) Given GATK-SV discovery pipeline output VCF files and fastq files of short reads sent for local assembly,
+ * interpret inversions.
+ *
+ * <p>
+ *     This is an experimental tool and should not be of interest to most researchers.
+ *     It scans the input VCF file containing BND records,
+ *     applies a primitive filtering step, then
+ *     tries to make inversion calls on BND records that pass the filter.
+ *     Note that BND records that don't pass the filtering step
+ *     are NOT necessarily bad variants, it is simply an indication
+ *     that this tool's logic is not applicable to them.
+ * </p>
+ *
+ * <h3>Inputs</h3>
+ * <ul>
+ *     <li>GATK-SV discovery pipeline output simple variant vcf</li>
+ *     <li>GATK-SV discovery pipeline output simple variant vcf</li>
+ *     <li>Path to directory containing FASTQ files used for local assembly in the discovery pipeline</li>
+ * </ul>
+ *
+ * <h3>Output</h3>
+ * <ul>
+ *     <li>BED file annotating BND records that are not suited for this tool</li>
+ *     <li>VCF containing inversion calls, and when available, associated deletion and duplication calls</li>
+ *     <li>(optional) intermediate files used in making the records in the above VCF file</li>
+ * </ul>
+ *
+ * <h3>Usage example</h3>
+ * <pre>
+ *   gatk InversionBreakendInterpreterSpark \
+ *     -R reference.2bit \
+ *     -O pathToOutput \
+ *     --simple-vcf \
+ *     --cpx-vcf \
+ *     --intermediate-files # optional
+ * </pre>
+ *
+ * <h3>Notes</h3>
+ * <p>The reference is broadcast by Spark, and must therefore be a .2bit file due to current restrictions.</p>
+ */
+@DocumentedFeature
+@BetaFeature
+@CommandLineProgramProperties(
+        oneLineSummary = "(Internal) Examines aligned contigs from local assemblies and calls structural variants or their breakpoints",
+        summary =
+                "This tool is used in development and should not be of interest to most researchers. It is a prototype of" +
+                        " structural variant calling, and has been under active developments. For more stable version," +
+                        " please see DiscoverVariantsFromContigAlignmentsSAMSpark." +
+                        " This tool takes a file containing the alignments of assembled contigs" +
+                        " (typically the output file produced by FindBreakpointEvidenceSpark) and searches for reads with" +
+                        " split alignments or large gaps indicating the presence of structural variation breakpoints." +
+                        " Variations' types are determined by analyzing the signatures of the split alignments," +
+                        " and are written to VCF files in the designated output directory.",
+        programGroup = StructuralVariantDiscoveryProgramGroup.class)
+public final class InversionBreakendInterpreterSpark extends GATKSparkTool {
+    private static final long serialVersionUID = 1L;
+    private final Logger localLogger = LogManager.getLogger(InversionBreakendInterpreterSpark.class);
+
+    @Argument(doc = "input VCF containing simple variants, particularly BND variants that are inversion breakpoint suspects",
+            fullName = "simple-vcf")
+    private String nonComplexVCF;
+
+    @Argument(doc = "file containing complex variants as output by GATK-SV",
+            fullName = "cpx-vcf")
+    private String complexVCF;
+
+    @Argument(doc = "path to directory containing fastqs",
+            fullName = "fastqDir")
+    private String pathToFastqsDir;
+
+    @Argument(doc = "path to a (temporary) path on a local FS to score bwa mem reference index files",
+            fullName = "local-fs-temp-dir")
+    private String localFileSystemTempDir;
+
+    @Argument(doc = "prefix for where to dump results, including intermediate files (if requested via --intermediate-files)",
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
+    private String outputPrefix;
+
+    @Argument(doc = "flag to indicate intermediate files (alignments of short reads to artificial references) are requested",
+            fullName = "intermediate-files", optional = true)
+    @Advanced
+    private Boolean dumpIntermediateFiles = false;
+
+    @Argument(doc = "", fullName = "mate-dist-threshold")
+    @Advanced
+    private Integer mateDistanceThreshold = 100_000;
+
+    @Argument(doc = "", fullName = "contig-mq-filter")
+    @Advanced
+    private Integer contigMQFilter = 30;
+
+
+    @Override
+    public boolean requiresReference() {
+        return true;
+    }
+
+
+    @Override
+    protected void runTool(final JavaSparkContext ctx) {
+
+        validateParamns();
+
+        final ReferenceMultiSource reference = getReference();
+        final List<SimpleInterval> intervals = getIntervals();
+        final VCFHeader vcfHeader = VariantsSparkSource.getHeader(nonComplexVCF);
+        final SAMSequenceDictionary refDict = vcfHeader.getSequenceDictionary();
+        final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
+
+        final JavaRDD<VariantContext> complexVariants = variantsSparkSource.getParallelVariantContexts(complexVCF, intervals);
+        final JavaRDD<InvBreakEndContext> inversionBreakends = variantsSparkSource.getParallelVariantContexts(nonComplexVCF, intervals)
+                .filter(SVLocalContext::indicatesInversion).map(SVLocalContext.InvBreakEndContext::new);
+
+        // note: we are doing this because we know there's going to be only ~500 mate pairs on a particular sample, so paralleling with RDD may hurt performance
+        List<InversionBreakendPreFilter.OverlappingPair> preprocessingResult = InversionBreakendPreFilter
+                .preprocess(inversionBreakends.collect(), complexVariants.collect(),
+                        mateDistanceThreshold, contigMQFilter, outputPrefix, refDict, localLogger);
+
+        final List<VariantContext> variantContexts = LinkedInversionBreakpointsInference
+                .makeInterpretation(preprocessingResult, pathToFastqsDir, reference, localLogger);
+
+        // TODO: 5/16/18 artifact that we currently don't have sample columns for discovery VCF (until genotyping code is in)
+        final String sampleId = "sample";
+        final String vcfName = outputPrefix + (outputPrefix.endsWith("/") ? "" : "/") + sampleId + "_inversions_from_bnds.vcf" ;
+        SVVCFWriter.writeVCF(variantContexts, vcfName, refDict, localLogger);
+    }
+
+    private void validateParamns() {
+        IOUtils.assertFileIsReadable(IOUtils.getPath(nonComplexVCF));
+        IOUtils.assertFileIsReadable(IOUtils.getPath(complexVCF));
+        ParamUtils.isPositiveOrZero(mateDistanceThreshold,
+                "Invalid value provided to mateDistanceThreshold: " + mateDistanceThreshold);
+        ParamUtils.isPositiveOrZero(contigMQFilter,
+                "Invalid value provided to contigMQFilter: " + contigMQFilter);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/InversionBreakendPreFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/InversionBreakendPreFilter.java
@@ -1,0 +1,247 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.inference;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFConstants;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVLocalContext;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.SVLocalContext.InvBreakEndContext;
+
+/**
+ * Strategy is to perform pre-filtering upfront because they are likely to be artifact or different types:
+ *
+ * 1) first filter out BND records that are (see {@link PrimitiveFilteringResult}):
+ *      a) inter-chromosome, no SS, 2nd in mate (redundant),
+ *      b) badly supported by MQ,
+ *      c) mates too far away,
+ *      d) covered by CPX variants
+ *
+ * then convert the paired mate locations into boundaries of an interval, then
+ *
+ * 2) filter out intervals that are (see {@link OverlapBasedFilteringResult}:
+ *      a) overlaps with multiple other intervals
+ *      b) overlaps with no other intervals (including those that only overlaps with the "popular" ones mentioned above)
+ *      c) overlaps with one other interval of the same type (INV55/55 or INV33/33 pairs)
+ *
+ * The resulting INV33/55 pairs are then returned.
+ */
+final class InversionBreakendPreFilter {
+
+    private enum ReasonForFilter {
+        LOW_MQ, MATE_DISTANCE, COVERED_BY_CPX,
+        NO_OVERLAPPER, MULTIPLE_OVERLAPPER,
+        SAME_DIRECTION_OVERLAPPER // INV55/33 overlapping with INV55/33
+    }
+
+    public static final class OverlappingPair implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        protected final InvBreakEndContext fivePrimeBreakEnd;
+        protected final InvBreakEndContext threePrimeBreakEnd;
+
+        protected final String chr;
+        protected final int fiveIntervalLeftBoundary;
+        protected final int fiveIntervalRightBoundary;
+        protected final int threeIntervalLeftBoundary;
+        protected final int threeIntervalRightBoundary;
+
+        OverlappingPair(final SVLocalContext.InvBreakEndContext first, final SVLocalContext.InvBreakEndContext second) {
+
+            if (first.isType33()) {
+                fivePrimeBreakEnd = second;
+                threePrimeBreakEnd = first;
+            } else {
+                fivePrimeBreakEnd = first;
+                threePrimeBreakEnd = second;
+            }
+            chr = fivePrimeBreakEnd.getContig();
+            fiveIntervalLeftBoundary = fivePrimeBreakEnd.getStart();
+            fiveIntervalRightBoundary = fivePrimeBreakEnd.getMateRefLoc().getEnd();
+            threeIntervalLeftBoundary = threePrimeBreakEnd.getStart();
+            threeIntervalRightBoundary = threePrimeBreakEnd.getMateRefLoc().getEnd();
+        }
+    }
+
+    // note: this function takes lists because we know there's going to be only ~500 mate pairs on a particular sample,
+    // so paralleling with RDD may hurt performance
+    static List<OverlappingPair> preprocess(final List<InvBreakEndContext> inversionBreakends,
+                                            final List<VariantContext> complexVariants,
+                                            final Integer mateDistanceThreshold,
+                                            final Integer contigContigMQFilter,
+                                            final String outputPrefix,
+                                            final SAMSequenceDictionary refDict,
+                                            final Logger toolLogger) {
+
+        final PrimitiveFilteringResult preprocessed;
+
+        final Comparator<InvBreakEndContext> invBreakEndContextComparator = InvBreakEndContext.makeComparator(refDict);
+
+        final OverlapBasedFilteringResult overlapBasedFilteringResult;
+
+        return overlapBasedFilteringResult.uniqueHetOverlappers.stream()
+                .sorted((pair1, pair2) -> {
+                    int compare = invBreakEndContextComparator.compare(pair1.fivePrimeBreakEnd, pair2.fivePrimeBreakEnd);
+                    if ( 0 == compare ) {
+                        return invBreakEndContextComparator.compare(pair1.threePrimeBreakEnd, pair2.threePrimeBreakEnd);
+                    } else
+                        return compare;
+                }).collect(Collectors.toList());
+    }
+
+    private static final class AnnotatedFilteredInterval {
+        private final SimpleInterval interval;   // interval
+        private final String annotation;
+
+        private AnnotatedFilteredInterval(final SimpleInterval interval, final String annotation) {
+            this.interval = interval;
+            this.annotation = annotation;
+        }
+
+        int compareTo(final AnnotatedFilteredInterval other, final SAMSequenceDictionary refDict) {
+            return IntervalUtils.compareLocatables(interval, other.interval, refDict);
+        }
+
+        private String toBedLine() {
+            return interval.getContig() + "\t" + interval.getStart() + "\t" + interval.getEnd() + "\t" + annotation;
+        }
+    }
+
+    private static void writeBedFileForFilteredVariants(final String outputPrefix,
+                                                        final Stream<AnnotatedFilteredInterval> annotatedMateIntervals) {
+        final String bedOutput = outputPrefix + ".bed";
+        try {
+            Files.write(IOUtils.getPath(bedOutput),
+                    annotatedMateIntervals
+                            .map(interval -> (CharSequence)interval.toBedLine())
+                            .collect(Collectors.toList()));
+        } catch (final IOException ex) {
+            throw new GATKException("Cannot write BED file for filtered INV breakend pairs " + bedOutput);
+        }
+    }
+
+    //==================================================================================================================
+
+    /**
+     * Note that this class holds the 1st mate only,
+     * since we currently don't have records with more than one mate,
+     * hence the only one mate is enough.
+     */
+    private static final class PrimitiveFilteringResult {
+        private final List<InvBreakEndContext> filteredAwayDueToMQ;             // variants whose evidence contigs' MQ are below a specified value
+        private final List<InvBreakEndContext> filteredAwayDueToSize;           // variants whose distance between mates are over a specified value
+        private final Map<InvBreakEndContext, String> coveredByComplexVariants; // variants whose corresponding interval is overlapping a detected Cpx variant
+
+        private final SVIntervalTree<InvBreakEndContext> picked;                // variants picked for downstream analysis
+
+        private PrimitiveFilteringResult(final List<InvBreakEndContext> filteredAwayDueToMQ,
+                                         final List<InvBreakEndContext> filteredAwayDueToSize,
+                                         final SVIntervalTree<InvBreakEndContext> picked) {
+            this.filteredAwayDueToMQ = filteredAwayDueToMQ;
+            this.filteredAwayDueToSize = filteredAwayDueToSize;
+            this.picked = picked;
+            coveredByComplexVariants = new HashMap<>();
+        }
+
+        private void moveFromPickedIfCoveredByComplex(final VariantContext complexVC, final SAMSequenceDictionary refDict) {
+            final SVInterval cpxInterval = new SVInterval(refDict.getSequenceIndex(complexVC.getContig()),
+                    complexVC.getStart() - 1, complexVC.getEnd());
+            if ( picked.hasOverlapper(cpxInterval) ) {
+                picked.overlappers(cpxInterval)
+                        .forEachRemaining(bnd -> {
+                            picked.remove(bnd.getInterval());
+                            coveredByComplexVariants.put(bnd.getValue(), complexVC.getID());
+                        });
+            }
+        }
+
+        private Stream<AnnotatedFilteredInterval> getFilteredVariants() {
+
+            Stream<AnnotatedFilteredInterval> mq = filteredAwayDueToMQ.stream().map(vc ->
+                    new AnnotatedFilteredInterval(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getMateRefLoc().getEnd()),
+                            vc.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.LOW_MQ.name())
+            );
+            Stream<AnnotatedFilteredInterval> dist = filteredAwayDueToSize.stream().map(vc ->
+                    new AnnotatedFilteredInterval(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getMateRefLoc().getEnd()),
+                            vc.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.MATE_DISTANCE.name())
+            );
+            Stream<AnnotatedFilteredInterval> covered = coveredByComplexVariants.entrySet().stream().map(kV -> {
+                        InvBreakEndContext vc = kV.getKey();
+                        return new AnnotatedFilteredInterval(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getMateRefLoc().getEnd()),
+                                vc.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.COVERED_BY_CPX + ":" + kV.getValue());
+            });
+
+            return Stream.of(mq, dist, covered).flatMap(Function.identity());
+        }
+    }
+
+
+    //==================================================================================================================
+
+    /**
+     * Further cuts down the cases to look at after applying filters in {@link PrimitiveFilteringResult},
+     * that is, "filter" out breakends that
+     *   1) is not paired, i.e. the interval bounded by the suggested novel adjacency does not overlap with any other intra-chromosome SS BND s;
+     *   2) is paired with multiple intra-chromosome SS BND s;
+     *   3) is paired with one intra-chromosome SS BND, but a INV55/INV55 or INV33/INV33 pair
+     */
+    private static final class OverlapBasedFilteringResult {
+        private final Set<InvBreakEndContext> noOverlappers;                                        // variants whose has no overlapping INV BND suspects, or whose unique overlapper is one of {@code multipleOverlappers}
+        private final Map<InvBreakEndContext, List<String>> multipleOverlappers;                    // variants who overlaps multiple other records (note: not using map because VC.equals() is hard)
+        private final Set<Tuple2<InvBreakEndContext, InvBreakEndContext>> uniqueStrangeOverlappers; // pairs of variants (INV55/55, INV33/33) that overlap each other uniquely
+
+        private final Set<OverlappingPair> uniqueHetOverlappers;                                    // pairs of variants (INV55/33, INV33/55) that overlap each other uniquely, pairs that will be analyzed
+
+        OverlapBasedFilteringResult(final Set<InvBreakEndContext> noOverlappers,
+                                    final Map<InvBreakEndContext, List<String>> multipleOverlappers,
+                                    final Set<Tuple2<InvBreakEndContext, InvBreakEndContext>> uniqueStrangeOverlappers,
+                                    final Set<OverlappingPair> uniqueHetOverlappers) {
+            this.noOverlappers = noOverlappers;
+            this.multipleOverlappers = multipleOverlappers;
+            this.uniqueStrangeOverlappers = uniqueStrangeOverlappers;
+            this.uniqueHetOverlappers = uniqueHetOverlappers;
+        }
+
+        private Stream<AnnotatedFilteredInterval> getFilteredVariants() {
+
+            Stream<AnnotatedFilteredInterval> lonely = noOverlappers.stream().map(vc ->
+                    new AnnotatedFilteredInterval(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getMateRefLoc().getEnd()),
+                            vc.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.NO_OVERLAPPER.name())
+            );
+            Stream<AnnotatedFilteredInterval> tooPopular = multipleOverlappers.entrySet().stream().map(kV -> {
+                InvBreakEndContext vc = kV.getKey();
+                return new AnnotatedFilteredInterval(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getMateRefLoc().getEnd()),
+                        vc.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.MULTIPLE_OVERLAPPER + ":" + String.join(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR, kV.getValue()));
+            });
+
+            uniqueStrangeOverlappers.stream().flatMap(pair -> {
+                SimpleInterval firstInterval = new SimpleInterval(pair._1.getContig(), pair._1.getStart(), pair._1.getMateRefLoc().getEnd());
+                String firstAnnotation = pair._1.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.MULTIPLE_OVERLAPPER + ":" + pair._2.getID().replaceAll("_1$", "");
+                SimpleInterval secondInterval = new SimpleInterval(pair._2.getContig(), pair._2.getStart(), pair._2.getMateRefLoc().getEnd());
+                String secondAnnotation = pair._2.getID().replaceAll("_1$", "") + ";" + ReasonForFilter.MULTIPLE_OVERLAPPER + ":" + pair._1.getID().replaceAll("_1$", "");
+                return Stream.of(new AnnotatedFilteredInterval(firstInterval, firstAnnotation),
+                                 new AnnotatedFilteredInterval(secondInterval, secondAnnotation));
+            });
+
+            return Stream.of(lonely, tooPopular).flatMap(Function.identity());
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/LinkedInversionBreakpointsInference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/LinkedInversionBreakpointsInference.java
@@ -1,0 +1,84 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.inference;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordComparator;
+import htsjdk.samtools.SAMRecordCoordinateComparator;
+import htsjdk.samtools.util.SequenceUtil;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFConstants;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.datasources.ReferenceMultiSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.SimpleSVType;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.*;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import scala.Tuple2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.broadinstitute.hellbender.tools.spark.sv.discovery.inference.InversionBreakendPreFilter.OverlappingPair;
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.*;
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.SYMB_ALT_ALLELE_INV;
+
+/**
+ * Depending on how the two intervals overlap each other (see {@link OverlappingScenario}),
+ * the signatures tell us what possible types of events are involved.
+ * However, there are possibly some degeneracies in some of the overlap scenarios
+ * that needs to be resolved.
+ */
+final class LinkedInversionBreakpointsInference implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public enum OverlappingScenario {
+        // what it means for possible variation(s) is described in toString()
+        THREE_CONTAINS_FIVE,      // interval from INV33 contains that from INV55
+        FIVE_CONTAINS_THREE,      // interval from INV55 contains that from INV33
+        THREE_INTERLEAVES_FIVE,   // interval from INV33 upstream of that from INV55, but doesn't contain it
+        FIVE_INTERLEAVES_THREE;   // interval from INV55 upstream of that from INV33, but doesn't contain it
+
+        @Override
+        public String toString() { // a "primed-annotated" block is inverted
+            switch (this) {
+                case THREE_CONTAINS_FIVE:
+                    return " ABC -> A(B|B')A' ";
+                case FIVE_CONTAINS_THREE:
+                    return " ABC -> C'(B|B')C ";
+                case THREE_INTERLEAVES_FIVE:
+                    return " ABC -> AC'B'A'C  ";
+                case FIVE_INTERLEAVES_THREE:
+                    return " ABC ->    B'     ";
+                default: throw new IllegalStateException();
+            }
+        }
+
+        String getDescription() {
+            return toString();
+        }
+    }
+
+    //==================================================================================================================
+
+    /**
+     * See {@link OverlappingScenario}
+     */
+    static List<VariantContext> makeInterpretation(final List<OverlappingPair> overlappingPairs,
+                                                   final String pathToFastqsDir,
+                                                   final ReferenceMultiSource reference,
+                                                   final Logger toolLogger) {
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/LinkedInversionBreakpointsInference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/LinkedInversionBreakpointsInference.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 
 import static org.broadinstitute.hellbender.tools.spark.sv.discovery.inference.InversionBreakendPreFilter.OverlappingPair;
 import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.*;
-import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.SYMB_ALT_ALLELE_INV;
 
 /**
  * Depending on how the two intervals overlap each other (see {@link OverlappingScenario}),
@@ -39,8 +38,37 @@ import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConsta
  * However, there are possibly some degeneracies in some of the overlap scenarios
  * that needs to be resolved.
  */
-final class LinkedInversionBreakpointsInference implements Serializable {
+public final class LinkedInversionBreakpointsInference implements Serializable {
     private static final long serialVersionUID = 1L;
+    private static boolean DEV_MODE = false;
+
+    // see StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection.allowedShortFragmentOverhang
+    private static final int ALLOWED_SHORT_FRAGMENT_OVERHANG = 10;
+
+    private static final int PADDING_LENGTH = 6 * 151;     // length of short read assumed to be 151, to be used for padding when constructing artificial reference
+
+    private static final int tempRefFastaLineLength = 100;  // line length for writing out temporary fasta files containing artificial reference sequences
+
+    // TODO: 5/16/18 to be moved to GATKSVVCFConstants
+    static final String INV_FLANKING_MICRO_DEL_KEY = "FLANKING_MICRO_DEL";
+    static final String INV_FLANKING_MICRO_DUP_KEY = "FLANKING_MICRO_DUP";
+    static final String INV_SOURCE_BND_EVENT_KEY = "SOURCE_BNDS";
+    static final String EVENT_TYPE_KEY = "EVENT_TYPE";
+
+    // TODO: 5/16/18 to be moved to SimpleSVType
+    private static final Allele INV_SYMB_ALLELE = Allele.create(SimpleSVType.createBracketedSymbAlleleString(SimpleSVType.SupportedType.INV.name()), false);
+    private static final Allele DEL_SYMB_ALLELE = Allele.create(SimpleSVType.createBracketedSymbAlleleString(SimpleSVType.SupportedType.DEL.name()), false);
+    private static final Allele INS_SYMB_ALLELE = Allele.create(SimpleSVType.createBracketedSymbAlleleString(SimpleSVType.SupportedType.INS.name()), false);
+
+    private static final String DISPERSED_INVERTED_DUPLICATION_UPSTREAM_INSERTION_ORIENTATIONS = "-+";
+    private static final String DISPERSED_INVERTED_DUPLICATION_DOWNSTREAM_INSERTION_ORIENTATIONS = "+-";
+
+    private static String makeID(final String typeName, final String chr, final int start, final int stop) {
+        return typeName + INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                + chr + INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                + start + INTERVAL_VARIANT_ID_FIELD_SEPARATOR
+                + stop;
+    }
 
     public enum OverlappingScenario {
         // what it means for possible variation(s) is described in toString()
@@ -72,13 +100,836 @@ final class LinkedInversionBreakpointsInference implements Serializable {
     //==================================================================================================================
 
     /**
-     * See {@link OverlappingScenario}
+     * Main interface.
+     * Handles overlapping pairs of breakends.
+     * @see OverlappingScenario
      */
-    static List<VariantContext> makeInterpretation(final List<OverlappingPair> overlappingPairs,
-                                                   final String pathToFastqsDir,
-                                                   final ReferenceMultiSource reference,
-                                                   final Logger toolLogger) {
+    public static List<VariantContext> makeInterpretation(final List<OverlappingPair> overlappingPairs,
+                                                          final String pathToFastqsDir,
+                                                          final ReferenceMultiSource reference,
+                                                          final Logger toolLogger) {
 
-        return Collections.emptyList();
+        // two passes on the pairs, one pass to extract relevant short reads, one pass to make inference
+        final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2Reads = extractReads(overlappingPairs, pathToFastqsDir);
+
+        return overlappingPairs.stream()
+                .map(LinkedInversionBreakpointsInference::factory)
+                .flatMap(overlappingPairHandler ->
+                        overlappingPairHandler.toVariants(reference, assemblyID2Reads, pathToFastqsDir).stream())
+                .collect(Collectors.toList());
     }
+
+    //==================================================================================================================
+
+    private abstract static class OverlappingPairHandler implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        protected final OverlappingPair overlappingPair;
+
+        OverlappingPairHandler(final OverlappingPair overlappingPair) {
+            this.overlappingPair = overlappingPair;
+        }
+
+        /**
+         * Inference logic to be implemented case by case.
+         * @param reference         reference for extracting relevant bases
+         * @param assemblyID2Reads  map from assembly ID to short reads used for its assembly process
+         * @param pathToFastqsDir   a development artifact, because we want to save alignment results to file and study
+         * @return                  interpreted variants.
+         */
+        abstract List<VariantContext> toVariants(final ReferenceMultiSource reference,
+                                                 final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2Reads,
+                                                 final String pathToFastqsDir);
+    }
+
+    /**
+     * Depending on overlapping signatures of input {@code overlappingPair},
+     * make appropriate handler using scenarios recognized in {@link OverlappingScenario}.
+     */
+    private static OverlappingPairHandler factory(final OverlappingPair overlappingPair) {
+
+        final SimpleInterval intervalFive = overlappingPair.fivePrimeBreakEnd.getSpanningInterval();
+        final SimpleInterval intervalThree = overlappingPair.threePrimeBreakEnd.getSpanningInterval();
+
+        if (intervalFive.contains(intervalThree)) {
+            return new FiveContainsThree(overlappingPair);
+        } else if (intervalThree.contains(intervalFive)) {
+            return new ThreeContainsFive(overlappingPair);
+        } else if (compareIntervals(intervalFive, intervalThree) <= 0) {
+            return new FiveInterleavesThree(overlappingPair);
+        } else {
+            return new ThreeInterleavesFive(overlappingPair);
+        }
+    }
+
+    //==================================================================================================================
+
+    /**
+     * Scenario where re-alignment of short reads back to artificial reference haplotypes
+     * is NOT necessary
+     * to resolve which variants are here.
+     */
+    abstract static class NonDegenerateScenario extends OverlappingPairHandler {
+        private static final long serialVersionUID = 1L;
+
+        NonDegenerateScenario(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+    }
+    
+    private static final class FiveInterleavesThree extends NonDegenerateScenario {
+        private static final long serialVersionUID = 1L;
+        FiveInterleavesThree(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+
+        // TODO: 5/7/18 refactor the following code and learn from the refactoring made in PR #4602
+        @Override
+        public List<VariantContext> toVariants(final ReferenceMultiSource reference,
+                                               final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2Reads,
+                                               final String pathToFastqsDir) {
+
+            final List<String> contigNames =
+                    Stream.concat(overlappingPair.fivePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES),
+                            overlappingPair.threePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES))
+                            .sorted().distinct().collect(Collectors.toList());
+
+            final String sourceIDs = overlappingPair.fivePrimeBreakEnd.getID().replaceAll("_1$", "")
+                    + VCFConstants.INFO_FIELD_ARRAY_SEPARATOR
+                    + overlappingPair.threePrimeBreakEnd.getID().replaceAll("_1$", "");
+
+
+            final List<VariantContextBuilder> result = new ArrayList<>(3);
+
+
+            byte[] refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr,
+                    overlappingPair.threeIntervalLeftBoundary, overlappingPair.threeIntervalLeftBoundary));
+            final SimpleInterval invertedInterval = new SimpleInterval(overlappingPair.chr,
+                    overlappingPair.threeIntervalLeftBoundary, overlappingPair.fiveIntervalRightBoundary);
+            final VariantContextBuilder inversionBuilder = makeInversion(invertedInterval, Allele.create(refBase, true));
+
+            if ( overlappingPair.threeIntervalLeftBoundary - overlappingPair.fiveIntervalLeftBoundary - 1 > 49 ) {
+                refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary, overlappingPair.fiveIntervalLeftBoundary));
+                final SimpleInterval deletedInterval = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.fiveIntervalLeftBoundary, overlappingPair.threeIntervalLeftBoundary);
+                final VariantContextBuilder leftDel = makeDeletion(deletedInterval, Allele.create(refBase, true));
+                result.add(0, leftDel);
+            } else if (overlappingPair.fiveIntervalLeftBoundary + 1 != overlappingPair.threeIntervalLeftBoundary) {
+                inversionBuilder.attribute(INV_FLANKING_MICRO_DEL_KEY,
+                        new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary + 1, overlappingPair.threeIntervalLeftBoundary - 1).toString());
+            }
+
+            if ( overlappingPair.threeIntervalRightBoundary - overlappingPair.fiveIntervalRightBoundary - 1 > 49 ) {
+                refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary, overlappingPair.fiveIntervalLeftBoundary));
+                final SimpleInterval deletedInterval = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.fiveIntervalRightBoundary, overlappingPair.threeIntervalRightBoundary);
+                final VariantContextBuilder rightDel = makeDeletion(deletedInterval, Allele.create(refBase, true));
+                result.add(rightDel);
+            } else if (overlappingPair.fiveIntervalRightBoundary + 1 != overlappingPair.threeIntervalRightBoundary) {
+                inversionBuilder.attribute(INV_FLANKING_MICRO_DEL_KEY,
+                        new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary + 1, overlappingPair.threeIntervalRightBoundary - 1).toString());
+            }
+
+            result.add(inversionBuilder); // insertion order doesn't matter
+            return result.stream().map(builder ->
+                    builder.attribute(GATKSVVCFConstants.CONTIG_NAMES, contigNames)
+                            .attribute(INV_SOURCE_BND_EVENT_KEY, sourceIDs).make())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static final class ThreeInterleavesFive extends NonDegenerateScenario {
+        private static final long serialVersionUID = 1L;
+        ThreeInterleavesFive(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+
+        @Override
+        public List<VariantContext> toVariants(final ReferenceMultiSource reference,
+                                               final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2Reads,
+                                               final String pathToFastqsDir) {
+
+            final List<String> contigNames =
+                    Stream.concat(overlappingPair.threePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES),
+                            overlappingPair.fivePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES))
+                            .sorted().distinct().collect(Collectors.toList());
+
+            final String sourceIDs = overlappingPair.threePrimeBreakEnd.getID().replaceAll("_1$", "")
+                    + VCFConstants.INFO_FIELD_ARRAY_SEPARATOR
+                    + overlappingPair.fivePrimeBreakEnd.getID().replaceAll("_1$", "");
+
+            final List<VariantContextBuilder> result = new ArrayList<>(3);
+
+            byte[] refBase = getRefBase(reference, SVLocalContext.makeOneBpInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary));
+            final SimpleInterval invertedInterval = new SimpleInterval(overlappingPair.chr,
+                    overlappingPair.fiveIntervalLeftBoundary - 1, overlappingPair.threeIntervalRightBoundary - 1);
+            final VariantContextBuilder inversionBuilder = makeInversion(invertedInterval, Allele.create(refBase, true));
+
+            int svLen = overlappingPair.fiveIntervalLeftBoundary - overlappingPair.threeIntervalLeftBoundary + 1;
+            SimpleInterval dupRange = new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary, overlappingPair.fiveIntervalLeftBoundary);
+            if ( svLen > 49 ) {
+
+                refBase = getRefBase(reference, SVLocalContext.makeOneBpInterval(overlappingPair.chr, overlappingPair.threeIntervalRightBoundary - 1));
+                final VariantContextBuilder leftDup = makeDispersedDuplication(overlappingPair.chr,
+                        overlappingPair.threeIntervalRightBoundary - 1,
+                        dupRange,DISPERSED_INVERTED_DUPLICATION_DOWNSTREAM_INSERTION_ORIENTATIONS,
+                        Allele.create(refBase, true));
+                result.add(leftDup);
+            } else if (overlappingPair.threeIntervalLeftBoundary + 1 != overlappingPair.fiveIntervalLeftBoundary) {
+                inversionBuilder.attribute(INV_FLANKING_MICRO_DUP_KEY, dupRange.toString());
+            }
+
+            svLen = overlappingPair.fiveIntervalRightBoundary - overlappingPair.threeIntervalRightBoundary + 1;
+            dupRange = new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalRightBoundary, overlappingPair.fiveIntervalRightBoundary);
+            if ( svLen > 49 ) {
+                refBase = getRefBase(reference, SVLocalContext.makeOneBpInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary));
+                final VariantContextBuilder rightDup = makeDispersedDuplication(overlappingPair.chr,
+                        overlappingPair.fiveIntervalLeftBoundary,
+                        dupRange, DISPERSED_INVERTED_DUPLICATION_UPSTREAM_INSERTION_ORIENTATIONS,
+                        Allele.create(refBase, true));
+                result.add(rightDup);
+            } else if (overlappingPair.threeIntervalRightBoundary + 1 != overlappingPair.fiveIntervalRightBoundary) {
+                inversionBuilder.attribute(INV_FLANKING_MICRO_DUP_KEY, dupRange.toString());
+            }
+
+            result.add(inversionBuilder); // insertion order doesn't matter
+            return result.stream().map(builder ->
+                    builder.attribute(GATKSVVCFConstants.CONTIG_NAMES, contigNames)
+                            .attribute(INV_SOURCE_BND_EVENT_KEY, sourceIDs).make())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    //==================================================================================================================
+
+    /**
+     * Scenario where re-alignment of short reads back to artificial reference haplotypes
+     * is necessary
+     * to resolve which variants are here.
+     */
+    abstract static class DegenerateScenario extends OverlappingPairHandler {
+        private static final long serialVersionUID = 1L;
+        DegenerateScenario(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+
+        @Override
+        public final List<VariantContext> toVariants(final ReferenceMultiSource reference,
+                                                     final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2ShortReads,
+                                                     final String pathToFastqsDir) {
+
+            final Set<String> supportingAssemblyIDs = new HashSet<>( overlappingPair.fivePrimeBreakEnd.getSupportingAssemblyIDs() );
+            supportingAssemblyIDs.addAll(overlappingPair.threePrimeBreakEnd.getSupportingAssemblyIDs());
+
+            final Tuple2<AlignmentResult.ArtificialReferenceHaplotypes, AlignmentResult.ArtificialReferenceHaplotypes>
+                    artificialReferenceGroups = makeTwoArtificialReferenceGroups(reference);
+
+            final List<AlignmentResult> alignmentsForGroupOne =
+                    alignShortReadsToArtificialReference(artificialReferenceGroups._1, assemblyID2ShortReads, supportingAssemblyIDs,
+                            DEV_MODE ? makeReferenceFileName(pathToFastqsDir, supportingAssemblyIDs, true) : null);
+            final List<AlignmentResult> alignmentsForGroupTwo =
+                    alignShortReadsToArtificialReference(artificialReferenceGroups._2, assemblyID2ShortReads, supportingAssemblyIDs,
+                            DEV_MODE ? makeReferenceFileName(pathToFastqsDir, supportingAssemblyIDs, false) : null);
+
+            if (DEV_MODE) {
+                writeAlignments(pathToFastqsDir, alignmentsForGroupOne, true);
+                writeAlignments(pathToFastqsDir, alignmentsForGroupTwo, false);
+            }
+            return breakDegeneracyAndInterpret(alignmentsForGroupOne, alignmentsForGroupTwo, reference);
+        }
+
+        private String makeReferenceFileName(final String workingDir,
+                                             final Set<String> supportingAssemblyIDs,
+                                             final boolean simpler) {
+
+            String postfix = String.join("_", supportingAssemblyIDs);
+
+            return workingDir + (workingDir.endsWith("/") ? "" : "/") + postfix + (simpler ? "_0" : "_1") + ".fasta";
+        }
+
+        protected final List<AlignmentResult> alignShortReadsToArtificialReference(final AlignmentResult.ArtificialReferenceHaplotypes artificialReferenceHaplotypes,
+                                                                                   final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2ShortReads,
+                                                                                   final Set<String> supportingAssemblyIDs,
+                                                                                   final String pathToSaveArtificialReferenceFasta) {
+
+            try {
+                final List<AlignmentResult> alignmentResults = new ArrayList<>();
+
+                try (final ReferenceSequencesAligner aligner =
+                             new ReferenceSequencesAligner(
+                                     artificialReferenceHaplotypes.getRefNames(),
+                                     artificialReferenceHaplotypes.getDescribedRefContigs(),
+                                     true, true, tempRefFastaLineLength,
+                                     pathToSaveArtificialReferenceFasta) ) {
+
+                    final SAMFileHeader samFileHeader = new SAMFileHeader(aligner.getDict());
+
+                    final Map<String, List<List<SAMRecord>>> assemblyID2Sam = new HashMap<>(supportingAssemblyIDs.size());
+                    for (final String assemblyID : supportingAssemblyIDs) {
+                        final List<SVFastqUtils.FastqRead> fastqReads = assemblyID2ShortReads.get(assemblyID);
+                        final List<List<SAMRecord>> samRecords = aligner.align(fastqReads, samFileHeader, true);
+                        assemblyID2Sam.put(assemblyID, samRecords);
+                    }
+
+                    alignmentResults.add( new AlignmentResult(artificialReferenceHaplotypes, samFileHeader, assemblyID2Sam) );
+                }
+                return alignmentResults;
+            }
+            catch (final IOException ioex) {
+                throw new GATKException("fdsfs", ioex);
+            }
+        }
+        
+        abstract Tuple2<AlignmentResult.ArtificialReferenceHaplotypes, AlignmentResult.ArtificialReferenceHaplotypes>
+        makeTwoArtificialReferenceGroups(final ReferenceMultiSource reference);
+
+        abstract List<VariantContext> breakDegeneracyAndInterpret(final List<AlignmentResult> alignmentsForGroupOne,
+                                                                  final List<AlignmentResult> alignmentsForGroupTwo,
+                                                                  final ReferenceMultiSource reference);
+
+        private static void writeAlignments(final String workingDir, final List<AlignmentResult> alignmentResults,
+                                            final boolean simpler) {
+
+            for (final AlignmentResult alignmentResult : alignmentResults) {
+
+                final SAMFileHeader samFileHeader = alignmentResult.samFileHeader;
+                SAMFileHeader clone = samFileHeader.clone();
+                clone.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+                final SAMRecordComparator localComparator = new SAMRecordCoordinateComparator();
+
+                for (final Map.Entry<String, List<List<SAMRecord>>> pair : alignmentResult.assemblyID2Sam.entrySet()) {
+                    String key = pair.getKey() + (simpler ? "_0" : "_1");
+                    final String bamOut = workingDir.endsWith("/") ? workingDir.concat(key).concat(".bam")
+                                                                   : workingDir.concat("/").concat(key).concat(".bam");
+
+                    final List<SAMRecord> samRecords = pair.getValue().stream().flatMap(List::stream).collect(Collectors.toList());
+                    samRecords.sort(localComparator);
+                    SVFileUtils.writeSAMFile(bamOut, samRecords.iterator(), clone, true);
+                }
+            }
+        }
+
+        private enum PairOrientation {
+            LL, RR, RL,
+            LR
+        }
+        static final PairOrientation getPairOrientation(final SAMRecord samRecord) {
+            if (samRecord.getReadNegativeStrandFlag() == samRecord.getMateNegativeStrandFlag())
+                return samRecord.getReadNegativeStrandFlag() ? PairOrientation.LL : PairOrientation.RR;
+            else if (samRecord.getReadNegativeStrandFlag() ?
+                    samRecord.getStart() + ALLOWED_SHORT_FRAGMENT_OVERHANG < samRecord.getMateAlignmentStart() :
+                    samRecord.getStart() - ALLOWED_SHORT_FRAGMENT_OVERHANG > samRecord.getMateAlignmentStart()) {
+                return PairOrientation.RL;
+            } else {
+                return PairOrientation.LR;
+            }
+        }
+
+        final Long[] getLeftyAndRightPairCounts(final List<AlignmentResult> alignmentsForGroupOne,
+                                                final List<AlignmentResult> alignmentsForGroupTwo) {
+            final EnumMap<PairOrientation, Long> simple = alignmentsForGroupOne.stream()
+                    .flatMap(alignmentResult -> alignmentResult.assemblyID2Sam.values().stream().flatMap(List::stream).flatMap(List::stream))
+                    .filter(samRecord -> !(samRecord.getReadUnmappedFlag() || samRecord.isSecondaryOrSupplementary() || samRecord.getMateUnmappedFlag()))
+                    .collect(Collectors.groupingBy(DegenerateScenario::getPairOrientation,
+                            () -> new EnumMap<>(PairOrientation.class),
+                            Collectors.counting()));
+
+            final EnumMap<PairOrientation, Long> complex = alignmentsForGroupTwo.stream()
+                    .flatMap(alignmentResult -> alignmentResult.assemblyID2Sam.values().stream().flatMap(List::stream).flatMap(List::stream))
+                    .filter(samRecord -> !(samRecord.getReadUnmappedFlag() || samRecord.isSecondaryOrSupplementary() || samRecord.getMateUnmappedFlag()))
+                    .collect(Collectors.groupingBy(DegenerateScenario::getPairOrientation,
+                            () -> new EnumMap<>(PairOrientation.class),
+                            Collectors.counting()));
+
+            final String assemblyIDs = String.join(",",
+                    alignmentsForGroupOne.stream().flatMap(ar -> ar.getAssemblyIDs().stream()).collect(Collectors.toSet()));
+
+            final Long simpleCaseLefties = simple.get(PairOrientation.LL) == null ? 0L : simple.get(PairOrientation.LL);
+            final Long simpleCaseRighties = simple.get(PairOrientation.RR) == null ? 0L : simple.get(PairOrientation.RR);
+            final Long complexCaseLefties = complex.get(PairOrientation.LL) == null ? 0L : complex.get(PairOrientation.LL);
+            final Long complexCaseRighties = complex.get(PairOrientation.RR) == null ? 0L : complex.get(PairOrientation.RR);
+            if (DEV_MODE) {
+                String line = "BED" + "\t" + overlappingPair.chr + "\t" +
+                        Math.min(overlappingPair.fiveIntervalLeftBoundary, overlappingPair.threeIntervalLeftBoundary) + "\t" +
+                        Math.max(overlappingPair.fiveIntervalRightBoundary, overlappingPair.threeIntervalRightBoundary) + "\t" +
+                        simpleCaseLefties + "," + simpleCaseRighties + ";" + complexCaseLefties + "," + complexCaseRighties + ";" +
+                        assemblyIDs;
+                System.out.println(line);
+            }
+            return new Long[]{simpleCaseLefties, simpleCaseRighties, complexCaseLefties, complexCaseRighties};
+        }
+
+        // TODO: 5/18/18 couldn't be more naive, but is working
+        boolean shouldTriggerInversionCall(final List<AlignmentResult> alignmentsForGroupOne,
+                                           final List<AlignmentResult> alignmentsForGroupTwo) {
+            final Long[] leftyAndRightPairCounts = getLeftyAndRightPairCounts(alignmentsForGroupOne, alignmentsForGroupTwo);
+            return leftyAndRightPairCounts[0] + leftyAndRightPairCounts[1] >= 30;
+        }
+    }
+
+    /**
+     * Holding results of aligning short reads to artificial references.
+     */
+    private static final class AlignmentResult {
+        final ArtificialReferenceHaplotypes artificialReferenceHaplotypes;
+        final SAMFileHeader samFileHeader;
+        final Map<String, List<List<SAMRecord>>> assemblyID2Sam;
+
+        AlignmentResult(final ArtificialReferenceHaplotypes artificialReferenceHaplotypes,
+                        final SAMFileHeader samFileHeader,
+                        final Map<String, List<List<SAMRecord>>> alignments) {
+            this.artificialReferenceHaplotypes = artificialReferenceHaplotypes;
+            this.samFileHeader = samFileHeader;
+            this.assemblyID2Sam = alignments;
+        }
+
+        private Set<String> getAssemblyIDs() {
+            return assemblyID2Sam.keySet();
+        }
+
+        private static class ArtificialReferenceHaplotypes {
+
+            private final List<ReferenceSequencesAligner.DescribedRefContig> describedRefContigs;
+
+            private ArtificialReferenceHaplotypes(final List<ReferenceSequencesAligner.DescribedRefContig> describedRefContigs) {
+                this.describedRefContigs = describedRefContigs;
+            }
+
+            List<String> getRefNames() {
+                return describedRefContigs.stream().map(ReferenceSequencesAligner.DescribedRefContig::getName).collect(Collectors.toList());
+            }
+
+            List<ReferenceSequencesAligner.DescribedRefContig> getDescribedRefContigs() {
+                return describedRefContigs;
+            }
+        }
+    }
+
+    /**
+     * As described in {@link OverlappingScenario#toString()},
+     * there's a degeneracy in terms of whether the B block is inverted.
+     * Since C'BC and C'B'C are reverse complement of each other,
+     * we need to check alignment signatures from short reads
+     * that link this middle group of to left/right flanking regions
+     * to break this degeneracy.
+     */
+    private static final class ThreeContainsFive extends DegenerateScenario {
+        private static final long serialVersionUID = 1L;
+        ThreeContainsFive(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+
+        /**
+         * Based on the pair interval overlap scenario,
+         * artificial reference haplotypes are made for
+         * breaking degeneracy.
+         * (again, see {@link OverlappingScenario#toString()})
+         */
+        @Override
+        Tuple2<AlignmentResult.ArtificialReferenceHaplotypes, AlignmentResult.ArtificialReferenceHaplotypes>
+        makeTwoArtificialReferenceGroups(final ReferenceMultiSource reference) {
+
+            try {
+                final ReferenceBases leftFlanking = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary - PADDING_LENGTH,
+                                                                                    overlappingPair.threeIntervalLeftBoundary));
+                final ReferenceBases rightFlankingRegion = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalRightBoundary,
+                                                                         overlappingPair.threeIntervalRightBoundary + PADDING_LENGTH));
+                final ReferenceBases blockB = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary, overlappingPair.fiveIntervalRightBoundary));
+                final byte[] invertedBlockB = Arrays.copyOf(blockB.getBases(), blockB.getBases().length);
+                SequenceUtil.reverseComplement(invertedBlockB);
+
+//                final boolean blockCDeleted = overlappingPair.threeIntervalRightBoundary - overlappingPair.fiveIntervalRightBoundary > 1;
+                // if blockCDeleted is true, then then the deleted block C would be calculated as follows:
+//                ReferenceBases blockC = reference
+//                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary + 1, overlappingPair.threeIntervalRightBoundary - 1));
+
+                try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                    // guard against edge case
+                    final boolean blockAInverseDisperseDuplicated = (overlappingPair.fiveIntervalLeftBoundary - overlappingPair.threeIntervalLeftBoundary > 1);
+
+                    outputStream.write(leftFlanking.getBases());
+
+                    final ReferenceBases blockA;
+                    final byte[] invertedBlockA;
+                    String description;
+                    String name;
+                    if (blockAInverseDisperseDuplicated) {
+                        blockA = reference
+                                .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary - 1, overlappingPair.fiveIntervalLeftBoundary - 1));
+                        invertedBlockA = Arrays.copyOf(blockA.getBases(), blockA.getBases().length);
+                        SequenceUtil.reverseComplement(invertedBlockA);
+
+                        outputStream.write(blockA.getBases());
+                        outputStream.write(blockB.getBases());
+                        outputStream.write(invertedBlockA);
+
+                        description = leftFlanking.getInterval() + "+" + blockA.getInterval() + "+" +
+                                blockB.getInterval() + "+(" + blockA.getInterval() + ")'+" + rightFlankingRegion.getInterval();
+                        name = "LABaR";
+                    } else {
+                        blockA = null;
+                        invertedBlockA = null;
+                        outputStream.write(blockB.getBases());
+
+                        description = leftFlanking.getInterval() + "+" +
+                                blockB.getInterval() + "+" + rightFlankingRegion.getInterval();
+                        name = "LBR";
+                    }
+
+                    outputStream.write(rightFlankingRegion.getBases());
+                    final byte[] sequencesForFirstGroup = outputStream.toByteArray();
+                    outputStream.flush();
+
+                    final ReferenceSequencesAligner.DescribedRefContig firstGroup =
+                            new ReferenceSequencesAligner.DescribedRefContig(
+                                    name, description, sequencesForFirstGroup
+                            );
+
+
+                    outputStream.reset();
+                    outputStream.write(leftFlanking.getBases());
+
+                    if (blockAInverseDisperseDuplicated) {
+                        outputStream.write(blockA.getBases());
+                        outputStream.write(invertedBlockB);
+                        outputStream.write(invertedBlockA);
+                        description = leftFlanking.getInterval() + "+" + blockA.getInterval() + "+(" +
+                                blockB.getInterval() + ")'+(" + blockA.getInterval() + ")'+" + rightFlankingRegion.getInterval();
+                        name = "LAbaR";
+                    } else {
+                        outputStream.write(invertedBlockB);
+                        description = leftFlanking.getInterval() + "+(" +
+                                blockB.getInterval() + ")'+" + rightFlankingRegion.getInterval();
+                        name = "LbR";
+                    }
+                    outputStream.write(rightFlankingRegion.getBases());
+                    final byte[] sequencesForSecondGroup = outputStream.toByteArray();
+                    outputStream.flush();
+
+                    final ReferenceSequencesAligner.DescribedRefContig secondGroup = new ReferenceSequencesAligner.DescribedRefContig(
+                            name, description, sequencesForSecondGroup
+                    );
+
+                    return new Tuple2<>(new AlignmentResult.ArtificialReferenceHaplotypes(Collections.singletonList(firstGroup)),
+                                        new AlignmentResult.ArtificialReferenceHaplotypes(Collections.singletonList(secondGroup)));
+                }
+            } catch (final IOException ioex) {
+                throw new GATKException("Can not get reference bases", ioex);
+            }
+        }
+
+        @Override
+        List<VariantContext> breakDegeneracyAndInterpret(final List<AlignmentResult> alignmentsForGroupOne,
+                                                         final List<AlignmentResult> alignmentsForGroupTwo,
+                                                         final ReferenceMultiSource reference) {
+            final List<String> contigNames =
+                    Stream.concat(overlappingPair.fivePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES),
+                            overlappingPair.threePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES))
+                            .sorted().distinct().collect(Collectors.toList());
+
+            final String sourceIDs = overlappingPair.fivePrimeBreakEnd.getID().replaceAll("_1$", "")
+                    + VCFConstants.INFO_FIELD_ARRAY_SEPARATOR
+                    + overlappingPair.threePrimeBreakEnd.getID().replaceAll("_1$", "");
+
+            final List<VariantContextBuilder> result = new ArrayList<>(3);
+            if (overlappingPair.threeIntervalRightBoundary - overlappingPair.fiveIntervalRightBoundary - 1 > 49) {
+                final SimpleInterval delRange = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.fiveIntervalRightBoundary, overlappingPair.threeIntervalRightBoundary - 1);
+                byte[] refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary,
+                        overlappingPair.fiveIntervalRightBoundary));
+                final VariantContextBuilder builder = makeDeletion(delRange, Allele.create(refBase, true));
+                result.add(builder);
+            }
+            if (overlappingPair.fiveIntervalLeftBoundary - overlappingPair.threeIntervalLeftBoundary + 1 > 49) {
+                final SimpleInterval dupRange = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.threeIntervalLeftBoundary, overlappingPair.fiveIntervalLeftBoundary);
+                byte[] refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary,
+                        overlappingPair.fiveIntervalRightBoundary));
+                final VariantContextBuilder builder = makeDispersedDuplication(
+                        overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary,
+                        dupRange, DISPERSED_INVERTED_DUPLICATION_DOWNSTREAM_INSERTION_ORIENTATIONS,
+                        Allele.create(refBase, true));
+                result.add(builder);
+            }
+
+            if (shouldTriggerInversionCall(alignmentsForGroupOne, alignmentsForGroupTwo)) {
+                final SimpleInterval invRange = new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary + 1,
+                        overlappingPair.fiveIntervalRightBoundary);
+                final VariantContextBuilder builder = makeInversion(invRange, overlappingPair.fivePrimeBreakEnd.getReference());
+                result.add(builder);
+            }
+
+            return result.stream()
+                    .map(builder ->
+                            builder.attribute(GATKSVVCFConstants.CONTIG_NAMES, contigNames)
+                                    .attribute(INV_SOURCE_BND_EVENT_KEY, sourceIDs).make())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * As described in {@link OverlappingScenario#toString()},
+     * there's a degeneracy in terms of whether the B block is inverted.
+     * Since ABA' and AB'A' are reverse complement of each other,
+     * we need to check alignment signatures from short reads
+     * that link this middle group of to left/right flanking regions
+     * to break this degeneracy.
+     */
+    private static final class FiveContainsThree extends DegenerateScenario {
+        private static final long serialVersionUID = 1L;
+        FiveContainsThree(final OverlappingPair overlappingPair) {
+            super(overlappingPair);
+        }
+
+        /**
+         * Based on the pair interval overlap scenario,
+         * artificial reference haplotypes are made for
+         * breaking degeneracy.
+         * (again, see {@link OverlappingScenario#toString()})
+         */
+        @Override
+        Tuple2<AlignmentResult.ArtificialReferenceHaplotypes, AlignmentResult.ArtificialReferenceHaplotypes>
+        makeTwoArtificialReferenceGroups(final ReferenceMultiSource reference) {
+
+            try {
+                final ReferenceBases leftFlanking = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary - PADDING_LENGTH,
+                                overlappingPair.fiveIntervalLeftBoundary));
+                final ReferenceBases rightFlankingRegion = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalRightBoundary,
+                                overlappingPair.fiveIntervalRightBoundary + PADDING_LENGTH));
+
+//                final boolean blockADeleted = overlappingPair.threeIntervalLeftBoundary - overlappingPair.fiveIntervalLeftBoundary > 1;
+                // if blockADeleted is true, then then the deleted block A would be calculated as follows:
+//                ReferenceBases blockA = reference
+//                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary + 1, overlappingPair.threeIntervalLeftBoundary - 1));
+
+                final ReferenceBases blockB = reference
+                        .getReferenceBases(new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary, overlappingPair.threeIntervalRightBoundary));
+                final byte[] invertedBlockB = Arrays.copyOf(blockB.getBases(), blockB.getBases().length);
+                SequenceUtil.reverseComplement(invertedBlockB);
+
+                try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream() ){
+                    // guard against edge case
+                    final boolean blockCInverseDisperseDuplicated = (overlappingPair.fiveIntervalRightBoundary - overlappingPair.threeIntervalRightBoundary > 1);
+
+                    outputStream.write(leftFlanking.getBases());
+
+                    final ReferenceBases blockC;
+                    final byte[] invertedBlockC;
+                    String name;
+                    String description;
+                    if (blockCInverseDisperseDuplicated) {
+                        blockC = reference.getReferenceBases(new SimpleInterval(overlappingPair.chr,
+                                overlappingPair.threeIntervalRightBoundary + 1,
+                                overlappingPair.fiveIntervalRightBoundary - 1));
+                        invertedBlockC = Arrays.copyOf(blockC.getBases(), blockC.getBases().length);
+                        SequenceUtil.reverseComplement(invertedBlockC);
+                        outputStream.write(invertedBlockC);
+                        outputStream.write(blockB.getBases());
+                        outputStream.write(blockC.getBases());
+
+                        name = "LcBCR";
+                        description = leftFlanking.getInterval() + "+(" + blockC.getInterval() + ")'+" +
+                                blockB.getInterval() + "+" + blockC.getInterval()+ "+" +rightFlankingRegion.getInterval();
+                    } else {
+                        blockC = null;
+                        invertedBlockC = null;
+                        outputStream.write(blockB.getBases());
+
+                        name = "LBR";
+                        description = leftFlanking.getInterval() + "+" +
+                                blockB.getInterval() + "+" +rightFlankingRegion.getInterval();
+                    }
+
+                    outputStream.write(rightFlankingRegion.getBases());
+                    final byte[] sequencesForFirstGroup = outputStream.toByteArray();
+                    outputStream.flush();
+
+                    final ReferenceSequencesAligner.DescribedRefContig firstGroup =
+                            new ReferenceSequencesAligner.DescribedRefContig(
+                                    name, description, sequencesForFirstGroup
+                            );
+
+                    outputStream.reset();
+                    outputStream.write(leftFlanking.getBases());
+
+                    if (blockCInverseDisperseDuplicated) {
+                        outputStream.write(invertedBlockC);
+                        outputStream.write(invertedBlockB);
+                        outputStream.write(blockC.getBases());
+
+                        name = "LcbCR";
+                        description = leftFlanking.getInterval() + "+(" + blockC.getInterval() + ")'+(" +
+                                blockB.getInterval() + ")'+" + blockC.getInterval()+ "+" +rightFlankingRegion.getInterval();
+                    } else {
+                        outputStream.write(invertedBlockB);
+
+                        name = "LbR";
+                        description = leftFlanking.getInterval() + "+(" +
+                                blockB.getInterval() + ")'+" +rightFlankingRegion.getInterval();
+                    }
+
+                    outputStream.write(rightFlankingRegion.getBases());
+                    final byte[] sequencesForSecondGroup = outputStream.toByteArray();
+                    outputStream.flush();
+
+                    final ReferenceSequencesAligner.DescribedRefContig secondGroup = new ReferenceSequencesAligner.DescribedRefContig(
+                            name, description, sequencesForSecondGroup
+                    );
+
+                    return new Tuple2<>(new AlignmentResult.ArtificialReferenceHaplotypes(Collections.singletonList(firstGroup)),
+                                        new AlignmentResult.ArtificialReferenceHaplotypes(Collections.singletonList(secondGroup)));
+                }
+            } catch (final IOException ioex) {
+                throw new GATKException("Can not get reference bases", ioex);
+            }
+        }
+
+        @Override
+        List<VariantContext> breakDegeneracyAndInterpret(final List<AlignmentResult> alignmentsForGroupOne,
+                                                         final List<AlignmentResult> alignmentsForGroupTwo,
+                                                         final ReferenceMultiSource reference) {
+
+            final List<String> contigNames =
+                    Stream.concat(overlappingPair.fivePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES),
+                            overlappingPair.threePrimeBreakEnd.makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES))
+                            .sorted().distinct().collect(Collectors.toList());
+
+            final String sourceIDs = overlappingPair.fivePrimeBreakEnd.getID().replaceAll("_1$", "")
+                    + VCFConstants.INFO_FIELD_ARRAY_SEPARATOR
+                    + overlappingPair.threePrimeBreakEnd.getID().replaceAll("_1$", "");
+
+            final List<VariantContextBuilder> result = new ArrayList<>(3);
+            if (overlappingPair.threeIntervalLeftBoundary - overlappingPair.fiveIntervalLeftBoundary - 1 > 49) {
+                final SimpleInterval delRange = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.fiveIntervalLeftBoundary, overlappingPair.threeIntervalLeftBoundary - 1);
+                final VariantContextBuilder builder = makeDeletion(delRange, overlappingPair.fivePrimeBreakEnd.getReference());
+                result.add(builder);
+            }
+            if (overlappingPair.fiveIntervalRightBoundary - overlappingPair.threeIntervalRightBoundary + 1 > 49) {
+                final SimpleInterval dupRange = new SimpleInterval(overlappingPair.chr,
+                        overlappingPair.threeIntervalRightBoundary, overlappingPair.fiveIntervalRightBoundary);
+                final VariantContextBuilder builder = makeDispersedDuplication(
+                        overlappingPair.chr, overlappingPair.fiveIntervalLeftBoundary,
+                        dupRange, DISPERSED_INVERTED_DUPLICATION_UPSTREAM_INSERTION_ORIENTATIONS,
+                        overlappingPair.fivePrimeBreakEnd.getReference());
+                result.add(builder);
+            }
+
+            if (shouldTriggerInversionCall(alignmentsForGroupOne, alignmentsForGroupTwo)) {
+                final SimpleInterval invRange = new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary, overlappingPair.threeIntervalRightBoundary);
+                byte[] refBase = getRefBase(reference, new SimpleInterval(overlappingPair.chr, overlappingPair.threeIntervalLeftBoundary - 1,
+                        overlappingPair.threeIntervalLeftBoundary - 1));
+                final VariantContextBuilder builder = makeInversion(invRange, Allele.create(refBase, true));
+                result.add(builder);
+            }
+
+            return result.stream()
+                    .map(builder ->
+                            builder.attribute(GATKSVVCFConstants.CONTIG_NAMES, contigNames)
+                                    .attribute(INV_SOURCE_BND_EVENT_KEY, sourceIDs).make())
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    //==================================================================================================================
+
+    private static int compareIntervals(final SimpleInterval first, final SimpleInterval second) {
+        // compare start position
+        int result = Integer.compare(first.getStart(), second.getStart());
+        if (result == 0) {
+            // compare end position
+            result = Integer.compare(first.getEnd(), second.getEnd());
+        }
+        return result;
+    }
+
+    /**
+     * Get short reads used for local assembly that triggered the BND calls in {@code overlappingPairs}.
+     */
+    private static Map<String, List<SVFastqUtils.FastqRead>> extractReads(final List<OverlappingPair> overlappingPairs,
+                                                                          final String pathToFastqsDir) {
+        final Set<String> interestingAssemblyIDs = new HashSet<>();
+        overlappingPairs.forEach(pair -> {
+            interestingAssemblyIDs.addAll( pair.fivePrimeBreakEnd.getSupportingAssemblyIDs() );
+            interestingAssemblyIDs.addAll( pair.threePrimeBreakEnd.getSupportingAssemblyIDs() );
+        });
+
+        final Map<String, List<SVFastqUtils.FastqRead>> assemblyID2ShortReads = new HashMap<>();
+        final String dir = pathToFastqsDir.endsWith("/") ? pathToFastqsDir : pathToFastqsDir + "/";
+        try (Stream<Path> paths = Files.walk(IOUtils.getPath(dir))) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(path ->  {
+                        final String fileName = path.toAbsolutePath().toString();
+                        int idx = fileName.indexOf(".fastq");
+                        if (idx == -1) return; // no a fastq
+                        String assemblyId = fileName.substring(idx - 9, idx);// -9 to count chars asm[0-9]{6,6}
+                        if (interestingAssemblyIDs.contains(assemblyId)) {
+                            String filePath = String.format("%s%s.fastq", dir, assemblyId);
+                            List<SVFastqUtils.FastqRead> fastqReads = SVFastqUtils.readFastqFile(filePath);
+                            assemblyID2ShortReads.put(assemblyId, fastqReads);
+                        }
+                    });
+        } catch (final IOException ioex) {
+            throw new GATKException("Failed to traverse provided directory supposedly containing FASTQ files: " +
+                    pathToFastqsDir, ioex);
+        }
+        return assemblyID2ShortReads;
+    }
+
+    private static byte[] getRefBase(final ReferenceMultiSource reference, final SimpleInterval oneBpPos) {
+        try {
+            return reference.getReferenceBases(oneBpPos).getBases();
+        } catch (final IOException ioex) {
+            throw new GATKException("Could not read reference for extracting bases", ioex);
+        }
+    }
+
+    /**
+     * Note that {@code delRange} is expected to be pre-process to VCF spec compatible,
+     * e.g. if chr1:101-200 is deleted, then {@code delRange} should be chr1:100-200
+     */
+    @VisibleForTesting
+    static VariantContextBuilder makeDeletion(final SimpleInterval delRange, final Allele refAllele) {
+
+        return new VariantContextBuilder()
+                .chr(delRange.getContig()).start(delRange.getStart()).stop(delRange.getEnd())
+                .alleles(Arrays.asList(refAllele, DEL_SYMB_ALLELE))
+                .id(makeID(SimpleSVType.SupportedType.DEL.name(), delRange.getContig(), delRange.getStart(), delRange.getEnd()))
+                .attribute(VCFConstants.END_KEY, delRange.getEnd())
+                .attribute(SVLEN, - delRange.size() + 1)
+                .attribute(SVTYPE, SimpleSVType.SupportedType.DEL.name());
+    }
+
+    @VisibleForTesting
+    static VariantContextBuilder makeDispersedDuplication(final String insertionChr, final int insertionPos,
+                                                          final SimpleInterval duplicatedRegion, final String duplicationOrientations,
+                                                          final Allele refAllele) {
+        return new VariantContextBuilder().chr(insertionChr).start(insertionPos).stop(insertionPos)
+                .alleles(Arrays.asList(refAllele, INS_SYMB_ALLELE))
+                .id("INS-DUPLICATION-DISPERSED" + INTERVAL_VARIANT_ID_FIELD_SEPARATOR + insertionChr + INTERVAL_VARIANT_ID_FIELD_SEPARATOR + insertionPos)
+                .attribute(VCFConstants.END_KEY, insertionPos)
+                .attribute(SVLEN, duplicatedRegion.size())
+                .attribute(SVTYPE, SimpleSVType.SupportedType.INS.name())
+                .attribute(EVENT_TYPE_KEY, "DUP:DISPERSED")
+                .attribute(DUP_REPEAT_UNIT_REF_SPAN, duplicatedRegion)
+                .attribute(DUP_ORIENTATIONS, duplicationOrientations);
+    }
+
+    @VisibleForTesting
+    static VariantContextBuilder makeInversion(final SimpleInterval invertedRegion, final Allele refAllele) {
+        return new VariantContextBuilder()
+                .chr(invertedRegion.getContig()).start(invertedRegion.getStart() - 1).stop(invertedRegion.getEnd())     // TODO: 5/2/18 VCF spec doesn't requst left shift by 1 for inversion POS
+                .alleles(Arrays.asList(refAllele, INV_SYMB_ALLELE))
+                .id(makeID(SimpleSVType.SupportedType.INV.name(), invertedRegion.getContig(), invertedRegion.getStart() - 1, invertedRegion.getEnd()))
+                .attribute(VCFConstants.END_KEY, invertedRegion.getEnd())
+                .attribute(SVLEN, 0)                                                                 // TODO: 5/2/18 this is following VCF spec,
+                .attribute(SVTYPE, SimpleSVType.SupportedType.INV.name());
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/ReferenceSequencesAligner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/ReferenceSequencesAligner.java
@@ -1,0 +1,169 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import htsjdk.samtools.*;
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.AlignmentInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.bwa.BwaMemAligner;
+import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
+import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignmentUtils;
+import org.broadinstitute.hellbender.utils.bwa.BwaMemIndex;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.reference.FastaReferenceWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ReferenceSequencesAligner implements AutoCloseable {
+
+    private final File fasta;
+    private final File image;
+    private final BwaMemAligner aligner;
+    private final BwaMemIndex index;
+    private final List<String> refNames;
+
+    public static final class DescribedRefContig {
+        private final String name;
+        private final String description;
+        private final byte[] bases;
+
+        public DescribedRefContig(final String name, final String description, final byte[] bases) {
+            this.name = name;
+            this.description = description;
+            this.bases = bases;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public byte[] getBases() {
+            return bases;
+        }
+    }
+
+    public ReferenceSequencesAligner(final String name, final byte[] bases) {
+        try {
+            Utils.nonNull(bases);
+            refNames = Collections.singletonList( Utils.nonNull(name) );
+            fasta = File.createTempFile("ssvh-temp", ".fasta");
+            fasta.deleteOnExit();
+            image = File.createTempFile(fasta.getParent(), fasta.toString().replace(".fasta", ".img"));
+            image.deleteOnExit();
+            FastaReferenceWriter.writeSingleSequenceReference(fasta.toPath(), false, false, name, null, bases);
+            BwaMemIndex.createIndexImageFromFastaFile(fasta.toString(), image.toString());
+            index = new BwaMemIndex(image.toString());
+            aligner = new BwaMemAligner(index);
+        } catch (final IOException ex) {
+            throw new GATKException("could not create index files", ex);
+        }
+    }
+
+    /**
+     * Note: when {@code pathToSaveFasta} is {@code null},
+     * the fasta is saved in a temporary directory that will be deleted when the alignment step is finished.
+     */
+    public ReferenceSequencesAligner(final List<String> refNames, final List<DescribedRefContig> refContigs,
+                                     final boolean makeIndex, final boolean makeDict,
+                                     final int basesPerLine, final String pathToSaveFasta) {
+
+        this.refNames = Utils.nonNull(refNames);
+
+        try {
+            if (pathToSaveFasta == null) {
+                fasta = File.createTempFile("ssvh-temp", ".fasta");
+                fasta.deleteOnExit();
+            } else {
+                fasta = new File(pathToSaveFasta);
+            }
+
+            image = new File(fasta.toString().replace(".fasta", ".img"));
+            image.deleteOnExit();
+        } catch (final IOException ioex) {
+            throw new GATKException("could not create index files", ioex);
+        }
+
+        try (final FastaReferenceWriter fastaReferenceWriter =
+                     makeIndex ? new FastaReferenceWriter(fasta.toPath(), basesPerLine, makeIndex, makeDict)
+                               : new FastaReferenceWriter(fasta.toPath(), makeIndex, makeDict)
+        ) {
+            for (final DescribedRefContig contig : refContigs) {
+                fastaReferenceWriter.appendSequence(contig.name, contig.description, contig.bases);
+            }
+            BwaMemIndex.createIndexImageFromFastaFile(fasta.toString(), image.toString());
+            index = new BwaMemIndex(image.toString());
+            aligner = new BwaMemAligner(index);
+        } catch (final IOException ioex) {
+            throw new GATKException("could not create index files", ioex);
+        }
+    }
+
+    public final List<List<AlignmentInterval>> align(final List<byte[]> seqs) {
+        final List<List<BwaMemAlignment>> alignments = aligner.alignSeqs(seqs);
+        final List<List<AlignmentInterval>> result = new ArrayList<>(alignments.size());
+        for (int i = 0; i < alignments.size(); i++) {
+            final int queryLength = seqs.get(i).length;
+            final List<AlignmentInterval> intervals = alignments.get(i).stream()
+                    .filter(bwa -> bwa.getRefId() >= 0)
+                    .filter(bwa -> SAMFlag.SECONDARY_ALIGNMENT.isUnset(bwa.getSamFlag()))
+                    .map(bma -> new AlignmentInterval(bma, refNames, queryLength))
+                    .collect(Collectors.toList()); // ignore secondary alignments.
+            result.add(intervals);
+        }
+        return result;
+    }
+
+    public final List<List<SAMRecord>> align(final List<SVFastqUtils.FastqRead> reads,
+                                             final SAMFileHeader header,
+                                             final boolean pairedReadsInterleaved) {
+
+        final int readCount = reads.size();
+
+        final List<String> readNames = new ArrayList<>(readCount);
+        final List<byte[]> bases = new ArrayList<>(readCount);
+        reads.forEach(fastqRead -> {
+            readNames.add(fastqRead.getName());
+            bases.add(fastqRead.getBases());
+        });
+
+        if (pairedReadsInterleaved) aligner.alignPairs();
+        final List<List<BwaMemAlignment>> alignments = aligner.alignSeqs(bases);
+
+        final List<List<SAMRecord>> result = new ArrayList<>(readCount);
+        for (int i = 0; i < readNames.size(); ++i) {
+            final String readName = readNames.get(i);
+            final List<BwaMemAlignment> bwaMemAlignments = alignments.get(i);
+            final SAMReadGroupRecord readGroup = getReadGroup(readName);
+            final List<SAMRecord> samRecords =
+                    BwaMemAlignmentUtils.toSAMStreamForRead(readName, bases.get(i), bwaMemAlignments,
+                            header, refNames, readGroup).collect(Collectors.toList());
+            result.add(samRecords);
+        }
+        return result;
+    }
+
+    // TODO: 5/8/18 how?
+    private static SAMReadGroupRecord getReadGroup(final String readName) {
+        return null;
+    }
+
+    public SAMSequenceDictionary getDict() {
+        return SAMSequenceDictionaryExtractor
+                .extractDictionary(IOUtils.getPath(fasta.toString().replace(".fasta", ".dict")));
+    }
+
+    @Override
+    public void close() throws IOException {
+        aligner.close();
+        index.close();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVLocalContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVLocalContext.java
@@ -1,0 +1,239 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFConstants;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants.*;
+
+public abstract class SVLocalContext extends VariantContext {
+    public static final long serialVersionUID = 1L;
+
+    protected SVLocalContext(final VariantContext vc) {
+        super(vc);
+    }
+
+    public static boolean indicatesInversion(final VariantContext variantContext) {
+        return variantContext.getAttributeAsBoolean(INV33, false)
+                ||
+                variantContext.getAttributeAsBoolean(INV55, false);
+    }
+
+    private static String parseAssemblyID(final String localAssemblyContigName) {
+        if ( localAssemblyContigName.length() != 18
+                ||
+                ! localAssemblyContigName.startsWith("asm")
+                ||
+                ! localAssemblyContigName.contains("tig"))
+            throw new IllegalArgumentException("Badly formatted contig name: " + localAssemblyContigName);
+
+        final String assemblyID = localAssemblyContigName.split(":")[0];
+
+        if(assemblyID.length() != 9 )
+            throw new IllegalArgumentException("Badly formatted contig name: " + localAssemblyContigName);
+
+        return assemblyID;
+    }
+
+    public static SimpleInterval makeOneBpInterval(final String chr, final int pos) {
+        Utils.nonNull(chr);
+        Utils.validateArg(pos > 0, "given position " + pos + " is non-positive");
+        return new SimpleInterval(chr, pos, pos);
+    }
+
+    public final Set<String> getSupportingAssemblyIDs() {
+        return Collections.unmodifiableSet(
+                makeSureAttributeIsList(CONTIG_NAMES)
+                        .map(SVLocalContext::parseAssemblyID).collect(Collectors.toSet())
+        );
+    }
+    public final Set<String> getSupporintAssemblyContigNames() {
+        return Collections.unmodifiableSet(
+                makeSureAttributeIsList(CONTIG_NAMES)
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     * This exist because for whatever reason,
+     * {@link VariantContext#getAttributeAsStringList(String, String)} ()}
+     * sometimes returns a giant single string, while
+     * {@link VariantContext#getAttributeAsString(String, String)}
+     * gives back an array ......
+     */
+    public final Stream<String> makeSureAttributeIsList(final String attributeKey) {
+        return getAttributeAsStringList(attributeKey, "").stream()
+                .flatMap(s -> {
+                    if ( s.contains(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR) ) {
+                        return Arrays.stream( s.split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR) );
+                    } else {
+                        return Stream.of(s);
+                    }
+                });
+    }
+
+    public abstract boolean isBreakEnd();
+    public static boolean isBreakEnd(final VariantContext variantContext) {
+        return variantContext
+                .getAttributeAsString(SVTYPE, "")
+                .equals(BREAKEND_STR);
+    }
+
+    abstract Tuple2<SimpleInterval, String> toBedString();
+
+
+    //==================================================================================================================
+    public abstract static class BreakEndSVContext extends SVLocalContext {
+        public static final long serialVersionUID = 1L;
+
+        protected BreakEndSVContext(final VariantContext variantContext) {
+            super(variantContext);
+        }
+
+        @Override
+        public final boolean isBreakEnd() {
+            return true;
+        }
+
+        // TODO: 4/30/18 hack
+        public final boolean isUpstreamMate() {
+            return getID().endsWith("_1");
+        }
+
+        public static Stream<BreakEndSVContext> getOneEnd(final Stream<BreakEndSVContext> breakEndVariants,
+                                                                         final boolean firstMate) {
+            if (firstMate)
+                return breakEndVariants
+                        .filter(BreakEndSVContext::isUpstreamMate);// TODO: 3/15/18 insert this key into GATKSVVCFConstant
+            else
+                return breakEndVariants
+                        .filter(bnd -> ! bnd.isUpstreamMate());
+        }
+
+        // TODO: 3/16/18 hack for getting the mate location
+        public final SimpleInterval getMateRefLoc() {
+
+            final String altSymbAllele = getAlternateAllele(0).toString();
+
+            int i = altSymbAllele.indexOf("]");
+            int j;
+            if (i >= 0 ) {
+                j = altSymbAllele.lastIndexOf("]");
+            } else {
+                i = altSymbAllele.indexOf("[");
+                j = altSymbAllele.lastIndexOf("[");
+            }
+
+            return new SimpleInterval(altSymbAllele.substring(i + 1, j));
+        }
+    }
+
+    /**
+     * Exists for {@link #equals(Object)}, {@link #hashCode()} and custom comparator, no other reason.
+     * todo: is it possible to talk with {@link SVContext}
+     */
+    public static final class InvBreakEndContext extends BreakEndSVContext {
+        public static final long serialVersionUID = 1L;
+
+        public InvBreakEndContext(final VariantContext variantContext) {
+            super(variantContext);
+        }
+
+        public boolean isType33() {
+            return getAttributeAsBoolean(INV33, false);
+        }
+
+        public static Comparator<InvBreakEndContext> makeComparator(final SAMSequenceDictionary refDict) {
+            final Comparator<InvBreakEndContext> chrFirst =
+                    Comparator.comparingInt(lvc -> refDict.getSequenceIndex(lvc.getContig()));
+
+            return chrFirst
+                    .thenComparing(VariantContext::getStart)
+                    .thenComparing(VariantContext::getEnd);
+        }
+
+
+        public SimpleInterval getSpanningInterval() {
+            int end = getMateRefLoc().getEnd();
+            return new SimpleInterval(getContig(), getStart(), end);
+        }
+
+        /**
+         * Simulating
+         * {@link org.broadinstitute.hellbender.utils.test.VariantContextTestUtils#assertVariantContextsAreEqual(VariantContext, VariantContext, List)},
+         * but this local version is coded for inversion breakend suspects only,
+         * hence testing limited properties and private.
+         */
+        private static boolean twoVCareEquivalent(final VariantContext v1, final VariantContext v2) {
+
+            if ( !v1.getContig().equals(v2.getContig()) )
+                return false;
+            if ( v1.getStart() != v2.getStart() )
+                return false;
+            if ( !v1.getID().equals(v2.getID()) )
+                return false;
+            if ( !v1.getAlleles().equals(v2.getAlleles()) )
+                return false;
+            return v1.getAttributes().equals(v2.getAttributes());
+        }
+
+        // meant to be overridden
+        @Override
+        public Tuple2<SimpleInterval, String> toBedString() {
+            final String[] splitIdFields = getID().split("_", -1);
+            final int start = getStart();
+            final Integer end = Integer.valueOf(splitIdFields[splitIdFields.length - 2]);
+            final String sz = String.valueOf( end - start);
+            final String flag = getAttributeAsBoolean(GATKSVVCFConstants.INV33, false) ? GATKSVVCFConstants.INV33 : GATKSVVCFConstants.INV55;
+            final String ctgs = String.join(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR,
+                    makeSureAttributeIsList(GATKSVVCFConstants.CONTIG_NAMES).collect(Collectors.toList()));
+
+            final String separator = VCFConstants.INFO_FIELD_SEPARATOR;
+            final String annotation = getContig()+("\t")+(start)+("\t")+(end)+("\t")
+                    +(flag)+(separator)+(sz)+(separator)+(ctgs);
+            return new Tuple2<>( new SimpleInterval(getContig(), start, end), annotation);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) return true;
+            if (other == null || getClass() != other.getClass()) return false;
+
+            final InvBreakEndContext that = (InvBreakEndContext) other;
+
+            return twoVCareEquivalent(this, that);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getContig().hashCode();
+            result = 31 * result + getStart();
+            result = 31 * result + getID().hashCode();
+            result = 31 * result + getAlleles().hashCode();
+            result = 31 * result + getAttributes().hashCode();
+            return result;
+        }
+    }
+
+    //==================================================================================================================
+
+    public abstract static class SymbolicSVContext extends SVLocalContext {
+        public static final long serialVersionUID = 1L;
+
+        SymbolicSVContext(final VariantContext variantContext) {
+            super(variantContext);
+        }
+
+        @Override
+        final public boolean isBreakEnd() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This is for demo purpose only, so the code is not ready yet to be merged:

## Description

### background & goal
Currently, there are two parallel code path for structural variation breakpoint location and type inference using local assembly contig alignment signatures in the pipeline `StructuralVariationDiscoveryPipelineSpark`

* the stable code path: scanning neighbor chimeric alignment pairs of a contig iteratively and outputs inversion breakpoints as symbolic variant `<INV>`, annotated with `INV55` and `INV33` for signaling if it is the left or right breakpoint of the assumed inversion.
* the experimental code path that separates the alignment pre-processing step from the inference step, and studying the alignments in whole; this code path, in addition to outputting insertion, deletion and small duplication calls as does the stable path, outputs 
    * BND records representing assembled breakpoints for which type could not be completely determined using only the contig alignments; this includes supposedly inversion breakpoints
    * complex (`<CPX>`) variants from assembly contigs with more than 2 alignments
    
The tool proposed in this PR is based on [manual review](https://github.com/broadinstitute/dsde-methods-sv/tree/sh_inv_filter_init/docs/knowledgeBase/variantReview/inversion/chm) of a callset generated a long time ago (but still useful for studying filtering inversion breakpoints), and is designed to be integrated with the experimental code path.

### proposed algo

#### input:
* the "INV55/INV33"-annotated `BND` records output by the upstream experimental code path
  * BND's have related concepts of `MATE` and `PARTNER` (see figure below, left)
  * `MATE`: novel adjacency, i.e. contiguity on sample that is absent on reference (e.g. mobile element insertions, deletions)
  * `PARTNER`: novel disruption, i.e. contiguity on reference disrupted on sample (e.g. insertions, deletions)

![inversion_demo](https://user-images.githubusercontent.com/16310888/40271739-6d999b30-5b6f-11e8-86db-78fa11db4305.png)

* complex variants detected by the upstream experimental code path; the reason is that sometimes inversion calls are incorporated as part of a larger, more complex event and the logic implemented in the upstream code, theoretically, allows for arbitrarily complex rearrangement; shown above on the right is a table of inversion calls (TP/FP 12/7 using PacBio calls on CHM-1 & 13 cell lines as truth) extracted from the `<CPX>` calls, they were extracted by the tool proposed in PR #4602.

#### stages:

* Primitive filter on breakpoints 
    * low MQ of assembly contigs' mappings that evidenced the BND records, 
    * suspiciously large distance between mates (mate pairs whose distance are over $10^5$bp (~1/3 of input, see blelow) are more likely to be artifact or dispersed/segmental duplications)

  <p align="center"><img src="https://user-images.githubusercontent.com/16310888/40271740-6daa2b9e-5b6f-11e8-9dbb-89085450db6d.png" width="420" height="420" ></p>
    * if overlaps with CPX (supposedly they should be captured already, or is more complex than what can be comprehended by the logic proposed here)

The mates are then converted to intervals bounded by the mates' locations. These "normal sized" variants are sent down for further analysis.

* Filtering based on overlap signatures. Here we have several possible scenarios (total ~130 pairs of mates):
  * no overlappers (~ 50 mate pairs, balanced between ++/--)
  * multiple overlappers (~ 10 mate pairs, balanced between ++/--)
  * unique overlapping pairs of mate pairs (~ 60 mate pairs)
     * which overlaps with same type (++/++ or --/--, ~ 10 mate pairs)
     * which overlaps with opposite type (++/-- overlap, ~ 50 mate pairs). These are the overlapping pairs sent down for breakpoint linking, expecting a maximum of 20~30 inversion calls.

* Type inference. Here we have four possible cases, each signaling what could be involved (primed block is inverted):
  * INV55 interval left/right boundary upstream of INV33 interval's left/right boundary: `ABC ->    B'`
  * INV33 interval left/right boundary upstream of INV55 interval's left/right boundary: `ABC -> AC'B'A'C`
  * INV33 interval contains INV55 interval: `ABC -> ABA' or AB'A'`
  * INV55 interval contains INV33 interval: `ABC -> C'BC or C'B'C`

Note that for the last two cases, where the inverted dispersed duplication is guaranteed, the two possible alternate alleles are reverse complement&mdash;inversion&mdash;of each other, hence signatures of contig alignments along is not enough, and alignments of short reads within the affected region cannot break the degeneracy either.
So we need to attach left and right flanking regions to the affected region, and align short reads back to these two haplotypes and study the pair orientations of the alignments to break the degeneracy.


#### output:

* VCF containing the inversion and flanking deletion and dispersed duplication calls (together with CPX-derived inversion calls, total number of `INV` calls are ~ 30)

* BED file on filtered BND's citing reason for filtering

Relevant files, including an IGV session can be found in this [bucket](https://console.cloud.google.com/storage/browser/broad-dsde-methods/shuang/archive/inversion-algo-demo/?project=broad-dsde-methods&organizationId=548622027621)

## Todo:

* Large inversions. The primitive size-based filtering step and the filtering step requiring matched mate pairs undoubtedly will cause us false negatives, as sometimes we don't expect assembly of all breakpoints for inversions complicated by copy number events. The inversions currently captured tend to be small inversions
  
```
Min.     1st Qu.    Median      Mean     3rd Qu.       Max.
77.0       188.0     359.0    1144.5       823.2    12697.0
```
    
* run check against reference annotation: known Seg. Dup., RC-STR, centromere, as well as consistent pair support from short reads
    
  * __Question: is this pre-filtering a bad idea; if not, how to report?__

  *  __Question: is the number $10^5$ reasonable?__
  
  * __Question: any other suggestion on filtering criteria?__
 
* Corner cases here & there in the proposed tool