### PR TITLE
Updated doc templates to match website updates

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
@@ -5,9 +5,9 @@
 
         -->
 
-    <#global siteRoot = "http://software.broadinstitute.org/gatk/" />
-    <#global guideIndex = "http://software.broadinstitute.org/gatk/documentation/" />
-    <#global forum = "http://gatkforums.broadinstitute.org/gatk/" />
+    <#global siteRoot = "https://software.broadinstitute.org/gatk/" />
+    <#global guideIndex = "https://software.broadinstitute.org/gatk/documentation/" />
+    <#global forum = "https://gatkforums.broadinstitute.org/gatk/" />
 
     <#macro footerInfo>
         <hr>
@@ -15,7 +15,7 @@
         <hr>
         <p class="see-also">See also 
         	<a href="${guideIndex}">General Documentation</a> |
-        	<a class="hide_me_php" href="index.html">Tool Docs Index</a> <a class="hide_me_html" href="index">Tool Docs Index</a> |
+        	<a class="hide_me_php" href="index.html">Tool Docs Index</a> <a class="hide_me_html" href="index">Tool Documentation Index</a> |
         	<a href="${forum}">Support Forum</a>
         </p>
 

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
@@ -5,23 +5,23 @@
     $module = modules::GATK;
     $name = docSN::toolDocs;
 
-    printHeader($module, $name, "Documentation");
+    printHeader($module, $name, topSN::guide);
 
-    $dirs = array_diff(scandir("../", SCANDIR_SORT_DESCENDING), array('..', '.'));
-    $curr_version = file_get_contents(engConst::versions_dir.versionFiles::gatk);
+    $selected_major_version = 4;
+    $dirs = lookupVersionDirs($selected_major_version);
 ?>
 
 <link type='text/css' rel='stylesheet' href='gatkDoc.css'>
 
-<div class='row-fluid'>
+<div class='row'>
 
-    <aside class="span3">
+    <aside class="col-md-3">
 
         <?php echo produceGuideNav($module, $name) . makeTwitterFeed(); ?>
 
     </aside>
 
-    <div class='span9'>
+    <div class='col-md-9'>
 
 <#include "common.html"/>
 
@@ -60,12 +60,12 @@
         </div>
 </#macro>
 
-        <div class="row-fluid">
-            <div class="span6">
+        <div class="row">
+            <div class="col-md-6">
                 <h1 id="top"><i class='<?php print ico::toolDocsIcon; ?>'></i> Tool Documentation Index</h1>
             </div>
-            <div class="span6">
-                <div class="btn-group pull-right">
+            <div class="col-md-6">
+                <div class="btn-group pull-right" style='margin-top:14px;'>
                     <a class="btn btn-warning dropdown-toggle" data-toggle="dropdown" href="#">
                         Version ${version}
                         <span class="caret"></span>
@@ -79,8 +79,11 @@
             </div>
         </div>
 
-        <h1 class="hide_me_html"><small>Showing docs for version ${version} | The latest version is <?=$curr_version?></small></h1>
-        <hr />
+        <div class="hide_me_html">
+            <hr />
+            <em>Showing docs for version ${version} | The latest version is <?php print $latest_version; ?></em>
+            <hr />
+        </div>
 
         <div class="accordion" id="index">
             <#assign seq = ["engine", "tools", "other", "utilities"]>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -1,18 +1,38 @@
 <?php
 
-	define('noTWITTER', TRUE);
-    include '../../../../common/include/common.php';
+	include '../../../../common/include/common.php';
     include_once '../../../config.php';
     $module = modules::GATK;
-    printHeader($module, "Tool Documentation Index", "Documentation");
+    $name = docSN::toolDocs;
 
-    $curr_version = file_get_contents(engConst::versions_dir.versionFiles::gatk);
-    $dirs = array_diff(scandir("../", SCANDIR_SORT_DESCENDING), array('..', '.'));
+    printHeader($module, $name, topSN::guide);
+
+    $selected_major_version = 4;
+    $dirs = lookupVersionDirs($selected_major_version);
 ?>
 
 <link type='text/css' rel='stylesheet' href='gatkDoc.css'>
 
-<div class='row-fluid' id="top">
+<div class="row hide_me_html" style="margin: 14px 3px 14px 3px;" id="tippy-top">
+
+	<i class='<?php print ico::toolDocsIcon; ?>'></i> <em>Showing tool doc from version ${version} | The latest version is <?php print $latest_version; ?></em>
+	<div class="btn-group pull-right">
+		<a class="btn btn-warning dropdown-toggle" data-toggle="dropdown" href="#">
+			${version}
+			<span class="caret"></span>
+		</a>
+		<ul class="dropdown-menu">
+			<?php foreach($dirs as $dir) { ?>
+			<li class="hide_me_html"><a tabindex='-1' href='../<?=$dir?>' ><?=$dir?></a></li>
+			<?php } ?>
+		</ul>
+	</div>
+	<hr />
+
+</div>
+
+
+<div class='row' id="top">
 
 	<#include "common.html"/>
 
@@ -90,19 +110,19 @@
 
 	<?php $group = '${group}'; ?>
 
-	<section class="span4">
+	<section class="col-md-4">
 		<aside class="well">
-			<a class="hide_me_php" href="index.html"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
-			<a class="hide_me_html" href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+			<a class="hide_me_php" href="index.html"><h4><i class='fa fa-chevron-left'></i> Back to Tool Documentation Index</h4></a>
+			<a class="hide_me_html" href=".."><h4><i class='fa fa-chevron-left'></i> Back to Tool Documentation Index</h4></a>
 		</aside>
 		<aside class="well hide_me_html">
-			<h2>Categories</h2>
+			<h3>Browse tools by category</h3>
 			<@getCategories groups=groups />
 		</aside>
 
 	</section>
 
-	<div class="span8">
+	<div class="col-md-8">
 
 		<#if beta?? && beta == true>
 			<h1>**BETA** ${name}</h1>


### PR DESCRIPTION
- matches the bootstrap updates for formatting 
- minor text tweaks, displays version clearly
- adds version switching menu

These changes will make it easier to upload new version docs quickly. This should definitely go in before the next version release. 

Resulting docs are live at https://software.broadinstitute.org/gatk/documentation/tooldocs