### PR TITLE
Reduced some of the repeated steps in ReferenceConfidenceModel.calcNIndelinformativeReads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -10,7 +10,7 @@ import htsjdk.samtools.util.Tuple;
 import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFSimpleHeaderLine;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.PloidyModel;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -10,6 +10,8 @@ import htsjdk.samtools.util.Tuple;
 import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFSimpleHeaderLine;
+import javafx.util.Pair;
+import org.broadinstitute.hellbender.engine.AlignmentContext;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.PloidyModel;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.PosteriorProbabilitiesUtils;
@@ -486,20 +488,19 @@ public class ReferenceConfidenceModel {
         // We are safe to use the faster no-copy versions of getBases and getBaseQualities here,
         // since we're not modifying the returned arrays in any way. This makes a small difference
         // in the HaplotypeCaller profile, since this method is a major hotspot.
-        final Tuple<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlignedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
+        final Pair<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlignedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
 
-
-        final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart, refBases, refStart, Integer.MAX_VALUE);
+        final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart, refBases, refStart, Integer.MAX_VALUE);
 
         // consider each indel size up to max in term, checking if an indel that deletes either the ref bases (deletion
         // or read bases (insertion) would fit as well as the origin baseline sum of mismatching quality scores
         for ( int indelSize = 1; indelSize <= maxIndelSize; indelSize++ ) {
             // check insertions:
-            if (sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
             // check deletions:
-            if (sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.Tuple;
 import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFSimpleHeaderLine;
@@ -485,21 +486,20 @@ public class ReferenceConfidenceModel {
         // We are safe to use the faster no-copy versions of getBases and getBaseQualities here,
         // since we're not modifying the returned arrays in any way. This makes a small difference
         // in the HaplotypeCaller profile, since this method is a major hotspot.
-        final byte[] readBases = AlignmentUtils.getBasesAlignedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
-        final byte[] readQuals = AlignmentUtils.getBaseQualsAlignedOneToOne(read);
+        final Tuple<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlginedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
 
 
-        final int baselineMMSum = sumMismatchingQualities(readBases, readQuals, readStart, refBases, refStart, Integer.MAX_VALUE);
+        final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart, refBases, refStart, Integer.MAX_VALUE);
 
         // consider each indel size up to max in term, checking if an indel that deletes either the ref bases (deletion
         // or read bases (insertion) would fit as well as the origin baseline sum of mismatching quality scores
         for ( int indelSize = 1; indelSize <= maxIndelSize; indelSize++ ) {
             // check insertions:
-            if (sumMismatchingQualities(readBases, readQuals, readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
             // check deletions:
-            if (sumMismatchingQualities(readBases, readQuals, readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
         }
@@ -548,8 +548,8 @@ public class ReferenceConfidenceModel {
     protected int getCigarModifiedOffset (final PileupElement p){
         final GATKRead read = p.getRead();
         int offset = (p.getCurrentCigarElement().getOperator().consumesReferenceBases() || p.getCurrentCigarElement().getOperator() == CigarOperator.S)? p.getOffsetInCurrentCigar() : 0;
-        for (int i = 0; i < p.getCurrentCigarOffset(); i++ ) {
-            CigarElement elem = read.getCigarElement(i);
+        for (int i = 0; i < p.getCurrentCigarOffset(); i++) {
+            final CigarElement elem = read.getCigarElement(i);
             if (elem.getOperator().consumesReferenceBases() || elem.getOperator() == CigarOperator.S) {
                 offset += elem.getLength();
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -486,7 +486,7 @@ public class ReferenceConfidenceModel {
         // We are safe to use the faster no-copy versions of getBases and getBaseQualities here,
         // since we're not modifying the returned arrays in any way. This makes a small difference
         // in the HaplotypeCaller profile, since this method is a major hotspot.
-        final Tuple<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlginedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
+        final Tuple<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlignedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
 
 
         final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.a, readBasesAndBaseQualities.b, readStart, refBases, refStart, Integer.MAX_VALUE);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -490,22 +490,22 @@ public class ReferenceConfidenceModel {
         // in the HaplotypeCaller profile, since this method is a major hotspot.
         final Pair<byte[], byte[]> readBasesAndBaseQualities = AlignmentUtils.getBasesAndBaseQualitiesAlignedOneToOne(read);  //calls getBasesNoCopy if CIGAR is all match
 
-        final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart, refBases, refStart, Integer.MAX_VALUE);
+        final int baselineMMSum = sumMismatchingQualities(readBasesAndBaseQualities.getLeft(), readBasesAndBaseQualities.getRight(), readStart, refBases, refStart, Integer.MAX_VALUE);
 
         // consider each indel size up to max in term, checking if an indel that deletes either the ref bases (deletion
         // or read bases (insertion) would fit as well as the origin baseline sum of mismatching quality scores
         for ( int indelSize = 1; indelSize <= maxIndelSize; indelSize++ ) {
             // check insertions:
-            if (sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.getLeft(), readBasesAndBaseQualities.getRight(), readStart + indelSize, refBases, refStart, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
             // check deletions:
-            if (sumMismatchingQualities(readBasesAndBaseQualities.getKey(), readBasesAndBaseQualities.getValue(), readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
+            if (sumMismatchingQualities(readBasesAndBaseQualities.getLeft(), readBasesAndBaseQualities.getRight(), readStart, refBases, refStart + indelSize, baselineMMSum) <= baselineMMSum) {
                 return false;
             }
         }
 
-        return true;
+        return true;x
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -505,7 +505,7 @@ public class ReferenceConfidenceModel {
             }
         }
 
-        return true;x
+        return true;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -7,7 +7,6 @@ import htsjdk.samtools.util.Tuple;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
-import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
@@ -15,7 +14,6 @@ import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAlignment;
 
 import java.util.*;
-import java.util.function.Function;
 
 
 public final class AlignmentUtils {
@@ -201,11 +199,11 @@ public final class AlignmentUtils {
         return Arrays.copyOfRange(bases, basesStart, basesStop + 1);
     }
 
-    public static Tuple<byte[], byte[]> getBasesAndBaseQualitiesAlginedOneToOne(final GATKRead read) {
-        return getBasesAndBaseQualitiesAlginedOneToOne(read, GAP_CHARACTER, (byte)0);
+    public static Tuple<byte[], byte[]> getBasesAndBaseQualitiesAlignedOneToOne(final GATKRead read) {
+        return getBasesAndBaseQualitiesAlignedOneToOne(read, GAP_CHARACTER, (byte)0);
     }
 
-    public static Tuple<byte[], byte[]> getBasesAndBaseQualitiesAlginedOneToOne(final GATKRead read, final byte gapCharacter, final byte qualityPadCharacter) {
+    public static Tuple<byte[], byte[]> getBasesAndBaseQualitiesAlignedOneToOne(final GATKRead read, final byte gapCharacter, final byte qualityPadCharacter) {
         Utils.nonNull(read);
         final Cigar cigar = read.getCigar();
         final byte[] bases = read.getBasesNoCopy();

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -4,7 +4,8 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.util.Tuple;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
@@ -232,7 +233,7 @@ public final class AlignmentUtils {
             }
         }
         if (!sawIndel) {
-            return new Pair<>(bases, baseQualities);
+            return new ImmutablePair<>(bases, baseQualities);
         }
         else {
             int numberRefBasesIncludingSoftclips = CigarUtils.countRefBasesIncludingSoftClips(read, 0, numCigarElements);

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -263,7 +263,7 @@ public final class AlignmentUtils {
                     }
                 }
             }
-            return new Pair<>(paddedBases, paddedBaseQualities);
+            return new ImmutablePair<>(paddedBases, paddedBaseQualities);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -205,15 +205,14 @@ public final class AlignmentUtils {
 
     public static Tuple<byte[], byte[]> getBasesAndBaseQualitiesAlignedOneToOne(final GATKRead read, final byte gapCharacter, final byte qualityPadCharacter) {
         Utils.nonNull(read);
-        final Cigar cigar = read.getCigar();
         final byte[] bases = read.getBasesNoCopy();
         final byte[] baseQualities = read.getBaseQualitiesNoCopy();
-        final int numCigarElements = cigar.numCigarElements();
+        final int numCigarElements = read.numCigarElements();
         boolean sawIndel = false;
 
         // Check if the cigar contains indels
         for (int i = 0; i < numCigarElements; i++) {
-            final CigarOperator e = cigar.getCigarElement(i).getOperator();
+            final CigarOperator e = read.getCigarElement(i).getOperator();
             if (e == CigarOperator.INSERTION || e == CigarOperator.DELETION) {
                 sawIndel = true;
                 break;
@@ -228,8 +227,8 @@ public final class AlignmentUtils {
             final byte[] paddedBaseQualities = new byte[numberRefBasesIncludingSoftclips];
             int literalPos = 0;
             int paddedPos = 0;
-            for ( int i = 0; i < cigar.numCigarElements(); i++ ) {
-                final CigarElement ce = cigar.getCigarElement(i);
+            for ( int i = 0; i < read.numCigarElements(); i++ ) {
+                final CigarElement ce = read.getCigarElement(i);
                 final CigarOperator co = ce.getOperator();
                 if (co.consumesReadBases()) {
                     if (!co.consumesReferenceBases()) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/AlignmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/AlignmentUtilsUnitTest.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
-import javafx.util.Pair;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -811,7 +811,7 @@ public final class AlignmentUtilsUnitTest {
 
 
     @Test(dataProvider = "makeGetBasesAndBaseQualitiesAlignedOneToOneTest")
-    public void testCalcNIndelInformativeReads(final String readBases, final String cigar, final String expectedBases, final byte[] expectedQuals ) {
+    public void testGetBasesAndBaseQualitiesAlignedOneToOne(final String readBases, final String cigar, final String expectedBases, final byte[] expectedQuals ) {
         final byte qual = (byte)10;
         final byte[] quals = Utils.dupBytes(qual, readBases.length());
 
@@ -819,8 +819,8 @@ public final class AlignmentUtilsUnitTest {
 
         Pair<byte[], byte[]> actual = AlignmentUtils.getBasesAndBaseQualitiesAlignedOneToOne(read);
 
-        Assert.assertEquals(new String(actual.getKey()), expectedBases);
-        Assert.assertEquals(actual.getValue(), expectedQuals);
+        Assert.assertEquals(new String(actual.getLeft()), expectedBases);
+        Assert.assertEquals(actual.getRight(), expectedQuals);
     }
 
     //////////////////////////////////////////


### PR DESCRIPTION
This micro-optimization fell out of profiling of the HaplotypeCaller in GVCF mode. 

Profiler view over an Exome before this patch:
<img width="906" alt="screen shot 2018-11-30 at 2 06 34 pm" src="https://user-images.githubusercontent.com/16102845/49310230-bc44a380-f4ab-11e8-98aa-1c0b321223c0.png">

Profiler view over the same Exome after this patch:
<img width="886" alt="screen shot 2018-11-30 at 2 20 39 pm" src="https://user-images.githubusercontent.com/16102845/49310291-e4cc9d80-f4ab-11e8-9fb3-4d819fbce43a.png">

I suspect given the remaining 9% runtime could be reduced further by looking more closely at the array operations in `isReadInformativeAboutIndelsOfSize()`  

(It should be noted that these profiler results lie within the ReferenceModelForNoVariation codepath which since this is over an Exome we expect the runtime to overall be skewed towards no-variation blocks)

Resolves #5648