### PR TITLE
Restore array output in gCNV WDLs for efficient postprocessing.

### DIFF
--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -342,6 +342,10 @@ task PostprocessGermlineCNVCalls {
     String entity_id
     Array[File] gcnv_calls_tars
     Array[File] gcnv_model_tars
+    Array[File] calling_configs
+    Array[File] denoising_configs
+    Array[File] gcnvkernel_version
+    Array[File] sharded_interval_lists
     File contig_ploidy_calls_tar
     Array[String]? allosomal_contigs
     Int ref_copy_number_autosomal_contigs
@@ -370,13 +374,24 @@ task PostprocessGermlineCNVCalls {
         set -e
         export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
 
+        sharded_interval_lists_array=(${sep=" " sharded_interval_lists})
+
         # untar calls to CALLS_0, CALLS_1, etc directories and build the command line
+        # also copy over shard config and interval files
         gcnv_calls_tar_array=(${sep=" " gcnv_calls_tars})
+        calling_configs_array=(${sep=" " calling_configs})
+        denoising_configs_array=(${sep=" " denoising_configs})
+        gcnvkernel_version_array=(${sep=" " gcnvkernel_version})
+        sharded_interval_lists_array=(${sep=" " sharded_interval_lists})
         calls_args=""
         for index in ${dollar}{!gcnv_calls_tar_array[@]}; do
             gcnv_calls_tar=${dollar}{gcnv_calls_tar_array[$index]}
-            mkdir CALLS_$index
-            tar xzf $gcnv_calls_tar -C CALLS_$index
+            mkdir -p CALLS_$index/SAMPLE_${sample_index}
+            tar xzf $gcnv_calls_tar -C CALLS_$index/SAMPLE_${sample_index}
+            cp ${dollar}{calling_configs_array[$index]} CALLS_$index/
+            cp ${dollar}{denoising_configs_array[$index]} CALLS_$index/
+            cp ${dollar}{gcnvkernel_version_array[$index]} CALLS_$index/
+            cp ${dollar}{sharded_interval_lists_array[$index]} CALLS_$index/
             calls_args="$calls_args --calls-shard-path CALLS_$index"
         done
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -187,7 +187,7 @@ workflow CNVGermlineCaseScatteredWorkflow {
         Array[Array[File]] read_counts_entity_id = CNVGermlineCaseWorkflow.read_counts_entity_id
         Array[Array[File]] read_counts = CNVGermlineCaseWorkflow.read_counts
         Array[File] contig_ploidy_calls_tars = CNVGermlineCaseWorkflow.contig_ploidy_calls_tar
-        Array[Array[File]] gcnv_calls_tars = CNVGermlineCaseWorkflow.gcnv_calls_tars
+        Array[Array[Array[File]]] gcnv_calls_tars = CNVGermlineCaseWorkflow.gcnv_calls_tars
         Array[Array[File]] gcnv_tracking_tars = CNVGermlineCaseWorkflow.gcnv_tracking_tars
         Array[Array[File]] genotyped_intervals_vcf = CNVGermlineCaseWorkflow.genotyped_intervals_vcf
         Array[Array[File]] genotyped_segments_vcf = CNVGermlineCaseWorkflow.genotyped_segments_vcf

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
@@ -18,6 +18,7 @@ import org.broadinstitute.hellbender.tools.copynumber.formats.collections.Simple
 import org.broadinstitute.hellbender.tools.copynumber.formats.metadata.LocatableMetadata;
 import org.broadinstitute.hellbender.tools.copynumber.formats.records.CoveragePerContig;
 import org.broadinstitute.hellbender.tools.copynumber.formats.records.SimpleCount;
+import org.broadinstitute.hellbender.tools.copynumber.utils.CopyNumberUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -385,20 +386,20 @@ public final class DetermineGermlineContigPloidy extends CommandLineProgram {
                 : outputDir + File.separator;    //add trailing slash if necessary
         //note that the samples x coverage-by-contig table is referred to as "metadata" by gcnvkernel
         final List<String> arguments = new ArrayList<>(Arrays.asList(
-                "--sample_coverage_metadata=" + samplesByCoveragePerContigFile.getAbsolutePath(),
-                "--output_calls_path=" + outputDirArg + outputPrefix + CALLS_PATH_SUFFIX));
+                "--sample_coverage_metadata=" + CopyNumberUtils.getCanonicalPath(samplesByCoveragePerContigFile),
+                "--output_calls_path=" + CopyNumberUtils.getCanonicalPath(outputDirArg + outputPrefix + CALLS_PATH_SUFFIX)));
         arguments.addAll(germlineContigPloidyModelArgumentCollection.generatePythonArguments(runMode));
         arguments.addAll(germlineContigPloidyHybridADVIArgumentCollection.generatePythonArguments());
 
         final String script;
         if (runMode == RunMode.COHORT) {
             script = COHORT_DETERMINE_PLOIDY_AND_DEPTH_PYTHON_SCRIPT;
-            arguments.add("--interval_list=" + intervalsFile.getAbsolutePath());
-            arguments.add("--contig_ploidy_prior_table=" + inputContigPloidyPriorsFile.getAbsolutePath());
-            arguments.add("--output_model_path=" + outputDirArg + outputPrefix + MODEL_PATH_SUFFIX);
+            arguments.add("--interval_list=" + CopyNumberUtils.getCanonicalPath(intervalsFile));
+            arguments.add("--contig_ploidy_prior_table=" + CopyNumberUtils.getCanonicalPath(inputContigPloidyPriorsFile));
+            arguments.add("--output_model_path=" + CopyNumberUtils.getCanonicalPath(outputDirArg + outputPrefix + MODEL_PATH_SUFFIX));
         } else {
             script = CASE_DETERMINE_PLOIDY_AND_DEPTH_PYTHON_SCRIPT;
-            arguments.add("--input_model_path=" + inputModelDir);
+            arguments.add("--input_model_path=" + CopyNumberUtils.getCanonicalPath(inputModelDir));
         }
         return executor.executeScript(
                 new Resource(script, GermlineCNVCaller.class),

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.tools.copynumber.formats.collections.Annota
 import org.broadinstitute.hellbender.tools.copynumber.formats.collections.SimpleCountCollection;
 import org.broadinstitute.hellbender.tools.copynumber.formats.collections.SimpleIntervalCollection;
 import org.broadinstitute.hellbender.tools.copynumber.formats.records.SimpleCount;
+import org.broadinstitute.hellbender.tools.copynumber.utils.CopyNumberUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -406,21 +407,21 @@ public final class GermlineCNVCaller extends CommandLineProgram {
 
         //add required arguments
         final List<String> arguments = new ArrayList<>(Arrays.asList(
-                "--ploidy_calls_path=" + inputContigPloidyCallsDir,
-                "--output_calls_path=" + outputDirArg + outputPrefix + CALLS_PATH_SUFFIX,
-                "--output_tracking_path=" + outputDirArg + outputPrefix + TRACKING_PATH_SUFFIX));
+                "--ploidy_calls_path=" + CopyNumberUtils.getCanonicalPath(inputContigPloidyCallsDir),
+                "--output_calls_path=" + CopyNumberUtils.getCanonicalPath(outputDirArg + outputPrefix + CALLS_PATH_SUFFIX),
+                "--output_tracking_path=" + CopyNumberUtils.getCanonicalPath(outputDirArg + outputPrefix + TRACKING_PATH_SUFFIX)));
 
         //if a model path is given, add it to the argument (both COHORT and CASE modes)
         if (inputModelDir != null) {
-            arguments.add("--input_model_path=" + inputModelDir);
+            arguments.add("--input_model_path=" + CopyNumberUtils.getCanonicalPath(inputModelDir));
         }
 
         final String script;
         if (runMode == RunMode.COHORT) {
             script = COHORT_DENOISING_CALLING_PYTHON_SCRIPT;
             //these are the annotated intervals, if provided
-            arguments.add("--modeling_interval_list=" + specifiedIntervalsFile.getAbsolutePath());
-            arguments.add("--output_model_path=" + outputDirArg + outputPrefix + MODEL_PATH_SUFFIX);
+            arguments.add("--modeling_interval_list=" + CopyNumberUtils.getCanonicalPath(specifiedIntervalsFile));
+            arguments.add("--output_model_path=" + CopyNumberUtils.getCanonicalPath(outputDirArg + outputPrefix + MODEL_PATH_SUFFIX));
             if (inputAnnotatedIntervalsFile != null) {
                 arguments.add("--enable_explicit_gc_bias_modeling=True");
             } else {
@@ -432,7 +433,7 @@ public final class GermlineCNVCaller extends CommandLineProgram {
         }
 
         arguments.add("--read_count_tsv_files");
-        arguments.addAll(intervalSubsetReadCountFiles.stream().map(File::getAbsolutePath).collect(Collectors.toList()));
+        arguments.addAll(intervalSubsetReadCountFiles.stream().map(CopyNumberUtils::getCanonicalPath).collect(Collectors.toList()));
 
         arguments.addAll(germlineDenoisingModelArgumentCollection.generatePythonArguments(runMode));
         arguments.addAll(germlineCallingArgumentCollection.generatePythonArguments(runMode));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CopyNumberUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/CopyNumberUtils.java
@@ -1,0 +1,34 @@
+package org.broadinstitute.hellbender.tools.copynumber.utils;
+
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.python.PythonScriptExecutor;
+
+import java.io.File;
+import java.io.IOException;
+
+public final class CopyNumberUtils {
+    private CopyNumberUtils() {}
+
+    /**
+     * File paths that are passed to {@link PythonScriptExecutor} must be canonical (rather than absolute).
+     * See https://github.com/broadinstitute/gatk/issues/4724.
+     */
+    public static String getCanonicalPath(final File file) {
+        Utils.nonNull(file);
+        try {
+            return file.getCanonicalPath();
+        } catch (final IOException e) {
+            throw new UserException.BadInput(String.format("Could not resolve a canonical file path: %s", file));
+        }
+    }
+
+    /**
+     * File paths that are passed to {@link PythonScriptExecutor} must be canonical (rather than absolute).
+     * See https://github.com/broadinstitute/gatk/issues/4724.
+     */
+    public static String getCanonicalPath(final String filename) {
+        Utils.nonEmpty(filename);
+        return getCanonicalPath(new File(filename));
+    }
+}


### PR DESCRIPTION
Reverts the reversion in #5225, this time addressing the lexicographical ordering issue in #5217 at the WDL level by simply renaming gCNV output at the command line.  If desired, we can eventually change gCNV itself to output filenames that are robust against lexicographic ordering, but this is low priority in my opinion.

@vruano this is what we discussed last week.  Tests pass on Travis, and I'm pretty sure this fix should work OK, but I have not done an actual run with enough samples to see the fix in action.  Can I assign you to review once I get a chance to do this?

EDIT: Also went ahead and rolled an older PR #5304 into this one so I can test both at the same time.

Closes #4724.