### PR TITLE
Definine GenomicsDB "partitions" over the span of the input intervals in

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1261,6 +1261,13 @@ public final class IntervalUtils {
 
     // (end of shard-related code)
 
+    public static List<SimpleInterval> getSpanningIntervals(final List<? extends Locatable> locations, final SAMSequenceDictionary sequenceDictionary){
+        return locations.stream()
+                .collect(Collectors.groupingBy(Locatable::getContig))
+                .values().stream().map(IntervalUtils::getSpanningInterval).sorted((i1,i2)->compareLocatables(i1,i2,sequenceDictionary))
+                .collect(Collectors.toList());
+    }
+
     /**
      * Combine the breakpoints of multiple intervals and return a list of locatables based on the updated breakpoints.
      *

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -1261,6 +1261,13 @@ public final class IntervalUtils {
 
     // (end of shard-related code)
 
+    /**
+     * Get a single interval per contig that includes all of the specified intervals
+     * (This is used to improve GenomicsDB performance for exomes)
+     * @param locations the intervals to be merged/spanned
+     * @param sequenceDictionary for contig sorting
+     * @return a sorted list intervals containing the input intervals, one per contig
+     */
     public static List<SimpleInterval> getSpanningIntervals(final List<? extends Locatable> locations, final SAMSequenceDictionary sequenceDictionary){
         return locations.stream()
                 .collect(Collectors.groupingBy(Locatable::getContig))

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -152,7 +152,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
     }
 
     @Test
-    public void testGenomicsDBImportWith1000Intervals() throws IOException {
+    public void testGenomicsDBImportWith1000IntervalsToBeMerged() throws IOException {
         final String workspace = createTempDir("genomicsdb-tests-").getAbsolutePath() + "/workspace";
         LinkedList<SimpleInterval> intervals = new LinkedList<SimpleInterval>();
         //[ 17960187, 17981445 ]
@@ -444,9 +444,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         vcfInputs.forEach(vcf -> args.addArgument("V", vcf));
         args.addArgument("batch-size", String.valueOf(batchSize));
         args.addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(threads));
-        if (mergeIntervals) {
-            args.addArgument(GenomicsDBImport.MERGE_INPUT_INTERVALS_LONG_NAME);
-        }
+        args.addBooleanArgument(GenomicsDBImport.MERGE_INPUT_INTERVALS_LONG_NAME, mergeIntervals);
         if (useBufferSize) {
             args.addArgument("genomicsdb-vcf-buffer-size", String.valueOf(bufferSizePerSample));
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -151,14 +151,16 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         testGenomicsDBImporter(LOCAL_GVCFS, MULTIPLE_INTERVALS, COMBINED_MULTI_INTERVAL, b38_reference_20_21, true, 1);
     }
 
-    private void testGenomicsDBImportWith1000Intervals() throws IOException {
+    @Test
+    public void testGenomicsDBImportWith1000Intervals() throws IOException {
         final String workspace = createTempDir("genomicsdb-tests-").getAbsolutePath() + "/workspace";
         LinkedList<SimpleInterval> intervals = new LinkedList<SimpleInterval>();
         //[ 17960187, 17981445 ]
         int base = 17960187;
         for (int i = 0; i < 1000; ++i)
             intervals.add(new SimpleInterval("chr20", base + 20 * i, base + 20 * i + 10)); //intervals of size 10 separated by 10
-        writeToGenomicsDB(new ArrayList<String>(Arrays.asList(LOCAL_GVCFS.get(0))), intervals, workspace, 0, false, 0, 1);
+        writeToGenomicsDB(new ArrayList<String>(Arrays.asList(LOCAL_GVCFS.get(0))), intervals, workspace, 0,
+                false, 0, 1, true);
     }
 
     @Test
@@ -431,14 +433,23 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
 
     private void writeToGenomicsDB(final List<String> vcfInputs, final List<SimpleInterval> intervals, final String workspace,
                                    final int batchSize, final Boolean useBufferSize, final int bufferSizePerSample, int threads) {
+        writeToGenomicsDB(vcfInputs, intervals, workspace, batchSize, useBufferSize, bufferSizePerSample, threads, false);
+    }
+
+    private void writeToGenomicsDB(final List<String> vcfInputs, final List<SimpleInterval> intervals, final String workspace,
+                                   final int batchSize, final Boolean useBufferSize, final int bufferSizePerSample, int threads, final boolean mergeIntervals) {
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.addArgument(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
         intervals.forEach(interval -> args.addArgument("L", IntervalUtils.locatableToString(interval)));
         vcfInputs.forEach(vcf -> args.addArgument("V", vcf));
         args.addArgument("batch-size", String.valueOf(batchSize));
         args.addArgument(GenomicsDBImport.VCF_INITIALIZER_THREADS_LONG_NAME, String.valueOf(threads));
-        if (useBufferSize)
+        if (mergeIntervals) {
+            args.addArgument(GenomicsDBImport.MERGE_INPUT_INTERVALS_LONG_NAME);
+        }
+        if (useBufferSize) {
             args.addArgument("genomicsdb-vcf-buffer-size", String.valueOf(bufferSizePerSample));
+        }
 
         runCommandLine(args);
     }


### PR DESCRIPTION
order to dramatically improve exome performance

This makes an 81X speedup in the 1000interval test I put back in.  Exomes are just about unrunnable without some sort of interval manipulation.  The 65 sample exome joint calling callset output was exactly the same with this version.  I also did a comparison for a chr1 and chr20 import (so that we were looking at two intervals that were far apart) and the runtime was the same.  This is a huge improvement for some typical use cases.