### PR TITLE
 Make HaplotypeCallerSpark extend AssemblyRegionWalkerSpark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionArgumentCollection.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
+
+import java.io.Serializable;
+
+public abstract class AssemblyRegionArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(fullName = "minAssemblyRegionSize", shortName = "minAssemblyRegionSize", doc = "Minimum size of an assembly region", optional = true)
+    public int minAssemblyRegionSize = defaultMinAssemblyRegionSize();
+
+    @Argument(fullName = "maxAssemblyRegionSize", shortName = "maxAssemblyRegionSize", doc = "Maximum size of an assembly region", optional = true)
+    public int maxAssemblyRegionSize = defaultMaxAssemblyRegionSize();
+
+    @Argument(fullName = "assemblyRegionPadding", shortName = "assemblyRegionPadding", doc = "Number of additional bases of context to include around each assembly region", optional = true)
+    public int assemblyRegionPadding = defaultAssemblyRegionPadding();
+
+    @Argument(fullName = "maxReadsPerAlignmentStart", shortName = "maxReadsPerAlignmentStart", doc = "Maximum number of reads to retain per alignment start position. Reads above this threshold will be downsampled. Set to 0 to disable.", optional = true)
+    public int maxReadsPerAlignmentStart = defaultMaxReadsPerAlignmentStart();
+
+    @Advanced
+    @Argument(fullName = "activeProbabilityThreshold", shortName = "activeProbabilityThreshold", doc="Minimum probability for a locus to be considered active.", optional = true)
+    public double activeProbThreshold = defaultActiveProbThreshold();
+
+    @Advanced
+    @Argument(fullName = "maxProbPropagationDistance", shortName = "maxProbPropagationDistance", doc="Upper limit on how many bases away probability mass can be moved around when calculating the boundaries between active and inactive assembly regions", optional = true)
+    public int maxProbPropagationDistance = defaultMaxProbPropagationDistance();
+
+    /**
+     * @return Default value for the {@link #minAssemblyRegionSize} parameter, if none is provided on the command line
+     */
+    protected abstract int defaultMinAssemblyRegionSize();
+
+    /**
+     * @return Default value for the {@link #maxAssemblyRegionSize} parameter, if none is provided on the command line
+     */
+    protected abstract int defaultMaxAssemblyRegionSize();
+
+    /**
+     * @return Default value for the {@link #assemblyRegionPadding} parameter, if none is provided on the command line
+     */
+    protected abstract int defaultAssemblyRegionPadding();
+
+    /**
+     * @return Default value for the {@link #maxReadsPerAlignmentStart} parameter, if none is provided on the command line
+     */
+    protected abstract int defaultMaxReadsPerAlignmentStart();
+
+    /**
+     * @return Default value for the {@link #activeProbThreshold} parameter, if none is provided on the command line
+     */
+    protected abstract double defaultActiveProbThreshold();
+
+    /**
+     * @return Default value for the {@link #maxProbPropagationDistance} parameter, if none is provided on the command line
+     */
+    protected abstract int defaultMaxProbPropagationDistance();
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionReadShardArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionReadShardArgumentCollection.java
@@ -1,0 +1,18 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.broadinstitute.barclay.argparser.Argument;
+
+import java.io.Serializable;
+
+public class AssemblyRegionReadShardArgumentCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final int DEFAULT_READSHARD_SIZE = 5000;
+    public static final int DEFAULT_READSHARD_PADDING_SIZE = 100;
+
+    @Argument(fullName="readShardSize", shortName="readShardSize", doc = "Maximum size of each read shard, in bases. For good performance, this should be much larger than the maximum assembly region size.", optional = true)
+    public int readShardSize = DEFAULT_READSHARD_SIZE;
+
+    @Argument(fullName="readShardPadding", shortName="readShardPadding", doc = "Each read shard has this many bases of extra context on each side. Read shards must have as much or more padding than assembly regions.", optional = true)
+    public int readShardPadding = DEFAULT_READSHARD_PADDING_SIZE;
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.engine.spark;
 
