### PR TITLE
added option for ValidateBasicSomaticShortMutations to output a vcf

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicSomaticShortMutationValidator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicSomaticShortMutationValidator.java
@@ -70,13 +70,12 @@ public class BasicSomaticShortMutationValidator {
                                                                        int validationTumorAltCount, int validationTumorTotalCount,
                                                                        int minBaseQualityCutoff, final SimpleInterval interval, final String filters) {
 
-        if (!isAbleToValidateGenotype(genotype, referenceAllele)){
+        if (!isAbleToValidateGenotype(genotype, referenceAllele) || validationNormalPileup == null){
             return null;
         }
 
         Utils.nonNull(referenceAllele);
         Utils.nonNull(genotype);
-        Utils.nonNull(validationNormalPileup);
         Utils.nonNull(interval);
         Utils.nonNull(filters);
         ParamUtils.isPositiveOrZero(validationTumorAltCount, "Validation alt count must be >= 0");
@@ -87,6 +86,10 @@ public class BasicSomaticShortMutationValidator {
                 referenceAllele, minBaseQualityCutoff);
         final int discoveryTumorAltCount = genotype.getAD()[1];
         final int discoveryTumorTotalCount = genotype.getAD()[0] + discoveryTumorAltCount;
+
+        if (Double.isNaN(maxAltRatioSeenInNormalValidation) || discoveryTumorTotalCount == 0) {
+            return null;
+        }
 
         final int minCountForSignal = PowerCalculationUtils.calculateMinCountForSignal(validationTumorTotalCount, maxAltRatioSeenInNormalValidation);
         final double power = PowerCalculationUtils.calculatePower(validationTumorTotalCount, discoveryTumorAltCount, discoveryTumorTotalCount, minCountForSignal);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
@@ -227,10 +227,12 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
                 new SimpleInterval(discoveryVariantContext.getContig(), discoveryVariantContext.getStart(), discoveryVariantContext.getEnd()),
                 filterString);
 
-        results.add(basicValidationResult);
+        if (basicValidationResult != null) {
+            results.add(basicValidationResult);
+        }
 
-        final boolean validated = basicValidationResult.isOutOfNoiseFloor();
-        final boolean powered = basicValidationResult.getPower() > minPower;
+        final boolean validated = basicValidationResult != null && basicValidationResult.isOutOfNoiseFloor();
+        final boolean powered = basicValidationResult != null && basicValidationResult.getPower() > minPower;
 
         if (discoveryVariantContext.isSNP()) {
             if (validated) {
@@ -249,7 +251,7 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
         if (annotatedVcf != null) {
             vcfWriter.add(new VariantContextBuilder(discoveryVariantContext)
                     .attribute(JUDGMENT_INFO_FIELD_KEY, validated ? Judgment.VALIDATED : Judgment.UNVALIDATED)
-                    .attribute(POWER_INFO_FIELD_KEY, basicValidationResult.getPower())
+                    .attribute(POWER_INFO_FIELD_KEY, basicValidationResult == null ? 0 : basicValidationResult.getPower())
                     .attribute(VALIDATION_AD_INFO_FIELD_KEY, new int[] {validationTumorRefCount, validationTumorAltCount}).make());
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
@@ -20,11 +20,7 @@ import org.broadinstitute.hellbender.engine.VariantWalker;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.walkers.mutect.FilterMutectCalls;
-import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2Engine;
-import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2FilteringEngine;
 import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
-import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceState;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceSummaryRecord;
 import org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -32,16 +28,12 @@ import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
 import org.broadinstitute.hellbender.utils.tsv.DataLine;
 import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
 import org.broadinstitute.hellbender.utils.tsv.TableWriter;
-import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
-import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 import picard.cmdline.programgroups.VariantEvaluationProgramGroup;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static org.broadinstitute.hellbender.utils.variant.GATKVCFConstants.ALLELE_BALANCE_HET_KEY;
 
 @CommandLineProgramProperties(
         summary = "Bare-bones implementation heavily inspired by MutationValidator from Broad CGA group.\n" +
@@ -140,7 +132,7 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
             "Validation judgment: validated, unvalidated, or skipped.");
 
 
-    public static enum Judgment {
+    public enum Judgment {
         VALIDATED, UNVALIDATED, SKIPPED;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
@@ -33,6 +33,7 @@ public class ValidateBasicSomaticShortMutationsIntegrationTest extends CommandLi
         //  No variants should validate, since the validation bam is not the same one used for calling.
         final File outputFile = IOUtils.createTempFile("basicTest", ".seg");
         final File summaryFile = IOUtils.createTempFile("summary", ".txt");
+        final File annotatedVcf = IOUtils.createTempFile("annotated", ".vcf");
         final List<String> arguments = new ArrayList<>();
         arguments.add("--" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_DISCOVERY_VCF_LONG_NAME);
         arguments.add("synthetic.challenge.set1.tumor");
@@ -59,6 +60,8 @@ public class ValidateBasicSomaticShortMutationsIntegrationTest extends CommandLi
         arguments.add(outputFile.getAbsolutePath());
         arguments.add("-" + Concordance.SUMMARY_LONG_NAME);
         arguments.add(summaryFile.getAbsolutePath());
+        arguments.add("--" + ValidateBasicSomaticShortMutations.ANNOTATED_VCF_LONG_NAME);
+        arguments.add(annotatedVcf.getAbsolutePath());
         arguments.add("--verbosity");
         arguments.add("INFO");
         runCommandLine(arguments);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
@@ -180,4 +180,49 @@ public class ValidateBasicSomaticShortMutationsIntegrationTest extends CommandLi
                         discoveryAltCoverage, discoveryAltCoverage + discoveryRefCoverage,
                         minCount));
     }
+
+
+    //TODO delete this!!!!
+    @Test
+    public void DEBUG() {
+        // This test is simply running the full tool and making sure that there are no serious errors.
+        //  No variants should validate, since the validation bam is not the same one used for calling.
+        final File outputFile = IOUtils.createTempFile("basicTest", ".seg");
+        final File annotatedVcf = IOUtils.createTempFile("annotated", ".vcf");
+        final File summaryFile = IOUtils.createTempFile("summary", ".txt");
+        final List<String> arguments = new ArrayList<>();
+        arguments.add("--" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_DISCOVERY_VCF_LONG_NAME);
+        arguments.add("H_LS-A1-A0SM-01A-11D-A099-09");
+        arguments.add("-" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_VALIDATION_CASE);
+        arguments.add("H_LS-A1-A0SM-01A-11D-A19H-09");
+        arguments.add("-" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_VALIDATION_CONTROL);
+        arguments.add("H_LS-A1-A0SM-10A-02D-A099-09");
+
+        arguments.add("-" + StandardArgumentDefinitions.VARIANT_SHORT_NAME);
+        arguments.add("/Users/davidben/Desktop/mc3_debug/merged.vcf");
+
+        arguments.add("-" + StandardArgumentDefinitions.INPUT_SHORT_NAME);
+        arguments.add("/Users/davidben/Desktop/mc3_debug/tumor.bam");
+        arguments.add("-" + StandardArgumentDefinitions.INPUT_SHORT_NAME);
+        arguments.add("/Users/davidben/Desktop/mc3_debug/normal.bam");
+
+        //arguments.add("-XL");
+        //arguments.add("1");
+        arguments.add("-L");
+        arguments.add("/Users/davidben/Desktop/mc3_debug/bitgt.interval_list");
+
+        arguments.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME);
+        arguments.add("/Users/davidben/Desktop/mc3_debug/Homo_sapiens_assembly19.fasta");
+
+        arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
+        arguments.add(outputFile.getAbsolutePath());
+        arguments.add("-" + Concordance.SUMMARY_LONG_NAME);
+        arguments.add(summaryFile.getAbsolutePath());
+
+        arguments.add("--" + ValidateBasicSomaticShortMutations.ANNOTATED_VCF_LONG_NAME);
+        arguments.add(annotatedVcf.getAbsolutePath());
+
+        runCommandLine(arguments);
+        int h = 9;
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
@@ -180,49 +180,4 @@ public class ValidateBasicSomaticShortMutationsIntegrationTest extends CommandLi
                         discoveryAltCoverage, discoveryAltCoverage + discoveryRefCoverage,
                         minCount));
     }
