### PR TITLE
Fix inclusion of default read filters in doc (use valid freemarker property values).

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptor.java
@@ -149,7 +149,11 @@ public class GATKAnnotationPluginDescriptor  extends CommandLinePluginDescriptor
      * @return A short user-friendly name for this plugin.
      */
     @Override
-    public String getDisplayName() {
+    public String getDisplayName()
+    {
+        // The value returned by this method is placed into the freemarker property map by the docgen system,
+        // and must be a valid variable name in the freemarker template language (it cannot be a kebabified
+        // string with an embedded "-").
         return StandardArgumentDefinitions.ANNOTATION_LONG_NAME;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -32,6 +32,7 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
 
     private static final String pluginPackageName = "org.broadinstitute.hellbender.engine.filters";
     private static final Class<ReadFilter> pluginBaseClass = org.broadinstitute.hellbender.engine.filters.ReadFilter.class;
+    private static final String READ_PLUGIN_DISPLAY_NAME = "readFilter";
 
     // the purpose of this argument collection is to allow the caller to control the exposure of the command line arguments
     @VisibleForTesting
@@ -90,7 +91,14 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
      * @return A short user-friendly name for this plugin.
      */
     @Override
-    public String getDisplayName() { return ReadFilterArgumentDefinitions.READ_FILTER_LONG_NAME; }
+    public String getDisplayName() {
+        // The value returned by this method is placed into the freemarker property map by the docgen system,
+        // and becomes a variable in the freemarker template language. We can't use the actual argument name
+        // here because the kebabified version ("read-filter") isn't a valid freemarker variable (and is
+        // parsed as an expression with an embedded '-'). So use the pre-kebabified version, which matches
+        // what is used in the template).
+        return READ_PLUGIN_DISPLAY_NAME;
+    }
 
     /**
      * @return the class object for the base class of all plugins managed by this descriptor


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/4387. Tested manually.

Before (no default read filters in doc):

<img width="714" alt="screen shot 2019-01-14 at 10 38 26 am" src="https://user-images.githubusercontent.com/10062863/51122884-e26a9c80-17e8-11e9-82ef-e9105d2fb808.png">

After (read filters included):

<img width="682" alt="screen shot 2019-01-14 at 10 41 05 am" src="https://user-images.githubusercontent.com/10062863/51123000-2493de00-17e9-11e9-86e0-1d7fefa14ab4.png">

