### PR TITLE
Add description getter to GATKReportTable

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportTable.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/report/GATKReportTable.java
@@ -664,4 +664,8 @@ public final class GATKReportTable {
                 return underlyingData;
         }
     }
+
+    public String getTableDescription() {
+        return tableDescription;
+    }
 }


### PR DESCRIPTION
This PR is a simple addition to add GATKReportTable.getDescription(), to allow other classes to get the value of description.