### PR TITLE
AVX present?

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ releases of the toolkit.
       Python environment and dependencies required by GATK tools that have a Python dependency. The ```gatk``` environment, 
       requires hardware with AVX support for tools that depend on TensorFlow (e.g. CNNScoreVariant). The GATK Docker image 
       comes with the ```gatk``` environment pre-configured.
-    * To establish the conda environment when not using the Docker image, a conda environment must first be "created", and
+    * To establish the  environment when not using the Docker image, a conda environment must first be "created", and
       then "activated":
         * First, make sure [Miniconda or Conda](https://conda.io/docs/index.html) is installed (Miniconda is sufficient).
         * To "create" the conda environment:
@@ -270,7 +270,10 @@ You can download and run pre-built versions of GATK4 from the following places:
 
   * Examples:
 
-      ```n
+      ```      
+      ./gatk PrintReadsSpark \
+          -I gs://my-gcs-bucket/path/to/input.bam \
+          -O gs://my-gcs-bucket/path/to/output.bam \
           -- \
           --spark-runner GCS --cluster myGCSCluster
       ```

--- a/README.md
+++ b/README.md
@@ -73,12 +73,9 @@ releases of the toolkit.
    docker client, which can be found on the [docker website](https://www.docker.com/get-docker).
 * Python Dependencies:<a name="python"></a>
     * GATK4 uses the [Conda](https://conda.io/docs/index.html) package manager to establish and manage the
-      Python environment and dependencies required by GATK tools that have a Python dependency. There are two different
-      conda environments that can be used:
-        * The ```gatk``` environment, which has no special hardware requirements. The GATK Docker image comes with the
-          "gatk" environment pre-configured.
-        * The ```gatk-intel``` environment, which requires and uses Intel (AVX2 or AVX-512) hardware acceleration to
-          increase performance.
+      Python environment and dependencies required by GATK tools that have a Python dependency. The ```gatk``` environment, 
+      requires hardware with AVX support for tools that depend on TensorFlow (e.g. CNNScoreVariant). The GATK Docker image 
+      comes with the ```gatk``` environment pre-configured.
     * To establish the conda environment when not using the Docker image, a conda environment must first be "created", and
       then "activated":
         * First, make sure [Miniconda or Conda](https://conda.io/docs/index.html) is installed (Miniconda is sufficient).
@@ -273,10 +270,7 @@ You can download and run pre-built versions of GATK4 from the following places:
 
   * Examples:
 
-      ```
-      ./gatk PrintReadsSpark \
-          -I gs://my-gcs-bucket/path/to/input.bam \
-          -O gs://my-gcs-bucket/path/to/output.bam \
+      ```n
           -- \
           --spark-runner GCS --cluster myGCSCluster
       ```

--- a/build.gradle
+++ b/build.gradle
@@ -522,24 +522,10 @@ task condaStandardEnvironmentDefinition(type: Copy) {
     }
 }
 
-task condaIntelEnvironmentDefinition(type: Copy) {
-    from "scripts"
-    into buildDir
-    include gatkCondaTemplate
-    rename { file -> gatkCondaIntelYML }
-    expand(["condaEnvName":"gatk-intel",
-            "condaEnvDescription" : "Conda environment for GATK Python Tools running with Intel hardware acceleration",
-            "tensorFlowDependency" :
-                    "https://anaconda.org/intel/tensorflow/$tensorflowVersion/download/tensorflow-$tensorflowVersion-cp36-cp36m-linux_x86_64.whl"])
-    doLast {
-        logger.lifecycle("Created Intel Conda environment yml file: $gatkCondaIntelYML")
-    }
-}
 
-// Create two GATK conda environment yml files from the conda enc template
-// (one for standard GATK and one for running GATK with Intel hardware).
+// Create GATK conda environment yml file from the conda enc template
 task condaEnvironmentDefinition() {
-    dependsOn 'pythonPackageArchive', 'condaStandardEnvironmentDefinition', 'condaIntelEnvironmentDefinition'
+    dependsOn 'pythonPackageArchive', 'condaStandardEnvironmentDefinition'
 }
 
 // Create the Python package archive file

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -43,7 +43,7 @@ dependencies:
   - scikit-learn==0.19.1
   - scipy==1.0.0
   - six==1.11.0
-  - tensorflow==1.9.0
+  - $tensorFlowDependency
   - theano==0.9.0
   - tqdm==4.19.4
   - werkzeug==0.12.2

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -43,7 +43,7 @@ dependencies:
   - scikit-learn==0.19.1
   - scipy==1.0.0
   - six==1.11.0
-  - $tensorFlowDependency
+  - tensorflow=1.9.0
   - theano==0.9.0
   - tqdm==4.19.4
   - werkzeug==0.12.2

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -43,7 +43,7 @@ dependencies:
   - scikit-learn==0.19.1
   - scipy==1.0.0
   - six==1.11.0
-  - tensorflow=1.9.0
+  - tensorflow==1.9.0
   - theano==0.9.0
   - tqdm==4.19.4
   - werkzeug==0.12.2

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
@@ -112,7 +112,7 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
             "2D models look at aligned reads, reference sequence, and variant annotations." +
             "2D models require a BAM file as input as well as the tensor-type argument to be set.";
     static final String AVXREQUIRED_ERROR = "This tool requires AVX instruction set support by default due to its dependency on recent versions of the TensorFlow library.\n" +
