### PR TITLE
Refactor com.intel.genomicsdb package references to org.genomicsdb 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.1.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.9.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','0.10.2-proto-3.0.0-beta-1+90dad1af8ce0e4d')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.0.beta1')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
@@ -226,7 +226,7 @@ dependencies {
 
     compile 'com.github.broadinstitute:picard:' + picardVersion
     externalSourceConfiguration 'com.github.broadinstitute:picard:' + picardVersion + ':sources'
-    compile ('com.intel:genomicsdb:' + genomicsdbVersion)  {
+    compile ('org.genomicsdb:genomicsdb:' + genomicsdbVersion)  {
         exclude module: 'log4j'
         exclude module: 'spark-core_2.10'
         exclude module: 'htsjdk'

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.hellbender.engine;
 
-import com.intel.genomicsdb.model.GenomicsDBExportConfiguration;
-import com.intel.genomicsdb.reader.GenomicsDBFeatureReader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.*;
@@ -20,6 +18,8 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.nio.SeekableByteChannelPrefetcher;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
+import org.genomicsdb.reader.GenomicsDBFeatureReader;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -1,15 +1,6 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.intel.genomicsdb.GenomicsDBUtils;
-import com.intel.genomicsdb.importer.GenomicsDBImporter;
-import com.intel.genomicsdb.importer.model.ChromosomeInterval;
-import com.intel.genomicsdb.model.Coordinates;
-import com.intel.genomicsdb.model.GenomicsDBCallsetsMapProto;
-import com.intel.genomicsdb.model.GenomicsDBImportConfiguration;
-import com.intel.genomicsdb.GenomicsDBUtils;
-import com.intel.genomicsdb.model.ImportConfig;
-import com.intel.genomicsdb.model.BatchCompletionCallbackFunctionArgument;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -39,6 +30,14 @@ import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.nio.SeekableByteChannelPrefetcher;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.genomicsdb.GenomicsDBUtils;
+import org.genomicsdb.importer.GenomicsDBImporter;
+import org.genomicsdb.model.Coordinates;
+import org.genomicsdb.model.GenomicsDBCallsetsMapProto;
+import org.genomicsdb.model.GenomicsDBImportConfiguration;
+import org.genomicsdb.GenomicsDBUtils;
+import org.genomicsdb.model.ImportConfig;
+import org.genomicsdb.model.BatchCompletionCallbackFunctionArgument;
 
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
@@ -129,7 +128,7 @@ import java.net.URISyntaxException;
  * </ul>
  *
  * <h3>Developer Note</h3>
- * To read data from GenomicsDB, use the query interface {@link com.intel.genomicsdb.reader.GenomicsDBFeatureReader}
+ * To read data from GenomicsDB, use the query interface {@link org.genomicsdb.reader.GenomicsDBFeatureReader}
  */
 @DocumentedFeature
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -1,12 +1,12 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
 import com.googlecode.protobuf.format.JsonFormat;
-import com.intel.genomicsdb.model.GenomicsDBExportConfiguration;
-import com.intel.genomicsdb.model.GenomicsDBVidMapProto;
 import htsjdk.variant.variantcontext.GenotypeLikelihoods;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
+import org.genomicsdb.model.GenomicsDBVidMapProto;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.engine;
 
-import com.intel.genomicsdb.GenomicsDBLibLoader;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
@@ -9,6 +8,7 @@ import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.testutils.GenomicsDBTestUtils;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
+import org.genomicsdb.GenomicsDBLibLoader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -1,9 +1,5 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
-import com.intel.genomicsdb.GenomicsDBUtils;
-import com.intel.genomicsdb.model.GenomicsDBExportConfiguration;
-import com.intel.genomicsdb.model.GenomicsDBVidMapProto;
-import com.intel.genomicsdb.reader.GenomicsDBFeatureReader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -30,6 +26,10 @@ import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.genomicsdb.GenomicsDBUtils;
+import org.genomicsdb.model.GenomicsDBExportConfiguration;
+import org.genomicsdb.model.GenomicsDBVidMapProto;
+import org.genomicsdb.reader.GenomicsDBFeatureReader;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportUnitTest.java
@@ -1,11 +1,11 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
-import com.intel.genomicsdb.importer.GenomicsDBImporter;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.genomicsdb.importer.GenomicsDBImporter;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;


### PR DESCRIPTION
The first genomicsdb 1.0.0.beta jar consists of only a refactoring of all the packages to org.genomicsdb. Note that this pass should have no performance implications compared to the last [Intel release](https://mvnrepository.com/artifact/com.intel/genomicsdb/0.10.2-proto-3.0.0-beta-1+90dad1af8ce0e4d) as there is no change other than refactoring.

Issues [5568-buffer resizing excessive logging](https://github.com/broadinstitute/gatk/issues/5568) and [5342-file synching error](https://github.com/broadinstitute/gatk/issues/5342) will both be addressed in the next release.