### PR TITLE
Update Mutect2 javadoc to reflect v4.1 changes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -24,51 +24,138 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * <p>Call somatic short variants via local assembly of haplotypes.
- * Short variants include single nucleotide (SNV) and insertion and deletion (indel) variants.
- * The caller combines the DREAM challenge-winning somatic genotyping engine of the original MuTect
- * (<a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>) with the
- * assembly-based machinery of <a href="https://www.broadinstitute.org/gatk/documentation/tooldocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.
- * </p>
- * <p>
- *     This tool is featured in the <i>Somatic Short Mutation calling Best Practice Workflow</i>.
- *     See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
- *     step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
- *     for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
- *     <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
- *     Although we present the tool for somatic calling, it may apply to other contexts, such as mitochondrial variant calling.
- * </p>
+ * <p>Call somatic short mutations via local assembly of haplotypes.
+ * Short mutations include single nucleotide (SNA) and insertion and deletion (indel) alterations.
+ * The caller uses a Bayesian somatic genotyping model that differs from the original MuTect by
+ * <a href='http://www.nature.com/nbt/journal/v31/n3/full/nbt.2514.html'>Cibulskis et al., 2013</a>
+ * and uses the assembly-based machinery of
+ * <a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_haplotypecaller_HaplotypeCaller.php">HaplotypeCaller</a>.
+ * Of note, Mutect2 v4.1.0.0 onwards enables joint analysis of multiple samples.</p>
+ *
+ * <p>This tool is featured in the <i>Somatic Short Mutation calling Best Practice Workflow</i>.
+ * See <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11136">Tutorial#11136</a> for a
+ * step-by-step description of the workflow and <a href="https://software.broadinstitute.org/gatk/documentation/article?id=11127">Article#11127</a>
+ * for an overview of what traditional somatic calling entails. For the latest pipeline scripts, see the
+ * <a href="https://github.com/broadinstitute/gatk/tree/master/scripts/mutect2_wdl">Mutect2 WDL scripts directory</a>.
+ * For pipelines with example data, see the <a href="https://github.com/gatk-workflows/gatk4-somatic-snvs-indels">gatk-workflows repository</a>.
+ * Although we present the tool for somatic calling, it may apply to other contexts, such as mitochondrial variant calling and detection of somatic mosaicism.</p>
+ *
+ * <p>Starting with v4.1.0.0 Mutect2 accomodates extreme high depths, e.g. 20,000X. See the following articles for details on this and additional applications.
+ * <ul>
+ *   <li><a href="https://software.broadinstitute.org/gatk/blog?id=23400">Blog#23400</a> details general improvements to
+ *   Mutect2 v4.1.0.0.</li>
+ *   <li><a href="https://software.broadinstitute.org/gatk/blog?id=23598">Blog#23598</a> details Mutect2 mitochondrial
+ *   mode.</li>
+ *   <li><a href="https://software.broadinstitute.org/gatk/blog?id=XXX">Blog#XXX</a> (link to come) details use of Mutect2 in extremely
+ *   low allele fraction variant detection.</li>
+ * </ul></p>
  *
  * <h3>Usage examples</h3>
- * <p>Example commands show how to run Mutect2 for typical scenarios. The two modes are (i) <i>somatic mode</i> where a tumor sample is matched with a normal sample in analysis and
- * (ii) <i>tumor-only mode</i> where a single sample's alignment data undergoes analysis. </p>
+ * <p>Example commands show how to run Mutect2 for typical scenarios. The three modes are (i) tumor-normal mode where a
+ * tumor sample is matched with a normal sample in analysis, (ii) tumor-only mode where a single sample's alignment
+ * data undergoes analysis, and (iii) mitochondrial mode where sensitive calling at high depths is desirable.
+ * <ul>
+ *     <li>As of v4.1, there is no longer a need to specify the tumor sample name with -tumor. You need only specify
+ *     the normal sample name with <nobr>-normal,</nobr> if you include a normal.</li>
+ *     <li>Starting with v4.0.4.0, GATK recommends the default setting of --af-of-alleles-not-in-resource, which the
+ *     tool dynamically adjusts for different modes. tumor-only calling sets the default to 5e-8, tumor-normal calling
+ *     sets it to 1e-6 and mitochondrial mode sets it to 4e-3. For previous versions, the default was 0.001, the
+ *     average heterozygosity of humans. For other organisms, change --af-of-alleles-not-in-resource to
+ *     1/(ploidy*samples in resource).</li>
+ * </ul></p>
  *
  * <h4>(i) Tumor with matched normal</h4>
