### PR TITLE
Strand based annotations will use both reads in an overlapping read pair

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandArtifact.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandArtifact.java
@@ -9,6 +9,7 @@ import htsjdk.variant.vcf.VCFHeaderLineType;
 import org.apache.commons.math3.distribution.BetaDistribution;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.tools.walkers.mutect.SomaticGenotypingEngine;
 import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
@@ -16,6 +17,7 @@ import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.broadinstitute.hellbender.tools.walkers.annotator.StrandArtifact.ArtifactState.*;
 
@@ -88,13 +90,22 @@ public class StrandArtifact extends GenotypeAnnotation implements StandardMutect
             return;
         }
         final int indexOfMaxTumorLod = MathUtils.maxElementIndex(tumorLods);
-        final Allele altAlelle = vc.getAlternateAllele(indexOfMaxTumorLod);
+        final Allele altAllele = vc.getAlternateAllele(indexOfMaxTumorLod);
 
-        final Collection<ReadLikelihoods<Allele>.BestAllele> bestAlleles = likelihoods.bestAllelesBreakingTies(g.getSampleName());
-        final int numFwdAltReads = (int) bestAlleles.stream().filter(ba -> !ba.read.isReverseStrand() && ba.isInformative() && ba.allele.equals(altAlelle)).count();
-        final int numRevAltReads = (int) bestAlleles.stream().filter(ba -> ba.read.isReverseStrand() && ba.isInformative() && ba.allele.equals(altAlelle)).count();
-        final int numFwdReads = (int) bestAlleles.stream().filter(ba -> !ba.read.isReverseStrand() && ba.isInformative()).count();
-        final int numRevReads = (int) bestAlleles.stream().filter(ba -> ba.read.isReverseStrand() && ba.isInformative()).count();
+        final Collection<ReadLikelihoods<Allele>.BestAllele> informativeBestAlleles = likelihoods.bestAllelesBreakingTies(g.getSampleName()).stream().
+                filter(ba -> ba.isInformative()).collect(Collectors.toList());
+        final Map<Strand, List<ReadLikelihoods<Allele>.BestAllele>> altReads = informativeBestAlleles.stream().filter(ba -> ba.allele.equals(altAllele))
+                .collect(Collectors.groupingBy(ba -> ba.read.isReverseStrand() ? Strand.REV : Strand.FWD));
+        final Map<Strand, List<ReadLikelihoods<Allele>.BestAllele>> refReads = informativeBestAlleles.stream().filter(ba -> ba.allele.equals(vc.getReference()))
+                .collect(Collectors.groupingBy(ba -> ba.read.isReverseStrand() ? Strand.REV : Strand.FWD));
+
+        final int numFwdAltReads = countReads(altReads, Strand.FWD);
+        final int numRevAltReads = countReads(altReads, Strand.REV);
+        final int numFwdRefReads = countReads(refReads, Strand.FWD);
+        final int numRevRefReads = countReads(refReads, Strand.REV);
+
+        final int numFwdReads = numFwdRefReads + numFwdAltReads;
+        final int numRevReads = numRevRefReads + numRevAltReads;
         final int numAltReads = numFwdAltReads + numRevAltReads;
         final int numReads = numFwdReads + numRevReads;
 
@@ -162,6 +173,10 @@ public class StrandArtifact extends GenotypeAnnotation implements StandardMutect
         gb.attribute(MAP_ALLELE_FRACTIONS_KEY, estimatedAlleleFractions.values().stream().mapToDouble(Double::doubleValue).toArray());
     }
 
