### PR TITLE
Update htsjdk to 2.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ repositories {
 }
 
 final requiredJavaVersion = "8"
-final htsjdkVersion = System.getProperty('htsjdk.version','2.18.1')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.18.2')
 final picardVersion = System.getProperty('picard.version','2.18.16')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -3,16 +3,19 @@ package org.broadinstitute.hellbender.engine.spark.datasources;
 import com.google.common.io.Files;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.SamStreams;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.utils.VCFHeaderReader;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeBuilder;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
-import htsjdk.variant.vcf.*;
+import htsjdk.variant.vcf.VCFConstants;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import htsjdk.variant.vcf.VCFStandardHeaderLines;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -20,15 +23,15 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.testutils.MiniClusterUtils;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.IndexFeatureFile;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.testutils.MiniClusterUtils;
-import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -236,7 +239,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
     private static String getVcfFormat(String outputFile) throws IOException {
         try (InputStream in = openFile(outputFile)) {
             BufferedInputStream bis = new BufferedInputStream(in); // so mark/reset is supported
-            return inferFromUncompressedData(SamStreams.isGzippedSAMFile(bis) ? new GZIPInputStream(bis) : bis);
+            return inferFromUncompressedData(IOUtil.isGZIPInputStream(bis) ? new GZIPInputStream(bis) : bis);
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -1134,7 +1134,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         IntervalUtils.loadIntervals(intervalArgs, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser);
     }
 
-    @Test(expectedExceptions=UserException.MalformedFile.class, dataProvider="invalidIntervalTestData")
+    @Test(expectedExceptions={UserException.MalformedFile.class, UserException.MalformedGenomeLoc.class}, dataProvider="invalidIntervalTestData")
     public void testLoadIntervalsInvalidPicardIntervalHandling(GenomeLocParser genomeLocParser,
                                                   String contig, int intervalStart, int intervalEnd ) throws Exception {
 
@@ -1177,7 +1177,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         IntervalUtils.intervalFileToList(genomeLocParser, picardIntervalFile.getAbsolutePath());
     }
 
-    @Test(expectedExceptions=UserException.CouldNotReadInputFile.class, dataProvider="invalidIntervalTestData")
+    @Test(expectedExceptions={UserException.CouldNotReadInputFile.class, UserException.MalformedGenomeLoc.class}, dataProvider="invalidIntervalTestData")
     public void testIntervalFileToListInvalidPicardIntervalHandling(GenomeLocParser genomeLocParser,
                                        String contig, int intervalStart, int intervalEnd ) throws Exception {
 


### PR DESCRIPTION
* Updating htsjdk 2.18.1 -> 2.18.2
* Remove deprecated method use
* Changing IntervalUtilsUnitTest due to changes in IntervalList
   * IntervalList now rejects certain invalid intervals that it previously didn't and throw IllegalArgumentException.
   * This ends up changing which exceptions are thrown in some cases, updated some tests to accept both MalformedFile and MalforedGenomeLoc.