### PR TITLE
Update our google-cloud-java fork to 0.20.5-alpha-GCS-RETRY-FIX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.4-alpha-GCS-RETRY-FIX:shaded'
+final googleCloudNioDependency = 'org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.5-alpha-GCS-RETRY-FIX:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -430,7 +430,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
 
         logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration(NIO_MAX_REOPENS).maxChannelReopens());
-        logger.info("Using google-cloud-java patch 6d11bef1c81f885c26b2b56c8616b7a705171e4f from https://github.com/droazen/google-cloud-java/tree/dr_all_nio_fixes");
+        logger.info("Using google-cloud-java fork https://github.com/broadinstitute/google-cloud-java/releases/tag/0.20.5-alpha-GCS-RETRY-FIX");
     }
 
     /**


### PR DESCRIPTION
This brings in some additional retries for UnknownHostException and 502 errors,
and moves us from a fork in my personal github repository to the fork in
https://github.com/broadinstitute/google-cloud-java

Resolves #4888
Resolves #5094