### PR TITLE
Funcotator: get the NCBI build version from the datasource config file

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -139,6 +139,7 @@ public class FuncotatorArgumentDefinitions {
             @Override
             public void assertConfigFilePropertiesAreValid(final Properties configFileProperties, final Path configFilePath) {
                 DataSourceUtils.assertConfigPropertiesContainsKey(DataSourceUtils.CONFIG_FILE_FIELD_NAME_GENCODE_FASTA_PATH, configFileProperties, configFilePath);
+                DataSourceUtils.assertConfigPropertiesContainsKey(DataSourceUtils.CONFIG_FILE_FIELD_NAME_NCBI_BUILD_VERSION, configFileProperties, configFilePath);
 
                 // Assert that the path is good:
                 DataSourceUtils.assertPathFilePropertiesField(configFileProperties, DataSourceUtils.CONFIG_FILE_FIELD_NAME_GENCODE_FASTA_PATH, configFilePath);

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
@@ -91,6 +91,7 @@ final public class DataSourceUtils {
     public static final String CONFIG_FILE_FIELD_NAME_CONTIG_COLUMN        = "contig_column";
     public static final String CONFIG_FILE_FIELD_NAME_START_COLUMN         = "start_column";
     public static final String CONFIG_FILE_FIELD_NAME_END_COLUMN           = "end_column";
+    public static final String CONFIG_FILE_FIELD_NAME_NCBI_BUILD_VERSION   = "ncbi_build_version";
 
     // Optional config options:
     public static final String CONFIG_FILE_FIELD_NAME_IS_B37_DATA_SOURCE   = "isB37DataSource";
@@ -475,6 +476,8 @@ final public class DataSourceUtils {
         final String fastaPath = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_GENCODE_FASTA_PATH);
         final String version   = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_VERSION);
         final String name      = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NAME);
+        final String ncbiBuildVersion = dataSourceProperties.getProperty(CONFIG_FILE_FIELD_NAME_NCBI_BUILD_VERSION);
+
         final boolean isB37    = getIsB37PropertyValue(dataSourceProperties);
 
         // Create our gencode factory:
@@ -487,7 +490,8 @@ final public class DataSourceUtils {
                 annotationOverridesMap,
                 featureInput,
                 flankSettings,
-                isB37
+                isB37,
+                ncbiBuildVersion
             );
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMapUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotationMapUnitTest.java
@@ -428,7 +428,7 @@ public class FuncotationMapUnitTest extends GATKBaseTest {
         final String gencode_test = "GENCODE_TEST";
         final GencodeFuncotationFactory gencodeFactory = new GencodeFuncotationFactory(Paths.get(transcriptFastaFile),
         "TEST", gencode_test, transcriptSelectionMode, new HashSet<>(), new LinkedHashMap<>(),
-                new FeatureInput<>(transcriptGtfFile, gencode_test, Collections.emptyMap()));
+                new FeatureInput<>(transcriptGtfFile, gencode_test, Collections.emptyMap()), "TEST");
 
         final FeatureContext featureContext = FuncotatorTestUtils.createFeatureContext(Collections.singletonList(gencodeFactory), "FuncotationMapUnitTest",
                 variantInterval, 0, 0, 0, null);

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -55,7 +55,7 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
     // Whether to do debug output (i.e. leave output around).
     // This should always be false when checked in.
     // These tests would take ~30 minutes to complete each.
-    private static final boolean enableFullScaleValidationTest = true;
+    private static final boolean enableFullScaleValidationTest = false;
     private static final String  LARGE_DATASOURCES_FOLDER      = "funcotator_dataSources_latest";
     private static final String  GERMLINE_DATASOURCES_FOLDER   = "funcotator_dataSources_germline_latest";
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -77,7 +77,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                 new HashSet<>(),
                 new LinkedHashMap<>(),
-                createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME));
+                createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME),
+                "TEST");
 
         // Add all to the closeable list:
         autoCloseableList.add( muc16NonBasicFeatureReader );
@@ -716,6 +717,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                             .setTranscriptLength(0)
                             .setVersion(versionString)
                             .setGeneTranscriptType(transcript1.getTranscriptType())
+                            .setNcbiBuild("TEST")
                             .build()
                 },
         };
@@ -1363,7 +1365,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                 requestedTranscriptIds,
-                new LinkedHashMap<>(), createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
+                new LinkedHashMap<>(), createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME), "HG19")) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1423,8 +1425,9 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                                                                     GencodeFuncotationFactory.DEFAULT_NAME,
                                                                     FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_DEFAULT_VALUE,
                                                                     new HashSet<>(),
