### PR TITLE
set the same flags for all JavaCompile gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,14 +167,9 @@ configurations.all {
     all*.exclude group: 'junit', module: 'junit'
 }
 
-//NOTE: we ignore contracts for now
-compileJava {
+tasks.withType(JavaCompile) {
   options.compilerArgs = ['-proc:none', '-Xlint:all', '-Werror', '-Xdiags:verbose']
 }
-compileTestJava {
-  options.compilerArgs = ['-proc:none', '-Xlint:all', '-Werror', '-Xdiags:verbose']
-}
-
 
 sourceSets {
     testUtils


### PR DESCRIPTION
* simplifying a few line in build.gradle and making all JavaCompile tasks apply the same compiler arguments
* previously this didn't apply to compileJavaTestUtils