+import com.google.common.collect.Iterators;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.apache.spark.SparkFiles;
@@ -7,23 +8,25 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
-import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.hellbender.engine.*;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.tools.DownsampleableSparkReadShard;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.downsampling.PositionalDownsampler;
+import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -74,6 +77,20 @@ public abstract class AssemblyRegionWalkerSpark extends GATKSparkTool {
      */
     public abstract AssemblyRegionEvaluator assemblyRegionEvaluator();
 
+    /**
+     * Tools that use an evaluator that is expensive to create, and/or that is not compatible with Spark broadcast, can
+     * override this method to return a broadcast of a supplier of the evaluator. The supplier will be invoked once for
+     * each Spark partition, thus each partition will have its own evaluator instance.
+     */
+    protected Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast(final JavaSparkContext ctx) {
+        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, assemblyRegionEvaluator());
+    }
+
+    private static Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcastFunction(final JavaSparkContext ctx, final AssemblyRegionEvaluator assemblyRegionEvaluator) {
+        Supplier<AssemblyRegionEvaluator> supplier = () -> assemblyRegionEvaluator;
+        return ctx.broadcast(supplier);
+    }
+
     private List<ShardBoundary> intervalShards;
 
     /**
@@ -100,34 +117,61 @@ public abstract class AssemblyRegionWalkerSpark extends GATKSparkTool {
      */
     protected JavaRDD<AssemblyRegionWalkerContext> getAssemblyRegions(JavaSparkContext ctx) {
         SAMSequenceDictionary sequenceDictionary = getBestAvailableSequenceDictionary();
-        JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, getReads(), GATKRead.class, sequenceDictionary, intervalShards, shardingArgs.readShardSize, shuffle);
-        Broadcast<FeatureManager> bFeatureManager = features == null ? null : ctx.broadcast(features);
-        return shardedReads.flatMap(getAssemblyRegionsFunction(referenceFileName, bFeatureManager, getHeaderForReads(),
-                assemblyRegionEvaluator(), assemblyRegionArgs, includeReadsWithDeletionsInIsActivePileups()));
+        return getAssemblyRegions(ctx, getReads(), getHeaderForReads(), sequenceDictionary, referenceFileName, features,
+                intervalShards, assemblyRegionEvaluatorSupplierBroadcast(ctx), shardingArgs, assemblyRegionArgs,
+                includeReadsWithDeletionsInIsActivePileups(), shuffle);
     }
 
