### PR TITLE
Option to recover all dangling branches -- default in M2 mito mode

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -47,6 +47,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
                 useAdaptivePruning, initialErrorRateForPruning, pruningLog10OddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
+        assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);
 
         if ( graphOutput != null ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -25,6 +25,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
                 !disableAdaptivePruning, initialErrorRateForPruning, pruningLog10OddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
+        assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);
 
         if ( graphOutput != null ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -60,6 +60,14 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Argument(fullName="min-dangling-branch-length", doc="Minimum length of a dangling branch to attempt recovery", optional = true)
     public int minDanglingBranchLength = 4;
 
+    /**
+     * By default, the read threading assembler does not recover dangling branches that fork after splitting from the reference.  This argument
+     * tells the assembly engine to recover all dangling branches.
+     */
+    @Advanced
+    @Argument(fullName="recover-all-dangling-branches", doc="Recover all dangling branches", optional = true)
+    public boolean recoverAllDanglingBranches = false;
+
 
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -64,9 +64,13 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
 
     @Override
     public ReadThreadingAssembler createReadThreadingAssembler(){
-        if(mitochondria && assemblerArgs.pruningLog10OddsThreshold == ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD) {
-            assemblerArgs.pruningLog10OddsThreshold = DEFAULT_MITO_PRUNING_LOG_ODDS_THRESHOLD;
+        if(mitochondria ) {
+            assemblerArgs.recoverAllDanglingBranches = true;
+            if (assemblerArgs.pruningLog10OddsThreshold == ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD) {
+                assemblerArgs.pruningLog10OddsThreshold = DEFAULT_MITO_PRUNING_LOG_ODDS_THRESHOLD;
+            }
         }
+
         return super.createReadThreadingAssembler();
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
@@ -156,8 +156,8 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         pruner.pruneLowWeightChains(graph);
 
         final SmithWatermanAligner aligner = SmithWatermanJavaAligner.getInstance();
-        graph.recoverDanglingTails(1, 3, aligner);
-        graph.recoverDanglingHeads(1, 3, aligner);
+        graph.recoverDanglingTails(1, 3, false, aligner);
+        graph.recoverDanglingHeads(1, 3, false, aligner);
         graph.removePathsNotConnectedToRef();
 
         final SeqGraph seqGraph = graph.toSequenceGraph();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
@@ -303,7 +303,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         Assert.assertTrue(altSink != null, "We did not find a non-reference sink");
 
         // confirm that the SW alignment agrees with our expectations
-        final ReadThreadingGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstDownwardsReferencePath(altSink, 0, 4, SmithWatermanJavaAligner
+        final ReadThreadingGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstDownwardsReferencePath(altSink, 0, 4, false, SmithWatermanJavaAligner
                 .getInstance());
 
         if ( result == null ) {
@@ -410,7 +410,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         Assert.assertTrue(altSource != null, "We did not find a non-reference source");
 
         // confirm that the SW alignment agrees with our expectations
-        final ReadThreadingGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstUpwardsReferencePath(altSource, 0, 1, SmithWatermanJavaAligner
+        final ReadThreadingGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstUpwardsReferencePath(altSource, 0, 1, false, SmithWatermanJavaAligner
                 .getInstance());
 
         if ( result == null ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -724,7 +724,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
 
         final Map<String, VariantContext> variantMap2 = result_noThreshold.getRight().stream().collect(Collectors.toMap(vc -> keyForVariant(vc), Function.identity()));
 
-        //TLODs for variants should change too much for variant allele, should change significantly for non-ref
+        //TLODs for variants should not change too much for variant allele, should change significantly for non-ref
         // however, there are edge cases where this need not be true (this might indicate the need to fix our
         // LOD calculation for the NON-REF allele), so we allow one anomalous site
         final long changedRegularAlleleLodCount = expectedKeys.stream()

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -676,7 +676,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-ERC", "GVCF",
                 "-LODB", "-2.0",
                 "-LODB", "0.0",
-                "-min-AF", "0.01","-bamout","/Users/davidben/Desktop/bamout-0.01.bam");
+                "-min-AF", "0.01");
         runCommandLine(args);
 
         //check ref conf-specific headers are output
@@ -718,7 +718,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "-ERC", "GVCF",
                 "-LODB", "-2.0",
                 "-LODB", "0.0",
-                "-min-AF", "0.00","-bamout", "/Users/davidben/Desktop/bamout-0.00.bam");
+                "-min-AF", "0.00");
         runCommandLine(args3);
         final Pair<VCFHeader, List<VariantContext>> result_noThreshold = VariantContextTestUtils.readEntireVCFIntoMemory(unthresholded.getAbsolutePath());
 


### PR DESCRIPTION
@meganshand Could you review this?  It fixes most of the homoplasmic missed calls in broadinstitute/dsp-spec-ops#116.

I reviewed all of the false positive that were introduced to our somatic validations when attempting to make this the default in non-mitochondria mode.  Everything was due to mapping error, which I do not expect to be an issue in mitochondria, and not an inherent problem with recovering more dangling ends.  You will still want to run this branch through some of your validations, however.  In mitochondria mode it's the same as the dangling-1-29.jar that I shared earlier with you and Sarah.