### PR TITLE
SelectVariants use a GATKPathSpecifier for output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -776,7 +776,7 @@ public abstract class GATKTool extends CommandLineProgram {
 
     /**
      * Creates a VariantContextWriter whose outputFile type is determined by
-     * the outPathName's extension, using the best available sequence dictionary for
+     * the vcfOutput's extension, using the best available sequence dictionary for
      * this tool, and default index, leniency and md5 generation settings.
      *
      * Deprecated, use {@link #createVCFWriter(Path)} instead.
@@ -790,7 +790,7 @@ public abstract class GATKTool extends CommandLineProgram {
 
     /**
      * Creates a VariantContextWriter whose outputFile type is determined by
-     * outPath's extension, using the best available sequence dictionary for
+     * vcfOutput's extension, using the best available sequence dictionary for
      * this tool, and default index, leniency and md5 generation settings.
      *
      * @param outPath output Path for this writer. May not be null.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -18,8 +18,8 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.filters.*;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -137,7 +137,7 @@ public final class SelectVariants extends VariantWalker {
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
               shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
               doc="Path to which variants should be written")
-    public String outPathName = null;
+    public GATKPathSpecifier vcfOutput = null;
 
     /**
      * This argument can be specified multiple times in order to provide multiple sample names, or to specify
@@ -525,7 +525,7 @@ public final class SelectVariants extends VariantWalker {
             }
         }
 
-        final Path outPath = IOUtils.getPath(outPathName);
+        final Path outPath = vcfOutput.toPath();
         vcfWriter = createVCFWriter(outPath);
         vcfWriter.writeHeader(new VCFHeader(actualLines, samples));
     }


### PR DESCRIPTION
Instead of a String previously.

Tested like this:

```bash
$ ./gatk SelectVariants \
--variant src/test/resources/large/VQSR/dbsnp_132_b37.leftAligned.20.1M-10M.vcf \
--select-random-fraction 0.01 \
--output gs://$BUCKET/variants.vcf
```

and

```
$ ./gatk SelectVariants \
--variant src/test/resources/large/VQSR/dbsnp_132_b37.leftAligned.20.1M-10M.vcf \
--select-random-fraction 0.01 \
--output /tmp/variants.vcf
```

If this works, the plan is to change all tools to use this format, so they can all write VCF output to Google Cloud Storage.