### PR TITLE
SelectVariants can now write VCF to cloud

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -772,14 +772,28 @@ public abstract class GATKTool extends CommandLineProgram {
 
     /**
      * Creates a VariantContextWriter whose outputFile type is determined by
-     * the outFile's extension, using the best available sequence dictionary for
+     * the outPathName's extension, using the best available sequence dictionary for
      * this tool, and default index, leniency and md5 generation settings.
+     *
+     * Deprecated, use {@link #createVCFWriter(Path)} instead.
      *
      * @param outFile output File for this writer. May not be null.
      * @returns VariantContextWriter must be closed by the caller
      */
     public VariantContextWriter createVCFWriter(final File outFile) {
-        Utils.nonNull(outFile);
+        return createVCFWriter(outFile == null ? null : outFile.toPath());
+    }
+
+    /**
+     * Creates a VariantContextWriter whose outputFile type is determined by
+     * outPath's extension, using the best available sequence dictionary for
+     * this tool, and default index, leniency and md5 generation settings.
+     *
+     * @param outPath output Path for this writer. May not be null.
+     * @returns VariantContextWriter must be closed by the caller
+     */
+    public VariantContextWriter createVCFWriter(final Path outPath) {
+        Utils.nonNull(outPath);
 
         final SAMSequenceDictionary sequenceDictionary = getBestAvailableSequenceDictionary();
 
@@ -802,7 +816,7 @@ public abstract class GATKTool extends CommandLineProgram {
         }
 
         return GATKVariantContextUtils.createVCFWriter(
-                outFile,
+                outPath,
                 sequenceDictionary,
                 createOutputVariantMD5,
                 options.toArray(new Options[options.size()]));

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBuildReferenceTaxonomyUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBuildReferenceTaxonomyUtils.java
@@ -297,7 +297,7 @@ public final class PSBuildReferenceTaxonomyUtils {
      */
     public static BufferedReader getBufferedReaderGz(final String path) {
         try {
-            return new BufferedReader(IOUtils.makeReaderMaybeGzipped(new File(path)));
+            return new BufferedReader(IOUtils.makeReaderMaybeGzipped(IOUtils.getPath(path)));
         } catch (final IOException e) {
             throw new UserException.BadInput("Could not open file " + path, e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -35,6 +35,7 @@ import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.genotyper.SampleList;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.haplotype.HaplotypeBAMWriter;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
@@ -44,7 +45,6 @@ import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 import org.broadinstitute.hellbender.utils.variant.HomoSapiensConstants;
 import org.broadinstitute.hellbender.utils.variant.writers.GVCFWriter;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -348,7 +348,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         if (sitesOnlyMode) {options.add(Options.DO_NOT_WRITE_GENOTYPES);}
 
         VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(
-                new File(outputVCF),
+                IOUtils.getPath(outputVCF),
                 readsDictionary,
                 createOutputVariantMD5,
                 options.toArray(new Options[options.size()])

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CreateSomaticPanelOfNormals.java
@@ -9,28 +9,23 @@ import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
-import org.apache.commons.math3.special.Gamma;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.*;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.walkers.readorientation.BetaDistributionShape;
 import org.broadinstitute.hellbender.tools.walkers.validation.basicshortmutpileup.BetaBinomialDistribution;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.OptimizationUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.activityprofile.ActivityProfileState;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import picard.cmdline.programgroups.VariantFilteringProgramGroup;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 
-import java.io.File;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.function.DoubleUnaryOperator;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Create a panel of normals (PoN) containing germline and artifactual sites for use with Mutect2.
@@ -124,7 +119,7 @@ public class CreateSomaticPanelOfNormals extends VariantWalker {
         outputHeader.addMetaDataLine(new VCFInfoHeaderLine(FRACTION_INFO_FIELD, 1, VCFHeaderLineType.Float, "Fraction of samples exhibiting artifact"));
         outputHeader.addMetaDataLine(new VCFInfoHeaderLine(BETA_SHAPE_INFO_FIELD, 2, VCFHeaderLineType.Float, "Beta distribution parameters to fit artifact allele fractions"));
 
-        vcfWriter = createVCFWriter(new File(outputVcf));
+        vcfWriter = createVCFWriter(IOUtils.getPath(outputVcf));
         vcfWriter.writeHeader(outputHeader);
 
         numSamples = getHeaderForVariants().getNGenotypeSamples();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -19,6 +19,7 @@ import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.filters.*;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -135,8 +136,8 @@ public final class SelectVariants extends VariantWalker {
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
               shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
-              doc="File to which variants should be written")
-    public File outFile = null;
+              doc="Path to which variants should be written")
+    public String outPathName = null;
 
     /**
      * This argument can be specified multiple times in order to provide multiple sample names, or to specify
@@ -524,7 +525,8 @@ public final class SelectVariants extends VariantWalker {
             }
         }
 
-        vcfWriter = createVCFWriter(outFile);
+        final Path outPath = IOUtils.getPath(outPathName);
+        vcfWriter = createVCFWriter(outPath);
         vcfWriter.writeHeader(new VCFHeader(actualLines, samples));
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/AlleleBiasedDownsamplingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/AlleleBiasedDownsamplingUtils.java
@@ -180,7 +180,7 @@ public final class AlleleBiasedDownsamplingUtils {
     public static DefaultedMap<String, Double> loadContaminationFile(final File file, final double defaultContaminationFraction, final Set<String> sampleIDs, final Logger logger) {
         final DefaultedMap<String, Double> sampleContamination = new DefaultedMap<>(defaultContaminationFraction);
         final Set<String> nonSamplesInContaminationFile = new LinkedHashSet<>(sampleContamination.keySet());
-        try ( final XReadLines reader = new XReadLines(file, true) ){
+        try ( final XReadLines reader = new XReadLines(Utils.nonNull(file).toPath(), true) ){
             for (final String line : reader) {
                 if (line.isEmpty()) {
                     continue;

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -392,9 +392,10 @@ public final class IOUtils {
     /**
      * Makes a reader for a file, unzipping if the file's name ends with '.gz'.
      */
-    public static Reader makeReaderMaybeGzipped(File file) throws IOException {
-        final InputStream in = new BufferedInputStream( new FileInputStream(file));
-        return makeReaderMaybeGzipped(in, file.getPath().endsWith(".gz"));
+    public static Reader makeReaderMaybeGzipped(Path path) throws IOException {
+        final InputStream in = new BufferedInputStream(Files.newInputStream(path));
+        // toString because path.endsWith only checks whole path components, not substrings.
+        return makeReaderMaybeGzipped(in, path.toString().endsWith(".gz"));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/text/XReadLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/text/XReadLines.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.hellbender.utils.text;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.*;
@@ -39,15 +42,35 @@ public final class XReadLines implements Iterator<String>, Iterable<String>, Aut
      * By default, it will trim whitespaces.
      */
     public XReadLines(final File filename) throws IOException {
-        this(filename, true);
+        this(Utils.nonNull(filename).toPath(), true);
+    }
+
+    /**
+     * Opens the given file for reading lines.
+     * The file may be a text file or a gzipped text file (the distinction is made by the file extension).
+     * By default, it will trim whitespaces.
+     */
+    public XReadLines(final Path path) throws IOException {
+        this(path, true);
     }
 
     /**
      * Opens the given file for reading lines and optionally trim whitespaces.
      * The file may be a text file or a gzipped text file (the distinction is made by the file extension).
      */
-    public XReadLines(final File filename, final boolean trimWhitespace) throws IOException {
-        this(IOUtils.makeReaderMaybeGzipped(filename), trimWhitespace, null);
+    public XReadLines(final Path path, final boolean trimWhitespace) throws IOException {
+        this(path, trimWhitespace, null);
+    }
+
+    /**
+     * Opens the given file for reading lines and optionally trim whitespaces.
+     * The file may be a text file or a gzipped text file (the distinction is made by the file extension).
+     *
+     * @param trimWhitespace trim whitespace
+     * @param commentPrefix prefix for comments or null if no prefix is set
+     */
+    public XReadLines(final Path path, final boolean trimWhitespace, final String commentPrefix) throws IOException {
+        this(IOUtils.makeReaderMaybeGzipped(path), trimWhitespace, commentPrefix);
     }
 
     /**
@@ -74,7 +97,9 @@ public final class XReadLines implements Iterator<String>, Iterable<String>, Aut
      * @return all of the lines in the file.
      */
     public List<String> readLines() {
-        List<String> lines = new LinkedList<>();
+        // Using an ArrayList instead of LinkedList because it has the same add performance
+        // (asymptotically), but faster random access.
+        List<String> lines = new ArrayList<>();
         for ( String line : this ) {
             lines.add(line);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrderingIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/FixCallSetSampleOrderingIntegrationTest.java
@@ -46,7 +46,7 @@ public class FixCallSetSampleOrderingIntegrationTest extends CommandLineProgramT
         for( int i = 0; i < howMany ; i++) {
             final File out = File.createTempFile("tiny_", ".vcf");
 
-            try (final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(out, dict, false, Options.INDEX_ON_THE_FLY)) {
+            try (final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(out.toPath(), dict, false, Options.INDEX_ON_THE_FLY)) {
                 final String sampleName = "Sample_" + String.valueOf(i);
                 String sampleNameInHeader;
                 if ( samplesInHeaderCanMismatch && addDuplicateHeaderSamples && (i == 100 || i == 700) ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/GatherVcfsCloudIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/GatherVcfsCloudIntegrationTest.java
@@ -196,7 +196,7 @@ public class GatherVcfsCloudIntegrationTest extends CommandLineProgramTest{
 
     private static File writeShard(final List<VariantContext> variants, final VCFHeader header, final File dir, final int index){
         final File shard = new File( dir, + index + ".vcf.gz");
-        try(final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(shard, header.getSequenceDictionary(), false)){
+        try(final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(shard.toPath(), header.getSequenceDictionary(), false)){
             writer.writeHeader(header);
             variants.forEach(writer::add);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVIntervalVariantComposerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVIntervalVariantComposerUnitTest.java
@@ -72,7 +72,7 @@ public final class GermlineCNVIntervalVariantComposerUnitTest extends CommandLin
                                         final int baselineCopyNumber,
                                         final Allele expectedAllele) {
         final File outputFile = createTempFile("test", ".vcf");
-        final VariantContextWriter outputWriter = GATKVariantContextUtils.createVCFWriter(outputFile, null, false);
+        final VariantContextWriter outputWriter = GATKVariantContextUtils.createVCFWriter(outputFile.toPath(), null, false);
         final GermlineCNVIntervalVariantComposer variantComposer = new GermlineCNVIntervalVariantComposer(
                 outputWriter, "TEST_SAMPLE_NAME", new IntegerCopyNumberState(refAutosomalCopyNumber), allosomalContigs);
         final VariantContext var = variantComposer.composeVariantContext(

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVSegmentVariantComposerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVSegmentVariantComposerUnitTest.java
@@ -32,7 +32,7 @@ public final class GermlineCNVSegmentVariantComposerUnitTest extends GATKBaseTes
         final IntegerCopyNumberSegmentCollection collection = new IntegerCopyNumberSegmentCollection(
                 IntegerCopyNumberSegmentCollectionUnitTest.TEST_INTEGER_COPY_NUMBER_SEGMENTS_FILE);
         final File segmentsOutputVCF = createTempFile("test-write-segments", ".vcf");
-        final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(segmentsOutputVCF,
+        final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(segmentsOutputVCF.toPath(),
                 collection.getMetadata().getSequenceDictionary(), false);
         final GermlineCNVSegmentVariantComposer variantComposer = new GermlineCNVSegmentVariantComposer(
                 writer, IntegerCopyNumberSegmentCollectionUnitTest.EXPECTED_SAMPLE_NAME,

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
@@ -39,7 +39,7 @@ public class VcfOutputRendererUnitTest extends GATKBaseTest {
     public void testExclusionListOverridesManualDefaultAnnotations() {
         final Pair<VCFHeader, List<VariantContext>> entireInputVcf =  VariantContextTestUtils.readEntireVCFIntoMemory(TEST_VCF);
         final File outFile = createTempFile("vcf_output_renderer_exclusion", ".vcf");
-        final VariantContextWriter vcfWriter = GATKVariantContextUtils.createVCFWriter(outFile,null, false);
+        final VariantContextWriter vcfWriter = GATKVariantContextUtils.createVCFWriter(outFile.toPath(),null, false);
 
         final LinkedHashMap<String, String> dummyDefaults = new LinkedHashMap<>();
         dummyDefaults.put("FOO", "BAR");

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -719,7 +719,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         headerLines.add(VCFStandardHeaderLines.getFormatLine("GT"));
 
         final File out = createTempFile(sampleName +"_", ".vcf");
-        try (final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(out, dict, false,
+        try (final VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(out.toPath(), dict, false,
                                                                                          Options.INDEX_ON_THE_FLY)) {
             final VCFHeader vcfHeader = new VCFHeader(headerLines, Collections.singleton(sampleName));
             vcfHeader.setSequenceDictionary(dict);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -1,8 +1,12 @@
 package org.broadinstitute.hellbender.tools.walkers.variantutils;
 
+import java.util.List;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -899,5 +903,28 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                 Collections.singletonList(getToolTestDataDir() + "expected/" + expectedFile)
         );
         spec.executeTest("testDropAnnotations--" + testName, this);
+    }
+
+    @Test(groups = "bucket")
+    public void testSampleSelectionOnNio() throws IOException {
+        final String testFile = getToolTestDataDir() + "vcfexample2.vcf";
+
+        final String out = BucketUtils.getTempFilePath(
+            getGCPTestStaging() +"testSelectVariants_SimpleSelection", ".vcf");
+
+        final String[] args = new String[]{
+            "SelectVariants",
+            "-R", hg19MiniReference
+            , "--variant", testFile
+            , "-sn", "NA11918"
+            , "--suppress-reference-path" // suppress reference file path in output for test differencing
+            , "-O", out
+            , "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"};
+
+        final String expectedFile = getToolTestDataDir() + "expected/" + "testSelectVariants_SimpleSelection.vcf";
+
+        new Main().instanceMain(args);
+
+        IntegrationTestSpec.assertEqualTextFiles(IOUtils.getPath(out), IOUtils.getPath(expectedFile), null);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTrancheUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/TruthSensitivityTrancheUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.vqsr;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -21,7 +22,7 @@ public final class TruthSensitivityTrancheUnitTest extends GATKBaseTest {
 
     private ArrayList<VariantDatum> readData() throws IOException{
         ArrayList<VariantDatum> vd = new ArrayList<>();
-        try (XReadLines xrl = new XReadLines(QUAL_DATA, true)){
+        try (XReadLines xrl = new XReadLines(Utils.nonNull(QUAL_DATA).toPath(), true)){
             for ( String line : xrl ) {
                 String[] parts = line.split("\t");
                 // QUAL,TRANSITION,ID,LOD,FILTER

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantGaussianMixtureModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantGaussianMixtureModelUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.vqsr;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -23,7 +24,7 @@ public final class VariantGaussianMixtureModelUnitTest extends GATKBaseTest {
 
     private ArrayList<VariantDatum> readData() throws java.io.IOException{
         ArrayList<VariantDatum> vd = new ArrayList<VariantDatum>();
-        for ( String line : new XReadLines(QUAL_DATA, true) ) {
+        for ( String line : new XReadLines(Utils.nonNull(QUAL_DATA).toPath(), true) ) {
             String[] parts = line.split("\t");
             // QUAL,TRANSITION,ID,LOD,FILTER
             if ( ! parts[0].equals("QUAL") ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/GVCFWriterUnitTest.java
@@ -461,7 +461,7 @@ public class GVCFWriterUnitTest extends GATKBaseTest {
         final List<Number> gqPartitions = Arrays.asList(1, 10, 30);
         final File outputFile =  createTempFile("generated", ".g.vcf");
 
-        try (VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(outputFile, null, false);
+        try (VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(outputFile.toPath(), null, false);
              GVCFWriter gvcfWriter = new GVCFWriter(writer, gqPartitions, HomoSapiensConstants.DEFAULT_PLOIDY))
         {
             gvcfWriter.writeHeader(getMinimalVCFHeader());
@@ -579,7 +579,7 @@ public class GVCFWriterUnitTest extends GATKBaseTest {
                                                                                                               Allele.NON_REF_ALLELE))
                 .genotypes(block3genotypeBuilder.make());
 
-        try (VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(outputFile, null, false);
+        try (VariantContextWriter writer = GATKVariantContextUtils.createVCFWriter(outputFile.toPath(), null, false);
              GVCFWriter gvcfWriter = new GVCFWriter(writer, gqPartitions, HomoSapiensConstants.DEFAULT_PLOIDY))
         {
             gvcfWriter.writeHeader(getMinimalVCFHeader());
@@ -601,7 +601,6 @@ public class GVCFWriterUnitTest extends GATKBaseTest {
         }
 
         IntegrationTestSpec.assertEqualTextFiles(outputFile, comparisonFile);
-
     }
 
     @Test


### PR DESCRIPTION
NIO output support for SelectVariants. Tested like so:

```
$ ./gatk SelectVariants \
  --variant dbsnp_138.b37.excluding_sites_after_129.vcf \
  --select-random-fraction 0.01 \
  --output gs://mybucket/variants.vcf
$ gsutil ls -lh gs://mybucket/*.vcf
 23.38 MiB  2018-10-30T23:58:12Z  gs://mybucket/variants.vcf
```

Includes the required changes under the hood, plus test updates.

This change also gives NIO support to **HaplotypeCaller**, so it can write its VCF to cloud storage.

Also, fixes #2128.