### PR TITLE
Mutect2 ReadTransformer to hard clip inverted tandem repeats insertion artifacts

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -31,6 +31,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final String NORMAL_LOD_LONG_NAME = "normal-lod";
     public static final String MAX_MNP_DISTANCE_LONG_NAME = "max-mnp-distance";
     public static final String MAX_MNP_DISTANCE_SHORT_NAME = "mnp-dist";
+    public static final String DONT_CLIP_ITR_ARTIFACTS_LONG_NAME = "dont-clip-itr-artifacts";
 
 
     public static final double DEFAULT_AF_FOR_TUMOR_ONLY_CALLING = 5e-8;
@@ -142,5 +143,13 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     @Argument(fullName = MAX_MNP_DISTANCE_LONG_NAME, shortName = MAX_MNP_DISTANCE_SHORT_NAME,
             doc = "Two or more phased substitutions separated by this distance or less are merged into MNPs.", optional = true)
     public int maxMnpDistance = 1;
+
+    /**
+     * When opposite ends of a fragment are inverted tandem repeats of each other, the sequence past one end may be copied onto the other
+     * during library prep.  By default, Mutect2 identifies and clips these artifacts, which are especially prevalent when
+     * DNA is damaged as in the case of FFPE samples and ancient DNA.
+     */
+    @Argument(fullName= DONT_CLIP_ITR_ARTIFACTS_LONG_NAME, doc="Turn off read transformer that clips artifacts associated with end repair insertions near inverted tandem repeats.", optional = true)
+    public boolean dontClipITRArtifacts = false;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -31,7 +31,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final String NORMAL_LOD_LONG_NAME = "normal-lod";
     public static final String MAX_MNP_DISTANCE_LONG_NAME = "max-mnp-distance";
     public static final String MAX_MNP_DISTANCE_SHORT_NAME = "mnp-dist";
-    public static final String DONT_CLIP_ITR_ARTIFACTS_LONG_NAME = "dont-clip-itr-artifacts";
+    public static final String IGNORE_ITR_ARTIFACTS_LONG_NAME = "ignore-itr-artifacts";
 
 
     public static final double DEFAULT_AF_FOR_TUMOR_ONLY_CALLING = 5e-8;
@@ -149,7 +149,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      * during library prep.  By default, Mutect2 identifies and clips these artifacts, which are especially prevalent when
      * DNA is damaged as in the case of FFPE samples and ancient DNA.
      */
-    @Argument(fullName= DONT_CLIP_ITR_ARTIFACTS_LONG_NAME, doc="Turn off read transformer that clips artifacts associated with end repair insertions near inverted tandem repeats.", optional = true)
+    @Argument(fullName= IGNORE_ITR_ARTIFACTS_LONG_NAME, doc="Turn off read transformer that clips artifacts associated with end repair insertions near inverted tandem repeats.", optional = true)
     public boolean dontClipITRArtifacts = false;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine;
+import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.downsampling.MutectDownsampler;
 import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
 
