### PR TITLE
Add option for enabling or disabling writing tabix indexes for bgzipped VCF files from Spark.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -132,6 +132,11 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             doc = "If true, create a BAM splitting index (SBI) when writing a coordinate-sorted BAM file.", optional = true, common = true)
     public boolean createOutputBamSplittingIndex = ConfigFactory.getInstance().getGATKConfig().createOutputBamIndex();
 
+    @Argument(fullName = StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME,
+            shortName = StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_INDEX_SHORT_NAME,
+            doc = "If true, create a VCF index when writing a coordinate-sorted VCF file.", optional = true, common = true)
+    public boolean createOutputVariantIndex = true;
+
     private ReadsSparkSource readsSource;
     private SAMFileHeader readsHeader;
     private LinkedHashMap<String, SAMFileHeader> readInputs;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -80,6 +80,8 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
     public static final String NUM_REDUCERS_LONG_NAME = "num-reducers";
     public static final String SHARDED_OUTPUT_LONG_NAME = "sharded-output";
     public static final String OUTPUT_SHARD_DIR_LONG_NAME = "output-shard-tmp-dir";
+    public static final String WRITE_BAI_LONG_NAME = "write-bai";
+    public static final String WRITE_SBI_LONG_NAME = "write-sbi";
 
     @ArgumentCollection
     public final ReferenceInputArgumentCollection referenceArguments = requiresReference() ? new RequiredReferenceInputArgumentCollection() :  new OptionalReferenceInputArgumentCollection();
@@ -120,6 +122,16 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             fullName = NUM_REDUCERS_LONG_NAME,
             optional = true)
     protected int numReducers = 0;
+
+    @Argument(doc = "For tools that write output BAM, write an BAI file. Defaults to true.",
+            fullName = WRITE_SBI_LONG_NAME,
+            optional = true)
+    protected boolean writeBai = true;
+
+    @Argument(doc = "For tools that write output BAM, write an SBI file. Defaults to true.",
+            fullName = WRITE_SBI_LONG_NAME,
+            optional = true)
+    protected boolean writeSbi = true;
 
     private ReadsSparkSource readsSource;
     private SAMFileHeader readsHeader;
