### PR TITLE
Eliminated the filtering by user transcripts and fixed locus level issue

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -1971,7 +1971,8 @@ public final class FuncotatorUtils {
     public static boolean isFuncotationInTranscriptList( final GencodeFuncotation funcotation,
                                                   final Set<String> acceptableTranscripts ) {
         if ( funcotation.getAnnotationTranscript() != null ) {
-            return acceptableTranscripts.contains( getTranscriptIdWithoutVersionNumber(funcotation.getAnnotationTranscript()) );
+            final List<String> acceptableTranscriptsWithoutVersionNumbers = acceptableTranscripts.stream().map(tx -> getTranscriptIdWithoutVersionNumber(tx)).collect(Collectors.toList());
+            return acceptableTranscriptsWithoutVersionNumbers.contains( getTranscriptIdWithoutVersionNumber(funcotation.getAnnotationTranscript()) );
         }
         else {
             return false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/TranscriptSelectionMode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/TranscriptSelectionMode.java
@@ -160,7 +160,7 @@ public enum TranscriptSelectionMode {
      */
     CANONICAL {
         public Comparator<GencodeFuncotation> getComparator(final Set<String> userRequestedTranscripts) {
-            return new CannonicalGencodeFuncotationComparator(userRequestedTranscripts);
+            return new CanonicalGencodeFuncotationComparator(userRequestedTranscripts);
         }
     },
 
@@ -169,7 +169,7 @@ public enum TranscriptSelectionMode {
      */
     ALL {
         public Comparator<GencodeFuncotation> getComparator(final Set<String> userRequestedTranscripts) {
-            return new CannonicalGencodeFuncotationComparator(userRequestedTranscripts);
+            return new CanonicalGencodeFuncotationComparator(userRequestedTranscripts);
         }
     };
 
@@ -269,18 +269,17 @@ public enum TranscriptSelectionMode {
         @Override
         public int compare( final GencodeFuncotation a, final GencodeFuncotation b ) {
             // Check locus/curation levels:
-            // NOTE: For this field you want LOW, not high.  Therefore the final comparison starts with `b`, not `a`:
             if ( (a.getLocusLevel() != null) && (b.getLocusLevel() == null) ) {
                 return -1;
             }
             else if ( (a.getLocusLevel() == null ) && (b.getLocusLevel() != null) ) {
                 return 1;
             }
-            else if ( (a.getLocusLevel() != null) && (b.getLocusLevel() != null) && (!a.getLocusLevel().equals(b.getLocusLevel())) ) {
-                return b.getLocusLevel().compareTo( a.getLocusLevel() );
+            else if ( (a.getLocusLevel() == null ) && (b.getLocusLevel() == null) ) {
+                return 0;
             }
             else {
-                return 0;
+                return a.getLocusLevel().compareTo( b.getLocusLevel() );
             }
         }
     }
@@ -314,6 +313,7 @@ public enum TranscriptSelectionMode {
         @Override
         public int compare( final GencodeFuncotation a, final GencodeFuncotation b ) {
             // Check transcript sequence length:
+            // Note that since we want longer transcripts to be sorted earlier in the list, we reverse b and a in the last check.
             if ( (a.getTranscriptLength() != null) && (b.getTranscriptLength() == null) ) {
                 return -1;
             }
@@ -404,10 +404,10 @@ public enum TranscriptSelectionMode {
     }
 
     /**
-     * Comparator class for Cannonical order.
+     * Comparator class for Canonical order.
      * Complex enough that a Lambda would be utter madness.
      */
-    static class CannonicalGencodeFuncotationComparator implements Comparator<GencodeFuncotation> {
+    static class CanonicalGencodeFuncotationComparator implements Comparator<GencodeFuncotation> {
 
         private final Comparator<GencodeFuncotation> byUserTranscript;
         private final Comparator<GencodeFuncotation> byIgrStatus;
@@ -420,7 +420,7 @@ public enum TranscriptSelectionMode {
 
         private final Comparator<GencodeFuncotation> chainedComparator;
 
-        public CannonicalGencodeFuncotationComparator( final Set<String> userRequestedTranscripts ) {
+        public CanonicalGencodeFuncotationComparator(final Set<String> userRequestedTranscripts ) {
             byUserTranscript = new ComparatorByUserTranscript(userRequestedTranscripts);
             byIgrStatus = new ComparatorByIgrStatus();
             byVariantClassification = new ComparatorByVariantClassification();

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -175,7 +175,7 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
 
     /**
      * Comparator to be used when sorting {@link Funcotation}s created by this {@link GencodeFuncotationFactory}.
-     * Will be either {@link TranscriptSelectionMode.BestEffectGencodeFuncotationComparator} or {@link TranscriptSelectionMode.CannonicalGencodeFuncotationComparator}.
+     * Will be either {@link TranscriptSelectionMode.BestEffectGencodeFuncotationComparator} or {@link TranscriptSelectionMode.CanonicalGencodeFuncotationComparator}.
      */
     private final Comparator<GencodeFuncotation> gencodeFuncotationComparator;
 
@@ -291,10 +291,6 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
         if (gencodeFuncotationList.size() > 0) {
             // Get our "Best Transcript" from our list.
             sortFuncotationsByTranscriptForOutput(gencodeFuncotationList);
-
-            // Now we have to filter out the output gencodeFuncotations if they are not on the list the user provided:
-            // TODO: Is this correct behavior?  The sorting takes care of ordering the transcripts. See https://github.com/broadinstitute/gatk/issues/4918
-            filterAnnotationsByUserTranscripts(gencodeFuncotationList, userRequestedTranscripts);
 
             // Since the initial query was done on the entire gene footprint, we need to get rid of every transcript that does not overlap the variant at all (not even in flank)
             //   i.e. IGR.

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gencode/GencodeGtfFeature.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gencode/GencodeGtfFeature.java
@@ -1107,6 +1107,7 @@ public abstract class GencodeGtfFeature implements Feature, Comparable<GencodeGt
         /** shares an identical CDS but has alternative 3' UTR with respect to a reference variant. */
         ALTERNATIVE_5_UTR("alternative_5_UTR"),
 
+        /** Please note that the ordering of the APPRIS_* tags is also used in sorting here.  Do not re-order. */
         /** Transcript expected to code for the main functional isoform based on a range of protein features (APPRIS pipeline). */
         APPRIS_PRINCIPAL("appris_principal"),
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -159,7 +159,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
     }
 
     private static GencodeFuncotation createFuncotationForTestGencodeFuncotationComparatorUnitTest(
-            final String geneName,
+            final String transcriptId,
             final GencodeGtfFeature.FeatureTag apprisLevel,
             final Integer locusLevel,
             final GencodeFuncotation.VariantClassification variantClassification,
@@ -168,7 +168,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
 
         final GencodeFuncotationBuilder builder = new GencodeFuncotationBuilder();
 
-        builder.setAnnotationTranscript( geneName );
+        builder.setAnnotationTranscript( transcriptId );
         builder.setApprisRank( apprisLevel );
         builder.setLocusLevel( locusLevel );
         builder.setVariantClassification( variantClassification );
@@ -470,21 +470,21 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
 
         return new Object[][] {
                 // ==================================================================================================
-                // CannonicalGencodeFuncotationComparator
+                // CanonicalGencodeFuncotationComparator
                 // Transcript list:
                 {
                         // Goes down to Locus Level:
                         TranscriptSelectionMode.CANONICAL.getComparator(new HashSet<>()),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
+                        -1
                 },
                 {
                         // Goes down to Locus Level:
                         TranscriptSelectionMode.CANONICAL.getComparator(new HashSet<>(Collections.singletonList("TEST"))),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
+                        -1
                 },
                 {
                         TranscriptSelectionMode.CANONICAL.getComparator(transcriptSet),
@@ -515,13 +515,13 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                         TranscriptSelectionMode.CANONICAL.getComparator(transcriptSet),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
+                        -1
                 },
                 {
                         TranscriptSelectionMode.CANONICAL.getComparator(transcriptSet),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        -1
+                        1
                 },
                 // IGR / non-IGR:
                 {
@@ -634,24 +634,24 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                         TranscriptSelectionMode.BEST_EFFECT.getComparator(new HashSet<>()),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
+                        -1
                 },
                 {
                         // Goes down to Locus Level:
                         TranscriptSelectionMode.BEST_EFFECT.getComparator(new HashSet<>(Collections.singletonList("TEST"))),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
-                },
-                {
-                        TranscriptSelectionMode.BEST_EFFECT.getComparator(transcriptSet),
-                        createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        createFuncotationForTestGencodeFuncotationComparatorUnitTest("", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         -1
                 },
                 {
                         TranscriptSelectionMode.BEST_EFFECT.getComparator(transcriptSet),
-                        createFuncotationForTestGencodeFuncotationComparatorUnitTest("", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                        createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                        createFuncotationForTestGencodeFuncotationComparatorUnitTest("NOT_USER_REQUESTED", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                        -1
+                },
+                {
+                        TranscriptSelectionMode.BEST_EFFECT.getComparator(transcriptSet),
+                        createFuncotationForTestGencodeFuncotationComparatorUnitTest("NOT_USER_REQUESTED", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         1
                 },
@@ -698,13 +698,13 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                         TranscriptSelectionMode.BEST_EFFECT.getComparator(transcriptSet),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        1
+                        -1
                 },
                 {
                         TranscriptSelectionMode.BEST_EFFECT.getComparator(transcriptSet),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
-                        -1
+                        1
                 },
                 // Appris Annotation:
                 {
@@ -780,7 +780,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.NONSTOP, 5000),
                         createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1 + ".5", GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.NONSTOP, 5000),
                         transcriptId2.compareTo(transcriptId1)
-                },
+                }
         };
     }
 
@@ -1363,6 +1363,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 errorMessageStringBuilder.append(funcotation.getProteinChange());
                 errorMessageStringBuilder.append("]");
             }
+            errorMessageStringBuilder.append("\n");
+            errorMessageStringBuilder.append(funcotation.getAnnotationTranscript());
 
             Assert.assertTrue(
                     geneNameCorrect && variantClassificationCorrect && variantTypeCorrect &&
@@ -1407,5 +1409,108 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
     @Test(dataProvider = "provideDataForTestGetReferenceBases")
     void testGetReferenceBases(final Allele refAllele, final Allele altAllele, final ReferenceContext reference, final Strand strand, final String expected ) {
         Assert.assertEquals( GencodeFuncotationFactory.getReferenceBases(refAllele, altAllele, reference, strand) , expected);
+    }
+
+    @DataProvider
+    public Object[][] provideSortingOfUserRequestedTranscripts() {
+        final String transcriptId1 = "ENST0000001.4";
+        final String transcriptId2 = "ENST0000002.3";
+        final String transcriptId3 = "ENST0000003.8";
+        return new Object[][] {
+                {       Arrays.asList(
+                            createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                            createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                            createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId3, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        Collections.singleton(transcriptId2),
+                        transcriptId2
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId3, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        Collections.singleton(transcriptId1),
+                        transcriptId1
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId3, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId1
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId3, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId1
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId1
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId1
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 2, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId2
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_CANDIDATE, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId2
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_CANDIDATE_HIGHEST_SCORE, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId2
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 2000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),
+                        new HashSet<>(Arrays.asList(transcriptId2, transcriptId1)),
+                        transcriptId2
+                },
+                {       Arrays.asList(
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId1, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 2000),
+                                createFuncotationForTestGencodeFuncotationComparatorUnitTest(transcriptId2, GencodeGtfFeature.FeatureTag.APPRIS_PRINCIPAL, 1, GencodeFuncotation.VariantClassification.MISSENSE, 5000)
+                        ),Collections.singleton(transcriptId3),
+                        transcriptId2
+                }
+        };
+    }
+
+    /**
+     * Also, tests some basic sorting.
+     */
+    @Test(dataProvider = "provideSortingOfUserRequestedTranscripts")
+    public void testSortingOfUserRequestedTranscripts(final List<GencodeFuncotation> gencodeFuncotations, final Set<String> userRequestedTranscripts, final String gtFirstTranscript) {
+
+        final List<TranscriptSelectionMode> transcriptSelectionModes = Arrays.asList(TranscriptSelectionMode.ALL, TranscriptSelectionMode.BEST_EFFECT, TranscriptSelectionMode.CANONICAL);
+        for (final TranscriptSelectionMode transcriptSelectionMode : transcriptSelectionModes) {
+            final Comparator<GencodeFuncotation> comparator = transcriptSelectionMode.getComparator(userRequestedTranscripts);
+            gencodeFuncotations.sort(comparator);
+            Assert.assertEquals(gencodeFuncotations.get(0).getAnnotationTranscript(), gtFirstTranscript, " Failed on " + transcriptSelectionMode.toString());
+        }
     }
 }


### PR DESCRIPTION
- User defined transcripts were being used as a filter rather than a priority order.  The filtering step has been eliminated.  Closes #4918 
- Fixed previously unidentified issue where locus level ranking was being reversed.  Updated tests.  This was identified thanks to the thousands of tests in Funcotator (only one failed, but that was all it took).