### PR TITLE
Synchronize update of shared genotype likelihood tables.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
@@ -275,12 +275,11 @@ public final class GenotypeLikelihoodCalculators {
      * @param requestedMaximumAllele the new requested maximum allele maximum.
      * @param requestedMaximumPloidy the new requested ploidy maximum.
      */
-    private void ensureCapacity(final int requestedMaximumAllele, final int requestedMaximumPloidy) {
+    private synchronized void ensureCapacity(final int requestedMaximumAllele, final int requestedMaximumPloidy) {
 
         final boolean needsToExpandAlleleCapacity = requestedMaximumAllele > maximumAllele;
         final boolean needsToExpandPloidyCapacity = requestedMaximumPloidy > maximumPloidy;
 
-        // Double check with the lock on to avoid double work.
         if (!needsToExpandAlleleCapacity && !needsToExpandPloidyCapacity) {
             return;
         }
@@ -383,9 +382,7 @@ public final class GenotypeLikelihoodCalculators {
 
     private int calculateGenotypeCountUsingTables(int ploidy, int alleleCount) {
         checkPloidyAndMaximumAllele(ploidy, alleleCount);
-        if (ploidy > maximumPloidy || alleleCount > maximumAllele) {
-            ensureCapacity(alleleCount, ploidy);
-        }
+        ensureCapacity(alleleCount, ploidy);
         return alleleFirstGenotypeOffsetByPloidy[ploidy][alleleCount];
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
@@ -270,7 +270,9 @@ public final class GenotypeLikelihoodCalculators {
     }
 
     /**
-     * Update of shared tables
+     * Update of shared tables. Note that this method is synchronized to avoid race conditions in Spark. This is because
+     * in Spark each region has its own HaplotypeCallerEngine instance (so there can be multiple instances in a single
+     * JVM), but these share a single (static) instance of this class (via AlleleSubsettingUtils).
      *
      * @param requestedMaximumAllele the new requested maximum allele maximum.
      * @param requestedMaximumPloidy the new requested ploidy maximum.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
@@ -9,7 +9,8 @@ import org.apache.logging.log4j.Logger;
 import java.util.Arrays;
 
 /**
- * Genotype likelihood calculator utility.
+ * Genotype likelihood calculator utility. This class is thread-safe since access to shared mutable state is
+ * synchronized.
  *
  * <p>
  *     This class provide genotype likelihood calculators with any number of alleles able given an arbitrary ploidy and allele
@@ -257,7 +258,7 @@ public final class GenotypeLikelihoodCalculators {
      *
      * @return never {@code null}.
      */
-    public GenotypeLikelihoodCalculator getInstance(final int ploidy, final int alleleCount) {
+    public synchronized GenotypeLikelihoodCalculator getInstance(final int ploidy, final int alleleCount) {
         checkPloidyAndMaximumAllele(ploidy, alleleCount);
 
         if (calculateGenotypeCountUsingTables(ploidy, alleleCount) == GENOTYPE_COUNT_OVERFLOW) {
@@ -270,9 +271,7 @@ public final class GenotypeLikelihoodCalculators {
     }
 
     /**
-     * Update of shared tables. Note that this method is synchronized to avoid race conditions in Spark. This is because
-     * in Spark each region has its own HaplotypeCallerEngine instance (so there can be multiple instances in a single
-     * JVM), but these share a single (static) instance of this class (via AlleleSubsettingUtils).
+     * Update of shared tables.
      *
      * @param requestedMaximumAllele the new requested maximum allele maximum.
      * @param requestedMaximumPloidy the new requested ploidy maximum.
@@ -381,8 +380,7 @@ public final class GenotypeLikelihoodCalculators {
         throw new GATKException("Code should never reach here.");
     }
 
-
-    private int calculateGenotypeCountUsingTables(int ploidy, int alleleCount) {
+    private synchronized int calculateGenotypeCountUsingTables(int ploidy, int alleleCount) {
         checkPloidyAndMaximumAllele(ploidy, alleleCount);
         ensureCapacity(alleleCount, ploidy);
         return alleleFirstGenotypeOffsetByPloidy[ploidy][alleleCount];


### PR DESCRIPTION
Fixes #4661.

I managed to run `genome_reads-pipeline_hdfs.sh` with this change, whereas before it was failing (see details in #4661).

No unit test since it is very difficult to write a test for the effect of adding synchronization.