### PR TITLE
Added per-sample denoised coverage output to gCNV

### DIFF
--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
@@ -12,6 +12,7 @@ import pymc3 as pm
 from . import io_consts
 from .._version import __version__ as gcnvkernel_version
 from ..models.fancy_model import GeneralizedContinuousModel
+from ..models.model_denoising_calling import DenoisingModel
 
 _logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ def write_ndarray_to_tsv(output_file: str,
                          extra_comment_lines: Optional[List[str]] = None,
                          header: Optional[str] = None,
                          write_shape_info: bool = True) -> None:
-    """Write an vector or matrix ndarray to .tsv file.
+    """Write a vector or matrix ndarray to .tsv file.
 
     Note:
         Shape and dtype information are stored in the header.

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
@@ -12,7 +12,6 @@ import pymc3 as pm
 from . import io_consts
 from .._version import __version__ as gcnvkernel_version
 from ..models.fancy_model import GeneralizedContinuousModel
-from ..models.model_denoising_calling import DenoisingModel
 
 _logger = logging.getLogger(__name__)
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_consts.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_consts.py
@@ -32,6 +32,10 @@ quality_end_column_name = "QUALITY_END"
 # column name for baseline copy-number file
 baseline_copy_number_column_name = "BASELINE_COPY_NUMBER"
 
+# column name for denoised copy-number files
+denoised_copy_number_mean_column_name = "DENOISED_COUNT_MEAN"
+denoised_copy_number_std_column_name = "DENOISED_COUNT_STD"
+
 # regular expression for matching sample name from header comment line
 sample_name_header_regexp = "^@RG.*SM:(.*)[\t]*.*$"
 
@@ -50,6 +54,8 @@ default_copy_number_log_emission_tsv_filename = "log_c_emission_tc.tsv"
 default_class_log_posterior_tsv_filename = "log_q_tau_tk.tsv"
 default_baseline_copy_number_tsv_filename = "baseline_copy_number_t.tsv"
 default_copy_number_segments_tsv_filename = "copy_number_segments.tsv"
+default_denoised_copy_number_mean_tsv_filename = "denoised_counts_mu.tsv"
+default_denoised_copy_number_std_tsv_filename = "denoised_counts_std.tsv"
 
 default_denoising_config_json_filename = "denoising_config.json"
 default_calling_config_json_filename = "calling_config.json"

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_consts.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_consts.py
@@ -33,8 +33,8 @@ quality_end_column_name = "QUALITY_END"
 baseline_copy_number_column_name = "BASELINE_COPY_NUMBER"
 
 # column name for denoised copy-number files
-denoised_copy_number_mean_column_name = "DENOISED_COUNT_MEAN"
-denoised_copy_number_std_column_name = "DENOISED_COUNT_STD"
+denoised_copy_ratio_mean_column_name = "DENOISED_COPY_RATIO_MEAN"
+denoised_copy_ratio_std_column_name = "DENOISED_COPY_RATIO_STD"
 
 # regular expression for matching sample name from header comment line
 sample_name_header_regexp = "^@RG.*SM:(.*)[\t]*.*$"
@@ -54,8 +54,8 @@ default_copy_number_log_emission_tsv_filename = "log_c_emission_tc.tsv"
 default_class_log_posterior_tsv_filename = "log_q_tau_tk.tsv"
 default_baseline_copy_number_tsv_filename = "baseline_copy_number_t.tsv"
 default_copy_number_segments_tsv_filename = "copy_number_segments.tsv"
-default_denoised_copy_number_mean_tsv_filename = "denoised_counts_mu.tsv"
-default_denoised_copy_number_std_tsv_filename = "denoised_counts_std.tsv"
+default_denoised_copy_ratios_mean_tsv_filename = "denoised_copy_ratios_mu.tsv"
+default_denoised_copy_ratios_std_tsv_filename = "denoised_copy_ratios_std.tsv"
 
 default_denoising_config_json_filename = "denoising_config.json"
 default_calling_config_json_filename = "calling_config.json"

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_denoising_calling.py
@@ -10,6 +10,7 @@ from . import io_commons
 from . import io_consts
 from . import io_intervals_and_counts
 from .. import config
+from ..models import commons
 from ..models.model_denoising_calling import CopyNumberCallingConfig, DenoisingModelConfig
 from ..models.model_denoising_calling import DenoisingCallingWorkspace, DenoisingModel
 from ..utils import math
@@ -152,13 +153,13 @@ class SampleDenoisingAndCallingPosteriorsWriter:
         approx_var_set, approx_mu_map, approx_std_map = io_commons.extract_meanfield_posterior_parameters(
             self.denoising_model_approx)
 
