### PR TITLE
turn back on checking variant info fields against header in SV vcf writing 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriter.java
@@ -114,8 +114,6 @@ public class SVVCFWriter {
         if (null != referenceSequenceDictionary) {
             vcWriterBuilder = vcWriterBuilder.setReferenceDictionary(referenceSequenceDictionary);
         }
-        // todo: remove this when things are solid?
-        vcWriterBuilder = vcWriterBuilder.setOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER);
         for (final Options opt : new Options[]{}) {
             vcWriterBuilder = vcWriterBuilder.setOption(opt);
         }


### PR DESCRIPTION
turned off temporarily long time ago but slipped attention after implementation stablelized