### PR TITLE
Move to GenomicsDB 1.0.0-rc2 for #5568 and #5342

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.2.0')
 final tensorflowVersion = System.getProperty('tensorflow.version','1.9.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.0.beta1')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.0-rc2')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one


### PR DESCRIPTION
This addresses issues #5568 and #5342.
#5568 Buffer resize messages are now turned on only for Debug builds.
#5342: Added better general error reporting for system commands. For the file synching error in question, implemented a workaround. With environment variable - TILEDB_DISABLE_FILE_LOCKING - set to true or 1, there is no file locking and file synching error will only log warning messages and not return an error. Hopefully, this will mitigate the issues on NFS and CIFS.