### PR TITLE
Funcotation Engine Refactoring

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -21,7 +21,7 @@ public final class OptionalReadInputArgumentCollection extends ReadInputArgument
             doc = "BAM/SAM/CRAM file containing reads",
             optional = true,
             common = true)
-    private List<String> readFilesNames;
+    private List<String> readFilesNames = new ArrayList<>();
 
     @Override
     public List<File> getReadFiles() {

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -16,7 +16,11 @@ import java.util.List;
 public final class OptionalReadInputArgumentCollection extends ReadInputArgumentCollection {
     private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = true, common = true)
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
+            shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME,
+            doc = "BAM/SAM/CRAM file containing reads",
+            optional = true,
+            common = true)
     private List<String> readFilesNames;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -1,13 +1,12 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.tribble.Feature;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.nio.file.Path;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -289,5 +288,34 @@ public class FeatureContext {
      */
     private <T extends Feature> List<T> subsetToStartPosition(final Collection<T> features, final int start) {
         return features.stream().filter(feat -> feat.getStart() == start).collect(Collectors.toList());
+    }
+
+    /**
+     * Since funcotation factories need an instance of {@link FeatureContext} to funcotate, this convenience method can
+     *  create a new instance for test methods.
+     *
+     *  Typically, this method should be used for testing only.
+     *
+     * @param featureInputsWithType {@link Map} of a {@link FeatureInput} to the output type that must extend {@link Feature}.
+     *                                         Never {@code null}, but empty list is acceptable.
+     * @param dummyToolInstanceName A name to use for the "tool".  Any string will work here.  Never {@code null}.
+     * @param interval genomic interval for the result.  Typically, this would be the interval of the variant.  Never {@link null}.
+     * @param featureQueryLookahead When querying FeatureDataSources, cache this many extra bases of context beyond
+     *                              the end of query intervals in anticipation of future queries. Must be >= 0.  If uncertain, use zero.
+     * @param cloudPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use zero.
+     * @param cloudIndexPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use zero.
+     * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use {@code null}.
+     */
+    public static FeatureContext create(final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsWithType, final String dummyToolInstanceName,
+                                                      final SimpleInterval interval, final int featureQueryLookahead, final int cloudPrefetchBuffer,
+                                                      final int cloudIndexPrefetchBuffer, final Path reference) {
+        Utils.nonNull(featureInputsWithType);
+        Utils.nonNull(dummyToolInstanceName);
+        Utils.nonNull(interval);
+
+        final FeatureManager featureManager = new FeatureManager(featureInputsWithType, dummyToolInstanceName,
+                featureQueryLookahead, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference);
+
+        return new FeatureContext(featureManager, interval);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureContext.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -291,10 +292,8 @@ public class FeatureContext {
     }
 
     /**
-     * Since funcotation factories need an instance of {@link FeatureContext} to funcotate, this convenience method can
-     *  create a new instance for test methods.
-     *
-     *  Typically, this method should be used for testing only.
+     * Convenience method to create a new instance for test methods.
+     * This method should be used for testing only.
      *
      * @param featureInputsWithType {@link Map} of a {@link FeatureInput} to the output type that must extend {@link Feature}.
      *                                         Never {@code null}, but empty list is acceptable.
@@ -306,7 +305,8 @@ public class FeatureContext {
      * @param cloudIndexPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use zero.
      * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use {@code null}.
      */
-    public static FeatureContext create(final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsWithType, final String dummyToolInstanceName,
+    @VisibleForTesting
+    public static FeatureContext createFeatureContextForTesting(final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsWithType, final String dummyToolInstanceName,
                                                       final SimpleInterval interval, final int featureQueryLookahead, final int cloudPrefetchBuffer,
                                                       final int cloudIndexPrefetchBuffer, final Path reference) {
         Utils.nonNull(featureInputsWithType);

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -25,6 +25,9 @@ import java.util.Map;
  * system only in order to be recognized by the Feature management system. This is why the constructor is
  * marked as protected.
  *
+ * If you still want to instantiate this class directly, you will have to call {@link GATKTool#addFeatureInputsAfterInitialization(String, String, Class, int)}
+ *  in order to register the FeatureInput with the engine.
+ *
  * FeatureInputs can be assigned logical names on the command line using the syntax:
  *
  *     --argument_name logical_name:feature_file

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
@@ -167,6 +168,7 @@ public final class FeatureManager implements AutoCloseable {
      * @param cloudIndexPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
      * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
      */
+    @VisibleForTesting
     FeatureManager(final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsToTypeMap, final String toolInstanceName, final int featureQueryLookahead, final int cloudPrefetchBuffer, final int cloudIndexPrefetchBuffer, final Path reference) {
 
         Utils.nonNull(featureInputsToTypeMap);

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureManager.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.config.ConfigFactory;
 import org.broadinstitute.hellbender.utils.config.GATKConfig;
 
@@ -151,6 +152,29 @@ public final class FeatureManager implements AutoCloseable {
         this.featureSources = new LinkedHashMap<>();
 
         initializeFeatureSources(featureQueryLookahead, toolInstance, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference);
+    }
+
+    /**
+     * Same as {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}, except used when the
+     *  FeatureInputs (and associated types) are known.
+     *
+     *  This constructor should only be used in test code.
+     *
+     * @param featureInputsToTypeMap {@link Map} of a {@link FeatureInput} to the output type that must extend {@link Feature}.  Never {@code null}
+     * @param toolInstanceName See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
+     * @param featureQueryLookahead See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
+     * @param cloudPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
+     * @param cloudIndexPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
+     * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}
+     */
+    FeatureManager(final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsToTypeMap, final String toolInstanceName, final int featureQueryLookahead, final int cloudPrefetchBuffer, final int cloudIndexPrefetchBuffer, final Path reference) {
+
+        Utils.nonNull(featureInputsToTypeMap);
+
+        this.toolInstanceSimpleClassName = toolInstanceName;
+        this.featureSources = new LinkedHashMap<>();
+        Utils.nonNull(featureInputsToTypeMap);
+        featureInputsToTypeMap.forEach((k,v) -> addToFeatureSources(featureQueryLookahead, k, v, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -863,20 +863,6 @@ public abstract class GATKTool extends CommandLineProgram {
     }
 
     /**
-     * Call {@link GATKTool#addFeatureInputsAfterInitialization(String, String, Class, int)} with no caching.
-     *
-     * @param filePath See {@link #addFeatureInputsAfterInitialization(String, String, Class, int)}
-     * @param name See {@link #addFeatureInputsAfterInitialization(String, String, Class, int)}
-     * @param featureType See {@link #addFeatureInputsAfterInitialization(String, String, Class, int)}
-     * @return The {@link FeatureInput} used as the key for this data source.
-     */
-    protected FeatureInput<? extends Feature> addFeatureInputsAfterInitialization(final String filePath, final String name,
-                                                                                  final Class<? extends Feature> featureType) {
-
-        return addFeatureInputsAfterInitialization(filePath, name, featureType, 0);
-    }
-
-    /**
      * A method to allow a user to inject data sources after initialization that were not specified as command-line
      * arguments.
      *
@@ -886,14 +872,15 @@ public abstract class GATKTool extends CommandLineProgram {
      * @param featureQueryLookahead look ahead this many bases during queries that produce cache misses
      * @return The {@link FeatureInput} used as the key for this data source.
      */
-    protected FeatureInput<? extends Feature> addFeatureInputsAfterInitialization(final String filePath,
-                                                                                  final String name,
-                                                                                  final Class<? extends Feature> featureType, final int featureQueryLookahead) {
+    public FeatureInput<? extends Feature> addFeatureInputsAfterInitialization(final String filePath,
+                                                                               final String name,
+                                                                               final Class<? extends Feature> featureType,
+                                                                               final int featureQueryLookahead) {
 
         final FeatureInput<? extends Feature> featureInput = new FeatureInput<>(filePath, name);
 
-        //Add datasource to the feature manager too so that it can be queried. Setting lookahead to 0 to avoid caching.
-        //Note: we are disabling lookahead here because of windowed queries that need to "look behind" as well.
+        // Add datasource to the feature manager too so that it can be queried.
+        // Setting lookahead to user-requested value:
         features.addToFeatureSources(
                 featureQueryLookahead,
                 featureInput,

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -863,8 +863,8 @@ public abstract class GATKTool extends CommandLineProgram {
     }
 
     /**
-     * A method to allow a user to inject data sources after initialization that were not specified as command-line
-     * arguments.
+     * A method to allow a user to inject {@link FeatureInput}s after initialization that were not
+     * specified as command-line arguments.
      *
      * @param filePath path to the Feature file to register
      * @param name what to call the Feature input
@@ -879,8 +879,8 @@ public abstract class GATKTool extends CommandLineProgram {
 
         final FeatureInput<? extends Feature> featureInput = new FeatureInput<>(filePath, name);
 
-        // Add datasource to the feature manager too so that it can be queried.
-        // Setting lookahead to user-requested value:
+        // Add the FeatureInput to our FeatureManager so that it will be available for FeatureContext queries
+        // from the tool
         features.addToFeatureSources(
                 featureQueryLookahead,
                 featureInput,

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
@@ -45,6 +45,7 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
      */
     protected final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput;
 
+    @VisibleForTesting
     public FeatureInput<? extends Feature> getMainSourceFileAsFeatureInput() {
         return mainSourceFileAsFeatureInput;
     }
@@ -142,7 +143,7 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
     }
 
     /**
-     * Creates a {@link List} of {@link Funcotation} for the given {@code variant}, {@code referenceContext}, {@code List<Feature>}, and {@code gencodeFuncotations}.
+     * Creates a {@link List} of {@link Funcotation} for the given {@code variant}, {@code referenceContext}, {@code featureContext}, and {@code gencodeFuncotations}.
      * For some Data Sources knowledge of Gene Name or Transcript ID is required for annotation.
      * Accounts for override values passed into the constructor as well.
      * @param variant {@link VariantContext} to annotate.  Never {@code null}.
@@ -152,7 +153,6 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
      *   {@code null} is acceptable if there are no corresponding gencode funcotations.
      * @return {@link List} of {@link Funcotation} given the {@code variant}, {@code referenceContext}, and {@code featureContext}.  This should never be empty.
      */
-    @SuppressWarnings("unchecked")
     public List<Funcotation> createFuncotations(final VariantContext variant, final ReferenceContext referenceContext, final FeatureContext featureContext, final List<GencodeFuncotation> gencodeFuncotations) {
 
         Utils.nonNull(variant);
@@ -160,6 +160,7 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
         Utils.nonNull(featureContext);
 
         // Query this funcotation factory to get the list of overlapping features.
+        @SuppressWarnings("unchecked")
         final List<Feature> featureList = (List<Feature>) featureContext.getValues(mainSourceFileAsFeatureInput);
 
         final List<Funcotation> outputFuncotations;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
@@ -5,12 +5,14 @@ import htsjdk.tribble.Feature;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.utils.Utils;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 
 import java.io.Closeable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * An abstract class to allow for the creation of a {@link Funcotation} for a given data source.
@@ -36,6 +38,32 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
      * Map of ANNOTATION_NAME -> OVERRIDE_VALUE.
      */
     protected Map<String, String> annotationOverrideMap;
+
+    /**
+     * The backing data store as a FeatureInput to leverage tribble querying.  Can be {@code null} for non-locatable
+     * funcotation factories.
+     */
+    protected final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput;
+
+    public FeatureInput<? extends Feature> getMainSourceFileAsFeatureInput() {
+        return mainSourceFileAsFeatureInput;
+    }
+
+    /**
+     * Constructor to initialize final fields in this class with defaults.
+     */
+    protected DataSourceFuncotationFactory() {
+        this.mainSourceFileAsFeatureInput = null;
+    }
+
+    /**
+     * Constructor to initialize final fields in this class.
+     * @param mainSourceFileAsFeatureInput The backing data store as a FeatureInput to leverage tribble querying.  Can be {@code null} for non-locatable funcotation factories.
+     */
+    protected DataSourceFuncotationFactory(final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput) {
+        this.mainSourceFileAsFeatureInput = mainSourceFileAsFeatureInput;
+    }
+
 
     /**
      * Set values in {@link DataSourceFuncotationFactory#annotationOverrideMap} based on the given annotation override values
@@ -106,27 +134,33 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
      * Accounts for override values passed into the constructor as well.
      * @param variant {@link VariantContext} to annotate.
      * @param referenceContext {@link ReferenceContext} corresponding to the given {@code variant}.
-     * @param featureSourceMap {@link Map} of {@link String} -> {@link List} of {@link Feature} (data source name -> data source features corresponding to the given {@code variant}.
+     * @param featureContext {@link FeatureContext} corresponding to the variant.  Never {@code null}.
      * @return {@link List} of {@link Funcotation} given the {@code variant}, {@code referenceContext}, and {@code featureContext}.  This should never be empty.
      */
-    public List<Funcotation> createFuncotations(final VariantContext variant, final ReferenceContext referenceContext, final Map<String, List<Feature>> featureSourceMap) {
-        return createFuncotations(variant, referenceContext, featureSourceMap, null);
+    public List<Funcotation> createFuncotations(final VariantContext variant, final ReferenceContext referenceContext, final FeatureContext featureContext) {
+        return createFuncotations(variant, referenceContext, featureContext, null);
     }
 
     /**
-     * Creates a {@link List} of {@link Funcotation} for the given {@code variant}, {@code referenceContext}, {@code featureContext}, and {@code gencodeFuncotations}.
+     * Creates a {@link List} of {@link Funcotation} for the given {@code variant}, {@code referenceContext}, {@code List<Feature>}, and {@code gencodeFuncotations}.
      * For some Data Sources knowledge of Gene Name or Transcript ID is required for annotation.
      * Accounts for override values passed into the constructor as well.
-     * @param variant {@link VariantContext} to annotate.
-     * @param referenceContext {@link ReferenceContext} corresponding to the given {@code variant}.
-     * @param featureSourceMap {@link Map} of {@link String} -> {@link List} of {@link Feature} (data source name -> data source features corresponding to the given {@code variant}.
+     * @param variant {@link VariantContext} to annotate.  Never {@code null}.
+     * @param referenceContext {@link ReferenceContext} corresponding to the given {@code variant}.  Never {@code null}.
+     * @param featureContext {@link FeatureContext} corresponding to the variant.  Never {@code null}.
      * @param gencodeFuncotations {@link List} of {@link GencodeFuncotation} that have already been created for the given {@code variant}/{@code referenceContext}/{@code featureContext}.
+     *   {@code null} is acceptable if there are no corresponding gencode funcotations.
      * @return {@link List} of {@link Funcotation} given the {@code variant}, {@code referenceContext}, and {@code featureContext}.  This should never be empty.
      */
-    public List<Funcotation> createFuncotations(final VariantContext variant, final ReferenceContext referenceContext, final Map<String, List<Feature>> featureSourceMap, final List<GencodeFuncotation> gencodeFuncotations) {
+    @SuppressWarnings("unchecked")
+    public List<Funcotation> createFuncotations(final VariantContext variant, final ReferenceContext referenceContext, final FeatureContext featureContext, final List<GencodeFuncotation> gencodeFuncotations) {
 
-        // Get the features that this funcotation factory is responsible for:
-        final List<Feature> featureList = getFeatureListFromMap(featureSourceMap);
+        Utils.nonNull(variant);
+        Utils.nonNull(referenceContext);
+        Utils.nonNull(featureContext);
+
+        // Query this funcotation factory to get the list of overlapping features.
+        final List<Feature> featureList = (List<Feature>) featureContext.getValues(mainSourceFileAsFeatureInput);
 
         final List<Funcotation> outputFuncotations;
 
@@ -176,30 +210,6 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
     }
 
     /**
-     * Get the list of features to annotate from the given Map of features.
-     * Extracts the feature list given the name of this {@link DataSourceFuncotationFactory}.
-     * @param featureSourceMap {@link Map} of {@link String} -> ({@link List} of {@link Feature}) (Data source name -> feature list) containing all features that could be used for this {@link DataSourceFuncotationFactory}.
-     * @return A {@link List} of {@link Feature} that are to be annotated by this {@link DataSourceFuncotationFactory}
-     */
-    private List<Feature> getFeatureListFromMap(final Map<String, List<Feature>> featureSourceMap) {
-        // Get the features that this funcotation factory is responsible for:
-        final List<Feature> featureList;
-
-        // Only worry about name filtering if we care about the specific feature type:
-        // NOTE: This should probably be fixed to key off some other abstract class logic.
-        if ( getAnnotationFeatureClass().equals(Feature.class) ) {
-            featureList = featureSourceMap.entrySet().stream()
-                    .map(Map.Entry::getValue)
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
-        }
-        else {
-            featureList = featureSourceMap.getOrDefault( getName(), Collections.emptyList() );
-        }
-        return featureList;
-    }
-
-    /**
      * Creates a {@link List} of {@link Funcotation} for the given {@code variant} and {@code referenceContext}.
      * These will be default funcotations that essentially have empty values.
      * @param variant {@link VariantContext} to annotate.
@@ -234,5 +244,6 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
     /**
      * @return Get the {@link Class} of the feature type that can be used to create annotations by this {@link DataSourceFuncotationFactory}.
      */
-    protected abstract Class<? extends Feature> getAnnotationFeatureClass();
+    @VisibleForTesting
+    public abstract Class<? extends Feature> getAnnotationFeatureClass();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMap.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMap.java
@@ -61,7 +61,9 @@ public class FuncotationMap {
      * @param transcriptId the specified transcript ID.  Use {@see NO_TRANSCRIPT_AVAILABLE_KEY} if there are no transcripts.  Never {@code null}
      * @param fieldName The field name to search.  Never {@code null}
      * @param allele Only return fields from funcotations with the specified allele.  Never {@code null}
-     * @return Value of the given field for the transcript ID and allele.  Return {@code null} if field not found.
+     * @return Value of the given field for the transcript ID and allele.  Return {@code null} if field not found in any
+     *  funcotation.  Note that if the funcotations support the given field name, but the variant did not overlap any
+     *  records, an empty string will be returned.
      */
     public String getFieldValue(final String transcriptId, final String fieldName, final Allele allele) {
         Utils.nonNull(transcriptId);

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -4,12 +4,11 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.*;
@@ -317,7 +316,7 @@ public class Funcotator extends VariantWalker {
             default:
                 throw new GATKException("Unsupported output format type specified: " + funcotatorArgs.outputFormatType.toString());
         }
-        logger.info("Creating a " + outputFormatType + " file for output: " + outputFile.toURI());
+        logger.info("Creating a " + funcotatorArgs.outputFormatType + " file for output: " + funcotatorArgs.outputFile.toURI());
 
         // Check for reference version (in)compatibility:
         determineReferenceAndDatasourceCompatibility();

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
@@ -1,0 +1,104 @@
+package org.broadinstitute.hellbender.tools.funcotator;
+
+import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.Hidden;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Arguments to be be used by the {@link Funcotator} {@link org.broadinstitute.hellbender.engine.GATKTool},
+ * which are specific to {@link Funcotator}.
+ * Created by jonn on 9/12/18.
+ */
+public class FuncotatorArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    //-----------------------------------------------------
+    // Required args:
+
+    @Argument(
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            fullName  = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+            doc = "Output VCF file to which annotated variants should be written.")
+    public File outputFile;
+
+    @Argument(
+            fullName =  FuncotatorArgumentDefinitions.REFERENCE_VERSION_LONG_NAME,
+            doc = "The version of the Human Genome reference to use (e.g. hg19, hg38, etc.).  This will correspond to a sub-folder of each data source corresponding to that data source for the given reference."
+    )
+    public String referenceVersion;
+
+    @Argument(
+            fullName =  FuncotatorArgumentDefinitions.DATA_SOURCES_PATH_LONG_NAME,
+            doc = "The path to a data source folder for Funcotator.  May be specified more than once to handle multiple data source folders."
+    )
+    public List<String> dataSourceDirectories;
+
+    @Argument(
+            fullName =  FuncotatorArgumentDefinitions.OUTPUT_FORMAT_LONG_NAME,
+            doc = "The output file format.  Either VCF or MAF.  Please note that MAF output for germline use case VCFs is unsupported."
+    )
+    public FuncotatorArgumentDefinitions.OutputFormatType outputFormatType;
+
+    //-----------------------------------------------------
+    // Optional args:
+
+    @Argument(
+            fullName = FuncotatorArgumentDefinitions.REMOVE_FILTERED_VARIANTS_LONG_NAME,
+            optional = true,
+            doc = "Ignore/drop variants that have been filtered in the input.  These variants will not appear in the output file."
+    )
+    public boolean removeFilteredVariants = false;
+
+    @Argument(
+            fullName  = FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_LONG_NAME,
+            optional = true,
+            doc = "Method of detailed transcript selection.  This will select the transcript for detailed annotation (CANONICAL, ALL, or BEST_EFFECT)."
+    )
+    public TranscriptSelectionMode transcriptSelectionMode = FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE;
+
+    @Argument(
+            fullName  = FuncotatorArgumentDefinitions.TRANSCRIPT_LIST_LONG_NAME,
+            optional = true,
+            doc = "File to use as a list of transcripts (one transcript ID per line, version numbers are ignored) OR A set of transcript IDs to use for annotation to override selected transcript."
+    )
+    public Set<String> userTranscriptIdSet = new HashSet<>();
+
+    @Argument(
+            fullName  = FuncotatorArgumentDefinitions.ANNOTATION_DEFAULTS_LONG_NAME,
+            optional = true,
+            doc = "Annotations to include in all annotated variants if the annotation is not specified in the data sources (in the format <ANNOTATION>:<VALUE>).  This will add the specified annotation to every annotated variant if it is not already present."
+    )
+    public List<String> annotationDefaults = new ArrayList<>();
+
+    @Argument(
+            fullName  = FuncotatorArgumentDefinitions.ANNOTATION_OVERRIDES_LONG_NAME,
+            optional = true,
+            doc = "Override values for annotations (in the format <ANNOTATION>:<VALUE>).  Replaces existing annotations of the given name with given values."
+    )
+    public List<String> annotationOverrides = new ArrayList<>();
+
+    @Argument(
+            fullName = FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_NAME,
+            optional = true,
+            minValue = 0,
+            doc = "Number of base-pairs to cache when querying variants."
+    )
+    public int lookaheadFeatureCachingInBp = FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE;
+
+    @Advanced
+    @Hidden
+    @Argument(
+            fullName = FuncotatorArgumentDefinitions.FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION,
+            optional = true,
+            doc = "(Advanced / DO NOT USE*) If you select this flag, Funcotator will force a conversion of variant contig names from b37 to hg19.  *This option is useful in integration tests (written by devs) only."
+    )
+    public boolean forceB37ToHg19ContigNameConversion = false;
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -1,0 +1,122 @@
+package org.broadinstitute.hellbender.tools.funcotator;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.DataSourceUtils;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
+import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadata;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Class that performs functional annotation of variants.
+ *
+ * Requires a set of data sources ({@link DataSourceFuncotationFactory}) from which to create {@link Funcotation}s.
+ */
+public class FuncotatorEngine {
+
+    private static final Logger logger = LogManager.getLogger(FuncotatorEngine.class);
+
+    private final FuncotationMetadata inputMetadata;
+    private final List<DataSourceFuncotationFactory> dataSourceFactories;
+
+    /**
+     * Create a {@link FuncotatorEngine} using the given {@code metadata} and {@code funcotationFactories} representing
+     * the kinds of {@link Funcotation}s to be created and the data sources from which they should be created,
+     * respectively.
+     * @param metadata {@link FuncotationMetadata} containing information on the kinds of {@link Funcotation}s this {@link FuncotatorEngine} will create.
+     * @param funcotationFactories A {@link List<DataSourceFuncotationFactory>} which can create the desired {@link Funcotation}s.
+     */
+    public FuncotatorEngine(final FuncotationMetadata metadata, final List<DataSourceFuncotationFactory> funcotationFactories) {
+        inputMetadata = metadata;
+        dataSourceFactories = funcotationFactories;
+        dataSourceFactories.sort(DataSourceUtils::datasourceComparator);
+    }
+
+    /**
+     * @return A {@link List<DataSourceFuncotationFactory>} being used by this {@link FuncotatorEngine} to create {@link Funcotation}s.
+     */
+    public List<DataSourceFuncotationFactory> getFuncotationFactories() {
+        return dataSourceFactories;
+    }
+
+    /**
+     * Creates a {@link FuncotationMap} for the given {@code variantContext}.
+     *
+     * @param variantContext   {@link VariantContext} to annotate.  Never {@code null}.
+     * @param referenceContext {@link ReferenceContext} corresponding to the given {@code variantContext}.  Never {@code null}.
+     * @param featureContext {@link FeatureContext} corresponding to the given {@code variantContext}.  Never {@code null}.
+     * @return an instance of FuncotationMap that maps transcript IDs to lists of funcotations for the given variantContext context.
+     */
+    public FuncotationMap createFuncotationMapForVariant(final VariantContext variantContext, final ReferenceContext referenceContext, final FeatureContext featureContext) {
+
+        Utils.nonNull(variantContext);
+        Utils.nonNull(referenceContext);
+        Utils.nonNull(featureContext);
+
+        //==============================================================================================================
+        // First create only the transcript (Gencode) funcotations:
+
+        if (retrieveGencodeFuncotationFactoryStream().count() > 1) {
+            logger.warn("Attempting to annotate with more than one GENCODE datasource.  If these have overlapping transcript IDs, errors may occur.");
+        }
+
+        final List<GencodeFuncotation> transcriptFuncotations = retrieveGencodeFuncotationFactoryStream()
+                .map(gf -> gf.createFuncotations(variantContext, referenceContext, featureContext))
+                .flatMap(List::stream)
+                .map(gf -> (GencodeFuncotation) gf).collect(Collectors.toList());
+
+        //==============================================================================================================
+        // Create the funcotations for non-Gencode data sources:
+
+        // Create a place to keep our funcotations:
+        final FuncotationMap funcotationMap = FuncotationMap.createFromGencodeFuncotations(transcriptFuncotations);
+
+        // Perform the rest of the annotation.  Note that this code manually excludes the Gencode Funcotations.
+        for (final DataSourceFuncotationFactory funcotationFactory : dataSourceFactories ) {
+
+            // Note that this guarantees that we do not add GencodeFuncotations a second time.
+            if (!funcotationFactory.getType().equals(FuncotatorArgumentDefinitions.DataSourceType.GENCODE)) {
+                final List<String> txIds = funcotationMap.getTranscriptList();
+
+                for (final String txId: txIds) {
+                    funcotationMap.add(txId, funcotationFactory.createFuncotations(variantContext, referenceContext,
+                            featureContext, funcotationMap.getGencodeFuncotations(txId)));
+                }
+            }
+        }
+
+        //==============================================================================================================
+        // Create the funcotations for the input and add to all txID mappings.
+
+        final List<String> txIds = funcotationMap.getTranscriptList();
+
+        for (final String txId: txIds) {
+            funcotationMap.add(txId, FuncotatorUtils.createFuncotations(variantContext, inputMetadata, FuncotatorConstants.DATASOURCE_NAME_FOR_INPUT_VCFS));
+        }
+
+        return funcotationMap;
+    }
+
+    /**
+     * Shutdown the engine.  Closes all datasource factories.
+     */
+    public void close() {
+        for ( final DataSourceFuncotationFactory factory : dataSourceFactories ) {
+            if ( factory != null ) {
+                factory.close();
+            }
+        }
+    }
+
+    private Stream<DataSourceFuncotationFactory> retrieveGencodeFuncotationFactoryStream() {
+        return dataSourceFactories.stream()
+                .filter(f -> f.getType().equals(FuncotatorArgumentDefinitions.DataSourceType.GENCODE));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -1,16 +1,33 @@
 package org.broadinstitute.hellbender.tools.funcotator;
 
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.GATKTool;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.filters.VariantFilter;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.DataSourceUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
+import org.broadinstitute.hellbender.tools.funcotator.mafOutput.MafOutputRenderer;
 import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadata;
+import org.broadinstitute.hellbender.tools.funcotator.vcfOutput.VcfOutputRenderer;
+import org.broadinstitute.hellbender.transformers.VariantTransformer;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -19,12 +36,37 @@ import java.util.stream.Stream;
  *
  * Requires a set of data sources ({@link DataSourceFuncotationFactory}) from which to create {@link Funcotation}s.
  */
-public class FuncotatorEngine {
+public final class FuncotatorEngine implements AutoCloseable {
 
+    /** Obligatory logger. */
     private static final Logger logger = LogManager.getLogger(FuncotatorEngine.class);
 
+    /**
+     * Information about what kinds of {@link Funcotation}s are going to be created by this {@link FuncotatorEngine}.
+     */
     private final FuncotationMetadata inputMetadata;
+
+    /**
+     * The {@link DataSourceFuncotationFactory} that will create {@link Funcotation}s for this {@link FuncotatorEngine}.
+     */
     private final List<DataSourceFuncotationFactory> dataSourceFactories;
+
+    /**
+     * The arguments given to the instance of the {@link GATKTool} running this {@link FuncotatorEngine}.
+     */
+    private final FuncotatorArgumentCollection funcotatorArgs;
+
+    /**
+     * The {@link SAMSequenceDictionary} for the driving variants (i.e. the input variant file).
+     */
+    private final SAMSequenceDictionary sequenceDictionaryForDrivingVariants;
+
+    /**
+     * Whether the input variant contigs must be converted to hg19.
+     * This is only the case when the input reference is b37 AND when
+     * the reference version is hg19 (i.e. {@link FuncotatorArgumentCollection#referenceVersion} == {@link FuncotatorArgumentDefinitions#HG19_REFERENCE_VERSION_STRING}).
+     */
+    private final boolean mustConvertInputContigsToHg19;
 
     /**
      * Create a {@link FuncotatorEngine} using the given {@code metadata} and {@code funcotationFactories} representing
@@ -33,17 +75,31 @@ public class FuncotatorEngine {
      * @param metadata {@link FuncotationMetadata} containing information on the kinds of {@link Funcotation}s this {@link FuncotatorEngine} will create.
      * @param funcotationFactories A {@link List<DataSourceFuncotationFactory>} which can create the desired {@link Funcotation}s.
      */
-    public FuncotatorEngine(final FuncotationMetadata metadata, final List<DataSourceFuncotationFactory> funcotationFactories) {
+    public FuncotatorEngine(final FuncotatorArgumentCollection funcotatorArgs,
+                            final SAMSequenceDictionary sequenceDictionaryForDrivingVariants,
+                            final FuncotationMetadata metadata,
+                            final List<DataSourceFuncotationFactory> funcotationFactories) {
+
+        this.sequenceDictionaryForDrivingVariants = sequenceDictionaryForDrivingVariants;
+        this.funcotatorArgs = funcotatorArgs;
         inputMetadata = metadata;
+
         dataSourceFactories = funcotationFactories;
+        // Note: The dataSourceFactories must be sorted to ensure that as we iterate through them
+        // to create funcotations, the inherent dependencies between different funcotation types are preserved.
+        // For example, most FuncotationFactories require that a GencodeFuncotation is present before they can
+        // create their annotations.   This sorting enables such dependencies.
         dataSourceFactories.sort(DataSourceUtils::datasourceComparator);
+
+        // Determine whether we have to convert given variants from B37 to HG19:
+        mustConvertInputContigsToHg19 = determineReferenceAndDatasourceCompatibility();
     }
 
     /**
-     * @return A {@link List<DataSourceFuncotationFactory>} being used by this {@link FuncotatorEngine} to create {@link Funcotation}s.
+     * @return An unmodifiable {@link List<DataSourceFuncotationFactory>} being used by this {@link FuncotatorEngine} to create {@link Funcotation}s.
      */
     public List<DataSourceFuncotationFactory> getFuncotationFactories() {
-        return dataSourceFactories;
+        return Collections.unmodifiableList(dataSourceFactories);
     }
 
     /**
@@ -54,7 +110,9 @@ public class FuncotatorEngine {
      * @param featureContext {@link FeatureContext} corresponding to the given {@code variantContext}.  Never {@code null}.
      * @return an instance of FuncotationMap that maps transcript IDs to lists of funcotations for the given variantContext context.
      */
-    public FuncotationMap createFuncotationMapForVariant(final VariantContext variantContext, final ReferenceContext referenceContext, final FeatureContext featureContext) {
+    public FuncotationMap createFuncotationMapForVariant(final VariantContext variantContext,
+                                                         final ReferenceContext referenceContext,
+                                                         final FeatureContext featureContext) {
 
         Utils.nonNull(variantContext);
         Utils.nonNull(referenceContext);
@@ -105,6 +163,92 @@ public class FuncotatorEngine {
     }
 
     /**
+     * Create an output renderer for the data created by this instance of {@link FuncotatorEngine}.
+     * @param annotationDefaultsMap {@link LinkedHashMap<String, String>} of annotation names and their default values.
+     * @param annotationOverridesMap {@link LinkedHashMap<String, String>} of annotation names and the values for these fields overridden by the user.
+     * @param headerForVariants {@link VCFHeader} for the input VCF file containing the variants to annotate.
+     * @param defaultToolVcfHeaderLines {@link Set<VCFHeaderLine>} containing the default {@link VCFHeaderLine}s for the given {@code gatkToolInstance}.
+     * @param gatkToolInstance {@link GATKTool} instance from which we will be using this {@link FuncotatorEngine}.
+     * @return The requested {@link OutputRenderer} based on the given {@code funcotatorArgs}.
+     */
+    public OutputRenderer createOutputRenderer(final LinkedHashMap<String, String> annotationDefaultsMap,
+                                               final LinkedHashMap<String, String> annotationOverridesMap,
+                                               final VCFHeader headerForVariants,
+                                               final Set<VCFHeaderLine> defaultToolVcfHeaderLines,
+                                               final GATKTool gatkToolInstance) {
+
+        final OutputRenderer outputRenderer;
+
+        // Determine which annotations are accounted for (by the funcotation factories) and which are not.
+        final LinkedHashMap<String, String> unaccountedForDefaultAnnotations = getUnaccountedForAnnotations(  getFuncotationFactories(), annotationDefaultsMap );
+        final LinkedHashMap<String, String> unaccountedForOverrideAnnotations = getUnaccountedForAnnotations( getFuncotationFactories(), annotationOverridesMap );
+
+        // Set up our output renderer:
+        switch (funcotatorArgs.outputFormatType) {
+            case MAF:
+                outputRenderer = new MafOutputRenderer(funcotatorArgs.outputFile.toPath(),
+                        getFuncotationFactories(),
+                        headerForVariants,
+                        unaccountedForDefaultAnnotations,
+                        unaccountedForOverrideAnnotations,
+                        defaultToolVcfHeaderLines.stream().map(Object::toString).collect(Collectors.toCollection(LinkedHashSet::new)),
+                        funcotatorArgs.referenceVersion);
+                break;
+
+            case VCF:
+                outputRenderer = new VcfOutputRenderer(
+                        gatkToolInstance.createVCFWriter(funcotatorArgs.outputFile),
+                        getFuncotationFactories(),
+                        headerForVariants,
+                        unaccountedForDefaultAnnotations,
+                        unaccountedForOverrideAnnotations,
+                        defaultToolVcfHeaderLines
+                );
+                break;
+            default:
+                throw new GATKException("Unsupported output format type specified: " + funcotatorArgs.outputFormatType.toString());
+        }
+
+        return outputRenderer;
+    }
+
+    /**
+     * @return A {@link VariantFilter} that will ignore any variants that have been filtered (if the user requested that the filter is turned on).  Otherwise returns a no-op filter.
+     */
+    public VariantFilter makeVariantFilter() {
+        return  variant -> {
+            // Ignore variants that have been filtered if the user requests it:
+            if ( funcotatorArgs.removeFilteredVariants && variant.isFiltered() ) {
+                return false;
+            }
+            return true;
+        };
+    }
+
+    /**
+     * Create a new {@link VariantContext} which will match the given Reference if there is a mismatch for input between the B37 reference and the HG19 reference.
+     * @param variant A {@link VariantContext} object containing the variant to convert.
+     * @return A {@link VariantContext} whose contig has been transformed to HG19 if requested by the user.  Otherwise, an identical variant.
+     */
+    public VariantContext getCorrectVariantContextForReference(final VariantContext variant) {
+        if ( mustConvertInputContigsToHg19 ) {
+            final VariantContextBuilder vcb = new VariantContextBuilder(variant);
+            vcb.chr(FuncotatorUtils.convertB37ContigToHg19Contig(variant.getContig()));
+            return vcb.make();
+        }
+        else {
+            return variant;
+        }
+    }
+
+    /**
+     * @return The default {@link VariantTransformer} which will automatically convert from the B37 reference standard to the HG19 reference standard for contig names.
+     */
+    public VariantTransformer getDefaultVariantTransformer() {
+        return variantContext -> getCorrectVariantContextForReference(variantContext);
+    }
+
+    /**
      * Shutdown the engine.  Closes all datasource factories.
      */
     public void close() {
@@ -113,6 +257,151 @@ public class FuncotatorEngine {
                 factory.close();
             }
         }
+    }
+
+    /**
+     * Processes the given {@link Set} into a list of transcript IDs.
+     * This is necessary because the command-line input argument is overloaded to be either a file containing transcript
+     * IDs (1 per line) OR as a list of transcript IDs.
+     * @param rawTranscriptSet {@link Set} of {@link String}s from which to create a list of Transcript IDs.  If of size 1, will try to open as a file.
+     * @return A {@link Set} of {@link String} contianing Transcript IDs in which the user is interested.
+     */
+    public static Set<String> processTranscriptList(final Set<String> rawTranscriptSet) {
+        if ( rawTranscriptSet.size() == 1 ) {
+            final String filePathString = rawTranscriptSet.iterator().next();
+            try ( final BufferedReader bufferedReader = Files.newBufferedReader(IOUtils.getPath(filePathString)) ) {
+                logger.info("Opened transcript file: " + filePathString);
+
+                // Create a place to put our output:
+                final Set<String> transcriptIdSet = new HashSet<>();
+
+                String line = bufferedReader.readLine();
+                while ( line != null ) {
+                    logger.info("    Adding transcript ID to transcript set: " + line);
+                    transcriptIdSet.add(line);
+                    line = bufferedReader.readLine();
+                }
+                logger.info("Transcript parsing complete.");
+
+                return transcriptIdSet;
+            }
+            catch ( final IOException ex ) {
+                logger.warn("Could not open transcript selection list as a file.  Using it as a singleton list of transcript IDs: [" + filePathString + "]");
+                return rawTranscriptSet;
+            }
+        }
+        else {
+            return rawTranscriptSet;
+        }
+    }
+
+
+    /**
+     * Gets the correct {@link ReferenceContext} for the {@code variant} being processed based on if the B37->HG19 conversion is required.
+     * @param variant {@link VariantContext} to check for B37/HG19 compliance.
+     * @param referenceContext {@link ReferenceContext} on which the given {@code variant} was originally based before the variant transformation.
+     * @return A {@link ReferenceContext} that is guaranteed to match the given {@code variant} for HG19/B37 compliance.
+     */
+    public ReferenceContext getCorrectReferenceContext(final VariantContext variant, final ReferenceContext referenceContext) {
+
+        final ReferenceContext correctReferenceContext;
+
+        // Check to see if we need to revert the ReferenceContext's interval to the original variant interval
+        // (This would only happen in the case where we were given b37 variants with hg19 data sources):
+        if ( mustConvertInputContigsToHg19 ) {
+
+            // Convert our contig back to B37 here so it matches the variant:
+            final SimpleInterval interval = new SimpleInterval(
+                    FuncotatorUtils.convertHG19ContigToB37Contig(variant.getContig()), variant.getStart(), variant.getEnd()
+            );
+
+            correctReferenceContext = new ReferenceContext(referenceContext, interval);
+        }
+        else {
+            correctReferenceContext = referenceContext;
+        }
+
+        return correctReferenceContext;
+    }
+
+    // =================================================================================================================
+
+    /**
+     * Creates a {@link LinkedHashMap} of annotations in the given {@code annotationMap} that do not occur in the given {@code dataSourceFactories}.
+     * @param dataSourceFactories {@link List} of {@link DataSourceFuncotationFactory} to check for whether each annotation in the {@code annotationMap} is handled.
+     * @param annotationMap {@link Map} (of ANNOTATION_NAME : ANNOTATION_VALUE) to check
+     * @return A {@link LinkedHashMap} of annotations in the given {@code annotationMap} that do not occur in the given {@code dataSourceFactories}.
+     */
+    private LinkedHashMap<String, String> getUnaccountedForAnnotations( final List<DataSourceFuncotationFactory> dataSourceFactories,
+                                                                        final Map<String, String> annotationMap ) {
+        final LinkedHashMap<String, String> outAnnotations = new LinkedHashMap<>();
+
+        // Check each field in each factory:
+        for ( final String field : annotationMap.keySet() ) {
+            boolean accountedFor = false;
+            for ( final DataSourceFuncotationFactory funcotationFactory : dataSourceFactories ) {
+
+                if ( funcotationFactory.getSupportedFuncotationFields().contains(field) ) {
+                    accountedFor = true;
+                    break;
+                }
+            }
+            if ( !accountedFor ) {
+                outAnnotations.put(field, annotationMap.get(field));
+            }
+        }
+
+        return outAnnotations;
+    }
+
+    /**
+     * Split each element of the given {@link List} into a key and value.
+     * Assumes each element of the given {@link List} is formatted as follows:
+     *     KEY:VALUE
+     * @param annotationArgs {@link List} of strings formatted KEY:VALUE to turn into a {@link Map}.
+     * @return A {@link LinkedHashMap} of KEY:VALUE pairs corresponding to entries in the given list.
+     */
+    public static LinkedHashMap<String, String> splitAnnotationArgsIntoMap( final List<String> annotationArgs ) {
+
+        final LinkedHashMap<String, String> annotationMap = new LinkedHashMap<>();
+
+        for ( final String s : annotationArgs ) {
+            final List<String> keyVal = ParsingUtils.split(s, FuncotatorArgumentDefinitions.MAP_NAME_VALUE_DELIMITER);
+            if ( keyVal.size() != 2) {
+                throw new UserException.BadInput( "Argument annotation incorrectly formatted: " + s );
+            }
+
+            annotationMap.put( keyVal.get(0), keyVal.get(1) );
+        }
+
+        return annotationMap;
+    }
+
+    private boolean determineReferenceAndDatasourceCompatibility() {
+
+        boolean mustConvertInputContigsToHg19 = false;
+
+        if ( funcotatorArgs.forceB37ToHg19ContigNameConversion ||
+                ( funcotatorArgs.referenceVersion.equals(FuncotatorArgumentDefinitions.HG19_REFERENCE_VERSION_STRING) &&
+                        FuncotatorUtils.isSequenceDictionaryUsingB37Reference(sequenceDictionaryForDrivingVariants) )) {
+
+            // NOTE AND WARNING:
+            // hg19 is from ucsc. b37 is from the genome reference consortium.
+            // ucsc decided the grc version had some bad data in it, so they blocked out some of the bases, aka "masked" them
+            // so the lengths of the contigs are the same, the bases are just _slightly_ different.
+            // ALSO, the contig naming convention is different between hg19 and hg38:
+            //      hg19 uses contigs of the form "chr1"
+            //      b37 uses contigs of the form  "1"
+            // This naming convention difference causes a LOT of issues and was a bad idea.
+
+            logger.warn("WARNING: You are using B37 as a reference.  " +
+                    "Funcotator will convert your variants to GRCh37, and this will be fine in the vast majority of cases.  " +
+                    "There MAY be some errors (e.g. in the Y chromosome, but possibly in other places as well) due to changes between the two references.");
+
+            mustConvertInputContigsToHg19 = true;
+        }
+
+        return mustConvertInputContigsToHg19;
     }
 
     private Stream<DataSourceFuncotationFactory> retrieveGencodeFuncotationFactoryStream() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
@@ -1,12 +1,11 @@
 package org.broadinstitute.hellbender.tools.funcotator.dataSources;
 
 import com.google.common.annotations.VisibleForTesting;
+import htsjdk.tribble.Feature;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.broadinstitute.hellbender.engine.FeatureContext;
-import org.broadinstitute.hellbender.engine.ReadsContext;
-import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
@@ -19,6 +18,8 @@ import org.broadinstitute.hellbender.tools.funcotator.dataSources.vcf.VcfFuncota
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.xsv.LocatableXsvFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.xsv.SimpleKeyXsvFuncotationFactory;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.codecs.gencode.GencodeGtfFeature;
+import org.broadinstitute.hellbender.utils.codecs.xsvLocatableTable.XsvTableFeature;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.BufferedReader;
@@ -228,13 +229,16 @@ final public class DataSourceUtils {
      * @param annotationOverridesMap {@link LinkedHashMap} of {@link String}->{@link String} containing any annotation overrides to include in data sources.  Must not be {@code null}.
      * @param transcriptSelectionMode {@link TranscriptSelectionMode} to use when choosing the transcript for detailed reporting.  Must not be {@code null}.
      * @param userTranscriptIdSet {@link Set} of {@link String}s containing transcript IDs of interest to be selected for first.  Must not be {@code null}.
+     * @param funcotatorToolInstance Instance of the {@link Funcotator} {@link GATKTool} into which to add {@link FeatureInput}s.
+     * @param lookaheadFeatureCachingInBp Number of base-pairs to cache when querying variants.
      * @return A {@link List} of {@link DataSourceFuncotationFactory} given the data source metadata, overrides, and transcript reporting priority information.
      */
     public static List<DataSourceFuncotationFactory> createDataSourceFuncotationFactoriesForDataSources(final Map<Path, Properties> dataSourceMetaData,
                                                                                                         final LinkedHashMap<String, String> annotationOverridesMap,
                                                                                                         final TranscriptSelectionMode transcriptSelectionMode,
-                                                                                                        final Set<String> userTranscriptIdSet) {
-
+                                                                                                        final Set<String> userTranscriptIdSet,
+                                                                                                        final GATKTool funcotatorToolInstance,
+                                                                                                        final int lookaheadFeatureCachingInBp) {
         Utils.nonNull(dataSourceMetaData);
         Utils.nonNull(annotationOverridesMap);
         Utils.nonNull(transcriptSelectionMode);
@@ -246,7 +250,8 @@ final public class DataSourceUtils {
         // Now we must instantiate our data sources:
         for ( final Map.Entry<Path, Properties> entry : dataSourceMetaData.entrySet() ) {
 
-            logger.debug("Creating Funcotation Factory for " + entry.getValue().getProperty("name") + " ...");
+            final String funcotationFactoryName = entry.getValue().getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+            logger.debug("Creating Funcotation Factory for " + funcotationFactoryName + " ...");
 
             final Path path = entry.getKey();
             final Properties properties = entry.getValue();
@@ -255,9 +260,11 @@ final public class DataSourceUtils {
 
             // Note: we need no default case since we know these are valid:
             final String stringType = properties.getProperty("type");
+            final FeatureInput<? extends Feature> featureInput;
             switch ( FuncotatorArgumentDefinitions.DataSourceType.getEnum(stringType) ) {
                 case LOCATABLE_XSV:
-                    funcotationFactory = DataSourceUtils.createLocatableXsvDataSource(path, properties, annotationOverridesMap);
+                    featureInput = createAndRegisterFeatureInputs(path, properties, funcotatorToolInstance, lookaheadFeatureCachingInBp, XsvTableFeature.class);
+                    funcotationFactory = DataSourceUtils.createLocatableXsvDataSource(path, properties, annotationOverridesMap, featureInput);
                     break;
                 case SIMPLE_XSV:
                     funcotationFactory = DataSourceUtils.createSimpleXsvDataSource(path, properties, annotationOverridesMap);
@@ -266,10 +273,12 @@ final public class DataSourceUtils {
                     funcotationFactory = DataSourceUtils.createCosmicDataSource(path, properties, annotationOverridesMap);
                     break;
                 case GENCODE:
-                    funcotationFactory = DataSourceUtils.createGencodeDataSource(path, properties, annotationOverridesMap, transcriptSelectionMode, userTranscriptIdSet);
+                    featureInput = createAndRegisterFeatureInputs(path, properties, funcotatorToolInstance, lookaheadFeatureCachingInBp, GencodeGtfFeature.class);
+                    funcotationFactory = DataSourceUtils.createGencodeDataSource(path, properties, annotationOverridesMap, transcriptSelectionMode, userTranscriptIdSet, featureInput);
                     break;
                 case VCF:
-                    funcotationFactory = DataSourceUtils.createVcfDataSource(path, properties, annotationOverridesMap, transcriptSelectionMode, userTranscriptIdSet);
+                    featureInput = createAndRegisterFeatureInputs(path, properties, funcotatorToolInstance, lookaheadFeatureCachingInBp, VariantContext.class);
+                    funcotationFactory = DataSourceUtils.createVcfDataSource(path, properties, annotationOverridesMap, featureInput);
                     break;
                 default:
                     throw new GATKException("Unknown type of DataSourceFuncotationFactory encountered: " + stringType );
@@ -284,15 +293,119 @@ final public class DataSourceUtils {
     }
 
     /**
+     * Create a {@link List} of {@link DataSourceFuncotationFactory} based on meta data on the data sources, overrides, and transcript reporting priority information.
+     * THIS METHOD IS FOR TESTING ONLY!
+     * @param dataSourceMetaData {@link Map} of {@link Path}->{@link Properties} containing metadata about each data source.  Must not be {@code null}.
+     * @param annotationOverridesMap {@link LinkedHashMap} of {@link String}->{@link String} containing any annotation overrides to include in data sources.  Must not be {@code null}.
+     * @param transcriptSelectionMode {@link TranscriptSelectionMode} to use when choosing the transcript for detailed reporting.  Must not be {@code null}.
+     * @param userTranscriptIdSet {@link Set} of {@link String}s containing transcript IDs of interest to be selected for first.  Must not be {@code null}.
+     * @return A {@link List} of {@link DataSourceFuncotationFactory} given the data source metadata, overrides, and transcript reporting priority information.
+     */
+    @VisibleForTesting
+    public static List<DataSourceFuncotationFactory> createDataSourceFuncotationFactoriesForDataSourcesForTesting(
+                                                                                final Map<Path, Properties> dataSourceMetaData,
+                                                                                final LinkedHashMap<String, String> annotationOverridesMap,
+                                                                                final TranscriptSelectionMode transcriptSelectionMode,
+                                                                                final Set<String> userTranscriptIdSet) {
+        Utils.nonNull(dataSourceMetaData);
+        Utils.nonNull(annotationOverridesMap);
+        Utils.nonNull(transcriptSelectionMode);
+        Utils.nonNull(userTranscriptIdSet);
+
+        final List<DataSourceFuncotationFactory> dataSourceFactories = new ArrayList<>(dataSourceMetaData.size());
+
+        // Now we know we have unique and valid data.
+        // Now we must instantiate our data sources:
+        for ( final Map.Entry<Path, Properties> entry : dataSourceMetaData.entrySet() ) {
+
+            final String funcotationFactoryName = entry.getValue().getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+            logger.debug("Creating Funcotation Factory for " + funcotationFactoryName + " ...");
+
+            final Path path = entry.getKey();
+            final Properties properties = entry.getValue();
+
+            final DataSourceFuncotationFactory funcotationFactory;
+
+            // Note: we need no default case since we know these are valid:
+            final String stringType = properties.getProperty("type");
+            final FeatureInput<? extends Feature> featureInput;
+            switch ( FuncotatorArgumentDefinitions.DataSourceType.getEnum(stringType) ) {
+                case LOCATABLE_XSV:
+                    featureInput = createFeatureInputsForTesting(path, properties);
+                    funcotationFactory = DataSourceUtils.createLocatableXsvDataSource(path, properties, annotationOverridesMap, featureInput);
+                    break;
+                case SIMPLE_XSV:
+                    funcotationFactory = DataSourceUtils.createSimpleXsvDataSource(path, properties, annotationOverridesMap);
+                    break;
+                case COSMIC:
+                    funcotationFactory = DataSourceUtils.createCosmicDataSource(path, properties, annotationOverridesMap);
+                    break;
+                case GENCODE:
+                    featureInput = createFeatureInputsForTesting(path, properties);
+                    funcotationFactory = DataSourceUtils.createGencodeDataSource(path, properties, annotationOverridesMap, transcriptSelectionMode, userTranscriptIdSet, featureInput);
+                    break;
+                case VCF:
+                    featureInput = createFeatureInputsForTesting(path, properties);
+                    funcotationFactory = DataSourceUtils.createVcfDataSource(path, properties, annotationOverridesMap, featureInput);
+                    break;
+                default:
+                    throw new GATKException("Unknown type of DataSourceFuncotationFactory encountered: " + stringType );
+            }
+
+            // Add in our factory:
+            dataSourceFactories.add(funcotationFactory);
+        }
+
+        logger.debug("All Data Sources have been created.");
+        return dataSourceFactories;
+    }
+
+    private static FeatureInput<? extends Feature> createAndRegisterFeatureInputs(final Path dataSourceFile,
+                                                                                  final Properties dataSourceProperties,
+                                                                                  final GATKTool funcotatorToolInstance,
+                                                                                  final int lookaheadFeatureCachingInBp,
+                                                                                  final Class<? extends Feature> featureType) {
+        Utils.nonNull(dataSourceFile);
+        Utils.nonNull(dataSourceProperties);
+
+        final String name      = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+        final String sourceFile = dataSourceFile.resolveSibling(dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_SRC_FILE)).toString();
+
+        // Get feature inputs by creating them with the funcotator tool instance itself:
+        return funcotatorToolInstance.addFeatureInputsAfterInitialization(sourceFile, name, featureType, lookaheadFeatureCachingInBp);
+    }
+
+    /**
+     * Create {@link FeatureInput<? extends Feature>} FOR TESTING ONLY.
+     * @param dataSourceFile
+     * @param dataSourceProperties
+     * @return
+     */
+    private static FeatureInput<? extends Feature> createFeatureInputsForTesting(final Path dataSourceFile,
+                                                                                 final Properties dataSourceProperties) {
+
+        Utils.nonNull(dataSourceFile);
+        Utils.nonNull(dataSourceProperties);
+
+        final String name      = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+        final String sourceFile = dataSourceFile.resolveSibling(dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_SRC_FILE)).toString();
+
+        // Get feature inputs by creating them with the funcotator tool instance itself:
+        return new FeatureInput<>(sourceFile, name, Collections.emptyMap());
+    }
+
+    /**
      * Create a {@link LocatableXsvFuncotationFactory} from filesystem resources and field overrides.
      * @param dataSourceFile {@link Path} to the data source file.  Must not be {@code null}.
      * @param dataSourceProperties {@link Properties} consisting of the contents of the config file for the data source.  Must not be {@code null}.
      * @param annotationOverridesMap {@link LinkedHashMap}{@code <String->String>} containing any annotation overrides to be included in the resulting data source.  Must not be {@code null}.
+     * @param featureInput The {@link FeatureInput<? extends Feature>} object for the LocatableXsv data source we are creating.
      * @return A new {@link LocatableXsvFuncotationFactory} based on the given data source file information and field overrides map.
      */
-    public static LocatableXsvFuncotationFactory createLocatableXsvDataSource(final Path dataSourceFile,
-                                                                              final Properties dataSourceProperties,
-                                                                              final LinkedHashMap<String, String> annotationOverridesMap) {
+    private static LocatableXsvFuncotationFactory createLocatableXsvDataSource(final Path dataSourceFile,
+                                                                               final Properties dataSourceProperties,
+                                                                               final LinkedHashMap<String, String> annotationOverridesMap,
+                                                                               final FeatureInput<? extends Feature> featureInput) {
         Utils.nonNull(dataSourceFile);
         Utils.nonNull(dataSourceProperties);
         Utils.nonNull(annotationOverridesMap);
@@ -301,7 +414,13 @@ final public class DataSourceUtils {
         final String version   = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_VERSION);
 
         // Create a locatable XSV feature reader to handle XSV Locatable features:
-        final LocatableXsvFuncotationFactory locatableXsvFuncotationFactory = new LocatableXsvFuncotationFactory(name, version, annotationOverridesMap);
+        final LocatableXsvFuncotationFactory locatableXsvFuncotationFactory =
+                new LocatableXsvFuncotationFactory(
+                        name,
+                        version,
+                        annotationOverridesMap,
+                        featureInput
+                );
 
         // Set the supported fields by the LocatableXsvFuncotationFactory:
         locatableXsvFuncotationFactory.setSupportedFuncotationFields(
@@ -324,7 +443,7 @@ final public class DataSourceUtils {
      * @param annotationOverridesMap {@link LinkedHashMap}{@code <String->String>} containing any annotation overrides to be included in the resulting data source.  Must not be {@code null}.
      * @return A new {@link SimpleKeyXsvFuncotationFactory} based on the given data source file information and field overrides map.
      */
-    public static SimpleKeyXsvFuncotationFactory createSimpleXsvDataSource(final Path dataSourceFile,
+    private static SimpleKeyXsvFuncotationFactory createSimpleXsvDataSource(final Path dataSourceFile,
                                                                    final Properties dataSourceProperties,
                                                                    final LinkedHashMap<String, String> annotationOverridesMap) {
 
@@ -353,7 +472,7 @@ final public class DataSourceUtils {
      * @param annotationOverridesMap {@link LinkedHashMap}{@code <String->String>} containing any annotation overrides to be included in the resulting data source.  Must not be {@code null}.
      * @return A new {@link CosmicFuncotationFactory} based on the given data source file information and field overrides map.
      */
-    public static CosmicFuncotationFactory createCosmicDataSource(final Path dataSourceFile,
+    private static CosmicFuncotationFactory createCosmicDataSource(final Path dataSourceFile,
                                                                 final Properties dataSourceProperties,
                                                                 final LinkedHashMap<String, String> annotationOverridesMap) {
         Utils.nonNull(dataSourceFile);
@@ -376,13 +495,15 @@ final public class DataSourceUtils {
      * @param annotationOverridesMap {@link LinkedHashMap}{@code <String->String>} containing any annotation overrides to be included in the resulting data source.  Must not be {@code null}.
      * @param transcriptSelectionMode {@link TranscriptSelectionMode} to use when choosing the transcript for detailed reporting.  Must not be {@code null}.
      * @param userTranscriptIdSet {@link Set} of {@link String}s containing transcript IDs of interest to be selected for first.  Must not be {@code null}.
+     * @param featureInput The {@link FeatureInput<? extends Feature>} object for the Gencode data source we are creating.
      * @return A new {@link GencodeFuncotationFactory} based on the given data source file information, field overrides map, and transcript information.
      */
-    public static GencodeFuncotationFactory createGencodeDataSource(final Path dataSourceFile,
-                                                                 final Properties dataSourceProperties,
-                                                                 final LinkedHashMap<String, String> annotationOverridesMap,
-                                                                 final TranscriptSelectionMode transcriptSelectionMode,
-                                                                 final Set<String> userTranscriptIdSet) {
+    private static GencodeFuncotationFactory createGencodeDataSource(final Path dataSourceFile,
+                                                                     final Properties dataSourceProperties,
+                                                                     final LinkedHashMap<String, String> annotationOverridesMap,
+                                                                     final TranscriptSelectionMode transcriptSelectionMode,
+                                                                     final Set<String> userTranscriptIdSet,
+                                                                     final FeatureInput<? extends Feature> featureInput) {
 
         Utils.nonNull(dataSourceFile);
         Utils.nonNull(dataSourceProperties);
@@ -396,13 +517,15 @@ final public class DataSourceUtils {
         final String name      = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
 
         // Create our gencode factory:
-        return new GencodeFuncotationFactory(dataSourceFile.resolveSibling(fastaPath),
-                        version,
-                        name,
-                        transcriptSelectionMode,
-                        userTranscriptIdSet,
-                        annotationOverridesMap
-                );
+        return new GencodeFuncotationFactory(
+                dataSourceFile.resolveSibling(fastaPath),
+                version,
+                name,
+                transcriptSelectionMode,
+                userTranscriptIdSet,
+                annotationOverridesMap,
+                featureInput
+            );
     }
 
     /**
@@ -410,34 +533,30 @@ final public class DataSourceUtils {
      * @param dataSourceFile {@link Path} to the data source file.  Must not be {@code null}.
      * @param dataSourceProperties {@link Properties} consisting of the contents of the config file for the data source.  Must not be {@code null}.
      * @param annotationOverridesMap {@link LinkedHashMap}{@code <String->String>} containing any annotation overrides to be included in the resulting data source.  Must not be {@code null}.
-     * @param transcriptSelectionMode {@link TranscriptSelectionMode} to use when choosing the transcript for detailed reporting.  Must not be {@code null}.
-     * @param userTranscriptIdSet {@link Set} of {@link String}s containing transcript IDs of interest to be selected for first.  Must not be {@code null}.
+     * @param featureInput The {@link FeatureInput<? extends Feature>} object for the VCF data source we are creating.
      * @return A new {@link GencodeFuncotationFactory} based on the given data source file information, field overrides map, and transcript information.
      */
-    public static VcfFuncotationFactory createVcfDataSource(final Path dataSourceFile,
-                                                            final Properties dataSourceProperties,
-                                                            final LinkedHashMap<String, String> annotationOverridesMap,
-                                                            final TranscriptSelectionMode transcriptSelectionMode,
-                                                            final Set<String> userTranscriptIdSet) {
+    private static VcfFuncotationFactory createVcfDataSource(final Path dataSourceFile,
+                                                             final Properties dataSourceProperties,
+                                                             final LinkedHashMap<String, String> annotationOverridesMap,
+                                                             final FeatureInput<? extends Feature> featureInput) {
 
         Utils.nonNull(dataSourceFile);
         Utils.nonNull(dataSourceProperties);
         Utils.nonNull(annotationOverridesMap);
-        Utils.nonNull(transcriptSelectionMode);
-        Utils.nonNull(userTranscriptIdSet);
 
         // Get some metadata:
-        final String name      = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
-        final String srcFile   = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_SRC_FILE);
-        final String version   = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_VERSION);
+        final String name       = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+        final String srcFile    = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_SRC_FILE);
+        final String version    = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_VERSION);
 
         // Create our VCF factory:
-
         return new VcfFuncotationFactory(
                 name,
                 version,
                 dataSourceFile.resolveSibling(srcFile).toAbsolutePath(),
-                annotationOverridesMap
+                annotationOverridesMap,
+                featureInput
         );
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
@@ -129,8 +129,8 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
     public CosmicFuncotationFactory(final Path pathToCosmicDb,
                                     final LinkedHashMap<String, String> annotationOverridesMap,
                                     final String version) {
-        this.pathToCosmicDb = pathToCosmicDb;
 
+        this.pathToCosmicDb = pathToCosmicDb;
         this.version = version;
 
         // Connect to the DB:
@@ -165,7 +165,7 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
     // Override Methods:
 
     @Override
-    protected Class<? extends Feature> getAnnotationFeatureClass() {
+    public Class<? extends Feature> getAnnotationFeatureClass() {
         // Returning Feature.class here implies that this class doesn't care about what features it gets.
         return Feature.class;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -11,6 +11,7 @@ import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -182,7 +183,10 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
                                      final String name,
                                      final TranscriptSelectionMode transcriptSelectionMode,
                                      final Set<String> userRequestedTranscripts,
-                                     final LinkedHashMap<String, String> annotationOverrides) {
+                                     final LinkedHashMap<String, String> annotationOverrides,
+                                     final FeatureInput<? extends Feature> mainFeatureInput) {
+
+        super(mainFeatureInput);
 
         this.gencodeTranscriptFastaFile = gencodeTranscriptFastaFile;
 
@@ -212,7 +216,7 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
     // Override Methods:
 
     @Override
-    protected Class<? extends Feature> getAnnotationFeatureClass() {
+    public Class<? extends Feature> getAnnotationFeatureClass() {
         return GencodeGtfFeature.class;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -178,6 +178,16 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
     //==================================================================================================================
     // Constructors:
 
+    /**
+     * Create a {@link GencodeFuncotationFactory}.
+     * @param gencodeTranscriptFastaFile {@link Path} to the FASTA file contianing the sequences of all transcripts in the Gencode data source.
+     * @param version The version {@link String} of Gencode from which {@link Funcotation}s will be made.
+     * @param name A {@link String} containing the name of this {@link GencodeFuncotationFactory}.
+     * @param transcriptSelectionMode The {@link TranscriptSelectionMode} by which representative/verbose transcripts will be chosen for overlapping variants.
+     * @param userRequestedTranscripts A {@link Set<String>} containing Gencode TranscriptIDs that the user requests to be annotated with priority over all other transcripts for overlapping variants.
+     * @param annotationOverrides A {@link LinkedHashMap<String, String>} containing user-specified overrides for specific {@link Funcotation}s.
+     * @param mainFeatureInput The backing {@link FeatureInput} for this {@link GencodeFuncotationFactory}, from which all {@link Funcotation}s will be created.
+     */
     public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFile,
                                      final String version,
                                      final String name,
@@ -668,7 +678,7 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
         }
         else if ( GencodeGtfTranscriptFeature.class.isAssignableFrom(containingSubfeature.getClass()) ) {
             // We have an intron variant
-            gencodeFuncotation = createIntronFuncotation(variantToUse, altAllele, reference, gtfFeature, transcript, reference);
+            gencodeFuncotation = createIntronFuncotation(variantToUse, altAllele, reference, gtfFeature, transcript);
         }
         else {
             // Uh-oh!  Problemz.
@@ -1234,15 +1244,13 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
      * @param reference The {@link ReferenceContext} for the given {@code variant}.
      * @param gtfFeature The {@link GencodeGtfGeneFeature} in which the given {@code variant} occurs.
      * @param transcript The {@link GencodeGtfTranscriptFeature} in which the given {@code variant} occurs.
-     * @param referenceContext The {@link ReferenceContext} in which the given variant appears.
      * @return A {@link GencodeFuncotation} containing information about the given {@code variant} given the corresponding {@code transcript}.
      */
     private GencodeFuncotation createIntronFuncotation(final VariantContext variant,
                                                        final Allele altAllele,
                                                        final ReferenceContext reference,
                                                        final GencodeGtfGeneFeature gtfFeature,
-                                                       final GencodeGtfTranscriptFeature transcript,
-                                                       final ReferenceContext referenceContext) {
+                                                       final GencodeGtfTranscriptFeature transcript) {
 
         // Get the strand-corrected alleles from the inputs.
         // Also get the reference sequence for the variant region.

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
@@ -89,15 +89,17 @@ public class VcfFuncotationFactory extends DataSourceFuncotationFactory {
     // Constructors:
 
     /**
-     * Use this only for testing,
+     * Create a {@link VcfFuncotationFactory}.
+     * @param name A {@link String} containing the name of this {@link VcfFuncotationFactory}.
+     * @param version  The version {@link String} of the backing data source from which {@link Funcotation}s will be made.
+     * @param sourceFilePath {@link Path} to the VCF file from which {@link VariantContext}s will be read in and used as Features from which to create {@link Funcotation}s.
+     * @param annotationOverridesMap A {@link LinkedHashMap<String,String>} containing user-specified overrides for specific {@link Funcotation}s.
+     * @param mainSourceFileAsFeatureInput The backing {@link FeatureInput} for this {@link VcfFuncotationFactory}, from which all {@link Funcotation}s will be created.
      */
-    @VisibleForTesting
-    public VcfFuncotationFactory(final String name, final String version, final Path sourceFilePath) {
-        // The class in the FeatureInput must always match what is returned from {@link VcfFuncotationFactory#getAnnotationFeatureClass}
-        this(name, version, sourceFilePath, new LinkedHashMap<>(), new FeatureInput<VariantContext>(sourceFilePath.toString(), name, new HashMap<>()));
-    }
-
-    public VcfFuncotationFactory(final String name, final String version, final Path sourceFilePath, final LinkedHashMap<String, String> annotationOverridesMap,
+    public VcfFuncotationFactory(final String name,
+                                 final String version,
+                                 final Path sourceFilePath,
+                                 final LinkedHashMap<String, String> annotationOverridesMap,
                                  final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput) {
 
         super(mainSourceFileAsFeatureInput);

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
@@ -87,11 +88,20 @@ public class VcfFuncotationFactory extends DataSourceFuncotationFactory {
     //==================================================================================================================
     // Constructors:
 
+    /**
+     * Use this only for testing,
+     */
+    @VisibleForTesting
     public VcfFuncotationFactory(final String name, final String version, final Path sourceFilePath) {
-        this(name, version, sourceFilePath, new LinkedHashMap<>());
+        // The class in the FeatureInput must always match what is returned from {@link VcfFuncotationFactory#getAnnotationFeatureClass}
+        this(name, version, sourceFilePath, new LinkedHashMap<>(), new FeatureInput<VariantContext>(sourceFilePath.toString(), name, new HashMap<>()));
     }
 
-    public VcfFuncotationFactory(final String name, final String version, final Path sourceFilePath, final LinkedHashMap<String, String> annotationOverridesMap) {
+    public VcfFuncotationFactory(final String name, final String version, final Path sourceFilePath, final LinkedHashMap<String, String> annotationOverridesMap,
+                                 final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput) {
+
+        super(mainSourceFileAsFeatureInput);
+
         this.name = name;
         this.version = version;
         this.sourceFilePath = sourceFilePath;
@@ -157,7 +167,7 @@ public class VcfFuncotationFactory extends DataSourceFuncotationFactory {
     // Override Methods:
 
     @Override
-    protected Class<? extends Feature> getAnnotationFeatureClass() {
+    public Class<? extends Feature> getAnnotationFeatureClass() {
         return VariantContext.class;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
@@ -6,6 +6,7 @@ import htsjdk.tribble.readers.AsciiLineReader;
 import htsjdk.tribble.readers.AsciiLineReaderIterator;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -71,23 +72,14 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
     //==================================================================================================================
     // Constructors:
 
-    public LocatableXsvFuncotationFactory(){
+    @VisibleForTesting
+    LocatableXsvFuncotationFactory(){
         this(DEFAULT_NAME, DEFAULT_VERSION_STRING);
-    }
-
-    public LocatableXsvFuncotationFactory(final String name, final String version){
-        this(name, version, new LinkedHashMap<>());
-    }
-
-    public LocatableXsvFuncotationFactory(final String name, final String version, final LinkedHashMap<String, String> annotationOverridesMap){
-        this.name = name;
-        this.version = version;
-
-        this.annotationOverrideMap = new LinkedHashMap<>(annotationOverridesMap);
     }
 
     @VisibleForTesting
     LocatableXsvFuncotationFactory(final String name, final String version, final List<String> supportedFields){
+
         this.name = name;
         this.version = version;
 
@@ -95,11 +87,28 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
         initializeFieldNameLists();
     }
 
+    @VisibleForTesting
+    LocatableXsvFuncotationFactory(final String name, final String version){
+        this(name, version, new LinkedHashMap<>(), null);
+    }
+
+    public LocatableXsvFuncotationFactory(final String name, final String version, final LinkedHashMap<String, String> annotationOverridesMap,
+                                          final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput){
+
+        super(mainSourceFileAsFeatureInput);
+
+        this.name = name;
+        this.version = version;
+
+        this.annotationOverrideMap = new LinkedHashMap<>(annotationOverridesMap);
+    }
+
+
     //==================================================================================================================
     // Override Methods:
 
     @Override
-    protected Class<? extends Feature> getAnnotationFeatureClass() {
+    public Class<? extends Feature> getAnnotationFeatureClass() {
         return XsvTableFeature.class;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
@@ -72,26 +72,13 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
     //==================================================================================================================
     // Constructors:
 
-    @VisibleForTesting
-    LocatableXsvFuncotationFactory(){
-        this(DEFAULT_NAME, DEFAULT_VERSION_STRING);
-    }
-
-    @VisibleForTesting
-    LocatableXsvFuncotationFactory(final String name, final String version, final List<String> supportedFields){
-
-        this.name = name;
-        this.version = version;
-
-        supportedFieldNames = new LinkedHashSet<>(supportedFields);
-        initializeFieldNameLists();
-    }
-
-    @VisibleForTesting
-    LocatableXsvFuncotationFactory(final String name, final String version){
-        this(name, version, new LinkedHashMap<>(), null);
-    }
-
+    /**
+     * Create a {@link LocatableXsvFuncotationFactory}.
+     * @param name A {@link String} containing the name of this {@link LocatableXsvFuncotationFactory}.
+     * @param version  The version {@link String} of the backing data source from which {@link Funcotation}s will be made.
+     * @param annotationOverridesMap A {@link LinkedHashMap<String,String>} containing user-specified overrides for specific {@link Funcotation}s.
+     * @param mainSourceFileAsFeatureInput The backing {@link FeatureInput} for this {@link LocatableXsvFuncotationFactory}, from which all {@link Funcotation}s will be created.
+     */
     public LocatableXsvFuncotationFactory(final String name, final String version, final LinkedHashMap<String, String> annotationOverridesMap,
                                           final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput){
 
@@ -209,6 +196,11 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
         return funcotationList;
     }
 
+    /**
+     * Set the field names that this {@link LocatableXsvFuncotationFactory} can create.
+     * Does so by reading the headers of backing data files for this {@link LocatableXsvFuncotationFactory}.
+     * @param inputDataFilePaths {@link List<Path>} to backing data files from which annotations can be made for this {@link LocatableXsvFuncotationFactory}.
+     */
     public void setSupportedFuncotationFields(final List<Path> inputDataFilePaths) {
 
         if ( supportedFieldNames == null ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactory.java
@@ -107,6 +107,7 @@ public class SimpleKeyXsvFuncotationFactory extends DataSourceFuncotationFactory
                                           final LinkedHashMap<String, String> annotationOverrides,
                                           final int numHeaderLinesToIgnore,
                                           final boolean permissiveColumns ) {
+
         this.name = name;
 
         delimiter = delim;
@@ -150,7 +151,7 @@ public class SimpleKeyXsvFuncotationFactory extends DataSourceFuncotationFactory
     // Override Methods:
 
     @Override
-    protected Class<? extends Feature> getAnnotationFeatureClass() {
+    public Class<? extends Feature> getAnnotationFeatureClass() {
         // Returning Feature.class here implies that this class doesn't care about what features it gets.
         return Feature.class;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/xsvLocatableTable/XsvLocatableTableCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/xsvLocatableTable/XsvLocatableTableCodec.java
@@ -80,8 +80,8 @@ public final class XsvLocatableTableCodec extends AsciiFeatureCodec<XsvTableFeat
     //==================================================================================================================
     // Private Static Members:
 
-
-    private static final String CONFIG_FILE_EXTENSION = ".config";
+    @VisibleForTesting
+    public static final String CONFIG_FILE_EXTENSION = ".config";
 
     //==================================================================================================================
     // Private Members:

--- a/src/test/java/org/broadinstitute/hellbender/engine/DummyPlaceholderGatkTool.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/DummyPlaceholderGatkTool.java
@@ -1,11 +1,12 @@
-package org.broadinstitute.hellbender.tools.funcotator;
+package org.broadinstitute.hellbender.engine;
 
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
-import org.broadinstitute.hellbender.engine.GATKTool;
 
 /**
  * A Dummy / Placeholder class that can be used where a {@link GATKTool} is required.
+ * DO NOT USE THIS FOR ANYTHING OTHER THAN TESTING.
+ * THIS MUST BE IN THE ENGINE PACKAGE DUE TO SCOPE ON `features`!
  * Created by jonn on 9/19/18.
  */
 @CommandLineProgramProperties(
@@ -15,17 +16,19 @@ import org.broadinstitute.hellbender.engine.GATKTool;
 )
 public final class DummyPlaceholderGatkTool extends GATKTool {
 
+    public DummyPlaceholderGatkTool() {
+        parseArgs(new String[]{});
+        onStartup();
+    }
+
     @Override
     public void traverse() {
 
     }
 
-    /**
-     * Initialize this {@link DummyPlaceholderGatkTool} by running {@link GATKTool#onStartup()}.
-     * @return {@code this} {@link DummyPlaceholderGatkTool}.
-     */
-    public DummyPlaceholderGatkTool initialize() {
-        onStartup();
-        return this;
+    @Override
+    void initializeFeatures(){
+        features = new FeatureManager(this, FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
+                referenceArguments.getReferencePath());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/DummyPlaceholderGatkTool.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/DummyPlaceholderGatkTool.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.hellbender.tools.funcotator;
+
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.TestProgramGroup;
+import org.broadinstitute.hellbender.engine.GATKTool;
+
+/**
+ * A Dummy / Placeholder class that can be used where a {@link GATKTool} is required.
+ * Created by jonn on 9/19/18.
+ */
+@CommandLineProgramProperties(
+        summary = "A dummy GATKTool to help test Funcotator.",
+        oneLineSummary = "Dummy dumb dumb tool for testing.",
+        programGroup = TestProgramGroup.class
+)
+public final class DummyPlaceholderGatkTool extends GATKTool {
+
+    @Override
+    public void traverse() {
+
+    }
+
+    /**
+     * Initialize this {@link DummyPlaceholderGatkTool} by running {@link GATKTool#onStartup()}.
+     * @return {@code this} {@link DummyPlaceholderGatkTool}.
+     */
+    public DummyPlaceholderGatkTool initialize() {
+        onStartup();
+        return this;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMapUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMapUnitTest.java
@@ -12,9 +12,13 @@ import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.testutils.BaseTest;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationBuilder;
@@ -24,6 +28,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.codecs.gencode.GencodeGtfCodec;
 import org.broadinstitute.hellbender.utils.codecs.gencode.GencodeGtfFeature;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.FuncotatorTestUtils;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
@@ -43,8 +48,10 @@ public class FuncotationMapUnitTest extends BaseTest{
 
     private static final String DS_PIK3CA_DIR = GATKBaseTest.largeFileTestDir + "funcotator/small_ds_pik3ca/";
     private static final String DS_PIK3CA_HG19_GENCODE_FASTA = DS_PIK3CA_DIR + "gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta";
+    private static final String DS_PIK3CA_HG19_GENCODE_GTF = DS_PIK3CA_DIR + "gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf";
     private static final String DS_MUC16_DIR = GATKBaseTest.largeFileTestDir + "funcotator/small_ds_muc16/";
     private static final String DS_MUC16_HG19_GENCODE_FASTA = DS_MUC16_DIR + "gencode_muc16/hg19/gencode.v19.MUC16_transcript.fasta";
+    private static final String DS_MUC16_HG19_GENCODE_GTF = DS_MUC16_DIR + "gencode_muc16/hg19/gencode.v19.MUC16.gtf";
     private static final FeatureReader<GencodeGtfFeature> pik3caFeatureReader = AbstractFeatureReader.getFeatureReader( FuncotatorTestConstants.PIK3CA_GENCODE_ANNOTATIONS_FILE_NAME, new GencodeGtfCodec() );
     private static final FeatureReader<GencodeGtfFeature> muc16FeatureReader = AbstractFeatureReader.getFeatureReader(FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME, new GencodeGtfCodec() );
 
@@ -352,34 +359,34 @@ public class FuncotationMapUnitTest extends BaseTest{
         return new Object[][] {
                 {"chr3", 178916538, 178916538, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref())),
-                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA,
+                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA, DS_PIK3CA_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.ALL, Collections.singletonList("ENST00000263967.3")
                 },{"chr3", 178916538, 178916538, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref())),
-                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA,
+                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA, DS_PIK3CA_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.CANONICAL, Collections.singletonList("ENST00000263967.3")
                 },{"chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.ALL, Arrays.asList("ENST00000397910.4", "ENST00000380951.5")
 
                 // Next one tests where we would be in a gene with more than one basic transcript, but variant only overlaps one.  And we still ask for all,
                 //   but since one is IGR, it will never get added the the FuncotationMap.
                 }, {"chr19", 9014550, 9014550, "T", "A", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of(IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.ALL, Collections.singletonList("ENST00000397910.4")
 
                 // Next one tests where we would be in a gene with more than one basic transcript, variant overlaps both, but we are in canonical mode.
                 },{"chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.CANONICAL, Collections.singletonList("ENST00000397910.4")
 
                 // Next one tests where we would be in a gene with more than one basic transcript, variant overlaps both, but we are in effect mode.
                 },{"chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.BEST_EFFECT, Collections.singletonList("ENST00000397910.4")
                 }
         };
@@ -394,10 +401,11 @@ public class FuncotationMapUnitTest extends BaseTest{
                                                final ReferenceDataSource referenceDataSource,
                                                final FeatureReader<GencodeGtfFeature> featureReader,
                                                final String transcriptFastaFile,
+                                               final String transcriptGtfFile,
                                                final TranscriptSelectionMode transcriptSelectionMode,
                                                final List<String> gtTranscripts) {
 
-        final List<GencodeFuncotation> gencodeFuncotations = createGencodeFuncotations(contig, start, end, ref, alt, referenceFileName, referenceDataSource, featureReader, transcriptFastaFile, transcriptSelectionMode);
+        final List<GencodeFuncotation> gencodeFuncotations = createGencodeFuncotations(contig, start, end, ref, alt, referenceFileName, referenceDataSource, featureReader, transcriptFastaFile, transcriptGtfFile, transcriptSelectionMode);
 
         final FuncotationMap funcotationMap = FuncotationMap.createFromGencodeFuncotations(gencodeFuncotations);
 
@@ -409,7 +417,7 @@ public class FuncotationMapUnitTest extends BaseTest{
                 .noneMatch(k -> ((GencodeFuncotation) funcotationMap.get(k).get(0)).getVariantClassification().equals(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE) ));
     }
 
-    private static List<GencodeFuncotation> createGencodeFuncotations(final String contig, final int start, final int end, final String ref, final String alt, final String referenceFileName, final ReferenceDataSource referenceDataSource, final FeatureReader<GencodeGtfFeature> featureReader, final String transcriptFastaFile, final TranscriptSelectionMode transcriptSelectionMode) {
+    private static List<GencodeFuncotation> createGencodeFuncotations(final String contig, final int start, final int end, final String ref, final String alt, final String referenceFileName, final ReferenceDataSource referenceDataSource, final FeatureReader<GencodeGtfFeature> featureReader, final String transcriptFastaFile, final String transcriptGtfFile, final TranscriptSelectionMode transcriptSelectionMode) {
         final SimpleInterval variantInterval = new SimpleInterval( contig, start, end );
         final VariantContext variantContext = createVariantContext(contig, start, end, ref, alt, referenceFileName);
 
@@ -427,10 +435,14 @@ public class FuncotationMapUnitTest extends BaseTest{
 
         final String gencode_test = "GENCODE_TEST";
         final GencodeFuncotationFactory gencodeFactory = new GencodeFuncotationFactory(Paths.get(transcriptFastaFile),
-        "TEST", gencode_test, transcriptSelectionMode, new HashSet<>(), new LinkedHashMap<>());
+        "TEST", gencode_test, transcriptSelectionMode, new HashSet<>(), new LinkedHashMap<>(),
+                new FeatureInput<>(transcriptGtfFile, gencode_test, Collections.emptyMap()));
 
-        return gencodeFactory.createFuncotations(variantContext, referenceContext, Collections.singletonMap(gencode_test, featureList)).stream()
-        .map(f -> (GencodeFuncotation) f).collect(Collectors.toList());
+        final FeatureContext featureContext = FuncotatorTestUtils.createFeatureContext(Collections.singletonList(gencodeFactory), "FuncotationMapUnitTest",
+                variantInterval, 0, 0, 0, null);
+
+        return gencodeFactory.createFuncotations(variantContext, referenceContext, featureContext).stream()
+            .map(f -> (GencodeFuncotation) f).collect(Collectors.toList());
     }
 
     private List<String> createFieldValuesFromNameList(final String prefix, final List<String> baseFieldList) {
@@ -507,7 +519,7 @@ public class FuncotationMapUnitTest extends BaseTest{
         return new Object[][]{
                 {"chr3", 178916538, 178916538, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref())),
-                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA,
+                        pik3caFeatureReader, DS_PIK3CA_HG19_GENCODE_FASTA, DS_PIK3CA_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.ALL, Collections.singletonList("ENST00000263967.3"),
                         Arrays.asList(
                                 TableFuncotation.create(
@@ -531,7 +543,7 @@ public class FuncotationMapUnitTest extends BaseTest{
                         )
                 },{"chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.BEST_EFFECT, Collections.singletonList("ENST00000397910.4"),
                         Arrays.asList(
                         TableFuncotation.create(
@@ -555,7 +567,7 @@ public class FuncotationMapUnitTest extends BaseTest{
                 )
                 }, {"chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                         ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                        muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                         TranscriptSelectionMode.ALL, Arrays.asList("ENST00000397910.4", "ENST00000380951.5"),
                         Arrays.asList(
                                 TableFuncotation.create(
@@ -594,9 +606,10 @@ public class FuncotationMapUnitTest extends BaseTest{
                               final ReferenceDataSource referenceDataSource,
                               final FeatureReader<GencodeGtfFeature> featureReader,
                               final String transcriptFastaFile,
+                              final String transcriptGtfFile,
                               final TranscriptSelectionMode transcriptSelectionMode,
                               final List<String> gtTranscripts, final List<Funcotation> funcotationsToAdd){
-        final List<GencodeFuncotation> gencodeFuncotations = createGencodeFuncotations(contig, start, end, ref, alt, referenceFileName, referenceDataSource, featureReader, transcriptFastaFile, transcriptSelectionMode);
+        final List<GencodeFuncotation> gencodeFuncotations = createGencodeFuncotations(contig, start, end, ref, alt, referenceFileName, referenceDataSource, featureReader, transcriptFastaFile, transcriptGtfFile, transcriptSelectionMode);
         final FuncotationMap funcotationMap = FuncotationMap.createFromGencodeFuncotations(gencodeFuncotations);
 
         // Let's make sure that the gtTranscripts match what is in the map, even if this is tested elsewhere
@@ -672,7 +685,7 @@ public class FuncotationMapUnitTest extends BaseTest{
         // Create some gencode funcotations.  The content does not really matter here.
         final List<Funcotation> gencodeFuncotations = createGencodeFuncotations("chr19", 8994200, 8994200, "G", "C", FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(),
                 ReferenceDataSource.of( IOUtils.getPath(FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref())),
-                muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA,
+                muc16FeatureReader, DS_MUC16_HG19_GENCODE_FASTA, DS_MUC16_HG19_GENCODE_GTF,
                 TranscriptSelectionMode.ALL).stream().map(gf -> (Funcotation) gf).collect(Collectors.toList());
 
         // Create a funcotationMap with some pre-made funcotations.  Content does not really matter.

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.DummyPlaceholderGatkTool;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
@@ -57,7 +58,7 @@ public class FuncotatorEngineUnitTest extends GATKBaseTest {
                                 new LinkedHashMap<>(),
                                 TranscriptSelectionMode.CANONICAL,
                                 new HashSet<>(),
-                                new DummyPlaceholderGatkTool().initialize(),
+                                new DummyPlaceholderGatkTool(),
                                 FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE)
                 );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
@@ -1,0 +1,64 @@
+package org.broadinstitute.hellbender.tools.funcotator;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.ReferenceDataSource;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.DataSourceUtils;
+import org.broadinstitute.hellbender.tools.funcotator.metadata.VcfFuncotationMetadata;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.FuncotatorTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class FuncotatorEngineUnitTest extends GATKBaseTest {
+    final static private String INPUT_VCF = FuncotatorTestConstants.FUNCOTATOR_TEST_DIR + "/PIK3CA_SNPS_engine_test_chr3.vcf";
+    private static final String DS_PIK3CA_DIR = largeFileTestDir + "funcotator" + File.separator + "small_ds_pik3ca" + File.separator;
+    @DataProvider
+    public Object[][] provideGt() {
+        return new Object[][] {
+                // ground truth gene name, hasClinvarAnnotation
+                {new File(INPUT_VCF), Arrays.asList("PIK3CA", "PIK3CA", "PIK3CA"), new boolean[]{true, true, false}}
+        };
+    }
+    @Test(dataProvider = "provideGt")
+    public void testGetFuncotationFactoriesAndCreateFuncotationMapForVariant(final File vcfFile, final List<String> correspondingGeneName, final boolean[] hasClinvarHit) {
+
+        final Pair<VCFHeader, List<VariantContext>> entireVcf = VariantContextTestUtils.readEntireVCFIntoMemory(vcfFile.getAbsolutePath());
+        final Map<Path, Properties> configData = DataSourceUtils.getAndValidateDataSourcesFromPaths("hg19", Collections.singletonList(DS_PIK3CA_DIR));
+
+        // Create the metadata directly from the input.
+        final FuncotatorEngine funcotatorEngine = new FuncotatorEngine(VcfFuncotationMetadata.create(
+                new ArrayList<>(entireVcf.getLeft().getInfoHeaderLines())),
+                DataSourceUtils.createDataSourceFuncotationFactoriesForDataSourcesForTesting(configData, new LinkedHashMap<>(),
+                        TranscriptSelectionMode.CANONICAL, new HashSet<>()));
+
+        for (int i = 0; i < entireVcf.getRight().size(); i++) {
+            final VariantContext vc = entireVcf.getRight().get(i);
+            final SimpleInterval variantInterval = new SimpleInterval(vc.getContig(), vc.getStart(), vc.getEnd());
+            final ReferenceContext referenceContext = new ReferenceContext(ReferenceDataSource.of(Paths.get(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref())), variantInterval);
+            final FeatureContext featureContext = FuncotatorTestUtils.createFeatureContext(funcotatorEngine.getFuncotationFactories(), "TEST", variantInterval,
+                    0,0,0, null);
+            final FuncotationMap funcotationMap = funcotatorEngine.createFuncotationMapForVariant(vc, referenceContext, featureContext);
+
+            // Check that all of the transcripts at this location have the same gene name as the corresponding gene.
+            //  The ground truth selected has the same gene name for all transcripts.
+            //  Also, input VCF has no multiallelics.
+            for (final String txId : funcotationMap.getTranscriptList()) {
+                Assert.assertEquals(funcotationMap.getFieldValue(txId, "Gencode_19_hugoSymbol", vc.getAlternateAllele(0)), correspondingGeneName.get(i));
+                Assert.assertTrue((funcotationMap.getFieldValue(txId, "dummy_ClinVar_VCF_ALLELEID", vc.getAlternateAllele(0)).isEmpty()) != hasClinvarHit[i]);
+            }
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -14,16 +14,17 @@ import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceMemorySource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.broadinstitute.hellbender.tools.funcotator.*;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.codecs.gencode.*;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
-import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -76,7 +77,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                 new HashSet<>(),
-                new LinkedHashMap<>());
+                new LinkedHashMap<>(),
+                createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME));
     }
 
     //==================================================================================================================
@@ -133,19 +135,21 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                                                                  final String referenceFileName,
                                                                  final FeatureReader<GencodeGtfFeature> featureReader,
                                                                  final ReferenceDataSource referenceDataSource,
-                                                                 final String transcriptFastaFile) {
+                                                                 final String transcriptFastaFile,
+                                                                 final String transcriptGtfFile) {
 
         final List<Object[]> outList = new ArrayList<>(unitTestData.size());
 
         for ( final Object[] rawData : unitTestData ) {
-            final Object[] dataWithReference = new Object[rawData.length + 4];
+            final Object[] dataWithReference = new Object[rawData.length + 5];
             for ( int i = 0; i < rawData.length; ++i ) {
                 dataWithReference[i] = rawData[i];
             }
-            dataWithReference[dataWithReference.length-4] = referenceFileName;
-            dataWithReference[dataWithReference.length-3] = featureReader;
-            dataWithReference[dataWithReference.length-2] = referenceDataSource;
-            dataWithReference[dataWithReference.length-1] = transcriptFastaFile;
+            dataWithReference[dataWithReference.length-5] = referenceFileName;
+            dataWithReference[dataWithReference.length-4] = featureReader;
+            dataWithReference[dataWithReference.length-3] = referenceDataSource;
+            dataWithReference[dataWithReference.length-2] = transcriptFastaFile;
+            dataWithReference[dataWithReference.length-1] = transcriptGtfFile;
             outList.add(dataWithReference);
         }
 
@@ -371,24 +375,24 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         final List<Object[]> outList = new ArrayList<>();
 
         // MUC16 SNPs / DNPs:
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_1(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_2(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_3(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_4(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_5(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideEdgeCasesForMUC16Data_1(), FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_1(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_2(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME  ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_3(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME  ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_4(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME  ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideMnpDataForMuc16_5(),       FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME  ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16MnpFullData.provideEdgeCasesForMUC16Data_1(), FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME  ) );
 
         // MUC16 INDELs:
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16IndelData.provideIndelDataForMuc16(), FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForMuc16IndelData.provideIndelDataForMuc16(), FuncotatorReferenceTestUtils.retrieveHg19Chr19Ref(), muc16FeatureReader, refDataSourceHg19Ch19, FuncotatorTestConstants.MUC16_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME ) );
 
         // PIK3CA SNPs / DNPs:
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caMnpData(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caMnpData(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.PIK3CA_GENCODE_ANNOTATIONS_FILE_NAME ) );
 
         // PIK3CA INDELs:
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caInDelData(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caInDelData(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.PIK3CA_GENCODE_ANNOTATIONS_FILE_NAME ) );
 
         // PIK3CA Other Indels:
-        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caInDelData2(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE ) );
+        outList.addAll( addReferenceDataToUnitTestData(DataProviderForPik3caTestData.providePik3caInDelData2(), FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), pik3caFeatureReader, refDataSourceHg19Ch3, FuncotatorTestConstants.PIK3CA_GENCODE_TRANSCRIPT_FASTA_FILE, FuncotatorTestConstants.PIK3CA_GENCODE_ANNOTATIONS_FILE_NAME ) );
 
         return outList.toArray(new Object[][]{{}});
     }
@@ -1164,7 +1168,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                 requestedTranscriptIds,
-                new LinkedHashMap<>())) {
+                new LinkedHashMap<>(), createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1221,7 +1225,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                                                                     GencodeFuncotationFactory.DEFAULT_NAME,
                                                                     FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                                                                     new HashSet<>(),
-                                                                    new LinkedHashMap<>())) {
+                                                                    new LinkedHashMap<>(), createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME)
+                                                                    )) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1250,7 +1255,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                                 final String referenceFileName,
                                 final FeatureReader<GencodeGtfFeature> featureReader,
                                 final ReferenceDataSource referenceDataSource,
-                                final String transcriptFastaFile) {
+                                final String transcriptFastaFile, final String transcriptGtfFile) {
 
         final String contig = "chr" + Integer.toString(chromosomeNumber);
         final SimpleInterval variantInterval = new SimpleInterval( contig, start, end );
@@ -1291,7 +1296,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                 requestedTranscriptIds,
-                new LinkedHashMap<>())) {
+                new LinkedHashMap<>(),
+                new FeatureInput<>(transcriptGtfFile, GencodeFuncotationFactory.DEFAULT_NAME, Collections.emptyMap()))) {
 
             final List<Feature> featureList = new ArrayList<>();
             featureList.add( gene );
@@ -1565,7 +1571,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.CANONICAL,
                 Collections.emptySet(),
-                new LinkedHashMap<>())) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertEquals(gencodeFuncotations.size(), 1);
         }
@@ -1576,7 +1582,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.BEST_EFFECT,
                 Collections.emptySet(),
-                new LinkedHashMap<>())) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertEquals(gencodeFuncotations.size(), 1);
         }
@@ -1587,9 +1593,17 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.ALL,
                 Collections.emptySet(),
-                new LinkedHashMap<>())) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertTrue(gencodeFuncotations.size() > 1);
         }
+    }
+
+    private static FeatureInput<? extends Feature> createFeatureInputForMuc16Ds(final String dsName) {
+        return new FeatureInput<>(FuncotatorTestConstants.MUC16_GENCODE_ANNOTATIONS_FILE_NAME, dsName, Collections.emptyMap());
+    }
+
+    private static FeatureInput<? extends Feature> createFeatureInputForCntn4Ds(final String dsName) {
+        return new FeatureInput<>(CNTN4_GENCODE_ANNOTATIONS_FILE_NAME, dsName, Collections.emptyMap());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactoryUnitTest.java
@@ -12,21 +12,23 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
 import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.funcotator.FuncotatorTestConstants;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
-import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -188,26 +190,26 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
 
     @Test
     public void testGetAnnotationFeatureClass() {
-        final VcfFuncotationFactory vcfFuncotationFactory = new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
+        final VcfFuncotationFactory vcfFuncotationFactory = createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
         Assert.assertEquals(vcfFuncotationFactory.getAnnotationFeatureClass(), VariantContext.class);
     }
 
     @Test
     public void testGetType() {
-        final VcfFuncotationFactory vcfFuncotationFactory = new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
+        final VcfFuncotationFactory vcfFuncotationFactory = createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
         Assert.assertEquals(vcfFuncotationFactory.getType(), FuncotatorArgumentDefinitions.DataSourceType.VCF);
     }
 
     @Test(dataProvider = "provideForTestGetName")
     public void testGetName(final String name) {
-        final VcfFuncotationFactory vcfFuncotationFactory = new VcfFuncotationFactory(name, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
+        final VcfFuncotationFactory vcfFuncotationFactory = createVcfFuncotationFactory(name, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.VARIANT_FILE_HG19_CHR3));
         Assert.assertEquals(vcfFuncotationFactory.getName(), name);
     }
 
     @Test
     public void testGetSupportedFuncotationFields() {
         final VcfFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
+                createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
 
         final LinkedHashSet<String> expectedFieldNames = new LinkedHashSet<>();
 
@@ -225,7 +227,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
 
         // Make our factory:
         final VcfFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
+                createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
 
         // Create features from the file:
         final List<Feature> vcfFeatures;
@@ -262,7 +264,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
         // Don't need the expected gt for this test, but useful to reuse the data provider.
         // Make our factory:
         final VcfFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
+                createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
 
         // Create features from the file:
         final List<Feature> vcfFeatures;
@@ -346,7 +348,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
 
         // Make the factory
         final VcfFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(EXAC_SNIPPET));
+                createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(EXAC_SNIPPET));
 
         final ReferenceContext referenceContext = new ReferenceContext(ReferenceDataSource.of(Paths.get(FuncotatorReferenceTestUtils.retrieveB37Chr3Ref())), variantInterval);
 
@@ -414,7 +416,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
 
         // Create our funcotation factory to test
         final VcfFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(EXAC_SNIPPET));
+                createVcfFuncotationFactory(FACTORY_NAME, FACTORY_VERSION, IOUtils.getPath(EXAC_SNIPPET));
 
         for (int i = 0; i < VcfFuncotationFactory.LRUCache.MAX_ENTRIES; i++) {
             funcotateForCacheTest(vcfFuncotationFactory, dummyTriples.get(i));
@@ -460,5 +462,11 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
         }
 
         return Triple.of(vc, referenceContext, vcfFeatures);
+    }
+
+    private VcfFuncotationFactory createVcfFuncotationFactory(final String name,
+                                                              final String version,
+                                                              final Path sourceFilePath) {
+        return new VcfFuncotationFactory(name, version, sourceFilePath, new LinkedHashMap<>(), new FeatureInput<VariantContext>(sourceFilePath.toString(), name, new HashMap<>()));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/CustomMafFuncotationCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/CustomMafFuncotationCreatorUnitTest.java
@@ -8,6 +8,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
@@ -19,6 +20,7 @@ import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetada
 import org.broadinstitute.hellbender.tools.funcotator.metadata.TumorNormalPair;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.FuncotatorTestUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -166,7 +168,12 @@ public class CustomMafFuncotationCreatorUnitTest extends GATKBaseTest {
                 new SimpleInterval(variant.getContig(),
                 variant.getStart(), variant.getEnd()));
 
-        final List<Funcotation> funcotations = vcfFuncotationFactory.createFuncotations(variant, referenceContext, vcfFuncotationSourceMap);
+        final FeatureContext featureContext = FuncotatorTestUtils.createFeatureContext(Collections.singletonList(vcfFuncotationFactory),
+                "TEST_CREATE_DB_SNP_CUSTOM_FIELDS",
+                new SimpleInterval(variant.getContig(), variant.getStart(), variant.getEnd()),
+                0, 0, 0, null);
+
+        final List<Funcotation> funcotations = vcfFuncotationFactory.createFuncotations(variant, referenceContext, featureContext);
         Assert.assertTrue(funcotations.size() > 0);
         for (final Funcotation f : funcotations) {
             Assert.assertEquals(StringUtils.split(f.getField(DBSNP_DS_NAME + "_VLD"), "|").length, vcfFuncotationSourceMap.get(DBSNP_DS_NAME).size());

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/CustomMafFuncotationCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/CustomMafFuncotationCreatorUnitTest.java
@@ -9,6 +9,7 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
@@ -26,11 +27,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.broadinstitute.hellbender.tools.funcotator.mafOutput.CustomMafFuncotationCreator.MAF_DBSNP_VAL_STATUS_DELIMITER;
@@ -147,8 +146,15 @@ public class CustomMafFuncotationCreatorUnitTest extends GATKBaseTest {
      */
     @Test(dataProvider = "provideDbSnpVariants")
     public void testCreateDbSnpCustomFields(final VariantContext variant, final int gtNumHits, final String gtDbSnpValStatusField) {
+
+        final Path sourceFilePath = IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH);
         final DataSourceFuncotationFactory vcfFuncotationFactory =
-                new VcfFuncotationFactory(DBSNP_DS_NAME, "snippetTest", IOUtils.getPath(FuncotatorTestConstants.DBSNP_HG19_SNIPPET_FILE_PATH));
+                new VcfFuncotationFactory(DBSNP_DS_NAME,
+                        "snippetTest",
+                        sourceFilePath,
+                        new LinkedHashMap<>(),
+                        new FeatureInput<VariantContext>(sourceFilePath.toString(), DBSNP_DS_NAME, new HashMap<>())
+                );
 
         /* dbSNP records of relevance.
         1	10177	rs367896724	A	AC	.	.	RS=367896724;RSPOS=10177;dbSNPBuildID=138;SSR=0;SAO=0;VP=0x050000020005170026000200;GENEINFO=DDX11L1:100287102;WGT=1;VC=DIV;R5;ASP;VLD;G5A;G5;KGPhase3;CAF=0.5747,0.4253;COMMON=1

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -104,7 +104,7 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
                         Collections.singletonList(FuncotatorTestConstants.FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER)
                 );
 
-        final List<DataSourceFuncotationFactory> dataSourceFuncotationFactories = DataSourceUtils.createDataSourceFuncotationFactoriesForDataSources(
+        final List<DataSourceFuncotationFactory> dataSourceFuncotationFactories = DataSourceUtils.createDataSourceFuncotationFactoriesForDataSourcesForTesting(
                 configData,
                 new LinkedHashMap<>(),
                 TranscriptSelectionMode.BEST_EFFECT,

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -6,7 +6,9 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.collections.MapUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.DummyPlaceholderGatkTool;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.tools.funcotator.*;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.DataSourceUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
@@ -14,7 +16,6 @@ import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.Gencod
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.vcfOutput.VcfOutputRenderer;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -104,11 +104,13 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
                         Collections.singletonList(FuncotatorTestConstants.FUNCOTATOR_DATA_SOURCES_MAIN_FOLDER)
                 );
 
-        final List<DataSourceFuncotationFactory> dataSourceFuncotationFactories = DataSourceUtils.createDataSourceFuncotationFactoriesForDataSourcesForTesting(
+        final List<DataSourceFuncotationFactory> dataSourceFuncotationFactories = DataSourceUtils.createDataSourceFuncotationFactoriesForDataSources(
                 configData,
                 new LinkedHashMap<>(),
                 TranscriptSelectionMode.BEST_EFFECT,
-                new HashSet<>()
+                new HashSet<>(),
+                new DummyPlaceholderGatkTool(),
+                FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE
         );
 
         // Sort the datasources to ensure the same order every time:

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.hellbender.utils.test;
+
+import htsjdk.tribble.Feature;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.FeatureInput;
+import org.broadinstitute.hellbender.engine.FeatureManager;
+import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FuncotatorTestUtils {
+    private FuncotatorTestUtils() {}
+
+
+    /**
+     * Since funcotation factories need an instance of {@link FeatureContext} to funcotate, this convenience method can
+     *  create a new instance for test methods.
+     *
+     * @param funcotationFactories {@link List} of {@link DataSourceFuncotationFactory} that should be used to generate the
+     *                                         {@link FeatureContext}.  Never {@code null}, but empty list is acceptable.
+     * @param dummyToolInstanceName A name to use for the "tool".  Any string will work here.  Never {@code null}.
+     * @param interval genomic interval for the result.  Typically, this would be the interval of the variant.  Never {@link null}.
+     * @param featureQueryLookahead When querying FeatureDataSources, cache this many extra bases of context beyond
+     *                              the end of query intervals in anticipation of future queries. Must be >= 0.  If uncertain, use zero.
+     * @param cloudPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use zero.
+     * @param cloudIndexPrefetchBuffer See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use zero.
+     * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use {@code null}.
+     * @return a {@link FeatureContext} ready for querying the funcotation factories on the given interval.  Never {@code null}.
+     */
+    public static FeatureContext createFeatureContext(final List<DataSourceFuncotationFactory> funcotationFactories, final String dummyToolInstanceName,
+                                                      final SimpleInterval interval, final int featureQueryLookahead, final int cloudPrefetchBuffer,
+                                                      final int cloudIndexPrefetchBuffer, final Path reference) {
+        Utils.nonNull(funcotationFactories);
+        Utils.nonNull(dummyToolInstanceName);
+        Utils.nonNull(interval);
+
+        final Map<FeatureInput<? extends Feature>, Class<? extends Feature>> featureInputsWithType =
+                funcotationFactories.stream()
+                        .collect(Collectors.toMap(ff -> ff.getMainSourceFileAsFeatureInput(), ff -> ff.getAnnotationFeatureClass()));
+
+        return FeatureContext.create(featureInputsWithType, dummyToolInstanceName, interval,
+                featureQueryLookahead, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.test;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -33,6 +34,7 @@ public class FuncotatorTestUtils {
      * @param reference See {@link FeatureManager#FeatureManager(CommandLineProgram, int, int, int, Path)}  If uncertain, use {@code null}.
      * @return a {@link FeatureContext} ready for querying the funcotation factories on the given interval.  Never {@code null}.
      */
+    @VisibleForTesting
     public static FeatureContext createFeatureContext(final List<DataSourceFuncotationFactory> funcotationFactories, final String dummyToolInstanceName,
                                                       final SimpleInterval interval, final int featureQueryLookahead, final int cloudPrefetchBuffer,
                                                       final int cloudIndexPrefetchBuffer, final Path reference) {
@@ -44,7 +46,7 @@ public class FuncotatorTestUtils {
                 funcotationFactories.stream()
                         .collect(Collectors.toMap(ff -> ff.getMainSourceFileAsFeatureInput(), ff -> ff.getAnnotationFeatureClass()));
 
-        return FeatureContext.create(featureInputsWithType, dummyToolInstanceName, interval,
+        return FeatureContext.createFeatureContextForTesting(featureInputsWithType, dummyToolInstanceName, interval,
                 featureQueryLookahead, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference);
     }
 }

--- a/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/PIK3CA_SNPS_engine_test_chr3.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/PIK3CA_SNPS_engine_test_chr3.vcf
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.1
+##fileDate=201708028
+##source=FuncotatorTestsV0.1
+##reference=file:///Users/jonn/Development/references/Homo_sapiens_assembly19.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr3	178866587	.	G	A	40	.	.
+chr3	178916400	.	A	T	40	.	.
+chr3	178916617	.	C	T	40	.	.


### PR DESCRIPTION
- Added a `FuncotationEngine` class.  This is meant to decouple the CLI from the funcotation generation.
- Moved the querying of datasources into the funcotation factories.  This means that the funcotation factory generates the funcotations using a feature context, instead of a map of feature inputs.
- Funcotation factories now encapsulate the feature input of the source file.  Non-locatable funcotation factories will have a `null` for this attribute.