### PR TITLE
Replacing some uses of PrintWriter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/MetricsUtils.java
@@ -5,7 +5,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 
-import java.io.PrintWriter;
+import java.io.*;
 
 /**
  * Utility methods for dealing with {@link MetricsFile} and related classes.
@@ -20,9 +20,9 @@ public final class MetricsUtils {
      * @param metricsOutputPath the path (or uri) to write the metrics to
      */
     public static void saveMetrics(final MetricsFile<?, ?> metricsFile, String metricsOutputPath) {
-        try(PrintWriter out = new PrintWriter(BucketUtils.createFile(metricsOutputPath))) {
+        try(Writer out = new BufferedWriter(new OutputStreamWriter(BucketUtils.createFile(metricsOutputPath)))) {
             metricsFile.write(out);
-        } catch (SAMException e ){
+        } catch (IOException | SAMException e ){
             throw new UserException.CouldNotCreateOutputFile("Could not write metrics to file: " + metricsOutputPath, e);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
@@ -18,9 +18,7 @@ import org.broadinstitute.hellbender.tools.funcotator.metadata.TumorNormalPair;
 import org.broadinstitute.hellbender.tools.funcotator.vcfOutput.VcfOutputRenderer;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
@@ -261,7 +259,7 @@ public class MafOutputRenderer extends OutputRenderer {
 
         // Open the output object:
         try {
-            writer = new PrintWriter(Files.newOutputStream(outputFilePath));
+            writer = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(outputFilePath)));
         }
         catch (final IOException ex) {
             throw new UserException("Error opening output file path: " + outputFilePath.toUri().toString(), ex);


### PR DESCRIPTION
* PrintWriter doesn't throw exceptions on write failures and might therefore lead to unexpectedly trunacated data being produced without any notification
* replacing it's use in MetricsUtils and MafOutputRenderer where it might cause problems
* partial fix for https://github.com/broadinstitute/gatk/issues/5458