### PR TITLE
updating google-cloud-nio to 0.79.0?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.78.0-alpha:shaded'
+final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.80.0-alpha:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.62.0-alpha:shaded'
+final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.74.0-alpha:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
 // provided by dataproc).
-final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.74.0-alpha:shaded'
+final googleCloudNioDependency = 'com.google.cloud:google-cloud-nio:0.78.0-alpha:shaded'
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'

--- a/gatk
+++ b/gatk
@@ -379,7 +379,9 @@ def runCommand(cmd, dryrun):
     else:
         sys.stderr.write( "\nRunning:\n")
         sys.stderr.write("    " + " ".join(cmd)+"\n")
-        check_call(cmd)
+        gatk_env = os.environ.copy()
+        gatk_env["SUPPRESS_GCLOUD_CREDS_WARNING"] = "true"
+        check_call(cmd, env=gatk_env)
 
 def getSplitArgs(args):
     inFirstGroup = True

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -383,6 +383,9 @@ public final class BucketUtils {
             // enable requester pays and indicate who pays
             builder = builder.autoDetectRequesterPays(true).userProject(requesterProject);
         }
+
+        //this causes the gcs filesystem to treat files that end in a / as a directory
+        //true is the default but this protects against future changes in behavior
         builder.usePseudoDirectories(true);
         return builder.build();
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -383,6 +383,7 @@ public final class BucketUtils {
             // enable requester pays and indicate who pays
             builder = builder.autoDetectRequesterPays(true).userProject(requesterProject);
         }
+        builder.usePseudoDirectories(true);
         return builder.build();
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/RandomDNA.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/RandomDNA.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.utils;
 
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;

--- a/testsettings.gradle
+++ b/testsettings.gradle
@@ -42,6 +42,7 @@ tasks.withType(Test) {
     systemProperty "gatk.spark.debug", System.getProperty("gatk.spark.debug")
 
     environment "SPARK_LOCAL_IP","127.0.0.1"
+    environment "SUPPRESS_GCLOUD_CREDS_WARNING","true"
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"


### PR DESCRIPTION
* updating google-cloud-nio from 0.62.0 -> 0.74.0
* fixes confusing gcloud warning about end user credentials that was output on every start up
* improves https://github.com/broadinstitute/gatk/issues/5447 by reducing the warning to an info