### PR TITLE
Added a check to ensure previous caching information doesn't affect referenceConfidenceCalls

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -191,7 +191,7 @@ public class ReferenceConfidenceModel {
         final SimpleInterval refSpan = activeRegion.getSpan();
         // Ensuring that if the underlying reads have any cached indel informativeness data it gets purged before calling the next region.
         if (USE_CACHED_READ_INDEL_INFORMATIVENESS_VALUES) {
-            readLikelihoods.sampleReads(0).forEach(r -> r.setTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME, null));
+            readLikelihoods.sampleReads(0).forEach(r -> r.clearTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
         }
         final List<ReadPileup> refPileups = AssemblyBasedCallerUtils.getPileupsOverReference(activeRegion.getHeader(), refSpan, readLikelihoods, samples);
         final byte[] ref = refHaplotype.getBases();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -218,6 +218,8 @@ public class ReferenceConfidenceModel {
         }
 
         // Ensuring that we remove any indel informativeness data we may have attached to the underlying reads for caching purposes
+        // This is important as if multiple reference blocks are computed for a low complexity active region some reads may incorrectly
+        // be using caching values computed for a different reference block.
         if (USE_CACHED_READ_INDEL_INFORMATIVENESS_VALUES) {
             readLikelihoods.sampleReads(0).forEach(r -> r.clearTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -189,10 +189,6 @@ public class ReferenceConfidenceModel {
         final int ploidy = ploidyModel.samplePloidy(0); // the first sample = the only sample in reference-confidence mode.
 
         final SimpleInterval refSpan = activeRegion.getSpan();
-        // Ensuring that if the underlying reads have any cached indel informativeness data it gets purged before calling the next region.
-        if (USE_CACHED_READ_INDEL_INFORMATIVENESS_VALUES) {
-            readLikelihoods.sampleReads(0).forEach(r -> r.clearTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
-        }
         final List<ReadPileup> refPileups = AssemblyBasedCallerUtils.getPileupsOverReference(activeRegion.getHeader(), refSpan, readLikelihoods, samples);
         final byte[] ref = refHaplotype.getBases();
         final List<VariantContext> results = new ArrayList<>(refSpan.size());
@@ -219,6 +215,11 @@ public class ReferenceConfidenceModel {
                 // otherwise emit a reference confidence variant context
                 results.add(makeReferenceConfidenceVariantContext(ploidy, ref, sampleName, globalRefOffset, pileup, curPos, offset, applyPriors, currentPriors));
             }
+        }
+
+        // Ensuring that we remove any indel informativeness data we may have attached to the underlying reads for caching purposes
+        if (USE_CACHED_READ_INDEL_INFORMATIVENESS_VALUES) {
+            readLikelihoods.sampleReads(0).forEach(r -> r.clearTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
         }
 
         return results;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -189,6 +189,10 @@ public class ReferenceConfidenceModel {
         final int ploidy = ploidyModel.samplePloidy(0); // the first sample = the only sample in reference-confidence mode.
 
         final SimpleInterval refSpan = activeRegion.getSpan();
+        // Ensuring that if the underlying reads have any cached indel informativeness data it gets purged before calling the next region.
+        if (USE_CACHED_READ_INDEL_INFORMATIVENESS_VALUES) {
+            readLikelihoods.sampleReads(0).forEach(r -> r.setTransientAttribute(INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME, null));
+        }
         final List<ReadPileup> refPileups = AssemblyBasedCallerUtils.getPileupsOverReference(activeRegion.getHeader(), refSpan, readLikelihoods, samples);
         final byte[] ref = refHaplotype.getBases();
         final List<VariantContext> results = new ArrayList<>(refSpan.size());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModelUnitTest.java
@@ -508,6 +508,10 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
         final IndependentSampleGenotypesModel genotypingModel = new IndependentSampleGenotypesModel();
         final List<Integer> expectedDPs = Collections.nCopies(data.getActiveRegion().getSpan().size(), nReads);
         final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls, false, Collections.emptyList());
+        // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
+        for (GATKRead read : data.getActiveRegion().getReads()) {
+            Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+        }
         checkReferenceModelResult(data, contexts, expectedDPs, calls);
     }
 
@@ -529,6 +533,10 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
                 final List<Integer> expectedDPs = new ArrayList<>(Collections.nCopies(data.getActiveRegion().getSpan().size(), 0));
                 for ( int i = start; i < readLen + start; i++ ) expectedDPs.set(i, 1);
                 final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls);
+                // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
+                for (GATKRead read : data.getActiveRegion().getReads()) {
+                    Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+                }
                 checkReferenceModelResult(data, contexts, expectedDPs, calls);
             }
         }
@@ -565,6 +573,10 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
 
                     final List<Integer> expectedDPs = Collections.nCopies(data.getActiveRegion().getSpan().size(), nReads);
                     final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls);
+                    // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
+                    for (GATKRead read : data.getActiveRegion().getReads()) {
+                        Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+                    }
                     checkReferenceModelResult(data, contexts, expectedDPs, calls);
                 }
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModelUnitTest.java
@@ -510,7 +510,7 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
         final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls, false, Collections.emptyList());
         // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
         for (GATKRead read : data.getActiveRegion().getReads()) {
-            Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+            Assert.assertNull(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
         }
         checkReferenceModelResult(data, contexts, expectedDPs, calls);
     }
@@ -535,7 +535,7 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
                 final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls);
                 // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
                 for (GATKRead read : data.getActiveRegion().getReads()) {
-                    Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+                    Assert.assertNull(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
                 }
                 checkReferenceModelResult(data, contexts, expectedDPs, calls);
             }
@@ -575,7 +575,7 @@ public final class ReferenceConfidenceModelUnitTest extends GATKBaseTest {
                     final List<VariantContext> contexts = model.calculateRefConfidence(data.getRefHap(), haplotypes, data.getPaddedRefLoc(), data.getActiveRegion(), likelihoods, ploidyModel, calls);
                     // Asserting that none of the reads after calculateRefConfidence have indel informativeness caching values attached.
                     for (GATKRead read : data.getActiveRegion().getReads()) {
-                        Assert.assertTrue(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME) == null);
+                        Assert.assertNull(read.getTransientAttribute(ReferenceConfidenceModel.INDEL_INFORMATIVE_BASES_CACHE_ATTRIBUTE_NAME));
                     }
                     checkReferenceModelResult(data, contexts, expectedDPs, calls);
                 }


### PR DESCRIPTION
I don't doubt that there could be issues caused by reads with previously filled caches. Ultimately this shouldn't have too significant an impact except in very pathological circumstances with highly repetitive regions or reads that hang beyond a certain length into the next region and happen to have had good looking indel sites without the cirgar actually containing any indels for that read. This should eliminate any of these circumstances entirely so we can be sure the cache is clear before every call. 

Fixes #5908