### PR TITLE
Updated install_R_packages.R to fix broken ggplot2 dependency in gatkbase Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using OpenJDK 8
-FROM broadinstitute/gatk:gatkbase-2.0.0
+FROM broadinstitute/gatk:gatkbase-2.0.1
 
 # Location of the unzipped gatk bundle files
 ARG ZIPPATH

--- a/scripts/docker/gatkbase/build_docker_base.sh
+++ b/scripts/docker/gatkbase/build_docker_base.sh
@@ -6,7 +6,7 @@ set -e
 
 REPO=broadinstitute
 PROJECT=gatk
-VERSION=2.0.0
+VERSION=2.0.1
 FULL_PATH=${REPO}/${PROJECT}:gatkbase-${VERSION}
 
 #################################################

--- a/scripts/docker/gatkbase/install_R_packages.R
+++ b/scripts/docker/gatkbase/install_R_packages.R
@@ -6,34 +6,27 @@
 # pull request tests in order to make sure it's still working                 #
 ###############################################################################
 
-#Make sure to use http not https as this will give an "unsupported URL scheme" error
-getoptUrl="http://cran.r-project.org/src/contrib/Archive/getopt/getopt_1.20.0.tar.gz"
-if (!("getopt" %in% rownames(installed.packages()))) {
-  install.packages(getoptUrl, repos=NULL, type="source", clean = TRUE)
-}
-optparseUrl="http://cran.r-project.org/src/contrib/Archive/optparse/optparse_1.3.2.tar.gz"
-if (!("optparse" %in% rownames(installed.packages()))) {
-  install.packages(optparseUrl, repos=NULL, type="source", clean = TRUE)
-}
-datatableUrl="http://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.10.4-2.tar.gz"
-if (!("data.table" %in% rownames(installed.packages()))) {
-    install.packages(datatableUrl, repos=NULL, type="source", clean = TRUE)
-}
-dependencies = c("ggplot2","gplots","gsalib")
-repos <- c("http://cran.cnr.Berkeley.edu",
-           "https://cran.mtu.edu",
-           "http://lib.stat.cmu.edu/R/CRAN/")
-missing <- which(!(dependencies %in% rownames(installed.packages())))
-try <- 1
-while(length(missing)!=0 & try <= length(repos)) {
-    install.packages(dependencies[missing], repos = repos[try], clean = TRUE)
-    missing <- which(!(dependencies %in% rownames(installed.packages())))
-    try <- try + 1
+options(warn = 2)     # treat warnings as errors, otherwise script can fail silently if a package fails to install
+
+InstallPackageFromArchive = function(packageName, packageURL) {
+    # make sure to use http not https as this will give an "unsupported URL scheme" error
+    if (!(packageName %in% rownames(installed.packages()))) {
+        install.packages(packageURL, repos = NULL, type = "source", clean = TRUE)
+    }
 }
 
+dependencies = c("gplots",
+                 "digest", "gtable", "MASS", "plyr", "reshape2", "scales", "tibble", "lazyeval")    # ggplot2
+repos <- c("http://cran.cnr.Berkeley.edu", "http://cran.mtu.edu", "http://lib.stat.cmu.edu/R/CRAN/")
+install.packages(dependencies, repos = repos, clean = TRUE)
+
+InstallPackageFromArchive("getopt", "http://cran.r-project.org/src/contrib/Archive/getopt/getopt_1.20.0.tar.gz")
+InstallPackageFromArchive("optparse", "http://cran.r-project.org/src/contrib/Archive/optparse/optparse_1.3.2.tar.gz")
+InstallPackageFromArchive("data.table", "http://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.10.4-2.tar.gz")
+InstallPackageFromArchive("gsalib", "http://cran.r-project.org/src/contrib/gsalib_2.1.tar.gz")
+InstallPackageFromArchive("ggplot2", "http://cran.r-project.org/src/contrib/Archive/ggplot2/ggplot2_2.2.1.tar.gz")
+
 # HMM is only required for testing and not in production:
-hmmUrl = "http://cran.r-project.org/src/contrib/HMM_1.0.tar.gz"
-if (!("HMM" %in% rownames(installed.packages()))) {
-  install.packages(hmmUrl, repos=NULL, type="source", clean = TRUE)
-}
-q(save="no")
+InstallPackageFromArchive("HMM", "http://cran.r-project.org/src/contrib/HMM_1.0.tar.gz")
+
+q(save = "no")

--- a/scripts/docker/gatkbase/install_R_packages.R
+++ b/scripts/docker/gatkbase/install_R_packages.R
@@ -16,7 +16,7 @@ InstallPackageFromArchive = function(packageName, packageURL) {
 }
 
 dependencies = c("gplots",
-                 "digest", "gtable", "MASS", "plyr", "reshape2", "scales", "tibble", "lazyeval")    # ggplot2
+                 "digest", "gtable", "MASS", "plyr", "reshape2", "scales", "tibble", "lazyeval")    # for ggplot2
 repos <- c("http://cran.cnr.Berkeley.edu", "http://cran.mtu.edu", "http://lib.stat.cmu.edu/R/CRAN/")
 install.packages(dependencies, repos = repos, clean = TRUE)
 

--- a/src/main/resources/org/broadinstitute/hellbender/utils/recalibration/BQSR.R
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/recalibration/BQSR.R
@@ -1,6 +1,5 @@
 library("ggplot2")
 library(gplots)
-library("reshape")
 library("grid")
 library("tools") #For compactPDF in R 2.13+
 library(gsalib)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
@@ -124,19 +124,18 @@ public final class AnalyzeCovariatesIntegrationTest extends CommandLineProgramTe
         spec.executeTest("testInOutAbsencePresence", this);
     }
 
-
-
     @DataProvider
     public Iterator<Object[]> alternativeInOutAbsenceCombinations(Method m) {
         List<Object[]> result = new LinkedList<>();
         if (m.getName().endsWith("Exception")) {
-           result.add(new Object[] { true, false, false, false ,false});
-        }
-        else {
-           result.add(new Object[] { true, false, true, false, false });
-           result.add(new Object[] { true, false, false, true, false });
-           result.add(new Object[] { true, false, false, false, true });
-           result.add(new Object[] { true, false, false, true, false });
+            result.add(new Object[] { true, false, false, false ,false});
+        } else {
+            result.add(new Object[] { true, false, true, false, false });
+            result.add(new Object[] { true, false, false, true, false });
+            result.add(new Object[] { true, false, false, false, true });
+            result.add(new Object[] { true, true, true, false, false });
+            result.add(new Object[] { true, true, false, true, false });
+            result.add(new Object[] { true, true, false, false, true });
         }
         return result.iterator();
     }


### PR DESCRIPTION
The ggplot2 R dependency was not installed correctly in the gatkbase-2.0.0 Docker image.  It appears that this resulted from a recent ggplot2 update that has broken dependencies (perhaps for the version of R that we use).  This missing ggplot2 dependency was the root cause of #5022.

I updated the install_R_packages.R script, which should now fail if any package fails to install, and pushed an updated gatkbase-2.0.1 image.  The second commit addresses #5022.

This should be considered a temporary fix until #5026 is in.

Closes #5022.