### PR TITLE
Optimize some Mutect-related tools

### DIFF
--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -698,7 +698,7 @@ task CalculateContamination {
     Int? mem
 
     # Mem is in units of GB but our command and memory runtime values are in MB
-    Int machine_mem = if defined(mem) then mem * 1000 else 7000
+    Int machine_mem = if defined(mem) then mem * 1000 else 3000
     Int command_mem = machine_mem - 500
 
     command {
@@ -707,11 +707,13 @@ task CalculateContamination {
         export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk_override}
 
         if [[ -f "${normal_bam}" ]]; then
-            gatk --java-options "-Xmx${command_mem}m" GetPileupSummaries -I ${normal_bam} ${"-L " + intervals} -V ${variants_for_contamination} -O normal_pileups.table
+            gatk --java-options "-Xmx${command_mem}m" GetPileupSummaries -I ${normal_bam} ${"--interval-set-rule INTERSECTION -L " + intervals} \
+                -V ${variants_for_contamination} -L ${variants_for_contamination} -O normal_pileups.table
             NORMAL_CMD="-matched normal_pileups.table"
         fi
 
-        gatk --java-options "-Xmx${command_mem}m" GetPileupSummaries -R ${ref_fasta} -I ${tumor_bam} ${"-L " + intervals} -V ${variants_for_contamination} -O pileups.table
+        gatk --java-options "-Xmx${command_mem}m" GetPileupSummaries -R ${ref_fasta} -I ${tumor_bam} ${"--interval-set-rule INTERSECTION -L " + intervals} \
+            -V ${variants_for_contamination} -L ${variants_for_contamination} -O pileups.table
         gatk --java-options "-Xmx${command_mem}m" CalculateContamination -I pileups.table -O contamination.table --tumor-segmentation segments.table $NORMAL_CMD
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/AbstractConcordanceWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AbstractConcordanceWalker.java
@@ -77,7 +77,7 @@ public abstract class AbstractConcordanceWalker extends GATKTool {
         }
 
         if (truthVariants == null) {
-            truthVariants = new FeatureDataSource<>(new FeatureInput<>(truthVariantsFile, "truth"), CACHE_LOOKAHEAD, VariantContext.class);
+            truthVariants = new FeatureDataSource<>(new FeatureInput<>(truthVariantsFile, "truth"), CACHE_LOOKAHEAD, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer);
         }
     }
 
@@ -101,7 +101,7 @@ public abstract class AbstractConcordanceWalker extends GATKTool {
         super.onStartup();
 
         initializeTruthVariantsIfNecessary();
-        evalVariants = new FeatureDataSource<>(new FeatureInput<>(evalVariantsFile, "eval"), CACHE_LOOKAHEAD, VariantContext.class);
+        evalVariants = new FeatureDataSource<>(new FeatureInput<>(evalVariantsFile, "eval"), CACHE_LOOKAHEAD, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer);
 
         if ( hasUserSuppliedIntervals() ) {
             truthVariants.setIntervalsForTraversal(userIntervals);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
@@ -53,7 +53,7 @@ import java.util.List;
  * gatk GetPileupSummaries \
  *   -I tumor.bam \
  *   -V common_biallelic.vcf.gz \
- *   -V common_biallelic.vcf.gz \
+ *   -L common_biallelic.vcf.gz \
  *   -O pileups.table
  * </pre>
  *
@@ -64,6 +64,17 @@ import java.util.List;
  *   -L common_biallelic.vcf.gz \
  *   -O pileups.table
  * </pre>
+ *
+ * Although the sites (-L) and variants (-V) resources will often be identical, this need not be the case.  For example,
+ * <pre>
+ * gatk GetPileupSummaries \
+ *   -I normal.bam \
+ *   -V gnomad.vcf.gz \
+ *   -L common_snps.interval_list \
+ *   -O pileups.table
+ * </pre>
+ * attempts to get pileups at a list of common snps and emits output for those sites that are present in gnomAD, using the
+ * allele frequencies from gnomAD.
  *
  * <p>
  * GetPileupSummaries tabulates results into six columns as shown below.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummaries.java
@@ -74,7 +74,9 @@ import java.util.List;
  *   -O pileups.table
  * </pre>
  * attempts to get pileups at a list of common snps and emits output for those sites that are present in gnomAD, using the
- * allele frequencies from gnomAD.
+ * allele frequencies from gnomAD.  Note that the sites may be a subset of the variants, the variants may be a subset of the sites,
+ * or they may overlap partially.  In all cases pileup summaries are emitted for the overlap and nowhere else.  The most common use
+ * case in which sites and variants differ is when the variants resources is a large file and the sites is an interval list subset from that file.
  *
  * <p>
  * GetPileupSummaries tabulates results into six columns as shown below.

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
@@ -22,6 +22,7 @@ public class GetPileupSummariesIntegrationTest extends CommandLineProgramTest {
         final String[] args = {
                 "-I", NA12878.getAbsolutePath(),
                 "-V", thousandGenomes.getAbsolutePath(),
+                "-L", thousandGenomes.getAbsolutePath(),
                 "-O", output.getAbsolutePath(),
                 "-" + GetPileupSummaries.MAX_SITE_AF_SHORT_NAME, "0.9"
         };
@@ -66,6 +67,7 @@ public class GetPileupSummariesIntegrationTest extends CommandLineProgramTest {
         final String[] args = {
                 "-I", NA12878.getAbsolutePath(),
                 "-V", vcfWithoutAF.getAbsolutePath(),
+                "-L", vcfWithoutAF.getAbsolutePath(),
                 "-O", output.getAbsolutePath(),
         };
         runCommandLine(args);


### PR DESCRIPTION
@LeeTL1220 The first commit makes all concordance tools and MC3/M2 vcf merge much faster in Firecloud -- tasks that have been taking an hour will take a few minutes.  The second commit makes `GetPileupSummaries`, hence the contamination task much faster.  Previously that tool has cached all reads for the 100,000 bases around each site, so basically it had to do a whole bam's worth of I/O just to get ~60,000 pileups.