### PR TITLE
Updated COSMIC to annotate protein change strings with their counts.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
@@ -306,12 +306,8 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
     private void updateProteinChangeCountMap(final Map<String, Integer> proteinChangeCounts, final ResultSet resultSet) {
         final String proteinChange = getProteinChangeStringFromResults(resultSet);
         if ( !proteinChange.isEmpty() ) {
-            if ( proteinChangeCounts.containsKey(proteinChange) ) {
-                proteinChangeCounts.put(proteinChange, proteinChangeCounts.get(proteinChange) + 1);
-            }
-            else {
-                proteinChangeCounts.put(proteinChange, 1);
-            }
+            final int count = proteinChangeCounts.getOrDefault(proteinChange, 0);
+            proteinChangeCounts.put(proteinChange, count + 1);
         }
     }
 
@@ -390,7 +386,7 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
             return proteinChangeString == null ? "" : proteinChangeString;
         }
         catch (final SQLException ex) {
-            throw new GATKException("Cannot get Protein Change from column: " + GENOME_POSITION_COLUMN_NAME, ex);
+            throw new GATKException("Cannot get protein change from column: " + GENOME_POSITION_COLUMN_NAME, ex);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
@@ -23,6 +23,7 @@ import java.sql.*;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 
 /**
@@ -201,7 +202,7 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
             funcotationList.add(
                     TableFuncotation.create(
                             new ArrayList<>(supportedFields),
-                            new ArrayList<>(Collections.singletonList(String.valueOf(0))),
+                            new ArrayList<>(Collections.singletonList("")),
                             altAllele,
                             name, null
                     )
@@ -227,8 +228,8 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
 
         final List<Funcotation> outputFuncotations = new ArrayList<>();
 
-        // Keep count of our overlapping mutations here:
-        int numOverlappingMutations = 0;
+        // Keep count of each overlapping mutation here:
+        final Map<String, Integer> proteinChangeCounts = new LinkedHashMap<>();
 
         // If we have gencodeFuncotations we go through them and get the gene name
         // Then query our DB for matches on the gene name.
@@ -258,9 +259,9 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
 
                             // Try to match on genome position first:
                             if ( cosmicGenomePosition != null ) {
-                                // If we overlap the records, we update the counter:
                                 if ( genomePosition.overlaps(cosmicGenomePosition) ) {
-                                    ++numOverlappingMutations;
+                                    // If we overlap the records, we get the protein change and add it to the map:
+                                    updateProteinChangeCountMap(proteinChangeCounts, resultSet);
                                     continue;
                                 }
                             }
@@ -272,10 +273,10 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
                             if ( proteinPosition != null ) {
                                 // If we overlap the records, we update the counter:
                                 if ( proteinPosition.overlaps(cosmicProteinPosition) ) {
-                                    ++numOverlappingMutations;
+                                    updateProteinChangeCountMap(proteinChangeCounts, resultSet);
                                 }
                             }
-                            // NOTE: We can't annotate if the protein position and the genome position are null.
+                            // NOTE: We can't annotate if the protein position is null.
                         }
                     }
                 }
@@ -285,12 +286,14 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
             }
         }
 
-        // Add our tally for all alternate alleles in this variant:
+        // Add our counts to all alternate alleles in this variant:
         for ( final Allele altAllele : variant.getAlternateAlleles() ) {
             outputFuncotations.add(
                     TableFuncotation.create(
                             new ArrayList<>(supportedFields),
-                            new ArrayList<>(Collections.singletonList(String.valueOf(numOverlappingMutations))),
+                            Collections.singletonList(proteinChangeCounts.entrySet().stream()
+                                    .map(entry -> entry.getKey() + '('+ entry.getValue() + ')')
+                                    .collect(Collectors.joining("|"))),
                             altAllele,
                             name, null
                     )
@@ -298,6 +301,18 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
         }
 
         return outputFuncotations;
+    }
+
+    private void updateProteinChangeCountMap(final Map<String, Integer> proteinChangeCounts, final ResultSet resultSet) {
+        final String proteinChange = getProteinChangeStringFromResults(resultSet);
+        if ( !proteinChange.isEmpty() ) {
+            if ( proteinChangeCounts.containsKey(proteinChange) ) {
+                proteinChangeCounts.put(proteinChange, proteinChangeCounts.get(proteinChange) + 1);
+            }
+            else {
+                proteinChangeCounts.put(proteinChange, 1);
+            }
+        }
     }
 
     @Override
@@ -358,15 +373,24 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
      * @param resultSet The results of a query on the database with a current row (must not be {@code null}).
      * @return A {@link SimpleInterval} representing the extents of the protein position in the current record in the given {@link ResultSet} or {@code null}.
      */
-    private final SimpleInterval getProteinPositionFromResults(final ResultSet resultSet) {
+    private SimpleInterval getProteinPositionFromResults(final ResultSet resultSet) {
+        return parseProteinString( getProteinChangeStringFromResults(resultSet) );
+    }
+
+    /**
+     * Pulls a protein change string out of the current record in the given {@link ResultSet}.
+     * @param resultSet The results of a query on the database with a current row (must not be {@code null}).
+     * @return A {@link String} representing the protein change as found in the current record of the given {@link ResultSet}.  Will not be {@code null}.
+     */
+    private String getProteinChangeStringFromResults(final ResultSet resultSet) {
         Utils.nonNull(resultSet);
 
         try {
-            final String rawPosition = resultSet.getString(PROTEIN_POSITION_COLUMN_NAME);
-            return parseProteinString(rawPosition);
+            final String proteinChangeString = resultSet.getString(PROTEIN_POSITION_COLUMN_NAME);
+            return proteinChangeString == null ? "" : proteinChangeString;
         }
         catch (final SQLException ex) {
-            throw new GATKException("Cannot get Protein Position from column: " + GENOME_POSITION_COLUMN_NAME, ex);
+            throw new GATKException("Cannot get Protein Change from column: " + GENOME_POSITION_COLUMN_NAME, ex);
         }
     }
 
@@ -375,7 +399,7 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
      * @param proteinPositionString A {@link String} representing a protein position / protein change.
      * @return A {@link SimpleInterval} representing the extents of the given {@code proteinPositionString} or {@code null}.
      */
-    private final SimpleInterval parseProteinString(final String proteinPositionString) {
+    private SimpleInterval parseProteinString(final String proteinPositionString) {
         Utils.nonNull(proteinPositionString);
 
         final Matcher matcher = PROTEIN_POSITION_REGEX.matcher(proteinPositionString);

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactoryUnitTest.java
@@ -155,7 +155,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                 helpProvideForTestCreateFuncotations("chr3", 178916617, 178916617, "C", "A",
                         Collections.emptyList(),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("0"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList(""), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Trivial Case: Position is not in the database:
@@ -164,7 +164,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178916617).setEnd(178916617).setProteinChange("p.P2T").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("0"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList(""), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Protein position match:
@@ -174,7 +174,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178936091).setEnd(178936091).setProteinChange("p.E545K").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("2"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("p.E545K(2)"), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Genome position match:
@@ -183,7 +183,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178936091).setEnd(178936091).setProteinChange("p.E999K").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("1"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("p.E545K(1)"), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Protein and Genome position match:
@@ -192,7 +192,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178936091).setEnd(178936091).setProteinChange("p.E545K").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("2"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("p.E545K(2)"), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Huge Protein Match - all in the file:
@@ -201,7 +201,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178936091).setEnd(178936091).setProteinChange("p.E1_K3455").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("7"), Allele.create("A"), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("p.E545K(2)|p.E542K(2)|p.H1047R(2)|p.N345K(1)"), Allele.create("A"), "Cosmic", null)
                         )
                 ),
                 // Huge Genome Position Match - all in the file:
@@ -212,7 +212,7 @@ public class CosmicFuncotationFactoryUnitTest extends GATKBaseTest {
                                 new GencodeFuncotationBuilder().setHugoSymbol("PIK3CA").setChromosome("chr3").setStart(178921553).setEnd(178952085).setProteinChange("p.E1T").build()
                         ),
                         Collections.singletonList(
-                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("5"), Allele.create(String.join("", Collections.nCopies(178952085 - 178921553 + 1, "A"))), "Cosmic", null)
+                                TableFuncotation.create(Collections.singletonList("Cosmic_overlapping_mutations"), Collections.singletonList("p.E542K(2)|p.H1047R(1)|p.E545K(1)|p.N345K(1)"), Allele.create(String.join("", Collections.nCopies(178952085 - 178921553 + 1, "A"))), "Cosmic", null)
                         )
                 ),
         };


### PR DESCRIPTION
Now the COSMIC data source produces counts of each protein change found in the COSMIC database.

That is, rather than a raw count of the total number of protein changes (e.g. `2` or `7`), it produces a count of each specific protein change found in the COSMIC database that overlaps a variant (e.g. `p.E545K(2)` or `p.E545K(2)|p.E542K(2)|p.H1047R(2)|p.N345K(1)`).

Fixes #4400