### PR TITLE
Adding command line exclusion lists, so that users can prune fields from output. 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotation.java
@@ -26,12 +26,6 @@ public interface Funcotation {
     void setFieldSerializationOverrideValue( final String fieldName, final String overrideValue );
 
     /**
-     * Converts this {@link Funcotation} to a string suitable for insertion into a VCF file.
-     * @return a {@link String} representing this {@link Funcotation} suitable for insertion into a VCF file.
-     */
-    String serializeToVcfString();
-
-    /**
      * @return The name of the data source behind the {@link DataSourceFuncotationFactory} used to create this {@link Funcotation}.
      */
     String getDataSourceName();
@@ -74,17 +68,6 @@ public interface Funcotation {
                 setFieldSerializationOverrideValue(field, fieldSerializationOverrides.get(field));
             }
         }
-    }
-
-    /**
-     * TODO: This interface should have nothing specific to a VCF.  That should be the job of the VCFOutputRenderer to sanitize any strings.  https://github.com/broadinstitute/gatk/issues/4797
-     * Converts this {@link Funcotation} to a string suitable for insertion into a VCF file.
-     * {@code manualAnnotationString} should be written first, followed by the inherent annotations in this {@link Funcotation}.
-     * @param manualAnnotationString A {@link String} of manually-provided annotations to add to this {@link Funcotation}.
-     * @return a {@link String} representing this {@link Funcotation} suitable for insertion into a VCF file.
-     */
-    default String serializeToVcfString(final String manualAnnotationString) {
-        return (manualAnnotationString == null ? "" : manualAnnotationString) + serializeToVcfString();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
@@ -101,4 +101,11 @@ public class FuncotatorArgumentCollection implements Serializable {
             doc = "(Advanced / DO NOT USE*) If you select this flag, Funcotator will force a conversion of variant contig names from b37 to hg19.  *This option is useful in integration tests (written by devs) only."
     )
     public boolean forceB37ToHg19ContigNameConversion = false;
+
+    @Argument(
+            fullName  = FuncotatorArgumentDefinitions.EXCLUSION_FIELDS_LONG_NAME,
+            optional = true,
+            doc = "Fields that should not be rendered in the final output."
+    )
+    public Set<String> excludedFields = new HashSet<>();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentCollection.java
@@ -105,7 +105,7 @@ public class FuncotatorArgumentCollection implements Serializable {
     @Argument(
             fullName  = FuncotatorArgumentDefinitions.EXCLUSION_FIELDS_LONG_NAME,
             optional = true,
-            doc = "Fields that should not be rendered in the final output."
+            doc = "Fields that should not be rendered in the final output.  Only exact name matches will be excluded."
     )
     public Set<String> excludedFields = new HashSet<>();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -51,7 +51,7 @@ public class FuncotatorArgumentDefinitions {
     /**
      * List of final rendered fields to exclude from a final rendering
      */
-    public static final String EXCLUSION_FIELDS_LONG_NAME = "exclusion-list";
+    public static final String EXCLUSION_FIELDS_LONG_NAME = "exclude-field";
 
     public static final String HG19_REFERENCE_VERSION_STRING = "hg19";
     public static final String HG38_REFERENCE_VERSION_STRING = "hg38";

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -48,6 +48,11 @@ public class FuncotatorArgumentDefinitions {
      */
     public static final String ANNOTATION_OVERRIDES_LONG_NAME = "annotation-override";
 
+    /**
+     * List of final rendered fields to exclude from a final rendering
+     */
+    public static final String EXCLUSION_FIELDS_LONG_NAME = "exclusion-list";
+
     public static final String HG19_REFERENCE_VERSION_STRING = "hg19";
     public static final String HG38_REFERENCE_VERSION_STRING = "hg38";
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -192,7 +192,7 @@ public final class FuncotatorEngine implements AutoCloseable {
                         unaccountedForDefaultAnnotations,
                         unaccountedForOverrideAnnotations,
                         defaultToolVcfHeaderLines.stream().map(Object::toString).collect(Collectors.toCollection(LinkedHashSet::new)),
-                        funcotatorArgs.referenceVersion);
+                        funcotatorArgs.referenceVersion, funcotatorArgs.excludedFields);
                 break;
 
             case VCF:
@@ -202,7 +202,7 @@ public final class FuncotatorEngine implements AutoCloseable {
                         headerForVariants,
                         unaccountedForDefaultAnnotations,
                         unaccountedForOverrideAnnotations,
-                        defaultToolVcfHeaderLines
+                        defaultToolVcfHeaderLines, funcotatorArgs.excludedFields
                 );
                 break;
             default:

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -2077,14 +2077,25 @@ public final class FuncotatorUtils {
     }
 
     /**
-     * Make sure that an individual funcotation (i.e. single value of a funcotation) is sanitized for VCF consumption.
+     * Make sure that an individual funcotation field (i.e. single value of a funcotation) is sanitized for VCF consumption.
      * Particularly, make sure that it does not allow special characters that would interfere with VCF parsing.
-     * @param individualFuncotation  value from a funcotation Never {@code null}
-     * @return input string with special characters replaced by _%HEX%_ where HEX is the 2 digit ascii hex code.
+     * @param individualFuncotationField  value from a funcotation. Never {@code null}
+     * @return input string with special characters replaced by _%HEX%_ where HEX is the 2 digit ascii hex code.  Never {@code null}
      */
-    public static String sanitizeFuncotationForVcf(final String individualFuncotation) {
-        Utils.nonNull(individualFuncotation);
-        return StringUtils.replaceEach(individualFuncotation, new String[]{",", ";", "=", "\t", "|", " "}, new String[]{"_%2C_", "_%3B_", "_%3D_", "_%09_", "_%7C_", "_%20_"});
+    public static String sanitizeFuncotationFieldForVcf(final String individualFuncotationField) {
+        Utils.nonNull(individualFuncotationField);
+        return StringUtils.replaceEach(individualFuncotationField, new String[]{",", ";", "=", "\t", "|", " ", "\n"}, new String[]{"_%2C_", "_%3B_", "_%3D_", "_%09_", "_%7C_", "_%20_", "_%0A_"});
+    }
+
+    /**
+     * Make sure that an individual funcotation field (i.e. single value of a funcotation) is sanitized for MAF consumption.
+     * Particularly, make sure that it does not allow special characters that would interfere with MAF parsing.
+     * @param individualFuncotationField  value from a funcotation. Never {@code null}
+     * @return input string with special characters replaced by _%HEX%_ where HEX is the 2 digit ascii hex code.  Never {@code null}
+     */
+    public static String sanitizeFuncotationFieldForMaf(final String individualFuncotationField) {
+        Utils.nonNull(individualFuncotationField);
+        return StringUtils.replaceEach(individualFuncotationField, new String[]{"\t", "\n"}, new String[]{"_%09_", "_%0A_"});
     }
 
     /**
@@ -2174,6 +2185,25 @@ public final class FuncotatorUtils {
         }
 
         return result;
+    }
+
+    /**
+     * @param funcotation Funcotation to render for a VCF.  Never {@code null}
+     * @param includedFields List of fields to include.  Any that match fields in the funcotation will be rendered.
+     *                       Never {@code null}
+     * @return string with the VCF representation of a {@link VcfOutputRenderer#FUNCOTATOR_VCF_FIELD_NAME} for the given
+     * Funcotation.  Never {@code null}, but empty string is possible.
+     */
+    public static String renderSanitizedFuncotationForVcf(final Funcotation funcotation, final List<String> includedFields) {
+        Utils.nonNull(funcotation);
+        Utils.nonNull(includedFields);
+        if (includedFields.size() == 0) {
+            return "";
+        }
+        return funcotation.getFieldNames().stream()
+                .filter(f -> includedFields.contains(f))
+                .map(field -> FuncotatorUtils.sanitizeFuncotationFieldForVcf(funcotation.getField(field)))
+                .collect(Collectors.joining(VcfOutputRenderer.FIELD_DELIMITER));
     }
 }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/OutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/OutputRenderer.java
@@ -1,6 +1,12 @@
 package org.broadinstitute.hellbender.tools.funcotator;
 
+import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
+import org.broadinstitute.hellbender.tools.funcotator.metadata.VcfFuncotationMetadata;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,11 +28,6 @@ public abstract class OutputRenderer implements AutoCloseable {
      * to {@link OutputRenderer#write(VariantContext, FuncotationMap)}.
      */
     protected LinkedHashMap<String, String> manualAnnotations;
-
-    /**
-     * {@link String} representation of {@link OutputRenderer#manualAnnotations} serialized to the output format of this {@link OutputRenderer}.
-     */
-    protected String manualAnnotationSerializedString;
 
     /**
      * {@link List} of the {@link DataSourceFuncotationFactory} objects that are being used in this run of {@link Funcotator}.
@@ -56,4 +57,26 @@ public abstract class OutputRenderer implements AutoCloseable {
      * @param txToFuncotationMap {@link FuncotationMap} to add to the given {@code variant} on output.
      */
     public abstract void write(final VariantContext variant, final FuncotationMap txToFuncotationMap);
+
+    /**
+     * Utility for output renderers.
+     *
+     * Given a {@link LinkedHashMap} of field:value pairs (String:String), create a funcotation (funcotation metadata included!)
+     *  with the best representation possible.
+     *
+     * @param data Never {@code null}
+     * @param altAllele Never {@code null}
+     * @param datasourceName Name to use as the datasource.  Never {@code null}
+     * @return A funcotation with all fields considered strings and a generic description.  Funcotation metadata is populated.
+     *   Never {@code null}
+     */
+    public static Funcotation createFuncotationFromLinkedHashMap(final LinkedHashMap<String, String> data, final Allele altAllele, final String datasourceName) {
+        Utils.nonNull(data);
+        Utils.nonNull(altAllele);
+        Utils.nonNull(datasourceName);
+        final List<VCFInfoHeaderLine> manualAnnotationHeaderLines = data.entrySet().stream()
+                .map(e -> new VCFInfoHeaderLine(e.getKey(), 1, VCFHeaderLineType.String, "Specified from map: " + e.getKey() + ":" + e.getValue() ))
+                .collect(Collectors.toList());
+        return TableFuncotation.create(data, altAllele, datasourceName, VcfFuncotationMetadata.create(manualAnnotationHeaderLines));
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/TableFuncotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/TableFuncotation.java
@@ -5,12 +5,10 @@ import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
-import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.xsv.LocatableXsvFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.xsv.SimpleKeyXsvFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadata;
 import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadataUtils;
-import org.broadinstitute.hellbender.tools.funcotator.vcfOutput.VcfOutputRenderer;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.codecs.xsvLocatableTable.XsvTableFeature;
 
@@ -99,13 +97,6 @@ public class TableFuncotation implements Funcotation {
                     + fieldName + " is not one of [" + String.join(",", fieldMap.keySet()) + "]");
         }
         fieldMap.put(fieldName, overrideValue);
-    }
-
-    @Override
-    public String serializeToVcfString() {
-        return fieldMap.values().stream()
-                .map(f -> (f == null ? "" : FuncotatorUtils.sanitizeFuncotationForVcf(f)))
-                .collect(Collectors.joining(VcfOutputRenderer.FIELD_DELIMITER));
     }
 
     @Override
@@ -213,6 +204,21 @@ public class TableFuncotation implements Funcotation {
     public static TableFuncotation create(final Map<String, Object> data, final Allele altAllele, final String dataSourceName, final FuncotationMetadata metadata ) {
         final List<String> fieldNames = new ArrayList<>(data.keySet());
         final List<String> fieldValues = fieldNames.stream().map(f -> data.get(f).toString()).collect(Collectors.toList());
+        return create(fieldNames, fieldValues, altAllele, dataSourceName, metadata);
+    }
+
+    /**
+     *  See {@link TableFuncotation#create(List, List, Allele, String, FuncotationMetadata)}
+     *
+     * @param data Map for field name to field value.  Never {@code null}
+     * @param altAllele See {@link TableFuncotation#create(List, List, Allele, String, FuncotationMetadata)}
+     * @param dataSourceName See {@link TableFuncotation#create(List, List, Allele, String, FuncotationMetadata)}
+     * @param metadata See {@link TableFuncotation#create(List, List, Allele, String, FuncotationMetadata)}
+     * @return See {@link TableFuncotation#create(List, List, Allele, String, FuncotationMetadata)}
+     */
+    public static TableFuncotation create(final LinkedHashMap<String, String> data, final Allele altAllele, final String dataSourceName, final FuncotationMetadata metadata ) {
+        final List<String> fieldNames = new ArrayList<>(data.keySet());
+        final List<String> fieldValues = fieldNames.stream().map(f -> data.get(f)).collect(Collectors.toList());
         return create(fieldNames, fieldValues, altAllele, dataSourceName, metadata);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
@@ -180,7 +180,6 @@ public class GencodeFuncotation implements Funcotation {
         return Allele.create(tumorSeqAllele2.getBytes(), false);
     }
 
-    @Override
     public String serializeToVcfString() {
         // Alias for the FIELD_DELIMITER so we can have nicer looking code:
         final String DELIMITER = VcfOutputRenderer.FIELD_DELIMITER;
@@ -212,7 +211,7 @@ public class GencodeFuncotation implements Funcotation {
                 (otherTranscriptsSerializedOverride != null ? otherTranscriptsSerializedOverride : (otherTranscripts != null ? otherTranscripts.stream().map(Object::toString).collect(Collectors.joining(VcfOutputRenderer.OTHER_TRANSCRIPT_DELIMITER)) : ""))
             );
 
-        return funcotations.stream().map(FuncotatorUtils::sanitizeFuncotationForVcf).collect(Collectors.joining(DELIMITER));
+        return funcotations.stream().map(FuncotatorUtils::sanitizeFuncotationFieldForVcf).collect(Collectors.joining(DELIMITER));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationBuilder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationBuilder.java
@@ -35,7 +35,7 @@ public class GencodeFuncotationBuilder {
     }
 
     public GencodeFuncotation build() {
-        // TODO: In the future, we will need a mechanism for populating the metadata  (https://github.com/broadinstitute/gatk/issues/4857)
+        // TODO: In the future, we will need a mechanism for populating the metadata, especially if we want to support separate INFO fields in a VCF for each funcotation field (https://github.com/broadinstitute/gatk/issues/4857)
         gencodeFuncotation.setMetadata(FuncotationMetadataUtils.createWithUnknownAttributes(new ArrayList<>(gencodeFuncotation.getFieldNames())));
         return gencodeFuncotation;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
@@ -258,9 +258,6 @@ public class MafOutputRenderer extends OutputRenderer {
         defaultMap.put(MafOutputRendererConstants.FieldName_Score, MafOutputRendererConstants.UNUSED_STRING);
         defaultMap.put(MafOutputRendererConstants.FieldName_BAM_File, MafOutputRendererConstants.UNUSED_STRING);
 
-        // Cache the manual annotation string so we can pass it easily into any Funcotations:
-        //manualAnnotationSerializedString = (manualAnnotations.size() != 0 ? MafOutputRendererConstants.FIELD_DELIMITER + String.join( MafOutputRendererConstants.FIELD_DELIMITER, manualAnnotations.values() ) + MafOutputRendererConstants.FIELD_DELIMITER : "");
-
         // Open the output object:
         try {
             printWriter = new PrintWriter(Files.newOutputStream(outputFilePath));
@@ -334,7 +331,6 @@ public class MafOutputRenderer extends OutputRenderer {
                     writeString(entry.getValue());
                     writeString(MafOutputRendererConstants.FIELD_DELIMITER);
                 }
-//                writeLine(manualAnnotationSerializedString);
                 writeLine("");
             }
         }
@@ -377,7 +373,7 @@ public class MafOutputRenderer extends OutputRenderer {
         // Now translate fields to the field names that MAF likes:
         final LinkedHashMap<String, String> mafCompliantMap = replaceFuncotationValuesWithMafCompliantValues(outputMap);
 
-        // Remove any fields that are excluded.
+        // Remove any fields that are excluded and sanitize any field values.
         return mafCompliantMap.keySet().stream()
             .filter(k -> !excludedOutputFields.contains(k))
             .collect(Collectors.toMap(

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
@@ -9,6 +9,7 @@ import htsjdk.variant.vcf.VCFHeaderLine;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.funcotator.*;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
@@ -23,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -144,6 +146,9 @@ public class MafOutputRenderer extends OutputRenderer {
     /** The version of the reference used to create annotations that will be output by this {@link MafOutputRenderer}.*/
     private final String referenceVersion;
 
+    /** Fields that should be removed in the final MAF file. */
+    private final Set<String> excludedOutputFields;
+
     //==================================================================================================================
     // Constructors:
 
@@ -163,7 +168,7 @@ public class MafOutputRenderer extends OutputRenderer {
                              final LinkedHashMap<String, String> unaccountedForDefaultAnnotations,
                              final LinkedHashMap<String, String> unaccountedForOverrideAnnotations,
                              final Set<String> toolHeaderLines,
-                             final String referenceVersion) {
+                             final String referenceVersion, final Set<String> excludedOutputFields) {
 
         // Set our internal variables from the input:
         this.outputFilePath = outputFilePath;
@@ -254,7 +259,7 @@ public class MafOutputRenderer extends OutputRenderer {
         defaultMap.put(MafOutputRendererConstants.FieldName_BAM_File, MafOutputRendererConstants.UNUSED_STRING);
 
         // Cache the manual annotation string so we can pass it easily into any Funcotations:
-        manualAnnotationSerializedString = (manualAnnotations.size() != 0 ? MafOutputRendererConstants.FIELD_DELIMITER + String.join( MafOutputRendererConstants.FIELD_DELIMITER, manualAnnotations.values() ) + MafOutputRendererConstants.FIELD_DELIMITER : "");
+        //manualAnnotationSerializedString = (manualAnnotations.size() != 0 ? MafOutputRendererConstants.FIELD_DELIMITER + String.join( MafOutputRendererConstants.FIELD_DELIMITER, manualAnnotations.values() ) + MafOutputRendererConstants.FIELD_DELIMITER : "");
 
         // Open the output object:
         try {
@@ -263,6 +268,8 @@ public class MafOutputRenderer extends OutputRenderer {
         catch (final IOException ex) {
             throw new UserException("Error opening output file path: " + outputFilePath.toUri().toString(), ex);
         }
+
+        this.excludedOutputFields = excludedOutputFields;
     }
 
     //==================================================================================================================
@@ -327,12 +334,14 @@ public class MafOutputRenderer extends OutputRenderer {
                     writeString(entry.getValue());
                     writeString(MafOutputRendererConstants.FIELD_DELIMITER);
                 }
-                writeLine(manualAnnotationSerializedString);
+//                writeLine(manualAnnotationSerializedString);
+                writeLine("");
             }
         }
     }
 
-    private LinkedHashMap<String, String> createMafCompliantOutputMap(final Allele altAllele, final List<Funcotation> funcotations) {
+    @VisibleForTesting
+    LinkedHashMap<String, String> createMafCompliantOutputMap(final Allele altAllele, final List<Funcotation> funcotations) {
         // Create our output maps:
         final LinkedHashMap<String, Object> outputMap = new LinkedHashMap<>(defaultMap);
         final LinkedHashMap<String, Object> extraFieldOutputMap = new LinkedHashMap<>();
@@ -366,7 +375,17 @@ public class MafOutputRenderer extends OutputRenderer {
         outputMap.putAll(extraFieldOutputMap);
 
         // Now translate fields to the field names that MAF likes:
-        return replaceFuncotationValuesWithMafCompliantValues(outputMap);
+        final LinkedHashMap<String, String> mafCompliantMap = replaceFuncotationValuesWithMafCompliantValues(outputMap);
+
+        // Remove any fields that are excluded.
+        return mafCompliantMap.keySet().stream()
+            .filter(k -> !excludedOutputFields.contains(k))
+            .collect(Collectors.toMap(
+                    Function.identity(), k -> FuncotatorUtils.sanitizeFuncotationFieldForMaf(mafCompliantMap.get(k)),
+                    (u, v) -> {
+                        throw new GATKException.ShouldNeverReachHereException("Found duplicate keys for MAF output");
+                        },
+                    LinkedHashMap::new));
     }
 
     //==================================================================================================================

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -9,11 +9,13 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.VCFHeaderLineCount;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import org.apache.commons.collections.MapUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.ReferenceFileSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationBuilder;
 import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadata;
@@ -23,7 +25,6 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
-import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -1609,5 +1610,56 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
         Assert.assertTrue(funcotations.stream().allMatch(f -> f.getDataSourceName().equals(datasourceName)));
         Assert.assertEquals(funcotations.stream().map(f -> f.getAltAllele()).collect(Collectors.toSet()), new HashSet<>(vc.getAlternateAlleles()));
         Assert.assertEquals(funcotations.stream().map(f -> f.getMetadata()).collect(Collectors.toSet()), new HashSet<>(Collections.singletonList(metadata)));
+    }
+
+    @DataProvider
+    public Object[][] provideMafSanitizing() {
+        return new Object[][] {
+                {"\tHAHAHAH\t", "_%09_HAHAHAH_%09_"},
+                {"\tHAHAHAH\n", "_%09_HAHAHAH_%0A_"},
+                {"FOO", "FOO"}
+        };
+    }
+
+    @Test(dataProvider = "provideMafSanitizing")
+    public void testSanitizeFuncotationFieldForMaf(final String individualFuncotationField, final String gt) {
+        final String guess = FuncotatorUtils.sanitizeFuncotationFieldForMaf(individualFuncotationField);
+        Assert.assertEquals(guess, gt);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @DataProvider
+    public Object[][] provideForRenderSanitizedFuncotationForVcf() {
+
+        return new Object[][]{
+                {OutputRenderer.createFuncotationFromLinkedHashMap(
+                        (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
+                        new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
+                        Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "BAZ"),
+                        "BAR|HUH?"
+                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                        (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
+                        new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
+                        Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO"),
+                        "BAR"
+                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                        (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
+                        new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
+                        Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "NOTHERE"),
+                        "BAR"
+                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                        (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
+                        new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
+                        Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "BAZ", "NOTHERE"),
+                        "BAR|HUH?"
+                }
+        };
+    }
+
+    @Test(dataProvider = "provideForRenderSanitizedFuncotationForVcf" )
+    public void testRenderSanitizedFuncotationForVcf(final Funcotation funcotation, final List<String> includedFields, final String gt) {
+        final String guess = FuncotatorUtils.renderSanitizedFuncotationForVcf(funcotation, includedFields);
+        Assert.assertEquals(guess, gt);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -1633,22 +1633,34 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
     public Object[][] provideForRenderSanitizedFuncotationForVcf() {
 
         return new Object[][]{
+                // Test a very basic case where all fields are included
                 {OutputRenderer.createFuncotationFromLinkedHashMap(
                         (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
                         new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
                         Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "BAZ"),
                         "BAR|HUH?"
-                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                },
+
+                // Test case where only one field is included
+                {OutputRenderer.createFuncotationFromLinkedHashMap(
                         (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
                         new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
                         Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO"),
                         "BAR"
-                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                },
+
+                // Make sure that specifying a non-existent included field (NOTHERE) has no effect on the output,
+                //  even when another field is excluded.
+                {OutputRenderer.createFuncotationFromLinkedHashMap(
                         (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
                         new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
                         Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "NOTHERE"),
                         "BAR"
-                }, {OutputRenderer.createFuncotationFromLinkedHashMap(
+                },
+
+                // Make sure that specifying a non-existent included field (NOTHERE) has no effect on the output,
+                //  even when all fields are included..
+                {OutputRenderer.createFuncotationFromLinkedHashMap(
                         (LinkedHashMap) MapUtils.putAll(new LinkedHashMap<String, String>(),
                         new String[][]{{"FOO", "BAR"},{"BAZ", "HUH?"}}),
                         Allele.create("T"), "FAKEDATA"), Arrays.asList("FOO", "BAZ", "NOTHERE"),

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/TableFuncotationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/TableFuncotationUnitTest.java
@@ -3,14 +3,12 @@ package org.broadinstitute.hellbender.tools.funcotator.dataSources;
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -263,7 +261,7 @@ public class TableFuncotationUnitTest extends GATKBaseTest {
     @Test(dataProvider = "provideForTestSerializeToVcfString")
     public void testSerializeToVcfString(final TableFuncotation funcotation,
                                          final String expected) {
-        Assert.assertEquals( funcotation.serializeToVcfString(), expected );
+        Assert.assertEquals(FuncotatorUtils.renderSanitizedFuncotationForVcf(funcotation, new ArrayList<>(funcotation.getFieldNames())), expected );
     }
 
     @Test(dataProvider = "provideListOfStrings")

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationUnitTest.java
@@ -238,8 +238,7 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        "CRUMB BUM!!!!!",
-                        "CRUMB BUM!!!!!" + "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
+                        "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
                                 "3'" + D + "1" + D + 1 + D + "A" + D + "ATC" + D + "Lys" + D + "1.0" + D + "ATGCGCAT" + D + "ONE" + VcfOutputRenderer.OTHER_TRANSCRIPT_DELIMITER + "TWO" + VcfOutputRenderer.OTHER_TRANSCRIPT_DELIMITER + "THREE"
@@ -250,7 +249,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -261,7 +259,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys", 1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -272,7 +269,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -283,7 +279,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + D + 50 + D + 60 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -294,7 +289,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 null, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -305,7 +299,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, null, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -316,7 +309,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, null,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -327,7 +319,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "G", "C", null, "T1",
                                 "3'", 1, 1, "A", "ACC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "G" + D + "G" + D + "C" + D + D + "T1" + D +
@@ -338,7 +329,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", null,
                                 null, 1, 1, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + D +
@@ -349,7 +339,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", null, null, "A", "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -360,7 +349,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, null,  "ATC", "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -371,7 +359,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", null, "Lys",  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -382,7 +369,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", null,  1.0, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -393,7 +379,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys", null, "ATGCGCAT", Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -404,7 +389,6 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
                                 GencodeFuncotation.VariantClassification.NONSENSE, GencodeFuncotation.VariantClassification.INTRON, GencodeFuncotation.VariantType.SNP,
                                 "A", "T", "big_%20_changes", "T1",
                                 "3'", 1, 1, "A", "ATC", "Lys", 1.0, null, Arrays.asList("ONE", "TWO", "THREE")),
-                        null,
                         "TESTGENE" + D + "BUILD1" + D + "chr1" + D + 1 + D + 100 + D +
                                 GencodeFuncotation.VariantClassification.NONSENSE + D + GencodeFuncotation.VariantClassification.INTRON + D + GencodeFuncotation.VariantType.SNP + D +
                                 "A" + D + "A" + D + "T" + D + "big_%20_changes" + D + "T1" + D +
@@ -724,8 +708,8 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
     }
 
     @Test(dataProvider = "createGencodeFuncotationsAndStringSerializations")
-    void testSerializeToVcfString(final GencodeFuncotation gencodeFuncotation, final String manualAnnotationString, final String expected) {
-        Assert.assertEquals(gencodeFuncotation.serializeToVcfString(manualAnnotationString), expected);
+    void testSerializeToVcfString(final GencodeFuncotation gencodeFuncotation, final String expected) {
+        Assert.assertEquals(gencodeFuncotation.serializeToVcfString(), expected);
     }
 
     @Test(dataProvider = "provideForTestGetFieldNames")

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactoryUnitTest.java
@@ -23,6 +23,7 @@ import org.broadinstitute.hellbender.tools.funcotator.FuncotatorTestConstants;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.FuncotatorTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -108,25 +109,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
     //==================================================================================================================
     // Helper Methods:
 
-    private VariantContext createVariantContext(final String contig,
-                                                final int start,
-                                                final int end,
-                                                final String refString,
-                                                final String altString) {
 
-        final Allele refAllele = Allele.create(refString, true);
-        final Allele altAllele = Allele.create(altString);
-
-        final VariantContextBuilder variantContextBuilder = new VariantContextBuilder(
-                FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),
-                contig,
-                start,
-                end,
-                Arrays.asList(refAllele, altAllele)
-        );
-
-        return variantContextBuilder.make();
-    }
 
     private Object[] helpProvideForTestCreateFuncotations(final String contig,
                                                           final int start,
@@ -135,7 +118,7 @@ public class VcfFuncotationFactoryUnitTest extends GATKBaseTest {
                                                           final String altAlleleString,
                                                           final List<Funcotation> expected) {
         return new Object[]{
-                createVariantContext(contig, start, end, refAlleleString, altAlleleString),
+                FuncotatorTestUtils.createSimpleVariantContext(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(), contig, start, end, refAlleleString, altAlleleString),
                 new ReferenceContext(CHR3_REF_DATA_SOURCE, new SimpleInterval(contig, start, end)),
                 expected
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.funcotator.mafOutput;
 
+import htsjdk.tribble.annotation.Strand;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
@@ -8,7 +9,9 @@ import org.apache.commons.collections.MapUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.DummyPlaceholderGatkTool;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
+import org.broadinstitute.hellbender.tools.copynumber.utils.annotatedinterval.AnnotatedIntervalCollection;
 import org.broadinstitute.hellbender.tools.funcotator.*;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.DataSourceUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
@@ -16,6 +19,7 @@ import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.Gencod
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.vcfOutput.VcfOutputRenderer;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.test.FuncotatorTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -98,6 +102,10 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
     }
 
     private MafOutputRenderer createMafOutputRenderer(final File outputFile, final String referenceVersion) {
+        return createMafOutputRenderer(outputFile, referenceVersion, new HashSet<>());
+    }
+
+    private MafOutputRenderer createMafOutputRenderer(final File outputFile, final String referenceVersion, final Set<String> excludedFields) {
 
         final Map<Path, Properties> configData =
                 DataSourceUtils.getAndValidateDataSourcesFromPaths(
@@ -124,7 +132,7 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
                 new LinkedHashMap<>(),
                 new LinkedHashMap<>(),
                 new HashSet<>(),
-                referenceVersion
+                referenceVersion, excludedFields
         );
     }
 
@@ -1132,5 +1140,71 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
         catch (final IOException ex) {
             throw new GATKException("ERROR comparing text files: " + outFile.toURI().toString() + " and " + expectedFile.toURI().toString(), ex);
         }
+    }
+
+    /**
+     * Creatse a dummy gencode funcotation and a dummy funcotation from a fake datasource named FAKEDATA.
+     * Then exclude one of the FAKEDATA fields and make sure that it does not appear in the output.
+     */
+    @Test
+    public void testCreateMafCompliantOutputMapExclusion() {
+        final File outFile = getSafeNonExistentFile("TestMafOutputExclusionFile.maf");
+        final String dummyTranscriptName = "FAKE00001.1";
+        final VariantContext dummyVariantContext = FuncotatorTestUtils.createSimpleVariantContext(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),"3", 1000000, 1000000, "C", "T");
+        final GencodeFuncotation dummyGencodeFuncotation = (GencodeFuncotation) createDummyGencodeFuncotation(dummyTranscriptName, dummyVariantContext);
+        final Set<String> excludedFields = Collections.singleton("FAKEDATA_FOO");
+        try ( final MafOutputRenderer mafOutputRenderer = createMafOutputRenderer( outFile, "hg19", excludedFields) ) {
+            final FuncotationMap funcotationMap = FuncotationMap.createFromGencodeFuncotations(Collections.singletonList(dummyGencodeFuncotation));
+            funcotationMap.add(dummyTranscriptName, createDummyTableFuncotation());
+            mafOutputRenderer.write(dummyVariantContext, funcotationMap);
+        }
+
+        final AnnotatedIntervalCollection maf = AnnotatedIntervalCollection.create(outFile.toPath(), null);
+        Assert.assertTrue(maf.getRecords().size() > 0);
+        maf.getRecords().forEach(r -> Assert.assertFalse(r.hasAnnotation("FAKEDATA_FOO")));
+        maf.getRecords().forEach(r -> Assert.assertTrue(r.hasAnnotation("FAKEDATA_BAR")));
+    }
+
+    private static Funcotation createDummyGencodeFuncotation(final String dummyTranscriptName, final VariantContext dummyVariantContext) {
+        return FuncotatorTestUtils.createGencodeFuncotation("GENE","b37", dummyVariantContext.getContig(), dummyVariantContext.getStart(),dummyVariantContext.getEnd(),
+                GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, null, GencodeFuncotation.VariantType.SNP,
+                dummyVariantContext.getReference().getDisplayString(),
+                dummyVariantContext.getAlternateAllele(0).getDisplayString(), "g.1000000"+ dummyVariantContext.getReference().getDisplayString() + ">" + dummyVariantContext.getAlternateAllele(0).getDisplayString(),
+                dummyTranscriptName, Strand.FORWARD,
+        1, 1500,
+        " ", " ",
+        "p.L300P", 0.5,
+        "ACTGATCGATCGA",Collections.singletonList("FAKE00002.5"), "27");
+    }
+
+    private static Funcotation createDummyTableFuncotation() {
+        final String datasourceName = "FAKEDATA";
+        final LinkedHashMap<String, String> data = new LinkedHashMap<>();
+        data.put(datasourceName + "_FOO", "1");
+        data.put(datasourceName + "_BAR", "2");
+        data.put(datasourceName + "_BAZ", "\tYES\n");
+        final Allele altAllele = Allele.create("T");
+        return OutputRenderer.createFuncotationFromLinkedHashMap(data, altAllele, datasourceName);
+    }
+
+    @Test
+    public void testCreateMafCompliantOutputMapSanitized() {
+        final File outFile = getSafeNonExistentFile("TestMafOutputSanitized.maf");
+        final String dummyTranscriptName = "FAKE00001.1";
+        final VariantContext dummyVariantContext = FuncotatorTestUtils.createSimpleVariantContext(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),"3", 1000000, 1000000, "C", "T");
+        final GencodeFuncotation dummyGencodeFuncotation = (GencodeFuncotation) createDummyGencodeFuncotation(dummyTranscriptName, dummyVariantContext);
+        final Set<String> excludedFields = Collections.emptySet();
+        try ( final MafOutputRenderer mafOutputRenderer = createMafOutputRenderer( outFile, "hg19", excludedFields) ) {
+            final FuncotationMap funcotationMap = FuncotationMap.createFromGencodeFuncotations(Collections.singletonList(dummyGencodeFuncotation));
+            funcotationMap.add(dummyTranscriptName, createDummyTableFuncotation());
+            mafOutputRenderer.write(dummyVariantContext, funcotationMap);
+        }
+
+        final AnnotatedIntervalCollection maf = AnnotatedIntervalCollection.create(outFile.toPath(), null);
+        Assert.assertTrue(maf.getRecords().size() > 0);
+        maf.getRecords().forEach(r -> Assert.assertTrue(r.hasAnnotation("FAKEDATA_FOO")));
+        maf.getRecords().forEach(r -> Assert.assertTrue(r.hasAnnotation("FAKEDATA_BAR")));
+        maf.getRecords().forEach(r -> Assert.assertTrue(r.hasAnnotation("FAKEDATA_BAZ")));
+        maf.getRecords().forEach(r -> Assert.assertEquals(r.getAnnotationValue("FAKEDATA_BAZ"), "_%09_YES_%0A_"));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
@@ -1,6 +1,19 @@
 package org.broadinstitute.hellbender.tools.funcotator.vcfOutput;
 
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.vcf.VCFHeader;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotationMap;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
+import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.*;
 
 /**
  * Unit test class for the {@link VcfOutputRenderer} class.
@@ -10,6 +23,8 @@ public class VcfOutputRendererUnitTest extends GATKBaseTest {
     //==================================================================================================================
     // Static Variables:
 
+    private static final String TEST_VCF = toolsTestDir + "/funcotator/hg38_trio.pik3ca.vcf";
+
     //==================================================================================================================
     // Helper Methods:
 
@@ -18,4 +33,43 @@ public class VcfOutputRendererUnitTest extends GATKBaseTest {
 
     //==================================================================================================================
     // Tests:
+
+    /** Test that the exclusion list overrides the manually specified annotations */
+    @Test
+    public void testExclusionListOverridesManualDefaultAnnotations() {
+        final Pair<VCFHeader, List<VariantContext>> entireInputVcf =  VariantContextTestUtils.readEntireVCFIntoMemory(TEST_VCF);
+        final File outFile = createTempFile("vcf_output_renderer_exclusion", ".vcf");
+        final VariantContextWriter vcfWriter = GATKVariantContextUtils.createVCFWriter(outFile,null, false);
+
+        final LinkedHashMap<String, String> dummyDefaults = new LinkedHashMap<>();
+        dummyDefaults.put("FOO", "BAR");
+        dummyDefaults.put("BAZ", "HUH?");
+
+        final VcfOutputRenderer vcfOutputRenderer = new VcfOutputRenderer(vcfWriter,
+            new ArrayList<>(), entireInputVcf.getLeft(), new LinkedHashMap<>(dummyDefaults),
+            new LinkedHashMap<>(),
+            new HashSet<>(), new HashSet<>(Arrays.asList("BAZ", "AC")));
+
+        final VariantContext variant = entireInputVcf.getRight().get(0);
+
+        final FuncotationMap funcotationMap = FuncotationMap.createNoTranscriptInfo(Collections.emptyList());
+        vcfOutputRenderer.write(variant, funcotationMap);
+        vcfOutputRenderer.close();
+
+        // Check the output
+        final Pair<VCFHeader, List<VariantContext>> tempVcf =  VariantContextTestUtils.readEntireVCFIntoMemory(outFile.getAbsolutePath());
+        final VariantContext tempVariant = tempVcf.getRight().get(0);
+        final String[] funcotatorKeys = FuncotatorUtils.extractFuncotatorKeysFromHeaderDescription(tempVcf.getLeft().getInfoHeaderLine("FUNCOTATION").getDescription());
+        Assert.assertEquals(funcotatorKeys.length,1);
+        Assert.assertEquals(funcotatorKeys[0],"FOO");
+        final FuncotationMap tempFuncotationMap =
+                FuncotationMap.createAsAllTableFuncotationsFromVcf(FuncotationMap.NO_TRANSCRIPT_AVAILABLE_KEY, funcotatorKeys,
+                        tempVariant.getAttributeAsString("FUNCOTATION", ""), tempVariant.getAlternateAllele(0), "TEST");
+        Assert.assertTrue(tempFuncotationMap.get(FuncotationMap.NO_TRANSCRIPT_AVAILABLE_KEY).get(0).hasField("FOO"));
+        Assert.assertEquals(tempFuncotationMap.get(FuncotationMap.NO_TRANSCRIPT_AVAILABLE_KEY).get(0).getField("FOO"), "BAR");
+        Assert.assertFalse(tempFuncotationMap.get(FuncotationMap.NO_TRANSCRIPT_AVAILABLE_KEY).get(0).hasField("BAZ"));
+
+        // IMPORTANT: If the field is not a proper funcotation in VCFs, it will not be excluded.  I.e. if an input VCF has an excluded field, it will not be excluded.
+        Assert.assertEquals(tempVariant.getAttribute("AC"), "1");
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -2,15 +2,25 @@ package org.broadinstitute.hellbender.utils.test;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.tribble.Feature;
+import htsjdk.tribble.annotation.Strand;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.FeatureManager;
+import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationBuilder;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationFactory;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,5 +58,115 @@ public class FuncotatorTestUtils {
 
         return FeatureContext.createFeatureContextForTesting(featureInputsWithType, dummyToolInstanceName, interval,
                 featureQueryLookahead, cloudPrefetchBuffer, cloudIndexPrefetchBuffer, reference);
+    }
+
+    /**
+     * Create a dummy gencode funcotation in the most manual way possible.  This method does not check for consistency
+     *  or reasonable values.
+     *
+     * @param hugoSymbol
+     * @param ncbiBuild
+     * @param chromosome
+     * @param start
+     * @param end
+     * @param variantClassification
+     * @param secondaryVariantClassification
+     * @param variantType
+     * @param refAllele
+     * @param tumorSeqAllele2
+     * @param genomeChange
+     * @param annotationTranscript
+     * @param transcriptStrand
+     * @param transcriptExon
+     * @param transcriptPos
+     * @param cDnaChange
+     * @param codonChange
+     * @param proteinChange
+     * @param gcContent
+     * @param referenceContext
+     * @param otherTranscripts
+     * @param version Use "19" for hg19/b37 and "28" for hg38.
+     * @return
+     */
+    public static GencodeFuncotation createGencodeFuncotation(final String hugoSymbol, final String ncbiBuild,
+                                                                             final String chromosome, final int start, final int end,
+                                                                             final GencodeFuncotation.VariantClassification variantClassification,
+                                                                             final GencodeFuncotation.VariantClassification secondaryVariantClassification,
+                                                                             final GencodeFuncotation.VariantType variantType,
+                                                                             final String refAllele,
+                                                                             final String tumorSeqAllele2, final String genomeChange,
+                                                                             final String annotationTranscript, final Strand transcriptStrand,
+                                                                             final Integer transcriptExon, final Integer transcriptPos,
+                                                                             final String cDnaChange, final String codonChange,
+                                                                             final String proteinChange, final Double gcContent,
+                                                                             final String referenceContext,
+                                                                             final List<String> otherTranscripts, final String version) {
+
+        final GencodeFuncotationBuilder funcotationBuilder = new GencodeFuncotationBuilder();
+
+        funcotationBuilder.setVersion(version);
+        funcotationBuilder.setDataSourceName(GencodeFuncotationFactory.DEFAULT_NAME);
+
+        funcotationBuilder.setHugoSymbol( hugoSymbol );
+        funcotationBuilder.setNcbiBuild( ncbiBuild );
+        funcotationBuilder.setChromosome( chromosome );
+        funcotationBuilder.setStart( start );
+        funcotationBuilder.setEnd( end );
+        funcotationBuilder.setVariantClassification( variantClassification );
+        funcotationBuilder.setSecondaryVariantClassification(secondaryVariantClassification);
+        funcotationBuilder.setVariantType( variantType );
+        funcotationBuilder.setRefAllele(Allele.create(refAllele));
+        funcotationBuilder.setTumorSeqAllele2( tumorSeqAllele2 );
+
+        funcotationBuilder.setGenomeChange( genomeChange );
+        funcotationBuilder.setAnnotationTranscript( annotationTranscript );
+        funcotationBuilder.setStrand( transcriptStrand );
+        funcotationBuilder.setTranscriptExonNumber( transcriptExon );
+        funcotationBuilder.setTranscriptPos( transcriptPos );
+        funcotationBuilder.setcDnaChange( cDnaChange );
+        funcotationBuilder.setCodonChange( codonChange );
+        funcotationBuilder.setProteinChange( proteinChange );
+        funcotationBuilder.setGcContent( gcContent );
+        funcotationBuilder.setReferenceContext( referenceContext );
+        funcotationBuilder.setOtherTranscripts( otherTranscripts );
+
+        return funcotationBuilder.build();
+    }
+
+    /**
+     *  Create a variant context with the following fields.  Note that the genotype will be empty, as will
+     *  INFO annotations.
+     *
+     * @param reference E.g. {@link FuncotatorReferenceTestUtils#retrieveHg19Chr3Ref}
+     * @param contig Never {@code null}
+     * @param start Must be positive.
+     * @param end Must be positive.
+     * @param refAlleleString Valid string for an allele.  Do not include "*".  Never {@code null}
+     * @param altAlleleString Valid string for an allele.  Do not include "*".  Never {@code null}
+     * @return a simple, biallelic variant context
+     */
+    public static VariantContext createSimpleVariantContext(final String reference, final String contig,
+                                                            final int start,
+                                                            final int end,
+                                                            final String refAlleleString,
+                                                            final String altAlleleString) {
+        Utils.nonNull(contig);
+        Utils.nonNull(refAlleleString);
+        Utils.nonNull(altAlleleString);
+        ParamUtils.isPositive(start, "Invalid start position: " + start);
+        ParamUtils.isPositive(end, "Invalid end position: " + end);
+
+        final Allele refAllele = Allele.create(refAlleleString, true);
+        final Allele altAllele = Allele.create(altAlleleString);
+
+        final VariantContextBuilder variantContextBuilder = new VariantContextBuilder(
+                reference,
+                contig,
+                start,
+                end,
+                Arrays.asList(refAllele, altAllele)
+        );
+
+        return variantContextBuilder.make();
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -64,29 +64,38 @@ public class FuncotatorTestUtils {
      * Create a dummy gencode funcotation in the most manual way possible.  This method does not check for consistency
      *  or reasonable values.
      *
-     * @param hugoSymbol
-     * @param ncbiBuild
-     * @param chromosome
-     * @param start
-     * @param end
-     * @param variantClassification
-     * @param secondaryVariantClassification
-     * @param variantType
-     * @param refAllele
-     * @param tumorSeqAllele2
-     * @param genomeChange
-     * @param annotationTranscript
-     * @param transcriptStrand
-     * @param transcriptExon
-     * @param transcriptPos
-     * @param cDnaChange
-     * @param codonChange
-     * @param proteinChange
-     * @param gcContent
-     * @param referenceContext
-     * @param otherTranscripts
-     * @param version Use "19" for hg19/b37 and "28" for hg38.
-     * @return
+     *  This method is meant for use in test cases where the developer can provide reasonable values.  Please use
+     *   caution as it is easy to specify parameters that would result in a funcotation that would never be seen in the wild.
+     *
+     *  {@code null} is not recommended, but this method will not throw an exception.
+     *
+     * @param hugoSymbol gene name, such as PIK3CA or TEST_GENE
+     * @param ncbiBuild Associated build.  Typically, "hg38" or "hg19"
+     * @param chromosome Contig name.  Please note that this method will not enforce the value here.
+     * @param start Must be greater than zero.  No other checks provided.  For example, this method will not check whether a chromosome is of an appropriate length for this value.
+     * @param end Must be greater than zero.  No other checks provided.  For example, this method will not check whether a chromosome is of an appropriate length for this value.
+     * @param variantClassification Variant classification.
+     * @param secondaryVariantClassification Typically, only used for {@link org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation.VariantClassification#SPLICE_SITE} and other variant classifications that need more information to disambiguate.  For example, a splice site can be in an exon or an intron.  So if the Splice site is in an intron, this field would be {@link org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation.VariantClassification#INTRON}
+     * @param variantType Variant type to use.  Again, this method will not check consistency.  For example, this method will not throw an exception if you have {@link org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation.VariantType#SNP} with an indel-specific variant classification.
+     * @param refAllele reference allele
+     * @param tumorSeqAllele2 alternate allele
+     * @param genomeChange Genome change string.  This method will not check validity.
+     * @param annotationTranscript Transcript ID to use.  If you wish to fake a no transcript gencode funcotation, use {@link org.broadinstitute.hellbender.tools.funcotator.FuncotationMap#NO_TRANSCRIPT_AVAILABLE_KEY}
+     * @param transcriptStrand This method will not check validity against the annotation transcript.
+     * @param transcriptExon 1-based exon number.  In the Funcotator main code, this field takes into account coding direction, so exon 1 will be at the highest genomic position on a negative strand.
+     *                       This method will not check validity of the specified value.  Must be >= 1.
+     * @param transcriptPos 1-based position in the transcript genome sequence.  In the Funcotator main code, this field takes into account the coding direction, so it is possible to have
+     *                      a higher transcript position that is a lower position in genomic coordinate space.
+     *                      This method will not check validity against the annotation transcript and transcript exon. Must be >= 1.
+     * @param cDnaChange This method will not check validity of the specified value.
+     * @param codonChange This method will not check validity of the specified value.
+     * @param proteinChange This method will not check validity of the specified value.
+     * @param gcContent This method will not check validity.  Must be >= 0.0 and =< 1.0
+     * @param referenceContext This method will not check validity of the specified value.  This method will not even check that you are specifying valid bases.
+     * @param otherTranscripts This method will not check validity of the specified value.
+     * @param version Gencode version.  Use "19" for hg19/b37 and "28" for hg38.  This method will not check validity,
+     *                but much of the rendering code will fail if this field is not valid.
+     * @return a gencode funcotation representing the above parameters.  Never {@code null}
      */
     public static GencodeFuncotation createGencodeFuncotation(final String hugoSymbol, final String ncbiBuild,
                                                                              final String chromosome, final int start, final int end,
@@ -101,6 +110,13 @@ public class FuncotatorTestUtils {
                                                                              final String proteinChange, final Double gcContent,
                                                                              final String referenceContext,
                                                                              final List<String> otherTranscripts, final String version) {
+
+
+        ParamUtils.isPositive(start, "Start position is 1-based and must be greater that zero.");
+        ParamUtils.isPositive(end, "End position is 1-based and must be greater that zero.");
+        ParamUtils.isPositive(transcriptExon, "Transcript exon is a 1-based index.");
+        ParamUtils.isPositive(transcriptPos, "Transcript position is a 1-based index.");
+        ParamUtils.inRange(gcContent, 0.0, 1.0, "GC Content must be between 0.0 and 1.0.");
 
         final GencodeFuncotationBuilder funcotationBuilder = new GencodeFuncotationBuilder();
 


### PR DESCRIPTION
- Added support for `--exclusion-list` parameter, which can be specified multiple times.  This will remove some rendered fields from the output.  The field should appear exactly as written in the output MAF or VCF (e.g. ClinVar_ALLELEID). Closes #4359. 
- Does basic cleaning of field values for MAF.  I.e. cleaning tabs and \n.  Fixes #4693 
