### PR TITLE
combine_tracks.wdl supports GISTIC2 conversion (and bugfix)

### DIFF
--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/aggregate_combined_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/aggregate_combined_tracks.wdl
@@ -6,16 +6,16 @@ workflow AggregateCombinedTracksWorkflow {
     Array[File] tumors_igv_compat
     Array[File] tumors_gistic2_compat
 
-    call TsvCat as TsvCatTumorGermlinePruned {
+    call TsvCat as TsvCatTumorGermlineFiltered {
         input:
             input_files = tumor_with_germline_filtered_segs,
-            id = group_id + "_TumorGermlinePruned"
+            id = group_id + "_TumorGermlineFiltered"
     }
 
-    call TsvCatNoHeader as TsvCatTumorGermlinePrunedGistic2 {
+    call TsvCatNoHeader as TsvCatTumorGermlineFilteredGistic2 {
         input:
             input_files = tumors_gistic2_compat,
-            id = group_id + "_TumorGermlinePrunedGistic2"
+            id = group_id + "_TumorGermlineFilteredGistic2"
     }
 
     call TsvCat as TsvCatTumor {
@@ -32,8 +32,8 @@ workflow AggregateCombinedTracksWorkflow {
 
     output {
         File cnv_postprocessing_aggregated_tumors_pre = TsvCatTumor.aggregated_tsv
-        File cnv_postprocessing_aggregated_tumors_post = TsvCatTumorGermlinePruned.aggregated_tsv
-        File cnv_postprocessing_aggregated_tumors_post_gistic2 = TsvCatTumorGermlinePrunedGistic2.aggregated_tsv
+        File cnv_postprocessing_aggregated_tumors_post = TsvCatTumorGermlineFiltered.aggregated_tsv
+        File cnv_postprocessing_aggregated_tumors_post_gistic2 = TsvCatTumorGermlineFilteredGistic2.aggregated_tsv
         File cnv_postprocessing_aggregated_normals = TsvCatNormal.aggregated_tsv
     }
 }
@@ -62,7 +62,7 @@ task TsvCat {
 	runtime {
 		docker: "ubuntu:16.04"
 		memory: "2 GB"
-        cpu: "1"
+		cpu: "1"
 		disks: "local-disk 100 HDD"
 	}
 }

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/aggregate_combined_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/aggregate_combined_tracks.wdl
@@ -4,11 +4,18 @@ workflow AggregateCombinedTracksWorkflow {
     Array[File] tumor_with_germline_filtered_segs
     Array[File] normals_igv_compat
     Array[File] tumors_igv_compat
+    Array[File] tumors_gistic2_compat
 
     call TsvCat as TsvCatTumorGermlinePruned {
         input:
             input_files = tumor_with_germline_filtered_segs,
             id = group_id + "_TumorGermlinePruned"
+    }
+
+    call TsvCatNoHeader as TsvCatTumorGermlinePrunedGistic2 {
+        input:
+            input_files = tumors_gistic2_compat,
+            id = group_id + "_TumorGermlinePrunedGistic2"
     }
 
     call TsvCat as TsvCatTumor {
@@ -26,6 +33,7 @@ workflow AggregateCombinedTracksWorkflow {
     output {
         File cnv_postprocessing_aggregated_tumors_pre = TsvCatTumor.aggregated_tsv
         File cnv_postprocessing_aggregated_tumors_post = TsvCatTumorGermlinePruned.aggregated_tsv
+        File cnv_postprocessing_aggregated_tumors_post_gistic2 = TsvCatTumorGermlinePrunedGistic2.aggregated_tsv
         File cnv_postprocessing_aggregated_normals = TsvCatNormal.aggregated_tsv
     }
 }
@@ -44,6 +52,32 @@ task TsvCat {
     for FILE in ${sep=" " input_files}
     do
         egrep -v "CONTIG|Chromosome" $FILE >> ${id}.aggregated.seg
+    done
+	>>>
+
+	output {
+		File aggregated_tsv="${id}.aggregated.seg"
+	}
+
+	runtime {
+		docker: "ubuntu:16.04"
+		memory: "2 GB"
+        cpu: "1"
+		disks: "local-disk 100 HDD"
+	}
+}
+
+task TsvCatNoHeader {
+
+	String id
+	Array[File] input_files
+
+	command <<<
+    set -e
+
+    for FILE in ${sep=" " input_files}
+    do
+        cat $FILE >> ${id}.aggregated.seg
     done
 	>>>
 

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -179,6 +179,7 @@ workflow CombineTracksWorkflow {
         File cnv_postprocessing_tumor_acs_seg = PrototypeACSConversion.cnv_acs_conversion_seg
         File cnv_postprocessing_tumor_acs_skew = PrototypeACSConversion.cnv_acs_conversion_skew
         Float cnv_postprocessing_tumor_acs_skew_float = PrototypeACSConversion.cnv_acs_conversion_skew_float
+        Float cnv_postprocessing_tumor_acs_skew_string = PrototypeACSConversion.cnv_acs_conversion_skew_string
         File cnv_postprocessing_tumor_with_tracks_filtered_merged_seg_gistic2 = Gistic2Convert.output_file_gistic2
     }
 }
@@ -576,6 +577,7 @@ EOF
         File cnv_acs_conversion_seg = "${output_filename}"
         File cnv_acs_conversion_skew = "${output_skew_filename}"
         Float cnv_acs_conversion_skew_float = read_float(output_skew_filename)
+        String cnv_acs_conversion_skew_string = read_string(output_skew_filename)
     }
 }
 

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -496,7 +496,7 @@ model_segments_af_param_pd = pd.read_csv(model_segments_af_param_input_file, sep
 
 def simple_determine_allelic_fraction(model_segments_seg_pd):
     result = model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_50']
-    result[model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_90'].astype(float) > HAM_FIST_THRESHOLD] = 0.5
+    result[model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_90'] > HAM_FIST_THRESHOLD] = 0.5
     return result
 
 def convert_model_segments_to_alleliccapseg(model_segments_seg_pd,

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -637,6 +637,7 @@ task PrepareForACSConversion {
     }
 }
 
+# Must be python3 in the docker image
 task Gistic2Convert {
     File input_file
     String docker
@@ -661,12 +662,12 @@ output_file = "${output_file}"
 """
 
 if __name__ == "__main__":
-    with open(input_file, 'rb') as tsvinfp, open(output_file, 'wb') as tsvoutfp:
+    with open(input_file, 'r') as tsvinfp, open(output_file, 'w') as tsvoutfp:
         tsvin = csv.DictReader(tsvinfp, delimiter='\t')
         tsvout = csv.writer(tsvoutfp, delimiter="\t")
         for r in tsvin:
-            int_ify_num_points = r["NUM_POINTS_COPY_RATIO"].replace(".0", "")
-            outrow = [r["SAMPLE"], r["Chromosome"], r["Start"], r["End"], int_ify_num_points, r["MEAN_LOG2_COPY_RATIO"]]
+            int_ify_num_points = r["NUM_POINTS_COPY_RATIO_1"].replace(".0", "")
+            outrow = [r["SAMPLE"], r["CONTIG"], r["START"], r["END"], int_ify_num_points, r["MEAN_LOG2_COPY_RATIO"]]
             print(outrow)
             tsvout.writerow(outrow)
 

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -179,7 +179,7 @@ workflow CombineTracksWorkflow {
         File cnv_postprocessing_tumor_acs_seg = PrototypeACSConversion.cnv_acs_conversion_seg
         File cnv_postprocessing_tumor_acs_skew = PrototypeACSConversion.cnv_acs_conversion_skew
         Float cnv_postprocessing_tumor_acs_skew_float = PrototypeACSConversion.cnv_acs_conversion_skew_float
-        Float cnv_postprocessing_tumor_acs_skew_string = PrototypeACSConversion.cnv_acs_conversion_skew_string
+        String cnv_postprocessing_tumor_acs_skew_string = PrototypeACSConversion.cnv_acs_conversion_skew_string
         File cnv_postprocessing_tumor_with_tracks_filtered_merged_seg_gistic2 = Gistic2Convert.output_file_gistic2
     }
 }

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -35,7 +35,14 @@
 #  - This workflow has not been tested with hg38
 #  - Evaluation of germline tagging and blacklists on hg38 is still pending.
 #  - Evaluation of the conversion to ACS format for ABSOLUTE is still pending.
-#  TODO: Post the auxiliary files in a public bucket.  Permission has already been granted.
+#
+# Auxiliary files (hg19):
+#  - centromere_tracks_seg: gs://gatk-best-practices/somatic-b37/final_centromere_hg19.seg
+#  - gistic_blacklist_tracks_seg:  gs://gatk-best-practices/somatic-b37/CNV.hg19.bypos.v1.CR1_event_added.mod.seg
+#
+# Auxiliary files (hg38) -- these are untested and the gistic list is a liftover:
+#  - centromere_tracks_seg:  gs://gatk-best-practices/somatic-hg38/final_centromere_hg38.seg
+#  - gistic_blacklist_tracks_seg:  gs://gatk-best-practices/somatic-hg38/CNV.hg38liftover.bypos.v1.CR1_event_added.mod.seg
 #
 #  Dev note:  FYI...This workflow is easily tested on a laptop.
 #

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -25,6 +25,7 @@
 #      This should be considered the final output.  IGV compatible.
 #  - seg file that can be used as input to ABSOLUTE.  This uses an identical format as AllelicCapSeg.  This is NOT compatible with IGV.
 #      Please note that the balanced-segment calling in this file has not been evaluated heavily.
+#  - seg file that can be used as input to GISTIC2.  Note that since this workflow is meant for a single pair, users will need to aggregate the GISTIC2 seg files from this workflow for all pairs.
 #  - skew file for the skew parameter in ABSOLUTE
 #  - skew as a float for the skew parameter in ABSOLUTE
 #  - Intermediate files for browsing various steps of the workflow.
@@ -35,6 +36,9 @@
 #  - Evaluation of germline tagging and blacklists on hg38 is still pending.
 #  - Evaluation of the conversion to ACS format for ABSOLUTE is still pending.
 #  TODO: Post the auxiliary files in a public bucket.  Permission has already been granted.
+#
+#  Dev note:  FYI...This workflow is easily tested on a laptop.
+#
 workflow CombineTracksWorkflow {
     File tumor_called_seg
     File tumor_modeled_seg
@@ -51,6 +55,11 @@ workflow CombineTracksWorkflow {
     String group_id
     String gatk_docker
     Int? max_merge_distance
+    Array[String]? annotations_on_which_to_merge
+
+    Array[String]? annotations_on_which_to_merge_final = select_first([annotations_on_which_to_merge,
+    ["MEAN_LOG2_COPY_RATIO", "LOG2_COPY_RATIO_POSTERIOR_10", "LOG2_COPY_RATIO_POSTERIOR_50", "LOG2_COPY_RATIO_POSTERIOR_90",
+        "MINOR_ALLELE_FRACTION_POSTERIOR_10", "MINOR_ALLELE_FRACTION_POSTERIOR_50", "MINOR_ALLELE_FRACTION_POSTERIOR_90"]])
 
 	call CombineTracks {
         input:
@@ -120,7 +129,7 @@ workflow CombineTracksWorkflow {
     call MergeSegmentByAnnotation {
         input:
             seg_file = FilterGermlineTagged.tumor_with_germline_filtered_seg,
-            annotations = ["MEAN_LOG2_COPY_RATIO"],
+            annotations = annotations_on_which_to_merge_final,
             ref_fasta = ref_fasta,
             ref_fasta_dict = ref_fasta_dict,
             ref_fasta_fai = ref_fasta_fai,
@@ -147,6 +156,13 @@ workflow CombineTracksWorkflow {
             SEGMENT_MEAN_COL = "MEAN_LOG2_COPY_RATIO"
     }
 
+    call Gistic2Convert {
+        input:
+            input_file = IGVConvertMergedTumorOutput.outFile,
+            docker = gatk_docker
+    }
+
+
     output {
         File cnv_postprocessing_tumor_igv_compat = IGVConvertTumor.outFile
         File cnv_postprocessing_normal_igv_compat = IGVConvertNormal.outFile
@@ -156,6 +172,7 @@ workflow CombineTracksWorkflow {
         File cnv_postprocessing_tumor_acs_seg = PrototypeACSConversion.cnv_acs_conversion_seg
         File cnv_postprocessing_tumor_acs_skew = PrototypeACSConversion.cnv_acs_conversion_skew
         Float cnv_postprocessing_tumor_acs_skew_float = PrototypeACSConversion.cnv_acs_conversion_skew_float
+        File cnv_postprocessing_tumor_with_tracks_filtered_merged_seg_gistic2 = Gistic2Convert.output_file_gistic2
     }
 }
 
@@ -472,7 +489,7 @@ model_segments_af_param_pd = pd.read_csv(model_segments_af_param_input_file, sep
 
 def simple_determine_allelic_fraction(model_segments_seg_pd):
     result = model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_50']
-    result[model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_90'] > HAM_FIST_THRESHOLD] = 0.5
+    result[model_segments_seg_pd['MINOR_ALLELE_FRACTION_POSTERIOR_90'].astype(float) > HAM_FIST_THRESHOLD] = 0.5
     return result
 
 def convert_model_segments_to_alleliccapseg(model_segments_seg_pd,
@@ -617,5 +634,53 @@ task PrepareForACSConversion {
 
     output {
         File model_and_calls_merged_gatk_seg = "${output_name}.final.seg"
+    }
+}
+
+task Gistic2Convert {
+    File input_file
+    String docker
+    String output_file = basename(input_file) + ".gistic2.seg"
+
+    command <<<
+        set -e
+        python <<EOF
+import csv
+input_file = "${input_file}"
+output_file = "${output_file}"
+
+"""
+  The column headers are:
+
+(1)  Sample           (sample name)
+(2)  Chromosome  (chromosome number)
+(3)  Start Position  (segment start position, in bases)
+(4)  End Position   (segment end position, in bases)
+(5)  Num markers      (number of markers in segment)
+(6)  Seg.CN       (log2() -1 of copy number)
+"""
+
+if __name__ == "__main__":
+    with open(input_file, 'rb') as tsvinfp, open(output_file, 'wb') as tsvoutfp:
+        tsvin = csv.DictReader(tsvinfp, delimiter='\t')
+        tsvout = csv.writer(tsvoutfp, delimiter="\t")
+        for r in tsvin:
+            int_ify_num_points = r["NUM_POINTS_COPY_RATIO"].replace(".0", "")
+            outrow = [r["SAMPLE"], r["Chromosome"], r["Start"], r["End"], int_ify_num_points, r["MEAN_LOG2_COPY_RATIO"]]
+            print(outrow)
+            tsvout.writerow(outrow)
+
+EOF
+    >>>
+
+    runtime {
+        docker: docker
+        memory: "2000 MB"
+        disks: "local-disk 100 HDD"
+        preemptible: 3
+        cpu: 1
+    }
+    output {
+        File output_file_gistic2 = "${output_file}"
     }
 }

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/multi_combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/multi_combine_tracks.wdl
@@ -45,12 +45,14 @@ workflow MultiCombineTracks {
                     group_id = group_id,
                     tumor_with_germline_filtered_segs = CombineTracksWorkflow.cnv_postprocessing_tumor_with_tracks_filtered_merged_seg,
                     normals_igv_compat = CombineTracksWorkflow.cnv_postprocessing_normal_igv_compat,
-                    tumors_igv_compat = CombineTracksWorkflow.cnv_postprocessing_tumor_igv_compat
+                    tumors_igv_compat = CombineTracksWorkflow.cnv_postprocessing_tumor_igv_compat,
+                    tumors_gistic2_compat = CombineTracksWorkflow.cnv_postprocessing_tumor_with_tracks_filtered_merged_seg_gistic2
         }
         output {
             File tumor_with_germline_filtered_segs = Aggregate.cnv_postprocessing_aggregated_tumors_post
             File normals_igv_compat = Aggregate.cnv_postprocessing_aggregated_normals
             File tumors_igv_compat = Aggregate.cnv_postprocessing_aggregated_tumors_pre
+            File tumor_with_germline_filtered_segs_gistic2 = Aggregate.cnv_postprocessing_aggregated_tumors_post_gistic2
             Array[File] tumor_acs_compat = CombineTracksWorkflow.cnv_postprocessing_tumor_acs_seg
             Array[File] tumor_acs_skew = CombineTracksWorkflow.cnv_postprocessing_tumor_acs_skew
         }


### PR DESCRIPTION
There are no Java code changes in this PR.  Tests were done manually.  As a reminder, the modified files are still considered experimental.

Changes:
- combine_tracks.wdl:  Fixes bug where string was compared to a float.  Closes #5284 
- combine_tracks.wdl:  Converts the processed seg file into a format for GISTIC2.  This is a trivial conversion.  Closes #5283 
- Other changes in `aggregate_combine_tracks.wdl` to support the above, including aggregation of individual GISTIC2 seg files into a single GISTIC2 seg file.
- Added gs urls for necessary auxiliary files in the documentation.
- Added multiple output types for the ABSOLUTE skew parameter to support heterogeneous execution configurations.  File, Float, and String.  All are the same value.