### PR TITLE
Removing WellformedReadFilter from CountReadsSpark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -8,11 +8,15 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Calculate the overall number of reads in a SAM/BAM file
@@ -63,6 +67,11 @@ public final class CountReadsSpark extends GATKSparkTool {
             optional = true
     )
     public String out;
+
+    @Override
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.ALLOW_ALL_READS);
+    }
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {


### PR DESCRIPTION
I have been burned one too many times by the fact that this count silently filters reads for you. Since there is no logging output printing the number of filtered reads in spark it makes more sense to remove filtering from the tool altogether. 