### PR TITLE
Add nck with message to StreamingProcessController for passing fatal error messages.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerAckResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerAckResult.java
@@ -1,0 +1,66 @@
+package org.broadinstitute.hellbender.utils.runtime;
+
+import org.broadinstitute.hellbender.exceptions.GATKException;
+
+/**
+ * Command acknowledgements that are returned from a process managed by StreamingProcessController.
+ * Ack results can be positive, negative, or negative with a message.
+ */
+public class ProcessControllerAckResult {
+
+    private final boolean isPositiveAck;
+    private final String message;
+
+    // three message types can be used by the remote process
+    private static String ACK_LOG_MESSAGE               = "Ack received\n\n";
+    private static String NCK_LOG_MESSAGE               = "Nck received\n\n";
+    private static String NCK_WITH_MESSAGE_LOG_MESSAGE  = "Nkm received\n\n";
+
+    public ProcessControllerAckResult(final boolean isPositiveAck) {
+        this(isPositiveAck, "");
+    }
+
+    public ProcessControllerAckResult(final boolean isPositiveAck, final String message) {
+        this.isPositiveAck = isPositiveAck;
+        this.message = message;
+    }
+
+    /**
+     * @return true if this represents a positive ack, otherwise false
+     */
+    public boolean isPositiveAck() {
+        return isPositiveAck;
+    }
+
+    /**
+     * @return true if this ack is negative and includes a message
+     */
+    public boolean hasMessage() {
+        return !isPositiveAck() && !message.isEmpty();
+    }
+
+    /**
+     *
+     * @return A (possibly empty) String with any message sent from the remote process.
+     * Only defined for negative acknowledgements {@link #hasMessage()}.
+     */
+    public String getNegativeACKMessage() {
+        if (isPositiveAck()) {
+            throw new GATKException("Can only retrieve messages for negative acknowledgements");
+        }
+        return message;
+    }
+
+    /**
+     * @return A message string representing this ack/nck suitable for logging/display to the user.
+     */
+    public String getDisplayMessage() {
+        if (isPositiveAck()) {
+            return ACK_LOG_MESSAGE;
+        } else if (hasMessage()) {
+            return String.format("%s: %s", NCK_WITH_MESSAGE_LOG_MESSAGE, getNegativeACKMessage());
+        } else {
+            return NCK_LOG_MESSAGE;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerAckResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerAckResult.java
@@ -12,17 +12,27 @@ public class ProcessControllerAckResult {
     private final String message;
 
     // three message types can be used by the remote process
-    private static String ACK_LOG_MESSAGE               = "Ack received\n\n";
-    private static String NCK_LOG_MESSAGE               = "Nck received\n\n";
-    private static String NCK_WITH_MESSAGE_LOG_MESSAGE  = "Nkm received\n\n";
+    private static String displayMessageFormat = "%s received\n\n";
+    private static String ACK_LOG_MESSAGE               = String.format(displayMessageFormat, StreamingToolConstants.STREAMING_ACK_MESSAGE);
+    private static String NCK_LOG_MESSAGE               = String.format(displayMessageFormat, StreamingToolConstants.STREAMING_NCK_MESSAGE);
+    private static String NCK_WITH_MESSAGE_LOG_MESSAGE  = String.format(displayMessageFormat, StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MESSAGE);
 
+    /**
+     * Creates an ack result, for ACK or NCK.
+     * @param isPositiveAck true for a positive ack (ACK), false for negative ack (NCK)
+     */
     public ProcessControllerAckResult(final boolean isPositiveAck) {
-        this(isPositiveAck, "");
+        this.isPositiveAck = isPositiveAck;
+        this.message = null;
     }
 
-    public ProcessControllerAckResult(final boolean isPositiveAck, final String message) {
-        this.isPositiveAck = isPositiveAck;
-        this.message = message;
+    /**
+     * Creates an (negative NKM) ack result, with a message.
+     * @param nckMessage Message detail indicating reason for negative ack (NKM).
+     */
+    public ProcessControllerAckResult(final String nckMessage) {
+        this.isPositiveAck = false;
+        this.message = nckMessage;
     }
 
     /**
@@ -40,7 +50,6 @@ public class ProcessControllerAckResult {
     }
 
     /**
-     *
      * @return A (possibly empty) String with any message sent from the remote process.
      * Only defined for negative acknowledgements {@link #hasMessage()}.
      */

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/StreamingToolConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/StreamingToolConstants.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.hellbender.utils.runtime;
+
+/**
+ * Various constants used by StreamingProcessController that require synchronized equivalents in
+ * the companion process, i.e., if the streaming process is written in Python, there must be
+ * equivalent Python constants for use by the Python code.
+ *
+ * See the equivalents for Python in toolcontants.py.
+ */
+public class StreamingToolConstants {
+    /**
+     * Command acknowledgement messages used to signal positive acknowledgement ('ack'),
+     * negative acknowledgement ('nck'), and negative acknowledgement with an accompanying
+     * message ('nkm').
+     */
+    public static String STREAMING_ACK_MESSAGE = "ack";
+    public static String STREAMING_NCK_MESSAGE = "nck";
+    public static String STREAMING_NCK_WITH_MESSAGE_MESSAGE = "nkm";
+
+    // This is only used by Java, but is kept here since it represents the length of the constant
+    // strings defined above.
+    protected static int STREAMING_ACK_MESSAGE_SIZE = 3; // "ack", "nck", or "nkm"
+
+    /**
+     * Number of characters used to represent the length of the serialized message, fixed at a constant
+     * 4 characters to ensure we can deterministically know how much input to wait for when looking for
+     * a message length in the incoming stream.
+     */
+    public static int STREAMING_NCK_WITH_MESSAGE_MESSAGE_LEN_SIZE = 4;
+    public static int STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH = 9999;
+}

--- a/src/main/python/org/broadinstitute/hellbender/gatktool/tool.py
+++ b/src/main/python/org/broadinstitute/hellbender/gatktool/tool.py
@@ -16,6 +16,7 @@ import sys
 import os
 import cProfile, pstats, io
 import traceback
+from gatktool import toolconstants
 
 _ackFIFO = None
 _dataFIFO = None
@@ -152,9 +153,6 @@ class AckFIFO:
     Manage the FIFO used to notify GATK (via an ack) that a command has
     completed, or failed due to an unhandled exception (via a nck).
     """
-    _ackString = "ack"
-    _nackString = "nck"
-    _nkmString = "nkm"
 
     def __init__(self, ackFIFOName: str) -> None:
         """Open the ack fifo stream for writing only"""
@@ -168,7 +166,7 @@ class AckFIFO:
         """
         if self.fileWriter is None:
             raise RuntimeError("ack FIFO has not been initialized")
-        self.fileWriter.write(AckFIFO._ackString)
+        self.fileWriter.write(toolconstants._ackString)
         self.fileWriter.flush()
 
     def writeNack(self):
@@ -180,7 +178,7 @@ class AckFIFO:
         """
         if self.fileWriter is None:
             raise RuntimeError("ack FIFO has not been initialized")
-        self.fileWriter.write(AckFIFO._nackString)
+        self.fileWriter.write(toolconstants._nackString)
         self.fileWriter.flush()
 
     def writeNackWithMessage(self, message: str) -> None:
@@ -197,21 +195,18 @@ class AckFIFO:
         Calling this method will result in an exception being thrown
         in the GATK tool on whose behalf this module is running.
         """
-        """The length of the message to be written must be 4 bytes long when serialized as a string"""
-        nckMaxMessageLength = 9999
-        nckMessageLengthSerializedSize = 4
         if self.fileWriter is None:
             raise RuntimeError("ack FIFO has not been initialized")
-        self.fileWriter.write(AckFIFO._nkmString)
+        self.fileWriter.write(toolconstants._nkmString)
         actualMessageLength = len(message)
         """The message length must be exactly 4 bytes"""
-        if len(str(actualMessageLength)) <= nckMessageLengthSerializedSize:
-            self.fileWriter.write(str(actualMessageLength).zfill(nckMessageLengthSerializedSize))
+        if len(str(actualMessageLength)) <= toolconstants._nckMessageLengthSerializedSize:
+            self.fileWriter.write(str(actualMessageLength).zfill(toolconstants._nckMessageLengthSerializedSize))
             self.fileWriter.write(message)
         else:
             """Message is too long, trim to 9999 bytes"""
-            self.fileWriter.write(str(nckMaxMessageLength))
-            self.fileWriter.write(message[:nckMaxMessageLength])
+            self.fileWriter.write(str(toolconstants._nckMaxMessageLength))
+            self.fileWriter.write(message[:toolconstants._nckMaxMessageLength])
         self.fileWriter.flush()
 
 

--- a/src/main/python/org/broadinstitute/hellbender/gatktool/toolconstants.py
+++ b/src/main/python/org/broadinstitute/hellbender/gatktool/toolconstants.py
@@ -1,0 +1,22 @@
+"""
+Constants that must remain in sync with the companion StreamingProcessController Java
+code in GATK. See StreamingToolConstants.java.
+
+"""
+
+"""
+Command acknowledgement messages used to signal positive acknowledgement ('ack',
+negative acknowledgement ('nck'), and negative acknowledgement with an accompanying
+message ('nkm').
+"""
+_ackString = "ack"
+_nackString = "nck"
+_nkmString = "nkm"
+
+
+"""
+The length of a message written with a negative ack (nkm) must be 4 bytes long when
+serialized as a string, and cannot have a value > 9999.
+"""
+_nckMessageLengthSerializedSize = 4
+_nckMaxMessageLength = 9999

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/StreamingProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/StreamingProcessControllerUnitTest.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.hellbender.utils.runtime;
 
 import org.broadinstitute.hellbender.testutils.BaseTest;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.python.PythonScriptExecutorException;
+import org.broadinstitute.hellbender.utils.python.StreamingPythonScriptExecutor;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -10,9 +13,11 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 
-// Tests for the StreamingProcessController. Although these tests use Python, they do not test
-// or depend on the gatktool python package.
+// Tests for the StreamingProcessController. The StreamingProcessController depends on the remote
+// process cooperating via use of the ack fifo. Since the gatktool Python package implements the required
+// cooperative methods, some of these tests depend on that package.
 //
 // NOTE: TestNG has a bug where it throws ArrayIndexOutOfBoundsException instead of TimeoutException
 // exception when the test time exceeds the timeOut threshold. This is fixed but not yet released:
@@ -135,10 +140,10 @@ public class StreamingProcessControllerUnitTest extends BaseTest {
         Assert.assertFalse(catController.getProcess().isAlive());
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(groups = "python", expectedExceptions = IllegalStateException.class)
     public void testRedundantStart() {
-        final ProcessSettings catProcessSettings = new ProcessSettings(new String[] {"python", "-i", "-u"});
-        final StreamingProcessController catController = new StreamingProcessController(catProcessSettings);
+        final ProcessSettings processSettings = new ProcessSettings(new String[] {"python", "-i", "-u"});
+        final StreamingProcessController catController = new StreamingProcessController(processSettings);
         Assert.assertNotNull(catController.start());
 
         try {
@@ -146,6 +151,49 @@ public class StreamingProcessControllerUnitTest extends BaseTest {
         } finally {
             catController.terminate();
             Assert.assertFalse(catController.getProcess().isAlive());
+        }
+    }
+
+    @DataProvider(name="nckMessages")
+    private Object[][] getNckMessages() {
+        return new Object[][] {
+                // message, expected message length
+                { "", "" },     // message of length 0
+                { "1", "1" },   // message of length 1
+                { "Test roundtrip negative ack with message protocol", "Test roundtrip negative ack with message protocol" },
+                // one byte less than max
+                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1),
+                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1) },
+                // exactly max bytes
+                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH),
+                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) },  // 9999
+                // max bytes + 1000, trimmed to max
+                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH + 1000),
+                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) }, // > 9999 is trimmed to 9999
+        };
+    }
+
+    @Test(groups = "python", dataProvider = "nckMessages", timeOut = 50000, expectedExceptions={PythonScriptExecutorException.class})
+    public void testNckWithMessage(final String nkmMessage, final String expectedMessage) throws PythonScriptExecutorException {
+
+        // Since testing the nack w/message StreamingProcessController functionality requires a cooperative remote
+        // process that implements code to service the ack fifo, we test it indirectly via use of the
+        // StreamingPythonExecutor, since that already depends on Python code that knows how to participate
+        // in the protocol.
+        final StreamingPythonScriptExecutor<String> streamingPythonExecutor =
+                new StreamingPythonScriptExecutor<>(StreamingPythonScriptExecutor.PythonExecutableName.PYTHON3,true);
+        Assert.assertNotNull(streamingPythonExecutor);
+        Assert.assertTrue(streamingPythonExecutor.start(Collections.emptyList(), true, null));
+
+        try {
+            streamingPythonExecutor.sendSynchronousCommand(String.format("tool.sendNackWithMessage(\"%s\")" + NL, nkmMessage));
+        }
+        catch (PythonScriptExecutorException e) {
+            Assert.assertTrue(e.getMessage().contains(expectedMessage));
+            throw e;
+        }
+        finally {
+            streamingPythonExecutor.terminate();
         }
     }
 
