### PR TITLE
Handle all arguments in ApplyBQSRUniqueArgumentCollection

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.recalibration.RecalibrationArgumentCollection;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -58,12 +59,23 @@ public class ApplyBQSRUniqueArgumentCollection implements Serializable {
     @Argument(fullName = "global-qscore-prior", doc = "Global Qscore Bayesian prior to use for BQSR", optional = true)
     public double globalQScorePrior = -1.0;
 
-    public ApplyBQSRArgumentCollection toApplyBQSRArgumentCollection(int PRESERVE_QSCORES_LESS_THAN) {
+    /**
+     * Combine the extra arguments in {@link ApplyBQSRArgumentCollection} that are not in this {@link ApplyBQSRUniqueArgumentCollection}
+     * from the given {@link RecalibrationArgumentCollection} to create a {@link ApplyBQSRArgumentCollection}.
+     * @param bqsrArgs the recalibration arguments
+     * @return an argument collection with all the combined arguments
+     */
+    public ApplyBQSRArgumentCollection toApplyBQSRArgumentCollection(RecalibrationArgumentCollection bqsrArgs) {
         ApplyBQSRArgumentCollection ret = new ApplyBQSRArgumentCollection();
+        // include all the fields from ApplyBQSRArgumentCollection
         ret.quantizationLevels = this.quantizationLevels;
+        ret.staticQuantizationQuals = this.staticQuantizationQuals;
+        ret.roundDown = this.roundDown;
         ret.emitOriginalQuals = this.emitOriginalQuals;
-        ret.PRESERVE_QSCORES_LESS_THAN = PRESERVE_QSCORES_LESS_THAN;
         ret.globalQScorePrior = this.globalQScorePrior;
+        // include all the fields from RecalibrationArgumentCollection
+        ret.PRESERVE_QSCORES_LESS_THAN = bqsrArgs.PRESERVE_QSCORES_LESS_THAN;
+        ret.useOriginalBaseQualities = bqsrArgs.useOriginalBaseQualities;
         return ret;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSRUniqueArgumentCollection.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 /**
  * The collection of those arguments for ApplyBQSR that are not already defined in RecalibrationArgumentCollection.
+ * This is needed for tools (like {@link org.broadinstitute.hellbender.tools.spark.pipelines.ReadsPipelineSpark}
+ * that use both ApplyBSQR and Recalibration argument collections, and which would otherwise have duplicate arguments.
  */
 public class ApplyBQSRUniqueArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -116,7 +116,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(readsWithVariants, getHeaderForReads(), referenceFileName, bqsrArgs);
 
         final Broadcast<RecalibrationReport> reportBroadcast = ctx.broadcast(bqsrReport);
-        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(initialReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs.PRESERVE_QSCORES_LESS_THAN));
+        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(initialReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs));
 
         writeReads(ctx, output, finalReads);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -205,7 +205,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         final RecalibrationReport bqsrReport = BaseRecalibratorSparkFn.apply(readsWithVariants, getHeaderForReads(), referenceFileName, bqsrArgs);
 
         final Broadcast<RecalibrationReport> reportBroadcast = ctx.broadcast(bqsrReport);
-        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(sortedMarkedReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs.PRESERVE_QSCORES_LESS_THAN));
+        final JavaRDD<GATKRead> finalReads = ApplyBQSRSparkFn.apply(sortedMarkedReads, reportBroadcast, getHeaderForReads(), applyBqsrArgs.toApplyBQSRArgumentCollection(bqsrArgs));
 
         if (outputBam != null) { // only write output of BQSR if output BAM is specified
             writeReads(ctx, outputBam, finalReads, header, true);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
@@ -63,7 +63,7 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
         return new Object[][]{
                 // input local, computation local.
                 //Note: these output files were created by running GATK3
-                {new BQSRTest(GRCh37Ref_2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
+                {new BQSRTest(GRCh37Ref_2021, hiSeqBam_chr20, dbSNPb37_20, ".bam", "-indels --enable-baq --use-original-qualities false", getResourceDir() + "expected.CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.recalibrated.DIQ.bam")},
 
                 //Output generated with GATK4 (resulting BAM has 4 differences with GATK3)
                 {new BQSRTest(b37_reference_20_21 , hiSeqBam_20_21_100000, more20Sites, ".bam", "-indels --enable-baq --known-sites " + more21Sites, getResourceDir() + "expected.MultiSite.bqsr.pipeline.bam")},


### PR DESCRIPTION
Some new arguments have been added to `ApplyBQSRArgumentCollection` and `RecalibrationArgumentCollection` that were not reflected in `ApplyBQSRUniqueArgumentCollection`. This PR brings `ApplyBQSRUniqueArgumentCollection` up to date.