### PR TITLE
fixed edge case where SomaticValidator counts reads ending inside ref as alts

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/ValidateBasicSomaticShortMutationsIntegrationTest.java
@@ -144,12 +144,12 @@ public class ValidateBasicSomaticShortMutationsIntegrationTest extends CommandLi
         // INS2: 20	3076299	.	A	AAGAAGCATGC
 
         assertValidationResult(variantValidationResults, new SimpleInterval("20", 1330646, 1330646),
-                "CCTTGGCTTATTCCA", "C", 7, 21, 10,
+                "CCTTGGCTTATTCCA", "C", 7, 22, 10,
                 26, 0);
 
         // TODO: This next one actually has an incorrect gtNumAltReadsInValidationNormal, since the validator thinks of this as AT<insT>.  There are supporting reads in the validation normal for A<insT>T.  See https://github.com/broadinstitute/gatk/issues/5061
         assertValidationResult(variantValidationResults, new SimpleInterval("20", 3076247, 3076247),
-                "AT", "ATT", 4, 33, 4,
+                "AT", "ATT", 4, 35, 4,
                 25,0);
         assertValidationResult(variantValidationResults, new SimpleInterval("20", 3076299, 3076299),
                 "A", "AAGAAGCATGC", 9, 41, 12,

--- a/src/test/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtilsUnitTest.java
@@ -168,7 +168,7 @@ public class GATKProtectedVariantContextUtilsUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "testDeletions")
     public void testChooseBestAlleleDeletion(final int offsetIntoRead, final String refBases, final String altBases,
-                                              final boolean isSpliceInAlt) {
+                                              final boolean isSpliceInAlt, final boolean cantDecide) {
 
         // We assume that we are on the base right before the insertion.  We are pretending each read is 50 bases long.
         final Allele referenceAllele = Allele.create(refBases, true);
@@ -179,13 +179,13 @@ public class GATKProtectedVariantContextUtilsUnitTest extends GATKBaseTest {
             Assert.assertEquals(
                     GATKProtectedVariantContextUtils.chooseAlleleForRead(pileupElement, referenceAllele,
                             Collections.singletonList(deletionAllele), 0),
-                    deletionAllele);
+                    cantDecide ? null : deletionAllele);
         } else {
             final PileupElement pileupElement = ArtificialReadUtils.createNonIndelPileupElement(offsetIntoRead, referenceAllele, LENGTH_OF_ARTIFICIAL_READ);
             Assert.assertEquals(
                     GATKProtectedVariantContextUtils.chooseAlleleForRead(pileupElement, referenceAllele,
                             Collections.singletonList(deletionAllele), 0),
-                    referenceAllele);
+                    cantDecide ? null :referenceAllele);
         }
     }
 
@@ -221,10 +221,12 @@ public class GATKProtectedVariantContextUtilsUnitTest extends GATKBaseTest {
     @DataProvider(name="testDeletions")
     public Object[][] createTestDeletions() {
         return new Object[][] {
-                {0, "ATT", "A", true},
-                {0, "ATT", "A", false},
-                {10, "ATT", "A", true},
-                {10, "ATT", "A", false}
+                {0, "ATT", "A", true, false},
+                {0, "ATT", "A", false, false},
+                {10, "ATT", "A", true, false},
+                {10, "ATT", "A", false, false},
+                {LENGTH_OF_ARTIFICIAL_READ - 1, "AT", "A", true, true},
+                {LENGTH_OF_ARTIFICIAL_READ - 1, "AT", "A", false, true}
         };
     }
 


### PR DESCRIPTION
Closes #5325.

@takutosato Here's another little one to fix an apparent MC3 false negative that's actually a true negative (and a false positive for several other callers).