### PR TITLE
Add spark verbosity argument and default to WARN

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -37,7 +37,7 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     final List<String> sparkProperties = new ArrayList<>();
 
     @Argument(
-            doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE). Overrides --" + StandardArgumentDefinitions.VERBOSITY_NAME,
+            doc="Spark verbosity. Overrides --" + StandardArgumentDefinitions.VERBOSITY_NAME + " for Spark-generated logs only. Possible values: {ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE}",
             fullName = SPARK_VERBOSITY_LONG_NAME,
             optional = true)
     private String sparkVerbosity = null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -28,7 +28,7 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     private String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
 
     @Argument(
-            doc = "spark properties to set on the spark context in the format <property>=<value>",
+            doc = "Spark properties to set on the Spark context in the format <property>=<value>",
             fullName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
             shortName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
             optional = true

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -39,7 +39,7 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
             doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)",
             fullName = SPARK_VERBOSITY_LONG_NAME,
             optional = true)
-    private String sparkVerbosity = Level.WARN.name(); // Default INFO is too verbose
+    private String sparkVerbosity = Level.INFO.name(); // Default INFO is too verbose
 
     public Map<String,String> getSparkProperties(){
         final Map<String, String> propertyMap = new LinkedHashMap<>();

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -21,18 +21,24 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     public static final String SPARK_MASTER_LONG_NAME = "spark-master";
     public static final String SPARK_VERBOSITY_LONG_NAME = "spark-verbosity";
 
-    @Argument(fullName = SPARK_MASTER_LONG_NAME, doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
+    @Argument(
+            doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.",
+            fullName = SPARK_MASTER_LONG_NAME,
+            optional = true)
     private String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
 
     @Argument(
             doc = "spark properties to set on the spark context in the format <property>=<value>",
-            shortName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
             fullName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
+            shortName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
             optional = true
     )
     final List<String> sparkProperties = new ArrayList<>();
 
-    @Argument(fullName = SPARK_VERBOSITY_LONG_NAME, doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)", optional = true)
+    @Argument(
+            doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)",
+            fullName = SPARK_VERBOSITY_LONG_NAME,
+            optional = true)
     private String sparkVerbosity = Level.WARN.name(); // Default INFO is too verbose
 
     public Map<String,String> getSparkProperties(){
@@ -54,5 +60,4 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     public String getSparkVerbosity() {
         return sparkVerbosity;
     }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -39,7 +39,7 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
             doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)",
             fullName = SPARK_VERBOSITY_LONG_NAME,
             optional = true)
-    private String sparkVerbosity = Level.INFO.name(); // Default INFO is too verbose
+    private String sparkVerbosity = Level.INFO.name();
 
     public Map<String,String> getSparkProperties(){
         final Map<String, String> propertyMap = new LinkedHashMap<>();

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 
+import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.Level;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
@@ -36,10 +37,10 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     final List<String> sparkProperties = new ArrayList<>();
 
     @Argument(
-            doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)",
+            doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE). Overrides --" + StandardArgumentDefinitions.VERBOSITY_NAME,
             fullName = SPARK_VERBOSITY_LONG_NAME,
             optional = true)
