### PR TITLE
updating google-cloud-java nio to 0.62.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.59.0-alpha:shaded'
+final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.62.0-alpha:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'


### PR DESCRIPTION
* updating google-cloud-java 0.59.0 -> 0.62.0
* this includes retries on 502 errors see https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3557