### PR TITLE
Remove StreamingPythonExecutor testStderrOutput unit test.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonScriptExecutorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonScriptExecutorUnitTest.java
@@ -72,29 +72,6 @@ public class StreamingPythonScriptExecutorUnitTest extends GATKBaseTest {
     }
 
     @Test(groups = "python", dataProvider="supportedPythonVersions", dependsOnMethods = "testPythonExists")
-    public void testStderrOutput(final PythonScriptExecutor.PythonExecutableName executableName) {
-        // test write to stderr from python
-        final StreamingPythonScriptExecutor<String> streamingPythonExecutor =
-                new StreamingPythonScriptExecutor<>(executableName,true);
-        Assert.assertNotNull(streamingPythonExecutor);
-        Assert.assertTrue(streamingPythonExecutor.start(Collections.emptyList()));
-
-        try {
-            streamingPythonExecutor.sendSynchronousCommand("import sys" + NL);
-            final ProcessOutput po = streamingPythonExecutor.sendSynchronousCommand(
-                    "sys.stderr.write('error output to stderr\\n')" + NL);
-
-            Assert.assertNotNull(po.getStderr());
-            Assert.assertNotNull(po.getStderr().getBufferString());
-            Assert.assertNotNull(po.getStderr().getBufferString().contains("error output to stderr"));
-        }
-        finally {
-            streamingPythonExecutor.terminate();
-            Assert.assertFalse(streamingPythonExecutor.getProcess().isAlive());
-        }
-    }
-
-    @Test(groups = "python", dataProvider="supportedPythonVersions", dependsOnMethods = "testPythonExists")
     public void testTerminateWhilePythonBlocked(final PythonScriptExecutor.PythonExecutableName executableName) {
         // Test termination on a Python process that is blocked on I/O to ensure that we don't leave
         // zombie Python processes around. This unfinished code block will cause Python to hang with


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/5065. This test verifies that we receive output written to Python's stderr, but it fails occasionally due to an inherent race condition in the assert (occasionally the assert executes before the data is received and the test fails). I added a Python statement that explicitly flushes stderr first, and ran the test 1000 times and it still failed once for the same reason. Since I don't see any way to have a reliable test condition (that doesn't involve polling inside a loop and a long timeout), I'm just removing the test.