-        # compute approximate denoised read counts
-        denoising_counts_approx_generator = (self.denoising_model_approx.sample()['denoised_counts']
-                                             for i in range(self.denoising_config.denoised_counts_sampling_rounds))
-        denoised_read_counts_mean, denoised_read_counts_variance =\
-            math.calculate_mean_and_variance_online(denoising_counts_approx_generator)
-        denoised_read_counts_mean = np.transpose(denoised_read_counts_mean)
-        denoised_read_counts_std = np.transpose(np.sqrt(denoised_read_counts_variance))
+        # compute approximate denoised copy ratios
+        denoising_copy_ratios_approx_generator = commons.get_sampling_generator_for_model_approximation(
+            model_approx=self.denoising_model_approx, model_var_name='denoised_copy_ratios')
+        denoised_copy_ratios_mean, denoised_copy_ratios_variance =\
+            math.calculate_mean_and_variance_online(denoising_copy_ratios_approx_generator)
+        denoised_copy_ratios_mean = np.transpose(denoised_copy_ratios_mean)
+        denoised_copy_ratios_std = np.transpose(np.sqrt(denoised_copy_ratios_variance))
 
         for si, sample_name in enumerate(self.denoising_calling_workspace.sample_names):
             sample_name_comment_line = [io_consts.sample_name_sam_header_prefix + sample_name]
@@ -199,23 +200,23 @@ class SampleDenoisingAndCallingPosteriorsWriter:
                 header=io_consts.baseline_copy_number_column_name,
                 write_shape_info=False)
 
-            # write denoised copy number means
-            denoised_read_counts_mu_s = denoised_read_counts_mean[:, si]
+            # write denoised copy ratio means
+            denoised_copy_ratio_mu_s = denoised_copy_ratios_mean[:, si]
             io_commons.write_ndarray_to_tsv(
-                os.path.join(sample_posterior_path, io_consts.default_denoised_copy_number_mean_tsv_filename),
-                denoised_read_counts_mu_s,
+                os.path.join(sample_posterior_path, io_consts.default_denoised_copy_ratios_mean_tsv_filename),
+                denoised_copy_ratio_mu_s,
                 extra_comment_lines=sample_name_comment_line,
-                header=io_consts.denoised_copy_number_mean_column_name,
+                header=io_consts.denoised_copy_ratio_mean_column_name,
                 write_shape_info=False
             )
 
-            # write denoised copy numbers standard deviations
-            denoised_read_counts_std_s = denoised_read_counts_std[:, si]
+            # write denoised copy ratio standard deviations
+            denoised_copy_ratio_std_s = denoised_copy_ratios_std[:, si]
             io_commons.write_ndarray_to_tsv(
-                os.path.join(sample_posterior_path, io_consts.default_denoised_copy_number_std_tsv_filename),
-                denoised_read_counts_std_s,
+                os.path.join(sample_posterior_path, io_consts.default_denoised_copy_ratios_std_tsv_filename),
+                denoised_copy_ratio_std_s,
                 extra_comment_lines=sample_name_comment_line,
-                header=io_consts.denoised_copy_number_std_column_name,
+                header=io_consts.denoised_copy_ratio_std_column_name,
                 write_shape_info=False
             )
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
@@ -21,7 +21,7 @@ def get_normalized_prob_vector(prob_vector: np.ndarray, prob_sum_tol: float) -> 
 
     Returns:
         A new and normalized probability vector if it deviates from unity more than `prob_sum_tol`
-        Otherwise, `prov_vector` is return unchanged.
+        Otherwise, `prob_vector` is return unchanged.
     """
     assert all(prob_vector >= 0), "Probabilities must be non-negative"
     prob_sum = np.sum(prob_vector)

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
@@ -4,7 +4,7 @@ import theano.tensor as tt
 import pymc3 as pm
 import theano as th
 import pymc3.distributions.dist_math as pm_dist_math
-from typing import Tuple
+from typing import Tuple, Generator
 
 _logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ def get_normalized_prob_vector(prob_vector: np.ndarray, prob_sum_tol: float) -> 
 
     Returns:
         A new and normalized probability vector if it deviates from unity more than `prob_sum_tol`
-        Otherwise, `prob_vector` is return unchanged.
+        Otherwise, `prob_vector` is returned unchanged.
     """
     assert all(prob_vector >= 0), "Probabilities must be non-negative"
     prob_sum = np.sum(prob_vector)
@@ -224,3 +224,18 @@ def stochastic_node_mean_symbolic(approx: pm.MeanField, node, size=100,
                          n_steps=size)
 
     return outputs[-1] / size
