### PR TITLE
More excessively micro micro-optimizations

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -193,6 +193,7 @@ public class ReferenceConfidenceModel {
         final String sampleName = readLikelihoods.getSample(0);
 
         final int globalRefOffset = refSpan.getStart() - activeRegion.getExtendedSpan().getStart();
+        // Note, we use an indexed for-loop here because this method has a large impact on the profile of HaplotypeCaller runtime in GVCF mode
         final int refPileupsSize = refPileups.size();
         for (int i = 0; i < refPileupsSize; i++) {
             final ReadPileup pileup = refPileups.get(i);
@@ -424,7 +425,7 @@ public class ReferenceConfidenceModel {
     private List<VariantContext> getMatchingPriors(final Locatable curPos, final VariantContext call, final List<VariantContext> priorList) {
         final int position = call != null ? call.getStart() : curPos.getStart();
         final List<VariantContext> matchedPriors = new ArrayList<>(priorList.size());
-        // NOTE: a for loop is used here because this method ends up being called per-pileup, per-read and thus using faster alternates saves runtime
+        // NOTE: a for loop is used here because this method ends up being called per-pileup, per-read and using a loop instead of streaming saves runtime
         final int priorsListSize = priorList.size();
         for (int i = 0; i < priorsListSize; i++) {
             if (position == priorList.get(i).getStart()) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -425,7 +425,7 @@ public class ReferenceConfidenceModel {
         final int position = call != null ? call.getStart() : curPos.getStart();
         final List<VariantContext> matchedPriors = new ArrayList<>(priorList.size());
         // NOTE: a for loop is used here because this method ends up being called per-pileup, per-read and thus using faster alternates saves runtime
-        final int priorsListSize = priorList.size()
+        final int priorsListSize = priorList.size();
         for (int i = 0; i < priorsListSize; i++) {
             if (position == priorList.get(i).getStart()) {
                 matchedPriors.add(priorList.get(i));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -193,18 +193,18 @@ public class ReferenceConfidenceModel {
         final String sampleName = readLikelihoods.getSample(0);
 
         final int globalRefOffset = refSpan.getStart() - activeRegion.getExtendedSpan().getStart();
-        for ( final ReadPileup pileup : refPileups ) {
+        for (int i = 0, size = refPileups.size(); i < size; i++) {
+            ReadPileup pileup = refPileups.get(i);
             final Locatable curPos = pileup.getLocation();
             final int offset = curPos.getStart() - refSpan.getStart();
 
             final VariantContext overlappingSite = GATKVariantContextUtils.getOverlappingVariantContext(curPos, variantCalls);
             final List<VariantContext> currentPriors = getMatchingPriors(curPos, overlappingSite, VCpriors);
-            if ( overlappingSite != null && overlappingSite.getStart() == curPos.getStart() ) {
+            if (overlappingSite != null && overlappingSite.getStart() == curPos.getStart()) {
                 if (applyPriors) {
                     results.add(PosteriorProbabilitiesUtils.calculatePosteriorProbs(overlappingSite, currentPriors,
                             numRefSamplesForPrior, options));
-                }
-                else {
+                } else {
                     results.add(overlappingSite);
                 }
             } else {
@@ -420,9 +420,15 @@ public class ReferenceConfidenceModel {
      * @param priorList priors within the current ActiveRegion
      * @return prior VCs representing the same variant position as call
      */
-    List<VariantContext> getMatchingPriors(final Locatable curPos, final VariantContext call, final List<VariantContext> priorList) {
+    private List<VariantContext> getMatchingPriors(final Locatable curPos, final VariantContext call, final List<VariantContext> priorList) {
         final int position = call != null ? call.getStart() : curPos.getStart();
-        return priorList.stream().filter(vc -> position == vc.getStart()).collect(Collectors.toList());
+        List<VariantContext> list = new ArrayList<>(priorList.size());
+        for (int i = 0, size = priorList.size(); i < size; i++) {
+            if (position == priorList.get(i).getStart()) {
+                list.add(priorList.get(i));
+            }
+        }
+        return list;
     }
 
     /**


### PR DESCRIPTION
These methods were showing up as time syncs on the profile for #5607 
<img width="982" alt="screen shot 2019-01-28 at 3 44 55 pm" src="https://user-images.githubusercontent.com/16102845/51868464-1e8b1a80-231c-11e9-8221-5424f31cbdde.png">
<img width="980" alt="screen shot 2019-01-28 at 3 44 41 pm" src="https://user-images.githubusercontent.com/16102845/51868479-2480fb80-231c-11e9-9e51-8f66d11e2244.png">

I ran these a few times vs. its root branch, its probably a small improvement in runtime over this chr15 snippet of an exome on my local machine:
#5607:
```
2m57.516s, 2m56.677s, 3m2.531s, 3m4.116s
```
This branch:
```
2m50.112s, 2m46.981s, 2m43.764s, 2m40.806s
```

Depends On #5607 

