### PR TITLE
google-cloud-java: update to the official 0.59.0 release, and move off of our custom fork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.5-alpha-GCS-RETRY-FIX:shaded'
+final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.59.0-alpha:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'
@@ -159,15 +159,8 @@ configurations.all {
         force 'org.broadinstitute:barclay:' + barclayVersion
 
         // make sure we don't pick up an incorrect version of the GATK variant of the google-nio library
-        // via Picard, etc., or pick up the google variant of it
+        // via Picard, etc.
         force googleCloudNioDependency
-        componentSelection {
-            // This feature is incubating, and although it works, when its triggered it doesnt propagate
-            // the rejection message so the build fails saying it can't find google-cloud-nio.
-            withModule('com.google.cloud:google-cloud-nio') {
-                ComponentSelection selection -> selection.reject("The GATK version of this component is required")
-            }
-        }
     }
     all*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
     all*.exclude group: 'com.google.guava', module: 'guava-jdk5'

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -436,7 +436,6 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
         logger.info("Inflater: " + (usingIntelInflater ? "IntelInflater": "JdkInflater"));
 
         logger.info("GCS max retries/reopens: " + BucketUtils.getCloudStorageConfiguration(NIO_MAX_REOPENS).maxChannelReopens());
-        logger.info("Using google-cloud-java fork https://github.com/broadinstitute/google-cloud-java/releases/tag/0.20.5-alpha-GCS-RETRY-FIX");
     }
 
     /**


### PR DESCRIPTION
The google-cloud-java maintainers have merged a fix for the longstanding issue
https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2453 that prevented us
from running on a modern version of the library, and forced us to run off of a fork.
This PR updates us to the latest release, which incorporates the fix.

Resolves #3591
Resolves #3500
Resolves #4986