### PR TITLE
Read filter for unmapped reads and their mates

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibrary.java
@@ -279,6 +279,17 @@ public final class ReadFilterLibrary {
     }
 
     /**
+     * Filter reads whose mate is unmapped as well as unmapped reads.
+     */
+    @DocumentedFeature(groupName=HelpConstants.DOC_CAT_READFILTERS, groupSummary = HelpConstants.DOC_CAT_READFILTERS_SUMMARY, summary = "Filters reads whose mate is unmapped as well as unmapped reads.")
+    public static class MateUnmappedAndUnmappedReadFilter extends ReadFilter {
+        private static final long serialVersionUID = 1L;
+        @Override public boolean test(final GATKRead read) {
+            return !(read.isUnmapped() || (read.isPaired() && read.mateIsUnmapped()));
+        }
+    }
+
+    /**
      * Static, stateless read filter instances
      */
     public static final AllowAllReadsReadFilter ALLOW_ALL_READS = new AllowAllReadsReadFilter();
@@ -307,5 +318,5 @@ public final class ReadFilterLibrary {
     public static final ValidAlignmentStartReadFilter VALID_ALIGNMENT_START = new ValidAlignmentStartReadFilter();
     public static final ValidAlignmentEndReadFilter VALID_ALIGNMENT_END = new ValidAlignmentEndReadFilter();
     public static final NonChimericOriginalAlignmentReadFilter NON_CHIMERIC_ORIGINAL_ALIGNMENT_READ_FILTER = new NonChimericOriginalAlignmentReadFilter();
-
+    public static final MateUnmappedAndUnmappedReadFilter MATE_UNMAPPED_AND_UNMAPPED_READ_FILTER = new MateUnmappedAndUnmappedReadFilter();
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibraryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterLibraryUnitTest.java
@@ -816,4 +816,20 @@ public final class ReadFilterLibraryUnitTest {
         Assert.assertFalse(ReadFilterLibrary.NON_CHIMERIC_ORIGINAL_ALIGNMENT_READ_FILTER.test(read));
     }
 
+    @Test
+    public void testMateUnmappedAndUnmappedReadFilter() {
+        final GATKRead read = simpleGoodRead(createHeaderWithReadGroups());
+        //keep regular read
+        Assert.assertTrue(MATE_UNMAPPED_AND_UNMAPPED_READ_FILTER.test(read));
+
+        //filter when mate is unmapped
+        read.setIsPaired(true);
+        read.setMateIsUnmapped();
+        Assert.assertFalse(MATE_UNMAPPED_AND_UNMAPPED_READ_FILTER.test(read));
+
+        //filter when unmapped
+        read.setIsUnmapped();
+        Assert.assertFalse(MATE_UNMAPPED_AND_UNMAPPED_READ_FILTER.test(read));
+    }
+
 }


### PR DESCRIPTION
This read filter removes unnmapped reads and reads with unmapped mates. When used in combination with `MateOnSameContigOrNoMappedMateReadFilter` this subsets down to reads only on chrM whose mate is also on chrM. If we only used the `MateOnSameContigOrNoMappedMateReadFilter` we end up with reads whose mate is unmapped still in the BAM, but not the unmapped read, which causes problems downstream in the mitochondria pipeline. This read filter will make the subsetting step faster when we no longer need the NuMTs.

I would really appreciate this getting in before the next release (on Tuesday). (fyi @droazen) @ldgauthier @jsotobroad 