### PR TITLE
Fix line continuations in example commands

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -28,7 +28,7 @@ import java.text.NumberFormat;
  *
  * <h3>Example Usage</h3>
  * <pre>
- *   gatk FlagStat /
+ *   gatk FlagStat \
  *     -I input.bam
  * </pre>
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/GetSampleName.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/GetSampleName.java
@@ -37,8 +37,8 @@ import java.util.stream.Collectors;
  *
  * <h3>Example Usage</h3>
  * <pre>
- *   gatk GetSampleName /
- *     -I input.bam /
+ *   gatk GetSampleName \
+ *     -I input.bam \
  *     -O sample_name.txt
  * </pre>
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -49,11 +49,11 @@ import java.util.stream.Collectors;
  * <h3>Usage Example</h3>
  * <h4>Split reads in BAM file by sample name, read group and library name</h4>
  * <pre>
- *   gatk SplitReads /
- *     -I input.bam /
- *     -O outputDirectory /
- *     --split-sample /
- *     --split-read-group /
+ *   gatk SplitReads \
+ *     -I input.bam \
+ *     -O outputDirectory \
+ *     --split-sample \
+ *     --split-read-group \
  *     --split-library-name
  * </pre>
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
@@ -38,8 +38,8 @@ import java.io.PrintStream;
  *
  * <h3>Example Usage</h3>
  * <pre>
- *   gatk FlagStatSpark /
- *     -I input.bam /
+ *   gatk FlagStatSpark \
+ *     -I input.bam \
  *     -O statistics.txt
  * </pre>
  */


### PR DESCRIPTION
A few of the example commands in the documentation used a forward slash as the line continuation character rather than a backslash - this PR fixes that.