### PR TITLE
Add hint to Cloud IO errors ("check README")

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.engine;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.IOUtil;
 import java.nio.channels.SeekableByteChannel;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -14,6 +13,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.iterators.SAMRecordToReadIterator;
 import org.broadinstitute.hellbender.utils.iterators.SamReaderQueryingIterator;
 import org.broadinstitute.hellbender.utils.nio.SeekableByteChannelPrefetcher;
@@ -203,7 +203,7 @@ public final class ReadsDataSource implements GATKDataSource<GATKRead>, AutoClos
         for ( final Path samPath : samPaths ) {
             // Ensure each file can be read
             try {
-                IOUtil.assertFileIsReadable(samPath);
+                IOUtils.assertFileIsReadable(samPath);
             }
             catch ( SAMException|IllegalArgumentException e ) {
                 throw new UserException.CouldNotReadInputFile(samPath.toString(), e);

--- a/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
@@ -144,7 +144,7 @@ public final class GatherVcfsCloud extends CommandLineProgram {
 
         if(!ignoreSafetyChecks) {
             for (final Path f : inputPaths) {
-                IOUtil.assertFileIsReadable(f);
+                IOUtils.assertFileIsReadable(f);
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualities.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualities.java
@@ -13,6 +13,7 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.PositionalArguments;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import org.broadinstitute.hellbender.engine.ProgressMeter;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -124,8 +125,8 @@ public final class CompareBaseQualities extends PicardCommandLineProgram {
         }
         staticQuantizedMapping = constructStaticQuantizedMapping(staticQuantizationQuals, roundDown);
 
-        IOUtil.assertFileIsReadable(samFiles.get(0));
-        IOUtil.assertFileIsReadable(samFiles.get(1));
+        IOUtils.canReadFile(samFiles.get(0));
+        IOUtils.canReadFile(samFiles.get(1));
 
         final SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(VALIDATION_STRINGENCY);
         final SamReader reader1 = factory.referenceSequence(REFERENCE_SEQUENCE).open(samFiles.get(0));

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -835,17 +835,10 @@ public final class IOUtils {
                 throw new UserException.CouldNotReadInputFile(path, "It is not readable, check the file permissions");
             }
         } catch (com.google.cloud.storage.StorageException cloudBoom) {
-            // probably a permissions problem, or perhaps a disabled account.
-            // Looks like this for a disabled bucket error:
-            //   A USER ERROR has occurred: Couldn't read file gs://foo/bar. Error was:
-            //   403: The account for bucket "foo" has been disabled.
-            // For no access, it looks like this:
-            // (use `gcloud auth application-default revoke` to forget the default credentials)
-            //   A USER ERROR has occurred: Couldn't read file gs://(...). Error was:
-            //   401: Anonymous users does not have storage.objects.get access to object (...).
+            // Add some context.
             // The user can see the underlying exception by passing
             // -DGATK_STACKTRACE_ON_USER_EXCEPTION=true
-            throw new UserException.CouldNotReadInputFile(path, cloudBoom.getCode() + ": " + cloudBoom.getMessage(), cloudBoom);
+            throw new UserException.CouldNotReadInputFile(path, cloudBoom);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/AbstractAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/AbstractAlignmentMerger.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
@@ -126,9 +127,9 @@ public abstract class AbstractAlignmentMerger {
                                    final SAMFileHeader.SortOrder sortOrder,
                                    final PrimaryAlignmentSelectionStrategy primaryAlignmentSelectionStrategy,
                                    final boolean addMateCigar) {
-        IOUtil.assertFileIsReadable(unmappedBamFile);
-        IOUtil.assertFileIsWritable(targetBamFile);
-        IOUtil.assertFileIsReadable(referenceFasta);
+        IOUtils.canReadFile(unmappedBamFile);
+        IOUtils.canReadFile(targetBamFile);
+        IOUtils.canReadFile(referenceFasta);
 
         this.unmappedBamFile = unmappedBamFile;
         this.targetBamFile = targetBamFile;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 /**
  * Class that takes in a set of alignment information in SAM format and merges it with the set
@@ -90,14 +91,14 @@ public final class SamAlignmentMerger extends AbstractAlignmentMerger {
 
         if (alignedSamFile != null) {
             for (final File f : alignedSamFile) {
-                IOUtil.assertFileIsReadable(f);
+                IOUtils.canReadFile(f);
             }
         } else {
             for (final File f : read1AlignedSamFile) {
-                IOUtil.assertFileIsReadable(f);
+                IOUtils.canReadFile(f);
             }
             for (final File f : read2AlignedSamFile) {
-                IOUtil.assertFileIsReadable(f);
+                IOUtils.canReadFile(f);
             }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
@@ -4,9 +4,9 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -122,7 +122,7 @@ public final class SplitReadsIntegrationTest extends CommandLineProgramTest {
 
     private int getReadCounts(final Path tempDirectory, final String baseName, final String fileName) {
         final File path = tempDirectory.resolve(fileName).toFile();
-        IOUtil.assertFileIsReadable(path);
+        IOUtils.canReadFile(path);
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(new File(getTestDataDir(), getReferenceSequenceName(baseName))).open(path);
         int count = 0;
         for (@SuppressWarnings("unused") final SAMRecord rec : in) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.TextCigarCodec;
 import htsjdk.samtools.ValidationStringency;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.SamFiles;
 
@@ -18,6 +17,7 @@ import org.broadinstitute.hellbender.utils.genotyper.IndexedAlleleList;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
 import org.broadinstitute.hellbender.utils.genotyper.SampleList;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -333,7 +333,7 @@ public class HaplotypeBAMWriterUnitTest extends GATKBaseTest {
     }
 
     private int getReadCounts(final Path result) throws IOException {
-        IOUtil.assertFileIsReadable(result);
+        IOUtils.assertFileIsReadable(result);
 
         int count = 0;
         try (final SamReader in = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(result)) {


### PR DESCRIPTION
Also, update code to use Hellbender's IOUtils instead of htsjdk's IOUtil
for these checks. We have both, presumably there's a reason Hellbender has their own and we should use them (for example, we can only add the hinting in our own).

Sample error now:

A USER ERROR has occurred: Couldn't read file gs://foo/sam/m54113_160913_184949.scraps.beginning.sam. Error was: Error 403: jp-testing@redacted.iam.gserviceaccount.com does not have storage.objects.get access to foo/sam/m54113_160913_184949.scraps.beginning.sam. Potential cause: incorrect Google Cloud configuration; see instructions in the README.

Fixes: #5468