### PR TITLE
downgrading gcloud to 207.0.0 from 208.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ before_install:
     export BOTO_CONFIG=/dev/null;
     openssl aes-256-cbc -K $encrypted_29f3b7c4d8c3_key -iv $encrypted_29f3b7c4d8c3_iv  -in resources_for_CI/servicekey.json.enc -out servicekey.json -d;
     scripts/install_gcloud.sh;
-    printf 'y\n' | $GCLOUD_HOME/gcloud components update;
     if [[ $TEST_TYPE == cloud ]]; then
       printf 'y\n' | $GCLOUD_HOME/gcloud components install beta;
     fi;

--- a/scripts/install_gcloud.sh
+++ b/scripts/install_gcloud.sh
@@ -2,9 +2,9 @@
 #Install gcloud
 if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
     mkdir -p $HOME/gcloud &&
-    wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud &&
+    wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-207.0.0-linux-x86_64.tar.gz --directory-prefix=$HOME/gcloud &&
     cd $HOME/gcloud &&
-    tar xzf google-cloud-sdk.tar.gz &&
+    tar xzf google-cloud-sdk-207.0.0-linux-x86_64.tar.gz &&
     printf '\ny\n\ny\ny\n' | ./google-cloud-sdk/install.sh &&
     cd $TRAVIS_BUILD_DIR;
 fi


### PR DESCRIPTION
* There is a known issue in gcloud 208.0.0 which causes the dataproc
commands to fail.  This works around the issue by pinning the version on
travis to 207.0.0
* see https://github.com/broadinstitute/gatk/issues/5003 for more info