### PR TITLE
Clone read base qualities rather than reference them

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -86,7 +86,7 @@ public final class AssemblyBasedCallerUtils {
             if ( ! clippedRead.isEmpty() && clippedRead.getCigar().getReadLength() > 0 ) {
                 clippedRead = ReadClipper.hardClipToRegion( clippedRead, region.getExtendedSpan().getStart(), region.getExtendedSpan().getEnd() );
                 if ( region.readOverlapsRegion(clippedRead) && clippedRead.getLength() > 0 ) {
-                    readsToUse.add(clippedRead);
+                    readsToUse.add((clippedRead == myRead) ? clippedRead.deepCopy() : clippedRead);
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -45,9 +45,9 @@ public final class FragmentUtils {
         final int numOverlappingBases = Math.min(clippedFirstRead.getLength() - firstReadStop, clippedSecondRead.getLength());
 
         final byte[] firstReadBases = clippedFirstRead.getBases();
-        final byte[] firstReadQuals = clippedFirstRead.getBaseQualities();
+        final byte[] firstReadQuals = clippedFirstRead.getBaseQualities().clone();
         final byte[] secondReadBases = clippedSecondRead.getBases();
-        final byte[] secondReadQuals = clippedSecondRead.getBaseQualities();
+        final byte[] secondReadQuals = clippedSecondRead.getBaseQualities().clone();
 
         for ( int i = 0; i < numOverlappingBases; i++ ) {
             final int firstReadIndex = firstReadStop + i;

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -45,9 +45,9 @@ public final class FragmentUtils {
         final int numOverlappingBases = Math.min(clippedFirstRead.getLength() - firstReadStop, clippedSecondRead.getLength());
 
         final byte[] firstReadBases = clippedFirstRead.getBases();
-        final byte[] firstReadQuals = clippedFirstRead.getBaseQualities().clone();
+        final byte[] firstReadQuals = clippedFirstRead.getBaseQualities();
         final byte[] secondReadBases = clippedSecondRead.getBases();
-        final byte[] secondReadQuals = clippedSecondRead.getBaseQualities().clone();
+        final byte[] secondReadQuals = clippedSecondRead.getBaseQualities();
 
         for ( int i = 0; i < numOverlappingBases; i++ ) {
             final int firstReadIndex = firstReadStop + i;


### PR DESCRIPTION
When adjusting the base quality of overlapping read pairs, the modifications are made in place. If the modified reads are later used in another active region, the results from the later active region will be changed by the earlier modification.

This pull request clones the read's base quality, so that in place modifications do not affect later active regions.