### PR TITLE
gave LeftAlignIndels the usual command line for output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -51,7 +52,7 @@ import java.io.File;
 )
 public final class LeftAlignIndels extends ReadWalker {
 
-    @Argument(doc="Output BAM")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,doc="Output BAM")
     private String OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter = null;


### PR DESCRIPTION
Closes #5072.

@cmnbroad Personally, I'm in favor of making the command line consistent with the rest of the GATK, regardless of backward compatibility.  @vdauwera what do you say?