### PR TITLE
Changing defaults for mitochondria mode now that we have adaptive pruning

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
@@ -5,6 +5,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.StandardCallerArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 import org.broadinstitute.hellbender.utils.haplotype.HaplotypeBAMWriter;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
 
@@ -29,11 +30,21 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
     @ArgumentCollection
     public AssemblyRegionTrimmerArgumentCollection assemblyRegionTrimmerArgs = new AssemblyRegionTrimmerArgumentCollection();
 
-    protected boolean useMutectAssemblerArgumentCollection() { return false; }
+    public ReadThreadingAssembler createReadThreadingAssembler() {
+        final ReadThreadingAssemblerArgumentCollection rtaac = assemblerArgs;
+        final ReadThreadingAssembler assemblyEngine = rtaac.makeReadThreadingAssembler();
+        assemblyEngine.setDebug(debug);
+        assemblyEngine.setMinBaseQualityToUseInAssembly(minBaseQualityScore);
+
+        return assemblyEngine;
+    }
+
+    protected ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection() {
+        return new HaplotypeCallerReadThreadingAssemblerArgumentCollection();
+    }
 
     @ArgumentCollection
-    public ReadThreadingAssemblerArgumentCollection assemblerArgs = useMutectAssemblerArgumentCollection() ?
-            new MutectReadThreadingAssemblerArgumentCollection() : new HaplotypeCallerReadThreadingAssemblerArgumentCollection();
+    public ReadThreadingAssemblerArgumentCollection assemblerArgs = getReadThreadingAssemblerArgumentCollection();
 
     @ArgumentCollection
     public LikelihoodEngineArgumentCollection likelihoodArgs = new LikelihoodEngineArgumentCollection();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
@@ -31,17 +31,14 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
     public AssemblyRegionTrimmerArgumentCollection assemblyRegionTrimmerArgs = new AssemblyRegionTrimmerArgumentCollection();
 
     public ReadThreadingAssembler createReadThreadingAssembler() {
-        final ReadThreadingAssemblerArgumentCollection rtaac = assemblerArgs;
-        final ReadThreadingAssembler assemblyEngine = rtaac.makeReadThreadingAssembler();
+        final ReadThreadingAssembler assemblyEngine = assemblerArgs.makeReadThreadingAssembler();
         assemblyEngine.setDebug(debug);
         assemblyEngine.setMinBaseQualityToUseInAssembly(minBaseQualityScore);
 
         return assemblyEngine;
     }
 
-    protected ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection() {
-        return new HaplotypeCallerReadThreadingAssemblerArgumentCollection();
-    }
+    protected abstract ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection();
 
     @ArgumentCollection
     public ReadThreadingAssemblerArgumentCollection assemblerArgs = getReadThreadingAssemblerArgumentCollection();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -192,15 +192,6 @@ public final class AssemblyBasedCallerUtils {
         }
     }
 