-    private static FlatMapFunction<Shard<GATKRead>, AssemblyRegionWalkerContext> getAssemblyRegionsFunction(
+    protected static JavaRDD<AssemblyRegionWalkerContext> getAssemblyRegions(
+            final JavaSparkContext ctx,
+            final JavaRDD<GATKRead> reads,
+            final SAMFileHeader header,
+            final SAMSequenceDictionary sequenceDictionary,
+            final String referenceFileName,
+            final FeatureManager features,
+            final List<ShardBoundary> intervalShards,
+            final Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast,
+            final AssemblyRegionReadShardArgumentCollection shardingArgs,
+            final AssemblyRegionArgumentCollection assemblyRegionArgs,
+            final boolean includeReadsWithDeletionsInIsActivePileups,
+            final boolean shuffle) {
+        JavaRDD<Shard<GATKRead>> shardedReads = SparkSharder.shard(ctx, reads, GATKRead.class, sequenceDictionary, intervalShards, shardingArgs.readShardSize, shuffle);
+        Broadcast<FeatureManager> bFeatureManager = features == null ? null : ctx.broadcast(features);
+        return shardedReads.mapPartitions(getAssemblyRegionsFunction(referenceFileName, bFeatureManager, header,
+                assemblyRegionEvaluatorSupplierBroadcast, assemblyRegionArgs, includeReadsWithDeletionsInIsActivePileups));
+    }
+
+    private static FlatMapFunction<Iterator<Shard<GATKRead>>, AssemblyRegionWalkerContext> getAssemblyRegionsFunction(
             final String referenceFileName,
             final Broadcast<FeatureManager> bFeatureManager,
             final SAMFileHeader header,
-            final AssemblyRegionEvaluator evaluator,
+            final Broadcast<Supplier<AssemblyRegionEvaluator>> supplierBroadcast,
             final AssemblyRegionArgumentCollection assemblyRegionArgs,
             final boolean includeReadsWithDeletionsInIsActivePileups) {
-        return (FlatMapFunction<Shard<GATKRead>, AssemblyRegionWalkerContext>) shardedRead -> {
+        return (FlatMapFunction<Iterator<Shard<GATKRead>>, AssemblyRegionWalkerContext>) shardedReadIterator -> {
             ReferenceDataSource reference = referenceFileName == null ? null : new ReferenceFileSource(IOUtils.getPath(SparkFiles.get(referenceFileName)));
             final FeatureManager features = bFeatureManager == null ? null : bFeatureManager.getValue();
+            AssemblyRegionEvaluator assemblyRegionEvaluator = supplierBroadcast.getValue().get(); // one AssemblyRegionEvaluator instance per Spark partition
+            final ReadsDownsampler readsDownsampler = assemblyRegionArgs.maxReadsPerAlignmentStart > 0 ?
+                    new PositionalDownsampler(assemblyRegionArgs.maxReadsPerAlignmentStart, header) : null;
 
-            final Iterator<AssemblyRegion> assemblyRegionIter = new AssemblyRegionIterator(
-                    new ShardToMultiIntervalShardAdapter<>(shardedRead),
-                    header, reference, features, evaluator,
-                    assemblyRegionArgs.minAssemblyRegionSize, assemblyRegionArgs.maxAssemblyRegionSize,
-                    assemblyRegionArgs.assemblyRegionPadding, assemblyRegionArgs.activeProbThreshold,
-                    assemblyRegionArgs.maxProbPropagationDistance, includeReadsWithDeletionsInIsActivePileups);
-            final Iterable<AssemblyRegion> assemblyRegions = () -> assemblyRegionIter;
-            return Utils.stream(assemblyRegions).map(assemblyRegion ->
-                    new AssemblyRegionWalkerContext(assemblyRegion,
-                        new ReferenceContext(reference, assemblyRegion.getExtendedSpan()),
-                        new FeatureContext(features, assemblyRegion.getExtendedSpan()))).iterator();
+            Iterator<Iterator<AssemblyRegionWalkerContext>> iterators = Utils.stream(shardedReadIterator)
+                    .map(shardedRead -> new ShardToMultiIntervalShardAdapter<>(
+                            new DownsampleableSparkReadShard(
+                                    new ShardBoundary(shardedRead.getInterval(), shardedRead.getPaddedInterval()), shardedRead, readsDownsampler)))
+                    .map(shardedRead -> {
+                final Iterator<AssemblyRegion> assemblyRegionIter = new AssemblyRegionIterator(
+                        new ShardToMultiIntervalShardAdapter<>(shardedRead),
+                        header, reference, features, assemblyRegionEvaluator,
+                        assemblyRegionArgs.minAssemblyRegionSize, assemblyRegionArgs.maxAssemblyRegionSize,
+                        assemblyRegionArgs.assemblyRegionPadding, assemblyRegionArgs.activeProbThreshold,
+                        assemblyRegionArgs.maxProbPropagationDistance, includeReadsWithDeletionsInIsActivePileups);
+                return Utils.stream(assemblyRegionIter).map(assemblyRegion ->
+                        new AssemblyRegionWalkerContext(assemblyRegion,
+                                new ReferenceContext(reference, assemblyRegion.getExtendedSpan()),
+                                new FeatureContext(features, assemblyRegion.getExtendedSpan()))).iterator();
+            }).iterator();
+            return Iterators.concat(iterators);
         };
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -1,59 +1,55 @@
 package org.broadinstitute.hellbender.tools;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterators;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.logging.log4j.Logger;
 import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
-import org.broadinstitute.barclay.argparser.*;
-import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.*;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
-import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.engine.AssemblyRegion;
+import org.broadinstitute.hellbender.engine.AssemblyRegionEvaluator;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.ShardBoundary;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
 import org.broadinstitute.hellbender.engine.spark.AssemblyRegionReadShardArgumentCollection;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
-import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
-import org.broadinstitute.hellbender.engine.ShardToMultiIntervalShardAdapter;
-import org.broadinstitute.hellbender.engine.spark.SparkSharder;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionWalkerContext;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionWalkerSpark;
 import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSink;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.walkers.annotator.*;
+import org.broadinstitute.hellbender.tools.examples.ExampleAssemblyRegionWalkerSpark;
+import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
+import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCaller;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerEngine;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReferenceConfidenceMode;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.downsampling.PositionalDownsampler;
-import org.broadinstitute.hellbender.utils.downsampling.ReadsDownsampler;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
-import scala.Tuple2;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * ********************************************************************************
@@ -81,11 +77,10 @@ import java.util.stream.Stream;
 @CommandLineProgramProperties(summary = "HaplotypeCaller on Spark", oneLineSummary = "HaplotypeCaller on Spark", programGroup = ShortVariantDiscoveryProgramGroup.class)
 @DocumentedFeature
 @BetaFeature
-public final class HaplotypeCallerSpark extends GATKSparkTool {
+public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
     private static final long serialVersionUID = 1L;
 
     public static final int DEFAULT_READSHARD_SIZE = 5000;
-    private static final boolean INCLUDE_READS_WITH_DELETIONS_IN_IS_ACTIVE_PILEUPS = true;
 
     @Argument(fullName= StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Single file to which variants should be written")
     public String output;
@@ -112,22 +107,16 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         protected int defaultMaxProbPropagationDistance() { return HaplotypeCaller.DEFAULT_MAX_PROB_PROPAGATION_DISTANCE; }
     }
 
-    @ArgumentCollection
-    public final AssemblyRegionReadShardArgumentCollection shardingArgs = new AssemblyRegionReadShardArgumentCollection();
-
-    @ArgumentCollection
-    public final AssemblyRegionArgumentCollection assemblyRegionArgs = new HaplotypeCallerAssemblyRegionArgumentCollection();
+    @Override
+    protected AssemblyRegionArgumentCollection getAssemblyRegionArgumentCollection() {
+        return new ExampleAssemblyRegionWalkerSpark.ExampleAssemblyRegionArgumentCollection();
+    }
 
     @ArgumentCollection
     public HaplotypeCallerArgumentCollection hcArgs = new HaplotypeCallerArgumentCollection();
 
     @Override
-    public boolean requiresReads(){
-        return true;
-    }
-
-    @Override
-    public boolean requiresReference(){
+    protected boolean includeReadsWithDeletionsInIsActivePileups() {
         return true;
     }
 
@@ -145,12 +134,27 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
     }
 
     @Override
-    protected void runTool(final JavaSparkContext ctx) {
+    protected void processAssemblyRegions(JavaRDD<AssemblyRegionWalkerContext> rdd, JavaSparkContext ctx) {
+        processAssemblyRegions(rdd, ctx, getHeaderForReads(), referenceArguments.getReferenceFileName(), hcArgs, output, makeVariantAnnotations(), logger);
+    }
+
+    private static void processAssemblyRegions(
+            JavaRDD<AssemblyRegionWalkerContext> rdd,
+            final JavaSparkContext ctx,
+            final SAMFileHeader header,
+            final String reference,
+            final HaplotypeCallerArgumentCollection hcArgs,
+            final String output,
+            final Collection<Annotation> annotations,
+            final Logger logger) {
         //TODO remove me when https://github.com/broadinstitute/gatk/issues/4303 are fixed
         if (output.endsWith(IOUtil.BCF_FILE_EXTENSION) || output.endsWith(IOUtil.BCF_FILE_EXTENSION + ".gz")) {
             throw new UserException.UnimplementedFeature("It is currently not possible to write a BCF file on spark.  See https://github.com/broadinstitute/gatk/issues/4303 for more details .");
         }
-        SAMFileHeader header = getHeaderForReads();
+        Utils.validateArg(hcArgs.dbsnp.dbsnp == null, "HaplotypeCallerSpark does not yet support -D or --dbsnp arguments" );
+        Utils.validateArg(hcArgs.comps.isEmpty(), "HaplotypeCallerSpark does not yet support -comp or --comp arguments" );
+        Utils.validateArg(hcArgs.bamOutputPath == null, "HaplotypeCallerSpark does not yet support -bamout or --bamOutput");
+
         Utils.validate(header.getSortOrder() == SAMFileHeader.SortOrder.coordinate, "The reads must be coordinate sorted.");
         logger.info("********************************************************************************");
         logger.info("The output of this tool DOES NOT match the output of HaplotypeCaller. ");
@@ -158,50 +162,18 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         logger.info("For evaluation only.");
         logger.info("Use the non-spark HaplotypeCaller if you care about the results. ");
         logger.info("********************************************************************************");
-        addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
-        final List<SimpleInterval> intervals = hasUserSuppliedIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(header.getSequenceDictionary());
-        callVariantsWithHaplotypeCallerAndWriteOutput(ctx, getReads(), header, referenceArguments.getReferenceFileName(), intervals, hcArgs, shardingArgs, assemblyRegionArgs, numReducers, output, makeVariantAnnotations());
-    }
 
-    @Override
-    public List<ReadFilter> getDefaultReadFilters() {
-        return HaplotypeCallerEngine.makeStandardHCReadFilters();
-    }
-
-    /**
-     * Call Variants using HaplotypeCaller on Spark and write out a VCF file.
-     *
-     * This may be called from any spark pipeline in order to call variants from an RDD of GATKRead
-     *
-     * @param ctx the spark context
-     * @param reads the reads variants should be called from
-     * @param header the header that goes with the reads
-     * @param reference the full path to the reference file (must have been added via {@code SparkContext#addFile()})
-     * @param intervals the intervals to restrict calling to
-     * @param hcArgs haplotype caller arguments
-     * @param shardingArgs arguments to control how the assembly regions are sharded
-     * @param numReducers the number of reducers to use when sorting
-     * @param output the output path for the VCF
-     */
-    public static void callVariantsWithHaplotypeCallerAndWriteOutput(
-            final JavaSparkContext ctx,
-            final JavaRDD<GATKRead> reads,
-            final SAMFileHeader header,
-            final String reference,
-            final List<SimpleInterval> intervals,
-            final HaplotypeCallerArgumentCollection hcArgs,
-            final AssemblyRegionReadShardArgumentCollection shardingArgs,
-            final AssemblyRegionArgumentCollection assemblyRegionArgs,
-            final int numReducers,
-            final String output,
-            final Collection<Annotation> annotations) {
         final VariantAnnotatorEngine variantannotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE);
 
         final Path referencePath = IOUtils.getPath(reference);
         final ReferenceSequenceFile driverReferenceSequenceFile = new CachingIndexedFastaSequenceFile(referencePath);
         final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, false, false, header, driverReferenceSequenceFile, variantannotatorEngine);
         final String referenceFileName = referencePath.getFileName().toString();
-        final JavaRDD<VariantContext> variants = callVariantsWithHaplotypeCaller(ctx, reads, header, referenceFileName, intervals, hcArgs, shardingArgs, assemblyRegionArgs, variantannotatorEngine);
+        final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast = ctx.broadcast(hcArgs);
+        final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast = ctx.broadcast(variantannotatorEngine);
+
+        final JavaRDD<VariantContext> variants = rdd.mapPartitions(assemblyFunction(header, referenceFileName, hcArgsBroadcast, annotatorEngineBroadcast));
+
         variants.cache(); // without caching, computations are run twice as a side effect of finding partition boundaries for sorting
         try {
             VariantsSparkSink.writeVariants(ctx, output, variants, hcEngine.makeVCFHeader(header.getSequenceDictionary(), new HashSet<>()),
@@ -211,200 +183,106 @@ public final class HaplotypeCallerSpark extends GATKSparkTool {
         }
     }
 
+    private static FlatMapFunction<Iterator<AssemblyRegionWalkerContext>, VariantContext> assemblyFunction(final SAMFileHeader header,
+                                                                                                           final String referenceFileName,
+                                                                                                           final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast,
+                                                                                                           final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast) {
+        return (FlatMapFunction<Iterator<AssemblyRegionWalkerContext>, VariantContext>) contexts -> {
+            // HaplotypeCallerEngine isn't serializable but is expensive to instantiate, so construct and reuse one for every partition
+            final ReferenceSequenceFile taskReferenceSequenceFile = taskReferenceSequenceFile(referenceFileName);
+            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, taskReferenceSequenceFile, annotatorEngineBroadcast.getValue());
+            Iterator<Iterator<VariantContext>> iterators = Utils.stream(contexts).map(context -> {
+                AssemblyRegion region = context.getAssemblyRegion();
+                FeatureContext featureContext = context.getFeatureContext();
+                return hcEngine.callRegion(region, featureContext).iterator();
+            }).iterator();
+
+            return Iterators.concat(iterators);
+        };
+    }
+
+    @Override
+    public List<ReadFilter> getDefaultReadFilters() {
+        return HaplotypeCallerEngine.makeStandardHCReadFilters();
+    }
+
+    @Override
+    public AssemblyRegionEvaluator assemblyRegionEvaluator() {
+        return null; // not used (see assemblyRegionEvaluatorSupplierBroadcast)
+    }
+
+    @Override
+    protected Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast(final JavaSparkContext ctx) {
+        final Path referencePath = IOUtils.getPath(referenceArguments.getReferenceFileName());
+        final String referenceFileName = referencePath.getFileName().toString();
+        final String pathOnExecutor = SparkFiles.get(referenceFileName);
+        final ReferenceSequenceFile taskReferenceSequenceFile = new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
+        final Collection<Annotation> annotations = makeVariantAnnotations();
+        final VariantAnnotatorEngine annotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE);
+        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, getHeaderForReads(), taskReferenceSequenceFile, annotatorEngine);
+    }
+
+    private static Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast(
+            final JavaSparkContext ctx,
+            final HaplotypeCallerArgumentCollection hcArgs,
+            final SAMFileHeader header,
+            final String reference,
+            final Collection<Annotation> annotations) {
+        final Path referencePath = IOUtils.getPath(reference);
+        final String referenceFileName = referencePath.getFileName().toString();
+        final ReferenceSequenceFile taskReferenceSequenceFile = taskReferenceSequenceFile(referenceFileName);
+        final VariantAnnotatorEngine annotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE);
+        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, header, taskReferenceSequenceFile, annotatorEngine);
+    }
+
+    private static ReferenceSequenceFile taskReferenceSequenceFile(final String referenceFileName) {
+        final String pathOnExecutor = SparkFiles.get(referenceFileName);
+        return new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
+    }
+
+    private static Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcastFunction(
+            final JavaSparkContext ctx,
+            final HaplotypeCallerArgumentCollection hcArgs,
+            final SAMFileHeader header,
+            final ReferenceSequenceFile taskReferenceSequenceFile,
+            final VariantAnnotatorEngine annotatorEngine) {
+        Supplier<AssemblyRegionEvaluator> supplier = () -> new HaplotypeCallerEngine(hcArgs, false, false, header, taskReferenceSequenceFile, annotatorEngine);
+        return ctx.broadcast(supplier);
+    }
+
     /**
-     * Call Variants using HaplotypeCaller on Spark and return an RDD of  {@link VariantContext}
+     * Call Variants using HaplotypeCaller on Spark and write out a VCF file.
      *
      * This may be called from any spark pipeline in order to call variants from an RDD of GATKRead
-     *
      * @param ctx the spark context
      * @param reads the reads variants should be called from
      * @param header the header that goes with the reads
-     * @param referenceFileName the name of the reference file added via {@code SparkContext#addFile()}
-     * @param intervals the intervals to restrict calling to
+     * @param reference the full path to the reference file (must have been added via {@code SparkContext#addFile()})
+     * @param intervalShards the interval shards to restrict calling to
      * @param hcArgs haplotype caller arguments
      * @param shardingArgs arguments to control how the assembly regions are sharded
-     * @param variantannotatorEngine
-     * @return an RDD of Variants
+     * @param output the output path for the VCF
+     * @param logger
      */
