### PR TITLE
Use SparkFiles to localize reference and known sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ releases of the toolkit.
     * [Running GATK4 with inputs on Google Cloud Storage](#gcs)
     * [Running GATK4 Spark tools on a Spark cluster](#sparkcluster)
     * [Running GATK4 Spark tools on Google Cloud Dataproc](#dataproc)
-    * [Note on 2bit Reference](#2bit)
     * [Using R to generate plots](#R)
     * [GATK Tab Completion for Bash](#tab_completion)
 * [For GATK Developers](#developers)
@@ -301,9 +300,6 @@ You can download and run pre-built versions of GATK4 from the following places:
   * If you want to avoid uploading the GATK jar to GCS on every run, set the `GATK_GCS_STAGING`
     environment variable to a bucket you have write access to (eg., `export GATK_GCS_STAGING=gs://<my_bucket>/`)
   * Dataproc Spark clusters are configured with [dynamic allocation](https://spark.apache.org/docs/latest/job-scheduling.html#dynamic-resource-allocation) so you can omit the "--num-executors" argument and let YARN handle it automatically.
-
-#### <a name="2bit">Note on 2bit Reference</a>
-* Note: Some GATK Spark tools by default require the reference file to be in 2bit format (notably `BaseRecalibratorSpark`,`BQSRPipelineSpark` and `ReadsPipelineSpark`). You can convert your fasta to 2bit by using the `faToTwoBit` utility from [UCSC](http://hgdownload.soe.ucsc.edu/admin/exe/) - see also the [documentation for `faToTwoBit`](https://genome.ucsc.edu/goldenpath/help/blatSpec.html#faToTwoBitUsage).
 
 #### <a name="R">Using R to generate plots</a>
 Certain GATK tools may optionally generate plots if R is installed.  We recommend **R v3.2.5** if you want to produce plots.  If you are uninterested in plotting, R is still required by several of the unit tests.  Plotting is currently untested and should be viewed as a convenience rather than a primary output.

--- a/scripts/spark_eval/exome_reads-pipeline_hdfs.sh
+++ b/scripts/spark_eval/exome_reads-pipeline_hdfs.sh
@@ -4,7 +4,7 @@
 
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/exome_spark_eval/NA12878.ga2.exome.maq.raw.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/out/NA12878.ga2.exome.maq.raw.vcf -R hdfs:///user/$USER/exome_spark_eval/Homo_sapiens_assembly18.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/dbsnp_138.hg18.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 20 7 28g 4g
+time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/exome_spark_eval/NA12878.ga2.exome.maq.raw.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/out/NA12878.ga2.exome.maq.raw.vcf -R hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/Homo_sapiens_assembly18.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/dbsnp_138.hg18.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 20 7 28g 4g
 
 # Notes
 # 20 executors - 2 per node (this is run on a 10 node cluster of n1-standard-16, each with 16 cores, 60g)

--- a/scripts/spark_eval/exome_reads-pipeline_hdfs.sh
+++ b/scripts/spark_eval/exome_reads-pipeline_hdfs.sh
@@ -4,7 +4,7 @@
 
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/exome_spark_eval/NA12878.ga2.exome.maq.raw.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/out/NA12878.ga2.exome.maq.raw.vcf -R hdfs:///user/$USER/exome_spark_eval/Homo_sapiens_assembly18.2bit --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/dbsnp_138.hg18.vcf -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 20 7 28g 4g
+time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/exome_spark_eval/NA12878.ga2.exome.maq.raw.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/out/NA12878.ga2.exome.maq.raw.vcf -R hdfs:///user/$USER/exome_spark_eval/Homo_sapiens_assembly18.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/exome_spark_eval/dbsnp_138.hg18.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 20 7 28g 4g
 
 # Notes
 # 20 executors - 2 per node (this is run on a 10 node cluster of n1-standard-16, each with 16 cores, 60g)

--- a/scripts/spark_eval/genome_reads-pipeline_hdfs.sh
+++ b/scripts/spark_eval/genome_reads-pipeline_hdfs.sh
@@ -4,4 +4,4 @@
 
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/q4_spark_eval/WGS-G94982-NA12878-no-NC_007605.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/out/WGS-G94982-NA12878.vcf -R hdfs:///user/$USER/q4_spark_eval/human_g1k_v37.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/dbsnp_138.b37.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 40 7 20g 8g
+time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/q4_spark_eval/WGS-G94982-NA12878-no-NC_007605.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/out/WGS-G94982-NA12878.vcf -R hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/human_g1k_v37.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/dbsnp_138.b37.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 40 7 20g 8g

--- a/scripts/spark_eval/genome_reads-pipeline_hdfs.sh
+++ b/scripts/spark_eval/genome_reads-pipeline_hdfs.sh
@@ -4,4 +4,4 @@
 
 . utils.sh
 
-time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/q4_spark_eval/WGS-G94982-NA12878-no-NC_007605.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/out/WGS-G94982-NA12878.vcf -R hdfs:///user/$USER/q4_spark_eval/human_g1k_v37.2bit --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/dbsnp_138.b37.vcf -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 20 8 46g 8g
+time_gatk "ReadsPipelineSpark -I hdfs:///user/$USER/q4_spark_eval/WGS-G94982-NA12878-no-NC_007605.bam -O hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/out/WGS-G94982-NA12878.vcf -R hdfs:///user/$USER/q4_spark_eval/human_g1k_v37.fasta --known-sites hdfs://${HDFS_HOST_PORT}/user/$USER/q4_spark_eval/dbsnp_138.b37.vcf.gz -pairHMM AVX_LOGLESS_CACHING --max-reads-per-alignment-start 10" 40 7 20g 8g

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -585,7 +585,6 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(referencePath);
         Path dictPath = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(referencePath);
 
-        // TODO: check existence of all files
         ctx.addFile(referenceFile);
         ctx.addFile(indexPath.toUri().toString());
         ctx.addFile(dictPath.toUri().toString());
@@ -610,7 +609,6 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             } else {
                 throw new IllegalArgumentException("Unrecognized known sites file extension. Must be .vcf or .vcf.gz");
             }
-            // TODO: check existence of all files
             ctx.addFile(vcfFileName);
             ctx.addFile(vcfIndexFileName);
         }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -587,8 +587,8 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
 
         // TODO: check existence of all files
         ctx.addFile(referenceFile);
-        ctx.addFile(indexPath.toString());
-        ctx.addFile(dictPath.toString());
+        ctx.addFile(indexPath.toUri().toString());
+        ctx.addFile(dictPath.toUri().toString());
 
         return referencePath.getFileName().toString();
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariants.java
@@ -1,0 +1,73 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.Iterators;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.spark.SparkFiles;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.collections.AutoCloseableCollection;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.iterators.CloseAtEndIterator;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.variant.GATKVariant;
+import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
+import scala.Tuple2;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Joins an RDD of GATKReads to variant data by copying the variants files to every node, using Spark's file
+ * copying mechanism.
+ */
+public final class JoinReadsWithVariants {
+    private static final int DEFAULT_QUERY_LOOKAHEAD_BASES = 100000;
+
+    private JoinReadsWithVariants() {
+    }
+
+    /**
+     * Joins each read of an RDD<GATKRead> with overlapping variants from a list of variants files.
+     *
+     * @param reads the RDD of reads, in coordinate-sorted order
+     * @param variantsFileNames the names of the variants files added via {@code SparkContext#addFile()}
+     * @return an RDD that contains each read along with the overlapping variants
+     */
+    public static JavaPairRDD<GATKRead, Iterable<GATKVariant>> join(final JavaRDD<GATKRead> reads, final List<String> variantsFileNames) {
+        return reads.mapPartitionsToPair((PairFlatMapFunction<Iterator<GATKRead>, GATKRead, Iterable<GATKVariant>>) gatkReadIterator -> {
+            List<FeatureDataSource<VariantContext>> variantSources = variantsFileNames.stream().map(fileName -> openFeatureSource(SparkFiles.get(fileName))).collect(Collectors.toList());
+            Iterator<Tuple2<GATKRead, Iterable<GATKVariant>>> iterator = Iterators.transform(gatkReadIterator, read -> getOverlapping(read, variantSources));
+            return new CloseAtEndIterator<>(iterator, new AutoCloseableCollection(variantSources)); // close FeatureDataSource at end of iteration
+        });
+    }
+
+    private static Tuple2<GATKRead, Iterable<GATKVariant>> getOverlapping(final GATKRead read, final List<FeatureDataSource<VariantContext>> variantSources) {
+        if (SimpleInterval.isValid(read.getContig(), read.getStart(), read.getEnd())) {
+            return new Tuple2<>(read, getOverlapping(variantSources, new SimpleInterval(read)));
+        } else {
+            //Sometimes we have reads that do not form valid intervals (reads that do not consume any ref bases, eg CIGAR 61S90I
+            //In those cases, we'll just say that nothing overlaps the read
+            return new Tuple2<>(read, Collections.emptyList());
+        }
+    }
+
+    private static FeatureDataSource<VariantContext> openFeatureSource(String path) {
+        int cloudPrefetchBuffer = ConfigFactory.getInstance().getGATKConfig().cloudPrefetchBuffer();
+        int cloudIndexPrefetchBuffer = ConfigFactory.getInstance().getGATKConfig().cloudIndexPrefetchBuffer();
+        return new FeatureDataSource<>(path, null, DEFAULT_QUERY_LOOKAHEAD_BASES, null, cloudPrefetchBuffer, cloudIndexPrefetchBuffer);
+    }
+
+    private static List<GATKVariant> getOverlapping(FeatureDataSource<VariantContext> variantSource, SimpleInterval interval) {
+        return Utils.stream(variantSource.query(interval)).map(VariantContextVariantAdapter::sparkVariantAdapter).collect(Collectors.toList());
+    }
+
+    private static List<GATKVariant> getOverlapping(List<FeatureDataSource<VariantContext>> variantSources, SimpleInterval interval) {
+        return variantSources.stream().map(variantSource -> getOverlapping(variantSource, interval)).flatMap(List::stream).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -38,6 +39,8 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.downsampling.PositionalDownsampler;
 import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
+import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
@@ -45,6 +48,7 @@ import scala.Tuple2;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -157,8 +161,9 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         logger.info("For evaluation only.");
         logger.info("Use the non-spark HaplotypeCaller if you care about the results. ");
         logger.info("********************************************************************************");
+        addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
         final List<SimpleInterval> intervals = hasUserSuppliedIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(getHeaderForReads().getSequenceDictionary());
-        callVariantsWithHaplotypeCallerAndWriteOutput(ctx, getReads(), getHeaderForReads(), getReference(), intervals, hcArgs, shardingArgs, numReducers, output, makeVariantAnnotations());
+        callVariantsWithHaplotypeCallerAndWriteOutput(ctx, getReads(), getHeaderForReads(), referenceArguments.getReferenceFileName(), intervals, hcArgs, shardingArgs, numReducers, output, makeVariantAnnotations());
     }
 
     @Override
@@ -174,7 +179,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
      * @param ctx the spark context
      * @param reads the reads variants should be called from
      * @param header the header that goes with the reads
-     * @param reference the reference to use when calling
+     * @param reference the full path to the reference file (must have been added via {@code SparkContext#addFile()})
      * @param intervals the intervals to restrict calling to
      * @param hcArgs haplotype caller arguments
      * @param shardingArgs arguments to control how the assembly regions are sharded
@@ -185,7 +190,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
             final JavaSparkContext ctx,
             final JavaRDD<GATKRead> reads,
             final SAMFileHeader header,
-            final ReferenceMultiSparkSource reference,
+            final String reference,
             final List<SimpleInterval> intervals,
             final HaplotypeCallerArgumentCollection hcArgs,
             final ShardingArgumentCollection shardingArgs,
@@ -195,11 +200,14 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         // Reads must be coordinate sorted to use the overlaps partitioner
         final SAMFileHeader readsHeader = header.clone();
         readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-        final JavaRDD<GATKRead> coordinateSortedReads = SparkUtils.sortReadsAccordingToHeader(reads, readsHeader, numReducers);
+        final JavaRDD<GATKRead> coordinateSortedReads = reads;
         final VariantAnnotatorEngine variantannotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE);
 
-        final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, false, false, readsHeader, new ReferenceMultiSourceAdapter(reference), variantannotatorEngine);
-        final JavaRDD<VariantContext> variants = callVariantsWithHaplotypeCaller(ctx, coordinateSortedReads, readsHeader, reference, intervals, hcArgs, shardingArgs, variantannotatorEngine);
+        final Path referencePath = IOUtils.getPath(reference);
+        final ReferenceSequenceFile driverReferenceSequenceFile = CachingIndexedFastaSequenceFile.checkAndCreate(referencePath);
+        final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, false, false, readsHeader, driverReferenceSequenceFile, variantannotatorEngine);
+        final String referenceFileName = referencePath.getFileName().toString();
+        final JavaRDD<VariantContext> variants = callVariantsWithHaplotypeCaller(ctx, coordinateSortedReads, readsHeader, referenceFileName, intervals, hcArgs, shardingArgs, variantannotatorEngine);
         variants.cache(); // without caching, computations are run twice as a side effect of finding partition boundaries for sorting
         try {
             VariantsSparkSink.writeVariants(ctx, output, variants, hcEngine.makeVCFHeader(readsHeader.getSequenceDictionary(), new HashSet<>()),
@@ -217,7 +225,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
      * @param ctx the spark context
      * @param reads the reads variants should be called from
      * @param header the header that goes with the reads
-     * @param reference the reference to use when calling
+     * @param referenceFileName the name of the reference file added via {@code SparkContext#addFile()}
      * @param intervals the intervals to restrict calling to
      * @param hcArgs haplotype caller arguments
      * @param shardingArgs arguments to control how the assembly regions are sharded
@@ -228,7 +236,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
             final JavaSparkContext ctx,
             final JavaRDD<GATKRead> reads,
             final SAMFileHeader header,
-            final ReferenceMultiSparkSource reference,
+            final String referenceFileName,
             final List<SimpleInterval> intervals,
             final HaplotypeCallerArgumentCollection hcArgs,
             final ShardingArgumentCollection shardingArgs,
@@ -236,11 +244,7 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         Utils.validateArg(hcArgs.dbsnp.dbsnp == null, "HaplotypeCallerSpark does not yet support -D or --dbsnp arguments" );
         Utils.validateArg(hcArgs.comps.isEmpty(), "HaplotypeCallerSpark does not yet support -comp or --comp arguments" );
         Utils.validateArg(hcArgs.bamOutputPath == null, "HaplotypeCallerSpark does not yet support -bamout or --bamOutput");
-        if ( !reference.isCompatibleWithSparkBroadcast()){
-            throw new UserException.Require2BitReferenceForBroadcast();
-        }
 
-        final Broadcast<ReferenceMultiSparkSource> referenceBroadcast = ctx.broadcast(reference);
         final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast = ctx.broadcast(hcArgs);
 
         final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast = ctx.broadcast(variantannotatorEngine);
@@ -252,10 +256,10 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         final JavaRDD<Shard<GATKRead>> readShards = SparkSharder.shard(ctx, reads, GATKRead.class, header.getSequenceDictionary(), shardBoundaries, maxReadLength);
 
         final JavaRDD<Tuple2<AssemblyRegion, SimpleInterval>> assemblyRegions = readShards
-                .mapPartitions(shardsToAssemblyRegions(referenceBroadcast,
+                .mapPartitions(shardsToAssemblyRegions(referenceFileName,
                                                        hcArgsBroadcast, shardingArgs, header, annotatorEngineBroadcast));
 
-        return assemblyRegions.mapPartitions(callVariantsFromAssemblyRegions(header, referenceBroadcast, hcArgsBroadcast, annotatorEngineBroadcast));
+        return assemblyRegions.mapPartitions(callVariantsFromAssemblyRegions(header, referenceFileName, hcArgsBroadcast, annotatorEngineBroadcast));
     }
 
     /**
@@ -265,14 +269,14 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
      */
     private static FlatMapFunction<Iterator<Tuple2<AssemblyRegion, SimpleInterval>>, VariantContext> callVariantsFromAssemblyRegions(
             final SAMFileHeader header,
-            final Broadcast<ReferenceMultiSparkSource> referenceBroadcast,
+            final String referenceFileName,
             final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast,
             final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast) {
         return regionAndIntervals -> {
             //HaplotypeCallerEngine isn't serializable but is expensive to instantiate, so construct and reuse one for every partition
-            final ReferenceMultiSparkSource referenceMultiSource = referenceBroadcast.value();
-            final ReferenceMultiSourceAdapter referenceSource = new ReferenceMultiSourceAdapter(referenceMultiSource);
-            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, referenceSource, annotatorEngineBroadcast.getValue());
+            final String pathOnExecutor = SparkFiles.get(referenceFileName);
+            final ReferenceSequenceFile taskReferenceSequenceFile = CachingIndexedFastaSequenceFile.checkAndCreate(IOUtils.getPath(pathOnExecutor));
+            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, taskReferenceSequenceFile, annotatorEngineBroadcast.getValue());
             return Utils.stream(regionAndIntervals).flatMap(regionToVariants(hcEngine)).iterator();
         };
     }
@@ -302,36 +306,37 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
      * interval it was generated in
      */
     private static FlatMapFunction<Iterator<Shard<GATKRead>>, Tuple2<AssemblyRegion, SimpleInterval>> shardsToAssemblyRegions(
-            final Broadcast<ReferenceMultiSparkSource> reference,
+            final String referenceFileName,
             final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast,
             final ShardingArgumentCollection assemblyArgs,
             final SAMFileHeader header,
             final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast) {
         return shards -> {
-            final ReferenceMultiSparkSource referenceMultiSource = reference.value();
-            final ReferenceMultiSourceAdapter referenceSource = new ReferenceMultiSourceAdapter(referenceMultiSource);
-            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, referenceSource, annotatorEngineBroadcast.getValue());
+            final String pathOnExecutor = SparkFiles.get(referenceFileName);
+            final ReferenceSequenceFile taskReferenceSequenceFile = CachingIndexedFastaSequenceFile.checkAndCreate(IOUtils.getPath(pathOnExecutor));
+            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, taskReferenceSequenceFile, annotatorEngineBroadcast.getValue());
 
+            final ReferenceDataSource taskReferenceDataSource = new ReferenceFileSource(IOUtils.getPath(pathOnExecutor)); // TODO: share with taskReferenceSequenceFile
             final ReadsDownsampler readsDownsampler = assemblyArgs.maxReadsPerAlignmentStart > 0 ?
                 new PositionalDownsampler(assemblyArgs.maxReadsPerAlignmentStart, header) : null;
             return Utils.stream(shards)
                     //TODO we've hacked multi interval shards here with a shim, but we should investigate as smarter approach https://github.com/broadinstitute/gatk/issues/4299
                 .map(shard -> new ShardToMultiIntervalShardAdapter<>(
                         new DownsampleableSparkReadShard(new ShardBoundary(shard.getInterval(), shard.getPaddedInterval()), shard, readsDownsampler)))
-                .flatMap(shardToRegion(assemblyArgs, header, referenceSource, hcEngine)).iterator();
+                .flatMap(shardToRegion(assemblyArgs, header, taskReferenceDataSource, hcEngine)).iterator();
         };
     }
 
     private static Function<MultiIntervalShard<GATKRead>, Stream<? extends Tuple2<AssemblyRegion, SimpleInterval>>> shardToRegion(
             ShardingArgumentCollection assemblyArgs,
             SAMFileHeader header,
-            ReferenceMultiSourceAdapter referenceSource,
+            ReferenceDataSource referenceDataSource,
             HaplotypeCallerEngine evaluator) {
         return shard -> {
             //TODO load features as a side input
             final FeatureManager featureManager = null;
 
-            final Iterator<AssemblyRegion> assemblyRegionIter = new AssemblyRegionIterator(shard, header, referenceSource, featureManager, evaluator, assemblyArgs.minAssemblyRegionSize, assemblyArgs.maxAssemblyRegionSize, assemblyArgs.assemblyRegionPadding, assemblyArgs.activeProbThreshold, assemblyArgs.maxProbPropagationDistance,
+            final Iterator<AssemblyRegion> assemblyRegionIter = new AssemblyRegionIterator(shard, header, referenceDataSource, featureManager, evaluator, assemblyArgs.minAssemblyRegionSize, assemblyArgs.maxAssemblyRegionSize, assemblyArgs.assemblyRegionPadding, assemblyArgs.activeProbThreshold, assemblyArgs.maxProbPropagationDistance,
                                                                                            INCLUDE_READS_WITH_DELETIONS_IN_IS_ACTIVE_PILEUPS);
 
             return Utils.stream(assemblyRegionIter)

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -1,27 +1,24 @@
 package org.broadinstitute.hellbender.tools.spark;
 
-import htsjdk.samtools.SAMFileHeader;
-import org.broadinstitute.barclay.argparser.BetaFeature;
-import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.IOUtil;
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.engine.spark.AddContextDataToReadSpark;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinStrategy;
-import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
-import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.spark.transforms.BaseRecalibratorSparkFn;
 import org.broadinstitute.hellbender.tools.walkers.bqsr.BaseRecalibrator;
+import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.BaseRecalibrationEngine;
 import org.broadinstitute.hellbender.utils.recalibration.RecalUtils;
@@ -31,7 +28,11 @@ import org.broadinstitute.hellbender.utils.variant.GATKVariant;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
+
+;
 
 /**
  * Spark version of the first pass of the base quality score recalibration.
@@ -118,9 +119,6 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
     @Argument(doc = "the known variants", fullName = BaseRecalibrator.KNOWN_SITES_ARG_FULL_NAME, optional = false)
     private List<String> knownVariants;
 
-    @Argument(doc = "the join strategy for reference bases and known variants", fullName = "join-strategy", optional = true)
-    private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
-
     @Argument(doc = "Path to save the final recalibration tables to.",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     private String outputTablesPath = null;
@@ -131,32 +129,14 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
     @ArgumentCollection(doc = "all the command line arguments for BQSR and its covariates")
     private final RecalibrationArgumentCollection bqsrArgs = new RecalibrationArgumentCollection();
 
-    @Argument(fullName="read-shard-size", doc = "Maximum size of each read shard, in bases. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
-    public int readShardSize = 10000;
-
-    @Argument(fullName="read-shard-padding", doc = "Each read shard has this many bases of extra context on each side. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
-    public int readShardPadding = 1000;
-
     @Override
     protected void runTool( JavaSparkContext ctx ) {
-        if (joinStrategy == JoinStrategy.BROADCAST && ! getReference().isCompatibleWithSparkBroadcast()){
-            throw new UserException.Require2BitReferenceForBroadcast();
-        }
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
 
-        if (joinStrategy == JoinStrategy.OVERLAPS_PARTITIONER && getHeaderForReads().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
-            throw new UserException.BadInput("Reads must be coordinate sorted when using the overlaps partitioner join strategy.");
-        }
+        JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants = JoinReadsWithVariants.join(getReads(), localKnownSitesFilePaths);
 
-        JavaRDD<GATKRead> initialReads = getReads();
-        VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(knownVariants, getIntervals());
-
-        // TODO: Look into broadcasting the reference to all of the workers. This would make AddContextDataToReadSpark
-        // TODO: and ApplyBQSRStub simpler (#855).
-        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, initialReads, getReference(), bqsrKnownVariants, knownVariants, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
-
-        // TODO: broadcast the reads header?
-        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getReferenceSequenceDictionary(), bqsrArgs);
+        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(readsWithVariants, getHeaderForReads(), referenceFileName, bqsrArgs);
 
         try ( final PrintStream reportStream = new PrintStream(BucketUtils.createFile(outputTablesPath)) ) {
             RecalUtils.outputRecalibrationReport(reportStream, bqsrArgs, bqsrReport.getQuantizationInfo(), bqsrReport.getRecalibrationTables(), bqsrReport.getCovariates());

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.hellbender.tools.spark;
 
-import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import htsjdk.samtools.util.IOUtil;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
@@ -12,13 +10,12 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
+import org.broadinstitute.hellbender.utils.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.spark.transforms.BaseRecalibratorSparkFn;
 import org.broadinstitute.hellbender.tools.walkers.bqsr.BaseRecalibrator;
 import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.BaseRecalibrationEngine;
 import org.broadinstitute.hellbender.utils.recalibration.RecalUtils;
@@ -28,11 +25,7 @@ import org.broadinstitute.hellbender.utils.variant.GATKVariant;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 
 import java.io.PrintStream;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
-
-;
 
 /**
  * Spark version of the first pass of the base quality score recalibration.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -125,7 +125,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
     @Override
     protected void runTool( JavaSparkContext ctx ) {
         String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
-        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
+        List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants = JoinReadsWithVariants.join(getReads(), localKnownSitesFilePaths);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -12,7 +12,7 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
+import org.broadinstitute.hellbender.utils.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.ApplyBQSRUniqueArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.transforms.ApplyBQSRSparkFn;
 import org.broadinstitute.hellbender.tools.spark.transforms.BaseRecalibratorSparkFn;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -1,30 +1,23 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
-import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.barclay.argparser.BetaFeature;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.engine.spark.AddContextDataToReadSpark;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinStrategy;
-import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
-import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.ApplyBQSRUniqueArgumentCollection;
 import org.broadinstitute.hellbender.tools.spark.transforms.ApplyBQSRSparkFn;
 import org.broadinstitute.hellbender.tools.spark.transforms.BaseRecalibratorSparkFn;
 import org.broadinstitute.hellbender.tools.walkers.bqsr.BaseRecalibrator;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.recalibration.BaseRecalibrationEngine;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 import org.broadinstitute.hellbender.utils.variant.GATKVariant;
@@ -83,26 +76,17 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
     public boolean requiresReference() { return true; }
 
     @Argument(doc = "the known variants", fullName = BaseRecalibrator.KNOWN_SITES_ARG_FULL_NAME, optional = false)
-    protected List<String> baseRecalibrationKnownVariantPaths;
+    protected List<String> knownVariants;
 
     @Argument(doc = "the output bam", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     protected String output;
-
-    @Argument(doc = "the join strategy for reference bases and known variants", fullName = "join-strategy", optional = true)
-    private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
 
     /**
      * all the command line arguments for BQSR and its covariates
      */
     @ArgumentCollection(doc = "all the command line arguments for BQSR and its covariates")
     private final RecalibrationArgumentCollection bqsrArgs = new RecalibrationArgumentCollection();
-
-    @Argument(fullName="read-shard-size", doc = "Maximum size of each read shard, in bases. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
-    public int readShardSize = 10000;
-
-    @Argument(fullName="read-shard-padding", doc = "Each read shard has this many bases of extra context on each side. Only applies when using the OVERLAPS_PARTITIONER join strategy.", optional = true)
-    public int readShardPadding = 1000;
 
     /**
      * command-line arguments to fine tune the apply BQSR step.
@@ -111,15 +95,10 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
     public ApplyBQSRUniqueArgumentCollection applyBqsrArgs = new ApplyBQSRUniqueArgumentCollection();
 
     @Override
-    public SerializableFunction<GATKRead, SimpleInterval> getReferenceWindowFunction() {
-        return BaseRecalibrationEngine.BQSR_REFERENCE_WINDOW_FUNCTION;
-    }
-
-    @Override
     protected void runTool(final JavaSparkContext ctx) {
-        if (joinStrategy == JoinStrategy.BROADCAST && ! getReference().isCompatibleWithSparkBroadcast()){
-            throw new UserException.Require2BitReferenceForBroadcast();
-        }
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
+
         //Should this get the getUnfilteredReads? getReads will merge default and command line filters.
         //but the code below uses other filters for other parts of the pipeline that do not honor
         //the commandline.
@@ -132,12 +111,9 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         final ReadFilter bqsrReadFilter = ReadFilter.fromList(BaseRecalibrator.getBQSRSpecificReadFilterList(), getHeaderForReads());
         final JavaRDD<GATKRead> filteredReadsForBQSR = initialReads.filter(read -> bqsrReadFilter.test(read));
 
-        final VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        final JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariantPaths, getIntervals());
-
-        final JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, filteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariantPaths, joinStrategy, getHeaderForReads().getSequenceDictionary(), readShardSize, readShardPadding);
+        JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants = JoinReadsWithVariants.join(filteredReadsForBQSR, localKnownSitesFilePaths);
         //note: we use the reference dictionary from the reads themselves.
-        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, getHeaderForReads(), getHeaderForReads().getSequenceDictionary(), bqsrArgs);
+        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(readsWithVariants, getHeaderForReads(), referenceFileName, bqsrArgs);
 
         final Broadcast<RecalibrationReport> reportBroadcast = ctx.broadcast(bqsrReport);
         final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(initialReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs.PRESERVE_QSCORES_LESS_THAN));

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -97,7 +97,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
-        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
+        List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         //Should this get the getUnfilteredReads? getReads will merge default and command line filters.
         //but the code below uses other filters for other parts of the pipeline that do not honor

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -15,7 +15,7 @@ import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesS
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
+import org.broadinstitute.hellbender.utils.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.ApplyBQSRUniqueArgumentCollection;
 import org.broadinstitute.hellbender.tools.HaplotypeCallerSpark;
 import org.broadinstitute.hellbender.tools.spark.bwa.BwaArgumentCollection;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -5,7 +5,6 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
-import org.apache.spark.storage.StorageLevel;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.BetaFeature;
@@ -14,13 +13,9 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
-import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.engine.spark.AddContextDataToReadSpark;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.spark.JoinStrategy;
-import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
-import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.engine.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.ApplyBQSRUniqueArgumentCollection;
 import org.broadinstitute.hellbender.tools.HaplotypeCallerSpark;
 import org.broadinstitute.hellbender.tools.spark.bwa.BwaArgumentCollection;
@@ -34,11 +29,9 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCall
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerEngine;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReferenceConfidenceMode;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.markduplicates.SerializableOpticalDuplicatesFinder;
-import org.broadinstitute.hellbender.utils.recalibration.BaseRecalibrationEngine;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 import org.broadinstitute.hellbender.utils.spark.SparkUtils;
@@ -103,7 +96,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
     private boolean align;
 
     @Argument(doc = "the known variants", fullName = BaseRecalibrator.KNOWN_SITES_ARG_FULL_NAME, optional = false)
-    protected List<String> baseRecalibrationKnownVariants;
+    protected List<String> knownVariants;
 
     @Argument(doc = "the output vcf", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
@@ -111,9 +104,6 @@ public class ReadsPipelineSpark extends GATKSparkTool {
 
     @Argument(doc = "the output bam", fullName = "output-bam", optional = true)
     protected String outputBam;
-
-    @Argument(doc = "the join strategy for reference bases and known variants", fullName = "join-strategy", optional = true)
-    private JoinStrategy joinStrategy = JoinStrategy.BROADCAST;
 
     @ArgumentCollection
     protected MarkDuplicatesSparkArgumentCollection markDuplicatesSparkArgumentCollection = new MarkDuplicatesSparkArgumentCollection();
@@ -140,11 +130,6 @@ public class ReadsPipelineSpark extends GATKSparkTool {
     public HaplotypeCallerArgumentCollection hcArgs = new HaplotypeCallerArgumentCollection();
 
     @Override
-    public SerializableFunction<GATKRead, SimpleInterval> getReferenceWindowFunction() {
-        return BaseRecalibrationEngine.BQSR_REFERENCE_WINDOW_FUNCTION;
-    }
-
-    @Override
     public boolean useVariantAnnotations() { return true;}
 
     @Override
@@ -167,9 +152,8 @@ public class ReadsPipelineSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        if (joinStrategy == JoinStrategy.BROADCAST && ! getReference().isCompatibleWithSparkBroadcast()){
-            throw new UserException.Require2BitReferenceForBroadcast();
-        }
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
 
         final JavaRDD<GATKRead> alignedReads;
         final SAMFileHeader header;
@@ -192,29 +176,24 @@ public class ReadsPipelineSpark extends GATKSparkTool {
 
         final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.mark(alignedReads, header, markDuplicatesSparkArgumentCollection.duplicatesScoringStrategy, new SerializableOpticalDuplicatesFinder(), getRecommendedNumReducers(), markDuplicatesSparkArgumentCollection.dontMarkUnmappedMates);
 
+        // always coordinate-sort reads so BQSR can use queryLookaheadBases in FeatureDataSource
+        final SAMFileHeader readsHeader = header.clone();
+        readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final JavaRDD<GATKRead> sortedMarkedReads = SparkUtils.sortReadsAccordingToHeader(markedReads, readsHeader, numReducers);
+
         // The markedReads have already had the WellformedReadFilter applied to them, which
         // is all the filtering that MarkDupes and ApplyBQSR want. BQSR itself wants additional
         // filtering performed, so we do that here.
         //NOTE: this doesn't honor enabled/disabled commandline filters
         final ReadFilter bqsrReadFilter = ReadFilter.fromList(BaseRecalibrator.getBQSRSpecificReadFilterList(), header);
 
-        JavaRDD<GATKRead> markedFilteredReadsForBQSR = markedReads.filter(read -> bqsrReadFilter.test(read));
+        JavaRDD<GATKRead> markedFilteredReadsForBQSR = sortedMarkedReads.filter(bqsrReadFilter::test);
 
-        if (joinStrategy.equals(JoinStrategy.OVERLAPS_PARTITIONER)) {
-            // the overlaps partitioner requires that reads are coordinate-sorted
-            final SAMFileHeader readsHeader = header.clone();
-            readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-            markedFilteredReadsForBQSR = SparkUtils.sortReadsAccordingToHeader(markedFilteredReadsForBQSR, readsHeader, numReducers);
-        }
-
-        VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
-        JavaRDD<GATKVariant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants, getIntervals());
-
-        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(ctx, markedFilteredReadsForBQSR, getReference(), bqsrKnownVariants, baseRecalibrationKnownVariants, joinStrategy, header.getSequenceDictionary(), shardingArgs.readShardSize, shardingArgs.readShardPadding);
-        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(rddReadContext, header, getReferenceSequenceDictionary(), bqsrArgs);
+        JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants = JoinReadsWithVariants.join(markedFilteredReadsForBQSR, localKnownSitesFilePaths);
+        final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(readsWithVariants, getHeaderForReads(), referenceFileName, bqsrArgs);
 
         final Broadcast<RecalibrationReport> reportBroadcast = ctx.broadcast(bqsrReport);
-        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(markedReads, reportBroadcast, header, applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs.PRESERVE_QSCORES_LESS_THAN));
+        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(sortedMarkedReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs.PRESERVE_QSCORES_LESS_THAN));
 
         if (outputBam != null) { // only write output of BQSR if output BAM is specified
             writeReads(ctx, outputBam, finalReads, header);
@@ -222,10 +201,9 @@ public class ReadsPipelineSpark extends GATKSparkTool {
 
         // Run Haplotype Caller
         final ReadFilter hcReadFilter = ReadFilter.fromList(HaplotypeCallerEngine.makeStandardHCReadFilters(), header);
-        final JavaRDD<GATKRead> filteredReadsForHC = finalReads.filter(read -> hcReadFilter.test(read));
-        filteredReadsForHC.persist(StorageLevel.DISK_ONLY()); // without caching, computations are run twice as a side effect of finding partition boundaries for sorting
+        final JavaRDD<GATKRead> filteredReadsForHC = finalReads.filter(hcReadFilter::test);
         final List<SimpleInterval> intervals = hasUserSuppliedIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(header.getSequenceDictionary());
-        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, header, getReference(), intervals, hcArgs, shardingArgs, numReducers, output, makeVariantAnnotations());
+        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, header, referenceArguments.getReferenceFileName(), intervals, hcArgs, shardingArgs, numReducers, output, makeVariantAnnotations());
 
         if (bwaEngine != null) {
             bwaEngine.close();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -153,7 +153,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
     @Override
     protected void runTool(final JavaSparkContext ctx) {
         String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
-        List<String> localKnownSitesFilePaths = addKnownSitesForSpark(ctx, knownVariants);
+        List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         final JavaRDD<GATKRead> alignedReads;
         final SAMFileHeader header;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
@@ -9,17 +9,13 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
 public class ApplyBQSRSparkFn {
 
     public static JavaRDD<GATKRead> apply(JavaRDD<GATKRead> reads, final Broadcast<RecalibrationReport> reportBroadcast, final SAMFileHeader readsHeader, ApplyBQSRArgumentCollection args) {
         return reads.mapPartitions(readsIterator -> {
             final RecalibrationReport report = reportBroadcast.getValue();
-            final BQSRReadTransformer transformer = new BQSRReadTransformer(readsHeader, report, args);//reuse this for all reads in the partition
-            final Iterable<GATKRead> readsIterable = () -> readsIterator;
-            return Utils.stream(readsIterable).map(read -> transformer.apply(read)).collect(Collectors.toList()).iterator();
+            final BQSRReadTransformer transformer = new BQSRReadTransformer(readsHeader, report, args); // reuse this for all reads in the partition
+            return Utils.stream(readsIterator).map(transformer::apply).iterator();
         });
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
@@ -1,12 +1,17 @@
 package org.broadinstitute.hellbender.tools.spark.transforms;
 
+import com.google.common.collect.Iterators;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
+import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
+import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.engine.ReferenceMemorySource;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.*;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
@@ -33,6 +38,38 @@ public final class BaseRecalibratorSparkFn {
                 bqsr.processRead(readWithData._1(), refDS, variants);
             }
             return Arrays.asList(bqsr.getRecalibrationTables()).iterator();
+        });
+
+        final RecalibrationTables emptyRecalibrationTable = new RecalibrationTables(new StandardCovariateList(recalArgs, header));
+        final RecalibrationTables combinedTables = unmergedTables.treeAggregate(emptyRecalibrationTable,
+                RecalibrationTables::inPlaceCombine,
+                RecalibrationTables::inPlaceCombine,
+                Math.max(1, (int)(Math.log(unmergedTables.partitions().size()) / Math.log(2))));
+
+        BaseRecalibrationEngine.finalizeRecalibrationTables(combinedTables);
+
+        final QuantizationInfo quantizationInfo = new QuantizationInfo(combinedTables, recalArgs.QUANTIZING_LEVELS);
+
+        final StandardCovariateList covariates = new StandardCovariateList(recalArgs, header);
+        return RecalUtils.createRecalibrationReport(recalArgs.generateReportTable(covariates.covariateNames()), quantizationInfo.generateReportTable(), RecalUtils.generateReportTables(combinedTables, covariates));
+    }
+
+    /**
+     * Run the {@link BaseRecalibrationEngine} on reads and overlapping variants.
+     * @param readsWithVariants the RDD of reads with overlapping variants
+     * @param header the reads header
+     * @param referenceFileName the name of the reference file added via {@code SparkContext#addFile()}
+     * @param recalArgs arguments to use during recalibration
+     * @return the recalibration report object
+     */
+    public static RecalibrationReport apply(final JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants, final SAMFileHeader header, final String referenceFileName, final RecalibrationArgumentCollection recalArgs) {
+        JavaRDD<RecalibrationTables> unmergedTables = readsWithVariants.mapPartitions(readsWithVariantsIterator -> {
+            String pathOnExecutor = SparkFiles.get(referenceFileName);
+            ReferenceDataSource referenceDataSource = new ReferenceFileSource(IOUtils.getPath(pathOnExecutor));
+            final BaseRecalibrationEngine bqsr = new BaseRecalibrationEngine(recalArgs, header);
+            bqsr.logCovariatesUsed();
+            Utils.stream(readsWithVariantsIterator).forEach(t -> bqsr.processRead(t._1, referenceDataSource, t._2));
+            return Iterators.singletonIterator(bqsr.getRecalibrationTables());
         });
 
         final RecalibrationTables emptyRecalibrationTable = new RecalibrationTables(new StandardCovariateList(recalArgs, header));

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
@@ -2,57 +2,19 @@ package org.broadinstitute.hellbender.tools.spark.transforms;
 
 import com.google.common.collect.Iterators;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.ReadContextData;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
-import org.broadinstitute.hellbender.engine.ReferenceMemorySource;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.recalibration.*;
 import org.broadinstitute.hellbender.utils.recalibration.covariates.StandardCovariateList;
-import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.variant.GATKVariant;
-import scala.Tuple2;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public final class BaseRecalibratorSparkFn {
-
-    public static RecalibrationReport apply( final JavaPairRDD<GATKRead, ReadContextData> readsWithContext, final SAMFileHeader header, final SAMSequenceDictionary referenceDictionary, final RecalibrationArgumentCollection recalArgs ) {
-        JavaRDD<RecalibrationTables> unmergedTables = readsWithContext.mapPartitions(readWithContextIterator -> {
-            final BaseRecalibrationEngine bqsr = new BaseRecalibrationEngine(recalArgs, header);
-            bqsr.logCovariatesUsed();
-
-            while ( readWithContextIterator.hasNext() ) {
-                final Tuple2<GATKRead, ReadContextData> readWithData = readWithContextIterator.next();
-                Iterable<GATKVariant> variants = readWithData._2().getOverlappingVariants();
-                final ReferenceBases refBases = readWithData._2().getOverlappingReferenceBases();
-                ReferenceDataSource refDS = new ReferenceMemorySource(refBases, referenceDictionary);
-
-                bqsr.processRead(readWithData._1(), refDS, variants);
-            }
-            return Arrays.asList(bqsr.getRecalibrationTables()).iterator();
-        });
-
-        final RecalibrationTables emptyRecalibrationTable = new RecalibrationTables(new StandardCovariateList(recalArgs, header));
-        final RecalibrationTables combinedTables = unmergedTables.treeAggregate(emptyRecalibrationTable,
-                RecalibrationTables::inPlaceCombine,
-                RecalibrationTables::inPlaceCombine,
-                Math.max(1, (int)(Math.log(unmergedTables.partitions().size()) / Math.log(2))));
-
-        BaseRecalibrationEngine.finalizeRecalibrationTables(combinedTables);
-
-        final QuantizationInfo quantizationInfo = new QuantizationInfo(combinedTables, recalArgs.QUANTIZING_LEVELS);
-
-        final StandardCovariateList covariates = new StandardCovariateList(recalArgs, header);
-        return RecalUtils.createRecalibrationReport(recalArgs.generateReportTable(covariates.covariateNames()), quantizationInfo.generateReportTable(), RecalUtils.generateReportTables(combinedTables, covariates));
-    }
 
     /**
      * Run the {@link BaseRecalibrationEngine} on reads and overlapping variants.

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/AutoCloseableCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/AutoCloseableCollection.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.hellbender.utils.collections;
+
+import java.util.Collection;
+
+/**
+ * An {@link AutoCloseable} collection that will automatically close all of its elements.
+ */
+public class AutoCloseableCollection implements AutoCloseable {
+    private Collection<? extends AutoCloseable> autoCloseables;
+
+    public AutoCloseableCollection(final Collection<? extends AutoCloseable> autoCloseables) {
+        this.autoCloseables = autoCloseables;
+    }
+
+    @Override
+    public void close() {
+        // throw a RuntimeException due to unsuppressable warning when declaring 'throws Exception': https://bugs.openjdk.java.net/browse/JDK-8155591
+        RuntimeException exception = null;
+        for (AutoCloseable closeable : autoCloseables) {
+            try {
+                if (closeable != null) {
+                    closeable.close();
+                }
+            } catch (Exception e) {
+                if (exception == null) {
+                    exception = new RuntimeException("Problem closing AutoCloseable object(s)");
+                }
+                exception.addSuppressed(e);
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/CloseAtEndIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/CloseAtEndIterator.java
@@ -1,0 +1,49 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import java.util.Iterator;
+import java.util.function.Consumer;
+
+/**
+ * An {@link Iterator} that automatically closes a resource when the end of the iteration is
+ * reached.
+ *
+ * @param <E>
+ */
+public class CloseAtEndIterator<E> implements Iterator<E> {
+
+    private final Iterator<E> iterator;
+    private final AutoCloseable closeable;
+
+    public CloseAtEndIterator(Iterator<E> iterator, AutoCloseable closeable) {
+        this.iterator = iterator;
+        this.closeable = closeable;
+    }
+
+    @Override
+    public boolean hasNext() {
+        boolean hasNext = iterator.hasNext();
+        if (!hasNext) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return hasNext;
+    }
+
+    @Override
+    public E next() {
+        return iterator.next();
+    }
+
+    @Override
+    public void remove() {
+        iterator.remove();
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super E> action) {
+        iterator.forEachRemaining(action);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -48,7 +48,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
         final String[] args = {
                 "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING"
@@ -83,7 +83,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
         final String[] args = {
                 "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -116,7 +116,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
         final String[] args = {
                 "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
@@ -141,7 +141,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
     public void testBrokenGVCFConfigurationsAreDisallowed(String extension) {
         final String[] args = {
                 "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-R", b37_reference_20_21,
                 "-O", createTempFile("testGVCF_GZ_throw_exception", extension).getAbsolutePath(),
                 "-ERC", "GVCF",
         };
@@ -173,7 +173,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
         final String[] args = {
                 "-I", NA12878_20_21_WGS_bam,
-                "-R", b37_2bit_reference_20_21,
+                "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
@@ -190,7 +190,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
     @Test
     public void testReferenceAdapterIsSerializable() throws IOException {
-        final ReferenceMultiSparkSource referenceMultiSource = new ReferenceMultiSparkSource(b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        final ReferenceMultiSparkSource referenceMultiSource = new ReferenceMultiSparkSource(b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SparkTestUtils.roundTripInKryo(referenceMultiSource, ReferenceMultiSparkSource.class, SparkContextFactory.getTestSparkContext().getConf());
         final HaplotypeCallerSpark.ReferenceMultiSourceAdapter adapter = new HaplotypeCallerSpark.ReferenceMultiSourceAdapter(referenceMultiSource);
         SparkTestUtils.roundTripInKryo(adapter, HaplotypeCallerSpark.ReferenceMultiSourceAdapter.class, SparkContextFactory.getTestSparkContext().getConf());
@@ -213,7 +213,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
     @Test
     public void testReferenceMultiSourceIsSerializable() {
-        final ReferenceMultiSparkSource args = new ReferenceMultiSparkSource(GATKBaseTest.b37_2bit_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        final ReferenceMultiSparkSource args = new ReferenceMultiSparkSource(GATKBaseTest.b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SparkTestUtils.roundTripInKryo(args, ReferenceMultiSparkSource.class, SparkContextFactory.getTestSparkContext().getConf());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -62,7 +62,6 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     public Object[][] createBQSRTestData() {
         final String localResources =  getResourceDir();
 
-        final String GRCh37Ref2bit_chr2021 = b37_2bit_reference_20_21;
         final String GRCh37Ref_chr2021 = b37_reference_20_21;
         final String hiSeqBam_chr20 = localResources + WGS_B37_CH20_1M_1M1K_BAM;
         final String hiSeqBam_1read = localResources + "overlappingRead.bam";
@@ -70,7 +69,6 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String dbSNPb37_chr2021 = dbsnp_138_b37_20_21_vcf;
 
         final String hg19Chr171Mb = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
-        final String hg19Chr171Mb_2bit = publicTestDir + "human_g1k_v37.chr17_1Mb.2bit";
         final String HiSeqBam_chr17 = localResources + "NA12878.chr17_69k_70k.dictFix.bam";
         final String dbSNPb37_chr17 =  localResources + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
         final String more17Sites = localResources + "bqsr.fakeSitesForTesting.b37.chr17.vcf";
@@ -86,51 +84,19 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 // See MathUtilsUniTest.testAddDoubles for a demonstration how that can change the results.
                 // See RecalDatum for explanation of why the multiplier is needed.
 
-                // local input/computation/reference, SHUFFLE
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq " + "--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy SHUFFLE --indels-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy SHUFFLE --low-quality-tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy SHUFFLE --quantizing-levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy SHUFFLE --mismatches-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                // local input/computation/reference
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --indels-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --low-quality-tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --quantizing-levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37Ref_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --mismatches-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
                 // multiple known sites; output generated with GATK4 walker
-                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqBam_20_21_100000, more20Sites, "-indels --enable-baq " +" --join-strategy SHUFFLE --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
-                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqCram_20_21_100000, more20Sites, "-indels --enable-baq " +" --join-strategy SHUFFLE --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
-                // multiple known sites  with SHUFFLE; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb, HiSeqBam_chr17, dbSNPb37_chr17, "-indels --enable-baq " +" --join-strategy SHUFFLE --known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
-
-                // multiple known sites  with BROADCAST; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indels --enable-baq " +" --join-strategy BROADCAST --known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
-
-                // local input/computation, 2Bit Reference, BROADCAST
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST --indels-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST --low-quality-tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST --quantizing-levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST --mismatches-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
-                // multiple known sites with 2bit BROADCAST; same output used for multiple known sites SHUFFLE test above
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indels --enable-baq " +" --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
-                // Can't use 2 bit reference with a CRAM file: https://github.com/broadinstitute/gatk/issues/1443
-                //{new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqCram_20_21_100000, more20Sites, " -known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.1m-1m100.recal.txt")},
-
-                //// //{new BQSRTest(b36Reference, origQualsBam, dbSNPb36, "-OQ", getResourceDir() + "expected.originalQuals.1kg.chr1.1-1K.1RG.dictFix.OQ.txt")},
-
-                // multiple known sites  with OVERLAPS_PARTITIONER; entire test case shared with walker version
-                {new BQSRTest(hg19Chr171Mb_2bit, HiSeqBam_chr17, dbSNPb37_chr17, "-indels --enable-baq " +" --join-strategy OVERLAPS_PARTITIONER --known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
-
-                // local input/computation, 2Bit Reference, OVERLAPS_PARTITIONER
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER --indels-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER --low-quality-tail 5", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER --quantizing-levels 6", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER --mismatches-context-size 4", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
-                // multiple known sites with 2bit OVERLAPS_PARTITIONER; same output used for multiple known sites SHUFFLE test above
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_20_21_100000, more20Sites, "-indels --enable-baq " +" --join-strategy OVERLAPS_PARTITIONER --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqBam_20_21_100000, more20Sites, "-indels --enable-baq --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                {new BQSRTest(GRCh37Ref_chr2021 , hiSeqCram_20_21_100000, more20Sites, "-indels --enable-baq --known-sites " + more21Sites, getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.ch21.10m-10m100.recal.txt")},
+                // multiple known sites; entire test case shared with walker version
+                {new BQSRTest(hg19Chr171Mb, HiSeqBam_chr17, dbSNPb37_chr17, "-indels --enable-baq --known-sites " + more17Sites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
         };
     }
 
@@ -149,7 +115,6 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
         final String localResources =  getResourceDir();
 
         final String GRCh37RefCloud = GCS_b37_CHR20_21_REFERENCE;
-        final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
         final String hiSeqBam_chr20 = localResources + WGS_B37_CH20_1M_1M1K_BAM;
         final String hiSeqBam_1read = localResources + "overlappingRead.bam";
         final String dbSNPb37_chr20 = localResources + DBSNP_138_B37_CH20_1M_1M1K_VCF;
@@ -161,23 +126,14 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 // See MathUtilsUniTest.testAddDoubles for a demonstration how that can change the results.
                 // See RecalDatum for explanation of why the multiplier is needed.
 
-                // local input/computation, using a gs:// reference , SHUFFLE
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq " +" --join-strategy SHUFFLE", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, " --join-strategy SHUFFLE", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy SHUFFLE --indels-context-size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy SHUFFLE --low-quality-tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy SHUFFLE --quantizing-levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy SHUFFLE --mismatches-context-size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
-
-                // local input/computation, using a 2bit reference file in a GCS bucket, BROADCAST
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq " +" --join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, " --join-strategy BROADCAST", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy BROADCAST --indels-context-size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy BROADCAST --low-quality-tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy BROADCAST --quantizing-levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
-                {new BQSRTest(chr2021Reference2bit, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +" --join-strategy BROADCAST --mismatches-context-size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
+                // local input/computation, using a gs:// reference
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_1read, dbSNPb37_chr2021, "-indels --enable-baq", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1READ_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_NOINDEL_NOBAQ_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --indels-context-size 4",  localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_INDELS_CONTEXT_SIZE_4_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --low-quality-tail 5",     localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_LOW_QUALITY_TAIL_5_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --quantizing-levels 6",    localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_QUANTIZING_LEVELS_6_RECAL)},
+                {new BQSRTest(GRCh37RefCloud, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq --mismatches-context-size 4", localResources + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_MISMATCHES_CONTEXT_SIZE_4_RECAL)},
         };
     }
 
@@ -188,22 +144,6 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
                 ab.getString(),
                 Arrays.asList(params.expectedFileName));
         spec.executeTest("testBQSRSparkCloud-" + params.args, this);
-    }
-
-    @Test(groups = "spark")
-    public void testBlowUpOnBroadcastIncompatibleReference() throws IOException {
-        //this should blow up because broadcast requires a 2bit reference
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-
-        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
-
-        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
-        IntegrationTestSpec spec = new IntegrationTestSpec(
-                ab.getString(),
-                1,
-                UserException.Require2BitReferenceForBroadcast.class);
-        spec.executeTest("testBQSR-" + params.args, this);
     }
 
     //This data provider is for tests that use BAM files stored in buckets

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
@@ -2,12 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSparkSource;
-import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.walkers.bqsr.BQSRTestData;
-import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.testutils.SamAssertionUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -57,7 +52,6 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
     @DataProvider(name = "BQSRLocalRefTest")
     public Object[][] createBQSRLocalRefTestData() {
         final String GRCh37Ref_2021 = b37_reference_20_21;
-        final String GRCh37Ref2bit_chr2021 = b37_2bit_reference_20_21;
         final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
         final String dbSNPb37_20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
 
@@ -69,16 +63,11 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
         return new Object[][]{
                 // input local, computation local.
                 //Note: these output files were created by running GATK3
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
-                {new BQSRTest(GRCh37Ref_2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq " +"--join-strategy SHUFFLE", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
-                {new BQSRTest(GRCh37Ref_2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
-                {new BQSRTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
+                {new BQSRTest(GRCh37Ref_2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
 
                 //Output generated with GATK4 (resulting BAM has 4 differences with GATK3)
-                {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indels --enable-baq " +"--join-strategy SHUFFLE --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
-                {new BQSRTest(b37_reference_20_21 , hiSeqCram_20_21_100000, more20Sites, ".cram", "-indels --enable-baq " +"--join-strategy SHUFFLE --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.cram")},
-                {new BQSRTest(b37_2bit_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indels --enable-baq " +"--join-strategy BROADCAST --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
-                {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indels --enable-baq " +"--join-strategy OVERLAPS_PARTITIONER --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
+                {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indels --enable-baq --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},
+                {new BQSRTest(b37_reference_20_21 , hiSeqCram_20_21_100000, more20Sites, ".cram", "-indels --enable-baq --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.cram")},
        };
     }
 
@@ -106,27 +95,6 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
 
         runCommandLine(args);
 
-        if (referenceFile != null && !ReferenceTwoBitSparkSource.isTwoBit(referenceFile.getName())) { // htsjdk can't handle 2bit reference files
-            SamAssertionUtils.assertEqualBamFiles(outFile, new File(params.expectedFileName), referenceFile, true, ValidationStringency.SILENT);
-        }
-        else {
-            SamAssertionUtils.assertEqualBamFiles(outFile, new File(params.expectedFileName), true, ValidationStringency.SILENT);
-        }
-    }
-
-    @Test(groups = "spark")
-    public void testBlowUpOnBroadcastIncompatibleReference() throws IOException {
-        //this should blow up because broadcast requires a 2bit reference
-        final String hiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
-        final String dbSNPb37_chr20 = getResourceDir() + DBSNP_138_B37_CH20_1M_1M1K_VCF;
-
-        BQSRTest params = new BQSRTest(b37_reference_20_21, hiSeqBam_chr20, dbSNPb37_chr20, ".bam", "-indels --enable-baq " +"--join-strategy BROADCAST", getResourceDir() + BQSRTestData.EXPECTED_WGS_B37_CH20_1M_1M1K_RECAL);
-
-        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
-        IntegrationTestSpec spec = new IntegrationTestSpec(
-                ab.getString(),
-                1,
-                UserException.Require2BitReferenceForBroadcast.class);
-        spec.executeTest("testBQSR-" + params.args, this);
+        SamAssertionUtils.assertEqualBamFiles(outFile, new File(params.expectedFileName), referenceFile, true, ValidationStringency.SILENT);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceTwoBitSparkSource;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerIntegrationTest;
 import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -51,7 +50,6 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
     @DataProvider(name = "ReadsPipeline")
     public Object[][] createReadsPipelineSparkTestData() {
         final String GRCh37Ref_2021 = GATKBaseTest.b37_reference_20_21;
-        final String GRCh37Ref2bit_chr2021 = GATKBaseTest.b37_2bit_reference_20_21;
         final String GRCh37Ref_2021_img = GATKBaseTest.b37_reference_20_21_img;
         final String hiSeqBam_chr20 = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.bam";
         final String hiSeqBam_chr20_queryNameSorted = getResourceDir() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.noMD.noBQSR.queryNameSorted.bam";
@@ -77,19 +75,18 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
                 //        -O src/test/resources/org/broadinstitute/hellbender/tools/BQSR/expected.MultiSite.reads.pipeline.vcf \
                 //        -pairHMM AVX_LOGLESS_CACHING \
                 //        -stand_call_conf 30.0
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", null, getResourceDir() + expectedSingleKnownSitesVcf)}, // don't write intermediate BAM
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy OVERLAPS_PARTITIONER --read-shard-padding 1000", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20_queryNameSorted, ".bam", dbSNPb37_20, "--join-strategy BROADCAST", getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, null, null, getResourceDir() + expectedSingleKnownSitesVcf)}, // don't write intermediate BAM
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, null, getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--read-shard-padding 1000", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20_queryNameSorted, ".bam", dbSNPb37_20, null, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
 
                 // Output generated with GATK4
-                // CRAM test fails since can't use 2bit with CRAM, can only use 2bit with HC.
-//                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqCram_chr20, ".cram", dbSNPb37_20, "--joinStrategy BROADCAST --knownSites " + more20Sites, getResourceDir() + expectedMultipleKnownSitesCram, getResourceDir() + expectedMultipleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy BROADCAST --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref2bit_chr2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--join-strategy OVERLAPS_PARTITIONER --read-shard-padding 1000 --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqCram_chr20, ".cram", dbSNPb37_20, "--known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSitesCram, getResourceDir() + expectedMultipleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
+                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--read-shard-padding 1000 --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
 
                 // BWA-MEM
-                {new PipelineTest(GRCh37Ref2bit_chr2021, unalignedBam, ".bam", dbSNPb37_20, "--align --bwa-mem-index-image " + GRCh37Ref_2021_img + " --join-strategy BROADCAST --known-sites " + more20Sites, null, largeFileTestDir + expectedMultipleKnownSitesFromUnalignedVcf)},
+                {new PipelineTest(GRCh37Ref_2021, unalignedBam, ".bam", dbSNPb37_20, "--align --bwa-mem-index-image " + GRCh37Ref_2021_img + " --known-sites " + more20Sites, null, largeFileTestDir + expectedMultipleKnownSitesFromUnalignedVcf)},
         };
     }
 
@@ -130,11 +127,7 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
         runCommandLine(args);
 
         if (params.expectedBamFileName != null) {
-            if (referenceFile != null && !ReferenceTwoBitSparkSource.isTwoBit(referenceFile.getName())) { // htsjdk can't handle 2bit reference files
-                SamAssertionUtils.assertEqualBamFiles(outFileBam, new File(params.expectedBamFileName), referenceFile, true, ValidationStringency.SILENT);
-            } else {
-                SamAssertionUtils.assertEqualBamFiles(outFileBam, new File(params.expectedBamFileName), true, ValidationStringency.SILENT);
-            }
+            SamAssertionUtils.assertEqualBamFiles(outFileBam, new File(params.expectedBamFileName), referenceFile, true, ValidationStringency.SILENT);
         }
 
         final double concordance = HaplotypeCallerIntegrationTest.calculateConcordance(outFile, new File(params.expectedVcfFileName));


### PR DESCRIPTION
... for BaseRecalibratorSpark, BQSRPipelineSpark, ReadsPipelineSpark, and to localise reference for HaplotypeCallerSpark.

As a consequence of this change, the reference can be a standard fasta file for Spark
tools (indeed 2bit is no longer supported, since htsjdk does not have support for it).

Also:
* Add AutoCloseableCollection to automatically close all objects in a collection.
* Add CloseAtEndIterator to call close on an object at the end of the iteration.
* Don't materialize all reads in memory in ApplyBQSRSparkFn.

See #5103 