### PR TITLE
Restore link in VariantFiltration to point to update online JEXL doc.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -93,6 +93,8 @@ import static java.util.Collections.singleton;
  *    --filter-name "my_filter" \
  *    --filter-expression "AB < 0.2 || MQ0 > 50"
  *  </pre>
+ * See this <a href="https://www.broadinstitute.org/gatk/guide/article?id=1255">article about using JEXL expressions</a>
+ * for more information.
  */
 @CommandLineProgramProperties(
         summary = "Filter variant calls based on INFO and/or FORMAT annotations.",


### PR DESCRIPTION
Fixes the gatk doc part of https://github.com/broadinstitute/gatk/issues/5509 now that the public doc has been updated.