### PR TITLE
Move to GenomicsDB 1.0.4 version to get AS_QUALapprox and AS_VarDP fields treated as array of int vectors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.2.0')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.3.0')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.3')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.0.4')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one


### PR DESCRIPTION
See https://github.com/GenomicsDB/GenomicsDB/commit/10d9ea7ffdfa758a5775a995f9e911a076dbf55e for the relevant changes.