-    public static JavaRDD<VariantContext> callVariantsWithHaplotypeCaller(
+    public static void callVariantsWithHaplotypeCallerAndWriteOutput(
             final JavaSparkContext ctx,
             final JavaRDD<GATKRead> reads,
             final SAMFileHeader header,
-            final String referenceFileName,
-            final List<SimpleInterval> intervals,
+            final SAMSequenceDictionary sequenceDictionary,
+            final String reference,
+            final List<ShardBoundary> intervalShards,
             final HaplotypeCallerArgumentCollection hcArgs,
             final AssemblyRegionReadShardArgumentCollection shardingArgs,
             final AssemblyRegionArgumentCollection assemblyRegionArgs,
-            final VariantAnnotatorEngine variantannotatorEngine) {
-        Utils.validateArg(hcArgs.dbsnp.dbsnp == null, "HaplotypeCallerSpark does not yet support -D or --dbsnp arguments" );
-        Utils.validateArg(hcArgs.comps.isEmpty(), "HaplotypeCallerSpark does not yet support -comp or --comp arguments" );
-        Utils.validateArg(hcArgs.bamOutputPath == null, "HaplotypeCallerSpark does not yet support -bamout or --bamOutput");
+            final boolean includeReadsWithDeletionsInIsActivePileups,
+            final String output,
+            final Collection<Annotation> annotations,
+            final Logger logger) {
 
-        final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast = ctx.broadcast(hcArgs);
-
-        final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast = ctx.broadcast(variantannotatorEngine);
-
-        final List<ShardBoundary> shardBoundaries = getShardBoundaries(header, intervals, shardingArgs.readShardSize, shardingArgs.readShardPadding);
-
-        final int maxReadLength = reads.map(r -> r.getEnd() - r.getStart() + 1).reduce(Math::max);
-
-        final JavaRDD<Shard<GATKRead>> readShards = SparkSharder.shard(ctx, reads, GATKRead.class, header.getSequenceDictionary(), shardBoundaries, maxReadLength);
-
-        final JavaRDD<Tuple2<AssemblyRegion, SimpleInterval>> assemblyRegions = readShards
-                .mapPartitions(shardsToAssemblyRegions(referenceFileName,
-                                                       hcArgsBroadcast, assemblyRegionArgs, header, annotatorEngineBroadcast));
-
-        return assemblyRegions.mapPartitions(callVariantsFromAssemblyRegions(header, referenceFileName, hcArgsBroadcast, annotatorEngineBroadcast));
+        final Path referencePath = IOUtils.getPath(reference);
+        final String referenceFileName = referencePath.getFileName().toString();
+        Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast = assemblyRegionEvaluatorSupplierBroadcast(ctx, hcArgs, header, reference, annotations);
+        JavaRDD<AssemblyRegionWalkerContext> assemblyRegions = getAssemblyRegions(ctx, reads, header, sequenceDictionary, referenceFileName, null, intervalShards, assemblyRegionEvaluatorSupplierBroadcast, shardingArgs, assemblyRegionArgs, includeReadsWithDeletionsInIsActivePileups, false);
+        processAssemblyRegions(assemblyRegions, ctx, header, reference, hcArgs, output, annotations, logger);
     }
-
-    /**
-     * Call variants from Tuples of AssemblyRegion and Simple Interval
-     * The interval should be the non-padded shard boundary for the shard that the corresponding AssemblyRegion was
-     * created in, it's used to eliminate redundant variant calls at the edge of shard boundaries.
-     */
-    private static FlatMapFunction<Iterator<Tuple2<AssemblyRegion, SimpleInterval>>, VariantContext> callVariantsFromAssemblyRegions(
-            final SAMFileHeader header,
-            final String referenceFileName,
-            final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast,
-            final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast) {
-        return regionAndIntervals -> {
-            //HaplotypeCallerEngine isn't serializable but is expensive to instantiate, so construct and reuse one for every partition
-            final String pathOnExecutor = SparkFiles.get(referenceFileName);
-            final ReferenceSequenceFile taskReferenceSequenceFile = new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
-            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, taskReferenceSequenceFile, annotatorEngineBroadcast.getValue());
-            return Utils.stream(regionAndIntervals).flatMap(regionToVariants(hcEngine)).iterator();
-        };
-    }
-
-    private static Function<Tuple2<AssemblyRegion, SimpleInterval>, Stream<? extends VariantContext>> regionToVariants(HaplotypeCallerEngine hcEngine) {
-        return regionAndInterval -> {
-            final List<VariantContext> variantContexts = hcEngine.callRegion(regionAndInterval._1(), new FeatureContext());
-            final SimpleInterval shardBoundary = regionAndInterval._2();
-            return variantContexts.stream()
-                .filter(vc -> shardBoundary.contains(new SimpleInterval(vc.getContig(), vc.getStart(), vc.getStart())));
-        };
-    }
-
-    /**
-     * @return a list of {@link ShardBoundary}
-     * based on the -L intervals
-     */
-    private static List<ShardBoundary> getShardBoundaries(final SAMFileHeader
-        header, final List<SimpleInterval> intervals, final int readShardSize, final int readShardPadding) {
-        return intervals.stream()
-            .flatMap(interval -> Shard.divideIntervalIntoShards(interval, readShardSize, readShardPadding, header.getSequenceDictionary()).stream())
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * @return and RDD of {@link Tuple2<AssemblyRegion, SimpleInterval>} which pairs each AssemblyRegion with the
-     * interval it was generated in
-     */
-    private static FlatMapFunction<Iterator<Shard<GATKRead>>, Tuple2<AssemblyRegion, SimpleInterval>> shardsToAssemblyRegions(
-            final String referenceFileName,
-            final Broadcast<HaplotypeCallerArgumentCollection> hcArgsBroadcast,
-            final AssemblyRegionArgumentCollection assemblyRegionArgs,
-            final SAMFileHeader header,
-            final Broadcast<VariantAnnotatorEngine> annotatorEngineBroadcast) {
-        return shards -> {
-            final String pathOnExecutor = SparkFiles.get(referenceFileName);
-            final ReferenceSequenceFile taskReferenceSequenceFile = new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
-            final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgsBroadcast.value(), false, false, header, taskReferenceSequenceFile, annotatorEngineBroadcast.getValue());
-
-            final ReferenceDataSource taskReferenceDataSource = new ReferenceFileSource(IOUtils.getPath(pathOnExecutor)); // TODO: share with taskReferenceSequenceFile
-            final ReadsDownsampler readsDownsampler = assemblyRegionArgs.maxReadsPerAlignmentStart > 0 ?
-                new PositionalDownsampler(assemblyRegionArgs.maxReadsPerAlignmentStart, header) : null;
-            return Utils.stream(shards)
-                    //TODO we've hacked multi interval shards here with a shim, but we should investigate as smarter approach https://github.com/broadinstitute/gatk/issues/4299
-                .map(shard -> new ShardToMultiIntervalShardAdapter<>(
-                        new DownsampleableSparkReadShard(new ShardBoundary(shard.getInterval(), shard.getPaddedInterval()), shard, readsDownsampler)))
-                .flatMap(shardToRegion(assemblyRegionArgs, header, taskReferenceDataSource, hcEngine)).iterator();
-        };
-    }
-
-    private static Function<MultiIntervalShard<GATKRead>, Stream<? extends Tuple2<AssemblyRegion, SimpleInterval>>> shardToRegion(
-            AssemblyRegionArgumentCollection assemblyRegionArgs,
-            SAMFileHeader header,
-            ReferenceDataSource referenceDataSource,
-            HaplotypeCallerEngine evaluator) {
-        return shard -> {
-            //TODO load features as a side input
-            final FeatureManager featureManager = null;
-
-            final Iterator<AssemblyRegion> assemblyRegionIter = new AssemblyRegionIterator(shard, header, referenceDataSource, featureManager, evaluator, assemblyRegionArgs.minAssemblyRegionSize, assemblyRegionArgs.maxAssemblyRegionSize, assemblyRegionArgs.assemblyRegionPadding, assemblyRegionArgs.activeProbThreshold, assemblyRegionArgs.maxProbPropagationDistance,
-                                                                                           INCLUDE_READS_WITH_DELETIONS_IN_IS_ACTIVE_PILEUPS);
-
-            return Utils.stream(assemblyRegionIter)
-                    .map(a -> new Tuple2<>(a, shard.getIntervals().get(0)));
-        };
-    }
-
-    /**
-     * Adapter to allow a 2bit reference to be used in HaplotypeCallerEngine.
-     * This is not intended as a general purpose adapter, it only enables the operations needed in {@link HaplotypeCallerEngine}
-     * This should not be used outside of this class except for testing purposes.
-     */
-    @VisibleForTesting
-    public static final class ReferenceMultiSourceAdapter implements ReferenceSequenceFile, ReferenceDataSource, Serializable{
-        private static final long serialVersionUID = 1L;
-
-        private final ReferenceMultiSparkSource source;
-        private final SAMSequenceDictionary sequenceDictionary;
-
-        public ReferenceMultiSourceAdapter(final ReferenceMultiSparkSource source) {
-            this.source = source;
-            sequenceDictionary = source.getReferenceSequenceDictionary(null);
-        }
-
-        @Override
-        public ReferenceSequence queryAndPrefetch(final String contig, final long start, final long stop) {
-           return getSubsequenceAt(contig, start, stop);
-        }
-
-        @Override
-        public SAMSequenceDictionary getSequenceDictionary() {
-            return source.getReferenceSequenceDictionary(null);
-        }
-
-        @Override
-        public ReferenceSequence nextSequence() {
-            throw new UnsupportedOperationException("nextSequence is not implemented");
-        }
-
-        @Override
-        public void reset() {
-            throw new UnsupportedOperationException("reset is not implemented");
-        }
-
-        @Override
-        public boolean isIndexed() {
-            return true;
-        }
-
-        @Override
-        public ReferenceSequence getSequence(final String contig) {
-            throw new UnsupportedOperationException("getSequence is not supported");
-        }
-
-        @Override
-        public ReferenceSequence getSubsequenceAt(final String contig, final long start, final long stop) {
-            try {
-                final ReferenceBases bases = source.getReferenceBases(new SimpleInterval(contig, (int) start, (int) stop));
-                return new ReferenceSequence(contig, sequenceDictionary.getSequenceIndex(contig), bases.getBases());
-            } catch (final IOException e) {
-                throw new GATKException(String.format("Failed to load reference bases for %s:%d-%d", contig, start, stop));
-            }
-        }
-
-        @Override
-        public void close() {
-            // doesn't do anything because you can't close a two-bit file
-        }
-
-        @Override
-        public Iterator<Byte> iterator() {
-            throw new UnsupportedOperationException("iterator is not supported");
-        }
-    }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/ExampleAssemblyRegionWalkerSpark.java
@@ -5,10 +5,12 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ExampleProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
 import org.broadinstitute.hellbender.engine.spark.AssemblyRegionWalkerContext;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.activityprofile.ActivityProfileState;
