### PR TITLE
Updates for latest data source release.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorDataSourceDownloader.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorDataSourceDownloader.java
@@ -51,7 +51,7 @@ public class FuncotatorDataSourceDownloader extends CommandLineProgram {
     //==================================================================================================================
     // Private Static Members:
 
-    private static String BASE_URL = "gs://broad-public-datasets/funcotator/funcotator_dataSources.v1.4.20180829";
+    private static String BASE_URL = "gs://broad-public-datasets/funcotator/funcotator_dataSources.v1.6.20190124";
 
     private static String GERMLINE_GCLOUD_DATASOURCES_BASEURL     = BASE_URL + "g";
     @VisibleForTesting

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/DataSourceUtils.java
@@ -59,13 +59,13 @@ final public class DataSourceUtils {
     @VisibleForTesting
     static final int MIN_MAJOR_VERSION_NUMBER = 1;
     @VisibleForTesting
-    static final int MIN_MINOR_VERSION_NUMBER = 4;
+    static final int MIN_MINOR_VERSION_NUMBER = 6;
     @VisibleForTesting
-    static final int MIN_YEAR_RELEASED        = 2018;
+    static final int MIN_YEAR_RELEASED        = 2019;
     @VisibleForTesting
-    static final int MIN_MONTH_RELEASED       = 8;
+    static final int MIN_MONTH_RELEASED       = 1;
     @VisibleForTesting
-    static final int MIN_DAY_RELEASED         = 29;
+    static final int MIN_DAY_RELEASED         = 24;
 
     //==================================================================================================================
     // Public Static Members:


### PR DESCRIPTION
- Released new data sources to google bucket and FTP site for both somatic and germline (clinical pipeline)
- Updated data source download URL to point to the bucket for v1.6.20190124
- Updated minimum version of data sources to v1.6.20190124.

With the release and these changes, the following issues are addressed:

Fixes #5259 
Fixes #5428 
Fixes #5429 