### PR TITLE
Doing away with stream api call in place that showed up on the profile for GVCF mode

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/RefVsAnyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/RefVsAnyResult.java
@@ -41,6 +41,10 @@ public final class RefVsAnyResult extends ReferenceConfidenceResult {
      * The capping is done on the fly.
      */
     double[] getGenotypeLikelihoodsCappedByHomRefLikelihood() {
-        return DoubleStream.of(genotypeLikelihoods).map(d -> Math.min(d, genotypeLikelihoods[0])).toArray();
+        final double[] output = new double[genotypeLikelihoods.length];
+        for (int i = 0; i < genotypeLikelihoods.length; i++) {
+            output[i] = Math.min(genotypeLikelihoods[i], genotypeLikelihoods[0]);
+        }
+        return output;
     }
 }


### PR DESCRIPTION
This made a moderate difference in the `ReferenceModelForNoVariation` runtime as I have been profiling the HaplotypeCaller GVCF mode. 

Before: 
<img width="1032" alt="screen shot 2018-11-30 at 3 44 26 pm" src="https://user-images.githubusercontent.com/16102845/49314850-bb1a7300-f4b9-11e8-8218-dacf183c05ba.png">

After:
<img width="870" alt="screen shot 2018-11-30 at 3 57 21 pm" src="https://user-images.githubusercontent.com/16102845/49314863-c40b4480-f4b9-11e8-8607-f9f20cb8627d.png">

