### PR TITLE
Run HaplotypeCallerSpark on WGS in strict mode

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/FindAssemblyRegionsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/FindAssemblyRegionsSpark.java
@@ -159,6 +159,8 @@ public class FindAssemblyRegionsSpark {
         // at which points the reads can be filled in. (See next step.)
         JavaRDD<ReadlessAssemblyRegion> readlessAssemblyRegions = contigToGroupedStates
                 .flatMap(getReadlessAssemblyRegionsFunction(header, assemblyRegionArgs));
+        // repartition to distribute the data evenly across the cluster again
+        readlessAssemblyRegions = readlessAssemblyRegions.repartition(readlessAssemblyRegions.getNumPartitions());
 
         // 4. Fill in the reads. Each shard is an assembly region, with its overlapping reads.
         JavaRDD<Shard<GATKRead>> assemblyRegionShardedReads = SparkSharder.shard(ctx, reads, GATKRead.class, header.getSequenceDictionary(), readlessAssemblyRegions, shardingArgs.readShardSize);

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/FindAssemblyRegionsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/FindAssemblyRegionsSpark.java
@@ -165,8 +165,8 @@ public class FindAssemblyRegionsSpark {
         // 4. Fill in the reads. Each shard is an assembly region, with its overlapping reads.
         JavaRDD<Shard<GATKRead>> assemblyRegionShardedReads = SparkSharder.shard(ctx, reads, GATKRead.class, header.getSequenceDictionary(), readlessAssemblyRegions, shardingArgs.readShardSize);
 
-        // 5. Convert shards to assembly regions. Reads downsampling is done again here, and is assumed to be consistent
-        // with the downsampling done in step 1, since it is deterministic by locus.
+        // 5. Convert shards to assembly regions. Reads downsampling is done again here. Note it will only be
+        // consistent with the downsampling done in step 1 when https://github.com/broadinstitute/gatk/issues/5437 is in.
         JavaRDD<AssemblyRegion> assemblyRegions = assemblyRegionShardedReads.mapPartitions((FlatMapFunction<Iterator<Shard<GATKRead>>, AssemblyRegion>) shardedReadIterator -> {
             final ReadsDownsampler readsDownsampler = assemblyRegionArgs.maxReadsPerAlignmentStart > 0 ?
                     new PositionalDownsampler(assemblyRegionArgs.maxReadsPerAlignmentStart, header) : null;

--- a/src/main/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileStateRange.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/activityprofile/ActivityProfileStateRange.java
@@ -19,7 +19,7 @@ public class ActivityProfileStateRange {
     private final SimpleInterval interval;
     private final double[] activeProb;
     private final ActivityProfileState.Type[] resultState;
-    private final Number[] resultValue;
+    private final double[] resultValue; // don't store as a Number since it uses more memory
 
     public ActivityProfileStateRange(MultiIntervalShard<?> shard, Iterator<ActivityProfileState> activityProfileStateIterator) {
         List<SimpleInterval> intervals = shard.getIntervals();
@@ -27,7 +27,7 @@ public class ActivityProfileStateRange {
         int size = interval.size();
         this.activeProb = new double[size];
         this.resultState = new ActivityProfileState.Type[size];
-        this.resultValue = new Number[size];
+        this.resultValue = new double[size];
 
         int i = 0;
         ActivityProfileState prev = null;
@@ -39,7 +39,8 @@ public class ActivityProfileStateRange {
             }
             activeProb[i] = next.isActiveProb();
             resultState[i] = next.getResultState();
-            resultValue[i] = next.getResultValue();
+            // store null result value as a negative number, since negative numbers are illegal in ActivityProfileState
+            resultValue[i] = next.getResultValue() == null ? Double.NEGATIVE_INFINITY : next.getResultValue().doubleValue();
             i++;
             prev = next;
         }
@@ -59,7 +60,8 @@ public class ActivityProfileStateRange {
                     return endOfData();
                 }
                 int pos = interval.getStart() + i;
-                ActivityProfileState state = new ActivityProfileState(new SimpleInterval(interval.getContig(), pos, pos), activeProb[i], resultState[i], resultValue[i]);
+                double v = resultValue[i];
+                ActivityProfileState state = new ActivityProfileState(new SimpleInterval(interval.getContig(), pos, pos), activeProb[i], resultState[i], v == Double.NEGATIVE_INFINITY ? null : v);
                 i++;
                 return state;
             }


### PR DESCRIPTION
These are the changes needed to run on a whole genome in strict mode. We get out of memory errors without these changes.

Reads downsampling was missing for the part where `AssemblyRegion`s are filled with reads - this PR adds it in. Downsampling is not deterministic yet, since that depends on #5437, but that's an orthogonal issue so it's OK to merge this change and add #5437 later.