### PR TITLE
Add bamout read annotations for alignement and callable regions, and supported genotypes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public final class AssemblyBasedCallerUtils {
 
     static final int REFERENCE_PADDING_FOR_ASSEMBLY = 500;
-    public static final String SUPPORTED_GENOTYPES_TAG="SG";
+    public static final String SUPPORTED_ALLELES_TAG="SA";
     public static final String CALLABLE_REGION_TAG = "CR";
     public static final String ALIGNMENT_REGION_TAG = "AR";
 
@@ -308,14 +308,14 @@ public final class AssemblyBasedCallerUtils {
     }
 
     /**
-     * Annotates reads in ReadLiklihoods with genotype supported by each read.  If a read already has a
-     * supported genotypes annotation this additional annotation is appended to the previous annotation, it does not replace it.
+     * For the given variant, reads are annotated with which alleles they support, if any.  If a read already has a
+     * supported alleles annotation this additional annotation is appended to the previous annotation, it does not replace it.
      * @param vc The variant for which to annotate the reads
      * @param likelihoodsAllele ReadLiklihoods containing reads to be annotated along with alleles of the variant vc
      */
-    public static void annotateReadLikelihoodsWithSupportedGenotypes(final VariantContext vc,
+    public static void annotateReadLikelihoodsWithSupportedAlleles(final VariantContext vc,
                                                                      final ReadLikelihoods<Allele> likelihoodsAllele) {
-        //assign supported Genotypes to each read
+        //assign supported alleles to each read
         final Map<Allele, List<Allele>> alleleSubset = vc.getAlleles().stream().collect(Collectors.toMap(a -> a, Arrays::asList));
         final ReadLikelihoods<Allele> subsettedLikelihoods = likelihoodsAllele.marginalize(alleleSubset);
         final Collection<ReadLikelihoods<Allele>.BestAllele> bestAlleles = subsettedLikelihoods.bestAllelesBreakingTies().stream()
@@ -323,9 +323,9 @@ public final class AssemblyBasedCallerUtils {
         for (ReadLikelihoods<Allele>.BestAllele bestAllele : bestAlleles) {
             GATKRead read = bestAllele.read;
             Allele allele = bestAllele.allele;
-            final String prevGenotypesString = read.hasAttribute(SUPPORTED_GENOTYPES_TAG) ? read.getAttributeAsString(SUPPORTED_GENOTYPES_TAG) + ", " : "";
-            final String newGenotypeString = vc.getContig() + ":" + vc.getStart() + "=" + vc.getAlleleIndex(allele);
-            read.setAttribute(SUPPORTED_GENOTYPES_TAG, prevGenotypesString + newGenotypeString);
+            final String prevAllelesString = read.hasAttribute(SUPPORTED_ALLELES_TAG) ? read.getAttributeAsString(SUPPORTED_ALLELES_TAG) + ", " : "";
+            final String newAllelesString = vc.getContig() + ":" + vc.getStart() + "=" + vc.getAlleleIndex(allele);
+            read.setAttribute(SUPPORTED_ALLELES_TAG, prevAllelesString + newAllelesString);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
-import ngs.Read;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -282,6 +281,13 @@ public final class AssemblyBasedCallerUtils {
         }
     }
 
+    /**
+     * Annotates reads in ReadLikelihoods with alignment region (the ref region spanned by the haplotype the read is aligned to) and
+     * callable region (the ref region over which a caller is using these ReadLikelihoods to call variants)
+     *
+     * @param likelihoodsHaplotype ReadLikelihoods containing reads to be annotated along with haplotypes to which these reads have been aligned
+     * @param callableRegion ref region over which caller is using these ReadLikelihoods to call variants
+     */
     public static void annotateReadLikelihoodsWithRegions(final ReadLikelihoods<Haplotype> likelihoodsHaplotype,
                                                           final Locatable callableRegion) {
         //assign alignment regions to each read
@@ -301,6 +307,12 @@ public final class AssemblyBasedCallerUtils {
         }
     }
 
+    /**
+     * Annotates reads in ReadLiklihoods with genotype supported by each read a particular variant.  If a read already has a
+     * supported genotypes annotation this additional annotation is appended to the previous annotation, it does not replace it.
+     * @param vc The variant for which to annotate the reads
+     * @param likelihoodsAllele ReadLiklihoods containing reads to be annotated along with alleles of the variant vc
+     */
     public static void annotateReadLikelihoodsWithSupportedGenotypes(final VariantContext vc,
                                                                      final ReadLikelihoods<Allele> likelihoodsAllele) {
         //assign supported Genotypes to each read

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -614,7 +614,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             if ( hcArgs.disableOptimizations ) {
                 calledHaplotypeSet.add(assemblyResult.getReferenceHaplotype());
             }
-            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(), haplotypes,
+            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(), haplotypes,
                                                              calledHaplotypeSet, readLikelihoods);
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -615,8 +615,8 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             if ( hcArgs.disableOptimizations ) {
                 calledHaplotypeSet.add(assemblyResult.getReferenceHaplotype());
             }
-            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(), haplotypes,
-                                                             calledHaplotypeSet, readLikelihoods,calledHaplotypes.getCalls());
+            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(), haplotypes,
+                                                             calledHaplotypeSet, readLikelihoods,regionForGenotyping.getSpan());
         }
 
         if( hcArgs.debug) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -614,7 +614,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             if ( hcArgs.disableOptimizations ) {
                 calledHaplotypeSet.add(assemblyResult.getReferenceHaplotype());
             }
-            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(), haplotypes,
+            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(),trimmingResult.getCallableRegion().getExtendedSpan(), haplotypes,
                                                              calledHaplotypeSet, readLikelihoods);
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -607,15 +607,16 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
                 (hcArgs.assemblerArgs.consensusMode ? Collections.<VariantContext>emptyList() : givenAlleles),
                 emitReferenceConfidence(),
                 hcArgs.maxMnpDistance,
-                readsHeader);
+                readsHeader,
+                haplotypeBAMWriter.isPresent());
 
         if ( haplotypeBAMWriter.isPresent() ) {
             final Set<Haplotype> calledHaplotypeSet = new HashSet<>(calledHaplotypes.getCalledHaplotypes());
             if ( hcArgs.disableOptimizations ) {
                 calledHaplotypeSet.add(assemblyResult.getReferenceHaplotype());
             }
-            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(),trimmingResult.getCallableRegion().getExtendedSpan(), haplotypes,
-                                                             calledHaplotypeSet, readLikelihoods);
+            haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(haplotypes, assemblyResult.getPaddedReferenceLoc(),regionForGenotyping.getSpan(), haplotypes,
+                                                             calledHaplotypeSet, readLikelihoods,calledHaplotypes.getCalls());
         }
 
         if( hcArgs.debug) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -94,6 +94,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
      *                       are merged until a substitution is separated from the previous one by a greater distance.
      *                       That is, if maxMnpDistance = 1, substitutions at 10,11,12,14,15,17 are partitioned into a MNP
      *                       at 10-12, a MNP at 14-15, and a SNP at 17.  May not be negative.
