### PR TITLE
stop using 32 bit key hash on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_install:
    sudo mkdir -p /usr/local/lib/R/;
    sudo mkdir -p site-library;
    sudo ln -sFv ~/site-library /usr/local/lib/R/site-library;
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9;
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9;
    sudo add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/";
    sudo apt-get update;
    sudo apt-get install -y --force-yes r-base-dev=3.1.3-1trusty;


### PR DESCRIPTION
* changing the key hash we use to download R package keys on travis from an insecure 32 bit hash that has been compromised to a more secure longer hash
* we will no longer be installing the "Totally Legit Signing Key"
* see https://evil32.com/ for a summary of the problem