### PR TITLE
Unused args in VCF merge

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -57,7 +57,7 @@ public final class GenotypingGivenAllelesUtils {
         final List<String> haplotypeSources = vcsAtLoc.stream().map(VariantContext::getSource).collect(Collectors.toList());
         final VariantContext mergedVc = GATKVariantContextUtils.simpleMerge(vcsAtLoc, haplotypeSources,
                 keepFiltered ? KEEP_UNCONDITIONAL : KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false);
 
         return mergedVc;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -57,7 +57,7 @@ public final class GenotypingGivenAllelesUtils {
         final List<String> haplotypeSources = vcsAtLoc.stream().map(VariantContext::getSource).collect(Collectors.toList());
         final VariantContext mergedVc = GATKVariantContextUtils.simpleMerge(vcsAtLoc, haplotypeSources,
                 keepFiltered ? KEEP_UNCONDITIONAL : KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, null, false, false);
 
         return mergedVc;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -57,7 +57,7 @@ public final class GenotypingGivenAllelesUtils {
         final List<String> haplotypeSources = vcsAtLoc.stream().map(VariantContext::getSource).collect(Collectors.toList());
         final VariantContext mergedVc = GATKVariantContextUtils.simpleMerge(vcsAtLoc, haplotypeSources,
                 keepFiltered ? KEEP_UNCONDITIONAL : KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, null, false, false);
 
         return mergedVc;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingGivenAllelesUtils.java
@@ -57,7 +57,7 @@ public final class GenotypingGivenAllelesUtils {
         final List<String> haplotypeSources = vcsAtLoc.stream().map(VariantContext::getSource).collect(Collectors.toList());
         final VariantContext mergedVc = GATKVariantContextUtils.simpleMerge(vcsAtLoc, haplotypeSources,
                 keepFiltered ? KEEP_UNCONDITIONAL : KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
 
         return mergedVc;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -226,7 +226,7 @@ public final class AssemblyBasedCallerUtils {
         final List<String> haplotypeSources = vcs.stream().map(VariantContext::getSource).collect(Collectors.toList());
         return GATKVariantContextUtils.simpleMerge(vcs, haplotypeSources,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, null, false, false);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -226,7 +226,7 @@ public final class AssemblyBasedCallerUtils {
         final List<String> haplotypeSources = vcs.stream().map(VariantContext::getSource).collect(Collectors.toList());
         return GATKVariantContextUtils.simpleMerge(vcs, haplotypeSources,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -226,7 +226,7 @@ public final class AssemblyBasedCallerUtils {
         final List<String> haplotypeSources = vcs.stream().map(VariantContext::getSource).collect(Collectors.toList());
         return GATKVariantContextUtils.simpleMerge(vcs, haplotypeSources,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -14,7 +14,6 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.clipping.ReadClipper;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.fragments.FragmentCollection;
@@ -227,7 +226,7 @@ public final class AssemblyBasedCallerUtils {
         final List<String> haplotypeSources = vcs.stream().map(VariantContext::getSource).collect(Collectors.toList());
         return GATKVariantContextUtils.simpleMerge(vcs, haplotypeSources,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false, null, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, null, false, false);
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -627,7 +627,6 @@ public final class GATKVariantContextUtils {
      * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
-     * @param setKey                    the key name of the set
      * @param filteredAreUncalled       are filtered records uncalled?
      * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
      * @return new VariantContext       representing the merge of unsortedVCs
@@ -636,11 +635,10 @@ public final class GATKVariantContextUtils {
                                              final List<String> priorityListOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final String setKey,
                                              final boolean filteredAreUncalled,
                                              final boolean mergeInfoWithMaxAC) {
         int originalNumOfVCs = priorityListOfVCs == null ? 0 : priorityListOfVCs.size();
-        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, setKey, filteredAreUncalled, mergeInfoWithMaxAC);
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, mergeInfoWithMaxAC);
     }
 
     /**
@@ -656,7 +654,6 @@ public final class GATKVariantContextUtils {
      * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
-     * @param setKey                    the key name of the set
      * @param filteredAreUncalled       are filtered records uncalled?
      * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
      * @return new VariantContext       representing the merge of unsortedVCs
@@ -666,7 +663,6 @@ public final class GATKVariantContextUtils {
                                              final int originalNumOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final String setKey,
                                              final boolean filteredAreUncalled,
                                              final boolean mergeInfoWithMaxAC) {
         if ( unsortedVCs == null || unsortedVCs.isEmpty() )

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -628,17 +628,15 @@ public final class GATKVariantContextUtils {
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
      * @param filteredAreUncalled       are filtered records uncalled?
-     * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
      * @return new VariantContext       representing the merge of unsortedVCs
      */
     public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,
                                              final List<String> priorityListOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final boolean filteredAreUncalled,
-                                             final boolean mergeInfoWithMaxAC) {
+                                             final boolean filteredAreUncalled) {
         int originalNumOfVCs = priorityListOfVCs == null ? 0 : priorityListOfVCs.size();
-        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, mergeInfoWithMaxAC);
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled);
     }
 
     /**
@@ -655,7 +653,6 @@ public final class GATKVariantContextUtils {
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
      * @param filteredAreUncalled       are filtered records uncalled?
-     * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
      * @return new VariantContext       representing the merge of unsortedVCs
      */
     public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,
@@ -663,8 +660,7 @@ public final class GATKVariantContextUtils {
                                              final int originalNumOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final boolean filteredAreUncalled,
-                                             final boolean mergeInfoWithMaxAC) {
+                                             final boolean filteredAreUncalled) {
         if ( unsortedVCs == null || unsortedVCs.isEmpty() )
             return null;
 
@@ -694,11 +690,8 @@ public final class GATKVariantContextUtils {
 
         VariantContext longestVC = first;
         int depth = 0;
-        int maxAC = -1;
-        final Map<String, Object> attributesWithMaxAC = new LinkedHashMap<>();
         double log10PError = CommonInfo.NO_LOG10_PERROR;
         boolean anyVCHadFiltersApplied = false;
-        VariantContext vcWithMaxAC = null;
         GenotypesContext genotypes = GenotypesContext.create();
 
         // counting the number of filtered and variant VCs
@@ -735,26 +728,6 @@ public final class GATKVariantContextUtils {
             if (vc.hasAttribute(VCFConstants.DEPTH_KEY))
                 depth += vc.getAttributeAsInt(VCFConstants.DEPTH_KEY, 0);
             if ( vc.hasID() ) rsIDs.add(vc.getID());
-            if (mergeInfoWithMaxAC && vc.hasAttribute(VCFConstants.ALLELE_COUNT_KEY)) {
-                String rawAlleleCounts = vc.getAttributeAsString(VCFConstants.ALLELE_COUNT_KEY, null);
-                // lets see if the string contains a "," separator
-                if (rawAlleleCounts.contains(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)) {
-                    final List<String> alleleCountArray = Arrays.asList(rawAlleleCounts.substring(1, rawAlleleCounts.length() - 1).split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR));
-                    for (final String alleleCount : alleleCountArray) {
-                        final int ac = Integer.valueOf(alleleCount.trim());
-                        if (ac > maxAC) {
-                            maxAC = ac;
-                            vcWithMaxAC = vc;
-                        }
-                    }
-                } else {
-                    final int ac = Integer.valueOf(rawAlleleCounts);
-                    if (ac > maxAC) {
-                        maxAC = ac;
-                        vcWithMaxAC = vc;
-                    }
-                }
-            }
 
             for (final Map.Entry<String, Object> p : vc.getAttributes().entrySet()) {
                 final String key = p.getKey();
@@ -794,11 +767,6 @@ public final class GATKVariantContextUtils {
             }
         }
 
-        // take the VC with the maxAC and pull the attributes into a modifiable map
-        if ( mergeInfoWithMaxAC && vcWithMaxAC != null ) {
-            attributesWithMaxAC.putAll(vcWithMaxAC.getAttributes());
-        }
-
         // if at least one record was unfiltered and we want a union, clear all of the filters
         if ( (filteredRecordMergeType == FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED && nFiltered != VCs.size()) || filteredRecordMergeType == FilteredRecordMergeType.KEEP_UNCONDITIONAL )
             filters.clear();
@@ -816,7 +784,7 @@ public final class GATKVariantContextUtils {
         if ( anyVCHadFiltersApplied ) {
             builder.filters(filters.isEmpty() ? filters : new TreeSet<>(filters));
         }
-        builder.attributes(new TreeMap<>(mergeInfoWithMaxAC ? attributesWithMaxAC : attributes));
+        builder.attributes(new TreeMap<>(attributes));
 
         // Trim the padded bases of all alleles if necessary
         final VariantContext merged = builder.make();

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -627,7 +627,6 @@ public final class GATKVariantContextUtils {
      * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
-     * @param annotateOrigin            should we annotate the set it came from?
      * @param setKey                    the key name of the set
      * @param filteredAreUncalled       are filtered records uncalled?
      * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
@@ -637,12 +636,11 @@ public final class GATKVariantContextUtils {
                                              final List<String> priorityListOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final boolean annotateOrigin,
                                              final String setKey,
                                              final boolean filteredAreUncalled,
                                              final boolean mergeInfoWithMaxAC) {
         int originalNumOfVCs = priorityListOfVCs == null ? 0 : priorityListOfVCs.size();
-        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, annotateOrigin, setKey, filteredAreUncalled, mergeInfoWithMaxAC);
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, setKey, filteredAreUncalled, mergeInfoWithMaxAC);
     }
 
     /**
@@ -658,7 +656,6 @@ public final class GATKVariantContextUtils {
      * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
      * @param filteredRecordMergeType   merge type for filtered records
      * @param genotypeMergeOptions      merge option for genotypes
-     * @param annotateOrigin            should we annotate the set it came from?
      * @param setKey                    the key name of the set
      * @param filteredAreUncalled       are filtered records uncalled?
      * @param mergeInfoWithMaxAC        should we merge in info from the VC with maximum allele count?
@@ -669,18 +666,14 @@ public final class GATKVariantContextUtils {
                                              final int originalNumOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final boolean annotateOrigin,
                                              final String setKey,
                                              final boolean filteredAreUncalled,
-                                             final boolean mergeInfoWithMaxAC ) {
+                                             final boolean mergeInfoWithMaxAC) {
         if ( unsortedVCs == null || unsortedVCs.isEmpty() )
             return null;
 
         if (priorityListOfVCs != null && originalNumOfVCs != priorityListOfVCs.size())
             throw new IllegalArgumentException("the number of the original VariantContexts must be the same as the number of VariantContexts in the priority list");
-
-        if ( annotateOrigin && priorityListOfVCs == null && originalNumOfVCs == 0)
-            throw new IllegalArgumentException("Cannot merge calls and annotate their origins without a complete priority list of VariantContexts or the number of original VariantContexts");
 
         final List<VariantContext> preFilteredVCs = sortVariantContextsByPriority(unsortedVCs, priorityListOfVCs, genotypeMergeOptions);
         // Make sure all variant contexts are padded with reference base in case of indels if necessary
@@ -813,31 +806,6 @@ public final class GATKVariantContextUtils {
         // if at least one record was unfiltered and we want a union, clear all of the filters
         if ( (filteredRecordMergeType == FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED && nFiltered != VCs.size()) || filteredRecordMergeType == FilteredRecordMergeType.KEEP_UNCONDITIONAL )
             filters.clear();
-
-
-        if ( annotateOrigin ) { // we care about where the call came from
-            String setValue;
-            if ( nFiltered == 0 && variantSources.size() == originalNumOfVCs ) // nothing was unfiltered
-                setValue = MERGE_INTERSECTION;
-            else if ( nFiltered == VCs.size() )     // everything was filtered out
-                setValue = MERGE_FILTER_IN_ALL;
-            else if ( variantSources.isEmpty() )    // everyone was reference
-                setValue = MERGE_REF_IN_ALL;
-            else {
-                final LinkedHashSet<String> s = new LinkedHashSet<>();
-                for ( final VariantContext vc : VCs )
-                    if ( vc.isVariant() )
-                        s.add( vc.isFiltered() ? MERGE_FILTER_PREFIX + vc.getSource() : vc.getSource() );
-                setValue = Utils.join("-", s);
-            }
-
-            if ( setKey != null ) {
-                attributes.put(setKey, setValue);
-                if( mergeInfoWithMaxAC && vcWithMaxAC != null ) {
-                    attributesWithMaxAC.put(setKey, setValue);
-                }
-            }
-        }
 
         if ( depth > 0 )
             attributes.put(VCFConstants.DEPTH_KEY, String.valueOf(depth));

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -244,7 +244,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs, priority,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, "set", false, false);
 
         Assert.assertEquals(merged.getAlleles().size(),cfg.expected.size());
         Assert.assertEquals(new LinkedHashSet<>(merged.getAlleles()), new LinkedHashSet<>(cfg.expected));   //HACK this is a hack to get around a bug in the htsjdk.  The method returns a list with an unspecified order.
@@ -301,7 +301,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs,null,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false, "set", false, false);
         Assert.assertEquals(merged.getID(), cfg.expected);
     }
 
@@ -416,7 +416,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeFiltered(MergeFilteredTest cfg) {
         final List<String> priority = vcs2priority(cfg.inputs);
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
-                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, false, "set", false, false);
+                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, "set", false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -557,7 +557,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeGenotypes(MergeGenotypesTest cfg) {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 cfg.inputs, cfg.priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, "set", false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -598,7 +598,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 Arrays.asList(vc1, vc2), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, "set", false, false);
 
         // test genotypes
         Assert.assertEquals(merged.getSampleNames(), new LinkedHashSet<>(Arrays.asList("s1.1", "s1.2")));
@@ -631,7 +631,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
                 final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                         Arrays.asList(vc1, vc2), priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                        GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, annotate, false, set, false, false);
+                        GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, annotate, set, false, false);
 
                 if ( annotate )
                     Assert.assertEquals(merged.getAttribute(set), GATKVariantContextUtils.MERGE_INTERSECTION);

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -244,7 +244,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs, priority,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false);
 
         Assert.assertEquals(merged.getAlleles().size(),cfg.expected.size());
         Assert.assertEquals(new LinkedHashSet<>(merged.getAlleles()), new LinkedHashSet<>(cfg.expected));   //HACK this is a hack to get around a bug in the htsjdk.  The method returns a list with an unspecified order.
@@ -301,7 +301,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs,null,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false);
         Assert.assertEquals(merged.getID(), cfg.expected);
     }
 
@@ -416,7 +416,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeFiltered(MergeFilteredTest cfg) {
         final List<String> priority = vcs2priority(cfg.inputs);
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
-                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
+                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -554,7 +554,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeGenotypes(MergeGenotypesTest cfg) {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 cfg.inputs, cfg.priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -595,7 +595,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 Arrays.asList(vc1, vc2), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false);
 
         // test genotypes
         Assert.assertEquals(merged.getSampleNames(), new LinkedHashSet<>(Arrays.asList("s1.1", "s1.2")));

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -244,7 +244,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs, priority,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
 
         Assert.assertEquals(merged.getAlleles().size(),cfg.expected.size());
         Assert.assertEquals(new LinkedHashSet<>(merged.getAlleles()), new LinkedHashSet<>(cfg.expected));   //HACK this is a hack to get around a bug in the htsjdk.  The method returns a list with an unspecified order.
@@ -301,7 +301,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs,null,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false, false);
         Assert.assertEquals(merged.getID(), cfg.expected);
     }
 
@@ -416,7 +416,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeFiltered(MergeFilteredTest cfg) {
         final List<String> priority = vcs2priority(cfg.inputs);
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
-                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
+                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -554,7 +554,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeGenotypes(MergeGenotypesTest cfg) {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 cfg.inputs, cfg.priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -595,7 +595,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 Arrays.asList(vc1, vc2), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, false);
 
         // test genotypes
         Assert.assertEquals(merged.getSampleNames(), new LinkedHashSet<>(Arrays.asList("s1.1", "s1.2")));
@@ -617,27 +617,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     // Misc. tests
     //
     // --------------------------------------------------------------------------------
-
-    @Test
-    public void testAnnotationSet() {
-        for ( final boolean annotate : Arrays.asList(true, false)) {
-            for ( final String set : Arrays.asList("set", "combine", "x")) {
-                final List<String> priority = Arrays.asList("1", "2");
-                VariantContext vc1 = makeVC("1", Arrays.asList(Aref, T), VariantContext.PASSES_FILTERS);
-                VariantContext vc2 = makeVC("2", Arrays.asList(Aref, T), VariantContext.PASSES_FILTERS);
-
-                final VariantContext merged = GATKVariantContextUtils.simpleMerge(
-                        Arrays.asList(vc1, vc2), priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                        GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, set, false, false);
-
-                if ( annotate )
-                    Assert.assertEquals(merged.getAttribute(set), GATKVariantContextUtils.MERGE_INTERSECTION);
-                else
-                    Assert.assertFalse(merged.hasAttribute(set));
-            }
-        }
-    }
-
+    
     private static List<String> vcs2priority(final Collection<VariantContext> vcs) {
         return vcs.stream()
                 .map(VariantContext::getSource)

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -244,7 +244,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs, priority,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
 
         Assert.assertEquals(merged.getAlleles().size(),cfg.expected.size());
         Assert.assertEquals(new LinkedHashSet<>(merged.getAlleles()), new LinkedHashSet<>(cfg.expected));   //HACK this is a hack to get around a bug in the htsjdk.  The method returns a list with an unspecified order.
@@ -301,7 +301,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 inputs,null,
                 GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNSORTED, "set", false, false);
         Assert.assertEquals(merged.getID(), cfg.expected);
     }
 
@@ -416,13 +416,10 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeFiltered(MergeFilteredTest cfg) {
         final List<String> priority = vcs2priority(cfg.inputs);
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
-                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, "set", false, false);
+                cfg.inputs, priority, cfg.type, GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
-
-        // test set field
-        Assert.assertEquals(merged.getAttribute("set"), cfg.setExpected);
 
         // test filter field
         Assert.assertEquals(merged.getFilters(), cfg.expected.getFilters());
@@ -557,7 +554,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
     public void testMergeGenotypes(MergeGenotypesTest cfg) {
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 cfg.inputs, cfg.priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, true, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, "set", false, false);
 
         // test alleles are equal
         Assert.assertEquals(merged.getAlleles(), cfg.expected.getAlleles());
@@ -598,7 +595,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 Arrays.asList(vc1, vc2), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, "set", false, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, "set", false, false);
 
         // test genotypes
         Assert.assertEquals(merged.getSampleNames(), new LinkedHashSet<>(Arrays.asList("s1.1", "s1.2")));
@@ -631,7 +628,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
 
                 final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                         Arrays.asList(vc1, vc2), priority, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                        GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, annotate, set, false, false);
+                        GATKVariantContextUtils.GenotypeMergeType.PRIORITIZE, set, false, false);
 
                 if ( annotate )
                     Assert.assertEquals(merged.getAttribute(set), GATKVariantContextUtils.MERGE_INTERSECTION);


### PR DESCRIPTION
@lbergelson The merge vcfs code is notoriously hard to understand.  Removing a bunch of arguments that the GATK never uses seems like a start.