### PR TITLE
XsvTableFeatures now always put out the right number of columns.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/xsvLocatableTable/XsvTableFeature.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/xsvLocatableTable/XsvTableFeature.java
@@ -77,7 +77,14 @@ public class XsvTableFeature implements Feature {
         this.columnValues = columnValues;
 
         // Create our list of indices to remove:
-        locationColumnRemoveIndiciesInOrder = new ArrayList<>(Arrays.asList(contigColumn, startColumn, endColumn));
+        if ( startColumn == endColumn ) {
+            // Don't add the same column more than once:
+            locationColumnRemoveIndiciesInOrder = new ArrayList<>(Arrays.asList(contigColumn, startColumn));
+        }
+        else {
+            locationColumnRemoveIndiciesInOrder = new ArrayList<>(Arrays.asList(contigColumn, startColumn, endColumn));
+        }
+        
         locationColumnRemoveIndiciesInOrder.sort(Collections.reverseOrder());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorTestConstants.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorTestConstants.java
@@ -16,6 +16,7 @@ public class FuncotatorTestConstants {
     public static final String HG19_CHR3_REFERENCE_FILE_NAME = GATKBaseTest.largeFileTestDir + "funcotator" + File.separator + "GRCh37.p13.chr3.tar.gz";
     public static final String HG19_3_REFERENCE_FILE_NAME = GATKBaseTest.largeFileTestDir + "funcotator" + File.separator + "b37.3.tar.gz";
     public static final String HG38_3_REFERENCE_FILE_NAME = GATKBaseTest.largeFileTestDir + "funcotator" + File.separator + "hg38.3.tar.gz";
+    public static final String HG19_2_REFERENCE_FILE_NAME = GATKBaseTest.largeFileTestDir + "funcotator" + File.separator + "b37.2.tar.gz";
 
     public static final String FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER = GATKBaseTest.largeFileTestDir + "funcotator" + File.separator + "funcotator_dataSources" + File.separator;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorReferenceTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorReferenceTestUtils.java
@@ -26,12 +26,14 @@ public class FuncotatorReferenceTestUtils {
     private static Lazy<String> hg19Chr3Ref;
     private static Lazy<String> hg19Chr19Ref;
     private static Lazy<String> b37Chr3Ref;
+    private static Lazy<String> b37Chr2Ref;
     private static Lazy<String> hg38Chr3Ref;
 
     static {
         hg19Chr3Ref = new Lazy<>(createInitializer(new File(FuncotatorTestConstants.HG19_CHR3_REFERENCE_FILE_NAME)));
         hg19Chr19Ref = new Lazy<>(createInitializer(new File(FuncotatorTestConstants.HG19_CHR19_REFERENCE_FILE_NAME)));
         b37Chr3Ref = new Lazy<>(createInitializer(new File(FuncotatorTestConstants.HG19_3_REFERENCE_FILE_NAME)));
+        b37Chr2Ref = new Lazy<>(createInitializer(new File(FuncotatorTestConstants.HG19_2_REFERENCE_FILE_NAME)));
         hg38Chr3Ref = new Lazy<>(createInitializer(new File(FuncotatorTestConstants.HG38_3_REFERENCE_FILE_NAME)));
     }
 
@@ -101,6 +103,11 @@ public class FuncotatorReferenceTestUtils {
      * @return a path (as String) to the b37 chromosome 3 only reference.  ("3")
      */
     public static String retrieveB37Chr3Ref() { return b37Chr3Ref.get(); }
+
+    /**
+     * @return a path (as String) to the b37 chromosome 2 only reference.  ("2")
+     */
+    public static String retrieveB37Chr2Ref() { return b37Chr2Ref.get(); }
 
     /**
      * @return a path (as String) to the hg38 chromosome 3 only reference.  ("chr3" in hg38)

--- a/src/test/resources/large/funcotator/b37.2.tar.gz
+++ b/src/test/resources/large/funcotator/b37.2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:807186acf26d458e19dc8508cc892c639d3d10f9bd17b90df21a2d31e775d9d3
+size 71551117

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.config
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.config
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db17d3a45a1fd89d525342a7a23cf1bd2c3051883d8a28eb681cd83d1c6dc16
+size 1671

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.tsv
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f18e63dd2b4f54f71de4683b863af6b77755e08a0a6af0aaa9d56a1f0ca05ad1
+size 3342686

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.tsv.idx
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/clinvar/hg19/clinvar_hgmd.tsv.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1ca3de2675fbaa18a20aa9b114c9e10e01995ebaea4d94e088402a29e6f0b19
+size 10135929

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.config
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb604e5862217c3978cc2fb0abf2f6f2cb8b4cf34681a026fedcd891aa0aa6f0
+size 1679

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7c09d309121a8664c3f465ca169fadbfe539a188ab541052c4e6719aa209a15
+size 23214

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf.idx
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2aa8475b77a6c8e2c782a2de47c7ec8070bfd541303e548e96f787a8920c1d
+size 312

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.dict
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74883af09a5772034d53f2df884a82e34df415951081e5754bedf1517ee9faa9
+size 968

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d3f582d1ca1ed259c77e4a82f4bfed8e9253b4b5c3aba9a63eb08f75f5cc68d
+size 10353

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta.fai
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4e49f4d57d32943e1663cf9902460ff7a2e2c03dfaf0bd3c5fc7ad9f01c2d47
+size 441

--- a/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/clinvar_hg19_column_test.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/clinvar_hg19_column_test.vcf
@@ -1,0 +1,205 @@
+##fileformat=VCFv4.2
+##Biotin(Bgnd)=Biotin(Bgnd)|Staining|508|179
+##Biotin(High)=Biotin(High)|Staining|778|5902
+##DNP(Bgnd)=DNP(Bgnd)|Staining|1058|245
+##DNP(High)=DNP(High)|Staining|32198|156
+##Extension(A)=Extension(A)|Extension|41089|480
+##Extension(C)=Extension(C)|Extension|2446|11515
+##Extension(G)=Extension(G)|Extension|2936|11197
+##Extension(T)=Extension(T)|Extension|43350|395
+##FILTER=<ID=DUPE,Description="Duplicate assays position.">
+##FILTER=<ID=FAIL_REF,Description="Assay failed to map to reference.">
+##FILTER=<ID=TRIALLELIC,Description="Tri-allelic assay.">
+##FILTER=<ID=ZCALL_DIFF,Description="ZCALL_DIFF">
+##FORMAT=<ID=BAF,Number=1,Type=Float,Description="B Allele Frequency">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GTA,Number=1,Type=String,Description="Illumina Autocall Genotype">
+##FORMAT=<ID=GTZ,Number=1,Type=String,Description="zCall Genotype">
+##FORMAT=<ID=IGC,Number=1,Type=Float,Description="Illumina GenCall Confidence Score">
+##FORMAT=<ID=LRR,Number=1,Type=Float,Description="Log R Ratio">
+##FORMAT=<ID=NORMX,Number=1,Type=Float,Description="Normalized X intensity">
+##FORMAT=<ID=NORMY,Number=1,Type=Float,Description="Normalized Y intensity">
+##FORMAT=<ID=R,Number=1,Type=Float,Description="Normalized R value">
+##FORMAT=<ID=THETA,Number=1,Type=Float,Description="Normalized Theta value">
+##FORMAT=<ID=X,Number=1,Type=Integer,Description="Raw X intensity">
+##FORMAT=<ID=Y,Number=1,Type=Integer,Description="Raw Y intensity">
+##Hyb(High)=Hyb(High)|Hybridization|3310|11184
+##Hyb(Low)=Hyb(Low)|Hybridization|3436|1823
+##Hyb(Medium)=Hyb(Medium)|Hybridization|1307|6426
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=ALLELE_A,Number=1,Type=String,Description="A allele">
+##INFO=<ID=ALLELE_B,Number=1,Type=String,Description="B allele">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BEADSET_ID,Number=1,Type=Integer,Description="Bead set ID for normalization">
+##INFO=<ID=GC_SCORE,Number=1,Type=Float,Description="Gentrain Score">
+##INFO=<ID=ILLUMINA_BUILD,Number=1,Type=String,Description="Genome Build in Illumina manifest">
+##INFO=<ID=ILLUMINA_CHR,Number=1,Type=String,Description="Chromosome in Illumina manifest">
+##INFO=<ID=ILLUMINA_POS,Number=1,Type=Integer,Description="Position in Illumina manifest">
+##INFO=<ID=ILLUMINA_STRAND,Number=1,Type=String,Description="Probe strand">
+##INFO=<ID=N_AA,Number=1,Type=Integer,Description="Number of AA calls in training set">
+##INFO=<ID=N_AB,Number=1,Type=Integer,Description="Number of AB calls in training set">
+##INFO=<ID=N_BB,Number=1,Type=Integer,Description="Number of BB calls in training set">
+##INFO=<ID=PROBE_A,Number=1,Type=String,Description="Probe base pair sequence">
+##INFO=<ID=PROBE_B,Number=1,Type=String,Description="Probe base pair sequence; not missing for strand-ambiguous SNPs">
+##INFO=<ID=SOURCE,Number=1,Type=String,Description="Probe source">
+##INFO=<ID=devR_AA,Number=1,Type=Float,Description="Standard deviation of normalized R for AA cluster">
+##INFO=<ID=devR_AB,Number=1,Type=Float,Description="Standard deviation of normalized R for AB cluster">
+##INFO=<ID=devR_BB,Number=1,Type=Float,Description="Standard deviation of normalized R for BB cluster">
+##INFO=<ID=devTHETA_AA,Number=1,Type=Float,Description="Standard deviation of normalized THETA for AA cluster">
+##INFO=<ID=devTHETA_AB,Number=1,Type=Float,Description="Standard deviation of normalized THETA for AB cluster">
+##INFO=<ID=devTHETA_BB,Number=1,Type=Float,Description="Standard deviation of normalized THETA for BB cluster">
+##INFO=<ID=devX_AA,Number=1,Type=Float,Description="Standard deviation of normalized X for AA cluster">
+##INFO=<ID=devX_AB,Number=1,Type=Float,Description="Standard deviation of normalized X for AB cluster">
+##INFO=<ID=devX_BB,Number=1,Type=Float,Description="Standard deviation of normalized X for BB cluster">
+##INFO=<ID=devY_AA,Number=1,Type=Float,Description="Standard deviation of normalized Y for AA cluster">
+##INFO=<ID=devY_AB,Number=1,Type=Float,Description="Standard deviation of normalized Y for AB cluster">
+##INFO=<ID=devY_BB,Number=1,Type=Float,Description="Standard deviation of normalized Y for BB cluster">
+##INFO=<ID=meanR_AA,Number=1,Type=Float,Description="Mean of normalized R for AA cluster">
+##INFO=<ID=meanR_AB,Number=1,Type=Float,Description="Mean of normalized R for AB cluster">
+##INFO=<ID=meanR_BB,Number=1,Type=Float,Description="Mean of normalized R for BB cluster">
+##INFO=<ID=meanTHETA_AA,Number=1,Type=Float,Description="Mean of normalized THETA for AA cluster">
+##INFO=<ID=meanTHETA_AB,Number=1,Type=Float,Description="Mean of normalized THETA for AB cluster">
+##INFO=<ID=meanTHETA_BB,Number=1,Type=Float,Description="Mean of normalized THETA for BB cluster">
+##INFO=<ID=meanX_AA,Number=1,Type=Float,Description="Mean of normalized X for AA cluster">
+##INFO=<ID=meanX_AB,Number=1,Type=Float,Description="Mean of normalized X for AB cluster">
+##INFO=<ID=meanX_BB,Number=1,Type=Float,Description="Mean of normalized X for BB cluster">
+##INFO=<ID=meanY_AA,Number=1,Type=Float,Description="Mean of normalized Y for AA cluster">
+##INFO=<ID=meanY_AB,Number=1,Type=Float,Description="Mean of normalized Y for AB cluster">
+##INFO=<ID=meanY_BB,Number=1,Type=Float,Description="Mean of normalized Y for BB cluster">
+##INFO=<ID=refSNP,Number=1,Type=String,Description="dbSNP rs ID">
+##INFO=<ID=zthresh_X,Number=1,Type=Float,Description="zCall X threshold">
+##INFO=<ID=zthresh_Y,Number=1,Type=Float,Description="zCall Y threshold">
+##NP(A)=NP(A)|Non-Polymorphic|17148|391
+##NP(C)=NP(C)|Non-Polymorphic|1093|6000
+##NP(G)=NP(G)|Non-Polymorphic|1286|5170
+##NP(T)=NP(T)|Non-Polymorphic|15772|304
+##NSB(Bgnd)Blue=NSB(Bgnd)Blue|Non-SpecificBinding|922|301
+##NSB(Bgnd)Green=NSB(Bgnd)Green|Non-SpecificBinding|842|238
+##NSB(Bgnd)Purple=NSB(Bgnd)Purple|Non-SpecificBinding|912|204
+##NSB(Bgnd)Red=NSB(Bgnd)Red|Non-SpecificBinding|1016|295
+##Restore=Restore|Restoration|961|374
+##String(MM)=String(MM)|Stringency|4768|259
+##String(PM)=String(PM)|Stringency|29830|468
+##TargetRemoval=TargetRemoval|TargetRemoval|2492|281
+##analysisVersionNumber=1
+##arrayType=PsychChip_v1-1_15073391_A1
+##autocallDate=08/17/2017 00:40
+##autocallGender=F
+##autocallVersion=2.0.0.137
+##chipWellBarcode=0816201804HC0_R01C01
+##clusterFile=PsychChip_v1-1_15073391_A1_ClusterFile.egt
+##content=PsychChip_v1-1_15073391_A1.1.2.extended.csv
+##contig=<ID=1,length=249250621,assembly=GRCh37>
+##contig=<ID=2,length=243199373,assembly=GRCh37>
+##contig=<ID=3,length=198022430,assembly=GRCh37>
+##contig=<ID=4,length=191154276,assembly=GRCh37>
+##contig=<ID=5,length=180915260,assembly=GRCh37>
+##contig=<ID=6,length=171115067,assembly=GRCh37>
+##contig=<ID=7,length=159138663,assembly=GRCh37>
+##contig=<ID=8,length=146364022,assembly=GRCh37>
+##contig=<ID=9,length=141213431,assembly=GRCh37>
+##contig=<ID=10,length=135534747,assembly=GRCh37>
+##contig=<ID=11,length=135006516,assembly=GRCh37>
+##contig=<ID=12,length=133851895,assembly=GRCh37>
+##contig=<ID=13,length=115169878,assembly=GRCh37>
+##contig=<ID=14,length=107349540,assembly=GRCh37>
+##contig=<ID=15,length=102531392,assembly=GRCh37>
+##contig=<ID=16,length=90354753,assembly=GRCh37>
+##contig=<ID=17,length=81195210,assembly=GRCh37>
+##contig=<ID=18,length=78077248,assembly=GRCh37>
+##contig=<ID=19,length=59128983,assembly=GRCh37>
+##contig=<ID=20,length=63025520,assembly=GRCh37>
+##contig=<ID=21,length=48129895,assembly=GRCh37>
+##contig=<ID=22,length=51304566,assembly=GRCh37>
+##contig=<ID=X,length=155270560,assembly=GRCh37>
+##contig=<ID=Y,length=59373566,assembly=GRCh37>
+##contig=<ID=MT,length=16569,assembly=GRCh37>
+##contig=<ID=GL000207.1,length=4262,assembly=GRCh37>
+##contig=<ID=GL000226.1,length=15008,assembly=GRCh37>
+##contig=<ID=GL000229.1,length=19913,assembly=GRCh37>
+##contig=<ID=GL000231.1,length=27386,assembly=GRCh37>
+##contig=<ID=GL000210.1,length=27682,assembly=GRCh37>
+##contig=<ID=GL000239.1,length=33824,assembly=GRCh37>
+##contig=<ID=GL000235.1,length=34474,assembly=GRCh37>
+##contig=<ID=GL000201.1,length=36148,assembly=GRCh37>
+##contig=<ID=GL000247.1,length=36422,assembly=GRCh37>
+##contig=<ID=GL000245.1,length=36651,assembly=GRCh37>
+##contig=<ID=GL000197.1,length=37175,assembly=GRCh37>
+##contig=<ID=GL000203.1,length=37498,assembly=GRCh37>
+##contig=<ID=GL000246.1,length=38154,assembly=GRCh37>
+##contig=<ID=GL000249.1,length=38502,assembly=GRCh37>
+##contig=<ID=GL000196.1,length=38914,assembly=GRCh37>
+##contig=<ID=GL000248.1,length=39786,assembly=GRCh37>
+##contig=<ID=GL000244.1,length=39929,assembly=GRCh37>
+##contig=<ID=GL000238.1,length=39939,assembly=GRCh37>
+##contig=<ID=GL000202.1,length=40103,assembly=GRCh37>
+##contig=<ID=GL000234.1,length=40531,assembly=GRCh37>
+##contig=<ID=GL000232.1,length=40652,assembly=GRCh37>
+##contig=<ID=GL000206.1,length=41001,assembly=GRCh37>
+##contig=<ID=GL000240.1,length=41933,assembly=GRCh37>
+##contig=<ID=GL000236.1,length=41934,assembly=GRCh37>
+##contig=<ID=GL000241.1,length=42152,assembly=GRCh37>
+##contig=<ID=GL000243.1,length=43341,assembly=GRCh37>
+##contig=<ID=GL000242.1,length=43523,assembly=GRCh37>
+##contig=<ID=GL000230.1,length=43691,assembly=GRCh37>
+##contig=<ID=GL000237.1,length=45867,assembly=GRCh37>
+##contig=<ID=GL000233.1,length=45941,assembly=GRCh37>
+##contig=<ID=GL000204.1,length=81310,assembly=GRCh37>
+##contig=<ID=GL000198.1,length=90085,assembly=GRCh37>
+##contig=<ID=GL000208.1,length=92689,assembly=GRCh37>
+##contig=<ID=GL000191.1,length=106433,assembly=GRCh37>
+##contig=<ID=GL000227.1,length=128374,assembly=GRCh37>
+##contig=<ID=GL000228.1,length=129120,assembly=GRCh37>
+##contig=<ID=GL000214.1,length=137718,assembly=GRCh37>
+##contig=<ID=GL000221.1,length=155397,assembly=GRCh37>
+##contig=<ID=GL000209.1,length=159169,assembly=GRCh37>
+##contig=<ID=GL000218.1,length=161147,assembly=GRCh37>
+##contig=<ID=GL000220.1,length=161802,assembly=GRCh37>
+##contig=<ID=GL000213.1,length=164239,assembly=GRCh37>
+##contig=<ID=GL000211.1,length=166566,assembly=GRCh37>
+##contig=<ID=GL000199.1,length=169874,assembly=GRCh37>
+##contig=<ID=GL000217.1,length=172149,assembly=GRCh37>
+##contig=<ID=GL000216.1,length=172294,assembly=GRCh37>
+##contig=<ID=GL000215.1,length=172545,assembly=GRCh37>
+##contig=<ID=GL000205.1,length=174588,assembly=GRCh37>
+##contig=<ID=GL000219.1,length=179198,assembly=GRCh37>
+##contig=<ID=GL000224.1,length=179693,assembly=GRCh37>
+##contig=<ID=GL000223.1,length=180455,assembly=GRCh37>
+##contig=<ID=GL000195.1,length=182896,assembly=GRCh37>
+##contig=<ID=GL000212.1,length=186858,assembly=GRCh37>
+##contig=<ID=GL000222.1,length=186861,assembly=GRCh37>
+##contig=<ID=GL000200.1,length=187035,assembly=GRCh37>
+##contig=<ID=GL000193.1,length=189789,assembly=GRCh37>
+##contig=<ID=GL000194.1,length=191469,assembly=GRCh37>
+##contig=<ID=GL000225.1,length=211173,assembly=GRCh37>
+##contig=<ID=GL000192.1,length=547496,assembly=GRCh37>
+##contig=<ID=NC_007605,length=171823,assembly=NC_007605.1>
+##expectedGender=Female
+##extendedIlluminaManifestVersion=1.2
+##extendedManifestFile=PsychChip_v1-1_15073391_A1.1.2.extended.csv
+##fileDate=Thu Aug 17 00:44:56 UTC 2017
+##fingerprintGender=Unknown
+##genomeBuild=HG19
+##imagingDate=8/14/2015 7:27:49 PM
+##manifestFile=PsychChip_v1-1_15073391_A1.csv
+##p95Green=7373
+##p95Red=22526
+##picardVersion=1.1222-SNAPSHOT
+##reference=/cromwell_root/broad-references/hg19/v0/Homo_sapiens_assembly19.fasta
+##sampleAlias=NA12878
+##scannerName=N0700
+##source=BPM file
+##zcallThresholds=thresholds.7.txt
+##zcallVersion=1.0.0.0
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	0816201804HC0_R01C01
+2	21230514	exm175660	G	T	.	.	AC=0;AF=0.00;ALLELE_A=T;ALLELE_B=G*;AN=2;BEADSET_ID=860;GC_SCORE=0.885;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21230514;ILLUMINA_STRAND=TOP;N_AA=0;N_AB=0;N_BB=1251;PROBE_A=GTTTTCCATTAAGGTTAACAGGGAAGATAGACTTCCTGAATAACTATGCA;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.1;devR_AB=0.1;devR_BB=0.1;devTHETA_AA=0.022;devTHETA_AB=0.022;devTHETA_BB=0.014;devX_AA=0.099;devX_AB=0.052;devX_BB=0.014;devY_AA=0.021;devY_AB=0.051;devY_BB=0.095;meanR_AA=0.639;meanR_AB=0.76;meanR_BB=0.655;meanTHETA_AA=0.024;meanTHETA_AB=0.492;meanTHETA_BB=0.96;meanX_AA=0.616;meanX_AB=0.385;meanX_BB=0.039;meanY_AA=0.023;meanY_AB=0.375;meanY_BB=0.616;refSNP=rs72653099;zthresh_X=0.129168772932;zthresh_Y=0.162602617756	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0.999:0/0:0/0:0.488:-0.035:0.039:0.6:0.639:0.959:1112:3435
+2	21230600	exm2275566	G	A	.	.	AC=0;AF=0.00;ALLELE_A=A;ALLELE_B=G*;AN=2;BEADSET_ID=850;GC_SCORE=0.873;ILLUMINA_BUILD=37.2;ILLUMINA_CHR=2;ILLUMINA_POS=21230600;ILLUMINA_STRAND=TOP;N_AA=0;N_AB=0;N_BB=1251;PROBE_A=ACCTTAATGGAAAACGAACTTTCAAATTCCCTTCATTGTTTGTGGATGCC;PROBE_B=.;SOURCE=1000genomes;devR_AA=0.114;devR_AB=0.169;devR_BB=0.1;devTHETA_AA=0.022;devTHETA_AB=0.022;devTHETA_BB=0.009;devX_AA=0.117;devX_AB=0.064;devX_BB=0.015;devY_AA=0.04;devY_AB=0.062;devY_BB=0.095;meanR_AA=1.205;meanR_AB=1.496;meanR_BB=1.159;meanTHETA_AA=0.024;meanTHETA_AB=0.491;meanTHETA_BB=0.958;meanX_AA=1.161;meanX_AB=0.759;meanX_BB=0.072;meanY_AA=0.044;meanY_AB=0.737;meanY_BB=1.087;refSNP=rs61742323;zthresh_X=0.173933925781;zthresh_Y=0.183776805468	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0.989:0/0:0/0:0.472:-0.014:0.089:1.067:1.156:0.947:1802:6030
+2	21230828	exm175670	T	G	.	.	AC=0;AF=0.00;ALLELE_A=T*;ALLELE_B=G;AN=2;BEADSET_ID=850;GC_SCORE=0.904;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21230828;ILLUMINA_STRAND=TOP;N_AA=1247;N_AB=0;N_BB=0;PROBE_A=CACTTCCTTTGGACTGTCCAATAAGATCAATAGCAAACACCTAAGAGTAA;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.1;devR_AB=0.135;devR_BB=0.1;devTHETA_AA=0.009;devTHETA_AB=0.022;devTHETA_BB=0.022;devX_AA=0.098;devX_AB=0.054;devX_BB=0.031;devY_AA=0.014;devY_AB=0.054;devY_BB=0.101;meanR_AA=0.974;meanR_AB=1.193;meanR_BB=0.959;meanTHETA_AA=0.018;meanTHETA_AB=0.497;meanTHETA_BB=0.975;meanX_AA=0.948;meanX_AB=0.6;meanX_BB=0.036;meanY_AA=0.026;meanY_AB=0.593;meanY_BB=0.923;refSNP=rs72653098;zthresh_X=0.180081021025;zthresh_Y=0.120748796487	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0:0/0:0/0:0.512:-0.077:0.907:0.012:0.919:0.009:15780:141
+2	21230858	exm175672	T	C	.	.	AC=0;AF=0.00;ALLELE_A=T*;ALLELE_B=C;AN=2;BEADSET_ID=850;GC_SCORE=0.814;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21230858;ILLUMINA_STRAND=TOP;N_AA=1242;N_AB=0;N_BB=0;PROBE_A=ACAAATTAGTTTCACCATAGAAGGACCCCTCACTTCCTTTGGACTGTCCA;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.226;devR_AB=0.295;devR_BB=0.159;devTHETA_AA=0.006;devTHETA_AB=0.022;devTHETA_BB=0.022;devX_AA=0.219;devX_AB=0.122;devX_BB=0.06;devY_AA=0.02;devY_AB=0.122;devY_BB=0.164;meanR_AA=2.068;meanR_AB=2.613;meanR_BB=1.82;meanTHETA_AA=0.021;meanTHETA_AB=0.498;meanTHETA_BB=0.976;meanX_AA=2.002;meanX_AB=1.31;meanX_BB=0.067;meanY_AA=0.066;meanY_AB=1.303;meanY_BB=1.752;refSNP=rs142756262;zthresh_X=0.201317790122;zthresh_Y=0.180326773873	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0:0/0:0/0:0.402:-0.073:1.918:0.04:1.958:0.013:33213:378
+2	21231190	exm175681	A	C	.	.	AC=0;AF=0.00;ALLELE_A=A*;ALLELE_B=C;AN=2;BEADSET_ID=850;GC_SCORE=0.896;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231190;ILLUMINA_STRAND=BOT;N_AA=1249;N_AB=1;N_BB=0;PROBE_A=TACCTGAGAACGGAGCATGGGAGTGAAATGCTGTTTTTTGGAAATGCTAT;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.1;devR_AB=0.164;devR_BB=0.1;devTHETA_AA=0.008;devTHETA_AB=0.022;devTHETA_BB=0.022;devX_AA=0.098;devX_AB=0.057;devX_BB=0.035;devY_AA=0.015;devY_AB=0.055;devY_BB=0.102;meanR_AA=1.309;meanR_AB=1.455;meanR_BB=1.074;meanTHETA_AA=0.023;meanTHETA_AB=0.49;meanTHETA_BB=0.974;meanX_AA=1.263;meanX_AB=0.739;meanX_BB=0.041;meanY_AA=0.046;meanY_AB=0.716;meanY_BB=1.032;refSNP=rs148498577;zthresh_X=0.188059715443;zthresh_Y=0.143747812155	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0:0/0:0/0:0.886:-0.154:1.143:0.032:1.175:0.018:19857:271
+2	21231278	exm175686	G	A	.	.	AC=0;AF=0.00;ALLELE_A=A;ALLELE_B=G*;AN=2;BEADSET_ID=850;GC_SCORE=0.89;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231278;ILLUMINA_STRAND=TOP;N_AA=0;N_AB=16;N_BB=1235;PROBE_A=CCGTTCTCAGGTACTTGCTGGAGAACTTCACTGACTCCTTCAGAGCCAGC;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.1;devR_AB=0.126;devR_BB=0.1;devTHETA_AA=0.022;devTHETA_AB=0.024;devTHETA_BB=0.009;devX_AA=0.101;devX_AB=0.05;devX_BB=0.014;devY_AA=0.031;devY_AB=0.06;devY_BB=0.097;meanR_AA=0.965;meanR_AB=1.232;meanR_BB=1.086;meanTHETA_AA=0.028;meanTHETA_AB=0.567;meanTHETA_BB=0.977;meanX_AA=0.924;meanX_AB=0.551;meanX_BB=0.038;meanY_AA=0.041;meanY_AB=0.682;meanY_BB=1.048;refSNP=rs72653095;zthresh_X=0.134428242171;zthresh_Y=0.164427908145	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0.995:0/0:0/0:0.879:-0.201:0.039:0.907:0.946:0.973:926:5125
+2	21231387	exm175691	T	G	.	.	AC=0;AF=0.00;ALLELE_A=T*;ALLELE_B=G;AN=2;BEADSET_ID=850;GC_SCORE=0.582;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231387;ILLUMINA_STRAND=BOT;N_AA=1248;N_AB=0;N_BB=2;PROBE_A=TAATTTGGACTCTCCTTTGGCAGTGATGGAAGCTGCGATACCTGCTTCGT;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.111;devR_AB=0.109;devR_BB=0.1;devTHETA_AA=0.017;devTHETA_AB=0.022;devTHETA_BB=0.027;devX_AA=0.105;devX_AB=0.068;devX_BB=0.039;devY_AA=0.017;devY_AB=0.049;devY_BB=0.072;meanR_AA=0.673;meanR_AB=0.966;meanR_BB=0.978;meanTHETA_AA=0.042;meanTHETA_AB=0.383;meanTHETA_BB=0.725;meanX_AA=0.631;meanX_AB=0.572;meanX_BB=0.308;meanY_AA=0.041;meanY_AB=0.393;meanY_BB=0.669;refSNP=rs2163204;zthresh_X=0.185697348714;zthresh_Y=0.136933556944	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0:0/0:0/0:0.375:0.008:0.636:0.033:0.669:0.033:11109:237
+2	21231431	exm175693	G	A	.	.	AC=0;AF=0.00;ALLELE_A=A;ALLELE_B=G*;AN=2;BEADSET_ID=850;GC_SCORE=0.82;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231431;ILLUMINA_STRAND=TOP;N_AA=0;N_AB=0;N_BB=1250;PROBE_A=CTTCGTTTGCTGAGGTGGTTCCATTCCCTATGTCAGCATTTGCATCTAAT;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.128;devR_AB=0.191;devR_BB=0.1;devTHETA_AA=0.022;devTHETA_AB=0.022;devTHETA_BB=0.008;devX_AA=0.131;devX_AB=0.071;devX_BB=0.016;devY_AA=0.044;devY_AB=0.07;devY_BB=0.096;meanR_AA=1.35;meanR_AB=1.69;meanR_BB=1.285;meanTHETA_AA=0.024;meanTHETA_AB=0.495;meanTHETA_BB=0.966;meanX_AA=1.301;meanX_AB=0.852;meanX_BB=0.066;meanY_AA=0.049;meanY_AB=0.838;meanY_BB=1.219;refSNP=rs138391809;zthresh_X=0.171782122099;zthresh_Y=0.182037318196	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0.994:0/0:0/0:0.409:-0.132:0.07:1.107:1.177:0.96:1491:6254
+2	21231446	exm175695	T	C	.	.	AC=0;AF=0.00;ALLELE_A=T*;ALLELE_B=C;AN=2;BEADSET_ID=850;GC_SCORE=0.866;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231446;ILLUMINA_STRAND=BOT;N_AA=1248;N_AB=2;N_BB=0;PROBE_A=TGGTTCCATTCCCTATGTCAGCATTTGCATCTAATGTGAAAAGAGGAGAT;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.1;devR_AB=0.135;devR_BB=0.1;devTHETA_AA=0.01;devTHETA_AB=0.022;devTHETA_BB=0.022;devX_AA=0.096;devX_AB=0.05;devX_BB=0.032;devY_AA=0.016;devY_AB=0.059;devY_BB=0.102;meanR_AA=0.999;meanR_AB=1.219;meanR_BB=0.973;meanTHETA_AA=0.035;meanTHETA_AB=0.557;meanTHETA_BB=0.978;meanX_AA=0.947;meanX_AB=0.555;meanX_BB=0.033;meanY_AA=0.053;meanY_AB=0.664;meanY_BB=0.941;refSNP=rs142796181;zthresh_X=0.194493034433;zthresh_Y=0.161130815802	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0:0/0:0/0:0.849:-0.056:0.915:0.045:0.96:0.031:15919:326
+2	21231524	exm175699	G	A	.	DUPE	AC=0;AF=0.00;ALLELE_A=A;ALLELE_B=G*;AN=2;BEADSET_ID=850;GC_SCORE=0.815;ILLUMINA_BUILD=37.1;ILLUMINA_CHR=2;ILLUMINA_POS=21231524;ILLUMINA_STRAND=BOT;N_AA=57;N_AB=370;N_BB=821;PROBE_A=AATCCCAACTCTCAACCTTAATGATTTTCAAGTTCCTGACCTTCACATAC;PROBE_B=.;SOURCE=ExomeSNPs;devR_AA=0.115;devR_AB=0.11;devR_BB=0.1;devTHETA_AA=0.012;devTHETA_AB=0.02;devTHETA_BB=0.009;devX_AA=0.113;devX_AB=0.066;devX_BB=0.016;devY_AA=0.024;devY_AB=0.059;devY_BB=0.096;meanR_AA=1.422;meanR_AB=1.628;meanR_BB=1.202;meanTHETA_AA=0.026;meanTHETA_AB=0.459;meanTHETA_BB=0.967;meanX_AA=1.367;meanX_AB=0.867;meanX_BB=0.06;meanY_AA=0.056;meanY_AB=0.761;meanY_BB=1.142;refSNP=rs676210;zthresh_X=0.164213543474;zthresh_Y=0.178427638367	GT:BAF:GTA:GTZ:IGC:LRR:NORMX:NORMY:R:THETA:X:Y	0/0:0.991:0/0:0/0:0.838:-0.022:0.075:1.116:1.191:0.957:1571:6307


### PR DESCRIPTION
Fixes #4193

`XsvTableFeature` no longer removes an extra column if start and end in
the config file for a `LocatableXsv` data source are the same.