### PR TITLE
Funcotator: remove hardcoded tool-level version, and use the GATK version instead

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -372,7 +372,7 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
      *
      * May be overridden by subclasses to provide a custom implementation if desired.
      */
-    protected String getVersion() {
+    public String getVersion() {
         String versionString = this.getClass().getPackage().getImplementationVersion();
         return versionString != null ?
                 versionString :

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -188,11 +188,6 @@ import java.util.*;
 public class Funcotator extends VariantWalker {
     private static final Logger logger = LogManager.getLogger(Funcotator.class);
 
-    /**
-     * The current version of {@link Funcotator}.
-     */
-    public static final String VERSION = "0.0.5";
-
     //==================================================================================================================
     // Arguments:
 
@@ -212,11 +207,6 @@ public class Funcotator extends VariantWalker {
      */
     public FuncotatorArgumentCollection getArguments() {
         return funcotatorArgs;
-    }
-
-    @Override
-    protected String getVersion() {
-        return super.getVersion() + "-" + VERSION;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -201,13 +201,17 @@ public final class FuncotatorEngine implements AutoCloseable {
         // Set up our output renderer:
         switch (funcotatorArgs.outputFormatType) {
             case MAF:
-                outputRenderer = new MafOutputRenderer(funcotatorArgs.outputFile.toPath(),
+                outputRenderer = new MafOutputRenderer(
+                        funcotatorArgs.outputFile.toPath(),
                         getFuncotationFactories(),
                         headerForVariants,
                         unaccountedForDefaultAnnotations,
                         unaccountedForOverrideAnnotations,
                         defaultToolVcfHeaderLines.stream().map(Object::toString).collect(Collectors.toCollection(LinkedHashSet::new)),
-                        funcotatorArgs.referenceVersion, funcotatorArgs.excludedFields);
+                        funcotatorArgs.referenceVersion,
+                        funcotatorArgs.excludedFields,
+                        gatkToolInstance.getVersion()
+                );
                 break;
 
             case VCF:
@@ -217,7 +221,9 @@ public final class FuncotatorEngine implements AutoCloseable {
                         headerForVariants,
                         unaccountedForDefaultAnnotations,
                         unaccountedForOverrideAnnotations,
-                        defaultToolVcfHeaderLines, funcotatorArgs.excludedFields
+                        defaultToolVcfHeaderLines,
+                        funcotatorArgs.excludedFields,
+                        gatkToolInstance.getVersion()
                 );
                 break;
             default:

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/OutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/OutputRenderer.java
@@ -34,7 +34,28 @@ public abstract class OutputRenderer implements AutoCloseable {
      */
     protected List<DataSourceFuncotationFactory> dataSourceFactories;
 
+    /**
+     * The version of the tool used to produce the output file.
+     */
+    protected final String toolVersion;
+
     //==================================================================================================================
+
+    /**
+     * Initialize an OutputRenderer
+     *
+     * @param toolVersion The version number of the tool used to produce the output file (must not be null).
+     */
+    public OutputRenderer(final String toolVersion) {
+        this.toolVersion = Utils.nonNull(toolVersion);
+    }
+
+    /**
+     * @return the version number of the tool used to produce the output file
+     */
+    public String getToolVersion() {
+        return toolVersion;
+    }
 
     /**
      * @return A {@link String} containing information about the data sources that are used to create the {@link Funcotation}s by this {@link OutputRenderer}.

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
@@ -148,9 +148,6 @@ public class MafOutputRenderer extends OutputRenderer {
     /** Fields that should be removed in the final MAF file. */
     private final Set<String> excludedOutputFields;
 
-    /** The version of the tool used to produce the MAF file. */
-    private final String toolVersion;
-
     //==================================================================================================================
     // Constructors:
 
@@ -176,6 +173,8 @@ public class MafOutputRenderer extends OutputRenderer {
                              final String referenceVersion,
                              final Set<String> excludedOutputFields,
                              final String toolVersion) {
+        super(toolVersion);
+
         Utils.nonNull(outputFilePath);
         Utils.nonNull(dataSources);
         Utils.nonNull(inputFileHeader);
@@ -184,7 +183,6 @@ public class MafOutputRenderer extends OutputRenderer {
         Utils.nonNull(toolHeaderLines);
         Utils.nonNull(referenceVersion);
         Utils.nonNull(excludedOutputFields);
-        Utils.nonNull(toolVersion);
 
         // Set our internal variables from the input:
         this.outputFilePath = outputFilePath;
@@ -192,7 +190,6 @@ public class MafOutputRenderer extends OutputRenderer {
         this.inputFileHeader = inputFileHeader;
         this.dataSourceFactories = dataSources;
         this.referenceVersion = referenceVersion;
-        this.toolVersion = toolVersion;
 
         this.tnPairs = SamplePairExtractor.extractPossibleTumorNormalPairs(this.inputFileHeader);
         if (tnPairs.size() == 0) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRenderer.java
@@ -148,6 +148,9 @@ public class MafOutputRenderer extends OutputRenderer {
     /** Fields that should be removed in the final MAF file. */
     private final Set<String> excludedOutputFields;
 
+    /** The version of the tool used to produce the MAF file. */
+    private final String toolVersion;
+
     //==================================================================================================================
     // Constructors:
 
@@ -156,10 +159,13 @@ public class MafOutputRenderer extends OutputRenderer {
      *
      * @param outputFilePath {@link Path} to output file (must not be null).
      * @param dataSources {@link List} of {@link DataSourceFuncotationFactory} to back our annotations (must not be null).
-     * @param inputFileHeader {@link VCFHeader} of input VCF file to preserve.
-     * @param unaccountedForDefaultAnnotations {@link LinkedHashMap} of default annotations that must be added.
-     * @param unaccountedForOverrideAnnotations {@link LinkedHashMap} of override annotations that must be added.
-     * @param toolHeaderLines Lines to add to the header with information about Funcotator.
+     * @param inputFileHeader {@link VCFHeader} of input VCF file to preserve (must not be null).
+     * @param unaccountedForDefaultAnnotations {@link LinkedHashMap} of default annotations that must be added (must not be null).
+     * @param unaccountedForOverrideAnnotations {@link LinkedHashMap} of override annotations that must be added (must not be null).
+     * @param toolHeaderLines Lines to add to the header with information about the tool (must not be null).
+     * @param referenceVersion Version of the reference we're using (must not be null).
+     * @param excludedOutputFields Fields that should not be rendered in the final output. Only exact name matches will be excluded (must not be null).
+     * @param toolVersion The version number of the tool used to produce the MAF file (must not be null).
      */
     public MafOutputRenderer(final Path outputFilePath,
                              final List<DataSourceFuncotationFactory> dataSources,
@@ -167,7 +173,18 @@ public class MafOutputRenderer extends OutputRenderer {
                              final LinkedHashMap<String, String> unaccountedForDefaultAnnotations,
                              final LinkedHashMap<String, String> unaccountedForOverrideAnnotations,
                              final Set<String> toolHeaderLines,
-                             final String referenceVersion, final Set<String> excludedOutputFields) {
+                             final String referenceVersion,
+                             final Set<String> excludedOutputFields,
+                             final String toolVersion) {
+        Utils.nonNull(outputFilePath);
+        Utils.nonNull(dataSources);
+        Utils.nonNull(inputFileHeader);
+        Utils.nonNull(unaccountedForDefaultAnnotations);
+        Utils.nonNull(unaccountedForOverrideAnnotations);
+        Utils.nonNull(toolHeaderLines);
+        Utils.nonNull(referenceVersion);
+        Utils.nonNull(excludedOutputFields);
+        Utils.nonNull(toolVersion);
 
         // Set our internal variables from the input:
         this.outputFilePath = outputFilePath;
@@ -175,6 +192,7 @@ public class MafOutputRenderer extends OutputRenderer {
         this.inputFileHeader = inputFileHeader;
         this.dataSourceFactories = dataSources;
         this.referenceVersion = referenceVersion;
+        this.toolVersion = toolVersion;
 
         this.tnPairs = SamplePairExtractor.extractPossibleTumorNormalPairs(this.inputFileHeader);
         if (tnPairs.size() == 0) {
@@ -190,9 +208,7 @@ public class MafOutputRenderer extends OutputRenderer {
 
         // Merge the default annotations into our manualAnnotations:
         manualAnnotations = new LinkedHashMap<>();
-        if ( unaccountedForDefaultAnnotations != null ) {
-            manualAnnotations.putAll(unaccountedForDefaultAnnotations);
-        }
+        manualAnnotations.putAll(unaccountedForDefaultAnnotations);
 
         // Handle our override annotations a little differently:
         this.overrideAnnotations = unaccountedForOverrideAnnotations;
@@ -639,7 +655,7 @@ public class MafOutputRenderer extends OutputRenderer {
             writer.write(MafOutputRendererConstants.COMMENT_STRING);
             writer.write(" ");
             writer.write(" Funcotator ");
-            writer.write(Funcotator.VERSION);
+            writer.write(toolVersion);
             writer.write(" | Date ");
             writer.write(new SimpleDateFormat("yyyymmdd'T'hhmmss").format(new Date()));
             writer.write(" | ");

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRenderer.java
@@ -75,9 +75,6 @@ public class VcfOutputRenderer extends OutputRenderer {
     /** List of the fields that will get rendered in the funcotation annotation.  Excluded fields have been removed.  */
     private final List<String> finalFuncotationFieldNames;
 
-    /** The version of the tool used to produce the VCF file. */
-    private final String toolVersion;
-
     //==================================================================================================================
     
     /**
@@ -100,6 +97,8 @@ public class VcfOutputRenderer extends OutputRenderer {
                              final Set<VCFHeaderLine> defaultToolVcfHeaderLines,
                              final Set<String> excludedOutputFields,
                              final String toolVersion) {
+        super(toolVersion);
+
         Utils.nonNull(vcfWriter);
         Utils.nonNull(dataSources);
         Utils.nonNull(existingHeader);
@@ -107,12 +106,10 @@ public class VcfOutputRenderer extends OutputRenderer {
         Utils.nonNull(unaccountedForOverrideAnnotations);
         Utils.nonNull(defaultToolVcfHeaderLines);
         Utils.nonNull(excludedOutputFields);
-        Utils.nonNull(toolVersion);
 
         this.vcfWriter = vcfWriter;
         this.existingHeader = existingHeader;
         this.dataSourceFactories = dataSources;
-        this.toolVersion = toolVersion;
 
         // Merge the annotations into our manualAnnotations:
         manualAnnotations = new LinkedHashMap<>();

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRenderer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRenderer.java
@@ -75,44 +75,44 @@ public class VcfOutputRenderer extends OutputRenderer {
     /** List of the fields that will get rendered in the funcotation annotation.  Excluded fields have been removed.  */
     private final List<String> finalFuncotationFieldNames;
 
+    /** The version of the tool used to produce the VCF file. */
+    private final String toolVersion;
+
     //==================================================================================================================
-
-    public VcfOutputRenderer(final VariantContextWriter vcfWriter,
-                             final VCFHeader existingHeader,
-                             final List<DataSourceFuncotationFactory> dataSources) {
-        this(vcfWriter, dataSources, existingHeader, new LinkedHashMap<>(), new LinkedHashMap<>());
-    }
-
-    public VcfOutputRenderer(final VariantContextWriter vcfWriter,
-                             final List<DataSourceFuncotationFactory> dataSources,
-                             final VCFHeader existingHeader,
-                             final LinkedHashMap<String, String> unaccountedForDefaultAnnotations,
-                             final LinkedHashMap<String, String> unaccountedForOverrideAnnotations) {
-        this(vcfWriter, dataSources, existingHeader, unaccountedForDefaultAnnotations, unaccountedForOverrideAnnotations,
-                new LinkedHashSet<>(), new LinkedHashSet<>());
-    }
-
-    @VisibleForTesting
+    
+    /**
+     * Create a {@link VcfOutputRenderer}.
+     *
+     * @param vcfWriter a pre-initialized {@link VariantContextWriter} used for writing the output (must not be null).
+     * @param dataSources {@link List} of {@link DataSourceFuncotationFactory} to back our annotations (must not be null).
+     * @param existingHeader {@link VCFHeader} of input VCF file to preserve (must not be null).
+     * @param unaccountedForDefaultAnnotations {@link LinkedHashMap} of default annotations that must be added (must not be null).
+     * @param unaccountedForOverrideAnnotations {@link LinkedHashMap} of override annotations that must be added (must not be null).
+     * @param defaultToolVcfHeaderLines Lines to add to the header with information about the tool (must not be null).
+     * @param excludedOutputFields Fields that should not be rendered in the final output. Only exact name matches will be excluded (must not be null).
+     * @param toolVersion The version number of the tool used to produce the VCF file (must not be null).
+     */
     public VcfOutputRenderer(final VariantContextWriter vcfWriter,
                              final List<DataSourceFuncotationFactory> dataSources,
                              final VCFHeader existingHeader,
                              final LinkedHashMap<String, String> unaccountedForDefaultAnnotations,
                              final LinkedHashMap<String, String> unaccountedForOverrideAnnotations,
-                             final Set<VCFHeaderLine> defaultToolVcfHeaderLines) {
-        this(vcfWriter, dataSources, existingHeader, unaccountedForDefaultAnnotations, unaccountedForOverrideAnnotations,
-               defaultToolVcfHeaderLines, new HashSet<>());
-    }
-
-    public VcfOutputRenderer(final VariantContextWriter vcfWriter,
-                             final List<DataSourceFuncotationFactory> dataSources,
-                             final VCFHeader existingHeader,
-                             final LinkedHashMap<String, String> unaccountedForDefaultAnnotations,
-                             final LinkedHashMap<String, String> unaccountedForOverrideAnnotations,
-                             final Set<VCFHeaderLine> defaultToolVcfHeaderLines, final Set<String> excludedOutputFields) {
+                             final Set<VCFHeaderLine> defaultToolVcfHeaderLines,
+                             final Set<String> excludedOutputFields,
+                             final String toolVersion) {
+        Utils.nonNull(vcfWriter);
+        Utils.nonNull(dataSources);
+        Utils.nonNull(existingHeader);
+        Utils.nonNull(unaccountedForDefaultAnnotations);
+        Utils.nonNull(unaccountedForOverrideAnnotations);
+        Utils.nonNull(defaultToolVcfHeaderLines);
+        Utils.nonNull(excludedOutputFields);
+        Utils.nonNull(toolVersion);
 
         this.vcfWriter = vcfWriter;
         this.existingHeader = existingHeader;
         this.dataSourceFactories = dataSources;
+        this.toolVersion = toolVersion;
 
         // Merge the annotations into our manualAnnotations:
         manualAnnotations = new LinkedHashMap<>();
@@ -286,7 +286,7 @@ public class VcfOutputRenderer extends OutputRenderer {
 
         // Add in the lines about Funcotations:
         headerLines.addAll(defaultToolVcfHeaderLines);
-        headerLines.add(new VCFHeaderLine("Funcotator Version", Funcotator.VERSION + " | " + getDataSourceInfoString()));
+        headerLines.add(new VCFHeaderLine("Funcotator Version", toolVersion + " | " + getDataSourceInfoString()));
         headerLines.add(new VCFInfoHeaderLine(FUNCOTATOR_VCF_FIELD_NAME, VCFHeaderLineCount.A,
                 VCFHeaderLineType.String, "Functional annotation from the Funcotator tool.  Funcotation fields are"
                 + DESCRIPTION_PREAMBLE_DELIMITER +

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -1316,7 +1316,7 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
         // Needs to get aliases from the MAF, since AF (and maybe more) has its name changed.  So create a dummy
         //  MafOutputRenderer that mimics the one that is used in the command line invocation above and get the aliases.
         final File dummyOutputFile = getOutputFile(FuncotatorArgumentDefinitions.OutputFormatType.MAF);
-        final MafOutputRenderer dummyMafOutputRenderer = new MafOutputRenderer(dummyOutputFile.toPath(), Collections.emptyList(), new VCFHeader(), new LinkedHashMap<>(), new LinkedHashMap<>(), new HashSet<>(), "b37", new HashSet<String>());
+        final MafOutputRenderer dummyMafOutputRenderer = new MafOutputRenderer(dummyOutputFile.toPath(), Collections.emptyList(), new VCFHeader(), new LinkedHashMap<>(), new LinkedHashMap<>(), new HashSet<>(), "b37", new HashSet<String>(), "Unknown");
         final Map<String, Set<String>> mafAliasMap = dummyMafOutputRenderer.getReverseOutputFieldNameMap();
 
         // Get all of the alias lists

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -133,7 +133,9 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
                 new LinkedHashMap<>(),
                 new LinkedHashMap<>(),
                 new HashSet<>(),
-                referenceVersion, excludedFields
+                referenceVersion,
+                excludedFields,
+                "Unknown"
         );
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/vcfOutput/VcfOutputRendererUnitTest.java
@@ -48,7 +48,7 @@ public class VcfOutputRendererUnitTest extends GATKBaseTest {
         final VcfOutputRenderer vcfOutputRenderer = new VcfOutputRenderer(vcfWriter,
             new ArrayList<>(), entireInputVcf.getLeft(), new LinkedHashMap<>(dummyDefaults),
             new LinkedHashMap<>(),
-            new HashSet<>(), new HashSet<>(Arrays.asList("BAZ", "AC")));
+            new HashSet<>(), new HashSet<>(Arrays.asList("BAZ", "AC")), "Unknown");
 
         final VariantContext variant = entireInputVcf.getRight().get(0);
 


### PR DESCRIPTION
Funcotator used to override getVersion() with a custom version number.
Now it uses the toolkit-wide version number, like other GATK tools.

Also improved javadoc for OutputRenderer constructors, and deleted
some unused constructors.

Resolves #5128