### PR TITLE
 Use Spark files to distribute the reference for Spark Walker classes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -582,6 +582,9 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * @return the reference file name; the absolute path of the file can be found by a Spark task using {@code SparkFiles#get()}
      */
     protected static String addReferenceFilesForSpark(JavaSparkContext ctx, String referenceFile) {
+        if (referenceFile == null) {
+            return null;
+        }
         Path referencePath = IOUtils.getPath(referenceFile);
         Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(referencePath);
         Path dictPath = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(referencePath);

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/IntervalWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/IntervalWalkerSpark.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -9,6 +10,7 @@ import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.Iterator;
@@ -31,8 +33,7 @@ public abstract class IntervalWalkerSpark extends GATKSparkTool {
     @Argument(doc = "whether to use the shuffle implementation or not", shortName = "shuffle", fullName = "shuffle", optional = true)
     public boolean shuffle = false;
 
-    @Argument(fullName="intervalShardPadding", shortName="intervalShardPadding", doc = "Each interval shard has this many bases of extra context on each side.", optional = true)
-    public int intervalShardPadding = 1000;
+    private String referenceFileName;
 
     /**
      * Customize initialization of the Feature data source for this traversal type to disable query lookahead.
@@ -60,18 +61,15 @@ public abstract class IntervalWalkerSpark extends GATKSparkTool {
         final List<ShardBoundary> intervalShardBoundaries = getIntervals().stream()
                 .map(i -> new ShardBoundary(i, i)).collect(Collectors.toList());
         JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, getReads(), GATKRead.class, sequenceDictionary, intervalShardBoundaries, Integer.MAX_VALUE, shuffle);
-        Broadcast<ReferenceMultiSparkSource> bReferenceSource = hasReference() ? ctx.broadcast(getReference()) : null;
         Broadcast<FeatureManager> bFeatureManager = features == null ? null : ctx.broadcast(features);
-        return shardedReads.map(getIntervalsFunction(bReferenceSource, bFeatureManager, sequenceDictionary, intervalShardPadding));
+        return shardedReads.map(getIntervalsFunction(referenceFileName, bFeatureManager));
     }
 
     private static org.apache.spark.api.java.function.Function<Shard<GATKRead>, IntervalWalkerContext> getIntervalsFunction(
-            Broadcast<ReferenceMultiSparkSource> bReferenceSource, Broadcast<FeatureManager> bFeatureManager,
-            SAMSequenceDictionary sequenceDictionary, int intervalShardPadding) {
+            String referenceFileName, Broadcast<FeatureManager> bFeatureManager) {
         return (org.apache.spark.api.java.function.Function<Shard<GATKRead>, IntervalWalkerContext>) shard -> {
             // get reference bases for this shard (padded)
             SimpleInterval interval = shard.getInterval();
-            SimpleInterval paddedInterval = shard.getInterval().expandWithinContig(intervalShardPadding, sequenceDictionary);
             ReadsContext readsContext = new ReadsContext(new GATKDataSource<GATKRead>() {
                 @Override
                 public Iterator<GATKRead> iterator() {
@@ -83,8 +81,7 @@ public abstract class IntervalWalkerSpark extends GATKSparkTool {
                             r -> IntervalUtils.overlaps(r, interval)).iterator();
                 }
             }, shard.getInterval());
-            ReferenceDataSource reference = bReferenceSource == null ? null :
-                    new ReferenceMemorySource(bReferenceSource.getValue().getReferenceBases(paddedInterval), sequenceDictionary);
+            ReferenceDataSource reference = referenceFileName == null ? null : new ReferenceFileSource(IOUtils.getPath(SparkFiles.get(referenceFileName)));
             FeatureManager features = bFeatureManager == null ? null : bFeatureManager.getValue();
             return new IntervalWalkerContext(interval, readsContext, new ReferenceContext(reference, interval), new FeatureContext(features, interval));
         };
@@ -92,6 +89,7 @@ public abstract class IntervalWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
         processIntervals(getIntervals(ctx), ctx);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -77,13 +77,11 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
                 //        -stand_call_conf 30.0
                 {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, null, null, getResourceDir() + expectedSingleKnownSitesVcf)}, // don't write intermediate BAM
                 {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, null, getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--read-shard-padding 1000", getResourceDir() + expectedSingleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
                 {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20_queryNameSorted, ".bam", dbSNPb37_20, null, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedSingleKnownSitesVcf)},
 
                 // Output generated with GATK4
                 {new PipelineTest(GRCh37Ref_2021, hiSeqCram_chr20, ".cram", dbSNPb37_20, "--known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSitesCram, getResourceDir() + expectedMultipleKnownSitesVcf)},
                 {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
-                {new PipelineTest(GRCh37Ref_2021, hiSeqBam_chr20, ".bam", dbSNPb37_20, "--read-shard-padding 1000 --known-sites " + more20Sites, getResourceDir() + expectedMultipleKnownSites, getResourceDir() + expectedMultipleKnownSitesVcf)},
 
                 // BWA-MEM
                 {new PipelineTest(GRCh37Ref_2021, unalignedBam, ".bam", dbSNPb37_20, "--align --bwa-mem-index-image " + GRCh37Ref_2021_img + " --known-sites " + more20Sites, null, largeFileTestDir + expectedMultipleKnownSitesFromUnalignedVcf)},


### PR DESCRIPTION
Using the technique in #5127, this change uses Spark files to distribute the reference for all of the Spark Walker classes. This makes Spark tools run faster and use less memory.

(Note that this PR includes #5127, since it hasn't been merged yet, so only the last commit should be reviewed here.)