### PR TITLE
update htsjdk 2.15.1 -> 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 }
 
 final requiredJavaVersion = "8"
-final htsjdkVersion = System.getProperty('htsjdk.version','2.15.1')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.16.0')
 final picardVersion = System.getProperty('picard.version','2.18.2')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import com.intel.genomicsdb.GenomicsDBFeatureReader;
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.*;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -266,7 +267,7 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
         }
         // Due to a bug in HTSJDK, unindexed block compressed input files may fail to parse completely. For safety,
         // these files have been disabled. See https://github.com/broadinstitute/gatk/issues/4224 for discussion
-        if (!hasIndex && TribbleIndexedFeatureReader.hasBlockCompressedExtension(featureInput.getFeaturePath())) {
+        if (!hasIndex && IOUtil.hasBlockCompressedExtension(featureInput.getFeaturePath())) {
             throw new UserException.MissingIndex(featureInput.toString(),"Support for unindexed block-compressed files has been temporarily disabled. Try running IndexFeatureFile on the input.");
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -756,22 +756,10 @@ public abstract class GATKTool extends CommandLineProgram {
             throw new UserException.MissingReference("A reference file is required for writing CRAM files");
         }
 
-        //TODO this is a workaround until #4039 is resolved
-        final File reference;
-        if ( isCramFile ){
-            try{
-                reference = referenceArguments.getReferencePath().toFile();
-            } catch ( final UnsupportedOperationException e){
-                throw new UserException("When writing a cram File a local reference file must be used", e);
-            }
-        } else {
-            reference = null;
-        }
-
         return new SAMFileGATKReadWriter(
             ReadUtils.createCommonSAMWriter(
                 outputPath,
-                reference,
+                referenceArguments.getReferencePath(),
                 getHeaderForSAMWriter(),
                 preSorted,
                 createOutputBamIndex,

--- a/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
@@ -212,7 +212,7 @@ public final class GatherVcfsCloud extends CommandLineProgram {
                 return false;
             }
             final String pathString = path.toUri().toString();
-            if ( pathString.endsWith(".bcf") || !AbstractFeatureReader.hasBlockCompressedExtension(pathString)){
+            if ( pathString.endsWith(".bcf") || !IOUtil.hasBlockCompressedExtension(pathString)){
                 return false;
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
@@ -1,6 +1,7 @@
 
 package org.broadinstitute.hellbender.tools;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.*;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
@@ -94,7 +95,7 @@ public final class IndexFeatureFile extends CommandLineProgram {
     private Index createAppropriateIndexInMemory(final FeatureCodec<? extends Feature, ?> codec) {
         try {
             // For block-compression files, write a Tabix index
-            if (AbstractFeatureReader.hasBlockCompressedExtension(featureFile)) {
+            if (IOUtil.hasBlockCompressedExtension(featureFile)) {
                 // Creating tabix indices with a non standard extensions can cause problems so we disable it
                 if (outputFile != null && !outputFile.getAbsolutePath().endsWith(TabixUtils.STANDARD_INDEX_EXTENSION)) {
                     throw new UserException("The index for " + featureFile + " must be written to a file with a \"" + TabixUtils.STANDARD_INDEX_EXTENSION + "\" extension");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/FilterVariantTranches.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/FilterVariantTranches.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.vqsr;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
@@ -168,7 +169,7 @@ public class FilterVariantTranches extends CommandLineProgram {
     private Index createAppropriateIndexInMemory(final FeatureCodec<? extends Feature, ?> codec, File featureFile, File indexFile) {
         try {
             // For block-compression files, write a Tabix index
-            if (AbstractFeatureReader.hasBlockCompressedExtension(featureFile)) {
+            if (IOUtil.hasBlockCompressedExtension(featureFile)) {
                 // Creating tabix indices with a non standard extensions can cause problems so we disable it
                 if (!indexFile.getAbsolutePath().endsWith(TabixUtils.STANDARD_INDEX_EXTENSION)) {
                     throw new UserException("The index for " + featureFile + " must be written to a file with a \"" + TabixUtils.STANDARD_INDEX_EXTENSION + "\" extension");

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/sampileup/SAMPileupCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/sampileup/SAMPileupCodec.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.codecs.sampileup;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMUtils;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.*;
 import htsjdk.tribble.exception.CodecLineParsingException;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -57,7 +58,7 @@ public class SAMPileupCodec extends AsciiFeatureCodec<SAMPileupFeature> {
     @Override
     public boolean canDecode(final String path) {
         final String noBlockCompressedPath;
-        if (AbstractFeatureReader.hasBlockCompressedExtension(path)) {
+        if (IOUtil.hasBlockCompressedExtension(path)) {
             noBlockCompressedPath = FilenameUtils.removeExtension(path).toLowerCase();
         } else {
             noBlockCompressedPath = path.toLowerCase();

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -6,6 +6,7 @@ import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration;
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystemProvider;
 import com.google.common.io.ByteStreams;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Tribble;
@@ -103,7 +104,7 @@ public final class BucketUtils {
                 inputStream = new FileInputStream(path);
             }
 
-            if(AbstractFeatureReader.hasBlockCompressedExtension(path)){
+            if(IOUtil.hasBlockCompressedExtension(path)){
                 return IOUtils.makeZippedInputStream(new BufferedInputStream(inputStream));
             } else {
                 return inputStream;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -1107,7 +1107,7 @@ public final class ReadUtils {
     {
         return createCommonSAMWriter(
             (null == outputFile ? null : outputFile.toPath()),
-            referenceFile,
+            null == referenceFile ? null : referenceFile.toPath(),
             header,
             preSorted,
             createOutputBamIndex,
@@ -1128,7 +1128,7 @@ public final class ReadUtils {
      */
     public static SAMFileWriter createCommonSAMWriter(
         final Path outputPath,
-        final File referenceFile,
+        final Path referenceFile,
         final SAMFileHeader header,
         final boolean preSorted,
         boolean createOutputBamIndex,
@@ -1166,7 +1166,7 @@ public final class ReadUtils {
             final boolean preSorted)
     {
         return createCommonSAMWriterFromFactory(factory,
-            Utils.nonNull(outputFile).toPath(), referenceFile, header, preSorted);
+            Utils.nonNull(outputFile).toPath(), referenceFile == null ? null : referenceFile.toPath(), header, preSorted);
     }
 
     /**
@@ -1184,7 +1184,7 @@ public final class ReadUtils {
     public static SAMFileWriter createCommonSAMWriterFromFactory(
         final SAMFileWriterFactory factory,
         final Path outputPath,
-        final File referenceFile,
+        final Path referenceFile,
         final SAMFileHeader header,
         final boolean preSorted,
         OpenOption... openOptions)

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.variant;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.TribbleException;
@@ -105,7 +106,7 @@ public final class GATKVariantContextUtils {
             return VariantContextWriterBuilder.OutputType.VCF;
         } else if (extension.equals(VcfUtils.BCF_FILE_EXTENSION)) {
             return VariantContextWriterBuilder.OutputType.BCF;
-        } else if (AbstractFeatureReader.hasBlockCompressedExtension(outputFile.getPath())) {
+        } else if (IOUtil.hasBlockCompressedExtension(outputFile.getPath())) {
             return VariantContextWriterBuilder.OutputType.BLOCK_COMPRESSED_VCF;
         }
         return VariantContextWriterBuilder.OutputType.UNSPECIFIED;

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/sampileup/SAMPileupCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/sampileup/SAMPileupCodecUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.codecs.sampileup;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.readers.LineIteratorImpl;
@@ -51,7 +52,7 @@ public class SAMPileupCodecUnitTest extends GATKBaseTest {
         final String EXTRA_CHAR = "1";
         for(final String ext: SAMPileupCodec.SAM_PILEUP_FILE_EXTENSIONS) {
             testCanDecodeExtension(ext);
-            for (final String bcExt: AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
+            for (final String bcExt: IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
                 testCanDecodeExtension(ext + bcExt);
             }
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsIntegrationTest.java
@@ -59,8 +59,10 @@ public class ReadUtilsIntegrationTest extends GATKBaseTest {
         Assert.assertEquals(expectIndex, header.getSortOrder() == SAMFileHeader.SortOrder.coordinate);
       }
 
+      final Path referencePath = referenceFile == null ? null : referenceFile.toPath();
+
       try (final SAMFileWriter samWriter = ReadUtils.createCommonSAMWriter
-          (outputPath, referenceFile, samReader.getFileHeader(), preSorted, createIndex, createMD5)) {
+          (outputPath, referencePath, samReader.getFileHeader(), preSorted, createIndex, createMD5)) {
         final Iterator<SAMRecord> samRecIt = samReader.iterator();
         while (samRecIt.hasNext()) {
           samWriter.addAlignment(samRecIt.next());


### PR DESCRIPTION
Update to htsjdk 2.16.0.  This only updates gatk to fix the compile warnings from deprecations.  An additional PR is needed in order to support fasta.gz files.

fixes #4039