### PR TITLE
Resolved issue: gatk-launch appends as needed to GATK_GCS_STAGING #1338

### DIFF
--- a/gatk
+++ b/gatk
@@ -287,9 +287,9 @@ def cacheJarOnGCS(jar, dryRun):
     if staging is not None:
         staging = staging.strip('/')
         staging = staging + '/'
-        if not staging[0:5] == "gs://":
+        if not staging.startswith("gs://"):
             staging = "gs://" + staging
-
+    
     if dryRun is True:
         return jar
     elif staging is None:

--- a/gatk
+++ b/gatk
@@ -283,6 +283,13 @@ def md5(file):
 
 def cacheJarOnGCS(jar, dryRun):
     staging = os.environ.get("GATK_GCS_STAGING")
+
+    if staging is not None:
+        staging = staging.strip('/')
+        staging = staging + '/'
+        if not staging[0:5] == "gs://":
+            staging = "gs://" + staging
+
     if dryRun is True:
         return jar
     elif staging is None:


### PR DESCRIPTION
Resolved the issue of adding gs:// to the beginning and / to the end of the environment variable GATK_GCS_STAGING. Tested it locally.