### PR TITLE
updating AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Cloudera Inc. <www.cloudera.com>
 Google Inc. <www.google.com>
 IBM Corp <www.ibm.com>
 Intel Corp. <www.intel.com>
+
 Anders Peterson <apete@optimatika.se>
 Axel Verdier <axel.verdier@inra.fr>
 Ayman Abdel Ghany <aymana.ghany@devfactory.com>
@@ -23,6 +24,7 @@ Daniel Gómez-Sánchez <daniel.gomez.sanchez@hotmail.es>
 Don Freed <donfreed12@gmail.com>
 Eugene Wolfson <evulfson@gmail.com>
 Frank Austin Nothaft <frank.nothaft@databricks.com>
+Jake VanCampen <jake.vancampen7@gmail.com>
 Jan van der Lugt <janlugt@gmail.com>
 Josh Holland <anowlcalledjosh@gmail.com>
 Kenji Kaneda <kenji.kaneda@gmail.com>
@@ -30,3 +32,4 @@ Kohl Kinning <kohlkinning@gmail.com>
 Mohammed Ezzat <mohamed.ezzat@devfactory.com>
 Nicholas Newell <nenewell@comcast.net>
 Nils Homer <nilshomer@gmail.com>
+Tim Fennell <tfenne@tfenne.com>


### PR DESCRIPTION
* adding new contributors Tim Fennell and Jake VanCampen
* adding a line break between companies and individuals for readability
* closes https://github.com/broadinstitute/gatk/issues/5238

@tfenne @jakevc Could you proofread this / provide any  corrections if you're not represented the way you would like to be.