- * <p>
- *     Given a matched normal, Mutect2 is designed to call somatic variants only. The tool includes logic to skip
- *     emitting variants that are clearly present in the germline based on provided evidence, e.g. in the matched normal.
- *     This is done at an early stage to avoid spending computational resources on germline events. If the variant's germline status is
- *     borderline, then Mutect2 will emit the variant to the callset for subsequent filtering and review.
- * </p>
+ * <p>Given a matched normal, Mutect2 is designed to call somatic variants only. The tool includes logic to skip
+ * emitting variants that are clearly present in the germline based on provided evidence, e.g. in the matched normal.
+ * This is done at an early stage to avoid spending computational resources on germline events. If the variant's
+ * germline status is borderline, then Mutect2 will emit the variant to the callset for subsequent filtering by
+ * <a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_mutect_FilterMutectCalls.php">FilterMutectCalls</a>
+ * and review.</p>
  *
  * <pre>
- * gatk Mutect2 \
- *   -R reference.fa \
- *   -I tumor.bam \
- *   -tumor tumor_sample_name \
- *   -I normal.bam \
- *   -normal normal_sample_name \
- *   --germline-resource af-only-gnomad.vcf.gz \
- *   --af-of-alleles-not-in-resource 0.00003125 \
- *   --panel-of-normals pon.vcf.gz \
- *   -O somatic.vcf.gz
+ *     gatk Mutect2 \
+ *     -R reference.fa \
+ *     -I tumor.bam \
+ *     -I normal.bam \
+ *     -normal normal_sample_name \
+ *     --germline-resource af-only-gnomad.vcf.gz \
+ *     --panel-of-normals pon.vcf.gz \
+ *     -O somatic.vcf.gz
  * </pre>
  *
- * <p>The --af-of-alleles-not-in-resource argument value should match expectations for alleles not found in the provided germline resource.
- * Note the tool does not require a germline resource nor a panel of normals (PoN) to run.
- * The tool prefilters sites for the matched normal and the PoN. For the germline resource, the tool prefilters on the allele.
- * Below is an excerpt of a known variants resource with population allele frequencies</p>
+ * <p> As of v4.1 Mutect2 supports joint calling of multiple tumor and normal samples from the same individual. The
+ * only difference is that -I and <nobr>-normal</nobr> must be specified for the extra samples.</p>
+ *
  * <pre>
+ *     gatk Mutect2 \
+ *     -R reference.fa \
+ *     -I tumor1.bam \
+ *     -I tumor2.bam \
+ *     -I normal1.bam \
+ *     -I normal2.bam \
+ *     -normal normal1_sample_name \
+ *     -normal normal2_sample_name \
+ *     --germline-resource af-only-gnomad.vcf.gz \
+ *     --panel-of-normals pon.vcf.gz \
+ *     -O somatic.vcf.gz
+ * </pre>
+ *
+ * <h4>(ii) Tumor-only mode</h4>
+ * <p>This mode runs on a single type of sample, e.g. the tumor or the normal.
+ * To create a PoN, call on each normal sample in this mode, then use
+ * <a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_mutect_CreateSomaticPanelOfNormals.php">CreateSomaticPanelOfNormals</a>
+ * to generate the PoN.</p>
+ *
+ * <pre>
+ *  gatk Mutect2 \
+ *   -R reference.fa \
+ *   -I sample.bam \
+ *   -O single_sample.vcf.gz
+ * </pre>
+ *
+ * <p>To call mutations on a tumor sample, call in this mode using a PoN and germline resource. After FilterMutectCalls
+ * filtering, consider additional filtering by functional significance with
+ * <a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_funcotator_Funcotator.php">Funcotator</a>.</p>
+ *
+ * <pre>
+ *  gatk Mutect2 \
+ *  -R reference.fa \
+ *  -I sample.bam \
+ *  --germline-resource af-only-gnomad.vcf.gz \
+ *  --panel-of-normals pon.vcf.gz \
+ *  -O single_sample.vcf.gz
+ * </pre>
+ *
+ * <h4>(iii) Mitochondrial mode</h4>
+ * <p>Mutect2 automatically sets parameters appropriately for calling on mitochondria with the <nobr>--mitochondria</nobr> flag.
+ * Specifically, the mode sets <nobr>–-initial-tumor-lod</nobr> to 0, <nobr>–-tumor-lod-to-emit</nobr> to 0, <nobr>--af-of-alleles-not-in-resource</nobr> to
+ * 4e-3, and the advanced parameter <nobr>--pruning-lod-threshold</nobr> to -4.</p>
+ *
+ * <pre>
+ *  gatk Mutect2 \
+ *  -R reference.fa \
+ *  -L chrM \
+ *  --mitochondria \
+ *  --median-autosomal-coverage 30 \
+ *  -I mitochondria.bam \
+ *  -O mitochondria.vcf.gz
+ * </pre>
+ *
+ * <p>Setting the advanced option --median-autosomal-coverage argument (default 0) activates a recommended filter against
+ * likely erroneously mapped  <a href="https://en.wikipedia.org/wiki/NUMT">NuMTs (nuclear mitochondrial DNA segments)</a>.
+ * For the value, provide the median coverage expected in autosomal regions with coverage.  The mode accepts only a
+ * single sample, which can be provided in multiple files.</p>
+ *
+ * <h3>Notes</h3>
+ * <ol>
+ *     <li>Mutect2 does not require a germline resource nor a panel of normals (PoN) to run. The tool prefilters sites
+ * for the matched normal and the PoN.
+ *     <li>For the germline resource, the tool prefilters on the allele. If a variant is absent from a given germline
+ *     resource, then the value for --af-of-alleles-not-in-resource applies such that an allele's absence from the
+ *     germline resource becomes evidence that it is not a germline variant. Below is an excerpt of a known variants
+ *     resource with population allele frequencies.
+ *
+ *     <pre>
  *     #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
  *      1       10067   .       T       TAACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAACCC      30.35   PASS    AC=3;AF=7.384E-5
  *      1       10108   .       CAACCCT C       46514.32        PASS    AC=6;AF=1.525E-4