@@ -37,29 +39,32 @@ public final class ExampleAssemblyRegionWalkerSpark extends AssemblyRegionWalker
     @Argument(fullName="knownVariants", shortName="knownVariants", doc="Known set of variants", optional=true)
     private FeatureInput<VariantContext> knownVariants;
 
-    @Override
-    protected int defaultReadShardSize() { return 5000; }
+    public static class ExampleAssemblyRegionArgumentCollection extends AssemblyRegionArgumentCollection {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected int defaultMinAssemblyRegionSize() { return 50; }
+
+        @Override
+        protected int defaultMaxAssemblyRegionSize() { return 300; }
+
+        @Override
+        protected int defaultAssemblyRegionPadding() { return 100; }
+
+        @Override
+        protected int defaultMaxReadsPerAlignmentStart() { return 50; }
+
+        @Override
+        protected double defaultActiveProbThreshold() { return 0.002; }
+
+        @Override
+        protected int defaultMaxProbPropagationDistance() { return 50; }
+    }
 
     @Override
-    protected int defaultReadShardPadding() { return 100; }
-
-    @Override
-    protected int defaultMinAssemblyRegionSize() { return 50; }
-
-    @Override
-    protected int defaultMaxAssemblyRegionSize() { return 300; }
-
-    @Override
-    protected int defaultAssemblyRegionPadding() { return 100; }
-
-    @Override
-    protected int defaultMaxReadsPerAlignmentStart() { return 50; }
-
-    @Override
-    protected double defaultActiveProbThreshold() { return 0.002; }
-
-    @Override
-    protected int defaultMaxProbPropagationDistance() { return 50; }
+    protected AssemblyRegionArgumentCollection getAssemblyRegionArgumentCollection() {
+        return new ExampleAssemblyRegionArgumentCollection();
+    }
 
     @Override
     protected boolean includeReadsWithDeletionsInIsActivePileups() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -14,6 +14,8 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionReadShardArgumentCollection;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.utils.spark.JoinReadsWithVariants;
 import org.broadinstitute.hellbender.tools.ApplyBQSRUniqueArgumentCollection;
