### PR TITLE
Completes #5260 on GitHub.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
@@ -24,9 +24,6 @@ public final class VariantIDsVariantFilter implements VariantFilter {
 
     @Override
     public boolean test(final VariantContext vc) {
-        if (vc.getID().indexOf(';') > 0) {
-            return Arrays.stream(vc.getID().split(";")).anyMatch(includeIDs::contains);
-        }
-        return includeIDs.contains(vc.getID());
+        return Arrays.stream(vc.getID().split(";")).anyMatch(includeIDs::contains);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
@@ -22,6 +22,16 @@ public final class VariantIDsVariantFilter implements VariantFilter {
 
     @Override
     public boolean test(final VariantContext vc) {
-        return includeIDs.contains(vc.getID());
+        if (vc.getID().indexOf(';') > 0) {
+            String[] vc_ids = vc.getID().split(";");
+            for (String vc_id : vc_ids) {
+                if (includeIDs.contains(vc_id)) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            return includeIDs.contains(vc.getID());
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/VariantIDsVariantFilter.java
@@ -5,6 +5,8 @@ import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Set;
 import java.util.LinkedHashSet;
+import java.util.*;
+import java.util.stream.*;
 
 /**
  * Keep only variants with any of these IDs.
@@ -23,15 +25,8 @@ public final class VariantIDsVariantFilter implements VariantFilter {
     @Override
     public boolean test(final VariantContext vc) {
         if (vc.getID().indexOf(';') > 0) {
-            String[] vc_ids = vc.getID().split(";");
-            for (String vc_id : vc_ids) {
-                if (includeIDs.contains(vc_id)) {
-                    return true;
-                }
-            }
-            return false;
-        } else {
-            return includeIDs.contains(vc.getID());
+            return Arrays.stream(vc.getID().split(";")).anyMatch(includeIDs::contains);
         }
+        return includeIDs.contains(vc.getID());
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -138,6 +138,8 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     private static final Allele FAKE_REF_ALLELE = Allele.create("N", true); // used in isActive function to call into UG Engine. Should never appear anywhere in a VCF file
     private static final Allele FAKE_ALT_ALLELE = Allele.create("<FAKE_ALT>", false); // used in isActive function to call into UG Engine. Should never appear anywhere in a VCF file
 
+    public static final int MINIMUM_READ_LENGTH = 10;
+
     /**
      * Create and initialize a new HaplotypeCallerEngine given a collection of HaplotypeCaller arguments, a reads header,
      * and a reference file
@@ -523,7 +525,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
 
         final List<VariantContext> givenAlleles = new ArrayList<>();
         if ( hcArgs.genotypingOutputMode == GenotypingOutputMode.GENOTYPE_GIVEN_ALLELES ) {
-            features.getValues(hcArgs.alleles).stream().filter(vc -> hcArgs.genotypeFilteredAlleles || vc.isNotFiltered()).forEach(givenAlleles::add);
+            features.getValues(hcArgs.alleles).stream().filter(vc -> (hcArgs.genotypeFilteredAlleles || vc.isNotFiltered()) && (vc.getEnd() - vc.getStart() + 1 >= MINIMUM_READ_LENGTH)).forEach(givenAlleles::add);
 
             // No alleles found in this region so nothing to do!
             if ( givenAlleles.isEmpty() ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -138,8 +138,6 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     private static final Allele FAKE_REF_ALLELE = Allele.create("N", true); // used in isActive function to call into UG Engine. Should never appear anywhere in a VCF file
     private static final Allele FAKE_ALT_ALLELE = Allele.create("<FAKE_ALT>", false); // used in isActive function to call into UG Engine. Should never appear anywhere in a VCF file
 
-    public static final int MINIMUM_READ_LENGTH = 10;
-
     /**
      * Create and initialize a new HaplotypeCallerEngine given a collection of HaplotypeCaller arguments, a reads header,
      * and a reference file
@@ -525,7 +523,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
 
         final List<VariantContext> givenAlleles = new ArrayList<>();
         if ( hcArgs.genotypingOutputMode == GenotypingOutputMode.GENOTYPE_GIVEN_ALLELES ) {
-            features.getValues(hcArgs.alleles).stream().filter(vc -> (hcArgs.genotypeFilteredAlleles || vc.isNotFiltered()) && (vc.getEnd() - vc.getStart() + 1 >= MINIMUM_READ_LENGTH)).forEach(givenAlleles::add);
+            features.getValues(hcArgs.alleles).stream().filter(vc -> hcArgs.genotypeFilteredAlleles || vc.isNotFiltered()).forEach(givenAlleles::add);
 
             // No alleles found in this region so nothing to do!
             if ( givenAlleles.isEmpty() ) {

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/complexExample1.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/complexExample1.vcf
@@ -29,5 +29,6 @@
 1	10044557	.	C	T	62.22	.	AF=0.50;AlleleBalance=0.68;DoC=31;HomopolymerRun=16;MAPQ0=0;NS=1;RMSMAPQ=85.34;SB=-0.00;SpanningDeletions=0	GT:DP:GQ	./.	./.	0/1:31:15
 1	10045603	.	AAAA	A	40.26	PASS	AF=0.50	GT:DP:GQ	0/1:15:8	0/0:15:8	1/1:15:8
 1	10045604	.	A	ACAT	41.26	PASS	AF=0.50	GT:DP:GQ	1/1:14:7	0/0:15:8	1/0:15:8
+1	10046982	testid0;testid1	C	T	32.01	PASS	AF=0.40;AlleleBalance=0.37;DoC=21;HomopolymerRun=0;MAPQ0=8;NS=1;RMSMAPQ=12.31;SB=-4.2;SpanningDeletions=0	GT:DP:GQ	1/0:3:49	./.	./.
 1	10048142	.	A	G	126.81	foo	AF=1.00;DoC=36;HomopolymerRun=4;MAPQ0=0;NS=1;RMSMAPQ=82.11;SB=-85.45;SpanningDeletions=0	GT:DP:GQ	0/1:15:8	0/0:15:8	1/1:15:8
 1	10048580	.	T	A	72.22	bar;baz	AF=0.50;AlleleBalance=0.69;DoC=33;HomopolymerRun=6;MAPQ0=0;NS=1;RMSMAPQ=84.45;SB=-27.41;SpanningDeletions=0	GT:DP:GQ	0/1:15:8	0/0:15:8	1/1:15:8

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_KeepSelectionID.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/expected/testSelectVariants_KeepSelectionID.vcf
@@ -23,3 +23,4 @@
 ##source=ArbitrarySource
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
 1	10001292	testid1	G	A	12.22	PASS	AF=0.50;AlleleBalance=0.57;DoC=23;HomopolymerRun=0;MAPQ0=8;NS=1;RMSMAPQ=46.31;SB=-24.92;SpanningDeletions=0	GT:DP:GQ	1/0:23:19	./.	./.
+1	10046982	testid0;testid1	C	T	32.01	PASS	AF=0.40;AlleleBalance=0.37;DoC=21;HomopolymerRun=0;MAPQ0=8;NS=1;RMSMAPQ=12.31;SB=-4.2;SpanningDeletions=0	GT:DP:GQ	1/0:3:49	./.	./.


### PR DESCRIPTION
Changed SelectVariants so that it can handle multiple rsIDs separated by ';' in a VCF file.
The corresponding entry gets removed if any of those rsIDs has been set by the user to be deleted.
I also changed testExcludeSelectionIDFromFile() in SelectVariantsIntegrationTest to check this case.