### PR TITLE
Update Docker to newer version of miniconda.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /gatk
 
 # Create a simple unit test runner
 ENV CI true
-RUN echo "source activate gatk" > /root/run_unit_tests.sh && \
+RUN echo "conda activate gatk" > /root/run_unit_tests.sh && \
     echo "export GATK_DOCKER_CONTAINER=true" >> /root/run_unit_tests.sh && \
     echo "export TEST_JAR=\$( find /jars -name \"gatk*test.jar\" )" >> /root/run_unit_tests.sh && \
     echo "export TEST_DEPENDENCY_JAR=\$( find /jars -name \"gatk*testDependencies.jar\" )" >> /root/run_unit_tests.sh && \
@@ -47,8 +47,8 @@ RUN cp -r install_R_packages.R /gatk
 # Start GATK Python environment
 
 ENV DOWNLOAD_DIR /downloads
-ENV CONDA_URL https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh
-ENV CONDA_MD5 = "0b80a152332a4ce5250f3c09589c7a81"
+ENV CONDA_URL https://repo.continuum.io/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh
+ENV CONDA_MD5 = "56c90370226fd410c9b0086bd693d9c0"
 ENV CONDA_PATH /opt/miniconda
 RUN mkdir $DOWNLOAD_DIR && \
     wget -nv -O $DOWNLOAD_DIR/miniconda.sh $CONDA_URL && \
@@ -58,7 +58,7 @@ RUN mkdir $DOWNLOAD_DIR && \
 WORKDIR /gatk
 ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
 RUN conda env create -n gatk -f /gatk/gatkcondaenv.yml && \
-    echo "source activate gatk" >> /gatk/gatkenv.rc && \
+    echo "conda activate gatk" >> /gatk/gatkenv.rc && \
     echo "source /gatk/gatk-completion.sh" >> /gatk/gatkenv.rc && \
     conda clean -y -all && \
     rm -rf /root/.cache/pip

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ releases of the toolkit.
    docker client, which can be found on the [docker website](https://www.docker.com/get-docker).
 * Python Dependencies:<a name="python"></a>
     * GATK4 uses the [Conda](https://conda.io/docs/index.html) package manager to establish and manage the
-      Python environment and dependencies required by GATK tools that have a Python dependency. The ```gatk``` environment, 
-      requires hardware with AVX support for tools that depend on TensorFlow (e.g. CNNScoreVariant). The GATK Docker image 
+      Python environment and dependencies required by GATK tools that have a Python dependency. The ```gatk``` environment 
+      requires hardware with AVX support for tools that depend on TensorFlow (e.g. CNNScoreVariants). The GATK Docker image 
       comes with the ```gatk``` environment pre-configured.
     * To establish the  environment when not using the Docker image, a conda environment must first be "created", and
       then "activated":
@@ -87,7 +87,7 @@ releases of the toolkit.
               the local  ```gatk``` conda environment.
         * To "activate" the conda environment (the conda environment must be activated within the same shell from which
           GATK is run):
-             * Execute the shell command ```source activate gatk``` to activate the ```gatk``` environment.
+             * Execute the shell command ```conda activate gatk``` to activate the ```gatk``` environment.
         * See the [Conda](https://conda.io/docs/user-guide/tasks/manage-environments.html) documentation for
           additional information about using and managing Conda environments.
 

--- a/build.gradle
+++ b/build.gradle
@@ -559,7 +559,7 @@ task localDevCondaEnv(type: Exec) {
     dependsOn 'condaEnvironmentDefinition'
     inputs.file("$buildDir/$pythonPackageArchiveName")
     workingDir "$buildDir"
-    commandLine "conda", "env", "update", "-f", gatkCondaYML
+    commandLine "conda", "env", "create", "-f", gatkCondaYML
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
The version of `conda` we use on the docker uses environment activation commands that are deprecated in newer versions of conda.

Update to the latest published version of miniconda, and update the doc to specify the newer commands. Also change the local environment to use `conda env create -f` rather than `conda env update`. Fixes https://github.com/broadinstitute/gatk/issues/5851 and https://github.com/broadinstitute/gatk/issues/5776.