### PR TITLE
Added the ability to reset random generation based on the start position of reads to the resivoirDownsample

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -66,6 +66,10 @@ public final class Utils {
         randomDataGenerator.reSeed(GATK_RANDOM_SEED);
     }
 
+    public static long getGatkDefaultRandomSeed() {
+        return GATK_RANDOM_SEED;
+    }
+
     private static final int TEXT_WARNING_WIDTH = 68;
     private static final String TEXT_WARNING_PREFIX = "* ";
     private static final String TEXT_WARNING_BORDER = StringUtils.repeat('*', TEXT_WARNING_PREFIX.length() + TEXT_WARNING_WIDTH);

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
@@ -92,7 +92,7 @@ public final class MutectDownsampler extends ReadsDownsampler {
             } else {
                 // if we exceed the max coverage, just use well-mapped reads.  Maybe the number of such reads won't reach
                 // the desired coverage, but if the region is decently mappable the shortfall will be minor.
-                final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage, false);
+                final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage, false, false);
                 pendingReads.stream().filter(read -> read.getMappingQuality() > SUSPICIOUS_MAPPING_QUALITY).forEach(wellMappedDownsampler::submit);
                 final List<GATKRead> readsToFinalize = wellMappedDownsampler.consumeFinalizedItems();
                 if (stride > 1) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -38,7 +38,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         Utils.validateArg(targetCoverage > 0, "targetCoverage must be > 0");
         Utils.nonNull(header);
 
-        this.reservoir = new ReservoirDownsampler(targetCoverage);
+        this.reservoir = new ReservoirDownsampler(targetCoverage, false, true);
         this.finalizedReads = new ArrayList<>();
         this.header = header;
         clearItems();
@@ -73,9 +73,14 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         // are assigned a nominal position.
         if ( previousRead != null && ReadCoordinateComparator.compareCoordinates(previousRead, newRead, header) != 0 ) {
             if ( reservoir.hasFinalizedItems() ) {
-                finalizeReservoir();
+                finalizeReservoir(newRead);
             }
         }
+    }
+
+    private void finalizeReservoir(final GATKRead newRead) {
+        finalizedReads.addAll(reservoir.consumeFinalizedItems(newRead));
+        reservoir.resetStats();
     }
 
     private void finalizeReservoir() {

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -71,10 +71,8 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         // Use ReadCoordinateComparator to determine whether we've moved to a new start position.
         // ReadCoordinateComparator will correctly distinguish between purely unmapped reads and unmapped reads that
         // are assigned a nominal position.
-        if ( previousRead != null && ReadCoordinateComparator.compareCoordinates(previousRead, newRead, header) != 0 ) {
-            if ( reservoir.hasFinalizedItems() ) {
-                finalizeReservoir(newRead);
-            }
+        if ( previousRead == null || ReadCoordinateComparator.compareCoordinates(previousRead, newRead, header) != 0 ) {
+            finalizeReservoir(newRead);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/SamplePartitioner.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/locusiterator/SamplePartitioner.java
@@ -64,7 +64,7 @@ final class SamplePartitioner {
      */
     private Downsampler<GATKRead> createDownsampler(final LIBSDownsamplingInfo LIBSDownsamplingInfo) {
         return LIBSDownsamplingInfo.isPerformDownsampling()
-                ? new ReservoirDownsampler(LIBSDownsamplingInfo.getToCoverage(), true)
+                ? new ReservoirDownsampler(LIBSDownsamplingInfo.getToCoverage(), true, false)
                 : new PassThroughDownsampler();
     }
 


### PR DESCRIPTION
I suspect this may be a somewhat controversial change. One of the issues we face for downsampling in spark is that we need to be able to reproduce the same downsampling behavior at a given site across different partitions/environments. To this end I have implemented the ability to reset the random generator used in the ReservoirDownsampler based on the start position of the next reservoir of reads and the gatk default random seed. I'm interested to know what peoples thoughts are on this change, as theoretically it will make the gatk downsampling the same for each start position in the genome. 

Fixes #5437 