### PR TITLE
Revert gCNV WDLs to tar calls from all samples.

### DIFF
--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -287,8 +287,8 @@ task PostprocessGermlineCNVCalls {
         calls_args=""
         for index in ${dollar}{!gcnv_calls_tar_array[@]}; do
             gcnv_calls_tar=${dollar}{gcnv_calls_tar_array[$index]}
-            mkdir -p CALLS_$index/SAMPLE_${sample_index}
-            tar xzf $gcnv_calls_tar -C CALLS_$index/SAMPLE_${sample_index}
+            mkdir CALLS_$index
+            tar xzf $gcnv_calls_tar -C CALLS_$index
             cp ${dollar}{calling_configs_array[$index]} CALLS_$index/
             cp ${dollar}{denoising_configs_array[$index]} CALLS_$index/
             cp ${dollar}{gcnvkernel_version_array[$index]} CALLS_$index/

--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -242,11 +242,6 @@ task ScatterIntervals {
 }
 
 task PostprocessGermlineCNVCalls {
-    Array[File] calling_configs
-    Array[File] denoising_configs
-    Array[File] gcnvkernel_version
-    Array[File] sharded_interval_lists
-
     String entity_id
     Array[File] gcnv_calls_tars
     Array[File] gcnv_model_tars
@@ -278,21 +273,12 @@ task PostprocessGermlineCNVCalls {
         export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
 
         # untar calls to CALLS_0, CALLS_1, etc directories and build the command line
-        # also copy over shard config and interval files
         gcnv_calls_tar_array=(${sep=" " gcnv_calls_tars})
-        calling_configs_array=(${sep=" " calling_configs})
-        denoising_configs_array=(${sep=" " denoising_configs})
-        gcnvkernel_version_array=(${sep=" " gcnvkernel_version})
-        sharded_interval_lists_array=(${sep=" " sharded_interval_lists})
         calls_args=""
         for index in ${dollar}{!gcnv_calls_tar_array[@]}; do
             gcnv_calls_tar=${dollar}{gcnv_calls_tar_array[$index]}
             mkdir CALLS_$index
             tar xzf $gcnv_calls_tar -C CALLS_$index
-            cp ${dollar}{calling_configs_array[$index]} CALLS_$index/
-            cp ${dollar}{denoising_configs_array[$index]} CALLS_$index/
-            cp ${dollar}{gcnvkernel_version_array[$index]} CALLS_$index/
-            cp ${dollar}{sharded_interval_lists_array[$index]} CALLS_$index/
             calls_args="$calls_args --calls-shard-path CALLS_$index"
         done
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -179,6 +179,9 @@ workflow CNVGermlineCaseScatteredWorkflow {
     }
 
     output {
+        Array[File] preprocessed_intervals = CNVGermlineCaseWorkflow.preprocessed_intervals
+        Array[Array[File]] read_counts_entity_id = CNVGermlineCaseWorkflow.read_counts_entity_id
+        Array[Array[File]] read_counts = CNVGermlineCaseWorkflow.read_counts
         Array[File] contig_ploidy_calls_tars = CNVGermlineCaseWorkflow.contig_ploidy_calls_tar
         Array[Array[File]] gcnv_calls_tars = CNVGermlineCaseWorkflow.gcnv_calls_tars
         Array[Array[File]] gcnv_tracking_tars = CNVGermlineCaseWorkflow.gcnv_tracking_tars

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -180,7 +180,7 @@ workflow CNVGermlineCaseScatteredWorkflow {
 
     output {
         Array[File] contig_ploidy_calls_tars = CNVGermlineCaseWorkflow.contig_ploidy_calls_tar
-        Array[Array[Array[File]]] gcnv_calls_tars = CNVGermlineCaseWorkflow.gcnv_calls_tars
+        Array[Array[File]] gcnv_calls_tars = CNVGermlineCaseWorkflow.gcnv_calls_tars
         Array[Array[File]] gcnv_tracking_tars = CNVGermlineCaseWorkflow.gcnv_tracking_tars
         Array[Array[File]] genotyped_intervals_vcf = CNVGermlineCaseWorkflow.genotyped_intervals_vcf
         Array[Array[File]] genotyped_segments_vcf = CNVGermlineCaseWorkflow.genotyped_segments_vcf

--- a/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
@@ -214,10 +214,6 @@ workflow CNVGermlineCaseWorkflow {
     scatter (sample_index in range(length(normal_bams))) {
         call CNVTasks.PostprocessGermlineCNVCalls {
             input:
-                calling_configs = GermlineCNVCallerCaseMode.calling_config_json,
-                denoising_configs = GermlineCNVCallerCaseMode.denoising_config_json,
-                gcnvkernel_version = GermlineCNVCallerCaseMode.gcnvkernel_version_json,
-                sharded_interval_lists = GermlineCNVCallerCaseMode.sharded_interval_list,
                 entity_id = CollectCounts.entity_id[sample_index],
                 gcnv_calls_tars = GermlineCNVCallerCaseMode.gcnv_calls_tar,
                 gcnv_model_tars = gcnv_model_tars,

--- a/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
@@ -211,8 +211,6 @@ workflow CNVGermlineCaseWorkflow {
         }
     }
 
-    Array[Array[File]] call_tars_sample_by_shard = transpose(GermlineCNVCallerCaseMode.gcnv_call_tars)
-
     scatter (sample_index in range(length(normal_bams))) {
         call CNVTasks.PostprocessGermlineCNVCalls {
             input:
@@ -221,7 +219,7 @@ workflow CNVGermlineCaseWorkflow {
                 gcnvkernel_version = GermlineCNVCallerCaseMode.gcnvkernel_version_json,
                 sharded_interval_lists = GermlineCNVCallerCaseMode.sharded_interval_list,
                 entity_id = CollectCounts.entity_id[sample_index],
-                gcnv_calls_tars = call_tars_sample_by_shard[sample_index],
+                gcnv_calls_tars = GermlineCNVCallerCaseMode.gcnv_calls_tar,
                 gcnv_model_tars = gcnv_model_tars,
                 allosomal_contigs = allosomal_contigs,
                 ref_copy_number_autosomal_contigs = ref_copy_number_autosomal_contigs,
@@ -238,7 +236,7 @@ workflow CNVGermlineCaseWorkflow {
         Array[File] read_counts_entity_id = CollectCounts.entity_id
         Array[File] read_counts = CollectCounts.counts
         File contig_ploidy_calls_tar = DetermineGermlineContigPloidyCaseMode.contig_ploidy_calls_tar
-        Array[Array[File]] gcnv_calls_tars = GermlineCNVCallerCaseMode.gcnv_call_tars
+        Array[File] gcnv_calls_tars = GermlineCNVCallerCaseMode.gcnv_calls_tar
         Array[File] gcnv_tracking_tars = GermlineCNVCallerCaseMode.gcnv_tracking_tar
         Array[File] genotyped_intervals_vcf = PostprocessGermlineCNVCalls.genotyped_intervals_vcf
         Array[File] genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf
@@ -364,7 +362,6 @@ task GermlineCNVCallerCaseMode {
     # If optional output_dir not specified, use "out"
     String output_dir_ = select_first([output_dir, "out"])
 
-    Int num_samples = length(read_count_files)
     command <<<
         set -e
         mkdir ${output_dir_}
@@ -415,11 +412,7 @@ task GermlineCNVCallerCaseMode {
             --caller-external-admixing-rate ${default="1.00" caller_external_admixing_rate} \
             --disable-annealing ${default="false" disable_annealing}
 
-        CURRENT_SAMPLE=0
-        while [ $CURRENT_SAMPLE -lt ${num_samples} ]; do
-            tar czf case-gcnv-shard-${scatter_index}-sample-$CURRENT_SAMPLE-gcnv-calls.tar.gz -C ${output_dir_}/case-calls/SAMPLE_$CURRENT_SAMPLE .
-            let CURRENT_SAMPLE=CURRENT_SAMPLE+1
-        done
+        tar czf case-gcnv-calls-${scatter_index}.tar.gz -C ${output_dir_}/case-calls .
         tar czf case-gcnv-tracking-${scatter_index}.tar.gz -C ${output_dir_}/case-tracking .
     >>>
 
@@ -432,11 +425,11 @@ task GermlineCNVCallerCaseMode {
     }
 
     output {
+        File gcnv_calls_tar = "case-gcnv-calls-${scatter_index}.tar.gz"
+        File gcnv_tracking_tar = "case-gcnv-tracking-${scatter_index}.tar.gz"
         File calling_config_json = "${output_dir_}/case-calls/calling_config.json"
         File denoising_config_json = "${output_dir_}/case-calls/denoising_config.json"
         File gcnvkernel_version_json = "${output_dir_}/case-calls/gcnvkernel_version.json"
         File sharded_interval_list = "${output_dir_}/case-calls/interval_list.tsv"
-        Array[File] gcnv_call_tars = glob("*-gcnv-calls.tar.gz")
-        File gcnv_tracking_tar = "case-gcnv-tracking-${scatter_index}.tar.gz"
     }
 }

--- a/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
@@ -259,8 +259,6 @@ workflow CNVGermlineCohortWorkflow {
         }
     }
 
-    Array[Array[File]] call_tars_sample_by_shard = transpose(GermlineCNVCallerCohortMode.gcnv_call_tars)
-
     scatter (sample_index in range(length(CollectCounts.entity_id))) {
         call CNVTasks.PostprocessGermlineCNVCalls {
             input:
@@ -269,7 +267,7 @@ workflow CNVGermlineCohortWorkflow {
                 gcnvkernel_version = GermlineCNVCallerCohortMode.gcnvkernel_version_json,
                 sharded_interval_lists = GermlineCNVCallerCohortMode.sharded_interval_list,
                 entity_id = CollectCounts.entity_id[sample_index],
-                gcnv_calls_tars = call_tars_sample_by_shard[sample_index],
+                gcnv_calls_tars = GermlineCNVCallerCohortMode.gcnv_calls_tar,
                 gcnv_model_tars = GermlineCNVCallerCohortMode.gcnv_model_tar,
                 contig_ploidy_calls_tar = DetermineGermlineContigPloidyCohortMode.contig_ploidy_calls_tar,
                 allosomal_contigs = allosomal_contigs,
@@ -288,7 +286,7 @@ workflow CNVGermlineCohortWorkflow {
         File contig_ploidy_model_tar = DetermineGermlineContigPloidyCohortMode.contig_ploidy_model_tar
         File contig_ploidy_calls_tar = DetermineGermlineContigPloidyCohortMode.contig_ploidy_calls_tar
         Array[File] gcnv_model_tars = GermlineCNVCallerCohortMode.gcnv_model_tar
-        Array[Array[File]] gcnv_calls_tars = GermlineCNVCallerCohortMode.gcnv_call_tars
+        Array[File] gcnv_calls_tars = GermlineCNVCallerCohortMode.gcnv_calls_tar
         Array[File] gcnv_tracking_tars = GermlineCNVCallerCohortMode.gcnv_tracking_tar
         Array[File] genotyped_intervals_vcfs = PostprocessGermlineCNVCalls.genotyped_intervals_vcf
         Array[File] genotyped_segments_vcfs = PostprocessGermlineCNVCalls.genotyped_segments_vcf
@@ -426,7 +424,6 @@ task GermlineCNVCallerCohortMode {
 
     # If optional output_dir not specified, use "out"
     String output_dir_ = select_first([output_dir, "out"])
-    Int num_samples = length(read_count_files)
 
     command <<<
         set -e
@@ -487,11 +484,7 @@ task GermlineCNVCallerCohortMode {
             --disable-annealing ${default="false" disable_annealing}
 
         tar czf ${cohort_entity_id}-gcnv-model-${scatter_index}.tar.gz -C ${output_dir_}/${cohort_entity_id}-model .
-        CURRENT_SAMPLE=0
-        while [ $CURRENT_SAMPLE -lt ${num_samples} ]; do
-            tar czf ${cohort_entity_id}-shard-${scatter_index}-sample-$CURRENT_SAMPLE-gcnv-calls.tar.gz -C ${output_dir_}/${cohort_entity_id}-calls/SAMPLE_$CURRENT_SAMPLE .
-            let CURRENT_SAMPLE=CURRENT_SAMPLE+1
-        done
+        tar czf ${cohort_entity_id}-gcnv-calls-${scatter_index}.tar.gz -C ${output_dir_}/${cohort_entity_id}-calls .
         tar czf ${cohort_entity_id}-gcnv-tracking-${scatter_index}.tar.gz -C ${output_dir_}/${cohort_entity_id}-tracking .
     >>>
 
@@ -505,11 +498,11 @@ task GermlineCNVCallerCohortMode {
 
     output {
         File gcnv_model_tar = "${cohort_entity_id}-gcnv-model-${scatter_index}.tar.gz"
+        File gcnv_calls_tar = "${cohort_entity_id}-gcnv-calls-${scatter_index}.tar.gz"
+        File gcnv_tracking_tar = "${cohort_entity_id}-gcnv-tracking-${scatter_index}.tar.gz"
         File calling_config_json = "${output_dir_}/${cohort_entity_id}-calls/calling_config.json"
         File denoising_config_json = "${output_dir_}/${cohort_entity_id}-calls/denoising_config.json"
         File gcnvkernel_version_json = "${output_dir_}/${cohort_entity_id}-calls/gcnvkernel_version.json"
         File sharded_interval_list = "${output_dir_}/${cohort_entity_id}-calls/interval_list.tsv"
-        Array[File] gcnv_call_tars = glob("*-gcnv-calls.tar.gz")
-        File gcnv_tracking_tar = "${cohort_entity_id}-gcnv-tracking-${scatter_index}.tar.gz"
     }
 }

--- a/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
@@ -262,10 +262,6 @@ workflow CNVGermlineCohortWorkflow {
     scatter (sample_index in range(length(CollectCounts.entity_id))) {
         call CNVTasks.PostprocessGermlineCNVCalls {
             input:
-                calling_configs = GermlineCNVCallerCohortMode.calling_config_json,
-                denoising_configs = GermlineCNVCallerCohortMode.denoising_config_json,
-                gcnvkernel_version = GermlineCNVCallerCohortMode.gcnvkernel_version_json,
-                sharded_interval_lists = GermlineCNVCallerCohortMode.sharded_interval_list,
                 entity_id = CollectCounts.entity_id[sample_index],
                 gcnv_calls_tars = GermlineCNVCallerCohortMode.gcnv_calls_tar,
                 gcnv_model_tars = GermlineCNVCallerCohortMode.gcnv_model_tar,


### PR DESCRIPTION
Closes #5217.

@vruano, I've verified that cohort and scattered-case mode WDLs run correctly on FC (to be precise, I tested the WDLs from my sl_filter branch rebased on this branch, but this branch alone should be fine as well).

However, #4397 should still be addressed at some point in the future.  This can wait until we have v1 of the FC evaluation in place.