### PR TITLE
Fix getAllowedValuesForDescriptorHelp in GATKAnnotationPluginDescriptor.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
@@ -228,7 +228,7 @@ public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor
      * Return the allowed values for annotationNames/disableAnnotations/annotationGroups for use by the help system.
      *
      * @param longArgName long name of the argument for which help is requested
-     * @return
+     * @return the set of allowed values for the argument, or null if the argument is not controlled by this descriptor
      */
     @Override
     public Set<String> getAllowedValuesForDescriptorHelp(String longArgName) {
@@ -243,7 +243,7 @@ public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor
         if (longArgName.equals(StandardArgumentDefinitions.ANNOTATION_GROUP_LONG_NAME)) {
             return discoveredGroups.keySet();
         }
-        throw new IllegalArgumentException("Allowed values request for unrecognized string argument: " + longArgName);
+        return null;
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKToolUnitTest.java
@@ -621,11 +621,6 @@ public final class GATKToolUnitTest extends GATKBaseTest {
         Assert.assertFalse(outFileMD5.exists(), "An md5 file was created and should not have been");
     }
 
-    private List<Annotation> instantiateAnnotations(final CommandLineParser clp) {
-        GATKAnnotationPluginDescriptor annotationPlugin = clp.getPluginDescriptor(GATKAnnotationPluginDescriptor.class);
-        return annotationPlugin.getResolvedInstances();
-    }
-
     @Test
     public void testMakeEmptyAnnotations() {
         final TestGATKToolWithVariants tool = createTestVariantTool(null);
@@ -753,6 +748,14 @@ public final class GATKToolUnitTest extends GATKBaseTest {
         Assert.assertFalse(annots.stream().anyMatch(a -> a.getClass()==Coverage.class));
         Assert.assertFalse(annots.stream().anyMatch(a -> a.getClass()==StandardAnnotation.class));
         Assert.assertFalse(annots.stream().anyMatch(a -> a.getClass()==ClippingRankSumTest.class));
+    }
+
+    @Test
+    public void testHelpWithAllPluginDescriptors() {
+        // Smoke test to ensure that requesting help from plugin descriptors doesn't crash. Use a tool
+        // (TestGATKToolWithVariants) that has both the read filter and annotation plugin descriptors enabled.
+        String[] args = {"-h"};
+        new TestGATKToolWithVariants().instanceMain(args);
     }
 
     private TestGATKToolWithVariants createTestVariantTool(final String args[]) {


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/4875. The newly added test fails without this change.