### PR TITLE
Don't redundantly delete temporary directories in RSCriptExecutor.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/R/RScriptExecutor.java
@@ -81,12 +81,9 @@ public final class RScriptExecutor extends ScriptExecutor {
     }
 
     public boolean exec() {
-        final List<File> tempDirs = new ArrayList<>();
         try {
             File tempLibSourceDir  = IOUtils.createTempDir("RlibSources.");
             File tempLibInstallationDir = IOUtils.createTempDir("Rlib.");
-            tempDirs.add(tempLibSourceDir);
-            tempDirs.add(tempLibInstallationDir);
 
             StringBuilder expression = new StringBuilder("tempLibDir = '").append(tempLibInstallationDir).append("';");
 
@@ -133,11 +130,6 @@ public final class RScriptExecutor extends ScriptExecutor {
             } else {
                 logger.warn(e.getMessage());
                 return false;
-            }
-        } finally {
-            for (final File tempDir: tempDirs) {
-                // deletes the dirs and their contents
-                FileUtils.deleteQuietly(tempDir);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/5893.