### PR TITLE
PrintBGZFBlockInformation: remove file extension check so that we can accept, eg., bams

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation.java
@@ -20,8 +20,8 @@ import java.util.List;
 
 /**
  * A diagnostic tool that prints information about the compressed blocks in a BGZF format file,
- * such as a .vcf.gz file. This tool can detect various kinds of BGZF file corruption such as
- * premature BGZF terminator blocks, truncated files, and files that were regular-GZIPPED by
+ * such as a .vcf.gz file or a .bam file. This tool can detect various kinds of BGZF file corruption
+ * such as premature BGZF terminator blocks, truncated files, and files that were regular-GZIPPED by
  * accident.
  * <p>
  * The output looks like this:
@@ -74,7 +74,7 @@ public class PrintBGZFBlockInformation extends CommandLineProgram {
         try {
             // Check that the file is in BGZF format. This catches the "regular GZIP" case as well:
             if ( ! IOUtil.isBlockCompressed(bgzfPath) ) {
-                throw new UserException.CouldNotReadInputFile(bgzfPath, "File is not a valid BGZF file. Could possibly be a regular GZIP file?");
+                throw new UserException.CouldNotReadInputFile(bgzfPath, "File is not a valid BGZF file. Could be a regular GZIP file, or some other non-BGZF format.");
             }
         }
         catch ( IOException e ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation.java
@@ -71,11 +71,6 @@ public class PrintBGZFBlockInformation extends CommandLineProgram {
             throw new UserException.CouldNotReadInputFile("File " + bgzfPathString + " does not exist");
         }
 
-        if ( ! IOUtil.hasBlockCompressedExtension(bgzfPathString) ) {
-            throw new UserException.CouldNotReadInputFile("File " + bgzfPathString + " does not end in a recognized BGZF file extension (" +
-                    StringUtils.join(IOUtil.BLOCK_COMPRESSED_EXTENSIONS, ",") + ")");
-        }
-
         try {
             // Check that the file is in BGZF format. This catches the "regular GZIP" case as well:
             if ( ! IOUtil.isBlockCompressed(bgzfPath) ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformationIntegrationTest.java
@@ -101,6 +101,19 @@ public class PrintBGZFBlockInformationIntegrationTest extends CommandLineProgram
         runCommandLine(args);
     }
 
+    /* We should get an exception for other non-BGZF formats as well */
+    @Test(expectedExceptions= UserException.CouldNotReadInputFile.class)
+    public void testNonBGZFFile() throws IOException{
+        final File input = new File(dbsnp_138_b37_1_65M_vcf);
+        final File actualOutput = createTempFile("PrintBGZFBlockInformationIntegrationTest_testNonBGZFFile", ".out");
+
+        final String[] args = {
+                "--bgzf-file", input.getAbsolutePath(),
+                "--"  + StandardArgumentDefinitions.OUTPUT_LONG_NAME, actualOutput.getAbsolutePath()
+        };
+        runCommandLine(args);
+    }
+
     /* Make sure that we can handle a standard BAM file */
     @Test
     public void testBamFile() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformationIntegrationTest.java
@@ -100,4 +100,20 @@ public class PrintBGZFBlockInformationIntegrationTest extends CommandLineProgram
         };
         runCommandLine(args);
     }
+
+    /* Make sure that we can handle a standard BAM file */
+    @Test
+    public void testBamFile() throws IOException {
+        final File input = new File(packageRootTestDir + "engine/reads_data_source_test1.bam");
+        final File actualOutput = createTempFile("PrintBGZFBlockInformationIntegrationTest_testBamFile", ".out");
+        final File expectedOutput = new File(toolsTestDir + "PrintBGZFBlockInformation/expected_PrintBGZFBlockInformationIntegrationTest_testBamFile.out");
+
+        final String[] args = {
+                "--bgzf-file", input.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.OUTPUT_LONG_NAME, actualOutput.getAbsolutePath()
+        };
+        runCommandLine(args);
+
+        IntegrationTestSpec.assertEqualTextFiles(actualOutput, expectedOutput);
+    }
 }

--- a/src/test/resources/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation/expected_PrintBGZFBlockInformationIntegrationTest_testBamFile.out
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/PrintBGZFBlockInformation/expected_PrintBGZFBlockInformationIntegrationTest_testBamFile.out
@@ -1,0 +1,14 @@
+BGZF block information for file: reads_data_source_test1.bam
+
+Block #1 at file offset 0
+	- compressed size: 380
+	- uncompressed size: 1971
+
+Block #2 at file offset 380
+	- compressed size: 28
+	- uncompressed size: 0
+
+***************************************************************************
+Final BGZF 0-byte terminator block FOUND as expected at block number 2
+***************************************************************************
+


### PR DESCRIPTION
The file extension check in this tool was redundant, since there is a subsequent check
that the input file is in BGZF format.

Resolves #5800