### PR TITLE
Intel-optimized TF 1.9, AVX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,15 @@ releases of the toolkit.
    docker client, which can be found on the [docker website](https://www.docker.com/get-docker).
 * Python Dependencies:<a name="python"></a>
     * GATK4 uses the [Conda](https://conda.io/docs/index.html) package manager to establish and manage the
-      Python environment and dependencies required by GATK tools that have a Python dependency. There are two different
-      conda environments that can be used:
-        * The ```gatk``` environment, which has no special hardware requirements. The GATK Docker image comes with the
-          "gatk" environment pre-configured.
-        * The ```gatk-intel``` environment, which requires and uses Intel (AVX2 or AVX-512) hardware acceleration to
-          increase performance.
+      Python environment and dependencies required by GATK tools that have a Python dependency. 
+    * The ```gatk``` environment requires and uses Intel hardware acceleration to increase performance (AVX, AVX2 or AVX-512 - 
+      [processors released since Sandy Bridge in 2011 are supported.](https://software.intel.com/en-us/blogs/2018/08/03/intel-optimizations-for-tensorflow-19-now-available)
     * To establish the conda environment when not using the Docker image, a conda environment must first be "created", and
       then "activated":
         * First, make sure [Miniconda or Conda](https://conda.io/docs/index.html) is installed (Miniconda is sufficient).
         * To "create" the conda environment:
             * If running from a zip or tar distribution, run the command ```conda env create -f gatkcondaenv.yml``` to
-              create the ```gatk``` environment, or the command ```conda env create -f gatkcondaenv.intel.yml``` to create
-              the ```gatk-intl``` environment.
+              create the ```gatk``` environment.
             * If running from a cloned repository, run ```./gradlew localDevCondaEnv```. This generates the Python
               package archive and conda yml dependency file(s) in the build directory, and also creates (or updates)
               the local  ```gatk``` conda environment. (To create the ```gatk-intel``` conda environment once the files

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ final docBuildDir = "$buildDir/docs"
 final pythonPackageArchiveName = 'gatkPythonPackageArchive.zip'
 final gatkCondaTemplate = "gatkcondaenv.yml.template"
 final gatkCondaYML = "gatkcondaenv.yml"
-final gatkCondaIntelYML = "gatkcondaenv.intel.yml"
 final largeResourcesFolder = "src/main/resources/large"
 final buildPrerequisitesMessage = "See https://github.com/broadinstitute/gatk#building for information on how to build GATK."
 
@@ -568,7 +567,6 @@ task collectBundleIntoDir(type: Copy) {
 
     from("$buildDir/$pythonPackageArchiveName")
     from("$buildDir/$gatkCondaYML")
-    from("$buildDir/$gatkCondaIntelYML")
     from("scripts/sv", { into("scripts/sv") })
     from("scripts/cnv_wdl/", { into("scripts/cnv_wdl") })
     from("scripts/mutect2_wdl/", { into("scripts/mutect2_wdl") })
@@ -609,31 +607,17 @@ task condaStandardEnvironmentDefinition(type: Copy) {
     include gatkCondaTemplate
     rename { file -> gatkCondaYML }
     expand(["condaEnvName":"gatk",
-            "condaEnvDescription" : "Conda environment for GATK Python Tools",
-            "tensorFlowDependency" : "tensorflow==$tensorflowVersion"])
+            "condaEnvDescription" : "Conda environment for GATK Python Tools"])
     doLast {
         logger.lifecycle("Created standard Conda environment yml file: $gatkCondaYML")
     }
 }
 
-task condaIntelEnvironmentDefinition(type: Copy) {
-    from "scripts"
-    into buildDir
-    include gatkCondaTemplate
-    rename { file -> gatkCondaIntelYML }
-    expand(["condaEnvName":"gatk-intel",
-            "condaEnvDescription" : "Conda environment for GATK Python Tools running with Intel hardware acceleration",
-            "tensorFlowDependency" :
-                    "https://anaconda.org/intel/tensorflow/$tensorflowVersion/download/tensorflow-$tensorflowVersion-cp36-cp36m-linux_x86_64.whl"])
-    doLast {
-        logger.lifecycle("Created Intel Conda environment yml file: $gatkCondaIntelYML")
-    }
-}
 
-// Create two GATK conda environment yml files from the conda enc template
-// (one for standard GATK and one for running GATK with Intel hardware).
+// Create a GATK conda environment yml file from the conda enc template
+// (used TensorFlow with Intel hardware acceleration).
 task condaEnvironmentDefinition() {
-    dependsOn 'pythonPackageArchive', 'condaStandardEnvironmentDefinition', 'condaIntelEnvironmentDefinition'
+    dependsOn 'pythonPackageArchive', 'condaStandardEnvironmentDefinition'
 }
 
 // Create the Python package archive file

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -14,6 +14,8 @@ dependencies:
 - readline=6.2=2
 - setuptools=36.4.0=py36_1
 - sqlite=3.13.0=0
+- tensorflow=1.9.0
+- tensorflow-base=1.9.0
 - tk=8.5.18=0
 - wheel=0.29.0=py36_0
 - xz=5.2.3=0
@@ -43,7 +45,6 @@ dependencies:
   - scikit-learn==0.19.1
   - scipy==1.0.0
   - six==1.11.0
-  - $tensorFlowDependency
   - tensorflow-tensorboard==0.4.0rc3
   - theano==0.9.0
   - tqdm==4.19.4


### PR DESCRIPTION
The Intel-optimized version of TensorFlow 1.9 is now the default for Anaconda users. It now supports all processors with AVX - so everything since Sandy Bridge, which was released in 2011.  With that in mind, I was thinking we could dispense with two different conda environments and fold everything into the ```gatk``` environment.  @samuelklee , I'm the new guy on the Intel team you've been dealing with.