### PR TITLE
SV read depth integration

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromReadDepthArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/DiscoverVariantsFromReadDepthArgumentCollection.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.hellbender.tools.spark.sv;
+
+import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
+
+import java.io.Serializable;
+
+public class DiscoverVariantsFromReadDepthArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final int DEFAULT_MIN_EVENT_SIZE = 50;
+    public static final int DEFAULT_INSERT_SIZE = 350;
+    public static final int DEFAULT_PLOIDY = 2;
+    public static final int DEFAULT_MIN_GRAPH_EVIDENCE_READ_PAIRS = 2;
+    public static final double DEFAULT_GRAPH_PARTITION_RECIPROCAL_OVERLAP = 0.9;
+    public static final int DEFAULT_MAX_GRAPH_BRANCHES = 100000;
+    public static final double DEFAULT_MIN_EVENT_PROBABILITY = 0.95;
+    public static final double DEFAULT_MAX_GRAPH_PATH_LENGTH_FACTOR = 10.0;
+    public static final int DEFAULT_MAX_GRAPH_EDGE_VISITS = 5;
+    public static final double DEFAULT_MIN_HAPLOTYPE_OUTPUT_PROBABILITY = 0.1;
+
+    public static final String MIN_EVENT_SIZE_LONG_NAME = "min-size";
+    public static final String INSERT_SIZE_LONG_NAME = "insert-size";
+    public static final String PLOIDY_LONG_NAME = "ploidy";
+    public static final String MIN_EVIDENCE_READ_PAIRS_LONG_NAME = "min-evidence-read-pairs";
+    public static final String GRAPH_PARTITION_RECIPROCAL_LONG_NAME = "partition-ro";
+    public static final String MAX_GRAPH_BRANCHES_LONG_NAME = "max-branches";
+    public static final String MIN_EVENT_PROBABILITY_LONG_NAME = "min-event-prob";
+    public static final String MAX_GRAPH_PATH_LENGTH_FACTOR_LONG_NAME = "max-path-length-factor";
+    public static final String MAX_GRAPH_EDGE_VISITS_LONG_NAME = "max-edge-visits";
+    public static final String MIN_HAPLOTYPE_OUTPUT_PROBABILITY_LONG_NAME = "min-haplotype-prob";
+
+    @Argument(doc = "Min event size (bp)",
+            fullName = MIN_EVENT_SIZE_LONG_NAME, optional = true)
+    public int minEventSize = DEFAULT_MIN_EVENT_SIZE;
+
+    @Argument(doc = "Library insert size (bp)",
+            fullName = INSERT_SIZE_LONG_NAME, optional = true)
+    public int insertSize = DEFAULT_INSERT_SIZE;
+
+    @Argument(doc = "Autosomal ploidy",
+            fullName = PLOIDY_LONG_NAME, optional = true)
+    public int ploidy = DEFAULT_PLOIDY;
+
+    @Argument(doc = "Min haplotype probability for output",
+            fullName = MIN_HAPLOTYPE_OUTPUT_PROBABILITY_LONG_NAME, optional = true)
+    public double minHaplotypeProb = DEFAULT_MIN_HAPLOTYPE_OUTPUT_PROBABILITY;
+
+    @Argument(doc = "Min called event probability",
+            fullName = MIN_EVENT_PROBABILITY_LONG_NAME, optional = true)
+    public double minEventProb = DEFAULT_MIN_EVENT_PROBABILITY;
+
+    @Advanced
+    @Argument(doc = "Min number pairs for read pair evidence clusters",
+            fullName = MIN_EVIDENCE_READ_PAIRS_LONG_NAME, optional = true)
+    public int minLinkReadPairs = DEFAULT_MIN_GRAPH_EVIDENCE_READ_PAIRS;
+
+    @Advanced
+    @Argument(doc = "Min reciprocal overlap for fully overlapping subgraphs to be merged",
+            fullName = GRAPH_PARTITION_RECIPROCAL_LONG_NAME, optional = true)
+    public double paritionReciprocalOverlap = DEFAULT_GRAPH_PARTITION_RECIPROCAL_OVERLAP;
+
+    @Advanced
+    @Argument(doc = "Max number of queued path branches to hold in memory",
+            fullName = MAX_GRAPH_BRANCHES_LONG_NAME, optional = true)
+    public int maxBranches = DEFAULT_MAX_GRAPH_BRANCHES;
+
+    @Advanced
+    @Argument(doc = "Max path length as a multiple of the number of reference edges",
+            fullName = MAX_GRAPH_PATH_LENGTH_FACTOR_LONG_NAME, optional = true)
+    public double maxPathLengthFactor = DEFAULT_MAX_GRAPH_PATH_LENGTH_FACTOR;
+
+    @Advanced
+    @Argument(doc = "Max number of visits allowed per edge",
+            fullName = MAX_GRAPH_EDGE_VISITS_LONG_NAME, optional = true)
+    public int maxEdgeVisits = DEFAULT_MAX_GRAPH_EDGE_VISITS;
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromReadDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/DiscoverVariantsFromReadDepth.java
@@ -1,0 +1,289 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFFileReader;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariantDiscoveryProgramGroup;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.spark.sv.DiscoverVariantsFromReadDepthArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth.*;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.utils.GenomeLocParser;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Call structural variants using SV evidence and germline CNV (gCNV) copy number calls
+ *
+ * <p>See StructuralVariationDiscoveryPipelineSpark and GermlineCNVCaller for information on the prerequisite pipelines.</p>
+ *
+ * <p>This tool is currently designed for detecting large (>5kbp) intrachromosomal events.</p>
+ *
+ * <h3>Methods</h3>
+ *
+ * <p>The tool looks for events supported by a combination of discordant read pairs (RP), split reads (SR), SV pipeline calls (SVPCs),
+ * assembled breakpoint pairs (BNDs), and copy number interval calls (a posterior likelihoods).</p>
+ *
+ * <p>Events are resolved using a graph-based approach that integrates all of the evidence types. A sequence graph is assembled
+ * from RP, SR, SVPC, and BND evidence. All possible paths on the graph are systematically enumerated, and the probability of each
+ * path is calculated based on copy number posteriors. Calls are made for each event type (DEL, DUP, INV, DUP_INV) by summing
+ * the probability over all paths at each reference position. Events with probability above a minimum threshold are then called.
+ * This approach is able to enumerate all possible haplotype combinations and resolve simple events comprising complex ones.</p>
+ *
+ * <p>Note that enumerating all paths across the entire genome would be computationally intractable. Therefore, the method employs a divide-and-conquer
+ * strategy, in which the full graph is partitioned into subgraphs that likely represent independent events. This permits path
+ * enumeration over most of the genome. In some partitions, however, local breakpoint complexity still results in combinatorial
+ * explosion of path branching. These cases are reported in the output as unresolved events (type U).</p>
+ *
+ * <h3>Input</h3>
+ *
+ * <ul>
+     * <li>Structural variant call VCF</li>
+     * <li>Breakpoint (BND) VCF</li>
+     * <li>Germline CNV interval calls VCF</li>
+     * <li>Evidence target links .bedpe file from StructuralVariationDiscoveryPipelineSpark</li>
+     * <li>High-coverage intervals from StructuralVariationDiscoveryPipelineSpark (optional)</li>
+     * <li>Blacklisted intervals file (optional)</li>
+ * </ul>
+ *
+ * <h3>Output</h3>
+ *
+ * <ul>
+     * <li>Event calls file</li>
+     * <li>Unresolved event intervals file/li>
+     * <li>Event haplotypes file</li>
+ * </ul>
+ *
+ * <p>The tool may also optionally produce:</p>
+ *
+ * <ul>
+ * <li>Breakpoint graph file</li>
+ * </ul>
+ *
+ * <h3>Usage example</h3>
+ *
+ * <pre>
+ * gatk DiscoverVariantsFromReadDepth  \
+ *   --sv-calls-vcf calls.vcf \
+ *   --bnd-vcf breakpoints.vcf \
+ *   --evidence-target-links-file target_links.bedpe \
+ *   --cnv-intervals-file genotyped-intervals.vcf \
+ *   --output output/
+ * </pre>
+ *
+ * @author Mark Walker &lt;markw@broadinstitute.org&gt;
+ */
+
+@ExperimentalFeature
+@CommandLineProgramProperties(
+        oneLineSummary = "Discovers structural variants using SV evidence and read depth",
+        summary = "This tool uses the output from StructuralVariationDiscoveryPipelineSpark and the gCNV pipeline " +
+                "to call structural variation events.",
+        programGroup = StructuralVariantDiscoveryProgramGroup.class)
+public final class DiscoverVariantsFromReadDepth extends CommandLineProgram {
+
+    public static final String SV_CALLS_LONG_NAME = "sv-calls-vcf";
+    public static final String BREAKPOINTS_LONG_NAME = "bnd-vcf";
+    public static final String EVIDENCE_TARGET_LINKS_LONG_NAME = "evidence-target-links-file";
+    public static final String CNV_INTERVALS_LONG_NAME = "cnv-intervals-file";
+    public static final String HIGH_COVERAGE_INTERVALS_LONG_NAME = "high-coverage-intervals";
+    public static final String BLACKLIST_LONG_NAME = "blacklist";
+    public static final String GRAPH_OUTPUT_LONG_NAME = "write-graph";
+
+    public static final String RESOLVED_CALLS_FILE_NAME = "calls";
+    public static final String UNRESOLVED_CALLS_FILE_NAME = "unresolved";
+    public static final String HAPLOTYPES_FILE_NAME = "haplotypes";
+    public static final String GRAPH_FILE_NAME = "graph";
+
+    private final DiscoverVariantsFromReadDepthArgumentCollection arguments = new DiscoverVariantsFromReadDepthArgumentCollection();
+
+    @Argument(doc = "Sequence dictionary", fullName = "sequence-dictionary")
+    private String sequenceDictionaryPath;
+    @Argument(doc = "BND list (.vcf)", fullName = BREAKPOINTS_LONG_NAME)
+    private String breakpointVCFPath;
+    @Argument(doc = "Structural variant calls list (.vcf)", fullName = SV_CALLS_LONG_NAME)
+    private String svCallVCFPath;
+    @Argument(doc = "Evidence target links file (.bedpe)", fullName = EVIDENCE_TARGET_LINKS_LONG_NAME)
+    private String evidenceTargetLinksFilePath;
+    @Argument(doc = "Germline CNV (gCNV) interval calls (.vcf)", fullName = CNV_INTERVALS_LONG_NAME)
+    private String intervalCallsFilePath;
+    @Argument(doc = "High coverage intervals file path", fullName = HIGH_COVERAGE_INTERVALS_LONG_NAME, optional = true)
+    private String highCoverageIntervalsPath;
+    @Argument(doc = "One or more blacklisted intervals files", fullName = BLACKLIST_LONG_NAME, optional = true)
+    private List<String> blacklistedPaths;
+    @Argument(doc = "Output directory path (must exist)", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
+    private String outputDirectoryPath;
+    @Argument(doc = "Sample name", shortName = StandardArgumentDefinitions.SAMPLE_NAME_SHORT_NAME, fullName = StandardArgumentDefinitions.SAMPLE_NAME_LONG_NAME)
+    private String sampleName;
+    @Argument(doc = "Write graph output", fullName = GRAPH_OUTPUT_LONG_NAME, optional = true)
+    private boolean writeGraph = false;
+
+    @Override
+    public Object doWork() {
+
+        //Read input data
+        final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(BucketUtils.openFile(sequenceDictionaryPath));
+        final List<SVInterval> highCoverageIntervals = getIntervals(highCoverageIntervalsPath, dictionary);
+        final List<SVInterval> blacklist = new ArrayList<>();
+        for (final String path : blacklistedPaths) {
+            blacklist.addAll(getIntervals(path, dictionary));
+        }
+        final Collection<VariantContext> breakpointCalls = readVCF(breakpointVCFPath, dictionary);
+        final Collection<VariantContext> svCalls = readVCF(svCallVCFPath, dictionary);
+        final List<SVCopyNumberInterval> copyNumberIntervals = getCalledCopyNumberIntervals(intervalCallsFilePath, dictionary);
+        final Collection<EvidenceTargetLink> evidenceTargetLinks = getEvidenceTargetLinks(evidenceTargetLinksFilePath, dictionary);
+
+        //Create graph
+        final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree = SVIntervalUtils.buildCopyNumberIntervalTree(copyNumberIntervals);
+        final SVEvidenceIntegrator evidenceIntegrator = new SVEvidenceIntegrator(breakpointCalls, svCalls, evidenceTargetLinks, copyNumberPosteriorsTree, highCoverageIntervals, blacklist, dictionary, arguments);
+        final SVGraph graph = evidenceIntegrator.buildGraph();
+
+        //Call events
+        final ReadDepthSVCaller caller = new ReadDepthSVCaller(graph, copyNumberPosteriorsTree, arguments);
+        final Tuple2<Collection<CalledSVGraphGenotype>, Collection<CalledSVGraphEvent>> callResult = caller.callEvents();
+        final Collection<CalledSVGraphGenotype> haplotypes = callResult._1;
+        final Collection<CalledSVGraphEvent> events = callResult._2;
+
+        //Write output
+        final Collection<CalledSVGraphEvent> resolvedEvents = events.stream().filter(CalledSVGraphEvent::isResolved).collect(Collectors.toList());
+        final Collection<CalledSVGraphEvent> unresolvedEvents = events.stream().filter(event -> !event.isResolved()).collect(Collectors.toList());
+        writeEvents(resolvedEvents, RESOLVED_CALLS_FILE_NAME, dictionary);
+        writeEvents(unresolvedEvents, UNRESOLVED_CALLS_FILE_NAME, dictionary);
+        writeHaplotypes(haplotypes);
+        if (writeGraph) {
+            writeGraph(graph);
+        }
+        return null;
+    }
+
+    /**
+     * Reads VCF to collection of VariantContext
+     */
+    private static Collection<VariantContext> readVCF(final String vcfPath, final SAMSequenceDictionary dictionary) {
+        try (final FeatureDataSource<VariantContext> dataSource =
+                     new FeatureDataSource<>(vcfPath, null, 0, VariantContext.class)) {
+            Collection<VariantContext> variants = Utils.stream(dataSource.iterator()).collect(Collectors.toList());
+            if (variants.stream().anyMatch(variant -> dictionary.getSequenceIndex(variant.getContig()) < 0)) {
+                throw new UserException("Found a VCF entry contig that does not appear in the dictionary.");
+            }
+            return variants;
+        }
+    }
+
+    /**
+     * Reads intervals file to SVInterval list
+     */
+    private static List<SVInterval> getIntervals(final String path, final SAMSequenceDictionary dictionary) {
+        if (path == null) {
+            return Collections.emptyList();
+        }
+        final GenomeLocParser genomeLocParser = new GenomeLocParser(dictionary);
+        return IntervalUtils.parseIntervalArguments(genomeLocParser, path).stream()
+                .map(genomeLoc -> new SVInterval(genomeLoc.getContigIndex(), genomeLoc.getStart(), genomeLoc.getEnd()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Reads CNV interval calls to list of SVCopyNumberInterval
+     */
+    private static List<SVCopyNumberInterval> getCalledCopyNumberIntervals(final String path, final SAMSequenceDictionary dictionary) {
+        final File file = new File(path);
+        if (path.toLowerCase().endsWith(IOUtil.VCF_FILE_EXTENSION.toLowerCase()) || path.toLowerCase().endsWith(IOUtil.COMPRESSED_VCF_FILE_EXTENSION.toLowerCase())) {
+            final VCFFileReader reader = new VCFFileReader(file, false);
+            return Utils.stream(reader.iterator()).map(variantContext -> new SVCopyNumberInterval(variantContext, dictionary)).collect(Collectors.toList());
+        }
+        throw new UserException.BadInput("CNV intervals file must be " + IOUtil.VCF_FILE_EXTENSION + " or " + IOUtil.COMPRESSED_VCF_FILE_EXTENSION);
+    }
+
+    /**
+     * Reads evidence target links file
+     */
+    private static Collection<EvidenceTargetLink> getEvidenceTargetLinks(final String path, final SAMSequenceDictionary dictionary) {
+        final File file = new File(path);
+        final Collection<EvidenceTargetLink> links = new ArrayList<>();
+        final String[] evidenceTargetFileLines = new String(IOUtils.readFileIntoByteArray(file)).split("\n");
+        for (final String line : evidenceTargetFileLines) {
+            links.add(EvidenceTargetLink.fromBedpeString(line.trim(), dictionary));
+        }
+        return links;
+    }
+
+    /**
+     * Writes events collection to BED file
+     */
+    private void writeEvents(final Collection<CalledSVGraphEvent> events, final String name, final SAMSequenceDictionary dictionary) {
+        final String fileName = sampleName + "-" + name + ".bed";
+        final String filePath = Paths.get(outputDirectoryPath, fileName).toAbsolutePath().toString();
+        try (final OutputStream outputStream = BucketUtils.createFile(filePath)) {
+            outputStream.write(("#" + CalledSVGraphEvent.bedHeader() + "\n").getBytes());
+            for (final CalledSVGraphEvent event : events) {
+                outputStream.write((event.bedString(dictionary) + "\n").getBytes());
+            }
+        } catch (final IOException e) {
+            throw new GATKException("Error writing calls BED file", e);
+        }
+    }
+
+    /**
+     * Writes haplotypes collection to BED file
+     */
+    private void writeHaplotypes(final Collection<CalledSVGraphGenotype> haplotypes) {
+        final String fileName = sampleName + "-" + HAPLOTYPES_FILE_NAME + ".bed";
+        final String filePath = Paths.get(outputDirectoryPath, fileName).toAbsolutePath().toString();
+        try (final OutputStream outputStream = BucketUtils.createFile(filePath)) {
+            outputStream.write(("#" + CalledSVGraphGenotype.bedHeader() + "\n").getBytes());
+            for (final CalledSVGraphGenotype haplotype : haplotypes) {
+                final List<String> lines = haplotype.bedStrings();
+                for (final String line : lines) {
+                    outputStream.write((line + "\n").getBytes());
+                }
+            }
+        } catch (final IOException e) {
+            throw new GATKException("Error writing haplotypes BED file", e);
+        }
+    }
+
+    /**
+     * Writes graph edges to tsv file
+     */
+    private void writeGraph(final SVGraph graph) {
+        final String fileName = sampleName + "-" + GRAPH_FILE_NAME + ".tsv";
+        final String filePath = Paths.get(outputDirectoryPath, fileName).toAbsolutePath().toString();
+        try (final OutputStream outputStream = BucketUtils.createFile(filePath)) {
+            outputStream.write(("sourceContig\ttargetContig\tsource\ttarget\tsourceStrand\ttargetStrand\tisReference\torientation\n").getBytes());
+            for (final IndexedSVGraphEdge indexedEdge : graph.getEdges()) {
+                final CoordinateSVGraphEdge edge = new CoordinateSVGraphEdge(indexedEdge, graph.generateNodes());
+                final String orientation = (edge.isStrandA() ? "R" : "L") + (edge.isStrandB() ? "R" : "L") + (edge.isReference() ? "_r" : "");
+                outputStream.write((edge.getContigA() + "\t" + edge.getContigB() + "\t" + (edge.getContigA() + ":" + edge.getNodeAPosition()) + "\t" + (edge.getContigB() + ":" + edge.getNodeBPosition()) + "\t" + edge.isStrandA() + "\t" + edge.isStrandB() + "\t" + edge.isReference() + "\t" + orientation + "\n").getBytes());
+            }
+        } catch (final IOException e) {
+            throw new GATKException("Error writing graph to " + filePath);
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEvent.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEvent.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Arrays;
+
+/**
+ * Structural variants called using an SVGraph
+ */
+public final class CalledSVGraphEvent {
+
+    public enum Type {
+        DEL,
+        DUP,
+        INV,
+        DUP_INV,    //Duplicated inversion
+        UR          //Unresolved
+    }
+
+    public static String CONTIG_COLUMN_STRING = "CHR";
+    public static String START_COLUMN_STRING = "POS";
+    public static String END_COLUMN_STRING = "END";
+    public static String TYPE_COLUMN_STRING = "TYPE";
+    public static String SIZE_COLUMN_STRING = "SIZE";
+    
+    private final int groupId;
+    private final int pathId;
+    private final Type type;
+    private final SVInterval interval;
+    private final boolean resolved; //False if solution not found
+
+    public CalledSVGraphEvent(final Type type, final SVInterval interval,
+                              final int groupId, final int pathId, final boolean resolved) {
+        Utils.nonNull(type, "Type cannot be null");
+        Utils.nonNull(interval, "Interval cannot be null");
+        this.type = type;
+        this.interval = interval;
+        this.groupId = groupId;
+        this.pathId = pathId;
+        this.resolved = resolved;
+    }
+
+    public boolean isResolved() {
+        return resolved;
+    }
+
+    public int getGroupId() {
+        return groupId;
+    }
+
+    public int getPathId() {
+        return pathId;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public SVInterval getInterval() {
+        return interval;
+    }
+
+    public static String bedHeader() {
+        return String.join("\t", Arrays.asList(CONTIG_COLUMN_STRING, START_COLUMN_STRING, END_COLUMN_STRING, TYPE_COLUMN_STRING, SIZE_COLUMN_STRING, CalledSVGraphGenotype.GRAPH_ID_COLUMN, CalledSVGraphGenotype.GENOTYPE_ID_COLUMN));
+    }
+
+    public String bedString(final SAMSequenceDictionary dictionary) {
+        final SimpleInterval simpleInterval = SVIntervalUtils.convertToSimpleInterval(interval, dictionary);
+        return simpleInterval.getContig() + "\t" + simpleInterval.getStart() + "\t" + simpleInterval.getEnd() + "\t" +
+                getType().toString() + "\t" + getInterval().getLength() + "\t" + getGroupId() + "\t" + getPathId();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEvent.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEvent.java
@@ -69,6 +69,7 @@ public final class CalledSVGraphEvent {
     }
 
     public String bedString(final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(dictionary, "Dictionary cannot be null");
         final SimpleInterval simpleInterval = SVIntervalUtils.convertToSimpleInterval(interval, dictionary);
         return simpleInterval.getContig() + "\t" + simpleInterval.getStart() + "\t" + simpleInterval.getEnd() + "\t" +
                 getType().toString() + "\t" + getInterval().getLength() + "\t" + getGroupId() + "\t" + getPathId();

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphGenotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphGenotype.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Called haplotypes class with associated list of coordinate-defined paths (for output)
+ */
+public final class CalledSVGraphGenotype extends SVGraphGenotype {
+
+    private final List<CoordinateSVGraphPath> coordinatePaths;
+
+    public final static String GRAPH_ID_COLUMN = "GID";
+    public final static String GENOTYPE_ID_COLUMN = "GTID";
+    public final static String HAPLOTYPE_ID_COLUMN = "HID";
+    public final static String LIKELIHOOD_COLUMN = "LIK";
+    public final static String PROBABILITY_COLUMN = "P";
+    public final static String PATHS_COLUMN = "PATHS";
+
+    public CalledSVGraphGenotype(final SVGraphGenotype genotype, final SVGraph graph) {
+        super(genotype.getGroupId(), genotype.getGenotypeId(), genotype.getLikelihood());
+        this.probability = genotype.getProbability();
+        this.coordinatePaths = genotype.getHaplotypes().stream().map(path -> path.convertToCoordinatePath(graph)).collect(Collectors.toList());
+    }
+
+    public static String bedHeader() {
+        return String.join("\t", Arrays.asList(GRAPH_ID_COLUMN, GENOTYPE_ID_COLUMN, HAPLOTYPE_ID_COLUMN, LIKELIHOOD_COLUMN, PROBABILITY_COLUMN, PATHS_COLUMN));
+    }
+
+    public List<String> bedStrings() {
+        final List<String> pathStrings = coordinatePaths.stream().map(CoordinateSVGraphPath::toString).collect(Collectors.toList());
+        final List<String> lines = new ArrayList<>(pathStrings.size());
+        for (int haplotypeId = 0; haplotypeId < pathStrings.size(); haplotypeId++) {
+            lines.add(getGroupId() + "\t" + getGenotypeId() + "\t" + haplotypeId + "\t" +
+                    getLikelihood() + "\t" + getProbability() + "\t" + pathStrings.get(haplotypeId));
+        }
+        return lines;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CoordinateSVGraphEdge.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CoordinateSVGraphEdge.java
@@ -1,0 +1,124 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.List;
+
+/**
+ * Graph edge class with endpoint coordinates A and B, where A < B in dictionary sorted order
+ */
+public final class CoordinateSVGraphEdge {
+    private final int contigA;
+    private final int contigB;
+    private final int nodeAPosition;
+    private final int nodeBPosition;
+    private final boolean strandA;
+    private final boolean strandB;
+    private final boolean inverted;
+    private final boolean isReference;
+    private final SVGraphEdgeEvidence evidence;
+
+    public CoordinateSVGraphEdge(final int contig1, final int position1, final boolean strand1,
+                                 final int contig2, final int position2, final boolean strand2,
+                                 final boolean isReference, final SVGraphEdgeEvidence evidence,
+                                 final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(evidence, "Evidence cannot be null");
+        Utils.nonNull(dictionary, "Sequence dictionary cannot be null");
+        Utils.validateArg(contig1 == contig2, "Interchromosomal edges not currently supported");
+        final SimpleInterval interval1 = SVIntervalUtils.createSimpleInterval(contig1, position1, position1 + 1, dictionary);
+        final SimpleInterval interval2 = SVIntervalUtils.createSimpleInterval(contig2, position2, position2 + 1, dictionary);
+        if (IntervalUtils.compareLocatables(interval1, interval2, dictionary) < 0) {
+            contigA = contig1;
+            contigB = contig2;
+            nodeAPosition = position1;
+            nodeBPosition = position2;
+            strandA = strand1;
+            strandB = strand2;
+        } else {
+            contigA = contig2;
+            contigB = contig1;
+            nodeAPosition = position2;
+            nodeBPosition = position1;
+            strandA = strand2;
+            strandB = strand1;
+        }
+        this.isReference = isReference;
+        this.inverted = false;
+        this.evidence = evidence;
+    }
+
+    public CoordinateSVGraphEdge(final IndexedSVGraphEdge indexedEdge, final List<SVGraphNode> nodes) {
+        Utils.nonNull(indexedEdge, "Indexed edge cannot be null");
+        Utils.nonNull(nodes, "Nodes list cannot be null");
+        Utils.validateArg(indexedEdge.getNodeAIndex() < nodes.size() && indexedEdge.getNodeAIndex() >= 0, "Edge node A index must be non-negative and less than node list size");
+        Utils.validateArg(indexedEdge.getNodeBIndex() < nodes.size() && indexedEdge.getNodeBIndex() >= 0, "Edge node B index must be non-negative and less than node list size");
+        final SVGraphNode nodeA = nodes.get(indexedEdge.getNodeAIndex());
+        final SVGraphNode nodeB = nodes.get(indexedEdge.getNodeBIndex());
+        contigA = nodeA.getContig();
+        contigB = nodeB.getContig();
+        nodeAPosition = nodeA.getPosition();
+        nodeBPosition = nodeB.getPosition();
+        isReference = indexedEdge.isReference();
+        strandA = indexedEdge.isStrandA();
+        strandB = indexedEdge.isStrandB();
+        inverted = indexedEdge.isInverted();
+        evidence = indexedEdge.getEvidence();
+    }
+
+    public SVGraphEdgeEvidence getEvidence() {
+        return evidence;
+    }
+
+    public SVInterval getInterval() {
+        if (contigA != contigB) return null;
+        if (nodeAPosition < nodeBPosition) return new SVInterval(contigA, nodeAPosition, nodeBPosition);
+        return new SVInterval(contigA, nodeBPosition, nodeAPosition);
+    }
+
+    public SVInterval getIntervalA() {
+        return new SVInterval(getContigA(), getNodeAPosition(), getNodeAPosition() + 1);
+    }
+
+    public SVInterval getIntervalB() {
+        return new SVInterval(getContigB(), getNodeBPosition(), getNodeBPosition() + 1);
+    }
+
+    public boolean isIntrachromosomal() { return contigA == contigB; }
+
+    public int getContigA() {
+        return contigA;
+    }
+
+    public int getContigB() {
+        return contigB;
+    }
+
+    public int getNodeAPosition() {
+        return nodeAPosition;
+    }
+
+    public int getNodeBPosition() {
+        return nodeBPosition;
+    }
+
+    public boolean isStrandA() {
+        return strandA;
+    }
+
+    public boolean isStrandB() {
+        return strandB;
+    }
+
+    public boolean isReference() {
+        return isReference;
+    }
+
+    public boolean isInverted() {
+        return inverted;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CoordinateSVGraphPath.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CoordinateSVGraphPath.java
@@ -1,0 +1,71 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Graph path class with edges defined in coordinates
+ */
+public final class CoordinateSVGraphPath {
+    private final List<CoordinateSVGraphEdge> edges;
+
+    public CoordinateSVGraphPath(final List<CoordinateSVGraphEdge> edges) {
+        Utils.nonNull(edges, "Edges list cannot be null");
+        this.edges = edges;
+    }
+
+    public List<CoordinateSVGraphEdge> getEdges() {
+        return edges;
+    }
+
+    /**
+     * String format is a series of segments specified as:
+     * +[contig:start-end]  -   Forward strand reference
+     * +(contig:start-end)  -   Forward strand breakpoint
+     * -[contig:start-end]  -   Reverse strand reference
+     * -(contig:start-end)  -   Reverse strand breakpoint
+     * Note start is always less than end, so the direction of each segment must be inferred in context.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder stringBuilder = new StringBuilder(edges.size());
+        for (final CoordinateSVGraphEdge edge : edges) {
+            if (edge.isInverted()) {
+                stringBuilder.append("-");
+            } else {
+                stringBuilder.append("+");
+            }
+            if (edge.isReference()) {
+                stringBuilder.append("[");
+            } else {
+                stringBuilder.append("(");
+            }
+            stringBuilder.append(edge.getContigA());
+            stringBuilder.append(":");
+            stringBuilder.append(edge.getNodeAPosition());
+            stringBuilder.append("-");
+            stringBuilder.append(edge.getNodeBPosition());
+            if (edge.isReference()) {
+                stringBuilder.append("]");
+            } else {
+                stringBuilder.append(")");
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CoordinateSVGraphPath)) return false;
+        CoordinateSVGraphPath that = (CoordinateSVGraphPath) o;
+        return Objects.equals(edges, that.edges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(edges);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/IndexedSVGraphEdge.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/IndexedSVGraphEdge.java
@@ -1,0 +1,208 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Edge with endpoint positions defined by graph node indices. This class is used for traversing SV graphs, as it
+ * also defines whether it is inverted and which node is upstream. For strand-switch edges, the upstream node is
+ * undefined by default but can be set during a traversal.
+ */
+public final class IndexedSVGraphEdge implements Comparable<IndexedSVGraphEdge> {
+
+    final static int UNDFINED_SOURCE_NODE_INDEX = -1;
+    private final int index;
+    private final boolean strandA;
+    private final boolean strandB;
+    private final boolean isReference;
+    private final boolean inverted;
+    private final int nodeAIndex;
+    private final int nodeBIndex;
+    private final int upstreamNodeIndex;
+    private final SVInterval interval;
+    private final SVGraphEdgeEvidence evidence;
+
+    private IndexedSVGraphEdge(final int index, final int nodeAIndex, final int nodeBIndex, final boolean strandA, final boolean strandB,
+                               final boolean isReference, final boolean inverted, final int upstreamNodeIndex, final SVGraphEdgeEvidence evidence,
+                               final SVInterval interval, final SVGraph graph, final SAMSequenceDictionary dictionary, final boolean isCopy) {
+        Utils.nonNull(evidence, "Evidence cannot be null");
+        if (!isCopy) {
+            //Validate node indices
+            Utils.nonNull(graph, "Graph cannot be null");
+            Utils.nonNull(dictionary, "Dictionary cannot be null");
+            final int nodesListSize = graph.getNodes().size();
+            Utils.validateArg(nodeAIndex >= 0 && nodeAIndex < nodesListSize, "Invalid node A index: " + nodeAIndex);
+            Utils.validateArg(nodeBIndex >= 0 && nodeBIndex < nodesListSize, "Invalid node B index: " + nodeBIndex);
+            Utils.validateArg(upstreamNodeIndex == nodeAIndex || upstreamNodeIndex == nodeBIndex || upstreamNodeIndex == UNDFINED_SOURCE_NODE_INDEX, "Source node index must be undefined, node A, or node B");
+            final SVGraphNode nodeA = graph.getNodes().get(nodeAIndex);
+            final SVGraphNode nodeB = graph.getNodes().get(nodeBIndex);
+            final SimpleInterval intervalA = SVIntervalUtils.createSimpleInterval(nodeA.getContig(), nodeA.getPosition(), nodeA.getPosition() + 1, dictionary);
+            final SimpleInterval intervalB = SVIntervalUtils.createSimpleInterval(nodeB.getContig(), nodeB.getPosition(), nodeB.getPosition() + 1, dictionary);
+            Utils.validateArg(IntervalUtils.compareLocatables(intervalA, intervalB, dictionary) <= 0, "Node A is not before node B");
+            this.interval = generateInterval(nodeAIndex, nodeBIndex, graph.getNodes());
+        } else {
+            Utils.nonNull(interval, "Interval cannot be null");
+            this.interval = interval;
+        }
+        this.index = index;
+        this.nodeAIndex = nodeAIndex;
+        this.nodeBIndex = nodeBIndex;
+        this.strandA = strandA;
+        this.strandB = strandB;
+        this.isReference = isReference;
+        this.inverted = inverted;
+        this.upstreamNodeIndex = upstreamNodeIndex;
+        this.evidence = evidence;
+    }
+
+    public IndexedSVGraphEdge(final int index, final int nodeAIndex, final int nodeBIndex, final boolean strandA, final boolean strandB,
+                              final boolean isReference, final SVGraphEdgeEvidence evidence, final SVGraph graph, final SAMSequenceDictionary dictionary) {
+        this(index, nodeAIndex, nodeBIndex, strandA, strandB, isReference, false, defaultUpstreamNode(false, nodeAIndex, nodeBIndex, strandA, strandB), evidence, null, graph, dictionary, false);
+    }
+
+    private static int defaultUpstreamNode(final boolean inverted, final int nodeAIndex, final int nodeBIndex, final boolean strandA, final boolean strandB) {
+        //Undefined if strand-switch
+        if (strandA == strandB) return UNDFINED_SOURCE_NODE_INDEX;
+        //Negative strand node if inverted
+        if (inverted) {
+            return strandA ? nodeBIndex : nodeAIndex;
+        }
+        //Positive strand node by default
+        return strandA ? nodeAIndex : nodeBIndex;
+    }
+
+    private static SVInterval generateInterval(final int nodeAIndex, final int nodeBIndex, final List<SVGraphNode> nodes) {
+        final SVGraphNode nodeA = nodes.get(nodeAIndex);
+        final SVGraphNode nodeB = nodes.get(nodeBIndex);
+        if (nodeA.getContig() != nodeB.getContig()) return null;
+        return new SVInterval(nodeA.getContig(), nodeA.getPosition(), nodeB.getPosition());
+    }
+
+    /**
+     * Creates a copy in the non-inverted state
+     */
+    public IndexedSVGraphEdge nonInvertedCopy() {
+        return new IndexedSVGraphEdge(index, nodeAIndex, nodeBIndex, strandA, strandB, isReference, false, getUpstreamNodeIndex(), evidence, interval, null, null, true);
+    }
+
+    /**
+     * Creates a copy in the inverted state
+     */
+    public IndexedSVGraphEdge invertedCopy() {
+        return new IndexedSVGraphEdge(index, nodeAIndex, nodeBIndex, strandA, strandB, isReference, true, getDownstreamNodeIndex(), evidence, interval, null, null, true);
+    }
+
+    /**
+     * For strand switch edges, creates a copy in the current inversion state
+     */
+    public IndexedSVGraphEdge copyWithUpstreamNodeAs(final int upstreamNodeIndex) {
+        Utils.validate(causesStrandSwitch(), "Cannot define source node for non-strand switch edge");
+        return new IndexedSVGraphEdge(index, nodeAIndex, nodeBIndex, strandA, strandB, isReference, inverted, upstreamNodeIndex, evidence, interval, null, null, true);
+    }
+
+    public SVInterval getInterval() {
+        return interval;
+    }
+
+    public SVGraphEdgeEvidence getEvidence() {
+        return evidence;
+    }
+
+    public boolean causesStrandSwitch() {
+        return strandA == strandB;
+    }
+
+    public boolean isInverted() {
+        return inverted;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public int getNodeAIndex() {
+        return nodeAIndex;
+    }
+
+    public int getUpstreamNodeIndex() {
+        return upstreamNodeIndex;
+    }
+
+    public int getDownstreamNodeIndex() {
+        if (upstreamNodeIndex == UNDFINED_SOURCE_NODE_INDEX) return UNDFINED_SOURCE_NODE_INDEX;
+        return upstreamNodeIndex == nodeAIndex ? nodeBIndex : nodeAIndex;
+    }
+
+    public int getNodeBIndex() {
+        return nodeBIndex;
+    }
+
+    public boolean isStrandA() {
+        return strandA;
+    }
+
+    public boolean isStrandB() {
+        return strandB;
+    }
+
+    public boolean isReference() {
+        return isReference;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IndexedSVGraphEdge)) return false;
+        IndexedSVGraphEdge that = (IndexedSVGraphEdge) o;
+        return index == that.index &&
+                strandA == that.strandA &&
+                strandB == that.strandB &&
+                isReference == that.isReference &&
+                inverted == that.inverted &&
+                nodeAIndex == that.nodeAIndex &&
+                nodeBIndex == that.nodeBIndex &&
+                upstreamNodeIndex == that.upstreamNodeIndex &&
+                Objects.equals(interval, that.interval) &&
+                Objects.equals(evidence, that.evidence);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, strandA, strandB, isReference, inverted, nodeAIndex, nodeBIndex, upstreamNodeIndex, interval, evidence);
+    }
+
+    @Override
+    public int compareTo(final IndexedSVGraphEdge other) {
+        int result = Integer.compare(index, other.index);
+        if (result == 0) {
+            result = Boolean.compare(strandA, other.strandA);
+            if (result == 0) {
+                result = Boolean.compare(strandB, other.strandB);
+                if (result == 0) {
+                    result = Boolean.compare(isReference, other.isReference);
+                    if (result == 0) {
+                        result = Boolean.compare(inverted, other.inverted);
+                        if (result == 0) {
+                            result = Integer.compare(nodeAIndex, other.nodeAIndex);
+                            if (result == 0) {
+                                result = Integer.compare(nodeBIndex, other.nodeBIndex);
+                                if (result == 0) {
+                                    result = Integer.compare(upstreamNodeIndex, other.upstreamNodeIndex);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/IndexedSVGraphPath.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/IndexedSVGraphPath.java
@@ -1,0 +1,54 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class IndexedSVGraphPath implements Comparable<IndexedSVGraphPath> {
+
+    private final List<IndexedSVGraphEdge> edges;
+
+    public IndexedSVGraphPath(final List<IndexedSVGraphEdge> edges) {
+        this.edges = edges;
+    }
+
+    public List<IndexedSVGraphEdge> getEdges() {
+        return edges;
+    }
+
+    public CoordinateSVGraphPath convertToCoordinatePath(final SVGraph graph) {
+        final List<CoordinateSVGraphEdge> coordinateEdges = edges.stream().map(edge -> new CoordinateSVGraphEdge(edge, graph.getNodes())).collect(Collectors.toList());
+        return new CoordinateSVGraphPath(coordinateEdges);
+    }
+
+    public int size() {
+        return edges.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IndexedSVGraphPath)) return false;
+        IndexedSVGraphPath that = (IndexedSVGraphPath) o;
+        return Objects.equals(edges, that.edges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(edges);
+    }
+
+    @Override
+    public int compareTo(final IndexedSVGraphPath other) {
+        if (this.size() > other.size()) return 1;
+        if (this.size() < other.size()) return -1;
+        for (int i = 0; i < edges.size(); i++) {
+            if (i >= other.size()) return 1;
+            int result = edges.get(i).compareTo(other.getEdges().get(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/ReadDepthSVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/ReadDepthSVCaller.java
@@ -1,0 +1,332 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import org.broadinstitute.hellbender.tools.spark.sv.DiscoverVariantsFromReadDepthArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Uses an SV graph and copy number posteriors to call SVs
+ */
+public final class ReadDepthSVCaller {
+
+    private final SVGraph graph;
+    private final DiscoverVariantsFromReadDepthArgumentCollection arguments;
+    private final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree;
+
+    public ReadDepthSVCaller(final SVGraph graph, final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree, final DiscoverVariantsFromReadDepthArgumentCollection arguments) {
+        this.graph = graph;
+        this.arguments = arguments;
+        this.copyNumberPosteriorsTree = copyNumberPosteriorsTree;
+    }
+
+    /**
+     * Returns true if the two edges each partially overlap one another or if they meet minimum reciprocal overlap
+     */
+    private static boolean graphPartitioningFunction(final SVInterval a, final SVInterval b, final double minReciprocalOverlap) {
+        if (!a.overlaps(b)) return false;
+        return (a.getStart() <= b.getStart() && a.getEnd() <= b.getEnd())
+                || (b.getStart() <= a.getStart() && b.getEnd() <= a.getEnd())
+                || SVIntervalUtils.hasReciprocalOverlap(a, b, minReciprocalOverlap);
+    }
+
+    /**
+     * Main function that enumerates graph paths, integrates event probabilities, and produces calls
+     */
+    public static Tuple2<Collection<CalledSVGraphGenotype>, Collection<CalledSVGraphEvent>> generateEvents(final SVGraph graph, final int groupId, final double minEventProb,
+                                                                                                           final double maxPathLengthFactor, final int maxEdgeVisits,
+                                                                                                           final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree,
+                                                                                                           final int maxQueueSize, final int ploidy, final int minSize, final double minHaplotypeProb) {
+        final SVGraphGenotyper searcher = new SVGraphGenotyper(graph);
+        final Collection<SVGraphGenotype> paths = searcher.enumerate(copyNumberPosteriorsTree, groupId, ploidy, maxPathLengthFactor, maxEdgeVisits, maxQueueSize);
+        if (paths == null) return null;
+        final Collection<Tuple2<CalledSVGraphEvent, Double>> integratedEvents = integrateEdgeEvents(paths, graph);
+        final Collection<CalledSVGraphEvent> probabilityFilteredEvents = filterEventsByProbability(integratedEvents, minEventProb);
+        final Collection<CalledSVGraphEvent> mergedEvents = mergeAdjacentEvents(probabilityFilteredEvents);
+        final Collection<CalledSVGraphEvent> sizeFilteredEvents = filterEventsBySize(mergedEvents, minSize);
+        final Collection<CalledSVGraphGenotype> haplotypes = convertToCalledHaplotypes(filterHaplotypesByProbability(paths, minHaplotypeProb), graph);
+        return new Tuple2<>(haplotypes, sizeFilteredEvents);
+    }
+
+    private static Collection<CalledSVGraphGenotype> convertToCalledHaplotypes(final Collection<SVGraphGenotype> haplotypes, final SVGraph graph) {
+        return haplotypes.stream().map(h -> new CalledSVGraphGenotype(h, graph)).collect(Collectors.toList());
+    }
+
+    private static Collection<SVGraphGenotype> filterHaplotypesByProbability(final Collection<SVGraphGenotype> haplotypes, final double minProb) {
+        return haplotypes.stream().filter(h -> h.getProbability() >= minProb).collect(Collectors.toList());
+    }
+
+    private static Collection<CalledSVGraphEvent> filterEventsByProbability(final Collection<Tuple2<CalledSVGraphEvent, Double>> calledSVGraphEvents, final double minProb) {
+        return calledSVGraphEvents.stream().filter(pair -> pair._2 >= minProb).map(Tuple2::_1).collect(Collectors.toList());
+    }
+
+    private static Collection<CalledSVGraphEvent> filterEventsBySize(final Collection<CalledSVGraphEvent> calledSVGraphEvents, final int minSize) {
+        return calledSVGraphEvents.stream().filter(sv -> sv.getInterval().getLength() >= minSize).collect(Collectors.toList());
+    }
+
+    /**
+     * Counts the number of times each reference edge was visited and whether each was inverted
+     */
+    private static Tuple2<List<int[]>, List<boolean[]>> getReferenceEdgeCountsAndInversions(final SVGraphGenotype haplotypes, final List<IndexedSVGraphEdge> edges) {
+        final int numHaplotypes = haplotypes.getHaplotypes().size();
+        final List<int[]> referenceEdgeCountsList = new ArrayList<>(numHaplotypes);
+        final List<boolean[]> referenceEdgeInversionsList = new ArrayList<>(numHaplotypes);
+        for (int haplotypeId = 0; haplotypeId < numHaplotypes; haplotypeId++) {
+            final int[] referenceEdgeCounts = new int[edges.size()];
+            final boolean[] referenceEdgeInversions = new boolean[edges.size()];
+            final IndexedSVGraphPath path = haplotypes.getHaplotypes().get(haplotypeId);
+            for (final IndexedSVGraphEdge edge : path.getEdges()) {
+                final int edgeIndex = edge.getIndex();
+                if (edge.isReference()) {
+                    referenceEdgeCounts[edgeIndex]++;
+                    if (edge.isInverted()) {
+                        referenceEdgeInversions[edgeIndex] = true; //True when visited at least once
+                    }
+                }
+            }
+            referenceEdgeCountsList.add(referenceEdgeCounts);
+            referenceEdgeInversionsList.add(referenceEdgeInversions);
+        }
+        return new Tuple2<>(referenceEdgeCountsList, referenceEdgeInversionsList);
+    }
+
+    /**
+     * Creates events occurring at the given reference edge
+     */
+    private static final List<SVGraphEvent> getEdgeEvents(final IndexedSVGraphEdge edge,
+                                                          final int groupId,
+                                                          final int pathId,
+                                                          final double probability,
+                                                          final List<int[]> referenceEdgeCountsList,
+                                                          final List<boolean[]> referenceEdgeInversionsList,
+                                                          final List<SVGraphNode> nodes) {
+        final int edgeIndex = edge.getIndex();
+        boolean deletion = referenceEdgeCountsList.stream().anyMatch(counts -> counts[edgeIndex] < 1);
+        boolean duplication = referenceEdgeCountsList.stream().anyMatch(counts -> counts[edgeIndex] > 1);
+        boolean inversion = referenceEdgeInversionsList.stream().anyMatch(arr -> arr[edgeIndex]);
+        final int numEvents = (deletion ? 1 : 0) + (duplication ? 1 : 0) + (inversion ? 1 : 0) - (deletion && duplication ? 1 : 0);
+        final List<SVGraphEvent> events = new ArrayList<>(numEvents);
+        if (numEvents > 0) {
+            final SVGraphNode nodeA = nodes.get(edge.getNodeAIndex());
+            final SVGraphNode nodeB = nodes.get(edge.getNodeBIndex());
+            final int start = nodeA.getPosition();
+            final int end = nodeB.getPosition();
+            final SVInterval interval = new SVInterval(nodeA.getContig(), start, end);
+            if (deletion) {
+                events.add(new SVGraphEvent(CalledSVGraphEvent.Type.DEL, interval, groupId, pathId, probability, true));
+            }
+            if (duplication && inversion) {
+                events.add(new SVGraphEvent(CalledSVGraphEvent.Type.DUP_INV, interval, groupId, pathId, probability, true));
+            } else {
+                if (duplication) {
+                    events.add(new SVGraphEvent(CalledSVGraphEvent.Type.DUP, interval, groupId, pathId, probability, true));
+                }
+                if (inversion) {
+                    events.add(new SVGraphEvent(CalledSVGraphEvent.Type.INV, interval, groupId, pathId, probability, true));
+                }
+            }
+        }
+        return events;
+    }
+
+    /**
+     * Aggregates potential event calls for the given haplotypes, producing a map from reference edge index to list of events
+     */
+    private static Map<Integer, List<SVGraphEvent>> getHaplotypeEvents(final SVGraphGenotype haplotypes, final SVGraph graph, final IndexedSVGraphPath referencePath) {
+        final List<IndexedSVGraphEdge> edges = graph.getEdges();
+        final Tuple2<List<int[]>, List<boolean[]>> referenceEdgeResults = getReferenceEdgeCountsAndInversions(haplotypes, edges);
+        final List<int[]> referenceEdgeCountsList = referenceEdgeResults._1;
+        final List<boolean[]> referenceEdgeInversionsList = referenceEdgeResults._2;
+
+        final List<SVGraphNode> nodes = graph.getNodes();
+        final Map<Integer, List<SVGraphEvent>> events = new HashMap<>(SVUtils.hashMapCapacity((edges).size()));
+        final int groupId = haplotypes.getGroupId();
+        final int pathId = haplotypes.getGenotypeId();
+        final double probability = haplotypes.getProbability();
+        for (final IndexedSVGraphEdge edge : referencePath.getEdges()) {
+            events.put(edge.getIndex(), getEdgeEvents(edge, groupId, pathId, probability, referenceEdgeCountsList, referenceEdgeInversionsList, nodes));
+        }
+        return events;
+    }
+
+    private static double sumProbabilities(final Collection<SVGraphEvent> events) {
+        return events.stream().mapToDouble(SVGraphEvent::getProbability).sum();
+    }
+
+    private static <T> Map<Integer, List<T>> flattenMaps(final Collection<Map<Integer, List<T>>> mapCollection, final int numReferenceEdges) {
+        final Map<Integer, List<T>> flattenedMap = new HashMap<>(SVUtils.hashMapCapacity(numReferenceEdges));
+        for (final Map<Integer, List<T>> map : mapCollection) {
+            for (final Map.Entry<Integer, List<T>> entry : map.entrySet()) {
+                flattenedMap.putIfAbsent(entry.getKey(), new ArrayList<>());
+                flattenedMap.get(entry.getKey()).addAll(entry.getValue());
+            }
+        }
+        return flattenedMap;
+    }
+
+    /**
+     * Integrates event probabilities over all haplotypes on each reference edge interval. Returns tuples of events and their probabilities.
+     */
+    private static Collection<Tuple2<CalledSVGraphEvent, Double>> integrateEdgeEvents(final Collection<SVGraphGenotype> paths, final SVGraph graph) {
+        final IndexedSVGraphPath referencePath = new IndexedSVGraphPath(graph.getReferenceEdges());
+        final Collection<Map<Integer, List<SVGraphEvent>>> edgeEventMapsCollection = paths.stream().map(path -> getHaplotypeEvents(path, graph, referencePath)).collect(Collectors.toList());
+        final Map<Integer, List<SVGraphEvent>> edgeEventMap = flattenMaps(edgeEventMapsCollection, referencePath.size());
+        final Collection<Tuple2<CalledSVGraphEvent, Double>> events = new ArrayList<>();
+        for (final Map.Entry<Integer, List<SVGraphEvent>> entry : edgeEventMap.entrySet()) {
+            final Map<CalledSVGraphEvent.Type, List<SVGraphEvent>> typeMap = entry.getValue().stream().collect(Collectors.groupingBy(SVGraphEvent::getType));
+            for (final CalledSVGraphEvent.Type type : typeMap.keySet()) {
+                final Collection<SVGraphEvent> typedEvents = typeMap.get(type);
+                final double totalProbability = sumProbabilities(typedEvents);
+                final SVGraphEvent firstEvent = typedEvents.iterator().next();
+                final int groupId = firstEvent.getGroupId();
+                final int pathId = firstEvent.getPathId();
+                final CalledSVGraphEvent newEvent = new CalledSVGraphEvent(type, firstEvent.getInterval(), groupId, pathId, true);
+                events.add(new Tuple2<>(newEvent, totalProbability));
+            }
+        }
+        return events;
+    }
+
+    /**
+     * Helper method for merging events
+     */
+    private static CalledSVGraphEvent mergeSortedEvents(final List<CalledSVGraphEvent> eventsToMerge) {
+        if (eventsToMerge == null || eventsToMerge.isEmpty()) {
+            throw new IllegalArgumentException("Events list cannot be empty or null");
+        }
+        final CalledSVGraphEvent firstEvent = eventsToMerge.get(0);
+        final CalledSVGraphEvent lastEvent = eventsToMerge.get(eventsToMerge.size() - 1);
+        final SVInterval firstInterval = firstEvent.getInterval();
+        final SVInterval interval = new SVInterval(firstInterval.getContig(), firstInterval.getStart(), lastEvent.getInterval().getEnd());
+        final CalledSVGraphEvent mergedEvent = new CalledSVGraphEvent(firstEvent.getType(), interval, firstEvent.getGroupId(), firstEvent.getPathId(), true);
+        return mergedEvent;
+    }
+
+    /**
+     * Finds and merges contiguous events
+     */
+    private static Collection<CalledSVGraphEvent> mergeAdjacentEvents(final Collection<CalledSVGraphEvent> events) {
+        final Collection<CalledSVGraphEvent> mergedEvents = new ArrayList<>(events.size());
+        final List<CalledSVGraphEvent> eventsToMerge = new ArrayList<>(events.size());
+        final Set<CalledSVGraphEvent.Type> types = events.stream().map(CalledSVGraphEvent::getType).collect(Collectors.toSet());
+        for (final CalledSVGraphEvent.Type type : types) {
+            final List<CalledSVGraphEvent> sortedEventList = events.stream()
+                    .filter(event -> event.getType().equals(type)).sorted((a, b) -> SVIntervalUtils.compareIntervals(a.getInterval(), b.getInterval()))
+                    .collect(Collectors.toList());
+            for (final CalledSVGraphEvent event : sortedEventList) {
+                if (eventsToMerge.isEmpty()) {
+                    eventsToMerge.add(event);
+                } else {
+                    final CalledSVGraphEvent previousEvent = eventsToMerge.get(eventsToMerge.size() - 1);
+                    final SVInterval previousEventInterval = previousEvent.getInterval();
+                    final SVInterval eventInterval = event.getInterval();
+                    if (previousEventInterval.getContig() == eventInterval.getContig() &&
+                            previousEventInterval.getEnd() == eventInterval.getStart()) {
+                        eventsToMerge.add(event);
+                    } else if (!eventInterval.equals(previousEventInterval)) {
+                        mergedEvents.add(mergeSortedEvents(eventsToMerge));
+                        eventsToMerge.clear();
+                        eventsToMerge.add(event);
+                    }
+                }
+            }
+            if (!eventsToMerge.isEmpty()) {
+                mergedEvents.add(mergeSortedEvents(eventsToMerge));
+                eventsToMerge.clear();
+            }
+        }
+        return mergedEvents;
+    }
+
+    /**
+     * Creates event that could not be successfully resolved
+     */
+    private CalledSVGraphEvent getUnresolvedEvent(final SVInterval interval, final int groupId) {
+        return new CalledSVGraphEvent(CalledSVGraphEvent.Type.UR, interval, groupId, 0, false);
+    }
+
+    /**
+     * Calls events over graph partitions
+     */
+    public Tuple2<Collection<CalledSVGraphGenotype>, Collection<CalledSVGraphEvent>> callEvents() {
+
+        final SVGraphPartitioner graphPartitioner = new SVGraphPartitioner(graph);
+        final BiFunction<SVInterval, SVInterval, Boolean> partitionFunction = (a, b) -> graphPartitioningFunction(a, b, arguments.paritionReciprocalOverlap);
+        final List<SVGraph> graphPartitions = graphPartitioner.getIndependentSubgraphs(partitionFunction);
+
+        final Collection<CalledSVGraphEvent> events = new ArrayList<>();
+        final Collection<CalledSVGraphGenotype> haplotypes = new ArrayList<>();
+        int partitionId = 0;
+        for (final SVGraph partition : graphPartitions) {
+            final Tuple2<Collection<CalledSVGraphGenotype>, Collection<CalledSVGraphEvent>> result = generateEvents(partition, partitionId, arguments.minEventProb,
+                    arguments.maxPathLengthFactor, arguments.maxEdgeVisits, copyNumberPosteriorsTree,
+                    arguments.maxBranches, arguments.ploidy, arguments.minEventSize, arguments.minHaplotypeProb);
+            if (result == null) {
+                for (final SVInterval interval : partition.getContigIntervals()) {
+                    events.add(getUnresolvedEvent(interval, partitionId));
+                }
+            } else {
+                haplotypes.addAll(result._1);
+                events.addAll(result._2);
+            }
+            partitionId++;
+        }
+        return new Tuple2<>(haplotypes, events);
+    }
+
+    /**
+     * Contains event information including probability
+     */
+    private static final class SVGraphEvent {
+        private final int groupId;
+        private final int pathId;
+        private final double probability;
+        private final CalledSVGraphEvent.Type type;
+        private final SVInterval interval;
+        private final boolean resolved; //False if solution not found
+
+        public SVGraphEvent(final CalledSVGraphEvent.Type type, final SVInterval interval,
+                            final int groupId, final int pathId, final double probability, final boolean resolved) {
+            Utils.nonNull(type, "Type cannot be null");
+            Utils.nonNull(interval, "Interval cannot be null");
+            this.type = type;
+            this.interval = interval;
+            this.groupId = groupId;
+            this.pathId = pathId;
+            this.probability = probability;
+            this.resolved = resolved;
+        }
+
+        public double getProbability() {
+            return probability;
+        }
+
+        public boolean isResolved() {
+            return resolved;
+        }
+
+        public int getGroupId() {
+            return groupId;
+        }
+
+        public int getPathId() {
+            return pathId;
+        }
+
+        public CalledSVGraphEvent.Type getType() {
+            return type;
+        }
+
+        public SVInterval getInterval() {
+            return interval;
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVCopyNumberInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVCopyNumberInterval.java
@@ -1,0 +1,49 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+
+public final class SVCopyNumberInterval {
+
+    private final SVInterval interval;
+    private final double[] copyNumberLogPosteriors;
+
+    public SVCopyNumberInterval(final VariantContext variantContext, final SAMSequenceDictionary dictionary) {
+        this.interval = new SVInterval(dictionary.getSequenceIndex(variantContext.getContig()), variantContext.getStart(), variantContext.getEnd());
+        final GenotypesContext genotypesContext = variantContext.getGenotypes();
+        if (genotypesContext.isEmpty()) {
+            throw new UserException.BadInput("No genotypes found in variant context " + variantContext.getID());
+        }
+        final Genotype genotype = genotypesContext.get(0);
+        if (!genotype.hasExtendedAttribute("CNLP")) {
+            throw new UserException.BadInput("Copy number genotype not found in variant context " + variantContext.getID());
+        }
+        final String[] phredScaledLikelihoodStrings = ((String) genotype.getExtendedAttribute("CNLP")).split(",");
+
+        //Posteriors reported as integer phred-scaled likelihoods and need to be renormalized
+        final double[] approximatePosteriors = new double[phredScaledLikelihoodStrings.length];
+        double total = 0;
+        for (int i = 0; i < phredScaledLikelihoodStrings.length; i++) {
+            final double logLikelihood = -Double.valueOf(phredScaledLikelihoodStrings[i]) / (10.0 * Math.log(10.0));
+            approximatePosteriors[i] = Math.max(Math.exp(logLikelihood), Double.MIN_NORMAL);
+            total += approximatePosteriors[i];
+        }
+
+        copyNumberLogPosteriors = new double[phredScaledLikelihoodStrings.length];
+        for (int i = 0; i < phredScaledLikelihoodStrings.length; i++) {
+            copyNumberLogPosteriors[i] = Math.min(Math.log(approximatePosteriors[i] / total), Double.MIN_NORMAL);
+        }
+    }
+
+    public SVInterval getInterval() {
+        return interval;
+    }
+
+    public double[] getCopyNumberLogPosteriorsArray() {
+        return copyNumberLogPosteriors;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVEvidenceIntegrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVEvidenceIntegrator.java
@@ -1,0 +1,208 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.StructuralVariantType;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.spark.sv.DiscoverVariantsFromReadDepthArgumentCollection;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.*;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Integrates split read, read pair, structural variant call, and assembled breakpoint pair evidence to generate a sequence graph.
+ */
+public final class SVEvidenceIntegrator {
+
+    private static final Logger logger = LogManager.getLogger(SVEvidenceIntegrator.class);
+    private final SVIntervalTree<Object> highCoverageIntervalTree;
+    private final SVIntervalTree<Object> blacklistTree;
+    private final Collection<VariantContext> structuralVariantCalls;
+    private final Collection<EvidenceTargetLink> evidenceTargetLinks;
+    private final Collection<BreakpointPair> pairedBreakpoints;
+    private final SVIntervalTree<SVCopyNumberInterval> copyNumberIntervalTree;
+    private final SAMSequenceDictionary dictionary;
+    private final DiscoverVariantsFromReadDepthArgumentCollection arguments;
+
+    public SVEvidenceIntegrator(final Collection<VariantContext> breakpoints,
+                                final Collection<VariantContext> structuralVariantCalls,
+                                final Collection<EvidenceTargetLink> evidenceTargetLinks,
+                                final SVIntervalTree<SVCopyNumberInterval> copyNumberIntervalTree,
+                                final Collection<SVInterval> highCoverageIntervals,
+                                final Collection<SVInterval> blacklist,
+                                final SAMSequenceDictionary dictionary,
+                                final DiscoverVariantsFromReadDepthArgumentCollection arguments) {
+        Utils.nonNull(breakpoints, "Breakpoints collection cannot be null");
+        Utils.nonNull(structuralVariantCalls, "Structural variant calls collection cannot be null");
+        Utils.nonNull(evidenceTargetLinks, "Evidence target links collection cannot be null");
+        Utils.nonNull(copyNumberIntervalTree, "Copy number posteriors tree cannot be null");
+        Utils.nonNull(highCoverageIntervals, "High coverage intervals collection cannot be null");
+        Utils.nonNull(blacklist, "Blacklist intervals collection cannot be null");
+        Utils.nonNull(dictionary, "Dictionary cannot be null");
+        Utils.nonNull(arguments, "Parameter arguments collection cannot be null");
+
+        this.dictionary = dictionary;
+        this.arguments = arguments;
+        this.structuralVariantCalls = structuralVariantCalls;
+        this.evidenceTargetLinks = evidenceTargetLinks;
+
+        pairedBreakpoints = getBreakpointPairs(breakpoints);
+        highCoverageIntervalTree = SVIntervalUtils.buildIntervalTreeWithNullValues(highCoverageIntervals);
+        blacklistTree = SVIntervalUtils.buildIntervalTreeWithNullValues(blacklist);
+        this.copyNumberIntervalTree = copyNumberIntervalTree;
+    }
+
+    /**
+     * Returns true if the two BNDs in vc1 and vc2 are a valid breakpoint pair, as indicated by their MATEID attributes
+     */
+    private static boolean isBreakpointPair(final VariantContext vc1, final VariantContext vc2) {
+        return vc1.hasAttribute(GATKSVVCFConstants.BND_MATEID_STR) &&
+                vc1.getAttributeAsString(GATKSVVCFConstants.BND_MATEID_STR, "").equals(vc2.getID()) &&
+                vc2.getAttributeAsString(GATKSVVCFConstants.BND_MATEID_STR, "").equals(vc1.getID());
+    }
+
+    /**
+     * Returns paired breakpoints from BND records
+     */
+    private Collection<BreakpointPair> getBreakpointPairs(final Collection<VariantContext> breakpoints) {
+        final Map<String, VariantContext> unpairedVariants = new HashMap<>();
+        final Collection<BreakpointPair> pairedBreakpoints = new ArrayList<>(breakpoints.size() / 2);
+        final Iterator<VariantContext> breakpointIter = breakpoints.iterator();
+        while (breakpointIter.hasNext()) {
+            final VariantContext vc1 = breakpointIter.next();
+            if (!vc1.hasAttribute(GATKSVVCFConstants.BND_MATEID_STR)) continue;
+            final String mate = vc1.getAttributeAsString(GATKSVVCFConstants.BND_MATEID_STR, "");
+            if (unpairedVariants.containsKey(mate)) {
+                final VariantContext vc2 = unpairedVariants.remove(mate);
+                if (isBreakpointPair(vc1, vc2)) {
+                    pairedBreakpoints.add(new BreakpointPair(vc1, vc2, dictionary));
+                } else {
+                    throw new UserException.BadInput("Variant mate attributes did not match: " + vc1 + "\t" + vc2);
+                }
+            } else {
+                unpairedVariants.put(vc1.getID(), vc1);
+            }
+        }
+        if (!unpairedVariants.isEmpty()) {
+            logger.warn("There were " + unpairedVariants.size() + " unpaired breakpoint variants with a " + GATKSVVCFConstants.BND_MATEID_STR + " attribute.");
+        }
+        return pairedBreakpoints;
+    }
+
+    /**
+     * Gets list of breakpoint edges from structural variant calls and adds them to the provided tree
+     */
+    private Collection<CoordinateSVGraphEdge> getStructuralVariantCallEdges(final SVIntervalTree<CoordinateSVGraphEdge> edgeTree) {
+        final Collection<CoordinateSVGraphEdge> edges = new ArrayList<>();
+        for (final VariantContext variantContext : structuralVariantCalls) {
+            if (variantContext.getStructuralVariantType() == StructuralVariantType.DEL) { //Only using DEL calls
+                final int contig = dictionary.getSequenceIndex(variantContext.getContig());
+                final int start = variantContext.getStart();
+                final int end = variantContext.getEnd();
+                final CoordinateSVGraphEdge edge = new CoordinateSVGraphEdge(contig, start, true, contig, end, false, false, new SVGraphEdgeEvidence(variantContext), dictionary);
+                edges.add(edge);
+                edgeTree.put(edge.getIntervalA(), edge);
+                edgeTree.put(edge.getIntervalB(), edge);
+            }
+        }
+        return edges;
+    }
+
+    /**
+     * Gets list of breakpoint edges from BND records and adds them to the provided tree. An edge is not created if a similar edge already exists in the tree.
+     */
+    private Collection<CoordinateSVGraphEdge> getBreakpointPairEdges(final SVIntervalTree<CoordinateSVGraphEdge> edgeTree, final int treeOverlapPadding) {
+        final Collection<CoordinateSVGraphEdge> edges = new ArrayList<>();
+        for (final BreakpointPair breakpointPair : pairedBreakpoints) {
+            if (breakpointPair.getContigA() == breakpointPair.getContigB()) { //Only intrachromosomal events
+                final CoordinateSVGraphEdge edge = new CoordinateSVGraphEdge(breakpointPair.getContigA(), breakpointPair.getPositionA(), breakpointPair.isStrandA(),
+                        breakpointPair.getContigB(), breakpointPair.getPositionB(), breakpointPair.isStrandB(), false, new SVGraphEdgeEvidence(breakpointPair), dictionary);
+                if (!hasEdgeOverlap(edgeTree, edge, treeOverlapPadding)) {
+                    edges.add(edge);
+                    edgeTree.put(edge.getIntervalA(), edge);
+                    edgeTree.put(edge.getIntervalB(), edge);
+                }
+            }
+        }
+        return edges;
+    }
+
+    /**
+     * Gets list of breakpoint edges from evidence target links and adds them to the provided tree. An edge is not created if a similar edge already exists in the tree.
+     */
+    private Collection<CoordinateSVGraphEdge> getEvidenceTargetLinkEdges(final SVIntervalTree<CoordinateSVGraphEdge> edgeTree, final int treeOverlapPadding) {
+        final Collection<CoordinateSVGraphEdge> edges = new ArrayList<>();
+        for (final EvidenceTargetLink link : evidenceTargetLinks) {
+            if (link.getReadPairs() >= arguments.minLinkReadPairs) {
+                final boolean leftStrand = link.getPairedStrandedIntervals().getLeft().getStrand();
+                final boolean rightStrand = link.getPairedStrandedIntervals().getRight().getStrand();
+                final SVInterval leftInterval = link.getPairedStrandedIntervals().getLeft().getInterval();
+                final SVInterval rightInterval = link.getPairedStrandedIntervals().getRight().getInterval();
+                if (leftInterval.getContig() == rightInterval.getContig()) {    //Only intrachromosomal events
+                    final int leftPosition = leftStrand ? leftInterval.getStart() : leftInterval.getEnd();
+                    final int rightPosition = rightStrand ? rightInterval.getStart() : rightInterval.getEnd();
+                    final CoordinateSVGraphEdge edge = new CoordinateSVGraphEdge(leftInterval.getContig(), leftPosition, leftStrand, rightInterval.getContig(), rightPosition, rightStrand, false, new SVGraphEdgeEvidence(link), dictionary);
+                    if (!hasEdgeOverlap(edgeTree, edge, treeOverlapPadding)) {
+                        edges.add(edge);
+                    }
+                }
+            }
+        }
+        return edges;
+    }
+
+    /**
+     * Filters edges that do not have CNV calls or whose ends overlap blacklist or high coverage intervals
+     */
+    private List<CoordinateSVGraphEdge> filterEdges(final Collection<CoordinateSVGraphEdge> edges, final int filterPadding) {
+        return edges.stream()
+                .filter(edge -> copyNumberIntervalTree.hasOverlapper(edge.getInterval()))
+                .filter(edge -> !edgeEndpointsHaveTreeOverlap(edge, blacklistTree, filterPadding))
+                .filter(edge -> !edgeEndpointsHaveTreeOverlap(edge, highCoverageIntervalTree, filterPadding))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns true if either endpoint of the edge (give or take padding) overlaps with an interval in the provided tree.
+     */
+    private boolean edgeEndpointsHaveTreeOverlap(final CoordinateSVGraphEdge edge, final SVIntervalTree<Object> tree, final int endpointPadding) {
+        return tree.hasOverlapper(SVIntervalUtils.getPaddedInterval(edge.getIntervalA(), endpointPadding, dictionary))
+                || tree.hasOverlapper(SVIntervalUtils.getPaddedInterval(edge.getIntervalB(), endpointPadding, dictionary));
+    }
+
+
+    /**
+     * Creates graph from structural variant calls, BNDs, and evidence target links
+     */
+    public SVGraph buildGraph() {
+        final Collection<CoordinateSVGraphEdge> edges = new ArrayList<>();
+        final SVIntervalTree<CoordinateSVGraphEdge> edgeTree = new SVIntervalTree<>();
+
+        edges.addAll(getStructuralVariantCallEdges(edgeTree));
+        edges.addAll(getBreakpointPairEdges(edgeTree, arguments.insertSize));
+        edges.addAll(getEvidenceTargetLinkEdges(edgeTree, arguments.insertSize));
+
+        final List<CoordinateSVGraphEdge> filteredEdges = filterEdges(edges, arguments.insertSize);
+        return new SVGraph(filteredEdges, dictionary);
+    }
+
+    /**
+     * Determines if a similar edges already exists in the provided tree, so as to not introduce duplicate evidence.
+     */
+    private boolean hasEdgeOverlap(final SVIntervalTree<CoordinateSVGraphEdge> tree, final CoordinateSVGraphEdge edge, final int padding) {
+        final SVInterval intervalA = SVIntervalUtils.getPaddedInterval(edge.getIntervalA(), padding, dictionary);
+        final SVInterval intervalB = SVIntervalUtils.getPaddedInterval(edge.getIntervalB(), padding, dictionary);
+        final Stream<SVIntervalTree.Entry<CoordinateSVGraphEdge>> overlapStreamA = Utils.stream(tree.overlappers(intervalA));
+        final Stream<SVIntervalTree.Entry<CoordinateSVGraphEdge>> overlapStreamB = Utils.stream(tree.overlappers(intervalB));
+        return Stream.concat(overlapStreamA, overlapStreamB).map(entry -> entry.getValue())
+                .anyMatch(overlapper -> overlapper.isStrandA() == edge.isStrandA() && overlapper.isStrandB() == edge.isStrandB()
+                        && overlapper.getIntervalA().overlaps(intervalA) && overlapper.getIntervalB().overlaps(intervalB));
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraph.java
@@ -1,0 +1,220 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Graph representation for resolving structural variants.
+ *
+ * In this graph, nodes represent breakpoint positions in the reference. There are two classes of edges: breakpoint
+ * edges and reference edges. A breakpoint edge is added for each piece of evidence. Reference edges, representing
+ * reference sequence, are added between adjacent nodes.
+ *
+ * For example, consider the reference sequence
+ *
+ * ATTCGAGACGAAGG
+ *
+ * and with a deletion breakpoint at positions 3 and 10:
+ *
+ * ATT^CGAGACG^AAGG
+ *
+ * where the ^ indicate the breakpoint positions. Then there would be nodes at these positions, as well as the beginning and
+ * end of the sequence (positions 0, 3, 10, and 14). A breakpoint edge b connects the nodes at 3 and 10:
+ *
+ *            ___b____
+ *            |      |
+ *            |      V
+ *    (0)    (3)    (10)    (14)
+ *
+ * Note the deletion breakpoint edge is directed, starting at (3) and ending at (10), since the deletion carries the
+ * sequence in that direction (left + strand, right - strand). In general, the direction of the edge is determined by
+ * the strand of each end, flowing from + to -. For inversions (+/+ and -/-), either direction is possible. In that case,
+ * the direction is undefined (and later determined during path enumeration).
+ *
+ * Next, reference edges are added between nodes 0 and 3 (representing r1 = ATT), 3 and 10 (r2 = CGAGACG), and 10 and 14 (r3 = AAGG):
+ *
+ *            ___b____
+ *            |      |
+ *            |      V
+ *    (0)--->(3)--->(10)--->(14)
+ *        r1     r2      r3
+ *
+ * By traversing this graph, one can generate sequences of r1, r2, and r3 corresponding to possible haplotypes:
+ *
+ *  r1,r2,r3 (ref)
+ *  r1,r3    (del of r2)
+ *
+ * which can later by filtered using read depth information.
+ */
+public final class SVGraph {
+
+    final List<IndexedSVGraphEdge> edges;
+    final List<SVGraphNode> nodes;
+    final Set<Integer> startingNodes;
+    final Set<Integer> endingNodes;
+    final SAMSequenceDictionary dictionary;
+    final Collection<SVInterval> intervals;
+
+    public SVGraph(final Collection<CoordinateSVGraphEdge> breakpointEdges, final SAMSequenceDictionary dictionary) {
+        this.dictionary = dictionary;
+
+        //Compute breakpoint positions
+        final Map<Integer, List<Integer>> contigToBreakpointPositionsMap = getContigToBreakpointPositionsMap(breakpointEdges);
+
+        //Compute reference edges between each pair of positions
+        final Collection<CoordinateSVGraphEdge> referenceEdges = getReferenceEdges(contigToBreakpointPositionsMap);
+
+        //Combine breakpoint and reference edges that form the entire graph
+        final Collection<CoordinateSVGraphEdge> inputEdges = new ArrayList<>(breakpointEdges.size() + referenceEdges.size());
+        inputEdges.addAll(breakpointEdges);
+        inputEdges.addAll(referenceEdges);
+
+        //Compute nodes and indexed edges
+        nodes = generateNodes(inputEdges, dictionary);
+        edges = generateIndexedEdgesAndUpdateNodes(inputEdges);
+
+        if (hasInterchromosomalEdge()) {
+            throw new IllegalArgumentException("Interchromosomal edges not currently supported");
+        }
+
+        //Find start and end nodes
+        startingNodes = generateStartNodes();
+        endingNodes = generateEndNodes();
+        intervals = generateIntervals();
+    }
+
+    private boolean hasInterchromosomalEdge() {
+        return edges.stream().anyMatch(edge -> nodes.get(edge.getNodeAIndex()).getContig() != nodes.get(edge.getNodeBIndex()).getContig());
+    }
+
+    public List<SVGraphNode> getNodes() {
+        return nodes;
+    }
+
+    private static Stream<Tuple2<Integer, Integer>> getEdgeContigsAndPositionsStream(final CoordinateSVGraphEdge edge) {
+        return Stream.of(new Tuple2<>(edge.getContigA(), edge.getNodeAPosition()), new Tuple2<>(edge.getContigB(), edge.getNodeBPosition()));
+    }
+
+    private static List<Integer> flattenAndSortUniqueValues(List<Tuple2<Integer, Integer>> tuplesList) {
+        return tuplesList.stream().map(pair -> pair._2).distinct().sorted().collect(Collectors.toList());
+    }
+
+    private static Tuple2<Integer, List<Integer>> flattenAndSortContigPositionPairs(final Integer contig, final List<Tuple2<Integer, Integer>> contigPositionPairsList) {
+        return new Tuple2<>(contig, flattenAndSortUniqueValues(contigPositionPairsList));
+    }
+
+    private static Map<Integer, List<Integer>> getContigToBreakpointPositionsMap(final Collection<CoordinateSVGraphEdge> edges) {
+        return edges.stream()
+                .flatMap(edge -> getEdgeContigsAndPositionsStream(edge)) //Get the two positions as contig-position pairs
+                .collect(Collectors.groupingBy(Tuple2::_1))     //Group pairs by contig
+                .entrySet().stream()
+                .map(entry -> flattenAndSortContigPositionPairs(entry.getKey(), entry.getValue())) //Convert contig-position pairs to sorted lists of positions keyed by contig
+                .collect(Collectors.toMap(Tuple2::_1, Tuple2::_2));
+    }
+
+    private Collection<CoordinateSVGraphEdge> getReferenceEdges(final Map<Integer, List<Integer>> contigToBreakpointPositionsMap) {
+        final Collection<CoordinateSVGraphEdge> referenceEdges = new ArrayList<>();
+        for (final Integer contig : contigToBreakpointPositionsMap.keySet()) {
+            final List<Integer> positions = contigToBreakpointPositionsMap.get(contig);
+            for (int i = 0; i < positions.size() - 1; i++) {
+                final int position1 = contigToBreakpointPositionsMap.get(contig).get(i);
+                final int position2 = contigToBreakpointPositionsMap.get(contig).get(i + 1);
+                final CoordinateSVGraphEdge edge = new CoordinateSVGraphEdge(contig, position1, true, contig, position2, false, true, new SVGraphEdgeEvidence(), dictionary);
+                referenceEdges.add(edge);
+            }
+        }
+        return referenceEdges;
+    }
+
+    private static List<SVGraphNode> generateNodes(final Collection<CoordinateSVGraphEdge> edges, final SAMSequenceDictionary dictionary) {
+        return edges.stream()
+                .flatMap(edge -> Stream.of(new SVGraphNode(edge.getContigA(), edge.getNodeAPosition()), new SVGraphNode(edge.getContigB(), edge.getNodeBPosition())))
+                .distinct()
+                .sorted((a, b) -> SVIntervalUtils.compareIntervals(new SVInterval(a.getContig(), a.getPosition(), a.getPosition()), new SVInterval(b.getContig(), b.getPosition(), b.getPosition())))
+                .collect(Collectors.toList());
+    }
+
+    private List<IndexedSVGraphEdge> generateIndexedEdgesAndUpdateNodes(final Collection<CoordinateSVGraphEdge> edges) {
+
+        //Needed for converting edge types
+        final Map<Tuple2<Integer,Integer>, Integer> contigAndPositionToNodeIndexMap = new HashMap<>(SVUtils.hashMapCapacity(nodes.size()));
+        int nodeIndex = 0;
+        for (final SVGraphNode node : nodes) {
+            contigAndPositionToNodeIndexMap.put(new Tuple2<>(node.getContig(), node.getPosition()), nodeIndex);
+            nodeIndex++;
+        }
+
+        //Generate indexed edges list from coordinate edges
+        final List<IndexedSVGraphEdge> indexedEdges = new ArrayList<>(edges.size());
+        for (final CoordinateSVGraphEdge edge : edges) {
+            final int nodeAIndex = contigAndPositionToNodeIndexMap.get(new Tuple2<>(edge.getContigA(), edge.getNodeAPosition()));
+            final int nodeBIndex = contigAndPositionToNodeIndexMap.get(new Tuple2<>(edge.getContigB(), edge.getNodeBPosition()));
+            final int edgeIndex = indexedEdges.size();
+            final IndexedSVGraphEdge newEdge = new IndexedSVGraphEdge(edgeIndex, nodeAIndex, nodeBIndex, edge.isStrandA(), edge.isStrandB(), edge.isReference(), edge.getEvidence(), this, dictionary);
+            indexedEdges.add(newEdge);
+            addIndexedEdgeToNodeEdgesList(newEdge, nodes.get(nodeAIndex), true);
+            addIndexedEdgeToNodeEdgesList(newEdge, nodes.get(nodeBIndex), false);
+        }
+        return indexedEdges;
+    }
+
+    private static void addIndexedEdgeToNodeEdgesList(final IndexedSVGraphEdge edge, final SVGraphNode node, final boolean isNodeA) {
+        if ((isNodeA && edge.isStrandA()) || (!isNodeA && edge.isStrandB())) {
+            node.getOutEdges().add(edge);
+        } else {
+            node.getInEdges().add(edge);
+        }
+    }
+
+    private Set<Integer> generateStartNodes() {
+        return IntStream.range(0, nodes.size()).filter(i -> nodes.get(i).countReferenceInEdges() == 0).boxed().collect(Collectors.toSet());
+    }
+
+    private Set<Integer> generateEndNodes() {
+        return IntStream.range(0, nodes.size()).filter(i -> nodes.get(i).countReferenceOutEdges() == 0).boxed().collect(Collectors.toSet());
+    }
+
+    public SAMSequenceDictionary getDictionary() {
+        return dictionary;
+    }
+
+    public List<IndexedSVGraphEdge> getReferenceEdges() {
+        return edges.stream().filter(edge -> edge.isReference()).distinct().collect(Collectors.toList());
+    }
+
+    private Collection<SVInterval> generateIntervals() {
+        return getReferenceEdges().stream().map(edge -> edge.getInterval()).collect(Collectors.groupingBy(interval -> interval.getContig())).entrySet().stream()
+                .map(entry -> new SVInterval(entry.getKey(), entry.getValue().stream().mapToInt(SVInterval::getStart).min().getAsInt(), entry.getValue().stream().mapToInt(SVInterval::getEnd).max().getAsInt()))
+                .collect(Collectors.toList());
+    }
+
+    public Collection<SVInterval> getContigIntervals() {
+        return intervals;
+    }
+
+    public List<IndexedSVGraphEdge> getEdges() {
+        return edges;
+    }
+
+    public List<SVGraphNode> generateNodes() {
+        return nodes;
+    }
+
+    public Set<Integer> getStartingNodes() {
+        return startingNodes;
+    }
+
+    public Set<Integer> getEndingNodes() {
+        return endingNodes;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphEdgeEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphEdgeEvidence.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.tools.spark.sv.evidence.EvidenceTargetLink;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.BreakpointPair;
+
+public final class SVGraphEdgeEvidence {
+    private final EvidenceTargetLink evidenceTargetLink;
+    private final VariantContext calledVariant;
+    private final BreakpointPair breakpointPair;
+
+    public SVGraphEdgeEvidence() {
+        this.evidenceTargetLink = null;
+        this.calledVariant = null;
+        this.breakpointPair = null;
+    }
+
+    public SVGraphEdgeEvidence(final EvidenceTargetLink evidenceTargetLink) {
+        this.evidenceTargetLink = evidenceTargetLink;
+        this.calledVariant = null;
+        this.breakpointPair = null;
+    }
+
+    public SVGraphEdgeEvidence(final VariantContext calledVariant) {
+        this.evidenceTargetLink = null;
+        this.calledVariant = calledVariant;
+        this.breakpointPair = null;
+    }
+
+    public SVGraphEdgeEvidence(final BreakpointPair breakpointPair) {
+        this.evidenceTargetLink = null;
+        this.calledVariant = null;
+        this.breakpointPair = breakpointPair;
+    }
+
+    public EvidenceTargetLink getEvidenceTargetLink() {
+        return evidenceTargetLink;
+    }
+
+    public VariantContext getCalledVariant() {
+        return calledVariant;
+    }
+
+    public BreakpointPair getBreakpointPair() {
+        return breakpointPair;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphGenotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphGenotype.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import java.util.*;
+
+public class SVGraphGenotype {
+
+    protected final List<IndexedSVGraphPath> haplotypes;
+    protected final int groupId;
+    protected final int genotypeId;
+    protected final double likelihood;
+    protected double probability;
+    private static final int DEFAULT_PLOIDY = 2;
+
+    public SVGraphGenotype(final int groupId, final int genotypeId, final double likelihood) {
+        this.haplotypes = new ArrayList<>(DEFAULT_PLOIDY);
+        this.groupId = groupId;
+        this.genotypeId = genotypeId;
+        this.likelihood = likelihood;
+        this.probability = Double.NaN;
+    }
+
+    public SVGraphGenotype(final int groupId, final int genotypeId, final double likelihood, final Collection<IndexedSVGraphPath> pathList) {
+        this(groupId, genotypeId, likelihood);
+        for (final IndexedSVGraphPath path : pathList) {
+            addPath(path);
+        }
+    }
+
+    public void addPath(final IndexedSVGraphPath path) {
+        haplotypes.add(path);
+        Collections.sort(haplotypes); //Maintain sorted haplotypes so genotypes can be easily deduplicated with a hash set
+    }
+
+    public double getProbability() {
+        return probability;
+    }
+
+    public void setProbability(double probability) {
+        this.probability = probability;
+    }
+
+    public List<IndexedSVGraphPath> getHaplotypes() {
+        return haplotypes;
+    }
+
+    public int getGroupId() {
+        return groupId;
+    }
+
+    public int getGenotypeId() {
+        return genotypeId;
+    }
+
+    public double getLikelihood() {
+        return likelihood;
+    }
+
+    /**
+     * The genotype ID is not checked in equals() or hashCode()
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SVGraphGenotype)) return false;
+        SVGraphGenotype that = (SVGraphGenotype) o;
+        return groupId == that.groupId &&
+                Double.compare(that.likelihood, likelihood) == 0 &&
+                Double.compare(that.probability, probability) == 0 &&
+                Objects.equals(haplotypes, that.haplotypes);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(haplotypes, groupId, likelihood, probability);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphGenotyper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphGenotyper.java
@@ -1,0 +1,302 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import scala.Tuple2;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Enumerates genotypes on an SV graph
+ */
+public final class SVGraphGenotyper {
+
+    final SVGraph graph;
+
+    public SVGraphGenotyper(final SVGraph graph) {
+        this.graph = graph;
+    }
+
+    /**
+     * Normalizes genotype likelihoods
+     */
+    private static final void setGenotypedProbabilities(final Collection<SVGraphGenotype> genotypes) {
+        final double logDenom = Math.log(genotypes.stream().mapToDouble(SVGraphGenotype::getLikelihood)
+                .map(Math::exp)
+                .map(val -> Math.max(val, Double.MIN_NORMAL))
+                .sum());
+        for (final SVGraphGenotype genotype : genotypes) {
+            genotype.setProbability(Math.exp(genotype.getLikelihood() - logDenom));
+        }
+    }
+
+    /**
+     * Edge visit for graph traversal
+     */
+    private static final void visitEdge(final IndexedSVGraphEdge edge, final SVGraphPathState path, final Queue<SVGraphPathState> queue, final int nodeIndex, final int maxEdgeVisits) {
+        final IndexedSVGraphEdge augmentingEdge;
+        if (edge.causesStrandSwitch()) {
+            augmentingEdge = path.isCurrentlyInverted() ? edge.invertedCopy().copyWithUpstreamNodeAs(nodeIndex) : edge.copyWithUpstreamNodeAs(nodeIndex);
+        } else {
+            augmentingEdge = path.isCurrentlyInverted() ? edge.invertedCopy() : edge.nonInvertedCopy();
+        }
+        final SVGraphPathState augmentedPath = path.copy();
+        if (augmentedPath.addEdge(augmentingEdge, maxEdgeVisits)) {
+            if (augmentingEdge.causesStrandSwitch()) {
+                augmentedPath.invert();
+            }
+            queue.add(augmentedPath);
+        }
+    }
+
+    /**
+     * Creates/adds haplotype when the path has reached an end node
+     */
+    private static final void completeHaplotype(final SVGraphPathState path, final Set<SVGraphGenotype> genotypes, final Queue<SVGraphPathState> queue, final Set<Integer> startingNodes, final int groupId, final int baselineCopyNumber) {
+        final int currentPloidy = path.getCurrentPloidy();
+        if (currentPloidy == baselineCopyNumber) {
+            //Finished all haplotypes
+            final double copyNumberScore = path.logLikelihood();
+            final List<IndexedSVGraphPath> haplotypePaths = path.getPathsList().stream().map(edgesList -> new IndexedSVGraphPath(edgesList)).collect(Collectors.toList());
+            final SVGraphGenotype genotype = new SVGraphGenotype(groupId, genotypes.size(), copyNumberScore, haplotypePaths);
+            genotypes.add(genotype);
+        } else if (currentPloidy < baselineCopyNumber) {
+            //Begin new haplotype
+            for (final Integer startingNode : startingNodes) {
+                final SVGraphPathState augmentedPath = path.copy();
+                augmentedPath.setCurrentNode(startingNode);
+                augmentedPath.incrementPloidy();
+                queue.add(augmentedPath);
+            }
+        }
+    }
+
+    /**
+     * Calculates (approximate) copy number posterior likelihoods for the given edge
+     */
+    private static final double[] computeEdgePosteriors(final IndexedSVGraphEdge edge, final SVIntervalTree<SVCopyNumberInterval> copyNumberIntervalTree, final int numCopyNumberStates) {
+        final double[] copyNumberPosterior = new double[numCopyNumberStates];
+        if (edge.isReference()) {
+            final SVInterval edgeInterval = edge.getInterval();
+            final List<Tuple2<double[], SVInterval>> posteriorsAndIntervalsList = Utils.stream(copyNumberIntervalTree.overlappers(edgeInterval))
+                    .map(entry -> new Tuple2<>(entry.getValue().getCopyNumberLogPosteriorsArray(), entry.getInterval()))
+                    .collect(Collectors.toList());
+            for (final Tuple2<double[], SVInterval> posteriorAndInterval : posteriorsAndIntervalsList) {
+                final double[] intervalPosterior = posteriorAndInterval._1;
+                final SVInterval interval = posteriorAndInterval._2;
+                //Down-weights partially-overlapping intervals
+                final double weight = interval.overlapLen(edgeInterval) / (double) interval.getLength();
+                for (int i = 0; i < numCopyNumberStates; i++) {
+                    copyNumberPosterior[i] += intervalPosterior[i] * weight;
+                }
+            }
+        }
+        return copyNumberPosterior;
+    }
+
+    private List<SVCopyNumberInterval> getSortedOverlappingCopyNumberIntervals(final Collection<IndexedSVGraphEdge> edges, final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree) {
+        return edges.stream()
+                .flatMap(edge -> Utils.stream(copyNumberPosteriorsTree.overlappers(edge.getInterval())))
+                .map(SVIntervalTree.Entry::getValue)
+                .distinct()
+                .sorted(SVIntervalUtils.getCopyNumberIntervalDictionaryOrderComparator())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets copy number posteriors for all edges
+     */
+    private List<EdgeCopyNumberPosterior> getEdgeCopyNumberPosteriors(final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree) {
+
+        final List<IndexedSVGraphEdge> edges = graph.getEdges();
+        final List<IndexedSVGraphEdge> referenceEdges = graph.getReferenceEdges();
+        final List<SVCopyNumberInterval> copyNumberIntervals = getSortedOverlappingCopyNumberIntervals(referenceEdges, copyNumberPosteriorsTree);
+        if (copyNumberIntervals.isEmpty()) return Collections.emptyList();
+
+        final SVIntervalTree<SVCopyNumberInterval> copyNumberIntervalTree = SVIntervalUtils.buildCopyNumberIntervalTree(copyNumberIntervals);
+        final List<EdgeCopyNumberPosterior> edgeCopyNumberPosteriors = new ArrayList<>(edges.size());
+
+        final int numCopyNumberStates = copyNumberIntervals.get(0).getCopyNumberLogPosteriorsArray().length;
+        for (final SVCopyNumberInterval copyNumberInterval : copyNumberIntervals) {
+            Utils.validate(copyNumberInterval.getCopyNumberLogPosteriorsArray().length == numCopyNumberStates, "Dimension of copy number interval posteriors is not consistent");
+        }
+
+        for (final IndexedSVGraphEdge edge : edges) {
+            final double[] edgePosterior = computeEdgePosteriors(edge, copyNumberIntervalTree, numCopyNumberStates);
+            edgeCopyNumberPosteriors.add(new EdgeCopyNumberPosterior(edgePosterior));
+        }
+
+        return edgeCopyNumberPosteriors;
+    }
+
+    /**
+     * Enumerates genotypes with breadth-first search
+     */
+    public Collection<SVGraphGenotype> enumerate(final SVIntervalTree<SVCopyNumberInterval> copyNumberPosteriorsTree,
+                                                 final int groupId, final int baselineCopyNumber,
+                                                 final double maxPathLengthFactor, final int maxEdgeVisits,
+                                                 final int maxQueueSize) {
+
+        final List<SVGraphNode> nodes = graph.generateNodes();
+        final Set<Integer> startingNodes = graph.getStartingNodes();
+        final Set<Integer> endingNodes = graph.getEndingNodes();
+
+        final List<EdgeCopyNumberPosterior> copyNumberPosteriors = getEdgeCopyNumberPosteriors(copyNumberPosteriorsTree);
+        final int maxPathLength = (int) (maxPathLengthFactor * graph.getReferenceEdges().size());
+
+        final Set<SVGraphGenotype> genotypes = new HashSet<>();
+        final Queue<SVGraphPathState> queue = new ArrayDeque<>();
+        for (final Integer startingNode : startingNodes) {
+            queue.add(new SVGraphPathState(startingNode, copyNumberPosteriors));
+        }
+        while (!queue.isEmpty()) {
+            if (queue.size() > maxQueueSize) return null;
+            final SVGraphPathState path = queue.poll();
+            final Integer nodeIndex = path.getCurrentNode();
+
+            //Cap max path length (extremely long paths caused by degenerate loops)
+            if (path.getCurrentPath().size() > maxPathLength) continue;
+
+            //Finish haplotype if we reach the other end of the event in an uninverted state
+            if (!path.isCurrentlyInverted() && endingNodes.contains(nodeIndex)) {
+                completeHaplotype(path, genotypes, queue, startingNodes, groupId, baselineCopyNumber);
+            }
+
+            //Visit neighbors
+            final boolean lastEdgeWasReference = path.getCurrentPath().isEmpty() || path.getCurrentPath().get(path.getCurrentPath().size() - 1).isReference();
+            final SVGraphNode node = nodes.get(nodeIndex);
+            final List<IndexedSVGraphEdge> neighborEdges = path.isCurrentlyInverted() ? node.getInEdges() : node.getOutEdges();
+            for (final IndexedSVGraphEdge edge : neighborEdges) {
+                //Breakpoint double-jumps are invalid
+                if (edge.isReference() || lastEdgeWasReference) {
+                    visitEdge(edge, path, queue, nodeIndex, maxEdgeVisits);
+                }
+            }
+        }
+        setGenotypedProbabilities(genotypes);
+        return genotypes;
+    }
+
+    /**
+     * Container for the state of a genotype during graph traversal
+     */
+    private static final class SVGraphPathState {
+        private final List<List<IndexedSVGraphEdge>> pathsList;
+        private final List<EdgeCopyNumberPosterior> edgeCopyNumberPosteriors;
+        private final int[] edgeCopyNumberStates;
+        private final int numCopyNumberStates;
+        private int currentNode;
+        private int currentPloidy;
+        boolean currentlyInverted;
+
+        public SVGraphPathState(final int initialNode, final List<EdgeCopyNumberPosterior> edgeCopyNumberPosteriors) {
+            this.pathsList = new ArrayList<>();
+            this.pathsList.add(new ArrayList<>());
+            this.edgeCopyNumberPosteriors = edgeCopyNumberPosteriors;
+            this.edgeCopyNumberStates = new int[edgeCopyNumberPosteriors.size()];
+            this.numCopyNumberStates = edgeCopyNumberPosteriors.isEmpty() ? 0 : edgeCopyNumberPosteriors.get(0).numCopyNumberStates();
+            this.currentNode = initialNode;
+            currentPloidy = 1;
+            currentlyInverted = false;
+        }
+
+        private SVGraphPathState(final int currentNode, final List<EdgeCopyNumberPosterior> edgeCopyNumberPosteriors,
+                                 final int[] edgeCopyNumberStates, final int currentPloidy,
+                                 final boolean currentlyInverted, final int numCopyNumberStates) {
+            this.currentNode = currentNode;
+            this.pathsList = new ArrayList<>();
+            this.edgeCopyNumberPosteriors = edgeCopyNumberPosteriors;
+            this.edgeCopyNumberStates = Arrays.copyOf(edgeCopyNumberStates, edgeCopyNumberStates.length);
+            this.currentPloidy = currentPloidy;
+            this.currentlyInverted = currentlyInverted;
+            this.numCopyNumberStates = numCopyNumberStates;
+        }
+
+        public boolean isCurrentlyInverted() {
+            return currentlyInverted;
+        }
+
+        public void invert() {
+            currentlyInverted = !currentlyInverted;
+        }
+
+        public List<List<IndexedSVGraphEdge>> getPathsList() {
+            return pathsList;
+        }
+
+        public List<IndexedSVGraphEdge> getCurrentPath() {
+            return pathsList.get(currentPloidy - 1);
+        }
+
+        public int getCurrentNode() {
+            return currentNode;
+        }
+
+        public void setCurrentNode(final int currentNode) {
+            this.currentNode = currentNode;
+        }
+
+        public double logLikelihood() {
+            return IntStream.range(0, edgeCopyNumberPosteriors.size()).mapToDouble(k -> edgeCopyNumberPosteriors.get(k).getLogPosterior(edgeCopyNumberStates[k])).sum();
+        }
+
+        public boolean addEdge(final IndexedSVGraphEdge edge, final double maxState) {
+            getCurrentPath().add(edge);
+            if (edge.isReference()) {
+                edgeCopyNumberStates[edge.getIndex()] += 1;
+                if (edgeCopyNumberStates[edge.getIndex()] > maxState) return false;
+            }
+            currentNode = edge.getDownstreamNodeIndex();
+            if (currentNode == -1) {
+                throw new GATKException("Attempted to add edge without a set upstream node");
+            }
+            return true;
+        }
+
+        public void incrementPloidy() {
+            currentPloidy++;
+            pathsList.add(new ArrayList<>());
+        }
+
+        public int getCurrentPloidy() {
+            return currentPloidy;
+        }
+
+        public SVGraphPathState copy() {
+            final SVGraphPathState copy = new SVGraphPathState(currentNode, edgeCopyNumberPosteriors, edgeCopyNumberStates, currentPloidy, currentlyInverted, numCopyNumberStates);
+            for (final List<IndexedSVGraphEdge> path : pathsList) {
+                final List<IndexedSVGraphEdge> pathCopy = new ArrayList<>(path.size());
+                for (final IndexedSVGraphEdge edge : path) {
+                    pathCopy.add(edge);
+                }
+                copy.pathsList.add(pathCopy);
+            }
+            return copy;
+        }
+    }
+
+    /**
+     * Container for copy number posterior likelihoods
+     */
+    private final static class EdgeCopyNumberPosterior {
+        private final double[] logPosteriors;
+
+        public EdgeCopyNumberPosterior(final double[] logPosteriors) {
+            this.logPosteriors = logPosteriors;
+        }
+
+        public double getLogPosterior(final int i) {
+            if (i >= logPosteriors.length || i < 0) return Double.NEGATIVE_INFINITY;
+            return logPosteriors[i];
+        }
+
+        public int numCopyNumberStates() {
+            return logPosteriors.length;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphNode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphNode.java
@@ -1,0 +1,65 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class SVGraphNode {
+
+    private final int contig;
+    private final int position;
+    private final List<IndexedSVGraphEdge> outEdges;
+    private final List<IndexedSVGraphEdge> inEdges;
+
+    public SVGraphNode(final int contig, final int position) {
+        this.contig = contig;
+        this.position = position;
+        this.outEdges = new ArrayList<>(1);
+        this.inEdges = new ArrayList<>(1);
+    }
+
+    public String toString() {
+        return contig + ":" + position;
+    }
+
+    public int getContig() {
+        return contig;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public List<IndexedSVGraphEdge> getOutEdges() {
+        return outEdges;
+    }
+
+    public List<IndexedSVGraphEdge> getInEdges() {
+        return inEdges;
+    }
+
+    public int countReferenceInEdges() {
+        return (int) inEdges.stream().filter(IndexedSVGraphEdge::isReference).count();
+    }
+
+    public int countReferenceOutEdges() {
+        return (int) outEdges.stream().filter(IndexedSVGraphEdge::isReference).count();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SVGraphNode)) return false;
+        SVGraphNode that = (SVGraphNode) o;
+        return contig == that.contig &&
+                position == that.position &&
+                Objects.equals(outEdges, that.outEdges) &&
+                Objects.equals(inEdges, that.inEdges);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(contig, position, outEdges, inEdges);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphPartitioner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/SVGraphPartitioner.java
@@ -1,0 +1,115 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Partitions SV graph into subgraphs using a provided edge dependence function
+ */
+public final class SVGraphPartitioner {
+
+    private final List<IndexedSVGraphEdge> edges;
+    private final List<SVGraphNode> nodes;
+    private final SAMSequenceDictionary dictionary;
+
+    public SVGraphPartitioner(final SVGraph graph) {
+        edges = graph.getEdges();
+        nodes = graph.generateNodes();
+        dictionary = graph.getDictionary();
+    }
+
+    public List<SVGraph> getIndependentSubgraphs(final BiFunction<SVInterval, SVInterval, Boolean> edgeDependenceFunction) {
+        //Tree must store collection of edges in case multiple edges have identical intervals
+        final SVIntervalTree<Collection<IndexedSVGraphEdge>> breakpointEdgeTree = new SVIntervalTree<>();
+        for (final IndexedSVGraphEdge edge : edges) {
+            addEdgeToCollectionTree(edge, breakpointEdgeTree);
+        }
+
+        //Visit each edge and cluster with dependent edges
+        final Collection<Set<IndexedSVGraphEdge>> subgraphEdgesCollection = new ArrayList<>();
+        final Set<Integer> visitedEdges = new HashSet<>(SVUtils.hashMapCapacity(breakpointEdgeTree.size()));
+        for (int i = 0; i < edges.size(); i++) {
+            //Seed a new cluster at each unvisited breakpoint edge
+            if (!visitedEdges.contains(i)) {
+                final IndexedSVGraphEdge seedEdge = edges.get(i);
+                if (!seedEdge.isReference()) {
+                    subgraphEdgesCollection.add(generateSubgraphEdges(seedEdge, visitedEdges, breakpointEdgeTree, edgeDependenceFunction));
+                }
+            }
+        }
+        return convertEdgeCollectionsToGraphs(subgraphEdgesCollection);
+    }
+
+    private Stream<IndexedSVGraphEdge> getDependentEdgesStream(final SVInterval interval,
+                                                               final SVIntervalTree<Collection<IndexedSVGraphEdge>> tree,
+                                                               final BiFunction<SVInterval, SVInterval, Boolean> edgeDependenceFunction) {
+        return Utils.stream(tree.overlappers(interval))
+                .flatMap(entry -> entry.getValue().stream())
+                .filter(overlappingEdge -> edgeDependenceFunction.apply(overlappingEdge.getInterval(), interval));
+    }
+
+    private Collection<IndexedSVGraphEdge> getNewDependentEdges(final Collection<IndexedSVGraphEdge> edges,
+                                                                final SVIntervalTree<Collection<IndexedSVGraphEdge>> tree,
+                                                                final BiFunction<SVInterval, SVInterval, Boolean> edgeDependenceFunction,
+                                                                final Set<IndexedSVGraphEdge> currentEdges) {
+        return edges.stream().map(edge -> edge.getInterval())
+                .flatMap(interval -> getDependentEdgesStream(interval, tree, edgeDependenceFunction))
+                .distinct()
+                .filter(edge -> !currentEdges.contains(edge))
+                .collect(Collectors.toList());
+    }
+
+    private Collection<CoordinateSVGraphEdge> convertIndexedEdges(final Collection<IndexedSVGraphEdge> edges) {
+        return edges.stream().map(edge -> new CoordinateSVGraphEdge(edge, nodes)).collect(Collectors.toList());
+    }
+
+    private List<SVGraph> convertEdgeCollectionsToGraphs(final Collection<Set<IndexedSVGraphEdge>> edgesCollection) {
+        return edgesCollection.stream().map(edgeSet -> convertIndexedEdges(edgeSet))
+                .map(edgeSet -> new SVGraph(edgeSet, dictionary))
+                .collect(Collectors.toList());
+    }
+
+    private final Set<IndexedSVGraphEdge> generateSubgraphEdges(final IndexedSVGraphEdge seedEdge,
+                                                                final Set<Integer> visitedEdges,
+                                                                final SVIntervalTree<Collection<IndexedSVGraphEdge>> tree,
+                                                                final BiFunction<SVInterval, SVInterval, Boolean> edgeDependenceFunction) {
+        visitedEdges.add(seedEdge.getIndex());
+        final Set<IndexedSVGraphEdge> subgraphEdges = new HashSet<>();
+        final Set<IndexedSVGraphEdge> newEdges = new HashSet<>();
+        subgraphEdges.add(seedEdge);
+        newEdges.add(seedEdge);
+
+        //Agglomerate intersecting edges
+        while (!newEdges.isEmpty()) {
+            final Collection<IndexedSVGraphEdge> newDependentEdges = getNewDependentEdges(newEdges, tree, edgeDependenceFunction, subgraphEdges);
+            newEdges.clear();
+            newEdges.addAll(newDependentEdges);
+            subgraphEdges.addAll(newEdges);
+            final Collection<Integer> newEdgeIndices = newEdges.stream().map(IndexedSVGraphEdge::getIndex).collect(Collectors.toList());
+            visitedEdges.addAll(newEdgeIndices);
+        }
+        return subgraphEdges;
+    }
+
+    private void addEdgeToCollectionTree(final IndexedSVGraphEdge edge, final SVIntervalTree<Collection<IndexedSVGraphEdge>> tree) {
+        if (!edge.isReference()) {
+            final SVInterval interval = edge.getInterval();
+            final SVIntervalTree.Entry<Collection<IndexedSVGraphEdge>> entry = tree.find(interval);
+            if (entry == null) {
+                final Collection<IndexedSVGraphEdge> newEdgeCollection = new LinkedList<>();
+                newEdgeCollection.add(edge);
+                tree.put(interval, newEdgeCollection);
+            } else {
+                entry.getValue().add(edge);
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
@@ -4,12 +4,17 @@ import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.Sets;
+import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.PairedStrandedIntervals;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.StrandedInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * This class holds information about pairs of intervals on the reference that are connected by one or more
@@ -19,15 +24,17 @@ import java.util.Set;
  * that contributed to the link, as well as the template names of the reads.
  */
 @DefaultSerializer(EvidenceTargetLink.Serializer.class)
-public final class EvidenceTargetLink {
+public final class EvidenceTargetLink implements Serializable {
     private static final StrandedInterval.Serializer intervalSerializer = new StrandedInterval.Serializer();
 
+    public static final long serialVersionUID = 1L;
     final StrandedInterval source;
     final StrandedInterval target;
     final int splitReads;
     final int readPairs;
     private final Set<String> readPairTemplateNames;
     private final Set<String> splitReadTemplateNames;
+    private static final int NUM_BEDPE_TOKENS = 12;
 
     public EvidenceTargetLink(final StrandedInterval source, final StrandedInterval target,
                               final int splitReads, final int readPairs,
@@ -85,6 +92,65 @@ public final class EvidenceTargetLink {
                 "\t"  + getId(readMetadata) + "\t" +
                 (readPairs + splitReads) + "\t" + (source.getStrand() ? "+" : "-") + "\t" + (target.getStrand() ? "+" : "-")
                 + "\t" + "SR:" + Utils.join(",", splitReadTemplateNames) + "\t" + "RP:" + Utils.join(",", readPairTemplateNames);
+    }
+
+    public static EvidenceTargetLink fromBedpeString(final String str, final SAMSequenceDictionary dictionary) {
+        return fromBedpeString(str, dictionary::getSequenceIndex);
+    }
+    public static EvidenceTargetLink fromBedpeString(final String str, final ReadMetadata readMetadata) {
+        return fromBedpeString(str, readMetadata::getContigID);
+    }
+
+    public static EvidenceTargetLink fromBedpeString(final String str, Function<String,Integer> sequenceNameToIndexFunction) {
+        final String[] tokens = str.split("\t");
+        if (tokens.length != NUM_BEDPE_TOKENS) {
+            throw new IllegalArgumentException("Could not create " + EvidenceTargetLink.class.getSimpleName() + " because " + NUM_BEDPE_TOKENS + " tab-delimited tokens were expected but found " + tokens.length + " in the bedpe string: " + str);
+        }
+        final int sourceContig = sequenceNameToIndexFunction.apply(tokens[0]);
+        final int sourceStart = parseInteger(tokens[1]);
+        final int sourceEnd = parseInteger(tokens[2]);
+        final int targetContig = sequenceNameToIndexFunction.apply(tokens[3]);
+        final int targetStart = parseInteger(tokens[4]);
+        final int targetEnd = parseInteger(tokens[5]);
+        final int numReadPairsAndSplitReads = parseInteger(tokens[7]);
+        final boolean sourceStrand = parseStrand(tokens[8]);
+        final boolean targetStrand = parseStrand(tokens[9]);
+        final Set<String> splitReadNames = parseTemplateNames(tokens[10]);
+        final Set<String> readPairNames = parseTemplateNames(tokens[11]);
+
+        if (numReadPairsAndSplitReads != splitReadNames.size() + readPairNames.size()) {
+            throw new IllegalArgumentException("Sum of split read (" + splitReadNames.size() + ") and read pair (" + readPairNames.size() + ") template names does not equal the listed sum " + numReadPairsAndSplitReads + " in record: " + str);
+        }
+
+        final StrandedInterval source = new StrandedInterval(new SVInterval(sourceContig, sourceStart, sourceEnd), sourceStrand);
+        final StrandedInterval target = new StrandedInterval(new SVInterval(targetContig, targetStart, targetEnd), targetStrand);
+        return new EvidenceTargetLink(source, target, splitReadNames.size(), readPairNames.size(), readPairNames, splitReadNames);
+
+    }
+
+    private static int parseInteger(final String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Could not parse string as integer: " + str);
+        }
+    }
+
+    private static boolean parseStrand(final String str) {
+        if (str.equals("+")) {
+            return true;
+        } else if (str.equals("-")) {
+            return false;
+        } else {
+            throw new IllegalArgumentException("Unrecognized strand token:" + str);
+        }
+    }
+
+    private static Set<String> parseTemplateNames(final String str) {
+        final String trimmedStr = str.substring(3); //remove "RP:" or "SR:" prefix
+        if (trimmedStr.isEmpty()) return Collections.emptySet();
+        final String[] tokens = trimmedStr.split(",");
+        return Sets.newHashSet(tokens);
     }
 
     private String getId(final ReadMetadata readMetadata) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/EvidenceTargetLink.java
@@ -11,7 +11,6 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.StrandedInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Function;
@@ -24,10 +23,9 @@ import java.util.function.Function;
  * that contributed to the link, as well as the template names of the reads.
  */
 @DefaultSerializer(EvidenceTargetLink.Serializer.class)
-public final class EvidenceTargetLink implements Serializable {
+public final class EvidenceTargetLink {
     private static final StrandedInterval.Serializer intervalSerializer = new StrandedInterval.Serializer();
 
-    public static final long serialVersionUID = 1L;
     final StrandedInterval source;
     final StrandedInterval target;
     final int splitReads;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/BreakpointPair.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/BreakpointPair.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+public final class BreakpointPair implements Serializable {
+    public static final long serialVersionUID = 1L;
+    private final int contigA;
+    private final int contigB;
+    private final int positionA;
+    private final int positionB;
+    private final boolean strandA;
+    private final boolean strandB;
+    private final Collection<String> assembledContigsA;
+    private final Collection<String> assembledContigsB;
+
+    public BreakpointPair(final VariantContext mateA, final VariantContext mateB, final SAMSequenceDictionary dictionary) {
+        positionA = mateA.getStart();
+        positionB = mateB.getStart();
+        contigA = dictionary.getSequenceIndex(mateA.getContig());
+        contigB = dictionary.getSequenceIndex(mateB.getContig());
+        final String altB = mateB.getAlternateAlleles().get(0).toString();
+        final String altA = mateA.getAlternateAlleles().get(0).toString();
+        if (altB.startsWith("]") || altB.endsWith("]")) {
+            strandA = true;
+        } else if (altB.startsWith("[") || altB.endsWith("[")) {
+            strandA = false;
+        } else {
+            throw new IllegalArgumentException("Could not get mate strandedness from ALT: " + altB);
+        }
+        if (altA.startsWith("]") || altA.endsWith("]")) {
+            strandB = true;
+        } else if (altA.startsWith("[") || altA.endsWith("[")) {
+            strandB = false;
+        } else {
+            throw new IllegalArgumentException("Could not get mate strandedness from ALT: " + altA);
+        }
+        assembledContigsA = mateA.getAttributeAsStringList(GATKSVVCFConstants.CONTIG_NAMES, "");
+        assembledContigsB = mateB.getAttributeAsStringList(GATKSVVCFConstants.CONTIG_NAMES, "");
+    }
+
+    public Collection<String> getAssembledContigsA() {
+        return assembledContigsA;
+    }
+
+    public Collection<String> getAssembledContigsB() {
+        return assembledContigsB;
+    }
+
+    public int getContigA() {
+        return contigA;
+    }
+
+    public int getContigB() {
+        return contigB;
+    }
+
+    public int getPositionA() {
+        return positionA;
+    }
+
+    public int getPositionB() { return positionB; }
+
+    public boolean isStrandA() {
+        return strandA;
+    }
+
+    public boolean isStrandB() {
+        return strandB;
+    }
+
+    public PairedStrandedIntervals getPairedStrandedInterval() {
+        final StrandedInterval intervalA = new StrandedInterval(new SVInterval(getContigA(), getPositionA(), getPositionA() + 1), isStrandA());
+        final StrandedInterval intervalB = new StrandedInterval(new SVInterval(getContigB(), getPositionB(), getPositionB() + 1), isStrandA());
+        if (getContigA() < getContigB() || (getContigA() == getContigB() && getPositionA() <= getPositionB())) {
+            return new PairedStrandedIntervals(intervalA, intervalB);
+        }
+        return new PairedStrandedIntervals(intervalB, intervalA);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtils.java
@@ -1,0 +1,128 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth.SVCopyNumberInterval;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Collection;
+import java.util.Comparator;
+
+/**
+ * Common utility functions for {@link SVInterval} and {@link SVIntervalTree}
+ */
+public class SVIntervalUtils {
+
+    /**
+     * Builds an interval tree of {@link SVInterval}s with null entry values
+     */
+    public static SVIntervalTree<Object> buildIntervalTreeWithNullValues(final Collection<SVInterval> intervals) {
+        final SVIntervalTree<Object> tree = new SVIntervalTree<>();
+        if (intervals != null) {
+            for (final SVInterval interval : intervals) {
+                tree.put(new SVInterval(interval.getContig(), interval.getStart(), interval.getEnd()), null);
+            }
+        }
+        return tree;
+    }
+
+    /**
+     * Gets comparator for {@link SVCopyNumberInterval} dictionary order
+     */
+    public static Comparator<SVCopyNumberInterval> getCopyNumberIntervalDictionaryOrderComparator() {
+        return (o1, o2) -> compareIntervals(o1.getInterval(), o2.getInterval());
+    }
+
+    /**
+     * Comparator function for {@link SVInterval} dictionary order
+     */
+    public static int compareIntervals(final SVInterval first, final SVInterval second) {
+        Utils.nonNull(first);
+        Utils.nonNull(second);
+
+        int result = 0;
+        if (first != second) {
+            // compare the contigs
+            result = Integer.compare(first.getContig(), second.getContig());
+            if (result == 0) {
+                // compare start position
+                result = Integer.compare(first.getStart(), second.getStart());
+                if (result == 0) {
+                    // compare end position
+                    result = Integer.compare(first.getEnd(), second.getEnd());
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns new interval with the specified amount of padding
+     */
+    public static SVInterval getPaddedInterval(final SVInterval interval, final int padding, final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(interval, "SVInterval cannot be null");
+        if (padding < 0) {
+            throw new IllegalArgumentException("Padding must be non-negative");
+        }
+        Utils.nonNull(dictionary, "SAMSequenceDictionary cannot be null");
+        final SAMSequenceRecord sequence = dictionary.getSequence(interval.getContig());
+        if (sequence == null) {
+            throw new IllegalArgumentException("Could not find interval contig with index " + interval.getContig() + " in the sequence dictionary");
+        }
+        final int leftBoundary = Math.max(0, interval.getStart() - padding);
+        final int contigLength = dictionary.getSequence(interval.getContig()).getSequenceLength();
+        final int rightBoundary = Math.min(contigLength - 1, interval.getEnd() + padding);
+        return new SVInterval(interval.getContig(), leftBoundary, rightBoundary);
+    }
+
+    /**
+     * Returns true if the two intervals have at least the given amount of reciprocal overlap
+     */
+    public static boolean hasReciprocalOverlap(final SVInterval a, final SVInterval b, final double minOverlapFraction) {
+        Utils.validateArg(minOverlapFraction >= 0, "Overlap fraction must be non-negative");
+        Utils.validateArg(minOverlapFraction <= 1, "Overlap fraction must less than or equal to 1");
+        return reciprocalOverlap(a, b) >= minOverlapFraction;
+    }
+
+    /**
+     * Calculates fraction reciprocal overlap of the given intervals
+     */
+    public static double reciprocalOverlap(final SVInterval a, final SVInterval b) {
+        Utils.nonNull(a, "SVInterval A cannot be null");
+        Utils.nonNull(b, "SVInterval B cannot be null");
+        final int overlapLen = a.overlapLen(b);
+        final double fractionOverlapA = overlapLen / (double) a.getLength();
+        final double fractionOverlapB = overlapLen / (double) b.getLength();
+        return Math.min(fractionOverlapA, fractionOverlapB);
+    }
+
+    /**
+     * Creates new {@link SimpleInterval} from contig index, assuming 0-based half-open input coordinates
+     */
+    public static SimpleInterval createSimpleInterval(final int contig, final int start, final int end, final SAMSequenceDictionary dictionary) {
+        final SAMSequenceRecord sequenceRecord = dictionary.getSequence(contig);
+        if (sequenceRecord == null) {
+            throw new IllegalArgumentException("Could not find contig " + contig + " in sequence ditionary");
+        }
+        return new SimpleInterval(sequenceRecord.getSequenceName(), start + 1, end);
+    }
+
+    /**
+     * Converts {@link SVInterval} to {@link SimpleInterval}, assuming 0-based half-open input coordinates
+     */
+    public static SimpleInterval convertToSimpleInterval(final SVInterval interval, final SAMSequenceDictionary dictionary) {
+        return createSimpleInterval(interval.getContig(), interval.getStart(), interval.getEnd(), dictionary);
+    }
+
+    /**
+     * Generates an interval tree from {@link SVCopyNumberInterval} collection
+     */
+    public static SVIntervalTree<SVCopyNumberInterval> buildCopyNumberIntervalTree(final Collection<SVCopyNumberInterval> copyNumberIntervals) {
+        final SVIntervalTree<SVCopyNumberInterval> tree = new SVIntervalTree<>();
+        for (final SVCopyNumberInterval interval : copyNumberIntervals) {
+            tree.put(interval.getInterval(), interval);
+        }
+        return tree;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEventTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/readdepth/CalledSVGraphEventTest.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.hellbender.tools.spark.sv.discovery.readdepth;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CalledSVGraphEventTest extends GATKBaseTest {
+
+    private static final List<SAMSequenceRecord> TEST_RECORDS = Arrays.asList(new SAMSequenceRecord("0", 10000),
+            new SAMSequenceRecord("1", 10000), new SAMSequenceRecord("2", 10000),
+            new SAMSequenceRecord("3", 10000));
+    private static final SAMSequenceDictionary TEST_DICT = new SAMSequenceDictionary(TEST_RECORDS);
+
+    @DataProvider(name="eventData")
+    private Object[][] eventDataGenerator() {
+        final List<Object[]> data = new ArrayList<>(20);
+
+        data.add(new Object[]{CalledSVGraphEvent.Type.DEL, 0, 1000, 2000, 0, 0, false});
+        data.add(new Object[]{CalledSVGraphEvent.Type.DUP, 3, 0, 100, 3, 1, false});
+        data.add(new Object[]{CalledSVGraphEvent.Type.UR, 0, 1000, 5000, 8, 1, true});
+
+        return data.toArray(new Object[data.size()][]);
+    }
+
+    @Test(groups = "sv", dataProvider = "eventData")
+    public void testConstructorAndGetters(final CalledSVGraphEvent.Type type, final int contig, final int start,
+                                          final int end, final int groupId, final int pathId, final boolean resolved) {
+        final SVInterval interval = new SVInterval(contig, start, end);
+        final CalledSVGraphEvent event = new CalledSVGraphEvent(type, interval, groupId, pathId, resolved);
+        Assert.assertEquals(type, event.getType());
+        Assert.assertEquals(interval, event.getInterval());
+        Assert.assertEquals(groupId, event.getGroupId());
+        Assert.assertEquals(pathId, event.getPathId());
+        Assert.assertEquals(resolved, event.isResolved());
+        Assert.assertNotNull(event.bedString(TEST_DICT));
+    }
+
+    @Test(groups = "sv")
+    public void testGetHeader() {
+        final String header = CalledSVGraphEvent.bedHeader();
+        Assert.assertNotNull(header);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtilsUnitTest.java
@@ -1,0 +1,67 @@
+package org.broadinstitute.hellbender.tools.spark.sv.utils;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SVIntervalUtilsUnitTest extends GATKBaseTest {
+
+    @Test(groups = "sv")
+    public void getPaddedIntervalTest() {
+        final SVInterval interval = new SVInterval(0, 100, 200);
+        final int padding = 10;
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
+        dictionary.addSequence(new SAMSequenceRecord("seq0", 1000));
+        final SVInterval paddedInterval = SVIntervalUtils.getPaddedInterval(interval, padding, dictionary);
+        Assert.assertEquals(paddedInterval.getContig(), 0);
+        Assert.assertEquals(paddedInterval.getStart(), 90);
+        Assert.assertEquals(paddedInterval.getEnd(), 210);
+
+        final SVInterval interval2 = new SVInterval(0, 5, 995);
+        final SVInterval paddedInterval2 = SVIntervalUtils.getPaddedInterval(interval2, padding, dictionary);
+        Assert.assertEquals(paddedInterval2.getContig(), 0);
+        Assert.assertEquals(paddedInterval2.getStart(), 0);
+        Assert.assertEquals(paddedInterval2.getEnd(), 999);
+    }
+
+    @DataProvider(name = "reciprocalOverlapTest")
+    public Object[][] getReciprocalOverlapData() {
+        return new Object[][]{
+                {10, 20, 0, 9, 0., 1.},
+                {10, 20, 20, 29, 0., 1.},
+                {10, 20, 5, 15, 5. / 10., 6. / 10.},
+                {10, 20, 15, 25, 5. / 10., 6. / 10.},
+                {10, 20, 19, 20, 1. / 10., 2. / 10.},
+                {10, 20, 19, 21, 1. / 10., 2. / 10.},
+                {10, 20, 18, 21, 2. / 10., 3. / 10.},
+                {10, 20, 18, 30, 2. / 12., 3. / 12.}
+        };
+    }
+
+    @Test(groups = "sv",
+            dataProvider = "reciprocalOverlapTest")
+    public void reciprocalOverlapTest(final int startA, final int endA, final int startB, final int endB, final double reciprocalOverlapEquals, final double reciprocalOverlapFalse) {
+        final SVInterval intervalA = new SVInterval(0, startA, endA);
+        final SVInterval intervalB1 = new SVInterval(0, startB, endB);
+        Assert.assertEquals(SVIntervalUtils.reciprocalOverlap(intervalA, intervalB1), reciprocalOverlapEquals);
+        Assert.assertTrue(SVIntervalUtils.hasReciprocalOverlap(intervalA, intervalB1, reciprocalOverlapEquals));
+        Assert.assertTrue(SVIntervalUtils.hasReciprocalOverlap(intervalA, intervalB1, reciprocalOverlapEquals / 2));
+        Assert.assertFalse(SVIntervalUtils.hasReciprocalOverlap(intervalA, intervalB1, reciprocalOverlapFalse));
+        final SVInterval intervalB2 = new SVInterval(1, startB, endB);
+        Assert.assertEquals(SVIntervalUtils.reciprocalOverlap(intervalA, intervalB2), 0.);
+    }
+
+    @Test(groups = "sv")
+    public void convertIntervalsTest() {
+        final SVInterval svInterval = new SVInterval(0, 100, 200);
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
+        dictionary.addSequence(new SAMSequenceRecord("seq0", 1000));
+        final SimpleInterval simpleInterval = SVIntervalUtils.convertToSimpleInterval(svInterval, dictionary);
+        Assert.assertEquals(simpleInterval, new SimpleInterval("seq0", 100, 200));
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVIntervalUtilsUnitTest.java
@@ -61,7 +61,7 @@ public class SVIntervalUtilsUnitTest extends GATKBaseTest {
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
         dictionary.addSequence(new SAMSequenceRecord("seq0", 1000));
         final SimpleInterval simpleInterval = SVIntervalUtils.convertToSimpleInterval(svInterval, dictionary);
-        Assert.assertEquals(simpleInterval, new SimpleInterval("seq0", 100, 200));
+        Assert.assertEquals(simpleInterval, new SimpleInterval("seq0", 101, 200));
     }
 
 }


### PR DESCRIPTION
Adds a tool for calling SVs using various SV evidence (BNDs, SV pipeline DEL calls, discordant read pairs, split reads) and copy number calls from gCNV. Possible haplotypes are enumerated using a traversal of the sequence graph supported by the SV evidence. The copy number posteriors are integrated to call likely events associated with the possible genotypes. Unit and integration tests forthcoming.