@@ -161,6 +162,11 @@ public final class Mutect2 extends AssemblyRegionWalker {
     @Override
     public List<ReadFilter> getDefaultReadFilters() {
         return Mutect2Engine.makeStandardMutect2ReadFilters();
+    }
+
+    @Override
+    public ReadTransformer makePostReadFilterTransformer() {
+        return super.makePostReadFilterTransformer().andThen(Mutect2Engine.makeStandardMutect2PostFilterReadTransformer(referenceArguments.getReferencePath(), true));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformer.java
@@ -1,0 +1,114 @@
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarOperator;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.broadinstitute.hellbender.engine.ReferenceDataSource;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.clipping.ClippingOp;
+import org.broadinstitute.hellbender.utils.clipping.ClippingRepresentation;
+import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+/**
+ * Trims (hard clips) soft-clipped bases due to the following artifact:
+ *
+ * When a sequence and its reverse complement occur near opposite ends of a fragment DNA damage (especially in the case
+ * of FFPE samples and ancient DNA) can disrupt base-pairing causing a single-strand loop of the sequence and its reverse
+ * complement, after which end repair copies the true 5' end of the fragment onto the 3' end of the fragment.  That is, the
+ * artifact looks like this (A' denotes the reverse complement of A)
+ *
+ * Biological sequence:
+ * Forward strand 3' A  B  . . . B' C 5'
+ * Reverse strand 5' A' B' . . . B  C' 3'
+ *
+ * Loop structure (B/B', C/C' between forward and strands are *not* hybridized due to damage)
+ * Reverse strand 3' C' B   . . . . . .
+ * Forward strand 5' C  B'  . . . . . .
+ *                      |           . .
+ * Forward strand 3'    B   . . . . . .
+ * Reverse strand 5'    B'  . . . . . .
+ *
+ * After end repair of 5' overhang of sequence C on self-looped forward strand
+ * Reverse strand 3' C' B   . . . . . .
+ * Forward strand 5' C  B'  . . . . . .
+ *                   |  |           . .
+ * Forward strand 3' C' B   . . . . . .
+ * Reverse strand 5'    B'  . . . . . .
+ *
+ * Forward strand with artifact after denaturing: (C' replaces A)
+ * Forward strand 3' C' B . . . B' C
+ *
+ * Since there is no good way early in GATK tools to collect reads and mates, here we filter only for the case where
+ * sequence C matches the reference, so that the reference sequence is a proxy for the 5' end of the mate.  This catches
+ * most errors and saves a lot of runtime by reducing false active regions and by simplifying the assembly.
+ */
+public final class PalindromeArtifactClipReadTransformer implements ReadTransformer {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final double MIN_FRACTION_OF_MATCHING_BASES = 0.9;
+
+    private final ReferenceDataSource referenceDataSource;
+
+    // the artifact requires a minimum number of palindromic bases to create the single-strand loop
+    private final int minPalindromeSize;
+
+    public PalindromeArtifactClipReadTransformer(final ReferenceDataSource referenceDataSource, final int minPalindromeSize) {
+        this.referenceDataSource = referenceDataSource;
+        this.minPalindromeSize = minPalindromeSize;
+    }
+
+    @Override
+    public GATKRead apply(final GATKRead read) {
+        final int adaptorBoundary = read.getAdaptorBoundary();
+        if (adaptorBoundary == ReadUtils.CANNOT_COMPUTE_ADAPTOR_BOUNDARY) {
+            return read;
+        }
+
+        final Cigar cigar = read.getCigar();
+        final CigarOperator firstOperator = cigar.getFirstCigarElement().getOperator();
+        final CigarOperator lastOperator = cigar.getLastCigarElement().getOperator();
+        final boolean readIsUpstreamOfMate = read.getFragmentLength() > 0;
+
+        if ((readIsUpstreamOfMate && firstOperator != CigarOperator.SOFT_CLIP && firstOperator != CigarOperator.INSERTION) ||
+                (!readIsUpstreamOfMate && lastOperator != CigarOperator.SOFT_CLIP && lastOperator != CigarOperator.INSERTION)) {
+            return read;
+        }
+
+        final int potentialArtifactBaseCount = readIsUpstreamOfMate ? cigar.getFirstCigarElement().getLength() :
+                cigar.getLastCigarElement().getLength();
+
+        final int numBasesToCompare = Math.min(potentialArtifactBaseCount + minPalindromeSize, read.getLength());
+        final SimpleInterval refInterval = readIsUpstreamOfMate ?
+                new SimpleInterval(read.getContig(), adaptorBoundary - numBasesToCompare, adaptorBoundary - 1) :
+                new SimpleInterval(read.getContig(), adaptorBoundary + 1, adaptorBoundary + numBasesToCompare);
+
+
+        final MutableInt numMatch = new MutableInt(0);
+
+        // we traverse the reference in the forward direction, hence the read in the reverse direction
+        final MutableInt readIndex = new MutableInt(readIsUpstreamOfMate ? numBasesToCompare - 1 : read.getLength() - 1);
+        referenceDataSource.query(refInterval).forEachRemaining(refBase -> {
+            if (BaseUtils.getComplement(refBase) == read.getBase(readIndex.getValue())) {
+                numMatch.increment();
+            }
+            readIndex.decrement();
+        });
+
+        if (numMatch.doubleValue() / numBasesToCompare >= MIN_FRACTION_OF_MATCHING_BASES) {
+            final ReadClipper readClipper = new ReadClipper(read);
+            final ClippingOp clippingOp = readIsUpstreamOfMate ? new ClippingOp(0, potentialArtifactBaseCount) :
+                    new ClippingOp(read.getLength() - potentialArtifactBaseCount, read.getLength());
+            readClipper.addOp(clippingOp);
+            return readClipper.clipRead(ClippingRepresentation.HARDCLIP_BASES);
+        } else {
+            return read;
+        }
+
+
+    }
+}
+

--- a/src/main/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformer.java
+++ b/src/main/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformer.java
@@ -100,15 +100,13 @@ public final class PalindromeArtifactClipReadTransformer implements ReadTransfor
 
         if (numMatch.doubleValue() / numBasesToCompare >= MIN_FRACTION_OF_MATCHING_BASES) {
             final ReadClipper readClipper = new ReadClipper(read);
-            final ClippingOp clippingOp = readIsUpstreamOfMate ? new ClippingOp(0, potentialArtifactBaseCount) :
+            final ClippingOp clippingOp = readIsUpstreamOfMate ? new ClippingOp(0, potentialArtifactBaseCount - 1) :
                     new ClippingOp(read.getLength() - potentialArtifactBaseCount, read.getLength());
             readClipper.addOp(clippingOp);
             return readClipper.clipRead(ClippingRepresentation.HARDCLIP_BASES);
         } else {
             return read;
         }
-
-
     }
 }
 

