### PR TITLE
Modified the gatk launch script to set MALLOC_ARENA_MAX to keep virtu…

### DIFF
--- a/gatk
+++ b/gatk
@@ -366,6 +366,14 @@ def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs
         raise GATKLaunchException("Value: " + sparkRunner + " is not a valid value for --spark-runner.  Choose one of LOCAL, SPARK, GCS")
 
 def runCommand(cmd, dryrun):
+    # If not already set to some value, set MALLOC_ARENA_MAX to constrain the number of memory pools (arenas)
+    # used by glibc to a reasonable number.  The default behaviour is to scale with the number of CPUs, which
+    # can cause VIRTUAL memory usage to be ~0.5GB per cpu core in the system, e.g. 32GB of a 64-core machine
+    # even when the heap and resident memory are only 1-4GB!  See the following link for more discussion:
+    #  https://www.ibm.com/developerworks/community/blogs/kevgrig/entry/linux_glibc_2_10_rhel_6_malloc_may_show_excessive_virtual_memory_usage?lang=en
+    if not os.environ.get("MALLOC_ARENA_MAX"):
+        os.environ["MALLOC_ARENA_MAX"] = "4"
+
     if dryrun:
         print("\nDry run:\n")
 


### PR DESCRIPTION
…al memory (as opposed to resident memory) under control.

This solves (I think) a long-time problem for anyone using the GATK under SGE or any other scheduler that imposes hard limits on _virual_ memory.  The posting at this link describes in detail what is going on:

https://www.ibm.com/developerworks/community/blogs/kevgrig/entry/linux_glibc_2_10_rhel_6_malloc_may_show_excessive_virtual_memory_usage?

TL;DR: there was a change in `malloc` in `glibc` several years ago that attempts to make memory allocation more efficient in multi-threaded apps on multi-core machines, by creating many memory pools (arenas) from which allocation requests are satisfied.  On systems with lots of CPUs it can cause virtual memory usage to balloon up to many times the heap size (e.g. we see 30GB VIRT with -Xmx4G and < 4G resident).  In some very limited testing I didn't see any significant performance change from limiting the number of arenas.  My suspicion is that since Java is allocating fairly large blocks of memory using `malloc` and then allocating internal to the JVM this shouldn't have much if any affect on Java programs.