-    public static ReadThreadingAssembler createReadThreadingAssembler(final AssemblyBasedCallerArgumentCollection args) {
-        final ReadThreadingAssemblerArgumentCollection rtaac = args.assemblerArgs;
-        final ReadThreadingAssembler assemblyEngine = rtaac.makeReadThreadingAssembler();
-        assemblyEngine.setDebug(args.debug);
-        assemblyEngine.setMinBaseQualityToUseInAssembly(args.minBaseQualityScore);
-
-        return assemblyEngine;
-    }
-
     public static Optional<HaplotypeBAMWriter> createBamWriter(final AssemblyBasedCallerArgumentCollection args,
                                                                final boolean createBamOutIndex,
                                                                final boolean createBamOutMD5,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -25,6 +25,11 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
     public static final String GQ_BAND_LONG_NAME = "gvcf-gq-bands";
     public static final String GQ_BAND_SHORT_NAME = "GQB";
 
+    @Override
+    protected ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection() {
+        return new HaplotypeCallerReadThreadingAssemblerArgumentCollection();
+    }
+
     /**
      * You can use this argument to specify that HC should process a single sample out of a multisample BAM file. This
      * is especially useful if your samples are all in the same file but you need to run them individually through HC

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -211,7 +211,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         }
 
         haplotypeBAMWriter = AssemblyBasedCallerUtils.createBamWriter(hcArgs, createBamOutIndex, createBamOutMD5, readsHeader);
-        assemblyEngine = AssemblyBasedCallerUtils.createReadThreadingAssembler(hcArgs);
+        assemblyEngine = hcArgs.createReadThreadingAssembler();
         likelihoodCalculationEngine = AssemblyBasedCallerUtils.createLikelihoodCalculationEngine(hcArgs.likelihoodArgs);
 
         trimmer.initialize(hcArgs.assemblyRegionTrimmerArgs, readsHeader.getSequenceDictionary(), hcArgs.debug,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -15,6 +15,8 @@ import java.util.List;
 public abstract class ReadThreadingAssemblerArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    public static final double DEFAULT_PRUNING_LOG_ODDS_THRESHOLD = 1.0;
+
     // -----------------------------------------------------------------------------------------------
     // arguments to control internal behavior of the read threading assembler
     // -----------------------------------------------------------------------------------------------
@@ -98,7 +100,7 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
      */
     @Advanced
     @Argument(fullName="pruning-lod-threshold", doc = "Log-10 likelihood ratio threshold for adaptive pruning algorithm", optional = true)
-    public double pruningLog10OddsThreshold = 1.0;
+    public double pruningLog10OddsThreshold = DEFAULT_PRUNING_LOG_ODDS_THRESHOLD;
 
     /**
      * The maximum number of variants in graph the adaptive pruner will allow

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
@@ -6,6 +6,7 @@ import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.util.*;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
 public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> extends ChainPruner<V,E> {
@@ -49,7 +50,8 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
         });
 
         chains.stream().filter(c -> isChainPossibleVariant(c, graph))
-                .sorted(Comparator.comparingDouble(chainLogOdds::get).reversed())
+                .sorted(Comparator.comparingDouble((ToDoubleFunction<Path<V, E>>) chainLogOdds::get)
+                        .reversed().thenComparingInt(Path::getScore))
                 .skip(maxUnprunedVariants)
                 .forEach(result::add);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -5,6 +5,9 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.MutectReadThreadingAssemblerArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadThreadingAssemblerArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 
 import java.io.File;
 
@@ -48,8 +51,20 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final double DEFAULT_INITIAL_LOD = 2.0;
     public static final double DEFAULT_MITO_INITIAL_LOD = 0;
 
+    public static final double DEFAULT_PRUNING_LOG_ODDS_THRESHOLD = -4;
+
     @Override
-    protected boolean useMutectAssemblerArgumentCollection() { return true; }
+    protected ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection(){
+        return new MutectReadThreadingAssemblerArgumentCollection();
+    }
+
+    @Override
+    public ReadThreadingAssembler createReadThreadingAssembler(){
+        if(mitochondria && assemblerArgs.pruningLog10OddsThreshold == ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD) {
+            assemblerArgs.pruningLog10OddsThreshold = DEFAULT_PRUNING_LOG_ODDS_THRESHOLD;
+        }
+        return super.createReadThreadingAssembler();
+    }
 
     //TODO: HACK ALERT HACK ALERT HACK ALERT
     //TODO: GATK4 does not yet have a way to tag inputs, eg -I:tumor tumor.bam -I:normal normal.bam,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -51,9 +51,8 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public static final double DEFAULT_INITIAL_LOD = 2.0;
     public static final double DEFAULT_MITO_INITIAL_LOD = 0;
 
-    public static final double DEFAULT_PRUNING_LOG_ODDS_THRESHOLD = -4;
+    public static final double DEFAULT_MITO_PRUNING_LOG_ODDS_THRESHOLD = -4;
 
-    @Override
     protected ReadThreadingAssemblerArgumentCollection getReadThreadingAssemblerArgumentCollection(){
         return new MutectReadThreadingAssemblerArgumentCollection();
     }
@@ -61,7 +60,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     @Override
     public ReadThreadingAssembler createReadThreadingAssembler(){
         if(mitochondria && assemblerArgs.pruningLog10OddsThreshold == ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD) {
-            assemblerArgs.pruningLog10OddsThreshold = DEFAULT_PRUNING_LOG_ODDS_THRESHOLD;
+            assemblerArgs.pruningLog10OddsThreshold = DEFAULT_MITO_PRUNING_LOG_ODDS_THRESHOLD;
         }
         return super.createReadThreadingAssembler();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
@@ -149,7 +149,7 @@ public class M2FiltersArgumentCollection {
      * Only variants with LOD divided by depth exceeding this threshold can pass filtering.
      */
     @Argument(fullName = LOD_BY_DEPTH, doc="LOD by depth threshold for filtering variant", optional = true)
-    public double lodByDepth = 0.005;
+    public double lodByDepth = 0.0035;
 
     /**
      * Only variants with alt reads originally aligned outside of the mitochondria (known NuMTs) divided by total alt

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -111,7 +111,7 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
         checkSampleInBamHeader(normalSample);
 
         annotationEngine = Utils.nonNull(annotatorEngine);
-        assemblyEngine = AssemblyBasedCallerUtils.createReadThreadingAssembler(MTAC);
+        assemblyEngine = MTAC.createReadThreadingAssembler();
         likelihoodCalculationEngine = AssemblyBasedCallerUtils.createLikelihoodCalculationEngine(MTAC.likelihoodArgs);
         genotypingEngine = new SomaticGenotypingEngine(samplesList, MTAC, tumorSample, normalSample);
         genotypingEngine.setAnnotationEngine(annotationEngine);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -18,6 +18,7 @@ import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.exome.orientationbiasvariantfilter.OrientationBiasUtils;
 import org.broadinstitute.hellbender.tools.walkers.annotator.StrandBiasBySample;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadThreadingAssemblerArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceSummaryRecord;
 import org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils;
 import org.broadinstitute.hellbender.utils.MathUtils;
@@ -562,7 +563,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "chrM:750-750 [A*, G]");
         Assert.assertTrue(expectedKeys.stream().allMatch(variantKeys::contains));
 
-        Assert.assertEquals(variants.get(0).getGenotype("NA12878").getAnyAttribute(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY), "1513");
+        Assert.assertEquals(Integer.parseInt(variants.get(0).getGenotype("NA12878").getAnyAttribute(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY).toString()), 1514, 5);
         Assert.assertEquals(variants.get(0).getGenotype("NA12878").getAnyAttribute(GATKVCFConstants.POTENTIAL_POLYMORPHIC_NUMT_KEY), "true");
     }
 
@@ -571,7 +572,8 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final File filteredVcf = createTempFile("filtered", ".vcf");
 
         new Main().instanceMain(makeCommandLineArgs(Arrays.asList("-V", NA12878_MITO_VCF.getPath(),
-                "-O", filteredVcf.getPath(), "--" + M2ArgumentCollection.MITOCHONDRIA_MODE_LONG_NAME), FilterMutectCalls.class.getSimpleName()));
+                "-O", filteredVcf.getPath(), "--" + M2ArgumentCollection.MITOCHONDRIA_MODE_LONG_NAME,
+                "--lod-divided-by-depth", ".005"), FilterMutectCalls.class.getSimpleName()));
 
         final List<VariantContext> variants = VariantContextTestUtils.streamVcf(filteredVcf).collect(Collectors.toList());
         final Iterator<String> expectedFilters = Arrays.asList(


### PR DESCRIPTION
This optimizes the defaults in mitochondria-mode for WGS mitochondria calling. It changes the `pruning-lod-threshold` in adaptive pruning and the `lod-divided-by-depth` threshold in `FilterMutectCalls`.