### PR TITLE
Don't output VCs with no ALT if * gets dropped

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ import java.util.stream.Collectors;
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of informative coverage for each sample (DP)")
 public final class DepthPerSampleHC extends GenotypeAnnotation implements StandardHCAnnotation, StandardMutectAnnotation {
-    private final static Logger logger = LogManager.getLogger(DepthPerSampleHC.class);
+    protected final OneShotLogger logger = new OneShotLogger(this.getClass());
 
     @Override
     public void annotate( final ReferenceContext ref,
@@ -53,7 +54,7 @@ public final class DepthPerSampleHC extends GenotypeAnnotation implements Standa
         Utils.nonNull(gb);
 
         if ( likelihoods == null || !g.isCalled() ) {
-            logger.warn("Annotation will not be calculated, genotype is not called or alleleLikelihoodMap is null");
+            logger.warn("Annotation will not be calculated for at least one sample at one variant position -- genotype is not called or alleleLikelihoodMap is null");
             return;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -14,7 +14,6 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
-import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of informative coverage for each sample (DP)")
 public final class DepthPerSampleHC extends GenotypeAnnotation implements StandardHCAnnotation, StandardMutectAnnotation {
-    protected final OneShotLogger logger = new OneShotLogger(this.getClass());
+    private final static Logger logger = LogManager.getLogger(DepthPerSampleHC.class);
 
     @Override
     public void annotate( final ReferenceContext ref,
@@ -54,7 +53,7 @@ public final class DepthPerSampleHC extends GenotypeAnnotation implements Standa
         Utils.nonNull(gb);
 
         if ( likelihoods == null || !g.isCalled() ) {
-            logger.warn("Annotation will not be calculated for at least one sample at one variant position -- genotype is not called or alleleLikelihoodMap is null");
+            logger.warn("Annotation will not be calculated, genotype is not called or alleleLikelihoodMap is null");
             return;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ import java.util.stream.Collectors;
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of informative coverage for each sample (DP)")
 public final class DepthPerSampleHC extends GenotypeAnnotation implements StandardHCAnnotation, StandardMutectAnnotation {
-    private final static Logger logger = LogManager.getLogger(DepthPerSampleHC.class);
+    private final transient OneShotLogger logger = new OneShotLogger(DepthPerSampleHC.class);
 
     @Override
     public void annotate( final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -387,11 +387,11 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
                 final boolean isNonRefWhichIsLoneAltAllele = alternativeAlleleCount == 1 && allele.equals(
                         Allele.NON_REF_ALLELE);
                 final boolean isPlausible = afCalculationResult.isPolymorphicPhredScaledQual(allele, configuration.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING);
-
-                siteIsMonomorphic &= !isPlausible;
-
                 //it's possible that the upstream deletion that spanned this site was not emitted, mooting the symbolic spanning deletion allele
                 final boolean isSpuriousSpanningDeletion = GATKVCFConstants.isSpanningDeletion(allele) && !isVcCoveredByDeletion(vc);
+
+                siteIsMonomorphic &= !(isPlausible && !isSpuriousSpanningDeletion);
+
                 final boolean toOutput = (isPlausible || forceKeepAllele(allele) || isNonRefWhichIsLoneAltAllele) && !isSpuriousSpanningDeletion;
 
                 if (toOutput) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -387,11 +387,11 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
                 final boolean isNonRefWhichIsLoneAltAllele = alternativeAlleleCount == 1 && allele.equals(
                         Allele.NON_REF_ALLELE);
                 final boolean isPlausible = afCalculationResult.isPolymorphicPhredScaledQual(allele, configuration.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING);
+
+                siteIsMonomorphic &= !isPlausible;
+
                 //it's possible that the upstream deletion that spanned this site was not emitted, mooting the symbolic spanning deletion allele
                 final boolean isSpuriousSpanningDeletion = GATKVCFConstants.isSpanningDeletion(allele) && !isVcCoveredByDeletion(vc);
-
-                siteIsMonomorphic &= !(isPlausible && !isSpuriousSpanningDeletion);
-
                 final boolean toOutput = (isPlausible || forceKeepAllele(allele) || isNonRefWhichIsLoneAltAllele) && !isSpuriousSpanningDeletion;
 
                 if (toOutput) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -53,6 +53,13 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         return new MinimalGenotypingEngine(uac, SAMPLES, new GeneralPloidyFailOverAFCalculatorProvider(genotypeArgs));
     }
 
+    private static GenotypingEngine<?> getNewQualGenotypingEngine() {
+        final GenotypeCalculationArgumentCollection genotypeArgs = new GenotypeCalculationArgumentCollection();
+        final UnifiedArgumentCollection uac = new UnifiedArgumentCollection();
+        uac.genotypeArgs = new GenotypeCalculationArgumentCollection(genotypeArgs);
+        return new MinimalGenotypingEngine(uac, SAMPLES, new GeneralPloidyFailOverAFCalculatorProvider(genotypeArgs));
+    }
+
     @DataProvider(name="testCoveredByDeletionData")
     public Object[][] testCoveredByDeletionData() {
         return new Object[][] {
@@ -92,6 +99,33 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
                 genotypes(genotypesSpanDel).make();
         final VariantContext vcOut1 = genotypingEngine.calculateGenotypes(vcSpanDel, GenotypeLikelihoodsCalculationModel.INDEL, null);
         Assert.assertFalse(vcOut1.getAlleles().contains(Allele.SPAN_DEL));
+
+        final List<Allele> mutliAllelicWithSpanDel = new ArrayList<>(Arrays.asList(refAlleleSpanDel, Allele.SPAN_DEL,
+                Allele.create("T")));
+        final List<Genotype> regressionGenotypes = Arrays.asList(
+                new GenotypeBuilder("s1564").alleles(gtAlleles).PL(new int[]{ 42,43,45,3,3,0}).make(),
+                new GenotypeBuilder("s1741").alleles(gtAlleles).PL(new int[]{0,0,0,0,0,0}).make(),
+                new GenotypeBuilder("s1851").alleles(gtAlleles).PL(new int[]{0,15,250,15,250,250}).make(),
+                new GenotypeBuilder("s1852").alleles(gtAlleles).PL(new int[]{0,9,184,9,184,184}).make(),
+                new GenotypeBuilder("s1862").alleles(gtAlleles).PL(new int[]{43,0,78,53,84,152}).make(),
+                new GenotypeBuilder("s1901").alleles(gtAlleles).PL(new int[]{210,15,0,216,15,225}).make(),
+                new GenotypeBuilder("s1912").alleles(gtAlleles).PL(new int[]{55,6,0,59,6,74}).make(),
+                new GenotypeBuilder("s1971").alleles(gtAlleles).PL(new int[]{0,3,45,3,45,45}).make(),
+                new GenotypeBuilder("s2017").alleles(gtAlleles).PL(new int[]{55,6,0,59,6,74}).make(),
+                new GenotypeBuilder("s2021").alleles(gtAlleles).PL(new int[]{30,0,123,40,126,168}).make(),
+                new GenotypeBuilder("s2026").alleles(gtAlleles).PL(new int[]{27,0,165,40,168,210}).make(),
+                new GenotypeBuilder("s2056").alleles(gtAlleles).PL(new int[]{0,6,131,9,132,135}).make(),
+                new GenotypeBuilder("s2100").alleles(gtAlleles).PL(new int[]{0,18,311,21,312,315}).make(),
+                new GenotypeBuilder("s2102").alleles(gtAlleles).PL(new int[]{0,12,180,12,180,180}).make(),
+                new GenotypeBuilder("s2104").alleles(gtAlleles).PL(new int[]{0,6,90,6,90,90}).make(),
+                new GenotypeBuilder("s2122").alleles(gtAlleles).PL(new int[]{0,6,90,6,90,90}).make(),
+                new GenotypeBuilder("s2124").alleles(gtAlleles).PL(new int[]{0,0,0,0,0,0}).make(),
+                new GenotypeBuilder("s2151").alleles(gtAlleles).PL(new int[]{52,0,246,74,252,336}).make(),
+                new GenotypeBuilder("s2157").alleles(gtAlleles).PL(new int[]{0,21,315,21,315,315}).make());
+        final VariantContext vcMultiWithSpanDel = new VariantContextBuilder("test2", "1",2, 2 + refAlleleSpanDel.length() - 1, mutliAllelicWithSpanDel).
+                genotypes(regressionGenotypes).make();
+        final VariantContext vcOut2 = genotypingEngine.calculateGenotypes(vcMultiWithSpanDel, GenotypeLikelihoodsCalculationModel.SNP, null);
+        Assert.assertFalse(vcOut2 == null || vcOut2.isMonomorphicInSamples());
     }
 
     @Test //test for https://github.com/broadinstitute/gatk/issues/2530

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -82,8 +82,8 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
 
          // Remove deletion
         final List<Genotype> genotypes = Arrays.asList(
-                new GenotypeBuilder("sample1").alleles(gtAlleles).PL(new double[]{0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}).make(),  // first alt
-                new GenotypeBuilder("sample2").alleles(gtAlleles).PL(new double[]{0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0}).make()); // second alt
+                new GenotypeBuilder("sample1").alleles(gtAlleles).PL(new double[]{0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}).make(),  // homVar for first alt -- note that these are doubles, so they get renormalized
+                new GenotypeBuilder("sample2").alleles(gtAlleles).PL(new double[]{0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0}).make()); // homVar for second alt
         final VariantContext vc = new VariantContextBuilder("test", "1",1, refAllele.length(), allelesDel).genotypes(genotypes).make();
         final VariantContext vcOut = genotypingEngine.calculateGenotypes(vc, GenotypeLikelihoodsCalculationModel.INDEL, null);
         Assert.assertFalse(vcOut.getAlleles().contains(altT));
@@ -98,7 +98,7 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         final VariantContext vcSpanDel = new VariantContextBuilder("test1", "1",2, 2 + refAlleleSpanDel.length() - 1, vcAllelesSpanDel).
                 genotypes(genotypesSpanDel).make();
         final VariantContext vcOut1 = genotypingEngine.calculateGenotypes(vcSpanDel, GenotypeLikelihoodsCalculationModel.INDEL, null);
-        Assert.assertFalse(vcOut1.getAlleles().contains(Allele.SPAN_DEL));
+        Assert.assertTrue(vcOut1 == null || !vcOut1.getAlleles().contains(Allele.SPAN_DEL));
 
         final List<Allele> mutliAllelicWithSpanDel = new ArrayList<>(Arrays.asList(refAlleleSpanDel, Allele.SPAN_DEL,
                 Allele.create("T")));
@@ -125,7 +125,7 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         final VariantContext vcMultiWithSpanDel = new VariantContextBuilder("test2", "1",2, 2 + refAlleleSpanDel.length() - 1, mutliAllelicWithSpanDel).
                 genotypes(regressionGenotypes).make();
         final VariantContext vcOut2 = genotypingEngine.calculateGenotypes(vcMultiWithSpanDel, GenotypeLikelihoodsCalculationModel.SNP, null);
-        Assert.assertFalse(vcOut2 == null || vcOut2.isMonomorphicInSamples());
+        Assert.assertTrue(vcOut2 == null || vcOut2.isMonomorphicInSamples());
     }
 
     @Test //test for https://github.com/broadinstitute/gatk/issues/2530


### PR DESCRIPTION
With the new qual model as the default for HC as of 4.1, occasionally sites get output with a . ALT when the * allele gets dropped.  Expected behavior is no output at that site in the VC.

Also limit logging for DepthPerSampleHC annotation.

Note that the expected behavior in one of the existing tests was also wrong and had to be fixed.

Fixes #5650 