-                                                                    new LinkedHashMap<>(), createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME)
-                                                                    )) {
+                                                                    new LinkedHashMap<>(),
+                                                                    createFeatureInputForMuc16Ds(GencodeFuncotationFactory.DEFAULT_NAME),
+                                                                    "HG19")) {
 
             // Generate our funcotations:
             final List<Feature> featureList = new ArrayList<>();
@@ -1506,7 +1509,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 requestedTranscriptIds,
                 new LinkedHashMap<>(),
                 new FeatureInput<>(transcriptGtfFile, GencodeFuncotationFactory.DEFAULT_NAME, Collections.emptyMap()),
-                flankSettingsForTesting)) {
+                flankSettingsForTesting,
+                "TEST")) {
 
             final List<Feature> featureList = new ArrayList<>();
             featureList.add( gene );
@@ -1622,14 +1626,14 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
 
         final GencodeFuncotationBuilder builder =
                 GencodeFuncotationFactory.createGencodeFuncotationBuilderWithTrivialFieldsPopulated(variant, altAllele,
-                        gtfFeature, transcript);
+                        gtfFeature, transcript, "TEST");
         final GencodeFuncotation gf = builder.gencodeFuncotation;
 
         // Ultra-trivial checks:
         Assert.assertEquals( gf.getRefAllele(), variant.getReference().getBaseString() );
         Assert.assertEquals( gf.getTranscriptStrand(), transcript.getGenomicStrand().encode() );
         Assert.assertEquals( gf.getHugoSymbol(), gtfFeature.getGeneName() );
-        Assert.assertEquals( gf.getNcbiBuild(), gtfFeature.getUcscGenomeVersion() );
+        Assert.assertEquals( gf.getNcbiBuild(), "TEST" );
         Assert.assertEquals( gf.getChromosome(), gtfFeature.getChromosomeName() );
         Assert.assertEquals( gf.getStart(), variant.getStart() );
         Assert.assertEquals( gf.getGeneTranscriptType(), transcript.getTranscriptType() );
@@ -1666,7 +1670,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                                                        final String dataSourceName,
                                                        final GencodeFuncotation expected) {
 
-        final GencodeFuncotation funcotation = GencodeFuncotationFactory.createDefaultFuncotationsOnProblemVariant(variant, altAllele, gtfFeature, reference, transcript, version, dataSourceName);
+        final GencodeFuncotation funcotation = GencodeFuncotationFactory.createDefaultFuncotationsOnProblemVariant(
+                variant, altAllele, gtfFeature, reference, transcript, version, dataSourceName, "TEST");
         Assert.assertEquals( funcotation, expected );
     }
 
@@ -1835,7 +1840,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.CANONICAL,
                 Collections.emptySet(),
-                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME),
+                "TEST")) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertEquals(gencodeFuncotations.size(), 1);
         }
@@ -1846,7 +1852,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.BEST_EFFECT,
                 Collections.emptySet(),
-                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME),
+                "TEST")) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertEquals(gencodeFuncotations.size(), 1);
         }
@@ -1857,7 +1864,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 GencodeFuncotationFactory.DEFAULT_NAME,
                 TranscriptSelectionMode.ALL,
                 Collections.emptySet(),
-                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME))) {
+                new LinkedHashMap<>(), createFeatureInputForCntn4Ds(GencodeFuncotationFactory.DEFAULT_NAME),
+                "TEST")) {
             final List<Funcotation> gencodeFuncotations = funcotationFactory.createFuncotationsOnVariant(vc, referenceContext, gencodeFeatures);
             Assert.assertTrue(gencodeFuncotations.size() > 1);
         }
@@ -2478,7 +2486,8 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
                 Collections.emptySet(),
                 new LinkedHashMap<>(),
                 gencodeFeatureInput,
