### PR TITLE
Fixed SplitNCigarReads ArrayIndexOutOfBounds error for short reads with deletions

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -140,14 +140,16 @@ public class OverhangFixingManager {
      * @param contig  the contig
      * @param start   the start of the split, inclusive
      * @param end     the end of the split, inclusive
+     * @return the splice created, for testing purposes
      */
+    @VisibleForTesting
     public Splice addSplicePosition(final String contig, final int start, final int end) {
         if ( doNotFixOverhangs ) {
             return null;
         }
 
         // is this a new splice?  if not, we are done
-        final Splice splice = getSplice(contig, start, end);
+        final Splice splice = new Splice(contig, start, end);
         if ( splices.contains(splice) ) {
             return null;
         }
@@ -463,11 +465,9 @@ public class OverhangFixingManager {
         }
     }
 
-    public SplitRead getSplitRead(final GATKRead read){
+    @VisibleForTesting
+    SplitRead getSplitRead(final GATKRead read){
         return new SplitRead(read);
-    }
-    public Splice getSplice(final String contig, final int start, final int end){
-        return new Splice(contig, start, end);
     }
 
     // class to represent the split positions

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -1,9 +1,10 @@
 package org.broadinstitute.hellbender.tools.walkers.rnaseq;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.TextCigarCodec;
-import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.util.Tuple;
 import org.apache.logging.log4j.LogManager;
@@ -140,15 +141,15 @@ public class OverhangFixingManager {
      * @param start   the start of the split, inclusive
      * @param end     the end of the split, inclusive
      */
-    public void addSplicePosition(final String contig, final int start, final int end) {
+    public Splice addSplicePosition(final String contig, final int start, final int end) {
         if ( doNotFixOverhangs ) {
-            return;
+            return null;
         }
 
         // is this a new splice?  if not, we are done
-        final Splice splice = new Splice(contig, start, end);
+        final Splice splice = getSplice(contig, start, end);
         if ( splices.contains(splice) ) {
-            return;
+            return null;
         }
 
         // initialize it with the reference context
@@ -174,6 +175,7 @@ public class OverhangFixingManager {
         if ( splices.size() > MAX_SPLICES_TO_KEEP ) {
             cleanSplices();
         }
+        return splice;
     }
 
     /**
@@ -202,7 +204,7 @@ public class OverhangFixingManager {
             writeReads(targetQueueSize);
         }
 
-        List<SplitRead> newReadGroup = readGroup.stream().map(SplitRead::new).collect(Collectors.toList());
+        List<SplitRead> newReadGroup = readGroup.stream().map(this::getSplitRead).collect(Collectors.toList());
 
         // Check every stored read for an overhang with the new splice
         for ( final Splice splice : splices) {
@@ -234,6 +236,7 @@ public class OverhangFixingManager {
      * @param splitRead        the splitRead to fix
      * @param splice      the split (bad region to clip out)
      */
+    @VisibleForTesting
     void fixSplit(final SplitRead splitRead, final Splice splice) {
         // if the splitRead doesn't even overlap the split position then we can just exit
         if ( splitRead.unclippedLoc == null || !splice.loc.overlapsP(splitRead.unclippedLoc) ) {
@@ -246,18 +249,21 @@ public class OverhangFixingManager {
 
         GenomeLoc readLoc = splitRead.unclippedLoc;
         GATKRead read = splitRead.read;
-        final int readReferenceLength = read.getEnd() - read.getStart() + 1;
-
+        // Compute the number of non-clipped bases consumed according to the cigar
+        final int readBasesLength = Utils.stream(read.getCigar().getCigarElements())
+                                         .filter(c -> c.getOperator().consumesReadBases() && !c.getOperator().isClipping())
+                                         .mapToInt(CigarElement::getLength)
+                                         .sum();
         if ( isLeftOverhang(readLoc, splice.loc) ) {
             final int overhang = splice.loc.getStop() - read.getStart() + 1;
-            if ( overhangingBasesMismatch(read.getBases(), read.getStart() - readLoc.getStart(), readReferenceLength, splice.reference, splice.reference.length - overhang, overhang) ) {
+            if ( overhangingBasesMismatch(read.getBases(), read.getStart() - readLoc.getStart(), readBasesLength, splice.reference, splice.reference.length - overhang, overhang) ) {
                 final GATKRead clippedRead = ReadClipper.softClipByReadCoordinates(read, 0, splice.loc.getStop() - readLoc.getStart());
                 splitRead.setRead(clippedRead);
             }
         }
         else if ( isRightOverhang(readLoc, splice.loc) ) {
             final int overhang = readLoc.getStop() - splice.loc.getStart() + 1;
-            if ( overhangingBasesMismatch(read.getBases(), read.getLength() - overhang, readReferenceLength, splice.reference, 0, read.getEnd() - splice.loc.getStart() + 1) ) {
+            if ( overhangingBasesMismatch(read.getBases(), read.getLength() - overhang, readBasesLength, splice.reference, 0, read.getEnd() - splice.loc.getStart() + 1) ) {
                 final GATKRead clippedRead = ReadClipper.softClipByReadCoordinates(read, read.getLength() - overhang, read.getLength() - 1);
                 splitRead.setRead(clippedRead);
             }
@@ -457,6 +463,12 @@ public class OverhangFixingManager {
         }
     }
 
+    public SplitRead getSplitRead(final GATKRead read){
+        return new SplitRead(read);
+    }
+    public Splice getSplice(final String contig, final int start, final int end){
+        return new Splice(contig, start, end);
+    }
 
     // class to represent the split positions
     protected final class Splice {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.rnaseq;
 
+import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
@@ -7,6 +8,7 @@ import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.GATKReadWriter;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -271,4 +273,12 @@ public final class OverhangFixingManagerUnitTest extends GATKBaseTest {
         Assert.assertEquals(manager.getReadsInQueueForTesting().size(), 1);
     }
 
+    @Test
+    public void testReadWithDeletionsWindowSpanning() {
+        final OverhangFixingManager manager = new OverhangFixingManager(getHG19Header(), null, hg19GenomeLocParser, hg19ReferenceReader, 100, 100, 30, false, true);
+        OverhangFixingManager.Splice splice = manager.addSplicePosition("1",6816, 11247);
+        GATKRead read = ArtificialReadUtils.createArtificialRead(hg19Header,"read1",0,11244, new byte[100], new byte[100],"97S2M18D1M");
+        OverhangFixingManager.SplitRead split = manager.getSplitRead(read);
+        manager.fixSplit(split,splice);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
@@ -276,9 +276,13 @@ public final class OverhangFixingManagerUnitTest extends GATKBaseTest {
     @Test
     public void testReadWithDeletionsWindowSpanning() {
         final OverhangFixingManager manager = new OverhangFixingManager(getHG19Header(), null, hg19GenomeLocParser, hg19ReferenceReader, 100, 100, 30, false, true);
+        // Create a splice that is going to overlap into the deletion of our read, forcing us to check for mismatches to the reference
         OverhangFixingManager.Splice splice = manager.addSplicePosition("1",6816, 11247);
-        GATKRead read = ArtificialReadUtils.createArtificialRead(hg19Header,"read1",0,11244, new byte[100], new byte[100],"97S2M18D1M");
+        // Create a read that has a long deletion relative to its remaining mapped bases after splitting
+        GATKRead read = ArtificialReadUtils.createArtificialRead(hg19Header, "read1", 0, 11244, new byte[100], new byte[100], "97S2M18D1M");
         OverhangFixingManager.SplitRead split = manager.getSplitRead(read);
         manager.fixSplit(split,splice);
+        // Assert that no splitting happened (and no array exception) by asserting a copy of the read was not placed in split.read
+        Assert.assertTrue(split.read==read);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -91,15 +91,4 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.noSecondaryAlignments.bam"));
         spec.executeTest("test splits with overhangs", this);
     }
-
-    @Test
-    public void test()  throws Exception {
-        final ArgumentsBuilder args = new ArgumentsBuilder()
-                .addReference(new File("splitNCigarReads/hg19.fa"))
-                .addInput(new File("splitNCigarReads/test4.bam"))
-                .addOutput(createTempFile("largeSplitNCigarReadsTest",".bam"));
-        //Just make sure this doesn't fail with NoClassDefFoundError
-        runCommandLine(args);
-
-    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -91,4 +91,15 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
                 Arrays.asList(largeFileTestDir + "expected.NA12878.RNAseq.splitNcigarReads.noSecondaryAlignments.bam"));
         spec.executeTest("test splits with overhangs", this);
     }
+
+    @Test
+    public void test()  throws Exception {
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addReference(new File("splitNCigarReads/hg19.fa"))
+                .addInput(new File("splitNCigarReads/test4.bam"))
+                .addOutput(createTempFile("largeSplitNCigarReadsTest",".bam"));
+        //Just make sure this doesn't fail with NoClassDefFoundError
+        runCommandLine(args);
+
+    }
 }


### PR DESCRIPTION
Before we were limiting the edge fixing from trimming to large a percentage of the reads, but we computed this percentage based on the reference length of the read, not the number of bases. This resulted in cases where we might check more than the number of bases in the read for mismatches. 

Fixes #5230