### PR TITLE
Changed count-collection tasks to use NIO for BAMs in CNV WDLs.

### DIFF
--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -93,8 +93,8 @@ task AnnotateIntervals {
 
 task CollectCounts {
     File intervals
-    File bam
-    File bam_idx
+    String bam
+    String bam_idx
     File ref_fasta
     File ref_fasta_fai
     File ref_fasta_dict
@@ -145,8 +145,8 @@ task CollectCounts {
 
 task CollectAllelicCounts {
     File common_sites
-    File bam
-    File bam_idx
+    String bam
+    String bam_idx
     File ref_fasta
     File ref_fasta_fai
     File ref_fasta_dict

--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -419,7 +419,7 @@ workflow CNVSomaticPairWorkflow {
     output {
         File preprocessed_intervals = PreprocessIntervals.preprocessed_intervals
 
-        File read_counts_entity_id_tumor = CollectCountsTumor.entity_id
+        String read_counts_entity_id_tumor = CollectCountsTumor.entity_id
         File read_counts_tumor = CollectCountsTumor.counts
         File allelic_counts_entity_id_tumor = CollectAllelicCountsTumor.entity_id
         File allelic_counts_tumor = CollectAllelicCountsTumor.allelic_counts
@@ -443,7 +443,7 @@ workflow CNVSomaticPairWorkflow {
         File scaled_delta_MAD_tumor = PlotDenoisedCopyRatiosTumor.scaled_delta_MAD
         File modeled_segments_plot_tumor = PlotModeledSegmentsTumor.modeled_segments_plot
 
-        File? read_counts_entity_id_normal = CollectCountsNormal.entity_id
+        String? read_counts_entity_id_normal = CollectCountsNormal.entity_id
         File? read_counts_normal = CollectCountsNormal.counts
         File? allelic_counts_entity_id_normal = CollectAllelicCountsNormal.entity_id
         File? allelic_counts_normal = CollectAllelicCountsNormal.allelic_counts


### PR DESCRIPTION
Going ahead and making this change so TAG team can start trying out the ModelSegments pipeline.

It's possible that we could use NIO for other files (reference, interval lists), but this will not have as much impact as using it for BAMs (and in some cases, decreases performance, see comments in #4806).

Closes #4806.