### PR TITLE
No longer refer to homebrew/science in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ R installation is not part of the gradle build.  See http://cran.r-project.org/ 
 * for ubuntu see these [ubuntu specific instructions](http://cran.r-project.org/bin/linux/ubuntu/README)
 * for OSX we recommend installation through [homebrew](http://brew.sh/)
 ```
-brew tap homebrew/science
 brew install R
 ```
 


### PR DESCRIPTION
the homebrew/science tap has been merged into core so it's no longer necessary to tap it to get R