### PR TITLE
Pair-HMM alignment algorithm description fix

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/Log10PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/Log10PairHMM.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import static org.broadinstitute.hellbender.utils.pairhmm.PairHMMModel.*;
 
 /**
- * Util class for performing the pair HMM for local alignment. Figure 4.3 in Durbin 1998 book.
+ * Util class for performing the pair HMM for global alignment. Figure 4.1 in Durbin 1998 book.
  */
 public final class Log10PairHMM extends N2MemoryPairHMM {
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Class for performing the pair HMM for local alignment. Figure 4.3 in Durbin 1998 book.
+ * Class for performing the pair HMM for global alignment. Figure 4.1 in Durbin 1998 book.
  */
 public abstract class PairHMM implements Closeable{
     protected static final Logger logger = LogManager.getLogger(PairHMM.class);

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/VectorLoglessPairHMM.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Class for performing the pair HMM for local alignment using AVX instructions contained in a native shared library.
+ * Class for performing the pair HMM for global alignment using AVX instructions contained in a native shared library.
  */
 public final class VectorLoglessPairHMM extends LoglessPairHMM {
 


### PR DESCRIPTION
Hello.
I believe there is an error in the description of the algorithm in the pairHMM alignment stage.

It states that it does **local** alignment, however the code implements a **global** alignment.
Therefore I fixed the comments and added the correct reference to Durbin's book. (The figure referenced is not the Finite State Machine implemented).

This was discussed on the GATK forum before I made the pull request.
See discussion here : [Discussion Thread](https://gatkforums.broadinstitute.org/gatk/discussion/23197/question-about-the-alignment-performed-in-the-haplotypecaller-pairhmm#latest)

I believe this is important,  because the difference between the two FSMs is as important as the difference between running the Needleman–Wunsch and Smith-Waterman algorithm (global vs local).

Regards.
Rick
