### PR TITLE
Updating Picard version in mitochondria WDL

### DIFF
--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -273,7 +273,7 @@ task CollectWgsMetrics {
     preemptible: select_first([preemptible_tries, 5])
     memory: "3 GB"
     disks: "local-disk " + disk_size + " HDD"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
   }
   output {
     File metrics = "metrics.txt"
@@ -325,7 +325,7 @@ task LiftoverAndCombineVcfs {
     runtime {
       disks: "local-disk " + disk_size + " HDD"
       memory: "1200 MB"
-      docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+      docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
       preemptible: select_first([preemptible_tries, 5])
     }
     output{

--- a/scripts/mitochondria_m2_wdl/AlignmentPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignmentPipeline.wdl
@@ -143,7 +143,7 @@ task AlignAndMarkDuplicates {
     memory: "6 GB"
     cpu: "2"
     disks: "local-disk " + disk_size + " HDD"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"
@@ -166,7 +166,7 @@ task GetBwaVersion {
   }
   runtime {
     memory: "1 GB"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
   }
   output {
     String version = read_string(stdout())

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -190,7 +190,7 @@ task SubsetBam {
   runtime {
     memory: "3 GB"
     disks: "local-disk " + disk_size + " HDD"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
     preemptible: final_preemptible_tries
   }
   output {
@@ -262,7 +262,7 @@ task RevertSam {
   runtime {
     disks: "local-disk " + disk_size + " HDD"
     memory: "2 GB"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
     preemptible: select_first([preemptible_tries, 5])
   }
   output {
@@ -339,7 +339,7 @@ task CoverageAtEveryBase {
   runtime {
     disks: "local-disk " + disk_size + " HDD"
     memory: "1200 MB"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.1-1540490856"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.2-1552931386"
     preemptible: select_first([preemptible_tries, 5])
   }
   output {


### PR DESCRIPTION
This update means the pipeline won't die on single-ended reads (it just filters them out).