### PR TITLE
mismatch ratio option in realignment filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
@@ -183,7 +183,8 @@ public class FilterAlignmentArtifacts extends VariantWalker {
                 } else {
                     plausiblePairs.sort(Comparator.comparingInt(pair -> -pairScore(pair)) );
                     final int scoreDiff = pairScore(plausiblePairs.get(0)) - pairScore(plausiblePairs.get(1));
-                    if (scoreDiff >= realignmentArgumentCollection.minAlignerScoreDifference) {
+                    final double mismatchRatio = (double) pairMismatches(plausiblePairs.get(1)) / pairMismatches(plausiblePairs.get(0));
+                    if (scoreDiff >= realignmentArgumentCollection.minAlignerScoreDifference && mismatchRatio > realignmentArgumentCollection.minMismatchRatio) {
                         succeededRealignmentCount.increment();
                     } else {
                         failedRealignmentCount.increment();
@@ -209,6 +210,10 @@ public class FilterAlignmentArtifacts extends VariantWalker {
 
     private static int pairScore(final Pair<BwaMemAlignment, BwaMemAlignment> pair) {
         return pair.getFirst().getAlignerScore() + pair.getSecond().getAlignerScore();
+    }
+
+    private static int pairMismatches(final Pair<BwaMemAlignment, BwaMemAlignment> pair) {
+        return pair.getFirst().getNMismatches() + pair.getSecond().getNMismatches();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentArgumentCollection.java
@@ -9,6 +9,7 @@ public class RealignmentArgumentCollection {
     public static final double DEFAULT_SEED_SPLIT_FACTOR = 0.5;
     public static final int DEFAULT_MAX_REASONABLE_FRAGMENT_LENGTH = 100000;
     public static final int DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE = 20;
+    public static final double DEFAULT_MIN_MISMATCH_RATIO = 2.5;
     public static final int DEFAULT_NUM_REGULAR_CONTIGS = 25;
 
     /**
@@ -34,6 +35,12 @@ public class RealignmentArgumentCollection {
      */
     @Argument(fullName = "min-aligner-score-difference", doc = "Minimum difference between best and second-best alignment for a read to be considered well-mapped", optional = true)
     public int minAlignerScoreDifference = DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE;
+
+    /**
+     * Minimum ratio between the number of mismatches in the second best and best alignments
+     */
+    @Argument(fullName = "min-mismatch-ratio", doc = "Minimum ratio between the number of mismatches in the second best and best alignments", optional = true)
+    public double minMismatchRatio = DEFAULT_MIN_MISMATCH_RATIO;
 
     /**
      * Number of regular i.e. non-alt contigs

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentEngineUnitTest.java
@@ -58,10 +58,10 @@ public class RealignmentEngineUnitTest {
         final BwaMemAlignment aln90 = makeAlignment(0,90, 1, false);
         final BwaMemAlignment aln80 = makeAlignment(1,80, 1, true);
         final BwaMemAlignment aln70 = makeAlignment(0,70, 1, false);
-        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln70), 1).isGood());
-        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80), 5).isGood());
-        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80, aln70), 5).isGood());
-        Assert.assertFalse(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80, aln70), 11).isGood());
+        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln70), 1, 0.0).isGood());
+        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80), 5, 0.0).isGood());
+        Assert.assertTrue(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80, aln70), 5,0.0).isGood());
+        Assert.assertFalse(RealignmentEngine.checkAlignments(Arrays.asList(aln90, aln80, aln70), 11,0.0).isGood());
     }
 
     @Test


### PR DESCRIPTION
The more the best alignment mismatches its assigned reference location, the more stringent the filter becomes, that is, the lower the threshold for secondary alignments to constitute a multi-mapping becomes.  If the best mapping mismatches at one base and the second best mismatches at three, that is very different from the best mismatching at four bases and the second best mismatching at six.

@takutosato This corrects a failure to filter some very obvious clustered events mapping artifacts.  For example, there were 11 "events" within 150 bp in one MC3 sample that were all being called as false negatives for M2 and true positives for M1.  If these are real, I will eat dog food.