### PR TITLE
Making OB filtering default to true

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -85,7 +85,7 @@ workflow Mutect2 {
     File? realignment_index_bundle
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, false])
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true])
     Array[String]? artifact_modes
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -21,7 +21,7 @@
 ## artifact_modes: types of artifacts to consider in the orientation bias filter (optional)
 ## m2_extra_args, m2_extra_filtering_args: additional arguments for Mutect2 calling and filtering (optional)
 ## split_intervals_extra_args: additional arguments for splitting intervals before scattering (optional)
-## run_orientation_bias_filter: if true, run the orientation bias filter post-processing step (optional, false by default)
+## run_orientation_bias_filter: if true, run the orientation bias filter post-processing step (optional, true by default)
 ## run_oncotator: if true, annotate the M2 VCFs using oncotator (to produce a TCGA MAF).  Important:  This requires a
 ##                   docker image and should  not be run in environments where docker is unavailable (e.g. SGE cluster on
 ##                   a Broad on-prem VM).  Access to docker hub is also required, since the task downloads a public docker image.
@@ -797,6 +797,9 @@ task FilterByOrientationBias {
     File pre_adapter_metrics
     Array[String]? artifact_modes
 
+    # TODO: Do not pass artifact_modes as an empty array [].  https://github.com/broadinstitute/gatk/issues/5025
+    Array[String] final_artifact_modes = if (defined(artifact_modes)) then artifact_modes else ["G/T", "C/T"]
+
     # runtime
     Int? preemptible_attempts
     String gatk_docker
@@ -816,7 +819,7 @@ task FilterByOrientationBias {
 
         gatk --java-options "-Xmx${command_mem}m" FilterByOrientationBias \
             -V ${input_vcf} \
-            -AM ${sep=" -AM " artifact_modes} \
+            -AM ${sep=" -AM " final_artifact_modes} \
             -P ${pre_adapter_metrics} \
             -O ${output_vcf}
     }

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -85,8 +85,8 @@ workflow Mutect2 {
     File? realignment_index_bundle
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true])
     Array[String]? artifact_modes
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(artifact_modes) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args
@@ -797,8 +797,8 @@ task FilterByOrientationBias {
     File pre_adapter_metrics
     Array[String]? artifact_modes
 
-    # TODO: Do not pass artifact_modes as an empty array [].  https://github.com/broadinstitute/gatk/issues/5025
-    Array[String] final_artifact_modes = if (defined(artifact_modes)) then artifact_modes else ["G/T", "C/T"]
+    # If artifact modes is passed in to the task as [], this task will fail.
+    Array[String] final_artifact_modes = select_first([artifact_modes, ["G/T", "C/T"]])
 
     # runtime
     Int? preemptible_attempts

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -86,7 +86,7 @@ workflow Mutect2 {
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
     Array[String]? artifact_modes
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, []])) > 0)
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, ["G/T", "C/T"]])) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -86,7 +86,7 @@ workflow Mutect2 {
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
     Array[String]? artifact_modes
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(artifact_modes) > 0)
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, []])) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -25,7 +25,7 @@
 ## artifact_modes: types of artifacts to consider in the orientation bias filter (optional)
 ## m2_extra_args, m2_extra_filtering_args: additional arguments for Mutect2 calling and filtering (optional)
 ## split_intervals_extra_args: additional arguments for splitting intervals before scattering (optional)
-## run_orientation_bias_filter: if true, run the orientation bias filter post-processing step (optional, false by default)
+## run_orientation_bias_filter: if true, run the orientation bias filter post-processing step (optional, true by default)
 ## run_oncotator: if true, annotate the M2 VCFs using oncotator (to produce a TCGA MAF).  Important:  This requires a
 ##                   docker image and should  not be run in environments where docker is unavailable (e.g. SGE cluster on
 ##                   a Broad on-prem VM).  Access to docker hub is also required, since the task downloads a public docker image.
@@ -768,6 +768,9 @@ task FilterByOrientationBias {
     File pre_adapter_metrics
     Array[String]? artifact_modes
 
+    # TODO: Do not pass artifact_modes as an empty array [].  https://github.com/broadinstitute/gatk/issues/5025
+    Array[String] final_artifact_modes = if (defined(artifact_modes)) then artifact_modes else ["G/T", "C/T"]
+
     # runtime
     Int? preemptible_attempts
     String gatk_docker
@@ -787,7 +790,7 @@ task FilterByOrientationBias {
 
         gatk --java-options "-Xmx${command_mem}m" FilterByOrientationBias \
             -V ${input_vcf} \
-            -AM ${sep=" -AM " artifact_modes} \
+            -AM ${sep=" -AM " final_artifact_modes} \
             -P ${pre_adapter_metrics} \
             -O ${output_vcf}
     }

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -86,7 +86,7 @@ workflow Mutect2 {
     File? realignment_index_bundle
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, false])
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true])
     Array[String]? artifact_modes
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -87,7 +87,7 @@ workflow Mutect2 {
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
     Array[String]? artifact_modes
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(artifact_modes) > 0)
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, []])) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -86,8 +86,8 @@ workflow Mutect2 {
     File? realignment_index_bundle
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true])
     Array[String]? artifact_modes
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(artifact_modes) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args
@@ -768,8 +768,8 @@ task FilterByOrientationBias {
     File pre_adapter_metrics
     Array[String]? artifact_modes
 
-    # TODO: Do not pass artifact_modes as an empty array [].  https://github.com/broadinstitute/gatk/issues/5025
-    Array[String] final_artifact_modes = if (defined(artifact_modes)) then artifact_modes else ["G/T", "C/T"]
+    # If artifact modes is passed in to the task as [], this task will fail.
+    Array[String] final_artifact_modes = select_first([artifact_modes, ["G/T", "C/T"]])
 
     # runtime
     Int? preemptible_attempts

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -87,7 +87,7 @@ workflow Mutect2 {
     String? realignment_extra_args
     Boolean? run_orientation_bias_filter
     Array[String]? artifact_modes
-    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, []])) > 0)
+    Boolean run_ob_filter = select_first([run_orientation_bias_filter, true]) && (length(select_first([artifact_modes, ["G/T", "C/T"]])) > 0)
     File? tumor_sequencing_artifact_metrics
     String? m2_extra_args
     String? m2_extra_filtering_args


### PR DESCRIPTION
- M2 WDL will now default to having the orientation bias filter (`FilterByOrientationBias`) turned on.  Closes #5016 
- Empty artifact modes parameter will no longer cause failure in `FilterByOrientationBias`.  Instead the task `FilterByOrientationBias` will not run.  Closes #5025 