-    private String sparkVerbosity = Level.INFO.name();
+    private String sparkVerbosity = null;
 
     public Map<String,String> getSparkProperties(){
         final Map<String, String> propertyMap = new LinkedHashMap<>();
@@ -57,7 +58,25 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     public String getSparkMaster() {
         return sparkMaster;
     }
-    public String getSparkVerbosity() {
-        return sparkVerbosity;
+
+    public String getSparkVerbosity(final Log.LogLevel toolVerbosity) {
+        if (sparkVerbosity != null) return sparkVerbosity;
+        if (toolVerbosity.equals(Log.LogLevel.DEBUG)) {
+            return Level.DEBUG.name();
+        }
+        if (toolVerbosity.equals(Log.LogLevel.INFO)) {
+            return Level.INFO.name();
+        }
+        if (toolVerbosity.equals(Log.LogLevel.WARNING)) {
+            return Level.WARN.name();
+        }
+        if (toolVerbosity.equals(Log.LogLevel.ERROR)) {
+            return Level.ERROR.name();
+        }
+        throw new IllegalStateException("Unknown tool verbosity: " + toolVerbosity.name());
+    }
+
+    public void setSparkVerbosity(String level) {
+        sparkVerbosity = level;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 
+import org.apache.logging.log4j.Level;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -17,7 +18,10 @@ import java.util.Map;
 public final class SparkCommandLineArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Argument(fullName = "spark-master", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
+    public static final String SPARK_MASTER_LONG_NAME = "spark-master";
+    public static final String SPARK_VERBOSITY_LONG_NAME = "spark-verbosity";
+
+    @Argument(fullName = SPARK_MASTER_LONG_NAME, doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
     private String sparkMaster = SparkContextFactory.DEFAULT_SPARK_MASTER;
 
     @Argument(
@@ -27,6 +31,9 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
             optional = true
     )
     final List<String> sparkProperties = new ArrayList<>();
+
+    @Argument(fullName = SPARK_VERBOSITY_LONG_NAME, doc="Spark verbosity (ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE)", optional = true)
+    private String sparkVerbosity = Level.WARN.name(); // Default INFO is too verbose
 
     public Map<String,String> getSparkProperties(){
         final Map<String, String> propertyMap = new LinkedHashMap<>();
@@ -43,6 +50,9 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
 
     public String getSparkMaster() {
         return sparkMaster;
+    }
+    public String getSparkVerbosity() {
+        return sparkVerbosity;
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollection.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.hellbender.engine.spark;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.util.Log;
 import org.apache.logging.log4j.Level;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -31,7 +33,6 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
     @Argument(
             doc = "Spark properties to set on the Spark context in the format <property>=<value>",
             fullName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
-            shortName = StandardArgumentDefinitions.SPARK_PROPERTY_NAME,
             optional = true
     )
     final List<String> sparkProperties = new ArrayList<>();
@@ -59,7 +60,16 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
         return sparkMaster;
     }
 
+    /**
+     * Returns the Spark log level for the argument set. This is simply sparkVerbosity
+     * if it was specified. Otherwise, it returns the log level corresponding to the
+     * provided tool (htsjdk) verbosity.
+     *
+     * @param  toolVerbosity  Current tool's htsjdk log level
+     * @return      Spark log level String
+     */
     public String getSparkVerbosity(final Log.LogLevel toolVerbosity) {
+        Utils.nonNull(toolVerbosity, "Tool verbosity cannot be null");
         if (sparkVerbosity != null) return sparkVerbosity;
         if (toolVerbosity.equals(Log.LogLevel.DEBUG)) {
             return Level.DEBUG.name();
@@ -76,6 +86,7 @@ public final class SparkCommandLineArgumentCollection implements Serializable {
         throw new IllegalStateException("Unknown tool verbosity: " + toolVerbosity.name());
     }
 
+    @VisibleForTesting
     public void setSparkVerbosity(String level) {
         sparkVerbosity = level;
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -36,8 +36,9 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
     }
 
     private final void setSparkVerbosity(final JavaSparkContext ctx) {
-        logger.info("Spark verbosity set to " + sparkArgs.getSparkVerbosity() + " (see --" + SparkCommandLineArgumentCollection.SPARK_VERBOSITY_LONG_NAME + " argument)");
-        ctx.setLogLevel(sparkArgs.getSparkVerbosity());
+        final String sparkVerbosity = sparkArgs.getSparkVerbosity(VERBOSITY);
+        logger.info("Spark verbosity set to " + sparkVerbosity + " (see --" + SparkCommandLineArgumentCollection.SPARK_VERBOSITY_LONG_NAME + " argument)");
+        ctx.setLogLevel(sparkVerbosity);
     }
 
     // ---------------------------------------------------

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -26,12 +26,18 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
     @Override
     protected Object doWork() {
         final JavaSparkContext ctx = SparkContextFactory.getSparkContext(getProgramName(), sparkArgs.getSparkProperties(), sparkArgs.getSparkMaster());
+        setSparkVerbosity(ctx);
         try{
             runPipeline(ctx);
             return null;
         } finally {
             afterPipeline(ctx);
         }
+    }
+
+    private final void setSparkVerbosity(final JavaSparkContext ctx) {
+        logger.info("Spark verbosity set to " + sparkArgs.getSparkVerbosity() + " (see --" + SparkCommandLineArgumentCollection.SPARK_VERBOSITY_LONG_NAME + " argument)");
+        ctx.setLogLevel(sparkArgs.getSparkVerbosity());
     }
 
     // ---------------------------------------------------

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineArgumentCollectionTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.engine.spark;
 
+import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Level;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -43,6 +45,45 @@ public class SparkCommandLineArgumentCollectionTest {
         final SparkCommandLineArgumentCollection sparkArgumentCollection = new SparkCommandLineArgumentCollection();
         sparkArgumentCollection.sparkProperties.add(property);
         sparkArgumentCollection.getSparkProperties();
+    }
+
+    @DataProvider(name="toolLogLevels")
+    public Object[][] toolLogLevels(){
+        return new Object[][] {
+                {Log.LogLevel.DEBUG, Level.DEBUG.name()},
+                {Log.LogLevel.INFO, Level.INFO.name()},
+                {Log.LogLevel.WARNING, Level.WARN.name()},
+                {Log.LogLevel.ERROR, Level.ERROR.name()},
+        };
+    }
+
+    @Test(dataProvider = "toolLogLevels")
+    public void testSparkVerbosityWithValidToolLogLevels(Log.LogLevel toolVerbosity, String expectedSparkLevel){
+        final SparkCommandLineArgumentCollection sparkArgumentCollection = new SparkCommandLineArgumentCollection();
+        final String level = sparkArgumentCollection.getSparkVerbosity(toolVerbosity);
+        Assert.assertEquals(level, expectedSparkLevel);
+    }
+
+    @DataProvider(name="sparkLogLevels")
+    public Object[][] sparkLogLevels(){
+        return new Object[][] {
+                {Level.ALL.name()},
+                {Level.DEBUG.name()},
+                {Level.INFO.name()},
+                {Level.WARN.name()},
+                {Level.ERROR.name()},
+                {Level.FATAL.name()},
+                {Level.TRACE.name()},
+                {Level.OFF.name()}
+        };
+    }
+
+    @Test(dataProvider = "sparkLogLevels")
+    public void test(String sparkLevel){
+        final SparkCommandLineArgumentCollection sparkArgumentCollection = new SparkCommandLineArgumentCollection();
+        sparkArgumentCollection.setSparkVerbosity(sparkLevel);
+        final String level = sparkArgumentCollection.getSparkVerbosity(Log.LogLevel.INFO);
+        Assert.assertEquals(level, sparkLevel);
     }
 
 }


### PR DESCRIPTION
Resolves issue #1370 by exposing the setting for Spark logging level with a separate CLI argument (`--spark-verbosity`). Also stifles overly-verbose executor INFO-level logging by setting the default to WARN.

This was much cleaner to implement than just applying the existing `--verbosity` to the Spark context for a few reasons. First, Spark's `INFO` level is far too verbose, but most GATK tools provide useful INFO messages. This gives the user the ability to tune them separately. Also, Spark offers more levels through log4j, and mapping from htsjdk logging levels with a bunch of `if` statements didn't seem ideal.

Verbose logging only seems to be a problem with when running `/gatk/gatk` inside the GATK docker (eg PathSeq log files easily in 100's of MB). Strangely, however, I found there was no verbose logging if I cloned GATK inside the docker and rebuilt from source with `gradlew buildAll`. Since I can't pinpoint the cause, I haven't included tests for this, but I don't expect test coverage to drop.

Note that Spark generates some INFO logging when the context is initialized. After that, the logging level is corrected. 