--- a/src/test/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/transformers/PalindromeArtifactClipReadTransformerUnitTest.java
@@ -1,0 +1,113 @@
+package org.broadinstitute.hellbender.transformers;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.engine.ReferenceDataSource;
+import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2Engine;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.*;
+
+public class PalindromeArtifactClipReadTransformerUnitTest {
+
+    @Test
+    public void test() {
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        final String contig = header.getSequence(0).toString();
+        final int refStart = 1000;
+
+        // some random reference sequence -- no ITR yet
+        final byte[] refBases = ("GATTCCCCAAGGGGGCTGCTCCCAGAGGGTGTGTTGCTGGGATTGCCCAGGACAGGGATGGCCCTCTCATCAGGTGGGGG" +
+                "GCCTCCTCTCGCCGCAGGTCTGGCTGGATGAAGGGCACGGCATAGGTCTGACCTGCCAGGGAGTGCTGCATCCTCACAGG" +
+                "GCACAAAAAATGTGCACACACGGGTTCTTCCCACTTTAACCCCTGAGGAATCTGAGGCCTGCTCCTGAAACAGACTGGGC" +
+                "GGATGAGTGTGGCATGAAGGGCCTAGGAGATTTCACTTGGGTTTAAAATGCTGTGACCTTGAGTAAGTTGCCGTCTCTGA" +
+                "CTGATGCCCAGCCAACTGAGAAACCCAACCCTCTGAGACCAGCACACCCCTTTCAAGCATGTTCCTCCCTCCCCTTCTTT").getBytes();
+        final int refEnd = refStart + refBases.length - 1; // inclusive
+
+        final ReferenceDataSource referenceDataSource =
+                ReferenceDataSource.of(new ReferenceBases(refBases, new SimpleInterval(contig, refStart, refEnd)), header.getSequenceDictionary());
+
+        final ReadTransformer transformer = new PalindromeArtifactClipReadTransformer(referenceDataSource, Mutect2Engine.MIN_PALINDROME_SIZE);
+
+        // put in an ITR by hand
+        final int itrLength = 15;
+        // position in reference where first inverted tandem repeat begins and second ends
+        final int firstITRStartOffset = 30;
+        final int secondITREndOffset = 200;
+        for (int n = 0; n < itrLength; n++) {
+            refBases[firstITRStartOffset + n] = BaseUtils.simpleComplement(refBases[secondITREndOffset - n]);
+        }
+
+        final int numSoftClippedBases = 10;
+        final int numUnclippedBases = 30;
+        final int readLength = numSoftClippedBases + numUnclippedBases;
+
+        // the fragment spans the ITR region with possibly artifactual soft-clipped bases in the read and the same number of bases in the mate
+        final int fragmentLength = (secondITREndOffset - firstITRStartOffset + 1) + 2 * numSoftClippedBases;
+        final int readOffset = firstITRStartOffset - numSoftClippedBases;
+        final int readStart = readOffset + refStart;
+
+        final byte[] quals = new byte[readLength];
+        Arrays.fill(quals, (byte) 30);
+
+
+        final String cigar = numSoftClippedBases + "S" + numUnclippedBases + "M";
+
+        final byte[] readBasesMatchingRef = Arrays.copyOfRange(refBases, readOffset, readOffset + readLength);
+        final byte[] readBasesWithArtifact = Arrays.copyOf(readBasesMatchingRef, readLength);
+        for (int n = 0; n < numSoftClippedBases; n++) {
+            readBasesWithArtifact[n] = BaseUtils.simpleComplement(refBases[readOffset + fragmentLength - 1 - n]);
+        }
+
+
+        // read is upstream of mate and has the artifact
+        final GATKRead artifactRead = makeRead(header, contig, readStart, fragmentLength, readBasesWithArtifact, quals, cigar);
+        Assert.assertTrue(transformer.apply(artifactRead).getCigar().getFirstCigarElement().getOperator() == CigarOperator.HARD_CLIP);
+
+        // shift the mate by one base and no hard-clipping should occur
+        final GATKRead notQuiteArtifactRead = makeRead(header, contig, readStart, fragmentLength + 1, readBasesWithArtifact, quals, cigar);
+        Assert.assertTrue(transformer.apply(notQuiteArtifactRead).getCigar().getFirstCigarElement().getOperator() == CigarOperator.SOFT_CLIP);
+
+        // definitely no artifact
+        final GATKRead definitelyNotArtifactRead = makeRead(header, contig, readStart, fragmentLength, readBasesMatchingRef, quals, cigar);
+        Assert.assertTrue(transformer.apply(definitelyNotArtifactRead).getCigar().getFirstCigarElement().getOperator() == CigarOperator.SOFT_CLIP);
+
+    }
+
+    private static GATKRead makeRead(final SAMFileHeader header, final String contig, final int readStart, final int fragmentLength, final byte[] bases, final byte[] qual, final String cigar) {
+        final SAMRecord read = new SAMRecord(header);
+        read.setReferenceName(contig);
+        read.setAlignmentStart(readStart);
+        read.setReadPairedFlag(true);
+        read.setReadUnmappedFlag(false);
+        read.setMateUnmappedFlag(false);
+        read.setMateReferenceName("Mate");
+        read.setReadNegativeStrandFlag(false);
+        read.setMateNegativeStrandFlag(true);
+        read.setReadBases(bases);
+        read.setBaseQualities(qual);
+
+
+        final int mateStart = readStart + fragmentLength - bases.length;
+        read.setMateAlignmentStart(mateStart);
+        read.setInferredInsertSize(fragmentLength);
+        read.setProperPairFlag(true);
+        read.setCigarString(cigar);
+
+
+        return new SAMRecordToGATKReadAdapter(read);
+    }
+
+}


### PR DESCRIPTION
@takutosato Here it is.  The failure has nothing to do with this branch -- every branch is failing in the same way currently.  I have tested and debugged this thoroughly and I am deliberately not writing unit tests for now because we're too busy with MC3 and the M2 paper.  I intend to come back to these later.