### PR TITLE
M2 wdl doesn't emit unfiltered vcf, which is redundant

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -399,8 +399,6 @@ workflow Mutect2 {
     }
 
     output {
-        File unfiltered_vcf = MergeVCFs.merged_vcf
-        File unfiltered_vcf_index = MergeVCFs.merged_vcf_index
         File filtered_vcf = select_first([FilterAlignmentArtifacts.filtered_vcf, FilterByOrientationBias.filtered_vcf, Filter.filtered_vcf])
         File filtered_vcf_index = select_first([FilterAlignmentArtifacts.filtered_vcf_index, FilterByOrientationBias.filtered_vcf_index, Filter.filtered_vcf_index])
         File? contamination_table = CalculateContamination.contamination_table

--- a/scripts/mutect2_wdl/mutect2_multi_sample.wdl
+++ b/scripts/mutect2_wdl/mutect2_multi_sample.wdl
@@ -118,8 +118,6 @@ workflow Mutect2_Multi {
     }
 
     output {
-        Array[File] unfiltered_vcf = Mutect2.unfiltered_vcf
-        Array[File] unfiltered_vcf_idx = Mutect2.unfiltered_vcf_index
         Array[File] filtered_vcf = Mutect2.filtered_vcf
         Array[File] filtered_vcf_idx = Mutect2.filtered_vcf_index
         Array[File?] contamination_tables = Mutect2.contamination_table

--- a/scripts/mutect2_wdl/mutect2_nio.wdl
+++ b/scripts/mutect2_wdl/mutect2_nio.wdl
@@ -382,8 +382,6 @@ workflow Mutect2 {
     }
 
     output {
-        File unfiltered_vcf = MergeVCFs.merged_vcf
-        File unfiltered_vcf_index = MergeVCFs.merged_vcf_index
         File filtered_vcf = select_first([FilterAlignmentArtifacts.filtered_vcf, FilterByOrientationBias.filtered_vcf, Filter.filtered_vcf])
         File filtered_vcf_index = select_first([FilterAlignmentArtifacts.filtered_vcf_index, FilterByOrientationBias.filtered_vcf_index, Filter.filtered_vcf_index])
         File? contamination_table = CalculateContamination.contamination_table

--- a/scripts/mutect2_wdl/mutect2_pon.wdl
+++ b/scripts/mutect2_wdl/mutect2_pon.wdl
@@ -61,8 +61,8 @@ workflow Mutect2_Panel {
 
     call CreatePanel {
         input:
-            input_vcfs = Mutect2.unfiltered_vcf,
-            input_vcfs_idx = Mutect2.unfiltered_vcf_index,
+            input_vcfs = Mutect2.filtered_vcf,
+            input_vcfs_idx = Mutect2.filtered_vcf_index,
             duplicate_sample_strategy = duplicate_sample_strategy,
             output_vcf_name = pon_name,
             gatk_override = gatk_override,
@@ -74,8 +74,8 @@ workflow Mutect2_Panel {
     output {
         File pon = CreatePanel.output_vcf
         File pon_idx = CreatePanel.output_vcf_index
-        Array[File] normal_calls = Mutect2.unfiltered_vcf
-        Array[File] normal_calls_idx = Mutect2.unfiltered_vcf_index
+        Array[File] normal_calls = Mutect2.filtered_vcf
+        Array[File] normal_calls_idx = Mutect2.filtered_vcf_index
     }
 }
 


### PR DESCRIPTION
@LeeTL1220 The unfiltered vcf has no additional information and I don't want to give users a chance to shoot themselves in the foot.