-            " If you have an older (pre-1.6) version of TensorFlow installed that does not require AVX, you may attempt to re-run the tool with the --disable-avx-check argument to bypass this check.\n" +
+            " If you have an older (pre-1.6) version of TensorFlow installed that does not require AVX you may attempt to re-run the tool with the --disable-avx-check argument to bypass this check.\n" +
             " Note that such configurations are not officially supported.";
 
     private static final int CONTIG_INDEX = 0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
@@ -111,8 +111,9 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
             "1D models will look at the reference sequence and variant annotations." +
             "2D models look at aligned reads, reference sequence, and variant annotations." +
             "2D models require a BAM file as input as well as the tensor-type argument to be set.";
+    static final String DISABLE_AVX_CHECK_NAME = "disable-avx-check";
     static final String AVXREQUIRED_ERROR = "This tool requires AVX instruction set support by default due to its dependency on recent versions of the TensorFlow library.\n" +
-            " If you have an older (pre-1.6) version of TensorFlow installed that does not require AVX you may attempt to re-run the tool with the --disable-avx-check argument to bypass this check.\n" +
+            " If you have an older (pre-1.6) version of TensorFlow installed that does not require AVX you may attempt to re-run the tool with the %s argument to bypass this check.\n" +
             " Note that such configurations are not officially supported.";
 
     private static final int CONTIG_INDEX = 0;
@@ -167,7 +168,7 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
     private String outputTensorsDir = "";
 
     @Advanced
-    @Argument(fullName = "disable-avx-check", shortName = "disable-avx-check", doc = "If set, no check will be made for AVX support.  " +
+    @Argument(fullName = DISABLE_AVX_CHECK_NAME, shortName = DISABLE_AVX_CHECK_NAME, doc = "If set, no check will be made for AVX support.  " +
             "Use only if you have installed a pre-1.6 TensorFlow build. ", optional = true)
     private boolean disableAVXCheck = false;
 
@@ -249,7 +250,7 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
             utils.load(null);
             if (utils.isAvxSupported() == false) {
                 // Give user the bad news, suggest remedies.
-                throw new UserException.HardwareFeatureException(CNNScoreVariants.AVXREQUIRED_ERROR);
+                throw new UserException.HardwareFeatureException(String.format(CNNScoreVariants.AVXREQUIRED_ERROR, DISABLE_AVX_CHECK_NAME));
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
@@ -20,7 +20,10 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.runtime.AsynchronousStreamWriter;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import picard.cmdline.programgroups.VariantFilteringProgramGroup;
+
+import com.intel.gkl.IntelGKLUtils;
 
 import java.io.*;
 import java.util.*;
@@ -108,6 +111,9 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
             "1D models will look at the reference sequence and variant annotations." +
             "2D models look at aligned reads, reference sequence, and variant annotations." +
             "2D models require a BAM file as input as well as the tensor-type argument to be set.";
+    static final String AVXREQUIRED_ERROR = "This tool requires AVX instruction set support by default due to its dependency on recent versions of the TensorFlow library.\n" +
+            " If you have an older (pre-1.6) version of TensorFlow installed that does not require AVX, you may attempt to re-run the tool with the --disable-avx-check argument to bypass this check.\n" +
+            " Note that such configurations are not officially supported.";
 
     private static final int CONTIG_INDEX = 0;
     private static final int POS_INDEX = 1;
@@ -159,6 +165,11 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
     @Advanced
     @Argument(fullName = "output-tensor-dir", shortName = "output-tensor-dir", doc = "Optional directory where tensors can be saved for debugging or visualization.", optional = true)
     private String outputTensorsDir = "";
+
+    @Advanced
+    @Argument(fullName = "disable-avx-check", shortName = "disable-avx-check", doc = "If set, no check will be made for AVX support.  " +
+            "Use only if you have installed a pre-1.6 TensorFlow build. ", optional = true)
+    private boolean disableAVXCheck = false;
 
     @Hidden
     @Argument(fullName = "enable-journal", shortName = "enable-journal", doc = "Enable streaming process journal.", optional = true)
@@ -232,8 +243,14 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
 
     @Override
     public void onTraversalStart() {
-        if (getHeaderForVariants().getGenotypeSamples().size() > 1) {
-            logger.warn("CNNScoreVariants is a single sample tool, but the input VCF has more than 1 sample.");
+        // Users can disable the AVX check to allow an older version of TF that doesn't require AVX to be used.
+        if(this.disableAVXCheck == false) {
+            IntelGKLUtils utils = new IntelGKLUtils();
+            utils.load(null);
+            if (utils.isAvxSupported() == false) {
+                // Give user the bad news, suggest remedies.
+                throw new UserException.HardwareFeatureException(CNNScoreVariants.AVXREQUIRED_ERROR);
+            }
         }
 
         // Start the Python process and initialize a stream writer for streaming data to the Python code


### PR DESCRIPTION
CNNScoreVariant relies on a computationally demanding operation - a deep neural network.  Using an Intel-optimized version of TensorFlow gives a 10X improvement in performance (e.g. 50 hours to 5 hours for a typical input).  However, these improvements mean that we now have a minimum hardware requirement - the availability of AVX.