### PR TITLE
No need to sort variants in HaplotypeCallerSpark.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSink.java
@@ -54,12 +54,33 @@ public final class VariantsSparkSink {
         writeVariants(ctx, outputFile, variants, header, writeTabixIndex, true);
     }
 
+    /**
+     * Write variants to the given output file in VCF format with the given header. Note that writing sharded output is not supported.
+     * @param ctx the JavaSparkContext
+     * @param outputFile path to the output VCF
+     * @param variants variants to write
+     * @param header the header to put at the top of the output file
+     * @param writeTabixIndex whether to write a tabix index (bgzipped VCF only)
+     * @param sortVariantsToHeader whether to sort variants to be consistent with the header
+     * @throws IOException if an error occurs while writing
+     */
     public static void writeVariants(
             final JavaSparkContext ctx, final String outputFile, final JavaRDD<VariantContext> variants,
-            final VCFHeader header, final boolean writeTabixIndex, final boolean sort) throws IOException {
-        writeVariants(ctx, outputFile, variants, header, false, null, 0, 0, writeTabixIndex, true);
+            final VCFHeader header, final boolean writeTabixIndex, final boolean sortVariantsToHeader) throws IOException {
+        writeVariants(ctx, outputFile, variants, header, false, null, 0, 0, writeTabixIndex, sortVariantsToHeader);
     }
 
+    /**
+     * Write variants to the given output file in VCF format with the given header. Note that writing sharded output is not supported.
+     * @param ctx the JavaSparkContext
+     * @param outputFile path to the output VCF
+     * @param variants variants to write
+     * @param header the header to put at the top of the output file
+     * @param writeGvcf whether to write GVCF output
+     * @param gqPartitions the GQ partitions for GVCF output
+     * @param defaultPloidy the default ploidy for GVCF output
+     * @throws IOException if an error occurs while writing
+     */
     public static void writeVariants(
             final JavaSparkContext ctx, final String outputFile, final JavaRDD<VariantContext> variants,
             final VCFHeader header, final boolean writeGvcf, final List<Number> gqPartitions, final int defaultPloidy) throws IOException {
@@ -72,17 +93,21 @@ public final class VariantsSparkSink {
      * @param outputFile path to the output VCF
      * @param variants variants to write
      * @param header the header to put at the top of the output file
+     * @param writeGvcf whether to write GVCF output
+     * @param gqPartitions the GQ partitions for GVCF output
+     * @param defaultPloidy the default ploidy for GVCF output
      * @param numReducers the number of reducers to use when writing a single file. A value of zero indicates that the default
      *                    should be used.
      * @param writeTabixIndex whether to write a tabix index (bgzipped VCF only)
+     * @param sortVariantsToHeader whether to sort variants to be consistent with the header
      * @throws IOException if an error occurs while writing
      */
     public static void writeVariants(
             final JavaSparkContext ctx, final String outputFile, final JavaRDD<VariantContext> variants,
             final VCFHeader header, final boolean writeGvcf, final List<Number> gqPartitions, final int defaultPloidy,
-            final int numReducers, final boolean writeTabixIndex, final boolean sort) throws IOException {
+            final int numReducers, final boolean writeTabixIndex, final boolean sortVariantsToHeader) throws IOException {
         String absoluteOutputFile = BucketUtils.makeFilePathAbsolute(outputFile);
-        writeVariantsSingle(ctx, absoluteOutputFile, variants, header, writeGvcf, gqPartitions, defaultPloidy, numReducers, writeTabixIndex, sort);
+        writeVariantsSingle(ctx, absoluteOutputFile, variants, header, writeGvcf, gqPartitions, defaultPloidy, numReducers, writeTabixIndex, sortVariantsToHeader);
     }
 
     private static void writeVariantsSingle(

--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -184,11 +184,10 @@ public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
 
         final JavaRDD<VariantContext> variants = rdd.mapPartitions(assemblyFunction(header, referenceFileName, hcArgsBroadcast, annotatorEngineBroadcast));
 
-        variants.cache(); // without caching, computations are run twice as a side effect of finding partition boundaries for sorting
         try {
             VariantsSparkSink.writeVariants(ctx, output, variants, hcEngine.makeVCFHeader(header.getSequenceDictionary(), new HashSet<>()),
                     hcArgs.emitReferenceConfidence == ReferenceConfidenceMode.GVCF, new ArrayList<Number>(hcArgs.GVCFGQBands), hcArgs.standardArgs.genotypeArgs.samplePloidy,
-                    0, createOutputVariantIndex);
+                    0, createOutputVariantIndex, false);
         } catch (IOException e) {
             throw new UserException.CouldNotCreateOutputFile(output, "writing failed", e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
@@ -58,7 +58,7 @@ public final class PrintVariantsSpark extends VariantWalkerSpark {
     protected void processVariants(JavaRDD<VariantWalkerContext> rdd, JavaSparkContext ctx) {
         try {
             VariantsSparkSink.writeVariants(ctx, output, rdd.map(VariantWalkerContext::getVariant), getHeaderForVariants(),
-                    createOutputVariantIndex);
+                    createOutputVariantIndex, false);
         } catch (IOException e) {
             throw new UserException.CouldNotCreateOutputFile(output, "writing failed", e);
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSinkUnitTest.java
@@ -115,7 +115,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
     public void testBrokenGVCFCasesAreDisallowed(boolean writeGvcf, String extension) throws IOException {
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
         VariantsSparkSink.writeVariants(ctx, createTempFile("test", extension).toString(), null,
-                new VCFHeader(), writeGvcf, Arrays.asList(1, 2, 4, 5), 2, 1, false);
+                new VCFHeader(), writeGvcf, Arrays.asList(1, 2, 4, 5), 2, 1, false, false);
     }
 
     @DataProvider
@@ -142,7 +142,7 @@ public final class VariantsSparkSinkUnitTest extends GATKBaseTest {
 
         final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
         final File output = createTempFile(outputFileName, extension);
-        VariantsSparkSink.writeVariants(ctx, output.toString(), ctx.parallelize(vcs), getHeader(), writeGvcf, Arrays.asList(100), 2, 1, true);
+        VariantsSparkSink.writeVariants(ctx, output.toString(), ctx.parallelize(vcs), getHeader(), writeGvcf, Arrays.asList(100), 2, 1, true, true);
 
         checkFileExtensionConsistentWithContents(output.toString(), true);
 


### PR DESCRIPTION
`VariantsSparkSink` will always sort variants before writing them out. However, `HaplotypeCallerSpark` always processes reads in coordinate-sorted order, and produces variants in the same order, so there is no need for `VariantsSparkSink` to sort variants. (In fact, in GVCF mode the sort is prohibitive since the engine creates a variant for every locus over the interval of interest, which go through the sort step before being merged into GVCF bands.)

This PR removes the sort step for `HaplotypeCallerSpark` (and `PrintVariantsSpark`, which doesn't need it either). All of the concordance unit tests pass, and as an additional sanity check I compared the GVCF output from running regular `HaplotypeCaller` on a large input BAM to `HaplotypeCallerSpark` (with and without variant sorting). Removing variant sorting actually made the GVCF output more similar to regular `HaplotypeCaller` - it reduced the number of differences from three to one. (The one difference is a minor difference in QUAL due to a boundary artifact.) See VCFs in [vcfs.zip](https://github.com/broadinstitute/gatk/files/3134046/vcfs.zip).