@@ -118,7 +120,10 @@ public class ReadsPipelineSpark extends GATKSparkTool {
     private final RecalibrationArgumentCollection bqsrArgs = new RecalibrationArgumentCollection();
 
     @ArgumentCollection
-    public final HaplotypeCallerSpark.ShardingArgumentCollection shardingArgs = new HaplotypeCallerSpark.ShardingArgumentCollection();
+    public final AssemblyRegionReadShardArgumentCollection shardingArgs = new AssemblyRegionReadShardArgumentCollection();
+
+    @ArgumentCollection
+    public final AssemblyRegionArgumentCollection assemblyRegionArgs = new HaplotypeCallerSpark.HaplotypeCallerAssemblyRegionArgumentCollection();
 
     /**
      * command-line arguments to fine tune the apply BQSR step.
@@ -203,7 +208,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         final ReadFilter hcReadFilter = ReadFilter.fromList(HaplotypeCallerEngine.makeStandardHCReadFilters(), header);
         final JavaRDD<GATKRead> filteredReadsForHC = finalReads.filter(hcReadFilter::test);
         final List<SimpleInterval> intervals = hasUserSuppliedIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(header.getSequenceDictionary());
-        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, header, referenceArguments.getReferenceFileName(), intervals, hcArgs, shardingArgs, numReducers, output, makeVariantAnnotations());
+        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, header, referenceArguments.getReferenceFileName(), intervals, hcArgs, shardingArgs, assemblyRegionArgs, numReducers, output, makeVariantAnnotations());
 
         if (bwaEngine != null) {
             bwaEngine.close();

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -189,15 +189,6 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
     }
 
     @Test
-    public void testReferenceAdapterIsSerializable() throws IOException {
-        final ReferenceMultiSparkSource referenceMultiSource = new ReferenceMultiSparkSource(b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
-        SparkTestUtils.roundTripInKryo(referenceMultiSource, ReferenceMultiSparkSource.class, SparkContextFactory.getTestSparkContext().getConf());
-        final HaplotypeCallerSpark.ReferenceMultiSourceAdapter adapter = new HaplotypeCallerSpark.ReferenceMultiSourceAdapter(referenceMultiSource);
-        SparkTestUtils.roundTripInKryo(adapter, HaplotypeCallerSpark.ReferenceMultiSourceAdapter.class, SparkContextFactory.getTestSparkContext().getConf());
-
-    }
-
-    @Test
     public void testGenotypeCalculationArgumentCollectionIsSerializable() {
         final GenotypeCalculationArgumentCollection args = new GenotypeCalculationArgumentCollection();
         SparkTestUtils.roundTripInKryo(args, GenotypeCalculationArgumentCollection.class, SparkContextFactory.getTestSparkContext().getConf());


### PR DESCRIPTION
This brings HaplotypeCallerSpark into closer alignment with the walker version.
 
cc @jonn-smith @jamesemery @droazen 