### PR TITLE
Put the actual date/time in the generated doc output.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import de.undercouch.gradle.tasks.download.Download
 
 import javax.tools.ToolProvider
+import java.time.format.DateTimeFormatter
+import java.time.ZonedDateTime
 
 mainClassName = "org.broadinstitute.hellbender.Main"
 
@@ -650,7 +652,7 @@ task gatkDoc(type: Javadoc, dependsOn: classes) {
         options.addStringOption("index-file-extension", phpExtension)
     }
     options.addStringOption("absolute-version", getVersion())
-    options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
+    options.addStringOption("build-timestamp", ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME))
 }
 
 // Generate GATK Bash Tab Completion File
@@ -685,7 +687,7 @@ task gatkTabComplete(type: Javadoc, dependsOn: classes) {
     options.addStringOption("output-file-extension", "sh")
     options.addStringOption("index-file-extension", "sh")
     options.addStringOption("absolute-version", getVersion())
-    options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
+    options.addStringOption("build-timestamp", ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME))
 
     options.addStringOption("caller-script-name", "gatk")
 


### PR DESCRIPTION
The documentation date is currently displayed incorrectly, and nonsensically, and sometimes from the future, in the generated doc. See the bottom of the page at https://software.broadinstitute.org/gatk/documentation/tooldocs/4.0.12.0/#, for example.

Before:
`GATK version 4.0.11.0-92-gf9a2e5c-SNAPSHOT built at 09-10-2019 06:10:16`
After:
`GATK version 4.0.11.0-92-gf9a2e5c-SNAPSHOT built at Wed, 9 Jan 2019 18:13:38 -0500`

@bhanugandham Can you test this when you get a chance.