-
-
-    //TODO delete this!!!!
-    @Test
-    public void DEBUG() {
-        // This test is simply running the full tool and making sure that there are no serious errors.
-        //  No variants should validate, since the validation bam is not the same one used for calling.
-        final File outputFile = IOUtils.createTempFile("basicTest", ".seg");
-        final File annotatedVcf = IOUtils.createTempFile("annotated", ".vcf");
-        final File summaryFile = IOUtils.createTempFile("summary", ".txt");
-        final List<String> arguments = new ArrayList<>();
-        arguments.add("--" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_DISCOVERY_VCF_LONG_NAME);
-        arguments.add("H_LS-A1-A0SM-01A-11D-A099-09");
-        arguments.add("-" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_VALIDATION_CASE);
-        arguments.add("H_LS-A1-A0SM-01A-11D-A19H-09");
-        arguments.add("-" + ValidateBasicSomaticShortMutations.SAMPLE_NAME_VALIDATION_CONTROL);
-        arguments.add("H_LS-A1-A0SM-10A-02D-A099-09");
-
-        arguments.add("-" + StandardArgumentDefinitions.VARIANT_SHORT_NAME);
-        arguments.add("/Users/davidben/Desktop/mc3_debug/merged.vcf");
-
-        arguments.add("-" + StandardArgumentDefinitions.INPUT_SHORT_NAME);
-        arguments.add("/Users/davidben/Desktop/mc3_debug/tumor.bam");
-        arguments.add("-" + StandardArgumentDefinitions.INPUT_SHORT_NAME);
-        arguments.add("/Users/davidben/Desktop/mc3_debug/normal.bam");
-
-        //arguments.add("-XL");
-        //arguments.add("1");
-        arguments.add("-L");
-        arguments.add("/Users/davidben/Desktop/mc3_debug/bitgt.interval_list");
-
-        arguments.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME);
-        arguments.add("/Users/davidben/Desktop/mc3_debug/Homo_sapiens_assembly19.fasta");
-
-        arguments.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
-        arguments.add(outputFile.getAbsolutePath());
-        arguments.add("-" + Concordance.SUMMARY_LONG_NAME);
-        arguments.add(summaryFile.getAbsolutePath());
-
-        arguments.add("--" + ValidateBasicSomaticShortMutations.ANNOTATED_VCF_LONG_NAME);
-        arguments.add(annotatedVcf.getAbsolutePath());
-
-        runCommandLine(arguments);
-        int h = 9;
-    }
 }


### PR DESCRIPTION
@takutosato This lets `ValidateBasicSomaticShortMutations` optionally annotate the `eval` vcf with validation `INFO` fields in addition to the standard output of a tsv.  Having a vcf is more convenient for some things in MC3.