### PR TITLE
Enable SelectVariants to drop specific annotation fields from output vcf.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -3,10 +3,12 @@ package org.broadinstitute.hellbender.engine;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
+import java.util.Set;
 import java.util.Spliterator;
 
 /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -3,12 +3,10 @@ package org.broadinstitute.hellbender.engine;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
-import htsjdk.variant.vcf.VCFHeaderLine;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
-import java.util.Set;
 import java.util.Spliterator;
 
 /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -591,7 +591,7 @@ public final class SelectVariants extends VariantWalker {
         ArrayList<Genotype> genotypesToWrite=new ArrayList<>();
         for (Genotype genotype : filteredGenotypeToNocall.getGenotypes()) {
             final GenotypeBuilder genotypeBuilder=new GenotypeBuilder(genotype).noAttributes();
-            Map<String, Object> attributes=genotype.getExtendedAttributes();
+            Map<String, Object> attributes=new HashMap<>(genotype.getExtendedAttributes());
             for(String genotypeAnnotation : genotypeAnnotationsToDrop) {
                 if (attributes.containsKey(genotypeAnnotation)) {
                     attributes.remove(genotypeAnnotation);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -597,9 +597,7 @@ public final class SelectVariants extends VariantWalker {
             final GenotypeBuilder genotypeBuilder = new GenotypeBuilder(genotype).noAttributes();
             Map<String, Object> attributes = new HashMap<>(genotype.getExtendedAttributes());
             for (String genotypeAnnotation : genotypeAnnotationsToDrop) {
-                if (attributes.containsKey(genotypeAnnotation)) {
                     attributes.remove(genotypeAnnotation);
-                }
             }
             genotypeBuilder.attributes(attributes);
             genotypesToWrite.add(genotypeBuilder.make());

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -518,7 +518,12 @@ public final class SelectVariants extends VariantWalker {
         }
         if (!infoFieldsToDrop.isEmpty()) {
             for (String infoField : infoFieldsToDrop) {
-                logger.info("Will drop info field: " + infoField);
+                logger.info("Will drop info annotation: " + infoField);
+            }
+        }
+        if (!genotypeAnnotationsToDrop.isEmpty()) {
+            for (String genotypeAnnotation : genotypeAnnotationsToDrop) {
+                logger.info("Will drop genotype annotation: " + genotypeAnnotation);
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -403,14 +403,14 @@ public final class SelectVariants extends VariantWalker {
     /**
      * Info annotation fields to be dropped
      */
-    @Argument(fullName="drop-annotation",shortName = "DA",optional = true, doc="Set info fields to drop from output vcf")
-    private List<String> infoFieldsToDrop=new ArrayList<>();
+    @Argument(fullName = "drop-annotation", shortName = "DA", optional = true, doc = "Set info fields to drop from output vcf")
+    private List<String> infoFieldsToDrop = new ArrayList<>();
 
     /**
      * Genotype annotation fields to be dropped
      */
-    @Argument(fullName="drop-genotype-annotation",shortName = "DGA",optional = true, doc="Set genotype annotations to drop from output vcf")
-    private List<String> genotypeAnnotationsToDrop=new ArrayList<>();
+    @Argument(fullName = "drop-genotype-annotation", shortName = "DGA", optional = true, doc = "Set genotype annotations to drop from output vcf")
+    private List<String> genotypeAnnotationsToDrop = new ArrayList<>();
 
     @Hidden
     @Argument(fullName="allow-nonoverlapping-command-line-samples", optional=true,
@@ -516,9 +516,9 @@ public final class SelectVariants extends VariantWalker {
                 actualLines = headerLines;
             }
         }
-        if(!infoFieldsToDrop.isEmpty()) {
-            for(String infoField : infoFieldsToDrop) {
-                logger.info("Will drop info field: "+infoField);
+        if (!infoFieldsToDrop.isEmpty()) {
+            for (String infoField : infoFieldsToDrop) {
+                logger.info("Will drop info field: " + infoField);
             }
         }
 
@@ -582,17 +582,16 @@ public final class SelectVariants extends VariantWalker {
         }
         final VariantContext filteredGenotypeToNocall = setFilteredGenotypesToNocall ? builder.make(): sub;
 
-        final VariantContextBuilder rmAnnotationsBuilder=new VariantContextBuilder(filteredGenotypeToNocall);
-
+        final VariantContextBuilder rmAnnotationsBuilder = new VariantContextBuilder(filteredGenotypeToNocall);
         for (String infoField : infoFieldsToDrop) {
             rmAnnotationsBuilder.rmAttribute(infoField);
         }
 
-        ArrayList<Genotype> genotypesToWrite=new ArrayList<>();
+        ArrayList<Genotype> genotypesToWrite = new ArrayList<>();
         for (Genotype genotype : filteredGenotypeToNocall.getGenotypes()) {
-            final GenotypeBuilder genotypeBuilder=new GenotypeBuilder(genotype).noAttributes();
-            Map<String, Object> attributes=new HashMap<>(genotype.getExtendedAttributes());
-            for(String genotypeAnnotation : genotypeAnnotationsToDrop) {
+            final GenotypeBuilder genotypeBuilder = new GenotypeBuilder(genotype).noAttributes();
+            Map<String, Object> attributes = new HashMap<>(genotype.getExtendedAttributes());
+            for (String genotypeAnnotation : genotypeAnnotationsToDrop) {
                 if (attributes.containsKey(genotypeAnnotation)) {
                     attributes.remove(genotypeAnnotation);
                 }
@@ -601,8 +600,7 @@ public final class SelectVariants extends VariantWalker {
             genotypesToWrite.add(genotypeBuilder.make());
         }
         rmAnnotationsBuilder.genotypes(GenotypesContext.create(genotypesToWrite));
-        final VariantContext variantContextToWrite=rmAnnotationsBuilder.make();
-
+        final VariantContext variantContextToWrite = rmAnnotationsBuilder.make();
 
         // Not excluding non-variants OR (subsetted polymorphic variants AND not spanning deletion) AND (including filtered loci OR subsetted variant) is not filtered
         // If exclude non-variants argument is not called, filtering will NOT occur.
@@ -816,14 +814,14 @@ public final class SelectVariants extends VariantWalker {
         headerLines.add(VCFStandardHeaderLines.getInfoLine(VCFConstants.DEPTH_KEY));
 
         //remove header lines for info field and genotype annotations being dropped
-        List<VCFHeaderLine> headerLinesToRemove=new ArrayList<>();
-        List<VCFInfoHeaderLine> infoHeaderLines = headerLines.stream().filter(l -> l instanceof VCFInfoHeaderLine).map(l->(VCFInfoHeaderLine)l).collect(Collectors.toList());
+        List<VCFHeaderLine> headerLinesToRemove = new ArrayList<>();
+        List<VCFInfoHeaderLine> infoHeaderLines = headerLines.stream().filter(l -> l instanceof VCFInfoHeaderLine).map(l -> (VCFInfoHeaderLine) l).collect(Collectors.toList());
         for (VCFInfoHeaderLine infoHeaderLine : infoHeaderLines) {
             if (infoFieldsToDrop.contains(infoHeaderLine.getID())) {
                 headerLinesToRemove.add(infoHeaderLine);
             }
         }
-        List<VCFFormatHeaderLine> formatHeaderLines = headerLines.stream().filter(l -> l instanceof VCFFormatHeaderLine).map(l->(VCFFormatHeaderLine)l).collect(Collectors.toList());
+        List<VCFFormatHeaderLine> formatHeaderLines = headerLines.stream().filter(l -> l instanceof VCFFormatHeaderLine).map(l -> (VCFFormatHeaderLine) l).collect(Collectors.toList());
         for (VCFFormatHeaderLine formatHeaderLine : formatHeaderLines) {
             if (genotypeAnnotationsToDrop.contains(formatHeaderLine.getID())) {
                 headerLinesToRemove.add(formatHeaderLine);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -878,26 +878,26 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         spec.executeTest("testSetFilteredGtoNocallUpdateInfo--" + testFile, this);
     }
 
-    @DataProvider(name="dropAnnotationsDataProvider")
+    @DataProvider(name = "dropAnnotationsDataProvider")
     Object[][] dropAnnotationsDataProvider() {
-        return new Object[][] {
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894","testSelectVariants_DropAnnotations.vcf","standard"},
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -DA NotAnAnnotation -DGA AlsoNotAnAnnotation","testSelectVariants_DropAnnotations.vcf","unused_annotations"},
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'FisherStrand > 10.0'","testSelectVariants_DropAnnotationsSelectFisherStrand.vcf","select_on_dropped_annotation"},
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'RMSMAPQ > 175.0'","testSelectVariants_DropAnnotationsSelectRMSMAPQ.vcf","select_on_kept_annotation"},
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getExtendedAttribute(\"RD\")>6'","testSelectVariants_DropAnnotationsSelectRD.vcf","select_on_dropped_genotype_annotation"},
-                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getGQ()==1'","testSelectVariants_DropAnnotationsSelectGQ.vcf","select_on_kept_genotype_annotation"}
+        return new Object[][]{
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894", "testSelectVariants_DropAnnotations.vcf", "standard"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -DA NotAnAnnotation -DGA AlsoNotAnAnnotation", "testSelectVariants_DropAnnotations.vcf", "unused_annotations"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'FisherStrand > 10.0'", "testSelectVariants_DropAnnotationsSelectFisherStrand.vcf", "select_on_dropped_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'RMSMAPQ > 175.0'", "testSelectVariants_DropAnnotationsSelectRMSMAPQ.vcf", "select_on_kept_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getExtendedAttribute(\"RD\")>6'", "testSelectVariants_DropAnnotationsSelectRD.vcf", "select_on_dropped_genotype_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getGQ()==1'", "testSelectVariants_DropAnnotationsSelectGQ.vcf", "select_on_kept_genotype_annotation"}
         };
     }
 
     @Test(dataProvider = "dropAnnotationsDataProvider")
-    public void testDropAnnotations(String args, String expectedFile,String name) throws IOException {
+    public void testDropAnnotations(String args, String expectedFile, String name) throws IOException {
         final String testFile = getToolTestDataDir() + "vcfexample2.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 baseTestString(args, testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + expectedFile)
         );
-        spec.executeTest("testDropAnnotations--"+name, this);
+        spec.executeTest("testDropAnnotations--" + name, this);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -877,4 +877,27 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
 
         spec.executeTest("testSetFilteredGtoNocallUpdateInfo--" + testFile, this);
     }
+
+    @DataProvider(name="dropAnnotationsDataProvider")
+    Object[][] dropAnnotationsDataProvider() {
+        return new Object[][] {
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894","testSelectVariants_DropAnnotations.vcf","standard"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -DA NotAnAnnotation -DGA AlsoNotAnAnnotation","testSelectVariants_DropAnnotations.vcf","unused_annotations"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'FisherStrand > 10.0'","testSelectVariants_DropAnnotationsSelectFisherStrand.vcf","select_on_dropped_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'RMSMAPQ > 175.0'","testSelectVariants_DropAnnotationsSelectRMSMAPQ.vcf","select_on_kept_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getExtendedAttribute(\"RD\")>6'","testSelectVariants_DropAnnotationsSelectRD.vcf","select_on_dropped_genotype_annotation"},
+                {"-DA FisherStrand -DA OnOffGenotype -DGA RD -sn NA11894 -select 'vc.getGenotype(\"NA11894\").getGQ()==1'","testSelectVariants_DropAnnotationsSelectGQ.vcf","select_on_kept_genotype_annotation"}
+        };
+    }
+
+    @Test(dataProvider = "dropAnnotationsDataProvider")
+    public void testDropAnnotations(String args, String expectedFile,String name) throws IOException {
+        final String testFile = getToolTestDataDir() + "vcfexample2.vcf";
+
+        final IntegrationTestSpec spec = new IntegrationTestSpec(
+                baseTestString(args, testFile),
+                Collections.singletonList(getToolTestDataDir() + "expected/" + expectedFile)
+        );
+        spec.executeTest("testDropAnnotations--"+name, this);
+    }
 }

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotations.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotations.vcf
@@ -1,0 +1,33 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AFrange,Number=2,Type=String,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AlleleBalance,Number=1,Type=Float,Description="Allele balance">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DoC,Number=1,Type=Integer,Description="Filtered Depth">
+##INFO=<ID=HomopolymerRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=MAPQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=NS,Number=1,Type=Float,Description="Number of samples">
+##INFO=<ID=RMSMAPQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">
+##INFO=<ID=SpanningDeletions,Number=1,Type=Integer,Description="No spanning deletions">
+##reference=human_b36_both.fasta
+##source=UnifiedGenotyper
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA11894	
+1	10020400	.	C	T	30.66	.	AC=1;AF=0.500;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.72;DoC=193;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=177.45;SB=-0.02;SpanningDeletions=0	GT:GQ	0/1:1	
+1	10020408	.	C	A	57.15	.	AC=1;AF=0.500;AFrange=0.01-0.11,95%;AN=2;AlleleBalance=0.73;DoC=179;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=174.11;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020416	.	G	A,T	40.12	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.73;DoC=166;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=176.69;SB=-0.01;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020436	.	A	T	64.57	.	AC=1;AF=0.500;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.73;DoC=168;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=170.66;SB=-1.53;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020439	.	G	A,T	57.80	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.13,95%;AN=2;AlleleBalance=0.73;DoC=156;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=167.02;SB=-0.33;SpanningDeletions=0	GT:GQ	1/0:2	
+1	10020447	.	C	T	68.03	.	AC=1;AF=0.500;AFrange=0.01-0.14,95%;AN=2;AlleleBalance=0.72;DoC=140;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=166.27;SB=-0.62;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020452	.	T	C	32.71	.	AC=1;AF=0.500;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.70;DoC=138;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=167.20;SB=-0.03;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020453	.	G	A,T	48.53	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.70;DoC=133;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=168.40;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:2	
+1	10020464	.	G	T	74.83	.	AC=1;AF=0.500;AFrange=0.01-0.13,95%;AN=2;AlleleBalance=0.74;DoC=152;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=170.06;SB=-0.04;SpanningDeletions=0	GT:GQ	0/1:3	
+1	10020470	.	A	G,T	91.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.13,95%;AN=2;AlleleBalance=0.70;DoC=182;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=174.37;SB=-0.25;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020484	.	A	C,T	55.89	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.76;DoC=239;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=181.59;SB=-0.03;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020485	.	G	A,T	32.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.08,95%;AN=2;AlleleBalance=0.75;DoC=237;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=180.16;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020492	.	T	A,G	44.35	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.68;DoC=284;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=184.59;SB=-0.04;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020615	.	C	T,A	162.10	.	AC=0,0;AF=0.00,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.72;DoC=285;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=195.54;SB=-67.56;SpanningDeletions=0	GT:GQ	0/0:2	

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectFisherStrand.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectFisherStrand.vcf
@@ -1,0 +1,26 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AFrange,Number=2,Type=String,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AlleleBalance,Number=1,Type=Float,Description="Allele balance">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DoC,Number=1,Type=Integer,Description="Filtered Depth">
+##INFO=<ID=HomopolymerRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=MAPQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=NS,Number=1,Type=Float,Description="Number of samples">
+##INFO=<ID=RMSMAPQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">
+##INFO=<ID=SpanningDeletions,Number=1,Type=Integer,Description="No spanning deletions">
+##reference=human_b36_both.fasta
+##source=UnifiedGenotyper
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA11894	
+1	10020408	.	C	A	57.15	.	AC=1;AF=0.500;AFrange=0.01-0.11,95%;AN=2;AlleleBalance=0.73;DoC=179;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=174.11;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020416	.	G	A,T	40.12	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.73;DoC=166;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=176.69;SB=-0.01;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020453	.	G	A,T	48.53	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.70;DoC=133;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=168.40;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:2	
+1	10020464	.	G	T	74.83	.	AC=1;AF=0.500;AFrange=0.01-0.13,95%;AN=2;AlleleBalance=0.74;DoC=152;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=170.06;SB=-0.04;SpanningDeletions=0	GT:GQ	0/1:3	
+1	10020470	.	A	G,T	91.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.13,95%;AN=2;AlleleBalance=0.70;DoC=182;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=174.37;SB=-0.25;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020484	.	A	C,T	55.89	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.76;DoC=239;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=181.59;SB=-0.03;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020485	.	G	A,T	32.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.08,95%;AN=2;AlleleBalance=0.75;DoC=237;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=180.16;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectGQ.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectGQ.vcf
@@ -1,0 +1,25 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AFrange,Number=2,Type=String,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AlleleBalance,Number=1,Type=Float,Description="Allele balance">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DoC,Number=1,Type=Integer,Description="Filtered Depth">
+##INFO=<ID=HomopolymerRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=MAPQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=NS,Number=1,Type=Float,Description="Number of samples">
+##INFO=<ID=RMSMAPQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">
+##INFO=<ID=SpanningDeletions,Number=1,Type=Integer,Description="No spanning deletions">
+##reference=human_b36_both.fasta
+##source=UnifiedGenotyper
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA11894	
+1	10020400	.	C	T	30.66	.	AC=1;AF=0.500;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.72;DoC=193;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=177.45;SB=-0.02;SpanningDeletions=0	GT:GQ	0/1:1	
+1	10020408	.	C	A	57.15	.	AC=1;AF=0.500;AFrange=0.01-0.11,95%;AN=2;AlleleBalance=0.73;DoC=179;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=174.11;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020416	.	G	A,T	40.12	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.73;DoC=166;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=176.69;SB=-0.01;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020452	.	T	C	32.71	.	AC=1;AF=0.500;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.70;DoC=138;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=167.20;SB=-0.03;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020485	.	G	A,T	32.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.08,95%;AN=2;AlleleBalance=0.75;DoC=237;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=180.16;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020492	.	T	A,G	44.35	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.68;DoC=284;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=184.59;SB=-0.04;SpanningDeletions=0	GT:GQ	1/0:1	

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectRD.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectRD.vcf
@@ -1,0 +1,25 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AFrange,Number=2,Type=String,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AlleleBalance,Number=1,Type=Float,Description="Allele balance">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DoC,Number=1,Type=Integer,Description="Filtered Depth">
+##INFO=<ID=HomopolymerRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=MAPQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=NS,Number=1,Type=Float,Description="Number of samples">
+##INFO=<ID=RMSMAPQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">
+##INFO=<ID=SpanningDeletions,Number=1,Type=Integer,Description="No spanning deletions">
+##reference=human_b36_both.fasta
+##source=UnifiedGenotyper
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA11894	
+1	10020408	.	C	A	57.15	.	AC=1;AF=0.500;AFrange=0.01-0.11,95%;AN=2;AlleleBalance=0.73;DoC=179;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=174.11;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020416	.	G	A,T	40.12	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.73;DoC=166;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=176.69;SB=-0.01;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020436	.	A	T	64.57	.	AC=1;AF=0.500;AFrange=0.01-0.12,95%;AN=2;AlleleBalance=0.73;DoC=168;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=170.66;SB=-1.53;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020484	.	A	C,T	55.89	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.76;DoC=239;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=181.59;SB=-0.03;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020485	.	G	A,T	32.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.08,95%;AN=2;AlleleBalance=0.75;DoC=237;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=180.16;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020492	.	T	A,G	44.35	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.68;DoC=284;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=184.59;SB=-0.04;SpanningDeletions=0	GT:GQ	1/0:1	

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectRMSMAPQ.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_DropAnnotationsSelectRMSMAPQ.vcf
@@ -1,0 +1,25 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AFrange,Number=2,Type=String,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AlleleBalance,Number=1,Type=Float,Description="Allele balance">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DoC,Number=1,Type=Integer,Description="Filtered Depth">
+##INFO=<ID=HomopolymerRun,Number=1,Type=Integer,Description="Largest Contiguous Homopolymer Run of Variant Allele In Either Direction">
+##INFO=<ID=MAPQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=NS,Number=1,Type=Float,Description="Number of samples">
+##INFO=<ID=RMSMAPQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">
+##INFO=<ID=SpanningDeletions,Number=1,Type=Integer,Description="No spanning deletions">
+##reference=human_b36_both.fasta
+##source=UnifiedGenotyper
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA11894	
+1	10020400	.	C	T	30.66	.	AC=1;AF=0.500;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.72;DoC=193;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=177.45;SB=-0.02;SpanningDeletions=0	GT:GQ	0/1:1	
+1	10020416	.	G	A,T	40.12	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.73;DoC=166;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=176.69;SB=-0.01;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020484	.	A	C,T	55.89	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.76;DoC=239;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=181.59;SB=-0.03;SpanningDeletions=0	GT:GQ	0/1:2	
+1	10020485	.	G	A,T	32.66	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.08,95%;AN=2;AlleleBalance=0.75;DoC=237;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=180.16;SB=-0.02;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020492	.	T	A,G	44.35	.	AC=1,0;AF=0.500,0.00;AFrange=0.01-0.09,95%;AN=2;AlleleBalance=0.68;DoC=284;HomopolymerRun=1;MAPQ0=0;NS=60;RMSMAPQ=184.59;SB=-0.04;SpanningDeletions=0	GT:GQ	1/0:1	
+1	10020615	.	C	T,A	162.10	.	AC=0,0;AF=0.00,0.00;AFrange=0.01-0.10,95%;AN=2;AlleleBalance=0.72;DoC=285;HomopolymerRun=0;MAPQ0=0;NS=60;RMSMAPQ=195.54;SB=-67.56;SpanningDeletions=0	GT:GQ	0/0:2	


### PR DESCRIPTION
Requested in #5235.  Specific info annotation fields can be dropped from output vcf by specifying them with ``-DA/--drop-annotation``, and genotype annotations can be dropped with ``-DGA/--drop-genotype-annotation``. (I would have used @vdauwera's initial suggestion of ``-DF``, but it is already used for ``disable-read-filters``).  Annotations can be used for selection of variants while simultaneously being dropped from the output vcf.