### PR TITLE
Add scripts/dataproc-cluster-ui to bundle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -478,6 +478,7 @@ task collectBundleIntoDir(type: Copy) {
     from("scripts/sv", { into("scripts/sv") })
     from("scripts/cnv_wdl/", { into("scripts/cnv_wdl") })
     from("scripts/mutect2_wdl/", { into("scripts/mutect2_wdl") })
+    from("scripts/dataproc-cluster-ui", { into("scripts/")})
     into "$buildDir/bundle-files-collected"
 }
 


### PR DESCRIPTION
* Adding the dataproc-cluster-ui script to the release bundle so users can access it.
* Fixes #5400