### PR TITLE
Changing SUPPORTED_ALLELES_TAG from SA to XA in bamout

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public final class AssemblyBasedCallerUtils {
 
     static final int REFERENCE_PADDING_FOR_ASSEMBLY = 500;
-    public static final String SUPPORTED_ALLELES_TAG="SA";
+    public static final String SUPPORTED_ALLELES_TAG="XA";
     public static final String CALLABLE_REGION_TAG = "CR";
     public static final String ALIGNMENT_REGION_TAG = "AR";
 


### PR DESCRIPTION
In #5215 the SA tag was used to add a "supported alleles" tag to the bamout from HaplotypeCaller and Mutect2.  However, SA is a standard tag reserved for other canonical alignments in a chimeric alignment (http://samtools.github.io/hts-specs/SAMtags.pdf).  This PR changes the tag for "supported alleles" in the bamout from SA to XA. 