### PR TITLE
Fix integer overflow bug in RMSMappingQuality

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -28,6 +28,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils.getAttributeAsLong;
+import static org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils.getAttributeAsLongList;
+
 
 /**
  * Root Mean Square of the mapping quality of reads across all samples.
@@ -258,25 +261,6 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
     }
 
     /**
-     * Private getter function to replace VariantContext::getAttributeAsIntList in instances where there is a chance
-     * that ints will overlow beyond Integer.MAX_VALUE
-     * @return VariantContext attribute indexed by key, as list of long.
-     */
-    static private List<Long> getAttributeAsLongList(final VariantContext vc, final String key, final Long defaultValue) {
-        return vc.getAttributeAsList(key).stream().map(
-            x -> {
-                if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
-                    return defaultValue;
-                } else if (x instanceof Number) {
-                    return ((Number) x).longValue();
-                } else {
-                    return Long.valueOf((String)x); // throws an exception if this isn't a string
-                }
-            }
-        ).collect(Collectors.toList());
-    }
-
-    /**
      *
      * @return the number of reads at the given site, trying first {@Link GATKVCFConstants.RAW_MAPPING_QUALITY_WITH_DEPTH_KEY},
      * falling back to calculating the value as InfoField {@link VCFConstants#DEPTH_KEY} minus the
@@ -296,7 +280,7 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
 
         long numOfReads = 0;
         if (vc.hasAttribute(VCFConstants.DEPTH_KEY)) {
-            numOfReads = vc.getAttributeAsInt(VCFConstants.DEPTH_KEY, -1);
+            numOfReads = getAttributeAsLong(vc, VCFConstants.DEPTH_KEY, -1L);
             if(vc.hasGenotypes()) {
                 for(final Genotype gt : vc.getGenotypes()) {
                     if(gt.isHomRef()) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
@@ -93,6 +93,48 @@ public class GATKProtectedVariantContextUtils {
         return attributeValueToIntArray(genotype.getExtendedAttribute(key), key, defaultValue, missingValue);
     }
 
+
+    /**
+     * Get Long attribute from a variant context.
+     *
+     * @param variantContext the target variant-context.
+     * @param attribute the name of the attribute containing the Long value.
+     * @return never {@code null}.
+     * @throws IllegalArgumentException if {@code variantContext} is {@code null} or {@code key} is {@code null}.
+     */
+    public static Long getAttributeAsLong(final VariantContext variantContext, final String attribute, final Long defaultValue) {
+        Utils.nonNull(variantContext);
+        Utils.nonNull(attribute);
+        Object x = variantContext.getAttribute(attribute);
+        if ( x == null || x == VCFConstants.MISSING_VALUE_v4 ) return defaultValue;
+        if ( x instanceof Number ) return ((Number) x).longValue();
+        return Long.valueOf((String)x); // throws an exception if this isn't a string
+    }
+
+    /**
+     * Composes the Long List from a variant context.
+     *
+     * @param variantContext the target variant-context.
+     * @param attribute the name of the attribute containing the Long list.
+     * @return never {@code null}.
+     * @throws IllegalArgumentException if {@code variantContext} is {@code null} or {@code key} is {@code null}.
+     */
+    public static List<Long> getAttributeAsLongList(final VariantContext variantContext, final String attribute, final Long defaultValue) {
+        Utils.nonNull(variantContext);
+        Utils.nonNull(attribute);
+        return variantContext.getAttributeAsList(attribute).stream().map(
+                x -> {
+                    if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                        return defaultValue;
+                    } else if (x instanceof Number) {
+                        return ((Number) x).longValue();
+                    } else {
+                        return Long.valueOf((String)x); // throws an exception if this isn't a string
+                    }
+                }
+        ).collect(Collectors.toList());
+    }
+
     private static double[] attributeValueToDoubleArray(final Object value, final String key, final Supplier<double[]> defaultResult, final double missingValue) {
         Utils.nonNull(key);
         final ToDoubleFunction<Object> doubleConverter = o -> {
@@ -166,6 +208,7 @@ public class GATKProtectedVariantContextUtils {
                     .mapToInt(intConverter).toArray();
         }
     }
+
 
     /**
      * Returns an attribute as a string.

--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedVariantContextUtils.java
@@ -106,7 +106,7 @@ public class GATKProtectedVariantContextUtils {
         Utils.nonNull(variantContext);
         Utils.nonNull(attribute);
         Object x = variantContext.getAttribute(attribute);
-        if ( x == null || x == VCFConstants.MISSING_VALUE_v4 ) return defaultValue;
+        if ( x == null || x.equals(VCFConstants.MISSING_VALUE_v4) ) return defaultValue;
         if ( x instanceof Number ) return ((Number) x).longValue();
         return Long.valueOf((String)x); // throws an exception if this isn't a string
     }
@@ -124,7 +124,7 @@ public class GATKProtectedVariantContextUtils {
         Utils.nonNull(attribute);
         return variantContext.getAttributeAsList(attribute).stream().map(
                 x -> {
-                    if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                    if (x == null || x.equals(VCFConstants.MISSING_VALUE_v4)) {
                         return defaultValue;
                     } else if (x instanceof Number) {
                         return ((Number) x).longValue();


### PR DESCRIPTION
Updated RMS Mapping quality annotations to be of type long/Long instead
of int/Integer. With int types, a large cohort could overflow
Integer.MAX_VALUE when handling sum of squared mapping qualities. With
long types this should not be a problem until we have off-world
colonies. This resolves issue 5433.