### PR TITLE
Removing an extraneous cigar copy from referenceConfidenceCalculation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -548,7 +548,8 @@ public class ReferenceConfidenceModel {
     protected int getCigarModifiedOffset (final PileupElement p){
         final GATKRead read = p.getRead();
         int offset = (p.getCurrentCigarElement().getOperator().consumesReferenceBases() || p.getCurrentCigarElement().getOperator() == CigarOperator.S)? p.getOffsetInCurrentCigar() : 0;
-        for (final CigarElement elem : read.getCigar().getCigarElements().subList(0, p.getCurrentCigarOffset())) {
+        for (int i = 0; i < p.getCurrentCigarOffset(); i++ ) {
+            CigarElement elem = read.getCigarElement(i);
             if (elem.getOperator().consumesReferenceBases() || elem.getOperator() == CigarOperator.S) {
                 offset += elem.getLength();
             }


### PR DESCRIPTION
This was showing up in the profile, as with a few other places this was copying the cigar for each read over each pileup, which is not efficient.
Before:
<img width="912" alt="screen shot 2019-02-07 at 11 55 24 am" src="https://user-images.githubusercontent.com/16102845/52429724-a4ecec80-2ad2-11e9-9e63-e79c62767215.png">
After:
<img width="951" alt="screen shot 2019-02-07 at 12 20 16 pm" src="https://user-images.githubusercontent.com/16102845/52429818-cf3eaa00-2ad2-11e9-84fb-b8cbcf7617b2.png">
