### PR TITLE
Fix Edge Cases in Reference Bases

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/NonStandardMutectAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/NonStandardMutectAnnotation.java
@@ -1,5 +1,0 @@
-package org.broadinstitute.hellbender.tools.walkers.annotator;
-
-public interface NonStandardMutectAnnotation extends Annotation {
-
-}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OrientationBiasMixtureModelAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OrientationBiasMixtureModelAnnotation.java
@@ -1,0 +1,5 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator;
+
+public interface OrientationBiasMixtureModelAnnotation extends Annotation {
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadOrientationArtifact.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReadOrientationArtifact.java
@@ -28,7 +28,7 @@ import static org.broadinstitute.hellbender.tools.walkers.readorientation.F1R2Fi
  * Computes the posterior probability of orientation bias. Uses the prior artifact probability calculated in
  * {@link LearnReadOrientationModel}
  */
-public class ReadOrientationArtifact extends GenotypeAnnotation implements NonStandardMutectAnnotation {
+public class ReadOrientationArtifact extends GenotypeAnnotation implements OrientationBiasMixtureModelAnnotation {
     private ArtifactPriorCollection artifactPriorCollection;
     private int minimumBaseQuality = 20;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
@@ -4,6 +4,7 @@ import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import org.apache.commons.lang.StringUtils;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -29,6 +30,7 @@ public class ReferenceBases extends InfoFieldAnnotation implements StandardMutec
     public static final String REFERENCE_BASES_KEY = "REF_BASES";
 
     private int NUM_BASES_ON_EITHER_SIDE = 10;
+    private int REFERENCE_CONTEXT_LENGTH = 2*NUM_BASES_ON_EITHER_SIDE + 1;
 
     protected final OneShotLogger warning = new OneShotLogger(this.getClass());
 
@@ -45,7 +47,12 @@ public class ReferenceBases extends InfoFieldAnnotation implements StandardMutec
         }
         final int basesToDiscardInFront = Math.max(vc.getStart() - ref.getWindow().getStart() - NUM_BASES_ON_EITHER_SIDE, 0);
         final String allBases = new String(ref.getBases());
-        final String localBases = allBases.substring(basesToDiscardInFront, basesToDiscardInFront + 2 * NUM_BASES_ON_EITHER_SIDE + 1);
+        final int endIndex = Math.min(basesToDiscardInFront + 2 * NUM_BASES_ON_EITHER_SIDE + 1, allBases.length());
+        String localBases = allBases.substring(basesToDiscardInFront, endIndex);
+        if (localBases.length() < REFERENCE_CONTEXT_LENGTH) {
+            localBases = String.join("", localBases, StringUtils.repeat("N", REFERENCE_CONTEXT_LENGTH - localBases.length()));
+        }
+
         return Collections.singletonMap(REFERENCE_BASES_KEY, localBases );
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
@@ -26,7 +26,7 @@ import java.util.Map;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Annotate with local reference bases (REF_BASES)")
-public class ReferenceBases extends InfoFieldAnnotation implements StandardMutectAnnotation {
+public class ReferenceBases extends InfoFieldAnnotation implements OrientationBiasMixtureModelAnnotation {
     public static final String REFERENCE_BASES_KEY = "REF_BASES";
 
     private int NUM_BASES_ON_EITHER_SIDE = 10;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.ReadOrientationArtifact;
+import org.broadinstitute.hellbender.tools.walkers.annotator.ReferenceBases;
 import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
 import org.broadinstitute.hellbender.utils.downsampling.MutectDownsampler;
@@ -195,9 +196,11 @@ public final class Mutect2 extends AssemblyRegionWalker {
     @Override
     public Collection<Annotation> makeVariantAnnotations(){
         final Collection<Annotation> annotations = super.makeVariantAnnotations();
+
         if (MTAC.artifactPriorTable != null){
             // Enable the annotations associated with the read orientation model
             annotations.add(new ReadOrientationArtifact(MTAC.artifactPriorTable));
+            annotations.add(new ReferenceBases());
         }
         return annotations;
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBasesUnitTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
  * Created by davidben on 3/23/17.
  */
 public class ReferenceBasesUnitTest extends GATKBaseTest {
-
     @Test
     public void test() {
         final Path refFasta = IOUtils.getPath(b37_reference_20_21);
@@ -40,6 +39,18 @@ public class ReferenceBasesUnitTest extends GATKBaseTest {
         final String refBases = (String) new ReferenceBases().annotate(null, vc, null)
                 .get(ReferenceBases.REFERENCE_BASES_KEY);
         Assert.assertNull(refBases);
+    }
+
+    @Test
+    public void testEndOfChromosome(){
+        final Path refFasta = IOUtils.getPath(v37_chr17_1Mb_Reference);
+
+        final ReferenceDataSource refDataSource = new ReferenceFileSource(refFasta);
+        final ReferenceContext ref = new ReferenceContext(refDataSource, new SimpleInterval("17", 1_000_000 - 300, 1_000_000));
+        final VariantContext vc = new VariantContextBuilder("source", "17", 1_000_000 - 5, 1_000_000 - 5, Collections.singleton(Allele.create((byte) 'A', true))).make();
+        final String refBases = (String) new ReferenceBases().annotate(ref, vc, null)
+                .get(ReferenceBases.REFERENCE_BASES_KEY);
+        Assert.assertEquals(refBases, "AGCTGGGGAAGGGGGGNNNNN");
     }
 
 


### PR DESCRIPTION
(Reported in #5130)

We had a user report that when a variant is within 10 base pairs from the end of the chromosome (as defined by the reference dictionary), `ReferenceBases` throws a String index out of range error. This bug was in the annotation prior to #4895. What #4895 did was that it made the `ReferenceBases` annotation part of `StandardMutectAnnotation,` which turned on `RefernceBases` by default, and that led to the user getting the error. 