### PR TITLE
New path for fixed blacklist file

### DIFF
--- a/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json
+++ b/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json
@@ -20,8 +20,8 @@
   "MitochondriaPipeline.mt_shifted_bwt": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.shifted_by_8000_bases.fasta.bwt",
   "MitochondriaPipeline.mt_shifted_pac": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.shifted_by_8000_bases.fasta.pac",
   "MitochondriaPipeline.mt_shifted_sa": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.shifted_by_8000_bases.fasta.sa",
-  "MitochondriaPipeline.blacklisted_sites_shifted": "gs://broad-references/hg38/v0/chrM/blacklist_sites.hg38.chrM.shifted_by_8000_bases.bed",
-  "MitochondriaPipeline.blacklisted_sites_shifted_index": "gs://broad-references/hg38/v0/chrM/blacklist_sites.hg38.chrM.shifted_by_8000_bases.bed.idx",
+  "MitochondriaPipeline.blacklisted_sites_shifted": "gs://broad-references/hg38/v0/chrM/blacklist_sites.hg38.chrM.shifted_by_8000_bases.fixed.bed",
+  "MitochondriaPipeline.blacklisted_sites_shifted_index": "gs://broad-references/hg38/v0/chrM/blacklist_sites.hg38.chrM.shifted_by_8000_bases.fixed.bed.idx",
   "MitochondriaPipeline.shift_back_chain": "gs://broad-references/hg38/v0/chrM/ShiftBack.chain",
   "MitochondriaPipeline.control_region_shifted_reference_interval_list": "gs://broad-references/hg38/v0/chrM/control_region_shifted.chrM.interval_list",
   "MitochondriaPipeline.non_control_region_interval_list": "gs://broad-references/hg38/v0/chrM/non_control_region.chrM.interval_list"


### PR DESCRIPTION
Ops fixed the bad blacklist in broad-references, but this means the old file is no longer there. @ldgauthier or @jsotobroad Can you please do a quick review? @droazen It would be really awesome if this (tiny!) commit could end up in the release.