### PR TITLE
Treat all source files as UTF-8 for java, javadoc, gatkdoc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,7 @@ configurations.all {
 
 tasks.withType(JavaCompile) {
   options.compilerArgs = ['-proc:none', '-Xlint:all', '-Werror', '-Xdiags:verbose']
+  options.encoding = 'UTF-8'
 }
 
 sourceSets {
@@ -580,6 +581,7 @@ task testUtilsJar(type: Jar){
 tasks.withType(Javadoc) {
     // do this for all javadoc tasks, including gatkDoc
     options.addStringOption('Xdoclint:none')
+    options.addStringOption('encoding', 'UTF-8')
 }
 
 javadoc {


### PR DESCRIPTION
I tested this using the following sketchy procedure: I temporarily reverted https://github.com/broadinstitute/gatk/pull/5936 on this branch, thereby re-introducing non-ASCII characters into the source. That builds without error, as it should. Then I temporarily changed the newly added encoding declarations included this PR in build.gradle from "UTF-8" to "US-ASCII", after which I was able to reproduce exactly the same errors as reported in https://github.com/broadinstitute/gatk/issues/5934, for both compile and gatkDoc tasks. So I think these changes achieve the desired result (accept UTF-8 in source).