### PR TITLE
Fixed an optimization in KBestHaplotypeFinder that caused some bestPaths to be lost while still preserving some of the optimization.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
@@ -78,15 +78,15 @@ public final class KBestHaplotypeFinder {
             if (sinks.contains(vertexToExtend)) {
                 result.add(pathToExtend);
             } else {
-                final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
-                int totalOutgoingMultiplicity = 0;
-                for (final BaseEdge edge : outgoingEdges) {
-                    totalOutgoingMultiplicity += edge.getMultiplicity();
-                }
+                if (vertexCounts.get(vertexToExtend).getAndIncrement() < maxNumberOfHaplotypes) {
+                    final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+                    int totalOutgoingMultiplicity = 0;
+                    for (final BaseEdge edge : outgoingEdges) {
+                        totalOutgoingMultiplicity += edge.getMultiplicity();
+                    }
 
-                for (final BaseEdge edge : outgoingEdges) {
-                    final SeqVertex targetVertex = graph.getEdgeTarget(edge);
-                    if (vertexCounts.get(targetVertex).getAndIncrement() < maxNumberOfHaplotypes) {
+                    for (final BaseEdge edge : outgoingEdges) {
+                        final SeqVertex targetVertex = graph.getEdgeTarget(edge);
                         queue.add(new KBestHaplotype(pathToExtend, edge, totalOutgoingMultiplicity));
                     }
                 }


### PR DESCRIPTION
@davidbenjamin Was familiarizing myself with `KBestHaplotypeFinder` and decided to take a crack at this issue. 

I have no idea how much of a performance hit this will end up being at extreme sites. At worst it involves adding more paths into the priority queues than existed before which could slow down the whole search algorithm. 

Fixes #5907 