### PR TITLE
fix message in GATKAnnotationPluginDescription

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
@@ -393,7 +393,7 @@ public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor
                             "Pedigree argument \"%s\" or \"%s\" was specified without a pedigree annotation being requested, (eg: %s))",
                             StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME,
                             "founder-id",
-                            allDiscoveredAnnotations.entrySet().stream().filter(PedigreeAnnotation.class::isInstance).map(a -> a.getClass().getSimpleName()).collect(Collectors.joining(", "))));
+                            allDiscoveredAnnotations.values().stream().filter(PedigreeAnnotation.class::isInstance).map(a -> a.getClass().getSimpleName()).collect(Collectors.joining(", "))));
         }
     }
 


### PR DESCRIPTION
* Fixing an obscure error in an error message in GATKAnnotationPluginDescription.
* entrySet was called instead of values as a result everything was always filtered from the error message.

Noticed this one completely by chance.