### PR TITLE
Use UserException IllegalArgumentException for duplicate feature inputs.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalker.java
@@ -6,6 +6,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MultiVariantInputArgumentCollection;
 import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ public abstract class MultiVariantWalker extends VariantWalkerBase {
                 f -> {
                     FeatureInput<VariantContext> featureInput = new FeatureInput<>(f);
                     if (drivingVariantsFeatureInputs.contains(featureInput)) {
-                        throw new IllegalArgumentException("Feature inputs must be unique: " + featureInput.toString());
+                        throw new UserException.BadInput("Feature inputs must be unique: " + featureInput.toString());
                     }
                     drivingVariantsFeatureInputs.add(featureInput);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerIntegrationTest.java
@@ -61,7 +61,7 @@ public final class MultiVariantWalkerIntegrationTest extends CommandLineProgramT
         }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = UserException.class)
     public void testDuplicateSources() throws Exception {
         final TestMultiVariantWalker tool = new TestMultiVariantWalker();
 


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/5947.