### PR TITLE
Correct PathSeqBuildReferenceTaxonomy doc usage example

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildReferenceTaxonomy.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildReferenceTaxonomy.java
@@ -43,7 +43,7 @@ import java.util.*;
  * <h3>Usage examples</h3>
  *
  * <pre>
- * gatk PathSeqBuildKmers  \
+ * gatk PathSeqBuildReferenceTaxonomy \
  *   --reference microbe_reference.fasta \
  *   --output taxonomy.db \
  *   --refseq-catalog RefSeq-releaseXX.catalog.gz \


### PR DESCRIPTION
Trivial correction that uses the correct tool name in the usage example. See ticket #4284 