### PR TITLE
changed default AF for Mutect2 tumor-only

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -35,7 +35,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
 
 
     public static final double DEFAULT_AF_FOR_TUMOR_ONLY_CALLING = 5e-8;
-    public static final double DEFAULT_AF_FOR_TUMOR_NORMAL_CALLING = 1e-5;
+    public static final double DEFAULT_AF_FOR_TUMOR_NORMAL_CALLING = 1e-6;
 
     //TODO: HACK ALERT HACK ALERT HACK ALERT
     //TODO: GATK4 does not yet have a way to tag inputs, eg -I:tumor tumor.bam -I:normal normal.bam,


### PR DESCRIPTION
This value is more correct. I didn't use it earlier because it was protecting against some false positives, but those were not contamination or germline (i.e. default AF was filtering them for the wrong reasons) and we can instead filter them by catching variants on the same haplotype as filtered variants.

This improves sensitivity in MC3.