### PR TITLE
Deal with read position annotation bug in M2 filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -134,7 +134,8 @@ public class Mutect2FilteringEngine {
     private void applyReadPositionFilter(final M2FiltersArgumentCollection MTFAC, final VariantContext vc, final FilterResult filterResult) {
         final int[] readPositionByAllele = getIntArrayTumorField(vc, ReadPosition.KEY);
         if (readPositionByAllele != null) {
-            if (readPositionByAllele[0] < MTFAC.minMedianReadPosition) {
+            // a negative value is possible due to a bug: https://github.com/broadinstitute/gatk/issues/5492
+            if (readPositionByAllele[0] > -1 && readPositionByAllele[0] < MTFAC.minMedianReadPosition) {
                 filterResult.addFilter(GATKVCFConstants.READ_POSITION_FILTER_NAME);
             }
         }


### PR DESCRIPTION
@takutosato This works around #5492 and eliminates a handful of false negatives.