### PR TITLE
Add full-sized B37 and HG38 references to our large test data

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
@@ -46,6 +46,14 @@ public abstract class GATKBaseTest extends BaseTest {
      */
     public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + "/";
 
+    // The complete B37 human reference, including the Epstein-Barr contig, in fasta.gz format.
+    // Source: /seq/references/Homo_sapiens_assembly19/v1/ in the Broad Institute filesystem.
+    public static final String b37Reference = largeFileTestDir + "Homo_sapiens_assembly19.fasta.gz";
+
+    // The complete HG38 human reference, in fasta.gz format.
+    // Source: /seq/references/Homo_sapiens_assembly38/v0/ in the Broad Institute filesystem.
+    public static final String hg38Reference = largeFileTestDir + "Homo_sapiens_assembly38.fasta.gz";
+
     // All of chromosomes 20 and 21 from the b37 reference
     public static final String b37_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.fasta";
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReferenceDataSourceUnitTest.java
@@ -103,4 +103,28 @@ public final class ReferenceDataSourceUnitTest extends GATKBaseTest {
             }
         }
     }
+
+    /**
+     * Test that we can successfully load and query our full-sized B37 reference.
+     */
+    @Test
+    public void testLoadAndQueryB37Reference() {
+        try (final ReferenceDataSource ref = new ReferenceFileSource(IOUtils.getPath(b37Reference))) {
+            Assert.assertEquals(ref.getSequenceDictionary().getSequences().size(), 85, "Wrong number of contigs in reference sequence dictionary");
+
+            Assert.assertTrue(Arrays.equals(ref.queryAndPrefetch("1", 10000000, 10000005).getBases(), new byte[]{ 'A', 'A', 'C', 'C', 'C', 'C' }), "Wrong reference bases returned for query on 1:10000000-10000005");
+        }
+    }
+
+    /**
+     * Test that we can successfully load and query our full-sized HG38 reference.
+     */
+    @Test
+    public void testLoadAndQueryHG38Reference() {
+        try (final ReferenceDataSource ref = new ReferenceFileSource(IOUtils.getPath(hg38Reference))) {
+            Assert.assertEquals(ref.getSequenceDictionary().getSequences().size(), 3366, "Wrong number of contigs in reference sequence dictionary");
+
+            Assert.assertTrue(Arrays.equals(ref.queryAndPrefetch("chr1", 10000000, 10000005).getBases(), new byte[]{ 'C', 'A', 'G', 'G', 'T', 'G' }), "Wrong reference bases returned for query on chr1:10000000-10000005");
+        }
+    }
 }

--- a/src/test/resources/large/Homo_sapiens_assembly19.dict
+++ b/src/test/resources/large/Homo_sapiens_assembly19.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64839c8ede282a7ba3bb0b19d9cc72b36279a70545d7d1b061489609f41dcbfd
+size 14811

--- a/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz
+++ b/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddde15d38793042adeae135ca140f7dfd4371a573a6b973fe77ae08c4c11f1f1
+size 861381544

--- a/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz.fai
+++ b/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:485ce3b03d6fa488bddbfca1e27474ee63e90daa3f97a5e40461d3098c7d42d6
+size 2780

--- a/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz.gzi
+++ b/src/test/resources/large/Homo_sapiens_assembly19.fasta.gz.gzi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90d44ba05312b6929669841deff180afdcca15895720e60d2cc9ef8a22d061c
+size 769800

--- a/src/test/resources/large/Homo_sapiens_assembly38.dict
+++ b/src/test/resources/large/Homo_sapiens_assembly38.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07523b4a0afd1127ae909f92f8b3911aff096461aed7eff3f1acf5bdfc1dc103
+size 581712

--- a/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz
+++ b/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3669c0260dbc1b6ed06bfa871cea5a962089f7781f21ce5b97115c37ad1ff50d
+size 896887306

--- a/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz.fai
+++ b/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edefd93c489dc1baefad312f40388089f8db5cf6dcc3ba0955669ead274e8b6b
+size 160928

--- a/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz.gzi
+++ b/src/test/resources/large/Homo_sapiens_assembly38.fasta.gz.gzi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6fe3ecb3aed48ad50d91a5596ca0bb469bdddeeabd2a9c35f6f7470beaa310b
+size 796552


### PR DESCRIPTION
Resolves #5111