### PR TITLE
Really don't output VCs with no ALT if * gets dropped 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -387,11 +387,11 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
                 final boolean isNonRefWhichIsLoneAltAllele = alternativeAlleleCount == 1 && allele.equals(Allele.NON_REF_ALLELE);
                 final boolean isPlausible = afCalculationResult.isPolymorphicPhredScaledQual(allele, configuration.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING);
 
-                siteIsMonomorphic &= !isPlausible;
-
                 //it's possible that the upstream deletion that spanned this site was not emitted, mooting the symbolic spanning deletion allele
                 final boolean isSpuriousSpanningDeletion = GATKVCFConstants.isSpanningDeletion(allele) && !isVcCoveredByDeletion(vc);
                 final boolean toOutput = (isPlausible || forceKeepAllele(allele) || isNonRefWhichIsLoneAltAllele) && !isSpuriousSpanningDeletion;
+
+                siteIsMonomorphic &= !(isPlausible && !isSpuriousSpanningDeletion);
 
                 if (toOutput) {
                     outputAlleles.add(allele);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -98,7 +98,8 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         final VariantContext vcSpanDel = new VariantContextBuilder("test1", "1",2, 2 + refAlleleSpanDel.length() - 1, vcAllelesSpanDel).
                 genotypes(genotypesSpanDel).make();
         final VariantContext vcOut1 = genotypingEngine.calculateGenotypes(vcSpanDel, GenotypeLikelihoodsCalculationModel.INDEL, null);
-        Assert.assertTrue(vcOut1 == null || !vcOut1.getAlleles().contains(Allele.SPAN_DEL));
+        //the site is monomorphic, which becomes null
+        Assert.assertTrue(vcOut1 == null);
 
         final List<Allele> mutliAllelicWithSpanDel = new ArrayList<>(Arrays.asList(refAlleleSpanDel, Allele.SPAN_DEL,
                 Allele.create("T")));
@@ -125,7 +126,8 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         final VariantContext vcMultiWithSpanDel = new VariantContextBuilder("test2", "1",2, 2 + refAlleleSpanDel.length() - 1, mutliAllelicWithSpanDel).
                 genotypes(regressionGenotypes).make();
         final VariantContext vcOut2 = genotypingEngine.calculateGenotypes(vcMultiWithSpanDel, GenotypeLikelihoodsCalculationModel.SNP, null);
-        Assert.assertTrue(vcOut2 == null || vcOut2.isMonomorphicInSamples());
+        //low quality T should get dropped, leaving only star, which shouldn't be output
+        Assert.assertTrue(vcOut2 == null);
     }
 
     @Test //test for https://github.com/broadinstitute/gatk/issues/2530


### PR DESCRIPTION
Fix botched squash, clarify test asserts

Fixes #5650