### PR TITLE
enable -L to read Feature Files from Paths

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -493,8 +493,8 @@ public final class FeatureManager implements AutoCloseable {
      * @param file file to check
      * @return True if the file exists and contains Features (ie., we have a FeatureCodec that can decode it), otherwise false
      */
-    public static boolean isFeatureFile( final File file ) {
-        return file.exists() && ! getCandidateCodecsForFile(file.toPath()).isEmpty();
+    public static boolean isFeatureFile( final Path file ) {
+        return Files.exists(file) && ! getCandidateCodecsForFile(file).isEmpty();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -270,7 +270,7 @@ public final class IntervalUtils {
                     "interval or an interval file instead.");
         }
         // If it's a Feature-containing file, convert it to a list of intervals
-        else if ( FeatureManager.isFeatureFile(new File(arg)) ) {
+        else if ( FeatureManager.isFeatureFile(IOUtils.getPath(arg)) ) {
             rawIntervals.addAll(featureFileToIntervals(parser, arg));
         }
         // If it's an interval file, add its contents to the raw interval list
@@ -307,12 +307,11 @@ public final class IntervalUtils {
      * Converts a Feature-containing file to a list of intervals
      *
      * @param parser GenomeLocParser for creating intervals
-     * @param featureFileName file containing Features to convert to intervals
+     * @param featureFile file containing Features to convert to intervals
      * @return a List of intervals corresponding to the locations of the Features in the provided file
      * @throws UserException.CouldNotReadInputFile if the provided file is not in a supported Feature file format
      */
-    public static List<GenomeLoc> featureFileToIntervals( final GenomeLocParser parser, final String featureFileName ) {
-        final File featureFile = new File(featureFileName);
+    public static List<GenomeLoc> featureFileToIntervals( final GenomeLocParser parser, final String featureFile ) {
 
         try ( final FeatureDataSource<? extends Feature> dataSource = new FeatureDataSource<>(featureFile) ) {
             final List<GenomeLoc> featureIntervals = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/FeatureManagerUnitTest.java
@@ -89,7 +89,7 @@ public final class FeatureManagerUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "IsFeatureFileTestData")
     public void testIsFeatureFile( final File file, final boolean expectedIsFeatureFile ) {
-        Assert.assertEquals(FeatureManager.isFeatureFile(file), expectedIsFeatureFile, "isFeatureFile() returned incorrect result for file " + file.getAbsolutePath());
+        Assert.assertEquals(FeatureManager.isFeatureFile(file.toPath()), expectedIsFeatureFile, "isFeatureFile() returned incorrect result for file " + file.getAbsolutePath());
     }
 
     @CommandLineProgramProperties(summary = "", oneLineSummary = "", programGroup = TestProgramGroup.class)


### PR DESCRIPTION
* expand -L support for Feature Files to work with Paths
* previously interval files could be read from Paths, but not feature
files like vcf and bed
* fixes #4852