+     * @param withBamOut whether to annotate reads in readLikelihoods for future writing to bamout
      *
      * @return                                       A CalledHaplotypes object containing a list of VC's with genotyped events and called haplotypes
      *
@@ -183,7 +184,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
                 returnCalls.add( annotatedCall );
 
                 if(withBamOut) {
-                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegionsAndSupportedGenotypes(call, readAlleleLikelihoods);
+                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegionsAndSupportedGenotypes(call, readAlleleLikelihoods, readLikelihoods, activeRegionWindow);
                 }
 
                 // maintain the set of all called haplotypes

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -136,7 +136,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
             ////add annotations to reads for alignment regions and calling regions
             AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(readLikelihoods, activeRegionWindow);
         }
-        
+
         for( final int loc : startPosKeySet ) {
             if( loc < activeRegionWindow.getStart() || loc > activeRegionWindow.getEnd() ) {
                 continue;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -136,8 +136,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
             ////add annotations to reads for alignment regions and calling regions
             AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(readLikelihoods, activeRegionWindow);
         }
-
-
+        
         for( final int loc : startPosKeySet ) {
             if( loc < activeRegionWindow.getStart() || loc > activeRegionWindow.getEnd() ) {
                 continue;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -132,6 +132,12 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
         final int ploidy = configuration.genotypeArgs.samplePloidy;
         final List<Allele> noCallAlleles = GATKVariantContextUtils.noCallAlleles(ploidy);
 
+        if (withBamOut) {
+            ////add annotations to reads for alignment regions and calling regions
+            AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(readLikelihoods, activeRegionWindow);
+        }
+
+
         for( final int loc : startPosKeySet ) {
             if( loc < activeRegionWindow.getStart() || loc > activeRegionWindow.getEnd() ) {
                 continue;
@@ -183,8 +189,9 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
                 final VariantContext annotatedCall = makeAnnotatedCall(ref, refLoc, tracker, header, mergedVC, readAlleleLikelihoods, call);
                 returnCalls.add( annotatedCall );
 
-                if(withBamOut) {
-                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegionsAndSupportedGenotypes(call, readAlleleLikelihoods, readLikelihoods, activeRegionWindow);
+                if (withBamOut) {
+                    //add annotations to reads for which genotypes are supported by each read
+                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(call, readAlleleLikelihoods);
                 }
 
                 // maintain the set of all called haplotypes

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -133,7 +133,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
         final List<Allele> noCallAlleles = GATKVariantContextUtils.noCallAlleles(ploidy);
 
         if (withBamOut) {
-            ////add annotations to reads for alignment regions and calling regions
+            //add annotations to reads for alignment regions and calling regions
             AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(readLikelihoods, activeRegionWindow);
         }
 
@@ -189,7 +189,6 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
                 returnCalls.add( annotatedCall );
 
                 if (withBamOut) {
-                    //add annotations to reads for which genotypes are supported by each read
                     AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(call, readAlleleLikelihoods);
                 }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -189,7 +189,7 @@ public class HaplotypeCallerGenotypingEngine extends AssemblyBasedCallerGenotypi
                 returnCalls.add( annotatedCall );
 
                 if (withBamOut) {
-                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(call, readAlleleLikelihoods);
+                    AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedAlleles(call, readAlleleLikelihoods);
                 }
 
                 // maintain the set of all called haplotypes

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.vcf.VCFConstants;
@@ -215,12 +216,12 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
         readLikelihoods.changeReads(readRealignments);
 
         final HaplotypeCallerGenotypingEngine.CalledHaplotypes calledHaplotypes = genotypingEngine.callMutations(
-                readLikelihoods, assemblyResult, referenceContext, regionForGenotyping.getSpan(), featureContext, givenAlleles, header);
-        writeBamOutput(assemblyResult, readLikelihoods, calledHaplotypes);
+                readLikelihoods, assemblyResult, referenceContext, regionForGenotyping.getSpan(), featureContext, givenAlleles, header, haplotypeBAMWriter.isPresent());
+        writeBamOutput(assemblyResult, readLikelihoods, calledHaplotypes,regionForGenotyping.getSpan());
         return calledHaplotypes.getCalls();
     }
 
-    private void writeBamOutput(AssemblyResultSet assemblyResult, ReadLikelihoods<Haplotype> readLikelihoods, HaplotypeCallerGenotypingEngine.CalledHaplotypes calledHaplotypes) {
+    private void writeBamOutput(AssemblyResultSet assemblyResult, ReadLikelihoods<Haplotype> readLikelihoods, HaplotypeCallerGenotypingEngine.CalledHaplotypes calledHaplotypes, Locatable callableRegion) {
         if ( haplotypeBAMWriter.isPresent() ) {
             final Set<Haplotype> calledHaplotypeSet = new HashSet<>(calledHaplotypes.getCalledHaplotypes());
             haplotypeBAMWriter.get().writeReadsAlignedToHaplotypes(
@@ -228,7 +229,8 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
                     assemblyResult.getPaddedReferenceLoc(),
                     assemblyResult.getHaplotypeList(),
                     calledHaplotypeSet,
-                    readLikelihoods);
+                    readLikelihoods,
+                    callableRegion);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -104,7 +104,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
         final List<VariantContext> returnCalls = new ArrayList<>();
 
         if(withBamOut){
-            ////add annotations to reads for alignment regions and calling regions
+            //add annotations to reads for alignment regions and calling regions
             AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(log10ReadLikelihoods, activeRegionWindow);
         }
 
@@ -178,7 +178,6 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
 
             final VariantContext annotatedCall =  annotationEngine.annotateContext(trimmedCall, featureContext, referenceContext, trimmedLikelihoods, a -> true);
             if(withBamOut) {
-                //add annotations to reads for which genotypes are supported by each read
                 AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(trimmedCall, trimmedLikelihoods);
             }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -103,6 +103,11 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
         final Set<Haplotype> calledHaplotypes = new HashSet<>();
         final List<VariantContext> returnCalls = new ArrayList<>();
 
+        if(withBamOut){
+            ////add annotations to reads for alignment regions and calling regions
+            AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(log10ReadLikelihoods, activeRegionWindow);
+        }
+
         for( final int loc : startPosKeySet ) {
             final List<VariantContext> eventsAtThisLoc = getVariantContextsFromActiveHaplotypes(loc, haplotypes, false);
             final VariantContext mergedVC = AssemblyBasedCallerUtils.makeMergedVariantContext(eventsAtThisLoc);
@@ -173,7 +178,8 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
 
             final VariantContext annotatedCall =  annotationEngine.annotateContext(trimmedCall, featureContext, referenceContext, trimmedLikelihoods, a -> true);
             if(withBamOut) {
-                AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegionsAndSupportedGenotypes(trimmedCall, trimmedLikelihoods, log10ReadLikelihoods, activeRegionWindow);
+                //add annotations to reads for which genotypes are supported by each read
+                AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(trimmedCall, trimmedLikelihoods);
             }
 
             call.getAlleles().stream().map(alleleMapper::get).filter(Objects::nonNull).forEach(calledHaplotypes::addAll);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -72,6 +72,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
      * The list of samples we're working with is obtained from the readLikelihoods
      * @param log10ReadLikelihoods                       Map from reads->(haplotypes,likelihoods)
      * @param activeRegionWindow                     Active window
+     * @param withBamOut                            whether to annotate reads in readLikelihoods for future writing to bamout
      *
      * @return                                       A CalledHaplotypes object containing a list of VC's with genotyped events and called haplotypes
      */
@@ -82,7 +83,8 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
             final SimpleInterval activeRegionWindow,
             final FeatureContext featureContext,
             final List<VariantContext> givenAlleles,
-            final SAMFileHeader header) {
+            final SAMFileHeader header,
+            final boolean withBamOut) {
         Utils.nonNull(log10ReadLikelihoods);
         Utils.validateArg(log10ReadLikelihoods.numberOfSamples() > 0, "likelihoods have no samples");
         Utils.nonNull(activeRegionWindow);
@@ -170,6 +172,9 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
             final ReadLikelihoods<Allele> trimmedLikelihoods = log10Likelihoods.marginalize(trimmedToUntrimmedAlleleMap);
 
             final VariantContext annotatedCall =  annotationEngine.annotateContext(trimmedCall, featureContext, referenceContext, trimmedLikelihoods, a -> true);
+            if(withBamOut) {
+                AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegionsAndSupportedGenotypes(trimmedCall, trimmedLikelihoods, log10ReadLikelihoods, activeRegionWindow);
+            }
 
             call.getAlleles().stream().map(alleleMapper::get).filter(Objects::nonNull).forEach(calledHaplotypes::addAll);
             returnCalls.add( annotatedCall );
@@ -181,6 +186,17 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
                 .map(vc -> new VariantContextBuilder(vc).attribute(GATKVCFConstants.EVENT_COUNT_IN_HAPLOTYPE_KEY, eventCount).make())
                 .collect(Collectors.toList());
         return new CalledHaplotypes(outputCallsWithEventCountAnnotation, calledHaplotypes);
+    }
+
+    public CalledHaplotypes callMutations(
+            final ReadLikelihoods<Haplotype> log10ReadLikelihoods,
+            final AssemblyResultSet assemblyResultSet,
+            final ReferenceContext referenceContext,
+            final SimpleInterval activeRegionWindow,
+            final FeatureContext featureContext,
+            final List<VariantContext> givenAlleles,
+            final SAMFileHeader header) {
+        return callMutations(log10ReadLikelihoods,assemblyResultSet, referenceContext, activeRegionWindow, featureContext, givenAlleles, header, false);
     }
 
     private Set<Allele> getAllelesConsistentWithGivenAlleles(List<VariantContext> givenAlleles, int loc, VariantContext mergedVC) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -178,7 +178,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
 
             final VariantContext annotatedCall =  annotationEngine.annotateContext(trimmedCall, featureContext, referenceContext, trimmedLikelihoods, a -> true);
             if(withBamOut) {
-                AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(trimmedCall, trimmedLikelihoods);
+                AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedAlleles(trimmedCall, trimmedLikelihoods);
             }
 
             call.getAlleles().stream().map(alleleMapper::get).filter(Objects::nonNull).forEach(calledHaplotypes::addAll);

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -7,6 +7,8 @@ import htsjdk.samtools.SAMTag;
 
 import htsjdk.samtools.util.Locatable;
 import java.nio.file.Path;
+
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerUtils;
 import org.broadinstitute.hellbender.utils.read.*;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
@@ -35,10 +37,6 @@ public class HaplotypeBAMWriter implements AutoCloseable {
     private final HaplotypeBAMDestination output;
     private WriterType writerType;
     private boolean writeHaplotypes = true;
-
-    protected static final String CALLABLE_REGION_TAG = "CR";
-    protected static final String ALIGNMENT_REGION_TAG = "AR";
-
     /**
      * Possible modes for writing haplotypes to BAMs
      */
@@ -134,10 +132,10 @@ public class HaplotypeBAMWriter implements AutoCloseable {
             if (calledHaplotypes.isEmpty()){
                 return;
             }
-            writeHaplotypesAsReads(calledHaplotypes, calledHaplotypes, paddedReferenceLoc,callableRegion);
+            writeHaplotypesAsReads(calledHaplotypes, calledHaplotypes, paddedReferenceLoc, callableRegion);
 
         } else {
-            writeHaplotypesAsReads(haplotypes, new LinkedHashSet<>(bestHaplotypes), paddedReferenceLoc,callableRegion);
+            writeHaplotypesAsReads(haplotypes, new LinkedHashSet<>(bestHaplotypes), paddedReferenceLoc, callableRegion);
         }
 
         final int sampleCount = readLikelihoods.numberOfSamples();
@@ -149,11 +147,11 @@ public class HaplotypeBAMWriter implements AutoCloseable {
     }
 
     public void writeReadsAlignedToHaplotypes(final Collection<Haplotype> haplotypes,
-                                                       final Locatable paddedReferenceLoc,
-                                                       final Collection<Haplotype> bestHaplotypes,
-                                                       final Set<Haplotype> calledHaplotypes,
-                                                       final ReadLikelihoods<Haplotype> readLikelihoods) {
-        writeReadsAlignedToHaplotypes(haplotypes,paddedReferenceLoc,bestHaplotypes,calledHaplotypes,readLikelihoods,null);
+                                              final Locatable paddedReferenceLoc,
+                                              final Collection<Haplotype> bestHaplotypes,
+                                              final Set<Haplotype> calledHaplotypes,
+                                              final ReadLikelihoods<Haplotype> readLikelihoods) {
+        writeReadsAlignedToHaplotypes(haplotypes, paddedReferenceLoc, bestHaplotypes, calledHaplotypes, readLikelihoods, null);
     }
 
     /**
@@ -185,7 +183,7 @@ public class HaplotypeBAMWriter implements AutoCloseable {
 
         if (writeHaplotypes) {
             for (final Haplotype haplotype : haplotypes) {
-                writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype),callableRegion);
+                writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype), callableRegion);
             }
         }
     }
@@ -219,7 +217,7 @@ public class HaplotypeBAMWriter implements AutoCloseable {
         record.setAttribute(SAMTag.RG.toString(), output.getHaplotypeReadGroupID());
         record.setFlags(SAMFlag.READ_REVERSE_STRAND.intValue());
         if (callableRegion != null) {
-            record.setAttribute(CALLABLE_REGION_TAG, callableRegion.toString());
+            record.setAttribute(AssemblyBasedCallerUtils.CALLABLE_REGION_TAG, callableRegion.toString());
         }
 
         output.add(new SAMRecordToGATKReadAdapter(record));

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -36,7 +36,8 @@ public class HaplotypeBAMWriter implements AutoCloseable {
     private WriterType writerType;
     private boolean writeHaplotypes = true;
 
-    protected static final String ACTIVE_REGION_TAG = "AR";
+    protected static final String CALLABLE_REGION_TAG = "CR";
+    protected static final String ALIGNMENT_REGION_TAG = "AR";
 
     /**
      * Possible modes for writing haplotypes to BAMs
@@ -114,14 +115,14 @@ public class HaplotypeBAMWriter implements AutoCloseable {
      * @param bestHaplotypes a list of the best (a subset of all) haplotypes that actually went forward into genotyping, cannot be null
      * @param calledHaplotypes a list of the haplotypes that where actually called as non-reference, cannot be null
      * @param readLikelihoods a map from sample -> likelihoods for each read for each of the best haplotypes, cannot be null
-     * @param activeRegion the genomic active region over which variants were just using these reads
+     * @param callableRegion the region over which variants are being called
      */
     public void writeReadsAlignedToHaplotypes(final Collection<Haplotype> haplotypes,
                                               final Locatable paddedReferenceLoc,
                                               final Collection<Haplotype> bestHaplotypes,
                                               final Set<Haplotype> calledHaplotypes,
                                               final ReadLikelihoods<Haplotype> readLikelihoods,
-                                              final Locatable activeRegion) {
+                                              final Locatable callableRegion) {
 
         Utils.nonNull(haplotypes, "haplotypes cannot be null");
         Utils.nonNull(paddedReferenceLoc, "paddedReferenceLoc cannot be null");
@@ -133,10 +134,10 @@ public class HaplotypeBAMWriter implements AutoCloseable {
             if (calledHaplotypes.isEmpty()){
                 return;
             }
-            writeHaplotypesAsReads(calledHaplotypes, calledHaplotypes, paddedReferenceLoc,activeRegion);
+            writeHaplotypesAsReads(calledHaplotypes, calledHaplotypes, paddedReferenceLoc,callableRegion);
 
         } else {
-            writeHaplotypesAsReads(haplotypes, new LinkedHashSet<>(bestHaplotypes), paddedReferenceLoc,activeRegion);
+            writeHaplotypesAsReads(haplotypes, new LinkedHashSet<>(bestHaplotypes), paddedReferenceLoc,callableRegion);
         }
 
         final int sampleCount = readLikelihoods.numberOfSamples();
@@ -172,19 +173,19 @@ public class HaplotypeBAMWriter implements AutoCloseable {
      * @param bestHaplotypes a subset of haplotypes that contains those that are best "either good or called", must not
      *                       be null
      * @param paddedReferenceLoc the genome loc of the padded reference, must not be null
-     * @param activeRegion active region
+     * @param callableRegion the region over which variants are being called
      */
     private void writeHaplotypesAsReads(final Collection<Haplotype> haplotypes,
                                           final Set<Haplotype> bestHaplotypes,
                                           final Locatable paddedReferenceLoc,
-                                          final Locatable activeRegion) {
+                                          final Locatable callableRegion) {
         Utils.nonNull(haplotypes, "haplotypes cannot be null");
         Utils.nonNull(bestHaplotypes, "bestHaplotypes cannot be null");
         Utils.nonNull(paddedReferenceLoc, "paddedReferenceLoc cannot be null");
 
         if (writeHaplotypes) {
             for (final Haplotype haplotype : haplotypes) {
-                writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype),activeRegion);
+                writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype),callableRegion);
             }
         }
     }
@@ -195,12 +196,12 @@ public class HaplotypeBAMWriter implements AutoCloseable {
      * @param haplotype a haplotype to write out, must not be null
      * @param paddedRefLoc the reference location, must not be null
      * @param isAmongBestHaplotypes true if among the best haplotypes, false if it was just one possible haplotype
-     * @param activeRegion active region
+     * @param callableRegion the region over which variants are being called
      */
     private void writeHaplotype(final Haplotype haplotype,
                                 final Locatable paddedRefLoc,
                                 final boolean isAmongBestHaplotypes,
-                                final Locatable activeRegion) {
+                                final Locatable callableRegion) {
         Utils.nonNull(haplotype, "haplotype cannot be null");
         Utils.nonNull(paddedRefLoc, "paddedRefLoc cannot be null");
 
@@ -217,8 +218,8 @@ public class HaplotypeBAMWriter implements AutoCloseable {
         record.setReferenceIndex(output.getBAMOutputHeader().getSequenceIndex(paddedRefLoc.getContig()));
         record.setAttribute(SAMTag.RG.toString(), output.getHaplotypeReadGroupID());
         record.setFlags(SAMFlag.READ_REVERSE_STRAND.intValue());
-        if (activeRegion != null) {
-            record.setAttribute(ACTIVE_REGION_TAG, activeRegion.toString());
+        if (callableRegion != null) {
+            record.setAttribute(CALLABLE_REGION_TAG, callableRegion.toString());
         }
 
         output.add(new SAMRecordToGATKReadAdapter(record));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -215,8 +215,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         }
     }
 
-    @DataProvider(name = "testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider")
-    public Object[][] testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider() {
+    @DataProvider(name = "testAnnotateReadLikelihoodsWithSupportedAllelesDataProvider")
+    public Object[][] testAnnotateReadLikelihoodsWithSupportedAllelesDataProvider() {
         final String refString = "ACGTGGCGTTGCACTTCAGATCGATCGGATCGATCGGCTAGTCGTCGCACTTCGCTAGGCTAG";
         final String contig = "1";
         final int start = 13763;
@@ -238,7 +238,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
                 Allele.create("TCGA", true), Allele.create("T", false))).make());
 
         Map<VariantContext, List<GATKRead>> vcReadsMap = new HashMap<>();
-        Map<GATKRead, Integer> supportedGenotypeMap = new HashMap<>();
+        Map<GATKRead, Integer> supportedAlleleMap = new HashMap<>();
         for (VariantContext vc : vcs) {
             vcReadsMap.put(vc, new ArrayList<>());
         }
@@ -260,7 +260,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
                     final String qname = "r" + qNameIndex;
                     qNameIndex++;
                     final SAMRecordToGATKReadAdapter read = buildRead(readString,cigar,readStart,qname,contig);
-                    supportedGenotypeMap.put(read, phase);
+                    supportedAlleleMap.put(read, phase);
                     for (final VariantContext vc : vcs) {
                         if (read.getStart() <= vc.getStart() && read.getEnd() >= vc.getEnd()) {
                             vcReadsMap.get(vc).add(read);
@@ -284,7 +284,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
                 final int readIndex = sampleMatrix.indexOfRead(read);
                 String attribute = contig + ":" + vc.getStart() + "=";
                 if (vc == vcs.get(1)) {
-                    attribute += supportedGenotypeMap.get(read);
+                    attribute += supportedAlleleMap.get(read);
                 } else {
                     attribute += "1";
                 }
@@ -292,7 +292,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
                 for (Allele allele : vc.getAlleles()) {
                     final int alleleIndex = sampleMatrix.indexOfAllele(allele);
                     if (vc == vcs.get(1)) {
-                        if (vc.getAlleleIndex(allele) == supportedGenotypeMap.get(read)) {
+                        if (vc.getAlleleIndex(allele) == supportedAlleleMap.get(read)) {
                             sampleMatrix.set(alleleIndex, readIndex, -1.0);
                         } else {
                             sampleMatrix.set(alleleIndex, readIndex, -8.0);
@@ -323,8 +323,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         return retHaplotype;
     }
 
-    @Test(dataProvider = "testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider")
-    public void testAnnotateReadLikelihoodsWithSupportedGenotypes(List<ReadLikelihoods<Allele>> readLikelihoodsList, final List<VariantContext> vcs, final List<List<String>> readAttributeListList) {
+    @Test(dataProvider = "testAnnotateReadLikelihoodsWithSupportedAllelesDataProvider")
+    public void testAnnotateReadLikelihoodsWithSupportedAlleles(List<ReadLikelihoods<Allele>> readLikelihoodsList, final List<VariantContext> vcs, final List<List<String>> readAttributeListList) {
         for (int i = 0; i < readLikelihoodsList.size(); i++) {
             ReadLikelihoods<Allele> readLikelihoods = readLikelihoodsList.get(i);
             VariantContext vc = vcs.get(i);
@@ -333,14 +333,14 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
 
             List<String> initReadAttributes = new ArrayList<>();
             for (GATKRead read : readLikelihoods.sampleReads(0)) {
-                initReadAttributes.add(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_GENOTYPES_TAG));
+                initReadAttributes.add(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_ALLELES_TAG));
             }
-            AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(vc, readLikelihoods);
+            AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedAlleles(vc, readLikelihoods);
             for (int j = 0; j < readLikelihoods.sampleReadCount(0); j++) {
                 GATKRead read = readLikelihoods.sampleReads(0).get(j);
 
                 String expectedAttribute = (initReadAttributes.get(j) != null ? initReadAttributes.get(j) + ", " : "") + readAttributeList.get(j);
-                Assert.assertEquals(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_GENOTYPES_TAG), expectedAttribute);
+                Assert.assertEquals(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_ALLELES_TAG), expectedAttribute);
             }
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -78,24 +78,24 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final int start = 13763;
         final SimpleInterval loc = new SimpleInterval(contig, start, start + hap1String.length());
         final SimpleInterval loc2 = new SimpleInterval(contig, loc.getStart() + 4, loc.getEnd() - 4);
-        List<Integer> snpIndecies = Arrays.asList(null, 12, 23);
+        List<Integer> snpIndices = Arrays.asList(null, 12, 23);
         List<Character> snpReplacements = Arrays.asList(null, 'G', 'C');
-        List<Integer> delIndecies = Arrays.asList(null, 27);
+        List<Integer> delIndices = Arrays.asList(null, 27);
         List<Integer> delLenghts = Arrays.asList(null, 4);
-        List<Integer> insIndecies = Arrays.asList(null, 34);
+        List<Integer> insIndices = Arrays.asList(null, 34);
         List<String> insStrings = Arrays.asList(null, "GGCTGGATCGAG");
 
         List<String> haplotypeStrings = new ArrayList<String>();
 
-        for (int iSnp = 0; iSnp < snpIndecies.size(); iSnp++) {
+        for (int iSnp = 0; iSnp < snpIndices.size(); iSnp++) {
             //create set of haplotype sequences with different combinations of snps, deletions, indels
-            Integer snpIndex = snpIndecies.get(iSnp);
+            Integer snpIndex = snpIndices.get(iSnp);
             Character snpReplacement = snpReplacements.get(iSnp);
-            for (int iDel = 0; iDel < delIndecies.size(); iDel++) {
-                Integer delIndex = delIndecies.get(iDel);
+            for (int iDel = 0; iDel < delIndices.size(); iDel++) {
+                Integer delIndex = delIndices.get(iDel);
                 Integer delLength = delLenghts.get(iDel);
-                for (int iIns = 0; iIns < insIndecies.size(); iIns++) {
-                    Integer insIndex = insIndecies.get(iIns);
+                for (int iIns = 0; iIns < insIndices.size(); iIns++) {
+                    Integer insIndex = insIndices.get(iIns);
                     String insString = insStrings.get(iIns);
                     String haplotypeString = hap1String;
                     if (snpIndex != null) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -22,7 +22,6 @@ import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import scala.Char;
 
 public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
     final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(1, 1, 100000000);
@@ -89,6 +88,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         List<String> haplotypeStrings = new ArrayList<String>();
 
         for (int iSnp = 0; iSnp < snpIndecies.size(); iSnp++) {
+            //create set of haplotype sequences with different combinations of snps, deletions, indels
             Integer snpIndex = snpIndecies.get(iSnp);
             Character snpReplacement = snpReplacements.get(iSnp);
             for (int iDel = 0; iDel < delIndecies.size(); iDel++) {
@@ -117,6 +117,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         List<GATKRead> reads = new ArrayList<>();
         Map<GATKRead, Haplotype> readHaplotypeMap = new HashMap<>();
         for (Haplotype haplotype : haplotypesList) {
+            //create a bunch of reads for different haplotypes
             final String hapString = haplotype.getBaseString();
             for (int readStart = 0; readStart < hapString.length() - 6; readStart += 3) {
                 for (int readEnd = Math.min(hapString.length(), readStart + 20); readEnd < Math.min(hapString.length(), readStart + 40); readEnd += 4) {
@@ -138,6 +139,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final ReadLikelihoods<Haplotype> readLikelihoods = new ReadLikelihoods<>(samples, haplotypes, sampleReadMap);
         LikelihoodMatrix<Haplotype> sampleMatrix = readLikelihoods.sampleMatrix(0);
         for (GATKRead read : reads) {
+            //set likelihoods, -1.0 for haplotype read assigned to, -8.0 for all other haplotypes
             final int readIndex = sampleMatrix.indexOfRead(read);
             for (Haplotype haplotype : haplotypesList) {
                 final int haplotypeIndex = sampleMatrix.indexOfAllele(haplotype);
@@ -226,6 +228,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final Cigar refCigar = new Cigar(Arrays.asList(new CigarElement(refString.length(), CigarOperator.M)));
         refHaplotype.setCigar(refCigar);
 
+        //add three variants (2 snps and an indel)
         List<VariantContext> vcs = new ArrayList<>();
         vcs.add(new VariantContextBuilder("source", contig, start + 3, start + 3, Arrays.asList(
                 Allele.create("T".getBytes(), true), Allele.create("G".getBytes(), false))).make());
@@ -241,6 +244,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         }
 
         int qNameIndex = 0;
+        //three true haplotypes.  All alt for first snp and indel, cycle through 3 alleles for second snp
         for (int readStart = loc.getStart(); readStart < loc.getEnd() - 6; readStart += 4) {
             for (int readEnd = Math.min(readStart + 20, loc.getEnd()); readEnd < Math.min(readStart + 50, loc.getEnd()); readEnd += 3) {
                 final SimpleInterval readLoc = new SimpleInterval(contig, readStart, readEnd);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -1,22 +1,28 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMLineParser;
-import htsjdk.samtools.SAMReadGroupRecord;
-import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.*;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
 
+import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.genotyper.SampleList;
+import org.broadinstitute.hellbender.utils.genotyper.*;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import scala.Char;
 
 public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
     private SAMFileHeader header;
@@ -57,5 +63,285 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         // make sure reads are not changed due to finalizeRegion()
         Assert.assertTrue(reads.get(0).convertToSAMRecord(header).equals(orgRead0));
         Assert.assertTrue(reads.get(1).convertToSAMRecord(header).equals(orgRead1));
+    }
+
+    @DataProvider(name = "testAnnotateReadLikelihoodsWithRegionsDataProvider")
+    public Object[][] testAnnotateReadLikelihoodsWithRegionsDataProvider() {
+
+        final String hap1String = "ACGTGGCGTTGCACTTCAGATCGATCGGATCGATCGGCTAGTCGTCGCACTTCGCTAGGCTAG";
+        final String contig = "1";
+        final int start = 13763;
+        final SimpleInterval loc = new SimpleInterval(contig, start, start + hap1String.length());
+        final SimpleInterval loc2 = new SimpleInterval(contig, loc.getStart() + 4, loc.getEnd() - 4);
+        List<Integer> snpIndecies = Arrays.asList(null, 12, 23);
+        List<Character> snpReplacements = Arrays.asList(null, 'G', 'C');
+        List<Integer> delIndecies = Arrays.asList(null, 27);
+        List<Integer> delLenghts = Arrays.asList(null, 4);
+        List<Integer> insIndecies = Arrays.asList(null, 34);
+        List<String> insStrings = Arrays.asList(null, "GGCTGGATCGAG");
+
+        List<String> haplotypeStrings = new ArrayList<String>();
+
+        for (int iSnp = 0; iSnp < snpIndecies.size(); iSnp++) {
+            Integer snpIndex = snpIndecies.get(iSnp);
+            Character snpReplacement = snpReplacements.get(iSnp);
+            for (int iDel = 0; iDel < delIndecies.size(); iDel++) {
+                Integer delIndex = delIndecies.get(iDel);
+                Integer delLength = delLenghts.get(iDel);
+                for (int iIns = 0; iIns < insIndecies.size(); iIns++) {
+                    Integer insIndex = insIndecies.get(iIns);
+                    String insString = insStrings.get(iIns);
+                    String haplotypeString = hap1String;
+                    if (snpIndex != null) {
+                        haplotypeString = applySNP(haplotypeString, snpIndex, snpReplacement);
+                    }
+                    if (insIndex != null) {
+                        haplotypeString = applyInsertion(haplotypeString, insIndex, insString);
+                    }
+                    if (delIndex != null) {
+                        haplotypeString = applyDeletion(haplotypeString, delIndex, delLength);
+                    }
+                    haplotypeStrings.add(haplotypeString);
+                }
+            }
+        }
+        final List<Haplotype> haplotypesList = haplotypeStrings.stream().map(h -> new Haplotype(h.getBytes(), loc)).collect(Collectors.toList());
+
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(1, 1, 100000000);
+        SAMLineParser parser = new SAMLineParser(header);
+
+        int qNameIndex = 0;
+        List<GATKRead> reads = new ArrayList<>();
+        Map<GATKRead, Haplotype> readHaplotypeMap = new HashMap<>();
+        for (Haplotype haplotype : haplotypesList) {
+            final String hapString = haplotype.getBaseString();
+            for (int readStart = 0; readStart < hapString.length() - 6; readStart += 3) {
+                for (int readEnd = Math.min(hapString.length(), readStart + 20); readEnd < Math.min(hapString.length(), readStart + 40); readEnd += 4) {
+                    final String readString = hapString.substring(readStart, readEnd);
+                    final String baseQuals = StringUtils.repeat("<", readString.length());  //actual basequals is unimportant for this test
+                    final String cigar = readString.length() + "M"; //actual cigar is unimportant for this test
+                    final String qname = "r" + qNameIndex;
+                    qNameIndex++;
+                    final int flag = 83;
+                    final String rname = contig;
+                    final int pos = start + readStart;
+                    final int mapq = 39;
+                    final String rnext = "=";
+                    final int pnext = pos + 100;
+                    final int tlen = 200;
+                    final String samLine = qname + "\t" + flag + "\t" + rname + "\t" + pos + "\t" + mapq + "\t" + cigar + "\t" + rnext + "\t" +
+                            pnext + "\t" + tlen + "\t" + readString + "\t" + baseQuals;
+                    final SAMRecord samRead = parser.parseLine(samLine);
+                    final SAMRecordToGATKReadAdapter read = new SAMRecordToGATKReadAdapter(samRead);
+                    reads.add(read);
+                    readHaplotypeMap.put(read, haplotype);
+                }
+            }
+        }
+        Map<String, List<GATKRead>> sampleReadMap = new HashMap<>();
+        sampleReadMap.put("sample1", reads);
+        final AlleleList<Haplotype> haplotypes = new IndexedAlleleList<>(haplotypesList);
+        final SampleList samples = new IndexedSampleList("sample1");
+
+        final ReadLikelihoods<Haplotype> readLikelihoods = new ReadLikelihoods<>(samples, haplotypes, sampleReadMap);
+        LikelihoodMatrix<Haplotype> sampleMatrix = readLikelihoods.sampleMatrix(0);
+        for (GATKRead read : reads) {
+            final int readIndex = sampleMatrix.indexOfRead(read);
+            for (Haplotype haplotype : haplotypesList) {
+                final int haplotypeIndex = sampleMatrix.indexOfAllele(haplotype);
+                if (readHaplotypeMap.get(read) == haplotype) {
+                    sampleMatrix.set(haplotypeIndex, readIndex, -1.0);
+                } else {
+                    sampleMatrix.set(haplotypeIndex, readIndex, -8.0);
+                }
+            }
+        }
+
+        return new Object[][]{{readLikelihoods, loc, loc},
+                {readLikelihoods, loc, loc2}
+        };
+
+    }
+
+
+    private String applySNP(final String initialSeq, final int iReplace, final char replaceWith) {
+        if (initialSeq.length() <= iReplace) {
+            return initialSeq;
+        }
+        String retSeq = initialSeq.substring(0, iReplace) + replaceWith;
+        if (initialSeq.length() > iReplace + 1) {
+            retSeq += initialSeq.substring(iReplace + 1);
+        }
+        return retSeq;
+    }
+
+    private String applyDeletion(final String initialSeq, final int iDelete, final int lengthDelete) {
+        if (initialSeq.length() <= iDelete) {
+            return initialSeq;
+        }
+        String retSeq = initialSeq.substring(0, iDelete);
+        if (initialSeq.length() > iDelete + lengthDelete) {
+            retSeq += initialSeq.substring(iDelete + lengthDelete);
+        }
+        return retSeq;
+    }
+
+    private String applyInsertion(final String initialSeq, final int iInsert, final String insertionSeq) {
+        if (initialSeq.length() <= iInsert) {
+            return initialSeq;
+        }
+        String retSeq = initialSeq.substring(0, iInsert) + insertionSeq;
+        if (initialSeq.length() > iInsert + 1) {
+            retSeq += initialSeq.substring(iInsert + 1);
+        }
+        return retSeq;
+    }
+
+    @Test(dataProvider = "testAnnotateReadLikelihoodsWithRegionsDataProvider")
+    public void testAnnotateReadLikelihoodsWithRegions(ReadLikelihoods<Haplotype> readLikelihoods, final Locatable loc, final Locatable callableLoc) {
+        AssemblyBasedCallerUtils.annotateReadLikelihoodsWithRegions(readLikelihoods, callableLoc);
+        for (GATKRead read : readLikelihoods.sampleReads(0)) {
+            Assert.assertEquals(read.getAttributeAsString(AssemblyBasedCallerUtils.ALIGNMENT_REGION_TAG), loc.toString());
+            Assert.assertEquals(read.getAttributeAsString(AssemblyBasedCallerUtils.CALLABLE_REGION_TAG), callableLoc.toString());
+        }
+    }
+
+    @DataProvider(name = "testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider")
+    public Object[][] testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider() {
+        final String refString = "ACGTGGCGTTGCACTTCAGATCGATCGGATCGATCGGCTAGTCGTCGCACTTCGCTAGGCTAG";
+        final String contig = "1";
+        final int start = 13763;
+        final SimpleInterval loc = new SimpleInterval(contig, start, start + refString.length());
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(1, 1, 100000000);
+        SAMLineParser parser = new SAMLineParser(header);
+
+        final Haplotype refHaplotype = new Haplotype(refString.getBytes(), loc);
+        final Cigar refCigar = new Cigar(Arrays.asList(new CigarElement(refString.length(), CigarOperator.M)));
+        refHaplotype.setCigar(refCigar);
+
+        List<VariantContext> vcs = new ArrayList<>();
+        vcs.add(new VariantContextBuilder("source", contig, start + 3, start + 3, Arrays.asList(
+                Allele.create("T".getBytes(), true), Allele.create("G".getBytes(), false))).make());
+        vcs.add(new VariantContextBuilder("source", contig, start + 38, start + 38, Arrays.asList(
+                Allele.create("T".getBytes(), true), Allele.create("G".getBytes(), false), Allele.create("C".getBytes(), false))).make());
+        vcs.add(new VariantContextBuilder("source", contig, start + 20, start + 23, Arrays.asList(
+                Allele.create("TCGA", true), Allele.create("T", false))).make());
+
+        Map<VariantContext, List<GATKRead>> vcReadsMap = new HashMap<>();
+        Map<GATKRead, Integer> supportedGenotypeMap = new HashMap<>();
+        for (VariantContext vc : vcs) {
+            vcReadsMap.put(vc, new ArrayList<>());
+        }
+
+        int qNameIndex = 0;
+        for (int readStart = loc.getStart(); readStart < loc.getEnd() - 6; readStart += 4) {
+            for (int readEnd = Math.min(readStart + 20, loc.getEnd()); readEnd < Math.min(readStart + 50, loc.getEnd()); readEnd += 3) {
+                final SimpleInterval readLoc = new SimpleInterval(contig, readStart, readEnd);
+                final Haplotype refRead = refHaplotype.trim(readLoc);
+                for (int phase = 0; phase < 3; phase++) {
+                    Haplotype readHaplotype = applyVariant(vcs.get(0), refRead, 0);
+                    if (phase > 0) {
+                        readHaplotype = applyVariant(vcs.get(1), readHaplotype, phase - 1);
+                    }
+                    readHaplotype = applyVariant(vcs.get(2), readHaplotype, 0);
+                    final String readString = readHaplotype.getBaseString();
+                    final String baseQuals = StringUtils.repeat("<", readString.length());  //actual basequals is unimportant for this test
+                    final String cigar = readString.length() + "M"; //actual cigar is unimportant for this test
+                    final String qname = "r" + qNameIndex;
+                    qNameIndex++;
+                    final int flag = 83;
+                    final String rname = contig;
+                    final int pos = readStart;
+                    final int mapq = 39;
+                    final String rnext = "=";
+                    final int pnext = pos + 100;
+                    final int tlen = 200;
+                    final String samLine = qname + "\t" + flag + "\t" + rname + "\t" + pos + "\t" + mapq + "\t" + cigar + "\t" + rnext + "\t" +
+                            pnext + "\t" + tlen + "\t" + readString + "\t" + baseQuals;
+                    final SAMRecord samRead = parser.parseLine(samLine);
+                    final SAMRecordToGATKReadAdapter read = new SAMRecordToGATKReadAdapter(samRead);
+                    supportedGenotypeMap.put(read, phase);
+                    for (final VariantContext vc : vcs) {
+                        if (read.getStart() <= vc.getStart() && read.getEnd() >= vc.getEnd()) {
+                            vcReadsMap.get(vc).add(read);
+                        }
+                    }
+
+                }
+            }
+        }
+        List<ReadLikelihoods<Allele>> readLikelihoodsList = new ArrayList<>();
+        List<List<String>> readAttributeListList = new ArrayList<>();
+        for (VariantContext vc : vcs) {
+            Map<String, List<GATKRead>> sampleReadMap = new HashMap<>();
+            sampleReadMap.put("sample1", vcReadsMap.get(vc));
+            final SampleList samples = new IndexedSampleList("sample1");
+            final AlleleList<Allele> alleles = new IndexedAlleleList<>(vc.getAlleles());
+            final ReadLikelihoods<Allele> readLikelihoods = new ReadLikelihoods<>(samples, alleles, sampleReadMap);
+            LikelihoodMatrix<Allele> sampleMatrix = readLikelihoods.sampleMatrix(0);
+            List<String> readAttributeList = new ArrayList<>();
+            for (GATKRead read : vcReadsMap.get(vc)) {
+                final int readIndex = sampleMatrix.indexOfRead(read);
+                String attribute = contig + ":" + vc.getStart() + "=";
+                if (vc == vcs.get(1)) {
+                    attribute += supportedGenotypeMap.get(read);
+                } else {
+                    attribute += "1";
+                }
+                readAttributeList.add(attribute);
+                for (Allele allele : vc.getAlleles()) {
+                    final int alleleIndex = sampleMatrix.indexOfAllele(allele);
+                    if (vc == vcs.get(1)) {
+                        if (vc.getAlleleIndex(allele) == supportedGenotypeMap.get(read)) {
+                            sampleMatrix.set(alleleIndex, readIndex, -1.0);
+                        } else {
+                            sampleMatrix.set(alleleIndex, readIndex, -8.0);
+                        }
+                    } else {
+                        if (vc.getAlleleIndex(allele) == 1) {
+                            sampleMatrix.set(alleleIndex, readIndex, -1.0);
+                        } else {
+                            sampleMatrix.set(alleleIndex, readIndex, -8.0);
+                        }
+                    }
+                }
+            }
+            readLikelihoodsList.add(readLikelihoods);
+            readAttributeListList.add(readAttributeList);
+        }
+        return new Object[][]{{readLikelihoodsList, vcs, readAttributeListList}};
+    }
+
+    private Haplotype applyVariant(final VariantContext vc, final Haplotype refHaplotype, final int altIndex) {
+        Haplotype retHaplotype = refHaplotype.insertAllele(vc.getReference(), vc.getAlternateAllele(altIndex), vc.getStart() - (int) refHaplotype.getStartPosition(), vc.getStart());
+        if (retHaplotype == null) {
+            return refHaplotype;
+        }
+        retHaplotype.setGenomeLocation(refHaplotype.getGenomeLocation());
+        final Cigar cigar = new Cigar(Arrays.asList(new CigarElement(retHaplotype.length(), CigarOperator.M)));
+        retHaplotype.setCigar(cigar);
+        return retHaplotype;
+    }
+
+    @Test(dataProvider = "testAnnotateReadLikelihoodsWithSupportedGenotypesDataProvider")
+    public void testAnnotateReadLikelihoodsWithSupportedGenotypes(List<ReadLikelihoods<Allele>> readLikelihoodsList, final List<VariantContext> vcs, final List<List<String>> readAttributeListList) {
+        for (int i = 0; i < readLikelihoodsList.size(); i++) {
+            ReadLikelihoods<Allele> readLikelihoods = readLikelihoodsList.get(i);
+            VariantContext vc = vcs.get(i);
+            List<String> readAttributeList = readAttributeListList.get(i);
+
+
+            List<String> initReadAttributes = new ArrayList<>();
+            for (GATKRead read : readLikelihoods.sampleReads(0)) {
+                initReadAttributes.add(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_GENOTYPES_TAG));
+            }
+            AssemblyBasedCallerUtils.annotateReadLikelihoodsWithSupportedGenotypes(vc, readLikelihoods);
+            for (int j = 0; j < readLikelihoods.sampleReadCount(0); j++) {
+                GATKRead read = readLikelihoods.sampleReads(0).get(j);
+
+                String expectedAttribute = (initReadAttributes.get(j) != null ? initReadAttributes.get(j) + ", " : "") + readAttributeList.get(j);
+                Assert.assertEquals(read.getAttributeAsString(AssemblyBasedCallerUtils.SUPPORTED_GENOTYPES_TAG), expectedAttribute);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds three annotations to reads in bamout produced by HaplotypeCaller and Mutect2:

1.  AR (Alignment Region)- The reference region over which a read is aligned to a haplotype
2. CR (Callable Region)- The reference region over which the caller is using this read to call variants
3. SG (Supported Genotypes)- A list of the genotypes supported by this read for variants called in the callable region