### PR TITLE
Multi-Allelic Variant Funcotation Filtration

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FilterFuncotations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FilterFuncotations.java
@@ -143,12 +143,12 @@ public class FilterFuncotations extends VariantWalker {
                 funcotationKeys, variant, "Gencode_" + reference.gencodeVersion + "_annotationTranscript", "FAKE_SOURCE");
 
         funcs.values().forEach(funcotationMap -> {
-            final Stream<Map<String, String>> transcriptFuncotations = funcotationMap.getTranscriptList().stream()
+            final Stream<Set<Map.Entry<String, String>>> transcriptFuncotations = funcotationMap.getTranscriptList().stream()
                     .map(funcotationMap::get)
                     .map(funcotations -> funcotations.stream()
                             .flatMap(this::extractFuncotationFields)
                             .filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                            .collect(Collectors.toSet()));
 
             transcriptFuncotations.forEach(funcotations -> {
                 final Set<String> matches = funcotationFilters.stream()

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/ClinVarFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/ClinVarFilter.java
@@ -2,6 +2,9 @@ package org.broadinstitute.hellbender.tools.funcotator.filtrationRules;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * {@link FuncotationFilter} matching variants which:
@@ -50,9 +53,11 @@ public class ClinVarFilter extends FuncotationFilter {
     @Override
     List<FuncotationFiltrationRule> getRules() {
         return Arrays.asList(
-                funcotations -> funcotations.containsKey(ACMG_DISEASE_FUNCOTATION),
+                funcotations -> containsKey(funcotations, ACMG_DISEASE_FUNCOTATION),
                 funcotations -> {
-                    final String significance = funcotations.getOrDefault(CLINVAR_SIGNIFICANCE_FUNCOTATION, "");
+                    final Set<String> significance = matchOnKeyOrDefault(funcotations, CLINVAR_SIGNIFICANCE_FUNCOTATION, "")
+                            .filter(value -> !value.isEmpty())
+                            .collect(Collectors.toSet());
                     return CLINVAR_SIGNIFICANCE_MATCHING_VALUES.stream().anyMatch(significance::contains);
                 },
                 FilterFuncotationsExacUtils.buildExacMaxMafRule(CLINVAR_MAX_MAF));

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/ClinVarFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/ClinVarFilter.java
@@ -39,7 +39,7 @@ public class ClinVarFilter extends FuncotationFilter {
     /**
      * Clinically-significant values to check for within the {@value CLINVAR_SIGNIFICANCE_FUNCOTATION} Funcotation.
      */
-    private static final List<String> CLINVAR_SIGNIFICANCE_MATCHING_VALUES = Arrays.asList("Pathogenic", "Likely_pathogenic");
+    private static final List<String> CLINVAR_SIGNIFICANCE_MATCHING_VALUES = Arrays.asList("Pathogenic", "Likely_pathogenic", "Pathogenic/Likely_pathogenic");
 
     /**
      * Maximum MAF a variant can have in ExAC to pass this rule.

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FilterFuncotationsExacUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FilterFuncotationsExacUtils.java
@@ -52,13 +52,13 @@ public class FilterFuncotationsExacUtils {
                     final String exacAlleleCount = EXAC_ALLELE_COUNT_PREFIX + subpop.name();
                     final String exacAlleleNumber = EXAC_ALLELE_NUMBER_PREFIX + subpop.name();
                     final List<String> keys = Arrays.asList(exacAlleleCount, exacAlleleNumber);
-                    final Stream<Map.Entry<String, String>> matchingFuncotations = funcotations.stream().filter(entry -> keys.contains(entry.getKey()));
-                    final Double ac = matchingFuncotations
+                    final Set<Map.Entry<String, String>> matchingFuncotations = funcotations.stream().filter(entry -> keys.contains(entry.getKey())).collect(Collectors.toSet());
+                    final Double ac = matchingFuncotations.stream()
                             .filter(entry1 -> entry1.getKey().equals(exacAlleleCount))
                             .findFirst()
                             .map(entry -> Double.valueOf(entry.getValue()))
                             .orElse(0d);
-                    final Integer an = matchingFuncotations
+                    final Integer an = matchingFuncotations.stream()
                             .filter(entry1 -> entry1.getKey().equals(exacAlleleNumber))
                             .findFirst()
                             .map(entry -> Integer.valueOf(entry.getValue()))

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FilterFuncotationsExacUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FilterFuncotationsExacUtils.java
@@ -3,7 +3,11 @@ package org.broadinstitute.hellbender.tools.funcotator.filtrationRules;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FilterFuncotationsExacUtils {
     /**
@@ -41,12 +45,24 @@ public class FilterFuncotationsExacUtils {
      *
      * If a sub-population has an allele number of zero, it will be assigned a MAF of zero.
      */
-    private static double getMaxMinorAlleleFreq(final Map<String, String> funcotations) {
+    private static double getMaxMinorAlleleFreq(final Set<Map.Entry<String, String>> funcotations) {
         return Arrays.stream(ExacSubPopulation.values())
-                .filter(subpop -> funcotations.containsKey(EXAC_ALLELE_COUNT_PREFIX + subpop.name()))
+                .filter(subpop -> funcotations.stream().anyMatch(entry -> entry.getKey().equals(EXAC_ALLELE_COUNT_PREFIX + subpop.name())))
                 .map(subpop -> {
-                    final Double ac = Double.valueOf(funcotations.get(EXAC_ALLELE_COUNT_PREFIX + subpop.name()));
-                    final Integer an = Integer.valueOf(funcotations.get(EXAC_ALLELE_NUMBER_PREFIX + subpop.name()));
+                    final String exacAlleleCount = EXAC_ALLELE_COUNT_PREFIX + subpop.name();
+                    final String exacAlleleNumber = EXAC_ALLELE_NUMBER_PREFIX + subpop.name();
+                    final List<String> keys = Arrays.asList(exacAlleleCount, exacAlleleNumber);
+                    final Stream<Map.Entry<String, String>> matchingFuncotations = funcotations.stream().filter(entry -> keys.contains(entry.getKey()));
+                    final Double ac = matchingFuncotations
+                            .filter(entry1 -> entry1.getKey().equals(exacAlleleCount))
+                            .findFirst()
+                            .map(entry -> Double.valueOf(entry.getValue()))
+                            .orElse(0d);
+                    final Integer an = matchingFuncotations
+                            .filter(entry1 -> entry1.getKey().equals(exacAlleleNumber))
+                            .findFirst()
+                            .map(entry -> Integer.valueOf(entry.getValue()))
+                            .orElse(0);
 
                     if (an == 0) {
                         // If a variant has never been seen in ExAC, report it as 0% MAF.

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFilter.java
@@ -52,10 +52,25 @@ public abstract class FuncotationFilter {
      */
     abstract List<FuncotationFiltrationRule> getRules();
 
+
+    /**
+     * Given a set of extracted funcotations of a variant, return a Stream of values that belong to the key.
+     * @param funcotations A Set of Map.Entry key-value pairs of funcotations
+     * @param key The funcotations to get
+     * @param defaultValue A default value to get if there are no matches
+     * @return A Stream of matched values
+     */
     protected Stream<String> matchOnKeyOrDefault(Set<Map.Entry<String, String>> funcotations, String key, String defaultValue) {
         return getMatchesOrDefault(funcotations, entry -> entry.getKey().equals(key), defaultValue);
     }
 
+    /**
+     * Given a set of extracted funcotations, return a Stream of values whose entry matches the supplied predicate
+     * @param funcotations A Set of Map.Entry key-value pairs of funcotations
+     * @param matcher A predicate taking a Map.Entry to filter on
+     * @param defaultValue A default value to get if there are no matches
+     * @return A Stream of matched values
+     */
     protected Stream<String> getMatchesOrDefault(Set<Map.Entry<String, String>> funcotations, Predicate<Map.Entry<String, String>> matcher, String defaultValue) {
         Set<String> matched = funcotations.stream().filter(matcher).map(Map.Entry::getValue).collect(Collectors.toSet());
         if (matched.isEmpty()) {
@@ -65,6 +80,12 @@ public abstract class FuncotationFilter {
         }
     }
 
+    /**
+     * Does the set of funcotations contain the key supplied
+     * @param funcotations A Set of Map.Entry key-value pairs of funcotations
+     * @param key The key to look for
+     * @return Whether or not the key exists in the funcotations
+     */
     protected Boolean containsKey(Set<Map.Entry<String, String>> funcotations, String key) {
         return funcotations.stream().anyMatch(entry -> entry.getKey().equals(key));
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFilter.java
@@ -2,8 +2,13 @@ package org.broadinstitute.hellbender.tools.funcotator.filtrationRules;
 
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A filter to apply to Funcotations in {@link org.broadinstitute.hellbender.tools.funcotator.FilterFuncotations}.
@@ -33,7 +38,7 @@ public abstract class FuncotationFilter {
      *                                     been "pruned" to remove null / empty values. Never {@code null}
      * @return true if the Funcotations match all of this filter's rules, and false otherwise
      */
-    public Boolean checkFilter(final Map<String, String> prunedTranscriptFuncotations) {
+    public Boolean checkFilter(final Set<Map.Entry<String, String>> prunedTranscriptFuncotations) {
         Utils.nonNull(prunedTranscriptFuncotations);
 
         return getRules().stream()
@@ -46,4 +51,22 @@ public abstract class FuncotationFilter {
      * Build the collection of rules which must match to pass this filter.
      */
     abstract List<FuncotationFiltrationRule> getRules();
+
+    protected Stream<String> matchOnKeyOrDefault(Set<Map.Entry<String, String>> funcotations, String key, String defaultValue) {
+        return getMatchesOrDefault(funcotations, entry -> entry.getKey().equals(key), defaultValue);
+    }
+
+    protected Stream<String> getMatchesOrDefault(Set<Map.Entry<String, String>> funcotations, Predicate<Map.Entry<String, String>> matcher, String defaultValue) {
+        Set<String> matched = funcotations.stream().filter(matcher).map(Map.Entry::getValue).collect(Collectors.toSet());
+        if (matched.isEmpty()) {
+            return Stream.of(defaultValue);
+        } else {
+            return matched.stream();
+        }
+    }
+
+    protected Boolean containsKey(Set<Map.Entry<String, String>> funcotations, String key) {
+        return funcotations.stream().anyMatch(entry -> entry.getKey().equals(key));
+    }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFiltrationRule.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/FuncotationFiltrationRule.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.funcotator.filtrationRules;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A rule to match against the Funcotations from a variant within a {@link FuncotationFilter}.
@@ -10,5 +11,5 @@ interface FuncotationFiltrationRule {
     /**
      * Check if a set of Funcotations matches this rule.
      */
-    boolean checkRule(final Map<String, String> funcotations);
+    boolean checkRule(final Set<Map.Entry<String, String>> funcotations);
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/LmmFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/LmmFilter.java
@@ -28,6 +28,11 @@ public class LmmFilter extends FuncotationFilter {
 
     @Override
     List<FuncotationFiltrationRule> getRules() {
-        return Collections.singletonList(funcotations -> Boolean.valueOf(funcotations.getOrDefault(LMM_FLAGGED, "false")));
+        return Collections.singletonList(funcotations ->
+                getMatchesOrDefault(funcotations, entry -> entry.getKey().equals(LMM_FLAGGED), "false")
+                        .map(Boolean::valueOf)
+                        .reduce(Boolean::logicalOr)
+                        .orElse(false) // Even though we've provided a default value, the Java type system complains without an orElse call.
+        );
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/LofFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/filtrationRules/LofFilter.java
@@ -61,8 +61,8 @@ public class LofFilter extends FuncotationFilter {
     @Override
     List<FuncotationFiltrationRule> getRules() {
         return Arrays.asList(
-                funcotations -> CONSTANT_LOF_CLASSIFICATIONS.contains(funcotations.getOrDefault(classificationFuncotation, "")),
-                funcotations -> funcotations.getOrDefault(LOF_GENE_FUNCOTATION, "").equals("YES"),
+                funcotations -> matchOnKeyOrDefault(funcotations, classificationFuncotation, "").anyMatch(CONSTANT_LOF_CLASSIFICATIONS::contains),
+                funcotations -> matchOnKeyOrDefault(funcotations, LOF_GENE_FUNCOTATION, "").anyMatch("YES"::equals),
                 FilterFuncotationsExacUtils.buildExacMaxMafRule(LOF_MAX_MAF));
     }
 }


### PR DESCRIPTION
Since Funcotation annotation can be multi-allelic, the filtration code needs to not assume that all Funcotated variants will have only one key of each funcotation.