### PR TITLE
Bug fix for Mitochondria Pipeline

### DIFF
--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -170,7 +170,7 @@ task SubsetBamToChrM {
   # runtime
   Int? preemptible_tries
   Float ref_size = if defined(ref_fasta) then size(ref_fasta, "GB") + size(ref_fasta_index, "GB") + size(ref_dict, "GB") else 0
-  Int disk_size = ceil(ref_size) + 20
+  Int disk_size = ceil(size(input_bam, "GB") + ref_size) + 20
 
   meta {
     description: "Subsets a whole genome bam to just Mitochondria reads"


### PR DESCRIPTION
When I turned off NIO for the first task, I forgot to redo the disk size. This now includes the size of the input bam/cram as a part of the disk size.