### PR TITLE
Modify the behavior of getNextReferenceVertex for non-ref paths

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -225,8 +225,8 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
         final Set<E> blacklistedEdgeSet = blacklistedEdge.isPresent() ? Collections.singleton(blacklistedEdge.get()) : Collections.emptySet();
 
         // if we got here, then we aren't on a reference path
-        final Optional<E> edge = outgoingEdges.stream().filter(e -> !blacklistedEdgeSet.contains(e)).findAny();
-        return edge.isPresent() ? getEdgeTarget(edge.get()) : null;
+        final List<E> edges = outgoingEdges.stream().filter(e -> !blacklistedEdgeSet.contains(e)).limit(2).collect(Collectors.toList());
+        return edges.size() == 1 ? getEdgeTarget(edges.get(0)) : null;
     }
 
     /**


### PR DESCRIPTION
There was a subtle change in the behavior of getNextReferenceVertex in the migration from GATK 3.x to the GATK 4.x that may be worth another look.

The original 3.x behavior is described in a comment of the function, if `@param allowNonRefPaths` is true, allow sub-paths that are non-reference _if there is only a single outgoing edge_. The 4.x migration copied the comment, but changed the behavior to if `@param allowNonRefPaths` is true, allow sub-paths that are non-reference _and pick a random outgoing edge_. 

This pull request restores the 3.x behavior, which we believe is the design intent.