### PR TITLE
Providing counts for supporting alt reads in the validation normal.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicSomaticShortMutationValidator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicSomaticShortMutationValidator.java
@@ -54,6 +54,8 @@ public class BasicSomaticShortMutationValidator {
 
     /** Perform basic somatic pileup validation and return a result instance.
      *
+     * NOTE: This only looks at the first alternate allele.  Multiallelics are not supported.
+     *
      * @param genotype given genotype to validate.  Never {@code null}
      * @param referenceAllele Never {@code null}
      * @param validationNormalPileup Pileup for the coresponding location of the genotype in the validation normal.  Never {@code null}
@@ -98,10 +100,11 @@ public class BasicSomaticShortMutationValidator {
         boolean isEnoughValidationCoverageToValidate = validationTumorAltCount >= 2;
 
         final String genotypeFilters = genotype.getFilters() == null ? "" : genotype.getFilters();
-
+        final long numReadsSupportingAltInValidationNormal = PowerCalculationUtils.calculateNumReadsSupportingAllele(validationNormalPileup,
+                genotype.getAllele(0), genotype.getAllele(1), minBaseQualityCutoff);
         return new BasicValidationResult(interval, minCountForSignal, isEnoughValidationCoverageToValidate,
                 isNotNoise, power, validationTumorAltCount, validationTumorTotalCount-validationTumorAltCount,
                 discoveryTumorAltCount, discoveryTumorTotalCount-discoveryTumorAltCount, referenceAllele,
-                genotype.getAllele(1), filters + genotypeFilters);
+                genotype.getAllele(1), filters + genotypeFilters, numReadsSupportingAltInValidationNormal);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicValidationResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/BasicValidationResult.java
@@ -16,11 +16,12 @@ public class BasicValidationResult implements Locatable {
     private final Allele reference;
     private final Allele alternate;
     private final String filters;
+    private final long numAltSupportingReadsInNormal;
 
     public BasicValidationResult(final Locatable interval, final int minValidationReadCount, final boolean isEnoughValidationReads,
                                  final boolean isOutOfNoiseFloor, final double power, final int validationAltCount,
                                  final int validationRefCount, final int discoveryAltCount, final int discoveryRefCount, final Allele ref,
-                                 final Allele alt, final String filters) {
+                                 final Allele alt, final String filters, final long numAltSupportingReadsInNormal) {
         this.minValidationReadCount = minValidationReadCount;
         this.isEnoughValidationReads = isEnoughValidationReads;
         this.isOutOfNoiseFloor = isOutOfNoiseFloor;
@@ -33,6 +34,7 @@ public class BasicValidationResult implements Locatable {
         this.alternate = alt;
         this.reference = ref;
         this.filters = filters;
+        this.numAltSupportingReadsInNormal = numAltSupportingReadsInNormal;
     }
 
     public int getValidationAltCount() {
@@ -97,5 +99,9 @@ public class BasicValidationResult implements Locatable {
 
     public String getFilters() {
         return filters;
+    }
+
+    public long getNumAltSupportingReadsInNormal() {
+        return numAltSupportingReadsInNormal;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/PowerCalculationUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/PowerCalculationUtils.java
@@ -10,6 +10,7 @@ import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,10 +71,7 @@ public class PowerCalculationUtils {
         Utils.nonNull(referenceAllele);
 
         // Go through the read pileup and find all new bases.
-        final List<PileupElement> pileupElementsPassingQuality = Utils.stream(readPileup.iterator())
-                .filter(pe -> !pe.isDeletion())
-                .filter(pe -> pe.getQual() >= minBaseQualityCutoff)
-                .collect(Collectors.toList());
+        final List<PileupElement> pileupElementsPassingQuality = retrievePileupElements(readPileup, minBaseQualityCutoff);
 
         final long numAlternate = pileupElementsPassingQuality.stream()
                 .filter(pe -> (GATKProtectedVariantContextUtils.doesReadContainAllele(pe, referenceAllele) == Trilean.FALSE)
@@ -84,5 +82,36 @@ public class PowerCalculationUtils {
                 && !pe.isBeforeDeletionStart() && !pe.isBeforeInsertion()).count();
 
         return (double) numAlternate / ((double) numReference + (double) numAlternate);
+    }
+
+    private static List<PileupElement> retrievePileupElements(final ReadPileup readPileup, final int minBaseQualityCutoff) {
+        return Utils.stream(readPileup.iterator())
+                    .filter(pe -> !pe.isDeletion())
+                    .filter(pe -> pe.getQual() >= minBaseQualityCutoff)
+                    .collect(Collectors.toList());
+    }
+
+    /**
+     * Get a count of the number of reads supporting an allele in a given pileup.
+     *
+     * @param readPileup pileup to query for the allele.  Never {@code null}
+     * @param referenceAllele  reference allele corresponding to alt allele.  Never {@code null}
+     * @param altAllele Allele to query. Never {@code null}
+     * @param minBaseQualityCutoff only count the bases that exceed the min base quality.  For xNP, it is the min quality
+     *                             all overlapping loci.  For indels, this is the base preceding the indel itself.  Must be positive or zero.
+     *                             Zero indicates that all reads should pass this filter.
+     * @return count of reads supporting the given allele in the given pileup.
+     */
+    public static long calculateNumReadsSupportingAllele(final ReadPileup readPileup, final Allele referenceAllele, final Allele altAllele, int minBaseQualityCutoff) {
+        ParamUtils.isPositiveOrZero(minBaseQualityCutoff, "Cannot have a negative minBaseQualityCutoff.");
+        Utils.nonNull(readPileup);
+        Utils.nonNull(altAllele);
+        Utils.nonNull(referenceAllele);
+
+        final List<PileupElement> pileupElementsPassingQuality = retrievePileupElements(readPileup, minBaseQualityCutoff);
+
+        return pileupElementsPassingQuality.stream()
+                .filter(pe -> altAllele.equals(GATKProtectedVariantContextUtils.chooseAlleleForRead(pe, referenceAllele, Collections.singletonList(altAllele), minBaseQualityCutoff)))
+                .count();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutations.java
@@ -116,6 +116,7 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
     public final static String IS_NOT_NOISE = "validated";
     public final static String IS_ENOUGH_VALIDATION_COVERAGE = "sufficient_tv_alt_coverage";
     public final static String DISCOVERY_VCF_FILTER = "discovery_vcf_filter";
+    public final static String NUM_ALT_READS_IN_VALIDATION_NORMAL = "num_alt_reads_in_validation_normal";
 
     // for the optional vcf
     public final static String POWER_INFO_FIELD_KEY = "POWER";
@@ -138,7 +139,8 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
 
 
     public static String[] headers = {CONTIG, START, END, REF, ALT, DISCOVERY_ALT_COVERAGE, DISCOVERY_REF_COVERAGE,
-            VALIDATION_ALT_COVERAGE, VALIDATION_REF_COVERAGE, MIN_VAL_COUNT, POWER, IS_NOT_NOISE, IS_ENOUGH_VALIDATION_COVERAGE, DISCOVERY_VCF_FILTER};
+            VALIDATION_ALT_COVERAGE, VALIDATION_REF_COVERAGE, MIN_VAL_COUNT, POWER, IS_NOT_NOISE, IS_ENOUGH_VALIDATION_COVERAGE,
+            DISCOVERY_VCF_FILTER, NUM_ALT_READS_IN_VALIDATION_NORMAL};
 
     private List<BasicValidationResult> results = new ArrayList<>();
 
@@ -268,6 +270,7 @@ public class ValidateBasicSomaticShortMutations extends VariantWalker {
                 dataLine.set(IS_NOT_NOISE, record.isOutOfNoiseFloor());
                 dataLine.set(IS_ENOUGH_VALIDATION_COVERAGE, record.isEnoughValidationReads());
                 dataLine.set(DISCOVERY_VCF_FILTER, record.getFilters() == null ? "" : record.getFilters());
+                dataLine.set(NUM_ALT_READS_IN_VALIDATION_NORMAL, record.getNumAltSupportingReadsInNormal());
             }
         }) {
             writer.writeHeaderIfApplies();

--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
@@ -408,7 +408,7 @@ public class GATKProtectedVariantContextUtils {
 
     /**
      * Given a set of alleles (reference and alternate), choose the allele that is the best match for the given read (and offset)
-     *
+     * TODO: This method cannot recognize equivalent alleles (See https://github.com/broadinstitute/gatk/issues/5061)
      * @param pileupElement read and offset.  Never {@code null}
      * @param referenceAllele Reference allele.  Never {@code null}
      * @param altAlleles List of candidate alternate alleles.  Never {@code null}


### PR DESCRIPTION
- `ValidateBasicSomaticShortMutations` will now provide a count of supporting alt alleles in the validation normals.  This value does not affect the validation status.  Closes #5059 
- Note that there are indels that will not be caught by this functionality.  See #5061 