+    private enum Strand {
+        FWD, REV
+    }
+
     @Override
     public List<VCFFormatHeaderLine> getDescriptions() {
         return Arrays.asList(new VCFFormatHeaderLine(POSTERIOR_PROBABILITIES_KEY, 3, VCFHeaderLineType.Float, "posterior probabilities of the presence of strand artifact"),
@@ -177,5 +192,19 @@ public class StrandArtifact extends GenotypeAnnotation implements StandardMutect
                 MathUtils.binomialProbability(nNoArtifact, xNoArtifact, f);
     }
 
+    /**
+     *
+     * Count the number of reads in {@param reads}, including the overlapping mates discarded by {@link SomaticGenotypingEngine}.
+     * @param strand is the strand of the reads we're counting. For example, if strand = Strand.FWD, the we look among {@param reads}
+     *               for reverse reads with {@link SomaticGenotypingEngine.DISCARDED_MATE_READ_TAG} set to 1
+     */
+    private int countReads(final Map<Strand, List<ReadLikelihoods<Allele>.BestAllele>> reads, final Strand strand){
+        final Strand strandOfKeptRead = strand == Strand.FWD ? Strand.REV : Strand.FWD;
 
+        // check of the key in case there are no forward or reverse in {@link reads}
+        final int numDiscardedReads = ! reads.containsKey(strandOfKeptRead) ? 0 : (int) reads.get(strandOfKeptRead).stream().filter(ba -> ba.read.hasAttribute(SomaticGenotypingEngine.DISCARDED_MATE_READ_TAG)).count();
+        final int numReads = ! reads.containsKey(strand) ? 0 : reads.get(strand).size();
+        return numReads + numDiscardedReads;
+
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasTest.java
@@ -6,6 +6,7 @@ import htsjdk.variant.variantcontext.GenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.walkers.mutect.SomaticGenotypingEngine;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
@@ -170,8 +171,14 @@ public abstract class StrandBiasTest extends InfoFieldAnnotation {
             final int offset = matchesRef ? 0 : ARRAY_DIM;
 
             // a normal read with an actual strand
-            final boolean isFW = !read.isReverseStrand();
-            table[offset + (isFW ? 0 : 1)]++;
+            final boolean isForward = !read.isReverseStrand();
+            table[offset + (isForward ? 0 : 1)]++;
+
+            // This read's mate got discarded by SomaticGenotypingEngine::clipOverlappingReads()
+            if (read.hasAttribute(SomaticGenotypingEngine.DISCARDED_MATE_READ_TAG)){
+                // Note that if this read is forward, then we increment its mate which we assume is reverse
+                table[offset + (isForward ? 1 : 0)]++;
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
@@ -24,6 +24,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
 
     public static final String MIN_BASE_QUALITY_SCORE_LONG_NAME = "min-base-quality-score";
     public static final String SMITH_WATERMAN_LONG_NAME = "smith-waterman";
+    public static final String CORRECT_OVERLAPPING_BASE_QUALITIES_LONG_NAME = "correct-overlapping-quality";
 
     @ArgumentCollection
     public AssemblyRegionTrimmerArgumentCollection assemblyRegionTrimmerArgs = new AssemblyRegionTrimmerArgumentCollection();
@@ -122,5 +123,8 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
     @Advanced
     @Argument(fullName = SMITH_WATERMAN_LONG_NAME, doc = "Which Smith-Waterman implementation to use, generally FASTEST_AVAILABLE is the right choice", optional = true)
     public SmithWatermanAligner.Implementation smithWatermanImplementation = SmithWatermanAligner.Implementation.JAVA;
+
+    @Argument(fullName = CORRECT_OVERLAPPING_BASE_QUALITIES_LONG_NAME)
+    public boolean doNotCorrectOverlappingBaseQualities = false;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -673,7 +673,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             //TODO - why the activeRegion cannot manage its own one-time finalization and filtering?
             //TODO - perhaps we can remove the last parameter of this method and the three lines bellow?
             if ( needsToBeFinalized ) {
-                finalizeRegion(region);
+                AssemblyBasedCallerUtils.finalizeRegion(region, hcArgs.errorCorrectReads, hcArgs.dontUseSoftClippedBases, minTailQuality, readsHeader, samplesList, ! hcArgs.doNotCorrectOverlappingBaseQualities);
             }
             filterNonPassingReads(region);
 
@@ -721,10 +721,6 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         }
 
 
-    }
-
-    private void finalizeRegion(final AssemblyRegion region) {
-        AssemblyBasedCallerUtils.finalizeRegion(region, hcArgs.errorCorrectReads, hcArgs.dontUseSoftClippedBases, minTailQuality, readsHeader, samplesList);
     }
 
     private Set<GATKRead> filterNonPassingReads( final AssemblyRegion activeRegion ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -37,6 +37,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final String IGNORE_ITR_ARTIFACTS_LONG_NAME = "ignore-itr-artifacts";
     public static final String ARTIFACT_PRIOR_TABLE_NAME = "orientation-bias-artifact-priors";
     public static final String GET_AF_FROM_AD_LONG_NAME = "get-af-from-ad";
+    public static final String ANNOTATE_BASED_ON_READS_LONG_NAME = "annotate-fragments";
 
     public static final double DEFAULT_AF_FOR_TUMOR_ONLY_CALLING = 5e-8;
     public static final double DEFAULT_AF_FOR_TUMOR_NORMAL_CALLING = 1e-6;
@@ -168,5 +169,13 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     @Advanced
     @Argument(fullName = GET_AF_FROM_AD_LONG_NAME, doc="Use allelic depth to calculate tumor allele fraction; recommended for mitochondrial applications", optional = true)
     public boolean calculateAFfromAD = false;
+
+    /**
+     * If set to true, count an overlapping read pair as two separate reads instead of one for {@link StrandArtifact} and {@link StrandBiasBySample} annotations,
+     * which is the correct behavior for these annotations. Note that doing so would break the independence assumption of reads and over-count the alt depth in these annotations.
+     * On the other hand it could prevent spurious false negatives that could arise if by chance one strand in overlapping pairs is dropped disproportionately
+     */
+    @Argument(fullName = ANNOTATE_BASED_ON_READS_LONG_NAME, doc = "If true, strand-based annotations use the number of reads, not fragments")
+    public boolean annotateBasedOnReads = false;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -190,7 +190,7 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
         final AssemblyRegion assemblyActiveRegion = AssemblyBasedCallerUtils.assemblyRegionWithWellMappedReads(originalAssemblyRegion, READ_QUALITY_FILTER_THRESHOLD, header);
         final AssemblyResultSet untrimmedAssemblyResult = AssemblyBasedCallerUtils.assembleReads(assemblyActiveRegion, givenAlleles, MTAC, header, samplesList, logger, referenceReader, assemblyEngine, aligner);
         final SortedSet<VariantContext> allVariationEvents = untrimmedAssemblyResult.getVariationEvents(MTAC.maxMnpDistance);
-        final AssemblyRegionTrimmer.Result trimmingResult = trimmer.trim(originalAssemblyRegion,allVariationEvents);
+        final AssemblyRegionTrimmer.Result trimmingResult = trimmer.trim(originalAssemblyRegion, allVariationEvents);
         if (!trimmingResult.isVariationPresent()) {
             return NO_CALLS;
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -25,12 +25,13 @@ public final class FragmentUtils {
      * Assumes that firstRead starts before secondRead (according to their soft clipped starts)
      * Sets the qualities of clippedFirstRead and clippedSecondRead to mimic a merged read or
      * nothing if the algorithm cannot create a meaningful one
-     *
-     * @param clippedFirstRead the left most read
+     *  @param clippedFirstRead the left most read
      * @param clippedSecondRead the right most read
+     * @param correctOverlappingBaseQualities
      *
      */
-    public static void adjustQualsOfOverlappingPairedFragments(final GATKRead clippedFirstRead, final GATKRead clippedSecondRead) {
+    public static void adjustQualsOfOverlappingPairedFragments(final GATKRead clippedFirstRead, final GATKRead clippedSecondRead,
+                                                               final boolean correctOverlappingBaseQualities) {
         Utils.nonNull(clippedFirstRead);
         Utils.nonNull(clippedSecondRead);
         Utils.validateArg(clippedFirstRead.getName().equals(clippedSecondRead.getName()), () ->
@@ -51,6 +52,10 @@ public final class FragmentUtils {
         final byte[] secondReadQuals = clippedSecondRead.getBaseQualities();
 
         for ( int i = 0; i < numOverlappingBases; i++ ) {
+            if (! correctOverlappingBaseQualities) {
+                break;
+            }
+
             final int firstReadIndex = firstReadStop + i;
             final byte firstReadBase = firstReadBases[firstReadIndex];
             final byte secondReadBase = secondReadBases[i];
@@ -69,17 +74,17 @@ public final class FragmentUtils {
         clippedSecondRead.setBaseQualities(secondReadQuals);
     }
 
-    public static void adjustQualsOfOverlappingPairedFragments( final List<GATKRead> overlappingPair ) {
+    public static void adjustQualsOfOverlappingPairedFragments(final List<GATKRead> overlappingPair, final boolean correctOverlappingBaseQualities) {
         Utils.validateArg( overlappingPair.size() == 2, () -> "Found overlapping pair with " + overlappingPair.size() + " reads, but expecting exactly 2.");
 
         final GATKRead firstRead = overlappingPair.get(0);
         final GATKRead secondRead = overlappingPair.get(1);
 
         if ( secondRead.getSoftStart() < firstRead.getSoftStart() ) {
-            adjustQualsOfOverlappingPairedFragments(secondRead, firstRead);
+            adjustQualsOfOverlappingPairedFragments(secondRead, firstRead, correctOverlappingBaseQualities);
         }
         else {
-            adjustQualsOfOverlappingPairedFragments(firstRead, secondRead);
+            adjustQualsOfOverlappingPairedFragments(firstRead, secondRead, correctOverlappingBaseQualities);
         }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -16,7 +16,6 @@ import java.util.*;
 
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
@@ -53,7 +52,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         activeRegion.addAll(reads);
         SampleList sampleList = SampleList.singletonSampleList("tumor");
         Byte minbq = 9;
-        AssemblyBasedCallerUtils.finalizeRegion(activeRegion, false, false, minbq, header, sampleList);
+        AssemblyBasedCallerUtils.finalizeRegion(activeRegion, false, false, minbq, header, sampleList, false);
 
         // make sure reads are not changed due to finalizeRegion()
         Assert.assertTrue(reads.get(0).convertToSAMRecord(header).equals(orgRead0));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2TestingUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2TestingUtils.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class M2TestingUtils {
-    private static final String DEFAULT_READ_GROUP_NAME = "READ_GROUP_1";
+    public static final String DEFAULT_READ_GROUP_NAME = "READ_GROUP_1";
     /**
      *
      * Reference at this position looks like this:
@@ -32,25 +32,31 @@ public class M2TestingUtils {
     public static final byte[] DEFAULT_REF_BASES = "CATCACACTCACTAAGCACACAGAGAATAAT".getBytes();
     // Bases for C->T SNP at position 100,000                *
     public static final byte[] DEFAULT_ALT_BASES = "CATCACACTTACTAAGCACACAGAGAATAAT".getBytes();
+    public static final int DEFAULT_START_POSITION = 99_991;
+    public static final int DEFAULT_END_POSITION = 100_021;
     public static final int DEFAULT_SNP_POSITION = 100_000;
+    public static final int DEFAULT_READ_LENGTH = DEFAULT_REF_BASES.length;
     public static final String DEFAULT_SAMPLE_NAME = "sample1";
 
     public static SAMFileGATKReadWriter getBareBonesSamWriter(final File samFile, final SAMFileHeader samHeader) {
         return new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(samFile, null, samHeader, true, true, false));
     }
 
-    // TODO: might have to address read name collisions
-    public static List<GATKRead> createReads(final int numReads, final byte[] bases, final SAMFileHeader samHeader,
-                                             final byte baseQuality){
-        final int readLength = bases.length;
+    public static byte[] getUniformBQArray(final byte quality, final int readLength){
         final byte[] quals = new byte[readLength];
-        Arrays.fill(quals, baseQuality);
+        Arrays.fill(quals, quality);
+        return quals;
+    }
+
+    public static List<GATKRead> createReads(final int numReads, final byte[] bases, final SAMFileHeader samHeader,
+                                             final byte baseQuality, final String namePrefix){
+        final int readLength = bases.length;
 
         final List<GATKRead> reads = new ArrayList<>(numReads);
         for (int i = 0; i < numReads; i++) {
             final String cigar = bases.length + "M";
-            final GATKRead read = ArtificialReadUtils.createArtificialRead(samHeader, "Read" + i, DEFAULT_CHROM_INDEX,
-                    DEFAULT_ALIGNMENT_START, bases, quals, cigar);
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(samHeader, namePrefix + i, DEFAULT_CHROM_INDEX,
+                    DEFAULT_ALIGNMENT_START, bases, getUniformBQArray(baseQuality, readLength), cigar);
             read.setReadGroup(DEFAULT_READ_GROUP_NAME);
             read.setMappingQuality(DEFAULT_MAPQ);
             read.setIsFirstOfPair();
@@ -62,7 +68,7 @@ public class M2TestingUtils {
     }
 
     public static List<GATKRead> createReads(final int numReads, final byte[] bases, final SAMFileHeader samHeader){
-        return createReads(numReads, bases, samHeader, DEFAULT_BASEQ);
+        return createReads(numReads, bases, samHeader, DEFAULT_BASEQ, "read");
     }
 
     public static SAMFileHeader createSamHeader(){

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -11,18 +11,23 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.AssemblyRegionWalker;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.exome.orientationbiasvariantfilter.OrientationBiasUtils;
+import org.broadinstitute.hellbender.tools.walkers.annotator.StrandBiasBySample;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceSummaryRecord;
+import org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -583,11 +588,11 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final byte poorQuality = 10;
         final byte goodQuality = 30;
         final int numReads = 20;
-        final List<GATKRead> refReads = M2TestingUtils.createReads(numReads, M2TestingUtils.DEFAULT_REF_BASES, samHeader, poorQuality);
-        final List<GATKRead> alt1Reads = M2TestingUtils.createReads(numReads, M2TestingUtils.DEFAULT_ALT_BASES, samHeader, goodQuality);
+        final List<GATKRead> refReads = M2TestingUtils.createReads(numReads, M2TestingUtils.DEFAULT_REF_BASES, samHeader, poorQuality, "ref");
+        final List<GATKRead> altReads = M2TestingUtils.createReads(numReads, M2TestingUtils.DEFAULT_ALT_BASES, samHeader, goodQuality, "alt");
 
         refReads.forEach(writer::addRead);
-        alt1Reads.forEach(writer::addRead);
+        altReads.forEach(writer::addRead);
         writer.close(); // closing the writer writes to the file
         // End creating sam file
 
@@ -610,6 +615,75 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         Assert.assertTrue(vc.isPresent());
         Assert.assertEquals(vc.get().getStart(), M2TestingUtils.DEFAULT_SNP_POSITION);
         Assert.assertFalse(vc.get().getFilters().contains(GATKVCFConstants.MEDIAN_BASE_QUALITY_FILTER_NAME));
+    }
+
+    public File createSamWithOverlappingReads(final int numAltPairs, final int refDepth) throws IOException {
+        final byte altQuality = 50;
+        final byte refQuality = 30;
+        final File samFile = File.createTempFile("liquid-biopsy", ".bam");
+        final SAMFileHeader samHeader = M2TestingUtils.createSamHeader();
+        final SAMFileGATKReadWriter writer = M2TestingUtils.getBareBonesSamWriter(samFile, samHeader);
+
+        final List<GATKRead> refReads = M2TestingUtils.createReads(refDepth, M2TestingUtils.DEFAULT_REF_BASES, samHeader, refQuality, "ref");
+        refReads.forEach(writer::addRead);
+        for (int i = 0; i < numAltPairs; i++){
+            // Create a read pair that completely overlap each other, which is not realistic but is easy to implement
+            // and captures the essence of the issue
+            final List<GATKRead> overlappingPair = ArtificialReadUtils.createPair(samHeader, "alt" + i, M2TestingUtils.DEFAULT_READ_LENGTH,
+                    M2TestingUtils.DEFAULT_START_POSITION, M2TestingUtils.DEFAULT_START_POSITION, true, false);
+            overlappingPair.forEach(read -> {
+                read.setReadGroup(M2TestingUtils.DEFAULT_READ_GROUP_NAME);
+                read.setMappingQuality(60);
+                read.setBases(M2TestingUtils.DEFAULT_ALT_BASES);
+                read.setBaseQualities(M2TestingUtils.getUniformBQArray(altQuality, M2TestingUtils.DEFAULT_READ_LENGTH));
+                writer.addRead(read);
+            });
+        }
+
+        writer.close(); // closing the writer writes to the file
+        return samFile;
+    }
+
+
+    // Test that the strand bias annotaitons can count the number of reads, not fragments, when requested
+    @Test
+    public void testReadBasedAnnotations() throws IOException {
+        // Case 1: with the read correction we lose the variant - blood biopsy-like case
+        final int numAltPairs = 5;
+        final int depth = 100;
+        final int refDepth = depth - 2*numAltPairs;
+        final File samFileWithOverlappingReads = createSamWithOverlappingReads(numAltPairs, refDepth);
+
+        final File unfilteredVcf = File.createTempFile("unfiltered", ".vcf");
+        final File bamout = File.createTempFile("realigned", ".bam");
+        final String[] args = makeCommandLineArgs(Arrays.asList(
+                "-R", hg19_chr1_1M_Reference,
+                "-I", samFileWithOverlappingReads.getAbsolutePath(),
+                "-tumor", M2TestingUtils.DEFAULT_SAMPLE_NAME,
+                "-O", unfilteredVcf.getAbsolutePath(),
+                "--bamout", bamout.getAbsolutePath(),
+                "--" + M2ArgumentCollection.ANNOTATE_BASED_ON_READS_LONG_NAME, "true",
+                "--annotation", StrandBiasBySample.class.getSimpleName(),
+                "--" + AssemblyRegionWalker.MAX_STARTS_LONG_NAME, String.valueOf(depth)), Mutect2.class.getSimpleName());
+        new Main().instanceMain(args);
+
+        final Optional<VariantContext> vc = VariantContextTestUtils.streamVcf(unfilteredVcf).findAny();
+        Assert.assertTrue(vc.isPresent());
+
+        // Test case 2: we lose strand artifact. Make sure to reproduce the error and so on
+        final Genotype g = vc.get().getGenotype(M2TestingUtils.DEFAULT_SAMPLE_NAME);
+        final int[] contingencyTable = GATKProtectedVariantContextUtils.getAttributeAsIntArray(g, GATKVCFConstants.STRAND_BIAS_BY_SAMPLE_KEY, () -> null, -1);
+
+        final int REF_FWD_INDEX = 0;
+        final int REF_REV_INDEX = 1;
+        final int ALT_FWD_INDEX = 2;
+        final int ALT_REV_INDEX = 3;
+        Assert.assertEquals(contingencyTable[REF_FWD_INDEX], refDepth/2);
+        Assert.assertEquals(contingencyTable[REF_REV_INDEX], refDepth/2);
+        Assert.assertEquals(contingencyTable[ALT_FWD_INDEX], numAltPairs);
+        Assert.assertEquals(contingencyTable[ALT_REV_INDEX], numAltPairs);
+
+        Assert.assertFalse(vc.get().getFilters().contains(GATKVCFConstants.STRAND_ARTIFACT_FILTER_NAME));
     }
 
     private void doMutect2Test(

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/CollectF1R2CountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/CollectF1R2CountsIntegrationTest.java
@@ -2,18 +2,13 @@ package org.broadinstitute.hellbender.tools.walkers.readorientation;
 
 import com.google.common.collect.ImmutableMap;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.mutect.M2TestingUtils;
-import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
-import org.broadinstitute.hellbender.utils.genotyper.SampleList;
-import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -21,7 +16,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -195,8 +189,8 @@ public class CollectF1R2CountsIntegrationTest extends CommandLineProgramTest {
         //            Ref Sequence: "CATCACACTCACTAAGCACACAGAGAATAAT".getBytes();
         //          SNPs positions:            *  * *  *
         final byte[] altReadBases = "CATCACACTCTCTGACCAAACAGAGAATAAT".getBytes();
-        final List<GATKRead> refReads = M2TestingUtils.createReads(refDepth, M2TestingUtils.DEFAULT_REF_BASES, samHeader, (byte)30);
-        final List<GATKRead> alt1Reads = M2TestingUtils.createReads(altDepth, altReadBases, samHeader, (byte)30);
+        final List<GATKRead> refReads = M2TestingUtils.createReads(refDepth, M2TestingUtils.DEFAULT_REF_BASES, samHeader, (byte)30, "ref");
+        final List<GATKRead> alt1Reads = M2TestingUtils.createReads(altDepth, altReadBases, samHeader, (byte)30, "alt");
         refReads.forEach(writer::addRead);
         alt1Reads.forEach(writer::addRead);
         writer.close(); // closing the writer writes to the file

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
@@ -60,7 +60,7 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "AdjustFragmentsTest")
     public void testAdjustingTwoReads(final GATKRead read1, final GATKRead read2, final int overlapSize) {
-        FragmentUtils.adjustQualsOfOverlappingPairedFragments(read1, read2);
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(read1, read2, true);
 
         for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
             Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);


### PR DESCRIPTION
This PR includes two changes:
1. Provide a command line argument to toggle the overlapping base quality correction (i.e. min(bq, 20)) before reassembly, which happens in FragmentUtils. I've found, however, that by the time SomaticGenotypingEngine runs, those the quality of these bases get bumped up to what they used to be, so this may be a no-op. I included it in case I missed something, and to be consistent with the branch @fleharty and @madduran have been using.
2. Provide a command line argument to count the two reads in an overlapping pair separately in StrandArtfiact and StrandBiasBySample. This feature is only available in Mutect i.e. it won't affect other tools that use StrandBiasBySample