### PR TITLE
Improvements in ProcessIntervals.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
-import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.iterators.ByteArrayIterator;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -62,10 +62,6 @@ public interface ReferenceDataSource extends GATKDataSource<Byte>, AutoCloseable
      * @return a ReferenceSequence containing all bases spanning the query interval, prefetched
      */
     default public ReferenceSequence queryAndPrefetch( final SimpleInterval interval ) {
-        return queryAndPrefetch(interval.getContig(), interval.getStart(), interval.getEnd());
-    }
-
-    default ReferenceSequence queryAndPrefetch(final Interval interval) {
         return queryAndPrefetch(interval.getContig(), interval.getStart(), interval.getEnd());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReferenceDataSource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.util.Interval;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.iterators.ByteArrayIterator;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -61,6 +62,10 @@ public interface ReferenceDataSource extends GATKDataSource<Byte>, AutoCloseable
      * @return a ReferenceSequence containing all bases spanning the query interval, prefetched
      */
     default public ReferenceSequence queryAndPrefetch( final SimpleInterval interval ) {
+        return queryAndPrefetch(interval.getContig(), interval.getStart(), interval.getEnd());
+    }
+
+    default ReferenceSequence queryAndPrefetch(final Interval interval) {
         return queryAndPrefetch(interval.getContig(), interval.getStart(), interval.getEnd());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
@@ -246,7 +246,7 @@ public final class PreprocessIntervals extends GATKTool {
 
     private static Stream<Interval> filterBinsContainingOnlyNs(final Stream<Interval> unfilteredBins, final ReferenceDataSource reference) {
         return unfilteredBins.filter(interval -> {
-            final byte[] bases = reference.queryAndPrefetch(interval).getBases();
+            final byte[] bases = reference.queryAndPrefetch(interval.getContig(), interval.getStart(), interval.getEnd()).getBases();
             for (byte b : bases) {
                 if (Nucleotide.decode(b) != Nucleotide.N) {
                     return true;

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervals.java
@@ -60,6 +60,20 @@ import java.util.stream.StreamSupport;
  *         different length than the others in that interval.  If zero is specified, then no binning will be performed;
  *         this is generally appropriate for targeted analyses.
  *     </li>
+ *     <li>
+ *         Minimum bin length (in bp).
+ *         With {@code min-bin-length} you can specify the minimum size for any given bin in case that these need to be
+ *         truncated to accommodate the size of the enclosing interval or contig. Bin shorter than that will be excluded
+ *         from the output.
+ *         By default this argument is set to 1, so that any non-empty bin will be emitted.
+ *     </li>
+ *     <li>
+ *         Gridded output bins.
+ *         Using the {@code grid} flag you can request that the bins start at specific position with in the interval regardless
+ *         of the start of the interval itself. These "grid points" position would be {@code n * bin-length + 1} where {@code n}
+ *         is any integer equal or greater than 0. As a consequence the first and last bin would be truncated or
+ *         skipped (see {@code min-bin-length}). By default bins are not gridded.
+ *     </li>
  * </ul>
  *
  * <h3>Output</h3>

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -3,6 +3,7 @@
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -338,5 +339,13 @@ public final class SimpleInterval implements Locatable, Serializable {
          Utils.nonNull( contigRecord, () -> "Contig " + contig + " not found in provided dictionary");
 
          return expandWithinContig(padding, contigRecord.getSequenceLength());
+     }
+
+     public static SimpleInterval valueOf(final Interval interval) {
+         if (interval == null) {
+             throw new IllegalArgumentException();
+         } else {
+             return new SimpleInterval(interval.getContig(), interval.getStart(), interval.getEnd());
+         }
      }
  }

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -340,12 +340,4 @@ public final class SimpleInterval implements Locatable, Serializable {
 
          return expandWithinContig(padding, contigRecord.getSequenceLength());
      }
-
-     public static SimpleInterval valueOf(final Interval interval) {
-         if (interval == null) {
-             throw new IllegalArgumentException();
-         } else {
-             return new SimpleInterval(interval.getContig(), interval.getStart(), interval.getEnd());
-         }
-     }
  }

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/PreprocessIntervalsIntegrationTest.java
@@ -209,7 +209,7 @@ public final class PreprocessIntervalsIntegrationTest extends CommandLineProgram
     @DataProvider
     public Object[][] gridTestData() {
         final List<Object[]> result = new ArrayList<>();
-        result.add(new Object[] { (int) 23, (int) 1,
+        result.add(new Object[] { 23, 1,
                 new String[] {"20:230000-230100"}, new String[] {},
                 new String[] {"20:230000-230000",
                               "20:230001-230023",
@@ -217,7 +217,7 @@ public final class PreprocessIntervalsIntegrationTest extends CommandLineProgram
                               "20:230047-230069",
                               "20:230070-230092",
                               "20:230093-230100"}});
-        result.add(new Object[] { (int) 23, (int) 1,
+        result.add(new Object[] { 23, 1,
                 new String[] {"20:230000-230100", "20:460005-460105"}, new String[] {},
                 new String[] {"20:230000-230000",
                         "20:230001-230023",
@@ -230,19 +230,19 @@ public final class PreprocessIntervalsIntegrationTest extends CommandLineProgram
                         "20:460047-460069",
                         "20:460070-460092",
                         "20:460093-460105"}});
-        result.add(new Object[] { (int) 23, (int) 23,
+        result.add(new Object[] { 23, 23,
                 new String[] {"20:229985-230105"}, new String[] {},
                 new String[] {"20:230001-230023",
                         "20:230024-230046",
                         "20:230047-230069",
                         "20:230070-230092"}});
-        result.add(new Object[] { (int) 23, (int) 9,
+        result.add(new Object[] { 23, 9,
                 new String[] {"20:230020-230100"}, new String[] {},
                 new String[] {
                         "20:230024-230046",
                         "20:230047-230069",
                         "20:230070-230092"}});
-        result.add(new Object[] { (int) 23, (int) 9,
+        result.add(new Object[] { 23, 9,
                 new String[] {"20:230020-230100"}, new String[] {"20:230040-230063"},
                 new String[] {
                         "20:230024-230039",


### PR DESCRIPTION
* Added the possibility of requesting a gridded output intervals set in ProcessIntervals.
* Also added a min-interval-length argument in case we want to skip smallish intervals (e.g.
  at the end of contig).
* Some possible performance improvements in filtering bins that only contain Ns (was using a Stream<Byte>, a bit abusive)

* IntervalUtils has now a rutine to write a interval file out of an stream of intervals. Works with NIO.