@@ -188,7 +236,7 @@ public class StreamingProcessControllerUnitTest extends BaseTest {
     private boolean requestAndWaitForAck(final StreamingProcessController controller) {
         controller.writeProcessInput("akcFIFOWriter.write('ack')" + NL);
         controller.writeProcessInput("akcFIFOWriter.flush()" + NL);
-        return controller.waitForAck();
+        return controller.waitForAck().isPositiveAck();
     }
 
     private String getLineFromTempFile(final File tempFile) throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/StreamingProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/StreamingProcessControllerUnitTest.java
@@ -162,14 +162,14 @@ public class StreamingProcessControllerUnitTest extends BaseTest {
                 { "1", "1" },   // message of length 1
                 { "Test roundtrip negative ack with message protocol", "Test roundtrip negative ack with message protocol" },
                 // one byte less than max
-                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1),
-                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1) },
+                { Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1),
+                        Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH - 1) },
                 // exactly max bytes
-                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH),
-                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) },  // 9999
+                { Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH),
+                        Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) },  // 9999
                 // max bytes + 1000, trimmed to max
-                { Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH + 1000),
-                        Utils.dupChar('s', StreamingProcessController.NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) }, // > 9999 is trimmed to 9999
+                { Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH + 1000),
+                        Utils.dupChar('s', StreamingToolConstants.STREAMING_NCK_WITH_MESSAGE_MAX_MESSAGE_LENGTH) }, // > 9999 is trimmed to 9999
         };
     }
 


### PR DESCRIPTION
This adds a new message to the StreamingProcessController ack FIFO protocol to allow additional message detail to be passed as part of a negative ack. Fixes https://github.com/broadinstitute/gatk/issues/5100.