### PR TITLE
Make sure the GATK tool python package is present before executing streaming commands.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /gatk
 # Create a simple unit test runner
 ENV CI true
 RUN echo "source activate gatk" > /root/run_unit_tests.sh && \
+    echo "export GATK_DOCKER_CONTAINER=true" >> /root/run_unit_tests.sh && \
     echo "export TEST_JAR=\$( find /jars -name \"gatk*test.jar\" )" >> /root/run_unit_tests.sh && \
     echo "export TEST_DEPENDENCY_JAR=\$( find /jars -name \"gatk*testDependencies.jar\" )" >> /root/run_unit_tests.sh && \
     echo "export GATK_JAR=$( find /gatk -name "gatk*local.jar" )" >> /root/run_unit_tests.sh && \

--- a/src/main/java/org/broadinstitute/hellbender/utils/python/PythonScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/python/PythonScriptExecutor.java
@@ -189,11 +189,20 @@ public class PythonScriptExecutor extends PythonExecutorBase {
 
     public static void checkPythonEnvironmentForPackage(final String packageName) {
         final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
-        if (!pythonExecutor.executeCommand(String.format("import %s", packageName) + System.lineSeparator(), null, null)) {
-            throw new RuntimeException(String.format("Importing \"%s\" in the python environment failed. Please " +
-                    "assert that the python environment is properly set and activated (if using a virtual " +
-                    "environment), and \"%s\" is installed along with its dependencies. Please refer to " +
-                    "GATK README.md file for instructions on setting up the python environment.", packageName, packageName));
+        final String errorMessage = String.format(
+                "A required Python package (\"%s\") could not be imported into the Python environment. This " +
+                "tool requires that the GATK Python environment is properly established and activated. " +
+                "Please refer to GATK README.md file for instructions on setting up the GATK Python environment.",
+                packageName, packageName);
+        try {
+            if (!pythonExecutor.executeCommand(String.format(
+                    "import %s", packageName) + System.lineSeparator(),
+                    null,
+                    null)) {
+                throw new RuntimeException(errorMessage);
+            }
+        } catch (PythonScriptExecutorException e) {
+            throw new RuntimeException(errorMessage, e);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/python/StreamingPythonScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/python/StreamingPythonScriptExecutor.java
@@ -111,6 +111,15 @@ public class StreamingPythonScriptExecutor<T> extends PythonExecutorBase {
      * @return true if the process is successfully started
      */
     public boolean start(final List<String> pythonProcessArgs, final boolean enableJournaling, final File profileResults) {
+
+        // Since the error reporting mechanism used by this class is dependent on the GATK Python environment
+        // having been properly established, we need to use an out-of-band mechanism to verify the environment
+        // before we start executing commands (otherwise the commands will hang because the error reporting mechanism
+        // isn't in place). So use the non-streaming Python executor, which has no requirements on the environment,
+        // to validate that the "gatktool" package is present. If it is, any subsequent environment errors will
+        // be propagated through the StreamingPythonExecutor's message passing mechanism.
+        PythonScriptExecutor.checkPythonEnvironmentForPackage("gatktool");
+
         this.profileResults = profileResults;
         final List<String> args = new ArrayList<>();
         args.add(externalScriptExecutableName);

--- a/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
@@ -41,6 +41,9 @@ public abstract class GATKBaseTest extends BaseTest {
     public static final String GCS_b37_CHR20_21_REFERENCE_2BIT = GCS_GATK_TEST_RESOURCES + "large/human_g1k_v37.20.21.2bit";
     public static final String GCS_b37_CHR20_21_REFERENCE = GCS_GATK_TEST_RESOURCES + "large/human_g1k_v37.20.21.fasta";
 
+    // environment variable set by the GATK Docker build file
+    private static final String GATK_DOCKER_CONTAINER = "GATK_DOCKER_CONTAINER";
+
     /**
      * LARGE FILES FOR TESTING (MANAGED BY GIT LFS)
      */
@@ -137,5 +140,14 @@ public abstract class GATKBaseTest extends BaseTest {
             locs.add(hg19GenomeLocParser.parseGenomeLoc(interval));
         return Collections.unmodifiableList(locs);
     }
+
+    /**
+     * @return true if we're running on the GATK Docker (which also implies we're running within the GATK conda environment)
+     */
+    protected boolean isGATKDockerContainer() {
+        final String gatkDockerContainer = System.getenv(GATK_DOCKER_CONTAINER);
+        return gatkDockerContainer != null && gatkDockerContainer.equalsIgnoreCase("true");
+    }
+
 }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariantsIntegrationTest.java
@@ -5,10 +5,16 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.python.PythonScriptExecutor;
+import org.broadinstitute.hellbender.utils.python.PythonScriptExecutorException;
+import org.broadinstitute.hellbender.utils.python.StreamingPythonScriptExecutor;
+import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Integration tests for {@link CNNScoreVariants}.
@@ -40,6 +46,19 @@ public class CNNScoreVariantsIntegrationTest extends CommandLineProgramTest {
         spec.executeTest("testInference", this);
     }
 
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testRequirePythonEnvironment() throws IOException {
+        // This test is deliberately left out of the "python" test group in order to ensure that
+        // it only executes when the Python environment has *NOT* been properly established. Also,
+        // skip this test if we're running on the Docker because the Python environment is always
+        // activated there.
+        final String isDockerCI = System.getenv("CI");
+        if (isDockerCI != null && isDockerCI.equalsIgnoreCase("true")) {
+            throw new SkipException("Python environment validation test must be skipped when running on the Docker");
+        }
+        // Re-running the "testAllDefaultArgs" test should throw when run outside of the GATK Python environment
+        testAllDefaultArgs();
+    }
 
     @Test(groups = {"python"})
     public void testInferenceArchitecture() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariantsIntegrationTest.java
@@ -52,10 +52,10 @@ public class CNNScoreVariantsIntegrationTest extends CommandLineProgramTest {
         // it only executes when the Python environment has *NOT* been properly established. Also,
         // skip this test if we're running on the Docker because the Python environment is always
         // activated there.
-        final String isDockerCI = System.getenv("CI");
-        if (isDockerCI != null && isDockerCI.equalsIgnoreCase("true")) {
+        if (isGATKDockerContainer()) {
             throw new SkipException("Python environment validation test must be skipped when running on the Docker");
         }
+
         // Re-running the "testAllDefaultArgs" test should throw when run outside of the GATK Python environment
         testAllDefaultArgs();
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonExecutorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonExecutorIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.utils.python;
+
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+public class StreamingPythonExecutorIntegrationTest extends GATKBaseTest {
+
+    // This test validates that the StreamingPythonScriptExecutor will throw if the Python environment
+    // is not activated, and will not pass if the environment is activated. It has to be an integration
+    // test because unit tests are run on the Docker image, which has the Python environment activated.
+
+    @Test()
+    public void testRequirePythonEnvironment() {
+        // This test is deliberately left out of the "python" test group in order to ensure that
+        // it only executes when the Python environment has *NOT* been properly established. Also,
+        // skip this test if we're running on the Docker because the Python environment is always
+        // activated there.
+        final String isDockerCI = System.getenv("CI");
+        if (isDockerCI != null && isDockerCI.equalsIgnoreCase("true")) {
+            throw new SkipException("Python environment validation test must be skipped when running on the Docker");
+        }
+
+        // validate that we throw if the GATK Python environment is not active
+        final RuntimeException rte = Assert.expectThrows(RuntimeException.class, ()-> {
+            final StreamingPythonScriptExecutor<String> streamingPythonExecutor =
+                    new StreamingPythonScriptExecutor<>(PythonScriptExecutor.PythonExecutableName.PYTHON3, true);
+            streamingPythonExecutor.start(Collections.emptyList());
+        });
+
+        // make sure that the underlying cause is actually a PythonScriptExecutorException
+        Assert.assertEquals(rte.getCause().getClass(), PythonScriptExecutorException.class);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonExecutorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/StreamingPythonExecutorIntegrationTest.java
@@ -19,8 +19,7 @@ public class StreamingPythonExecutorIntegrationTest extends GATKBaseTest {
         // it only executes when the Python environment has *NOT* been properly established. Also,
         // skip this test if we're running on the Docker because the Python environment is always
         // activated there.
-        final String isDockerCI = System.getenv("CI");
-        if (isDockerCI != null && isDockerCI.equalsIgnoreCase("true")) {
+        if (isGATKDockerContainer()) {
             throw new SkipException("Python environment validation test must be skipped when running on the Docker");
         }
 


### PR DESCRIPTION
Fixes #5751 and #4591. Longer term we'll still want to do package version-checking/verification per https://github.com/broadinstitute/gatk/issues/4995 as well.

@jamesemery I included tests for this change, but I need the tests to only run when the conda env is NOT activated. Unit tests are always run on the docker image, so thats out. Integration tests are run on both the docker and the travis image, so I throw a skip exception on the docker, which I detect using the "CI" env variable. But that seems fragile and confusing. Is there a better way to do this ?