### PR TITLE
Deleted an unused duplicated method in GenotypeGivenAllelesUtils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -60,35 +60,4 @@ public final class GenotypingGivenAllelesUtils {
         return vc;
     }
 
-    /**
-     * Create the list of artificial GGA-mode haplotypes by injecting each of the provided alternate alleles into the reference haplotype
-     *
-     * @param refHaplotype the reference haplotype
-     * @param givenHaplotypes the list of alternate alleles in VariantContexts
-     * @param activeRegionWindow the window containing the reference haplotype
-     *
-     * @return a non-null list of haplotypes
-     */
-    public static List<Haplotype> composeGivenHaplotypes(final Haplotype refHaplotype, final List<VariantContext> givenHaplotypes, final GenomeLoc activeRegionWindow) {
-        Utils.nonNull(refHaplotype, "reference haplotype may not be null");
-        Utils.nonNull(givenHaplotypes, "given haplotypes may not be null");
-        Utils.nonNull(activeRegionWindow, "active region window may not be null");
-        Utils.validateArg(activeRegionWindow.size() == refHaplotype.length(), "inconsistent reference haplotype and active region window");
-
-        final Set<Haplotype> returnHaplotypes = new LinkedHashSet<>();
-        final int activeRegionStart = refHaplotype.getAlignmentStartHapwrtRef();
-
-        for( final VariantContext compVC : givenHaplotypes ) {
-            Utils.validateArg(GATKVariantContextUtils.overlapsRegion(compVC, activeRegionWindow),
-                    " some variant provided does not overlap with active region window");
-            for( final Allele compAltAllele : compVC.getAlternateAlleles() ) {
-                final Haplotype insertedRefHaplotype = refHaplotype.insertAllele(compVC.getReference(), compAltAllele, activeRegionStart + compVC.getStart() - activeRegionWindow.getStart(), compVC.getStart());
-                if( insertedRefHaplotype != null ) { // can be null if the requested allele can't be inserted into the haplotype
-                    returnHaplotypes.add(insertedRefHaplotype);
-                }
-            }
-        }
-
-        return new ArrayList<>(returnHaplotypes);
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -1,21 +1,12 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
 import htsjdk.samtools.util.Locatable;
-import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.FeatureInput;
-import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
-import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
-
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Compendium of utils to work in GENOTYPE_GIVEN_ALLELES mode.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -176,7 +176,7 @@ public final class ReadThreadingAssembler {
         final int activeRegionStart = refHaplotype.getAlignmentStartHapwrtRef();
 
         for( final VariantContext compVC : givenHaplotypes ) {
-            Utils.validateArg(GATKVariantContextUtils.overlapsRegion(compVC, activeRegionWindow), " some variant provided does not overlap with active region window");
+            Utils.validateArg(compVC.overlaps(activeRegionWindow), " some variant provided does not overlap with active region window");
             for( final Allele compAltAllele : compVC.getAlternateAlleles() ) {
                 final Haplotype insertedRefHaplotype = refHaplotype.insertAllele(compVC.getReference(), compAltAllele, activeRegionStart + compVC.getStart() - activeRegionWindow.getStart(), compVC.getStart());
                 if( insertedRefHaplotype != null ) { // can be null if the requested allele can't be inserted into the haplotype

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -21,7 +21,6 @@ import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
-import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -145,54 +145,6 @@ public final class GATKVariantContextUtils {
     @Deprecated
     public final static List<Allele> NO_CALL_ALLELES = Arrays.asList(Allele.NO_CALL, Allele.NO_CALL);
 
-
-    /**
-     * Checks whether a variant-context overlaps with a region.
-     *
-     * <p>
-     *     No event overlaps an unmapped region.
-     * </p>
-     *
-     * @param variantContext variant-context to test the overlap with.
-     * @param region region to test the overlap with.
-     *
-     * @throws IllegalArgumentException if either region or event is {@code null}.
-     *
-     * @return {@code true} if there is an overlap between the event described and the active region provided.
-     */
-    public static boolean overlapsRegion(final VariantContext variantContext, final GenomeLoc region) {
-        Utils.nonNull(region, "the active region is null");
-        Utils.nonNull(variantContext);
-
-        if (region.isUnmapped())
-            return false;
-        if (variantContext.getEnd() < region.getStart())
-            return false;
-        if (variantContext.getStart() > region.getStop())
-            return false;
-        return variantContext.getContig().equals(region.getContig());
-    }
-
-    /**
-     * Checks whether a variant-context overlaps with a region.
-     *
-     * @param variantContext variant-context to test the overlap with.
-     * @param region region to test the overlap with.
-     *
-     * @throws IllegalArgumentException if either region or event is {@code null}.
-     *
-     * @return {@code true} if there is an overlap between the event described and the active region provided.
-     */
-    public static boolean overlapsRegion(final VariantContext variantContext, final SimpleInterval region) {
-        Utils.nonNull(region, "the active region is null");
-        Utils.nonNull(variantContext);
-        if (variantContext.getEnd() < region.getStart())
-            return false;
-        if (variantContext.getStart() > region.getEnd())
-            return false;
-        return variantContext.getContig().equals(region.getContig());
-    }
-
     private static boolean hasPLIncompatibleAlleles(final Collection<Allele> alleleSet1, final Collection<Allele> alleleSet2) {
         final Iterator<Allele> it1 = alleleSet1.iterator();
         final Iterator<Allele> it2 = alleleSet2.iterator();

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -22,7 +22,9 @@ import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAlleleCount
 import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAssignmentMethod;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeLikelihoodCalculator;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeLikelihoodCalculators;
-import org.broadinstitute.hellbender.utils.*;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.io.File;

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -1538,71 +1538,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
             }
         };
     }
-
-    @Test(dataProvider="overlapWithData")
-    public void testOverlapsWith(final VariantContext vc, final GenomeLoc genomeLoc) {
-        final boolean expected;
-
-        if (genomeLoc.isUnmapped())
-            expected = false;
-        else if (vc.getStart() > genomeLoc.getStop())
-            expected = false;
-        else if (vc.getEnd() < genomeLoc.getStart())
-            expected = false;
-        else if (!vc.getContig().equals(genomeLoc.getContig()))
-            expected = false;
-        else
-            expected = true;
-
-        Assert.assertEquals(GATKVariantContextUtils.overlapsRegion(vc, genomeLoc), expected);
-    }
-
-
-    private final String[] OVERLAP_WITH_CHROMOSOMES =  { "1", "2" };
-    private final int[] OVERLAP_WITH_EVENT_SIZES =  { -10, -1, 0, 1, 10 }; // 0 == SNP , -X xbp deletion, +X xbp insertion.
-    private final int[] OVERLAP_WITH_EVENT_STARTS = { 1000, 1001,
-            1005, 1010,
-            1009, 1011,
-            2000 };
-
-    @DataProvider(name="overlapWithData")
-    public Object[][] overlapWithData() {
-
-        final int totalLocations = OVERLAP_WITH_CHROMOSOMES.length * OVERLAP_WITH_EVENT_SIZES.length * OVERLAP_WITH_EVENT_STARTS.length + 1;
-        final int totalEvents = OVERLAP_WITH_CHROMOSOMES.length * OVERLAP_WITH_EVENT_SIZES.length * OVERLAP_WITH_EVENT_STARTS.length;
-        final GenomeLoc[] locs = new GenomeLoc[totalLocations];
-        final VariantContext[] events = new VariantContext[totalEvents];
-
-        generateAllLocationsAndVariantContextCombinations(OVERLAP_WITH_CHROMOSOMES, OVERLAP_WITH_EVENT_SIZES,
-                OVERLAP_WITH_EVENT_STARTS, locs, events);
-
-        return generateAllParameterCombinationsForOverlapWithData(locs, events);
-    }
-
-    private Object[][] generateAllParameterCombinationsForOverlapWithData(GenomeLoc[] locs, VariantContext[] events) {
-        final List<Object[]> result = new LinkedList<>();
-        for (final GenomeLoc loc : locs)
-            for (final VariantContext event : events)
-                result.add(new Object[] { event , loc });
-
-        return result.toArray(new Object[result.size()][]);
-    }
-
-    private void generateAllLocationsAndVariantContextCombinations(final String[] chrs, final int[] eventSizes,
-                                                                   final int[] eventStarts, final GenomeLoc[] locs,
-                                                                   final VariantContext[] events) {
-        int nextIndex = 0;
-        for (final String chr : chrs )
-            for (final int size : eventSizes )
-                for (final int starts : eventStarts ) {
-                    locs[nextIndex] = hg19GenomeLocParser.createGenomeLoc(chr,starts,starts + Math.max(0,size));
-                    events[nextIndex++] = new VariantContextBuilder().source("test").loc(chr,starts,starts + Math.max(0,size)).alleles(Arrays.asList(
-                            Allele.create(randomBases(size <= 0 ? 1 : size + 1, true), true), Allele.create(randomBases(size < 0 ? -size + 1 : 1, false), false))).make();
-                }
-
-        locs[nextIndex++]  = GenomeLoc.UNMAPPED;
-    }
-
+    
     @Test(dataProvider = "totalPloidyData")
     public void testTotalPloidy(final int[] ploidies, final int defaultPloidy, final int expected) {
         final Genotype[] genotypes = new Genotype[ploidies.length];


### PR DESCRIPTION
Closes #4182.  Note the duplicate method in `ReadThreadingAssembler`. @droazen Let me know if I should bother someone outside the engine team for things like this.