+
+
+def get_sampling_generator_for_model_approximation(model_approx: pm.MeanField, model_var_name: str,
+                                                   num_samples: int = 250) -> Generator:
+    """Get a generator that returns samples of a precomputed model approximation for a specific variable in that model
+
+    Args:
+        model_approx: an instance of PyMC3 meanfield approximation
+        model_var_name: a stochastic node in the model
+        num_samples: number of samples to draw
+
+    Returns:
+        A generator that will yield `num_samples` samples from an approximation to a posterior
+    """
+    return (model_approx.sample()[model_var_name] for _ in range(num_samples))

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
@@ -47,8 +47,7 @@ class DenoisingModelConfig:
                  active_class_padding_hybrid_mode: int = 50000,
                  enable_bias_factors: bool = True,
                  enable_explicit_gc_bias_modeling: bool = False,
-                 disable_bias_factors_in_active_class: bool = False,
-                 denoised_counts_sampling_rounds: int = 250):
+                 disable_bias_factors_in_active_class: bool = False):
         """See `expose_args` for the description of arguments"""
         self.max_bias_factors = max_bias_factors
         self.mapping_error_rate = mapping_error_rate
@@ -64,7 +63,6 @@ class DenoisingModelConfig:
         self.enable_bias_factors = enable_bias_factors
         self.enable_explicit_gc_bias_modeling = enable_explicit_gc_bias_modeling
         self.disable_bias_factors_in_active_class = disable_bias_factors_in_active_class
-        self.denoised_counts_sampling_rounds = denoised_counts_sampling_rounds
 
     @staticmethod
     def expose_args(args: argparse.ArgumentParser,
@@ -780,10 +778,10 @@ class DenoisingModel(GeneralizedContinuousModel):
         # the expected number of erroneously mapped reads
         mean_mapping_error_correction_s = eps * read_depth_s * shared_workspace.average_ploidy_s
 
-        denoised_counts = ((shared_workspace.n_st - mean_mapping_error_correction_s.dimshuffle(0, 'x'))
-                           / ((1.0 - eps) * read_depth_s.dimshuffle(0, 'x') * bias_st))
+        denoised_copy_ratios = ((shared_workspace.n_st - mean_mapping_error_correction_s.dimshuffle(0, 'x'))
+                                / ((1.0 - eps) * read_depth_s.dimshuffle(0, 'x') * bias_st))
 
-        Deterministic(name='denoised_counts', var=denoised_counts)
+        Deterministic(name='denoised_copy_ratios', var=denoised_copy_ratios)
 
         mu_stc = ((1.0 - eps) * read_depth_s.dimshuffle(0, 'x', 'x')
                   * bias_st.dimshuffle(0, 1, 'x')

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/utils/math.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/utils/math.py
@@ -1,6 +1,7 @@
 import sys
 
 import numpy as np
+from typing import Generator, Tuple
 
 # 10 / ln(10)
 INV_LN_10_TIMES_10 = 4.342944819032518
@@ -104,3 +105,29 @@ def logsumexp_double_complement(a: np.ndarray, rel_tol: float = 1e-3) -> float:
             else:
                 x = x_new
         return x
+
+
+def calculate_mean_and_variance_online(values_generator: Generator) -> Tuple[float, float]:
+    """
+    Implements Welford’s method for computing variance online using samples from a generator
+
+    Note: it's assumed that the generator eventually runs out of samples and throws StopIteration exception
+
+    Args:
+        values_generator: a generator of values
+
+    Returns:
+         (mean, variance) tuple
+    """
+    mean = 0.0
+    sum_sq = 0.0
+    num_samples = 0
+    while True:
+        try:
+            next_value = next(values_generator)
+            num_samples += 1
+            old_mean = mean
+            mean = mean + (next_value - mean)/num_samples
+            sum_sq = sum_sq + (next_value - mean) * (next_value - old_mean)
+        except StopIteration:
+            return mean, sum_sq / (num_samples - 1)

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/utils/math.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/utils/math.py
@@ -107,7 +107,7 @@ def logsumexp_double_complement(a: np.ndarray, rel_tol: float = 1e-3) -> float:
         return x
 
 
-def calculate_mean_and_variance_online(values_generator: Generator) -> Tuple[float, float]:
+def calculate_mean_and_variance_online(values_generator: Generator) -> Tuple:
     """
     Implements Welford’s method for computing variance online using samples from a generator
 


### PR DESCRIPTION
This PR adds two new files into the gCNV output directory - mean and the standard deviation of the denoised coverage, that is computed by drawing posterior samples from the computed model. 