### PR TITLE
Move GenomicsDB to 1.0.3 for Importer fix to Issue 5449

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.3.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.1')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.3')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one


### PR DESCRIPTION
@ldgauthier found a bug in GenomicsDBImport with overlapping deletions, specifically with  the * allele and the deletion spanning the interval specified - see https://github.com/broadinstitute/gatk/issues/5449#issuecomment-484558863. The fix for this issue(thanks @mlathara) is in 1.0.3 of GenomicsDB.