-                new FlankSettings(fivePrimeFlankSize,threePrimeFlankSize))) {
+                new FlankSettings(fivePrimeFlankSize,threePrimeFlankSize),
+                "TEST")) {
 
             // We test against createFuncotations() rather than createFuncotationsOnVariant() here because
             // the flanking feature relies on the query done in createFuncotations(), and we need to test

--- a/src/test/resources/large/funcotator/funcotator_dataSources/gencode/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources/gencode/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94c307d63e38dfd7c2736b0c10551f4d1d627bf3b8d0a9a90a8ede94205bd9a2
-size 1789
+oid sha256:4caa672f83c6a96ed8f3ea7cb5976c63effde95cc908b4d86d0b3882e6addc25
+size 1873

--- a/src/test/resources/large/funcotator/funcotator_dataSources/gencode/hg38/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources/gencode/hg38/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:364d9872e9b6ed83df0287e0157785b826c229070906638915b3a9da45e56e4e
-size 1751
+oid sha256:e3c5225a0167e4e32a83548d48b0ad51ac31afeedae5ca7530316df8a6756287
+size 1835

--- a/src/test/resources/large/funcotator/funcotator_dataSources_cloud/gencode/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources_cloud/gencode/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a85bcafc5971713c72b8e6e00a6ead025d9b5cb843981efb55795953561bb341
-size 1903
+oid sha256:71be8f77649a8def5cb4f968d89ce41f616a1cc3982718ce6a4bd9df85a33918
+size 1987

--- a/src/test/resources/large/funcotator/funcotator_dataSources_cloud/gencode/hg38/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources_cloud/gencode/hg38/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7ccffb3789c983b21b7a4deac3846ba01e1dfdfc920665abbe8f4614e37e02d
-size 1904
+oid sha256:0c08a0650e427d66a12e422d69dd138f3a9ab8a6278c80c777a2c73de02ccc5e
+size 1988

--- a/src/test/resources/large/funcotator/funcotator_dataSources_cloud_gnomad/gencode/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources_cloud_gnomad/gencode/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b90f80d36fa98d3f7721478b7d3f54d0c1439af5ef43a30c1f9469adc4291c0e
-size 1751
+oid sha256:11c06da65b00b9af98f9edc3b7132371a7353df80a567d046b2d8fc5349952a0
+size 1835

--- a/src/test/resources/large/funcotator/funcotator_dataSources_cloud_gnomad/gencode/hg38/gencode.config
+++ b/src/test/resources/large/funcotator/funcotator_dataSources_cloud_gnomad/gencode/hg38/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:364d9872e9b6ed83df0287e0157785b826c229070906638915b3a9da45e56e4e
-size 1751
+oid sha256:e3c5225a0167e4e32a83548d48b0ad51ac31afeedae5ca7530316df8a6756287
+size 1835

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_muc16/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0b9ee8ca0e98586dd47dee4feed5ec6306e8d00ccf049035f6fdc29ec015af8
-size 1677
+oid sha256:0f630c3184ac742c2411e22e70868bec73ec7a56a499e1c97b20973007e1901f
+size 1761

--- a/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/pik3ca_muc16_all_transcripts_ds/gencode_pik3ca/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb604e5862217c3978cc2fb0abf2f6f2cb8b4cf34681a026fedcd891aa0aa6f0
-size 1679
+oid sha256:fb92e5bea0e75a93df9e96da3cdf6b135700f90544f5c32c8af859317d74b8bb
+size 1763

--- a/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/small_ds_clinvar_hg19/gencode_pik3ca/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb604e5862217c3978cc2fb0abf2f6f2cb8b4cf34681a026fedcd891aa0aa6f0
-size 1679
+oid sha256:fb92e5bea0e75a93df9e96da3cdf6b135700f90544f5c32c8af859317d74b8bb
+size 1763

--- a/src/test/resources/large/funcotator/small_ds_pik3ca/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/large/funcotator/small_ds_pik3ca/gencode_pik3ca/hg19/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb604e5862217c3978cc2fb0abf2f6f2cb8b4cf34681a026fedcd891aa0aa6f0
-size 1679
+oid sha256:fb92e5bea0e75a93df9e96da3cdf6b135700f90544f5c32c8af859317d74b8bb
+size 1763

--- a/src/test/resources/large/funcotator/small_ds_pik3ca/gencode_pik3ca/hg38/gencode_pik3ca.config
+++ b/src/test/resources/large/funcotator/small_ds_pik3ca/gencode_pik3ca/hg38/gencode_pik3ca.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e192126fa75bfd7babf2bc889a467f5777d57a834d5e30574234bc536948e0f4
-size 1546
+oid sha256:cc5f9af4f1084531c724289993da96dce4ebea1c67b54750be769610e771ce8a
+size 1630

--- a/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/small_pik3ca_dbsnp_ds/gencode_pik3ca/hg19/gencode.config
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/funcotator/small_pik3ca_dbsnp_ds/gencode_pik3ca/hg19/gencode.config
@@ -15,6 +15,10 @@ type = gencode
 # Path to the FASTA file from which to load the sequences for GENCODE transcripts:
 gencode_fasta_path = gencode.v19.PIK3CA_transcript.fasta
 
+# Required field for GENCODE files.
+# NCBI build version
+ncbi_build_version = hg19
+
 # Required field for simpleXSV files.
 # Valid values:
 #     GENE_NAME


### PR DESCRIPTION
Store the NCBI build version in the Gencode datasource config files
in order to resolve an issue where this value was not always available
when annotating IGR variants.

Resolves #4404