### PR TITLE
CalculateContamination works much better for very small gene panels

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -153,7 +153,6 @@ public final class ReadThreadingAssembler {
                 assemblyResultByGraph.put(result.getGraph(),result);
                 nonRefGraphs.add(result.getGraph());
             }
-
         }
 
         findBestPaths(nonRefGraphs, refHaplotype, refLoc, activeRegionExtendedLocation, assemblyResultByGraph, resultSet, aligner);


### PR DESCRIPTION
Closes #5821.  @bhanugandham With this PR we will no longer have to recommend against using `CalculateContamination` for gene panels.

@takutosato This puts in a last-ditch calculation that uses hom ref sites *and* uses sites that didn't get a clear minor allele fraction segmentation.  To avoid distorting the signal with LoH hets, it removes the hom ref sites with the highest allele fraction, which will work unless there's a huge amount of CNV.  This will result in a slight underestimate, but for a small gene panel there's not much you can do.