### PR TITLE
Fix ReservoirDownsampler, PositionalDownsampler, and ReadsDownsamplingIterator.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/MutectDownsampler.java
@@ -94,6 +94,7 @@ public final class MutectDownsampler extends ReadsDownsampler {
                 // the desired coverage, but if the region is decently mappable the shortfall will be minor.
                 final ReservoirDownsampler wellMappedDownsampler = new ReservoirDownsampler(maxCoverage, false);
                 pendingReads.stream().filter(read -> read.getMappingQuality() > SUSPICIOUS_MAPPING_QUALITY).forEach(wellMappedDownsampler::submit);
+                wellMappedDownsampler.signalEndOfInput();
                 final List<GATKRead> readsToFinalize = wellMappedDownsampler.consumeFinalizedItems();
                 if (stride > 1) {
                     Collections.sort(readsToFinalize, Comparator.comparingInt(GATKRead::getAssignedStart));

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -31,6 +31,13 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     private List<GATKRead> finalizedReads;
 
     /**
+     * Reads may be submitted until signalEndOfInput is called, after which no more reads may be submitted unless
+     * one of {@link #consumeFinalizedItems()} or {@link #clearItems()} is called to reset the internal state of
+     * the downsampler.
+     */
+    private boolean endOfInputStream;
+
+    /**
      * Construct a PositionalDownsampler
      *
      * @param targetCoverage Maximum number of reads that may share any given alignment start position. Must be > 0
@@ -39,6 +46,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     public PositionalDownsampler( final int targetCoverage, final SAMFileHeader header ) {
         Utils.validateArg(targetCoverage > 0, "targetCoverage must be > 0");
         Utils.nonNull(header);
+        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         this.reservoir = new ReservoirDownsampler(targetCoverage);
         this.finalizedReads = new ArrayList<>();
@@ -140,6 +148,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
 
     @Override
     public void signalEndOfInput() {
+        endOfInputStream = true;
         finalizeReservoir(false);
     }
 
@@ -148,6 +157,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         reservoir.clearItems();
         reservoir.resetStats();
         finalizedReads.clear();
+        endOfInputStream = false;
         previousRead = null;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -31,13 +31,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     private List<GATKRead> finalizedReads;
 
     /**
-     * Reads may be submitted until signalEndOfInput is called, after which no more reads may be submitted unless
-     * one of {@link #consumeFinalizedItems()} or {@link #clearItems()} is called to reset the internal state of
-     * the downsampler.
-     */
-    private boolean endOfInputStream;
-
-    /**
      * Construct a PositionalDownsampler
      *
      * @param targetCoverage Maximum number of reads that may share any given alignment start position. Must be > 0
@@ -147,7 +140,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
 
     @Override
     public void signalEndOfInput() {
-        endOfInputStream = true;
         finalizeReservoir(false);
     }
 
@@ -156,7 +148,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         reservoir.clearItems();
         reservoir.resetStats();
         finalizedReads.clear();
-        endOfInputStream = false;
         previousRead = null;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -46,7 +46,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     public PositionalDownsampler( final int targetCoverage, final SAMFileHeader header ) {
         Utils.validateArg(targetCoverage > 0, "targetCoverage must be > 0");
         Utils.nonNull(header);
-        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         this.reservoir = new ReservoirDownsampler(targetCoverage);
         this.finalizedReads = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -31,13 +31,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     private List<GATKRead> finalizedReads;
 
     /**
-     * Reads may be submitted until signalEndOfInput is called, after which no more reads may be submitted unless
-     * one of {@link #consumeFinalizedItems()} or {@link #clearItems()} is called to reset the internal state of
-     * the downsampler.
-     */
-    private boolean endOfInputStream;
-
-    /**
      * Construct a PositionalDownsampler
      *
      * @param targetCoverage Maximum number of reads that may share any given alignment start position. Must be > 0
@@ -46,7 +39,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     public PositionalDownsampler( final int targetCoverage, final SAMFileHeader header ) {
         Utils.validateArg(targetCoverage > 0, "targetCoverage must be > 0");
         Utils.nonNull(header);
-        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         this.reservoir = new ReservoirDownsampler(targetCoverage);
         this.finalizedReads = new ArrayList<>();
@@ -148,7 +140,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
 
     @Override
     public void signalEndOfInput() {
-        endOfInputStream = true;
         finalizeReservoir(false);
     }
 
@@ -157,7 +148,6 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         reservoir.clearItems();
         reservoir.resetStats();
         finalizedReads.clear();
-        endOfInputStream = false;
         previousRead = null;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -31,6 +31,13 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     private List<GATKRead> finalizedReads;
 
     /**
+     * Reads may be submitted until signalEndOfInput is called, after which no more reads may be submitted unless
+     * one of {@link #consumeFinalizedItems()} or {@link #clearItems()} is called to reset the internal state of
+     * the downsampler.
+     */
+    private boolean endOfInputStream;
+
+    /**
      * Construct a PositionalDownsampler
      *
      * @param targetCoverage Maximum number of reads that may share any given alignment start position. Must be > 0
@@ -140,6 +147,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
 
     @Override
     public void signalEndOfInput() {
+        endOfInputStream = true;
         finalizeReservoir(false);
     }
 
@@ -148,6 +156,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
         reservoir.clearItems();
         reservoir.resetStats();
         finalizedReads.clear();
+        endOfInputStream = false;
         previousRead = null;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/PositionalDownsampler.java
@@ -46,6 +46,7 @@ public final class PositionalDownsampler extends ReadsDownsampler {
     public PositionalDownsampler( final int targetCoverage, final SAMFileHeader header ) {
         Utils.validateArg(targetCoverage > 0, "targetCoverage must be > 0");
         Utils.nonNull(header);
+        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         this.reservoir = new ReservoirDownsampler(targetCoverage);
         this.finalizedReads = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -133,7 +133,8 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
             clearItems();
             return downsampledItems;
         } else {
-            // if there's nothing here, don't bother allocating a new list
+            // We need to call clearItems() here for consistency with the case above where we have finalized items,
+            // so that in both cases we reset the endOfInputStream flag.
             clearItems();
             return Collections.emptyList();
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -95,9 +95,6 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
     @Override
     public void submit ( final GATKRead newRead ) {
         Utils.nonNull(newRead, "newRead");
-        // Once the end of the input stream has been seen, consumeFinalizedItems or clearItems must be called to
-        // reset the state of the ReservoirDownsampler before more items can be submitted
-        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         // Only count reads that are actually eligible for discarding for the purposes of the reservoir downsampling algorithm
         totalReadsSeen++;

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -95,9 +95,9 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
     @Override
     public void submit ( final GATKRead newRead ) {
         Utils.nonNull(newRead, "newRead");
-        // Once the end of the input stream has been seen, consumeFinalizedItems must be called to reset the state
-        // of the ReservoirDownsampler before more items can be submitted
-        Utils.validate(endOfInputStream == false, "attempt to submit read after end of input stream has been seen");
+        // Once the end of the input stream has been seen, consumeFinalizedItems or clearItems must be called to
+        // reset the state of the ReservoirDownsampler before more items can be submitted
+        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         // Only count reads that are actually eligible for discarding for the purposes of the reservoir downsampling algorithm
         totalReadsSeen++;

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -126,6 +126,7 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
 
     @Override
     public List<GATKRead> consumeFinalizedItems() {
+        Utils.validate(endOfInputStream == true, "signalEndOfInput must be called before finalized items can be consumed");
         if (hasFinalizedItems()) {
             // pass reservoir by reference rather than make a copy, for speed
             final List<GATKRead> downsampledItems = reservoir;
@@ -133,6 +134,7 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
             return downsampledItems;
         } else {
             // if there's nothing here, don't bother allocating a new list
+            clearItems();
             return Collections.emptyList();
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -95,6 +95,9 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
     @Override
     public void submit ( final GATKRead newRead ) {
         Utils.nonNull(newRead, "newRead");
+        // Once the end of the input stream has been seen, consumeFinalizedItems or clearItems must be called to
+        // reset the state of the ReservoirDownsampler before more items can be submitted
+        Utils.validate(! endOfInputStream, "attempt to submit read after end of input stream has been signaled");
 
         // Only count reads that are actually eligible for discarding for the purposes of the reservoir downsampling algorithm
         totalReadsSeen++;

--- a/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsampler.java
@@ -126,7 +126,6 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
 
     @Override
     public List<GATKRead> consumeFinalizedItems() {
-        Utils.validate(endOfInputStream == true, "signalEndOfInput must be called before finalized items can be consumed");
         if (hasFinalizedItems()) {
             // pass reservoir by reference rather than make a copy, for speed
             final List<GATKRead> downsampledItems = reservoir;
@@ -134,7 +133,6 @@ public final class ReservoirDownsampler extends ReadsDownsampler {
             return downsampledItems;
         } else {
             // if there's nothing here, don't bother allocating a new list
-            clearItems();
             return Collections.emptyList();
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -145,7 +145,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
      * Test that in VCF mode we're >= 99% concordant with GATK3.8 results
      * THIS TEST explodes with an exception because Allele-Specific annotations are not supported in vcf mode yet.
      * It's included to parallel the matching (also exploding) test for the non-spark HaplotypeCaller
-     * {@link org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerIntegrationTest#testVCFModeIsConcordantWithGATK3_8ResultsAlleleSpecificAnnotations()}
+     * {@link org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerIntegrationTest#testVCFModeIsConcordantWithGATK3_8ResultsAlleleSpecificAnnotations(String, String)}}
      */
     @Test(expectedExceptions = UserException.class)
     public void testVCFModeIsConcordantWithGATK3_8ResultsAlleleSpecificAnnotations() throws Exception {

--- a/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReadsDownsamplingIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReadsDownsamplingIteratorUnitTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.stream.IntStream;
 
 public class ReadsDownsamplingIteratorUnitTest extends GATKBaseTest {
 
@@ -130,6 +131,22 @@ public class ReadsDownsamplingIteratorUnitTest extends GATKBaseTest {
     public void testRemoveThrows() {
         final ReadsDownsamplingIterator iter = new ReadsDownsamplingIterator(Collections.<GATKRead>emptyIterator(), new KeepReadsBAndCOnlyDownsampler());
         iter.remove();
+    }
+
+    @Test
+    public void testReadsDownsamplingIteratorWithReservoirDownsampler() {
+        final int TOTAL_READ_COUNT = 100;
+        final int TARGET_COVERAGE = 45;
+        final List<GATKRead> reads = new ArrayList<>(TOTAL_READ_COUNT);
+        IntStream.range(1, TOTAL_READ_COUNT).forEach(i -> reads.add(readWithName(Integer.toString(i))));
+
+        final List<GATKRead> downsampledReads = new ArrayList<>();
+        final ReadsDownsamplingIterator downsamplingIter = new ReadsDownsamplingIterator(reads.iterator(), new ReservoirDownsampler(TARGET_COVERAGE));
+        for ( final GATKRead read : downsamplingIter ) {
+            downsampledReads.add(read);
+        }
+
+        Assert.assertEquals(downsampledReads.size(), TARGET_COVERAGE);
     }
 
     private GATKRead readWithName( final String name ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsamplerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/downsampling/ReservoirDownsamplerUnitTest.java
@@ -66,24 +66,26 @@ public final class ReservoirDownsamplerUnitTest extends GATKBaseTest {
 
         downsampler.submit(test.createReads());
 
+        // after submit, but before signalEndOfInput, all reads are pending, none are finalized
         if ( test.totalReads > 0 ) {
-            Assert.assertTrue(downsampler.hasFinalizedItems());
-            Assert.assertTrue(downsampler.peekFinalized() != null);
-            Assert.assertFalse(downsampler.hasPendingItems());
-            Assert.assertTrue(downsampler.peekPending() == null);
+            Assert.assertFalse(downsampler.hasFinalizedItems());
+            Assert.assertNull(downsampler.peekFinalized());
+            Assert.assertTrue(downsampler.hasPendingItems());
+            Assert.assertNotNull(downsampler.peekPending());
         }
         else {
             Assert.assertFalse(downsampler.hasFinalizedItems() || downsampler.hasPendingItems());
             Assert.assertTrue(downsampler.peekFinalized() == null && downsampler.peekPending() == null);
         }
 
+        // after signalEndOfInput, not reads are pending, all are finalized
         downsampler.signalEndOfInput();
 
         if ( test.totalReads > 0 ) {
             Assert.assertTrue(downsampler.hasFinalizedItems());
-            Assert.assertTrue(downsampler.peekFinalized() != null);
+            Assert.assertNotNull(downsampler.peekFinalized());
             Assert.assertFalse(downsampler.hasPendingItems());
-            Assert.assertTrue(downsampler.peekPending() == null);
+            Assert.assertNull(downsampler.peekPending());
         }
         else {
             Assert.assertFalse(downsampler.hasFinalizedItems() || downsampler.hasPendingItems());


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/4768.

The ReservoirDownsampler currently declares reads to be finalized immediately after they're submitted, but in order to guaranty that every read has equal probability of being discarded, it should consume the entire stream of input items before declaring any item to be finalized. When used with a ReadsDownsamplingIterator, no reads are ever downsampled because the iterator populates it's internal cache by eagerly consuming finalized reads as soon as they become available.

Also, PositionalDownsampler doesn't reset it's internal ReservoirDownsampler's state correctly.