### PR TITLE
Updating MarkDuplicatesSpark tiebreaking to reflect changes in picard

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -371,12 +371,12 @@ public class MarkDuplicatesSparkUtils {
         }
 
         final Pair bestPair = pairs.stream()
+                .peek(pair -> finder.addLocationInformation(pair.getName(), pair))
                 .max(PAIRED_ENDS_SCORE_COMPARATOR)
                 .orElseThrow(() -> new GATKException.ShouldNeverReachHereException("There was no best pair because the stream was empty, but it shouldn't have been empty."));
 
         // Split by orientation and count duplicates in each group separately.
         final Map<Byte, List<Pair>> groupByOrientation = pairs.stream()
-                .peek(pair -> finder.addLocationInformation(pair.getName(), pair))//TODO this needs me to handle the name better
                 .collect(Collectors.groupingBy(Pair::getOrientationForOpticalDuplicates));
         final int numOpticalDuplicates;
         //todo do we not have to split the reporting of these by orientation?

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSparkUtils.java
@@ -38,7 +38,7 @@ public class MarkDuplicatesSparkUtils {
     public static final String OPTICAL_DUPLICATE_TOTAL_ATTRIBUTE_NAME = "OD";
     // This comparator represents the tiebreaking for PairedEnds duplicate marking.
     // We compare first on score, followed by unclipped start position (which is reversed here because of the expected ordering)
-    private static final Comparator<PairedEnds> PAIRED_ENDS_SCORE_COMPARATOR = Comparator.comparing(PairedEnds::getScore)
+    private static final Comparator<TransientFieldPhysicalLocation> PAIRED_ENDS_SCORE_COMPARATOR = Comparator.comparing(TransientFieldPhysicalLocation::getScore)
             .thenComparing(PairedEndsCoordinateComparator.INSTANCE.reversed());
 
     /**
@@ -321,7 +321,7 @@ public class MarkDuplicatesSparkUtils {
             //empty MarkDuplicatesSparkRecord signify that a pair has a mate somewhere else
             // If there are any non-fragment placeholders at this site, mark everything as duplicates, otherwise compute the best score
             if (Utils.isNonEmpty(fragments) && !Utils.isNonEmpty(emptyFragments)) {
-                final Tuple2<IndexPair<String>, Integer> bestFragment = handleFragments(fragments);
+                final Tuple2<IndexPair<String>, Integer> bestFragment = handleFragments(fragments, finder);
                 nonDuplicates.add(bestFragment);
             }
 
@@ -365,6 +365,11 @@ public class MarkDuplicatesSparkUtils {
     }
 
     private static Tuple2<IndexPair<String>, Integer> handlePairs(List<Pair> pairs, OpticalDuplicateFinder finder) {
+        // save ourselves the trouble when there are no optical duplicates to worry about
+        if (pairs.size() == 1) {
+            return (new Tuple2<>(new IndexPair<>(pairs.get(0).getName(), pairs.get(0).getPartitionIndex()), 0));
+        }
+
         final Pair bestPair = pairs.stream()
                 .max(PAIRED_ENDS_SCORE_COMPARATOR)
                 .orElseThrow(() -> new GATKException.ShouldNeverReachHereException("There was no best pair because the stream was empty, but it shouldn't have been empty."));
@@ -399,9 +404,10 @@ public class MarkDuplicatesSparkUtils {
     /**
      * If there are fragments with no non-fragments overlapping at a site, select the best one according to PAIRED_ENDS_SCORE_COMPARATOR
      */
-    private static Tuple2<IndexPair<String>, Integer> handleFragments(List<MarkDuplicatesSparkRecord> duplicateFragmentGroup) {
+    private static Tuple2<IndexPair<String>, Integer> handleFragments(List<MarkDuplicatesSparkRecord> duplicateFragmentGroup, OpticalDuplicateFinder finder) {
         return duplicateFragmentGroup.stream()
                 .map(f -> (Fragment)f)
+                .peek(f -> finder.addLocationInformation(f.getName(), f))
                 .max(PAIRED_ENDS_SCORE_COMPARATOR)
                 .map(best -> new Tuple2<>(new IndexPair<>(best.getName(), best.getPartitionIndex()), -1))
                 .orElse(null);
@@ -488,14 +494,14 @@ public class MarkDuplicatesSparkUtils {
      * NOTE: Because the original records were grouped by readname, we know that they must be unique once they hit this
      *       comparator and thus we don't need to worry about further tiebreaking for this method.
      */
-    public static final class PairedEndsCoordinateComparator implements Comparator<PairedEnds>, Serializable {
+    public static final class PairedEndsCoordinateComparator implements Comparator<TransientFieldPhysicalLocation>, Serializable {
         private static final long serialVersionUID = 1L;
 
         public static final PairedEndsCoordinateComparator INSTANCE = new PairedEndsCoordinateComparator();
         private PairedEndsCoordinateComparator() { }
 
         @Override
-        public int compare( PairedEnds first, PairedEnds second ) {
+        public int compare( TransientFieldPhysicalLocation first, TransientFieldPhysicalLocation second ) {
             int result = Integer.compare(first.getFirstStartPosition(), second.getFirstStartPosition());
             if ( result != 0 ) {
                 return result;
@@ -504,6 +510,16 @@ public class MarkDuplicatesSparkUtils {
             //This is done to mimic SAMRecordCoordinateComparator's behavior
             if (first.isRead1ReverseStrand() != second.isRead1ReverseStrand()) {
                 return first.isRead1ReverseStrand() ? -1: 1;
+            }
+
+            if (first.getTile() != second.getTile()) {
+                return first.getTile() - second.getTile();
+            }
+            if (first.getX() != second.getX()) {
+                return first.getX() - second.getX();
+            }
+            if (first.getY() != second.getY()) {
+                return first.getY() - second.getY();
             }
 
             if ( first.getName() != null && second.getName() != null ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/Fragment.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/Fragment.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.utils.read.markduplicates.LibraryIdGenerato
 import org.broadinstitute.hellbender.utils.read.markduplicates.MarkDuplicatesScoringStrategy;
 import org.broadinstitute.hellbender.utils.read.markduplicates.ReadEnds;
 import org.broadinstitute.hellbender.utils.read.markduplicates.ReadsKey;
+import picard.sam.util.PhysicalLocation;
 
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import java.util.Map;
  * This class holds onto as little information as possible in an attempt to prevent excessive serialization of
  * during the processing step of MarkDuplicatesSpark
  */
-public class Fragment extends PairedEnds {
+public class Fragment extends TransientFieldPhysicalLocation {
     protected transient ReadsKey key;
 
     private final int firstStartPosition;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/Pair.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/Pair.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * during the processing step of MarkDuplicatesSpark
  */
 @DefaultSerializer(Pair.Serializer.class)
-public final class Pair extends PairedEnds implements PhysicalLocation {
+public final class Pair extends TransientFieldPhysicalLocation {
     protected transient ReadsKey key;
 
     private final int firstStartPosition;
@@ -31,14 +31,6 @@ public final class Pair extends PairedEnds implements PhysicalLocation {
     private final boolean isRead2ReverseStrand;
     private final int score;
     private final boolean wasFlipped;
-
-    // Information used to detect optical dupes
-    private short readGroupIndex = -1;
-
-    private transient short tile = -1;
-    private transient int x = -1;
-    private transient int y = -1;
-    private transient short libraryId = -1;
 
     public Pair(final GATKRead read1, final GATKRead read2, final SAMFileHeader header, int partitionIndex, MarkDuplicatesScoringStrategy scoringStrategy, Map<String, Byte> headerLibraryMap) {
         super(partitionIndex, read1.getName());
@@ -180,28 +172,6 @@ public final class Pair extends PairedEnds implements PhysicalLocation {
         }
         return ReadEnds.FF;  //at this point we know for sure isRead1ReverseStrand is false and isRead2ReverseStrand is false
     }
-
-    // Methods for OpticalDuplicateFinder.PhysicalLocation
-    @Override
-    public short getReadGroup() { return this.readGroupIndex; }
-    @Override
-    public void setReadGroup(final short readGroup) { this.readGroupIndex = readGroup; }
-    @Override
-    public short getTile() { return this.tile; }
-    @Override
-    public void setTile(final short tile) { this.tile = tile; }
-    @Override
-    public int getX() { return this.x; }
-    @Override
-    public void setX(final int x) { this.x = x; }
-    @Override
-    public int getY() { return this.y; }
-    @Override
-    public void setY(final int y) { this.y = y; }
-    @Override
-    public short getLibraryId() { return this.libraryId; }
-    @Override
-    public void setLibraryId(final short libraryId) { this.libraryId = libraryId; }
 
     /**
      * Serializers for each subclass of PairedEnds which rely on implementations of serializations within each class itself

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/TransientFieldPhysicalLocation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/TransientFieldPhysicalLocation.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.hellbender.utils.read.markduplicates.sparkrecords;
+
+import picard.sam.util.PhysicalLocation;
+
+/**
+ * A common interface for holding the fields in PhysicalLocation
+ */
+public abstract class TransientFieldPhysicalLocation extends PairedEnds implements PhysicalLocation {
+    // Information used to detect optical dupes
+    protected short readGroupIndex = -1;
+    protected transient short tile = -1;
+    protected transient int x = -1;
+    protected transient int y = -1;
+    protected transient short libraryId = -1;
+
+    public TransientFieldPhysicalLocation(int partitionIndex, String name) {
+        super(partitionIndex, name);
+    }
+
+    // Methods for OpticalDuplicateFinder.PhysicalLocation
+    @Override
+    public short getReadGroup() { return this.readGroupIndex; }
+
+    @Override
+    public void setReadGroup(final short readGroup) { this.readGroupIndex = readGroup; }
+
+    @Override
+    public short getTile() { return this.tile; }
+
+    @Override
+    public void setTile(final short tile) { this.tile = tile; }
+
+    @Override
+    public int getX() { return this.x; }
+
+    @Override
+    public void setX(final int x) { this.x = x; }
+
+    @Override
+    public int getY() { return this.y; }
+
+    @Override
+    public void setY(final int y) { this.y = y; }
+
+    @Override
+    public short getLibraryId() { return this.libraryId; }
+
+    @Override
+    public void setLibraryId(final short libraryId) { this.libraryId = libraryId; }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/TransientFieldPhysicalLocation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/sparkrecords/TransientFieldPhysicalLocation.java
@@ -3,7 +3,10 @@ package org.broadinstitute.hellbender.utils.read.markduplicates.sparkrecords;
 import picard.sam.util.PhysicalLocation;
 
 /**
- * A common interface for holding the fields in PhysicalLocation
+ * A common class for holding the fields in PhysicalLocation that we don't want to be serialized by kryo.
+ *
+ * NOTE: readGroupIndex is not transient as the readgroup is needed in several stages of MarkDuplicatesSpark, but is still
+ *       contained in this class to mirror {@link PhysicalLocation}
  */
 public abstract class TransientFieldPhysicalLocation extends PairedEnds implements PhysicalLocation {
     // Information used to detect optical dupes


### PR DESCRIPTION
Tests ported from picard: https://github.com/broadinstitute/picard/pull/1195

Fixes #4707 