@@ -79,47 +166,23 @@ import java.util.List;
  *      1       10128   .       ACCCTAACCCTAACCCTAAC    A,*     285.71  PASS    AC=3,1;AF=7.58E-5,2.527E-5
  *      1       10131   .       CT      C,*     378.93  PASS    AC=7,5;AF=1.765E-4,1.261E-4
  *      1       10132   .       TAACCC  *,T     18025.11        PASS    AC=12,2;AF=3.03E-4,5.049E-5
- * </pre>
+ *     </pre>
+ *     </li>
  *
- * <h4>(ii) Tumor-only mode</h4>
- * <p>This mode runs on a single sample, e.g. single tumor or single normal sample.
- * To create a PoN, call on each normal sample in this mode, then use {@link CreateSomaticPanelOfNormals} to generate the PoN. </p>
+ * <li>Additional parameters that factor towards filtering, including normal-artifact-lod (default threshold 0.0) and
+ * tumor-lod (default threshold 5.3), are available in
+ * <a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_mutect_FilterMutectCalls.php">FilterMutectCalls</a>.
+ * While the tool calculates normal-lod assuming a diploid genotype, it calculates
+ * normal-artifact-lod with the same approach it uses for tumor-lod, i.e. with a variable ploidy assumption.
  *
- * <pre>
- *  gatk Mutect2 \
- *   -R reference.fa \
- *   -I sample.bam \
- *   -tumor sample_name \
- *   -O single_sample.vcf.gz
- * </pre>
- *
- *
- * <h3>Further points of interest</h3>
- * <p>
- *     Additional parameters that factor towards filtering, including normal-artifact-lod (default threshold 0.0) and
- *     tumor-lod (default threshold 5.3), are available in {@link FilterMutectCalls}. While the tool calculates
- *     normal-lod assuming a diploid genotype, it calculates
- *     normal-artifact-lod with the same approach it uses for tumor-lod, i.e. with a variable ploidy assumption.
- * </p>
- *
- * <dl>
- *     <dd>- If the normal artifact log odds becomes large, then FilterMutectCalls applies the artifact-in-normal filter.
- *     For matched normal samples with tumor contamination, consider increasing the normal-artifact-lod threshold.</dd>
- *     <dd>- The tumor log odds, which is calculated independently of any matched normal, determines whether to filter a tumor
- *     variant. Variants with tumor LODs exceeding the threshold pass filtering.</dd>
- * </dl>
- *
- * <p>
- *     If a variant is absent from a given germline resource, then the value for --af-of-alleles-not-in-resource applies.
- *     For example, gnomAD's 16,000 samples (~32,000 homologs per locus) becomes a probability of one in 32,000 or less.
- *     Thus, an allele's absence from the germline resource becomes evidence that it is not a germline variant.
- * </p>
- *
- * <h3>Caveats</h3>
- * <p>
- *     Although GATK4 Mutect2 accomodates varying coverage depths, further optimization of parameters
- *     may improve calling for extreme high depths, e.g. 1000X.
- * </p>
+ * <ul>
+ *     <li>If the normal artifact log odds becomes large, then FilterMutectCalls applies the artifact-in-normal filter.
+ *     For matched normal samples with tumor contamination, consider increasing the normal-artifact-lod threshold.</li>
+ *     <li>The tumor log odds, which is calculated independently of any matched normal, determines whether to filter a tumor
+ *     variant. Variants with tumor LODs exceeding the threshold pass filtering.</li>
+ * </ul></p>
+ *</li>
+ * </ol>
  */
  @CommandLineProgramProperties(
          summary = "Call somatic SNVs and indels via local assembly of haplotypes",


### PR DESCRIPTION
    - Running in mitochonrial mode
    - Link to liquid biopsy blogpost will need to be added once it is posted
    - Specifying tumor name is no longer necessary
    - Af-of-alleles-not-in-resource is dynamically adjusted for modes
    - Joint calling on multiple tumor and normal samples
    - Mention and/or link to FilterMutectCalls, Funcotator and CreateSomaticPanelOfNormals
    - Remove caveat and state instead M2's ability to handle extreme high depths
    - Update HaplotypeCaller link from v3 to current
    - Add 'Notes' section and make ordered list
    - Move example AF resource snippet to 'Notes' section