### PR TITLE
Updated datasource version parsing

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
@@ -461,7 +461,7 @@ final public class DataSourceUtils {
      * We assume the data sources path is OK in the case that the version information cannot be read because the
      * user can create their own data sources directory, which may not contain the metadata we seek.
      *
-     * NOTE: The README file in a Data Sources directory is assumed to have the following properties:
+     * NOTE: The MANIFEST file in a Data Sources directory is assumed to have the following properties:
      *       - Its name must be {@link #MANIFEST_FILE_NAME}
      *       - It must contain a line starting with {@link #MANIFEST_VERSION_LINE_START} containing an alphanumeric string containing the version number information.
      *           - This version information takes the form of:


### PR DESCRIPTION
Now looks at manifest file, not readme.
Now supports version decorators (e.g. `somatic`) after version numbers in manifest file.
Added in a unit test to check the version regex.

Fixes #4582 
Fixes #4692 