### PR TITLE
Fixed edge case of zero-depth in FilterMutectCalls germline filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -268,6 +268,9 @@ public class Mutect2FilteringEngine {
             // this is \chi in the docs, the correction factor for tumor likelihoods if forced to have maf or 1 - maf
             // as the allele fraction
             final double[] log10OddsOfGermlineHetVsSomatic = new IndexRange(0, altAlleleFractions.length).mapToDouble(n -> {
+                if (altCounts[n] + refCount == 0) {
+                    return 0;
+                }
                 final double log10GermlineAltMinorLikelihood = refCount * Math.log10(1 - maf) + altCounts[n] * Math.log10(maf);
                 final double log10GermlineAltMajorLikelihood = refCount * Math.log10(maf) + altCounts[n] * Math.log10(1 - maf);
                 final double log10GermlineLikelihood = MathUtils.LOG10_ONE_HALF + MathUtils.log10SumLog10(log10GermlineAltMinorLikelihood, log10GermlineAltMajorLikelihood);


### PR DESCRIPTION
@takutosato Here's another bug fix.  After the big filtering refactor M2 filters will be unit-testable and these things will be easier to prevent.

This fixes the last edge case mentioned by @byoo in the discussion of #5563.