### PR TITLE
Relax CRAN remote failure mode.

### DIFF
--- a/scripts/docker/gatkbase/install_R_packages.R
+++ b/scripts/docker/gatkbase/install_R_packages.R
@@ -15,9 +15,10 @@ InstallPackageFromArchive = function(packageName, packageURL) {
     }
 }
 
+Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
 dependencies = c("gplots",
                  "digest", "gtable", "MASS", "plyr", "reshape2", "scales", "tibble", "lazyeval")    # for ggplot2
-repos <- c("http://cran.cnr.Berkeley.edu", "http://cran.mtu.edu")
+repos <- c("http://cran.cnr.Berkeley.edu", "http://cran.mtu.edu", "http://lib.stat.cmu.edu/R/CRAN/")
 install.packages(dependencies, repos = repos, clean = TRUE)
 
 InstallPackageFromArchive("getopt", "http://cran.r-project.org/src/contrib/Archive/getopt/getopt_1.20.0.tar.gz")


### PR DESCRIPTION
Some travis jobs are still failing even with the reduced set of CRAN mirrors. This is a possible alternative solution that restores the previous set of fallback repos, but relaxes the treatment of remote warnings. Might be overkill but it seems to work. See `R_REMOTES_NO_ERRORS_FROM_WARNINGS ` under https://github.com/r-lib/remotes#environment-variables.