### PR TITLE
Added in new data sources for funcotator testing.

### DIFF
--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.config
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0b9ee8ca0e98586dd47dee4feed5ec6306e8d00ccf049035f6fdc29ec015af8
+size 1677

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16.gtf
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16.gtf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce4a3da2c71a33e638a008a0770006a5b117d4651c704f7d7655010ec0c0f950
+size 224830

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16.gtf.idx
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16.gtf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4a107a92d471994b8d99c330128bbdf1edbc2631ce545844d94e21d9a527012
+size 334

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.dict
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e2452fe796180e450da2c90b5e3fdfba6c131975892f440e5af54d0ff1c5c44
+size 1601

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.fasta
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7661a40838a2dfb0903c527dd4452455311fa3f11a2e44b6bfcbb8beee7c41f
+size 59072

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.fasta.fai
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.v19.MUC16_transcript.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f7a463f1d193887c1d7f27614dca9b7f706bc1422f55f70ed5a77b3d38257df
+size 750

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.config
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb604e5862217c3978cc2fb0abf2f6f2cb8b4cf34681a026fedcd891aa0aa6f0
+size 1679

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77478623dfcaacc8fee3ad4484bd41175fbcbdf383bcda1a5b81807bc2aabc4b
+size 34143

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf.idx
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA.gtf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:709d5344fab268d249eee81300b56f198588e0c67ddd078833f76af9e5e8637a
+size 334

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.dict
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74883af09a5772034d53f2df884a82e34df415951081e5754bedf1517ee9faa9
+size 968

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d3f582d1ca1ed259c77e4a82f4bfed8e9253b4b5c3aba9a63eb08f75f5cc68d
+size 10353

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta.fai
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.v19.PIK3CA_transcript.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4e49f4d57d32943e1663cf9902460ff7a2e2c03dfaf0bd3c5fc7ad9f01c2d47
+size 441


### PR DESCRIPTION
New data source contains all gencode transcript information for PIK3CA
and MUC16.