@@ -347,7 +359,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             ReadsSparkSink.writeReads(ctx, outputFile,
                     hasReference() ? referenceArguments.getReferencePath().toAbsolutePath().toUri().toString() : null,
                     reads, header, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
-                    getRecommendedNumReducers(), shardedPartsDir);
+                    getRecommendedNumReducers(), shardedPartsDir, writeBai, writeSbi);
         } catch (IOException e) {
             throw new UserException.CouldNotCreateOutputFile(outputFile,"writing failed", e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
@@ -57,7 +57,8 @@ public final class PrintVariantsSpark extends VariantWalkerSpark {
     @Override
     protected void processVariants(JavaRDD<VariantWalkerContext> rdd, JavaSparkContext ctx) {
         try {
-            VariantsSparkSink.writeVariants(ctx, output, rdd.map(VariantWalkerContext::getVariant), getHeaderForVariants());
+            VariantsSparkSink.writeVariants(ctx, output, rdd.map(VariantWalkerContext::getVariant), getHeaderForVariants(),
+                    createOutputVariantIndex);
         } catch (IOException e) {
             throw new UserException.CouldNotCreateOutputFile(output, "writing failed", e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -221,7 +221,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
                 .flatMap(interval -> Shard.divideIntervalIntoShards(interval, shardingArgs.readShardSize, shardingArgs.readShardPadding, sequenceDictionary).stream())
                 .collect(Collectors.toList());
 
-        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, readsHeader, sequenceDictionary, referenceArguments.getReferenceFileName(), intervalShards, hcArgs, shardingArgs, assemblyRegionArgs, true, output, makeVariantAnnotations(), logger, strict);
+        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, readsHeader, sequenceDictionary, referenceArguments.getReferenceFileName(), intervalShards, hcArgs, shardingArgs, assemblyRegionArgs, true, output, makeVariantAnnotations(), logger, strict, createOutputVariantIndex);
 
         if (bwaEngine != null) {
             bwaEngine.close();

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -1,12 +1,14 @@
 package org.broadinstitute.hellbender.engine.spark.datasources;
 
 import com.google.common.io.Files;
+import htsjdk.samtools.BAMIndex;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamStreams;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.utils.VCFHeaderReader;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeBuilder;
@@ -59,39 +61,41 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
     @DataProvider(name = "loadVariants")
     public Object[][] loadVariants() {
         return new Object[][]{
-                {hg19_chr1_1M_dbSNP, ".vcf"},
-                {hg19_chr1_1M_dbSNP, ".vcf.bgz"},
-                {hg19_chr1_1M_dbSNP, ".vcf.gz"},
-                {hg19_chr1_1M_dbSNP_modified, ".vcf"},
+                {hg19_chr1_1M_dbSNP, ".vcf", true},
+                {hg19_chr1_1M_dbSNP, ".vcf.bgz", true},
+                {hg19_chr1_1M_dbSNP, ".vcf.bgz", false}, // disable writing tabix
+                {hg19_chr1_1M_dbSNP, ".vcf.gz", true},
+                {hg19_chr1_1M_dbSNP, ".vcf.gz", false}, // disable writing tabix
+                {hg19_chr1_1M_dbSNP_modified, ".vcf", true},
         };
     }
 
     @Test(dataProvider = "loadVariants", groups = "spark")
-    public void variantsSinkTest(String vcf, String outputFileExtension) throws IOException {
+    public void variantsSinkTest(String vcf, String outputFileExtension, boolean writeTabixIndex) throws IOException {
         final File outputFile = createTempFile(outputFileName, outputFileExtension);
-        assertSingleShardedWritingWorks(vcf, outputFile.getAbsolutePath());
+        assertSingleShardedWritingWorks(vcf, outputFile.getAbsolutePath(), writeTabixIndex);
     }
 
     @Test(dataProvider = "loadVariants", groups = "spark")
-    public void variantsSinkHDFSTest(String vcf, String outputFileExtension) throws IOException {
+    public void variantsSinkHDFSTest(String vcf, String outputFileExtension, boolean writeTabixIndex) throws IOException {
         final String outputHDFSPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension).toString();
         Assert.assertTrue(BucketUtils.isHadoopUrl(outputHDFSPath));
-        assertSingleShardedWritingWorks(vcf, outputHDFSPath);
+        assertSingleShardedWritingWorks(vcf, outputHDFSPath, writeTabixIndex);
     }
 
     @Test(dataProvider = "loadVariants", groups = "spark")
-    public void testWritingToAnExistingFileHDFS(String vcf, String outputFileExtension) throws IOException {
+    public void testWritingToAnExistingFileHDFS(String vcf, String outputFileExtension, boolean writeTabixIndex) throws IOException {
         final Path outputPath = MiniClusterUtils.getTempPath(cluster, outputFileName, outputFileExtension);
         final FileSystem fs = outputPath.getFileSystem(new Configuration());
         Assert.assertTrue(fs.createNewFile(outputPath));
         Assert.assertTrue(fs.exists(outputPath));
-        assertSingleShardedWritingWorks(vcf, outputPath.toString());
+        assertSingleShardedWritingWorks(vcf, outputPath.toString(), writeTabixIndex);
     }
 
     @Test(dataProvider = "loadVariants", groups = "spark")
-    public void testWritingToFileURL(String vcf, String outputFileExtension) throws IOException {
+    public void testWritingToFileURL(String vcf, String outputFileExtension, boolean writeTabixIndex) throws IOException {
         String outputUrl = "file://" + createTempFile(outputFileName, outputFileExtension).getAbsolutePath();
-        assertSingleShardedWritingWorks(vcf, outputUrl);
+        assertSingleShardedWritingWorks(vcf, outputUrl, writeTabixIndex);
     }
 
     @DataProvider
@@ -108,7 +112,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
     public void testBrokenGVCFCasesAreDisallowed(boolean writeGvcf, String extension) throws IOException {
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
         VariantsSparkSink.writeVariants(ctx, createTempFile("test", extension).toString(), null,
-                new VCFHeader(), writeGvcf, Arrays.asList(1, 2, 4, 5), 2, 1 );
+                new VCFHeader(), writeGvcf, Arrays.asList(1, 2, 4, 5), 2, 1, false);
     }
 
     @DataProvider
@@ -135,9 +139,9 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
 
         final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
         final File output = createTempFile(outputFileName, extension);
-        VariantsSparkSink.writeVariants(ctx, output.toString(), ctx.parallelize(vcs), getHeader(), writeGvcf, Arrays.asList(100), 2, 1 );
+        VariantsSparkSink.writeVariants(ctx, output.toString(), ctx.parallelize(vcs), getHeader(), writeGvcf, Arrays.asList(100), 2, 1, true);
 
-        checkFileExtensionConsistentWithContents(output.toString());
+        checkFileExtensionConsistentWithContents(output.toString(), true);
 
         new CommandLineProgramTest(){
             @Override
@@ -167,7 +171,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         return header;
     }
 
-    private void assertSingleShardedWritingWorks(String vcf, String outputPath) throws IOException {
+    private void assertSingleShardedWritingWorks(String vcf, String outputPath, boolean writeTabixIndex) throws IOException {
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
 
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
@@ -177,9 +181,9 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         }
         VCFHeader header = getHeader(vcf);
 
-        VariantsSparkSink.writeVariants(ctx, outputPath, variants, header);
+        VariantsSparkSink.writeVariants(ctx, outputPath, variants, header, writeTabixIndex);
 
-        checkFileExtensionConsistentWithContents(outputPath);
+        checkFileExtensionConsistentWithContents(outputPath, writeTabixIndex);
 
         JavaRDD<VariantContext> variants2 = variantsSparkSource.getParallelVariantContexts(outputPath, null);
         final List<VariantContext> writtenVariants = variants2.collect();
@@ -209,7 +213,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         return VariantsSparkSourceUnitTest.getSerialVariantContexts(actualVcf.getAbsolutePath());
     }
 
-    private void checkFileExtensionConsistentWithContents(String outputPath) throws IOException {
+    private void checkFileExtensionConsistentWithContents(String outputPath, boolean writeTabixIndex) throws IOException {
         String outputFile;
         if (BucketUtils.isFileUrl(outputPath)) {
             outputFile = new File(URI.create(outputPath)).getAbsolutePath();
@@ -224,6 +228,9 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
         } else if (outputFile.endsWith(".vcf.gz") || outputFile.endsWith(".vcf.bgz")) {
             Assert.assertEquals("VCF", vcfFormat);
             Assert.assertTrue(blockCompressed);
+            // check that a tabix index file is created or not
+            boolean tabixExists = java.nio.file.Files.exists(IOUtils.getPath(outputPath + TabixUtils.STANDARD_INDEX_EXTENSION));
+            Assert.assertEquals(tabixExists, writeTabixIndex);
         } else if (outputFile.endsWith(".bcf")) {
             Assert.assertEquals("BCF", vcfFormat);
             Assert.assertFalse(blockCompressed);


### PR DESCRIPTION
Like #5485 but for tabix. (Build will fail until new Disq release is made.)