### PR TITLE
More tooling of combine_tracks.wdl

### DIFF
--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -16,6 +16,10 @@
 #   This may be useful for excluding centromeric regions, etc. from analysis.  Alternatively, these regions may
 #   be manually filtered from the final callset.
 #
+#  A reasonable blacklist for excluded intervals (-XL) can be found at:
+#   hg19: gs://gatk-best-practices/somatic-b37/CNV_and_centromere_blacklist.hg19.list
+#   hg38: gs://gatk-best-practices/somatic-hg38/CNV_and_centromere_blacklist.hg38liftover.list (untested)
+#
 # - The sites file (common_sites) should be a Picard or GATK-style interval list.  This is a list of sites
 #   of known variation at which allelic counts will be collected for use in modeling minor-allele fractions.
 #

--- a/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
@@ -16,6 +16,10 @@
 #   This may be useful for excluding centromeric regions, etc. from analysis.  Alternatively, these regions may
 #   be manually filtered from the final callset.
 #
+#  A reasonable blacklist for excluded intervals (-XL) can be found at:
+#   hg19: gs://gatk-best-practices/somatic-b37/CNV_and_centromere_blacklist.hg19.list
+#   hg38: gs://gatk-best-practices/somatic-hg38/CNV_and_centromere_blacklist.hg38liftover.list (untested)
+#
 # - Example invocation:
 #
 #       java -jar cromwell.jar run cnv_somatic_panel_workflow.wdl -i my_parameters.json

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -177,6 +177,7 @@ workflow CombineTracksWorkflow {
         File cnv_postprocessing_normal_igv_compat = IGVConvertNormal.outFile
         File cnv_postprocessing_tumor_with_tracks_filtered_seg = FilterGermlineTagged.tumor_with_germline_filtered_seg
         File cnv_postprocessing_tumor_with_tracks_filtered_merged_seg = IGVConvertMergedTumorOutput.outFile
+        File cnv_postprocessing_tumor_with_tracks_filtered_merged_seg_ms_format = MergeSegmentByAnnotation.cnv_merged_seg
         File cnv_postprocessing_tumor_with_tracks_tagged_seg = CombineTracks.germline_tagged_with_tracks_seg
         File cnv_postprocessing_tumor_acs_seg = PrototypeACSConversion.cnv_acs_conversion_seg
         File cnv_postprocessing_tumor_acs_skew = PrototypeACSConversion.cnv_acs_conversion_skew
@@ -443,7 +444,7 @@ task PrototypeACSConversion {
     String output_filename = basename(model_seg) + ".acs.seg"
     String output_skew_filename = output_filename + ".skew"
     Int? min_hets_acs_results
-    Int min_hets_acs_results_final = select_first([min_hets_acs_results,10])
+    Int min_hets_acs_results_final = select_first([min_hets_acs_results, 0])
 
     command <<<
         set -e

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -1,4 +1,4 @@
-# A postprocessing workflow for GATK CNV.
+# A postprocessing workflow for GATK CNV ModelSegments.
 #
 # THIS CANNOT BE RUN IN TUMOR-ONLY MODE.  A MATCHED NORMAL IS REQUIRED.
 #
@@ -35,12 +35,19 @@
 #  - This workflow has not been tested with hg38
 #  - Evaluation of germline tagging and blacklists on hg38 is still pending.
 #  - Evaluation of the conversion to ACS format for ABSOLUTE is still pending.
+#  - Performance increases (both sensitivity and precision) over this workflow when using a blacklist during PoN creation and running of case samples.
 #
-# Auxiliary files (hg19):
+#  A blacklist for that can be found at:
+#   - hg19: gs://gatk-best-practices/somatic-b37/CNV_and_centromere_blacklist.hg19.list
+#   - hg38: gs://gatk-best-practices/somatic-hg38/CNV_and_centromere_blacklist.hg38liftover.seg
+#
+# Do not attempt to use the above blacklists for this workflow.  See below:
+#
+# Auxiliary files for this workflow (hg19):
 #  - centromere_tracks_seg: gs://gatk-best-practices/somatic-b37/final_centromere_hg19.seg
 #  - gistic_blacklist_tracks_seg:  gs://gatk-best-practices/somatic-b37/CNV.hg19.bypos.v1.CR1_event_added.mod.seg
 #
-# Auxiliary files (hg38) -- these are untested and the gistic list is a liftover:
+# Auxiliary files for this workflow (hg38) -- these are untested and the gistic list is a liftover:
 #  - centromere_tracks_seg:  gs://gatk-best-practices/somatic-hg38/final_centromere_hg38.seg
 #  - gistic_blacklist_tracks_seg:  gs://gatk-best-practices/somatic-hg38/CNV.hg38liftover.bypos.v1.CR1_event_added.mod.seg
 #

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -64,6 +64,7 @@ workflow CombineTracksWorkflow {
     Int? max_merge_distance
     Array[String]? annotations_on_which_to_merge
     Int? min_hets_acs_results
+    Float? maf90_threshold
 
     Array[String]? annotations_on_which_to_merge_final = select_first([annotations_on_which_to_merge,
     ["MEAN_LOG2_COPY_RATIO", "LOG2_COPY_RATIO_POSTERIOR_10", "LOG2_COPY_RATIO_POSTERIOR_50", "LOG2_COPY_RATIO_POSTERIOR_90",
@@ -151,7 +152,8 @@ workflow CombineTracksWorkflow {
             model_seg = MergeSegmentByAnnotation.cnv_merged_seg,
             af_param = af_param,
             docker = gatk_docker,
-            min_hets_acs_results = min_hets_acs_results
+            min_hets_acs_results = min_hets_acs_results,
+            maf90_threshold = maf90_threshold
     }
 
     call IGVConvert as IGVConvertMergedTumorOutput {

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -279,8 +279,10 @@ import pandas
 import os.path
 tumor_tagged = "${germline_tagged_seg}"
 
-tumor_tagged_df = pandas.read_csv(tumor_tagged, delimiter="\t", comment="@")
-tumor_tagged_pruned_df = tumor_tagged_df[(tumor_tagged_df["POSSIBLE_GERMLINE"] == "0") & (tumor_tagged_df["type"] != "centromere") & (tumor_tagged_df["ID"].isna())]
+tumor_tagged_df = pandas.read_csv(tumor_tagged, delimiter='\t', comment="@")
+tumor_tagged_df["POSSIBLE_GERMLINE"] = tumor_tagged_df["POSSIBLE_GERMLINE"].astype('str')
+tumor_tagged_pruned_df = tumor_tagged_df[((tumor_tagged_df["POSSIBLE_GERMLINE"] == "0.0") | (tumor_tagged_df["POSSIBLE_GERMLINE"] == "0") ) & (tumor_tagged_df["type"] != "centromere") & (tumor_tagged_df["ID"].isna())]
+
 output_filename = "${output_filename}"
 print(output_filename)
 tumor_tagged_pruned_df.to_csv(output_filename, sep="\t", index=False)

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/combine_tracks.wdl
@@ -474,7 +474,7 @@ model_segments_af_param_input_file = "${af_param}"
 alleliccapseg_seg_output_file = "${output_filename}"
 alleliccapseg_skew_output_file = "${output_skew_filename}"
 
-HAM_FIST_THRESHOLD=${default="0.485" maf90_threshold}
+HAM_FIST_THRESHOLD=${default="0.47" maf90_threshold}
 
 # regular expression for matching sample name from header comment line
 sample_name_header_regexp = "^@RG.*SM:(.*)[\t]*.*$"

--- a/scripts/unsupported/combine_tracks_postprocessing_cnv/multi_combine_tracks.wdl
+++ b/scripts/unsupported/combine_tracks_postprocessing_cnv/multi_combine_tracks.wdl
@@ -18,6 +18,7 @@ workflow MultiCombineTracks {
         Int? germline_tagging_padding
         String group_id
         String gatk_docker
+        Int? min_hets_acs_results
 
         scatter (i in range(length(tumor_called_segs))) {
 
@@ -36,7 +37,8 @@ workflow MultiCombineTracks {
                     columns_of_interest = columns_of_interest,
                     germline_tagging_padding = germline_tagging_padding,
                     group_id = group_id,
-                    gatk_docker = gatk_docker
+                    gatk_docker = gatk_docker,
+                    min_hets_acs_results = min_hets_acs_results
             }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/utils/annotatedinterval/AnnotatedIntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/utils/annotatedinterval/AnnotatedIntervalUtilsUnitTest.java
@@ -213,7 +213,7 @@ public class AnnotatedIntervalUtilsUnitTest extends GATKBaseTest {
                                     ImmutableSortedMap.of("Foo", "1234", "Bar", "abcd", "Baz", "wxyz")),
                             new AnnotatedInterval( new SimpleInterval("1", 250001, 300000),
                                     ImmutableSortedMap.of("Foo", "1234", "Bar", "abcd", "Baz", "wxyzabc")),
-                            new AnnotatedInterval( new SimpleInterval("1", 350001, 300000),
+                            new AnnotatedInterval( new SimpleInterval("1", 350001, 400000),
                                     ImmutableSortedMap.of("Foo", "5678", "Bar", "abcd", "Baz", "wxyzabc"))
                     ), Collections.singletonList("Foo"), 100000,
                     Arrays.asList(
@@ -222,6 +222,15 @@ public class AnnotatedIntervalUtilsUnitTest extends GATKBaseTest {
                             new AnnotatedInterval( new SimpleInterval("1", 350001, 400000),
                                     ImmutableSortedMap.of("Foo", "5678", "Bar", "abcd", "Baz", "wxyzabc"))
                     )
+                }, {
+                    Collections.singletonList(
+                            new AnnotatedInterval( new SimpleInterval("1", 100000, 200000),
+                                    ImmutableSortedMap.of("Foo", "1234", "Bar", "abcd", "Baz", "wxyz"))
+                            ), Collections.singletonList("Foo"), 100000,
+                    Collections.singletonList(
+                            new AnnotatedInterval( new SimpleInterval("1", 100000, 200000),
+                                ImmutableSortedMap.of("Foo", "1234", "Bar", "abcd", "Baz", "wxyz"))
+                            )
                 }
         };
     }


### PR DESCRIPTION
- Fixed automated test for that was being skipped.  When re-enabled, it passed without code changes.
- Added automated test.  Passed without any other code changes.
- Added documentation for blacklisting when running the PoN and case sample/pair workflows (as opposed to using the postprocessing combine_tracks.wdl).
- Added hard num het filter.  This helps guard against oversegmentation skewing MAF estimates.  For WGS, `10` is a reasonable value.
- Changed default maf threshold for calling balanced segments.  The previous value was too sensitive.