### PR TITLE
Removed LinkedList false optimization in ReservoirDownsampler

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
@@ -92,7 +92,7 @@ public final class MutectDownsampler extends ReadsDownsampler {
             } else {
                 // if we exceed the max coverage, just use well-mapped reads.  Maybe the number of such reads won't reach
                 // the desired coverage, but if the region is decently mappable the shortfall will be minor.
-                final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage, false);
+                final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage);
                 pendingReads.stream().filter(read -> read.getMappingQuality() > SUSPICIOUS_MAPPING_QUALITY).forEach(wellMappedDownsampler::submit);
                 final List<GATKRead> readsToFinalize = wellMappedDownsampler.consumeFinalizedItems();
                 if (stride > 1) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -39,7 +39,8 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
 
     /**
      * Construct a ReservoirDownsampler
-     *  @param targetSampleSize Size of the reservoir used by this downsampler.
+     *  @param targetSampleSize Size of the reservoir used by this downsampler.  Number of items retained after
+     *                          downsampling will be min(totalReads, targetSampleSize).
      *
      *
      */
@@ -80,11 +81,8 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
     @Override
     public List<GATKRead> consumeFinalizedItems() {
         if (hasFinalizedItems()) {
-            // one could either:
-            // 1) return copy the reservoir and then clear (but not reallocate) in clearItems, or
-            // 2) return the reservoir by reference and reallocate a new ArrayList in clearItems
-            // 2) is worse because it always reallocates the target sample size, instead of just the reads that are present
-            final List<GATKRead> downsampledItems = new ArrayList<>(reservoir);
+            // pass reservoir by reference rather than make a copy, for speed
+            final List<GATKRead> downsampledItems = reservoir;
             clearItems();
             return downsampledItems;
         } else {
@@ -123,7 +121,7 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
      */
     @Override
     public void clearItems() {
-        reservoir.clear();
+        reservoir = new ArrayList<>(targetSampleSize);
 
         // an internal stat used by the downsampling process, so not cleared by resetStats() below
         totalReadsSeen = 0;

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/SamplePartitioner.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/SamplePartitioner.java
@@ -64,7 +64,7 @@ final class SamplePartitioner {
      */
     private Downsampler<GATKRead> createDownsampler(final LIBSDownsamplingInfo LIBSDownsamplingInfo) {
         return LIBSDownsamplingInfo.isPerformDownsampling()
-                ? new ReservoirDownsampler(LIBSDownsamplingInfo.getToCoverage(), true)
+                ? new ReservoirDownsampler(LIBSDownsamplingInfo.getToCoverage())
                 : new PassThroughDownsampler();
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsamplerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsamplerUnitTest.java
@@ -116,7 +116,7 @@ public final class ReservoirDownsamplerUnitTest extends GATKBaseTest {
 
     @Test
     public void testSignalNoMoreReadsBefore() throws Exception {
-        ReservoirDownsampler rd = new ReservoirDownsampler(1, true);
+        ReservoirDownsampler rd = new ReservoirDownsampler(1);
         final GATKRead r1= ArtificialReadUtils.createArtificialRead("100M");
         final GATKRead r2= ArtificialReadUtils.createArtificialRead("101M");
         rd.submit(r1);
@@ -126,7 +126,7 @@ public final class ReservoirDownsamplerUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNoNullSignalNoMoreReadsBefore() throws Exception {
-        ReadsDownsampler rd = new ReservoirDownsampler(1, true);
+        ReadsDownsampler rd = new ReservoirDownsampler(1);
         rd.signalNoMoreReadsBefore(null);
     }
 }


### PR DESCRIPTION
Closes #1493.

@droazen @cmnbroad Is this what was intended by #1493 -- just replace `LinkedList` with `ArrayList` and `clear` the reservoir, keeping its capacity allocated, when possible?