### PR TITLE
TandemRepeat works with HaplotypeCaller

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
@@ -19,12 +19,6 @@ import java.util.*;
  * <p>This annotation tags variants that fall within tandem repeat sets. It also provides the composition of the tandem repeat units and the number of times they are repeated for each allele (including the REF allele).</p>
  *
  * <p>A tandem repeat unit is composed of one or more nucleotides that are repeated multiple times in series. Repetitive sequences are difficult to map to the reference because they are associated with multiple alignment possibilities. Knowing the number of repeat units in a set of tandem repeats tells you the number of different positions the tandem repeat can be placed in. The observation of many tandem repeat units multiplies the number of possible representations that can be made of the region.
- *
- * <h3>Caveat</h3>
- * <ul>
- *     <li>This annotation is currently not compatible with HaplotypeCaller.</li>
- * </ul>
- *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Tandem repeat unit composition and counts per allele (STR, RU, RPA)")
 public final class TandemRepeat extends InfoFieldAnnotation implements StandardMutectAnnotation {


### PR DESCRIPTION
I don't think this is true anymore.  We've been using it successfully with gatk4's `HaplotypeCaller`.  I'd love some confirmation, and then the docs could be updated.