### PR TITLE
Added an experimental mode to HaplotypeCaller and Mutect2 to disable sequence graph simplifications.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -19,7 +20,7 @@ public final class AssemblyResult {
      */
     public AssemblyResult(final Status status, final SeqGraph graph, final ReadThreadingGraph threadingGraph) {
         Utils.nonNull(status, "status cannot be null");
-        Utils.validateArg( status == Status.FAILED || graph != null, "graph is null but status is " + status);
+        Utils.validateArg( status == Status.FAILED || (graph != null || threadingGraph != null) , "graph is null but status is " + status);
 
         this.status = status;
         this.graph = graph;
@@ -34,12 +35,12 @@ public final class AssemblyResult {
         return status;
     }
 
-    public SeqGraph getGraph() {
+    public SeqGraph getSeqGraph() {
         return graph;
     }
 
     public int getKmerSize() {
-        return graph.getKmerSize();
+        return graph == null? threadingGraph.getKmerSize() : graph.getKmerSize();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
@@ -204,7 +204,7 @@ public final class AssemblyResultSet {
 
         for (final Map.Entry<Haplotype,AssemblyResult> e : assemblyResultByHaplotype.entrySet()) {
             final AssemblyResult as = e.getValue();
-            final int kmerSize = as.getGraph().getKmerSize();
+            final int kmerSize = as.getKmerSize();
             if (kmerSizeToCount.containsKey(kmerSize)) {
                 kmerSizeToCount.put(kmerSize,kmerSizeToCount.get(kmerSize) + 1);
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -44,7 +44,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -44,7 +44,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruction);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruction);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -152,6 +152,17 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Argument(fullName="max-unpruned-variants", doc = "Maximum number of variants in graph the adaptive pruner will allow", optional = true)
     public int maxUnprunedVariants = 100;
 
+    /**
+     * Disables graph simplification into a seq graph. This is experimental and may cause performance issues for the KBestHaplotypeFinder
+     *
+     * NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
+     *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
+     *        sites. Use this mode at your own risk.
+     */
+    @Hidden
+    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified debrujin graph", optional = true)
+    public boolean disableSeqGraphConstruciton = false;
+
     @Advanced
     @Argument(fullName="debug-assembly", shortName="debug", doc="Print out verbose debug information about each assembly region", optional = true)
     public boolean debugAssembly;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -160,8 +160,8 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
      *        sites. Use this mode at your own risk.
      */
     @Hidden
-    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified debrujin graph", optional = true)
-    public boolean disableSeqGraphConstruciton = false;
+    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified de Bruijn graph", optional = true)
+    public boolean disableSeqGraphConstruction = false;
 
     @Advanced
     @Argument(fullName="debug-assembly", shortName="debug", doc="Print out verbose debug information about each assembly region", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -131,6 +131,17 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     }
 
     /**
+     * Pull out the additional sequence implied by traversing this node in the graph
+     * @param v the vertex from which to pull out the additional base sequence
+     * @param isSource if true, treat v as a source vertex regardless of graph in degree
+     * @return  non-null byte array
+     */
+    public final byte[] getAdditionalSequence( final V v, final boolean isSource) {
+        Utils.nonNull(v, "Attempting to pull sequence from a null vertex.");
+        return v.getAdditionalSequence(isSource);
+    }
+
+    /**
      * @param v the vertex to test
      * @return  true if this vertex is a reference source
      */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -133,7 +133,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     /**
      * Pull out the additional sequence implied by traversing this node in the graph
      * @param v the vertex from which to pull out the additional base sequence
-     * @param isSource if true, treat v as a source vertex regardless of graph in degree
+     * @param isSource if true, treat v as a source vertex regardless of graph in-degree
      * @return  non-null byte array
      */
     public final byte[] getAdditionalSequence( final V v, final boolean isSource) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
@@ -20,7 +20,7 @@ public final class KBestHaplotype<V extends BaseVertex, E extends BaseEdge> exte
         score = 0;
     }
 
-    public KBestHaplotype(final KBestHaplotype p, final E edge, final int totalOutgoingMultiplicity) {
+    public KBestHaplotype(final KBestHaplotype<V, E> p, final E edge, final int totalOutgoingMultiplicity) {
         super(p, edge);
         score = p.score() + MathUtils.log10(edge.getMultiplicity()) - MathUtils.log10(totalOutgoingMultiplicity);
         isReference &= edge.isRef();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.utils.MathUtils;
-import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 
 /**
@@ -10,14 +8,14 @@ import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotype<T extends BaseVertex, E extends BaseEdge> extends Path<T, E>{
+public final class KBestHaplotype<V extends BaseVertex, E extends BaseEdge> extends Path<V, E>{
     private double score;
     private boolean isReference;
 
     public double score() { return score; }
     public boolean isReference() { return isReference; }
 
-    public KBestHaplotype(final T initialVertex, final BaseGraph<T,E> graph) {
+    public KBestHaplotype(final V initialVertex, final BaseGraph<V,E> graph) {
         super(initialVertex, graph);
         score = 0;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
@@ -9,19 +10,19 @@ import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotype extends Path<SeqVertex,BaseEdge>{
+public final class KBestHaplotype<T extends BaseVertex, E extends BaseEdge> extends Path<T, E>{
     private double score;
     private boolean isReference;
 
     public double score() { return score; }
     public boolean isReference() { return isReference; }
 
-    public KBestHaplotype(final SeqVertex initialVertex, final BaseGraph<SeqVertex,BaseEdge> graph) {
+    public KBestHaplotype(final T initialVertex, final BaseGraph<T,E> graph) {
         super(initialVertex, graph);
         score = 0;
     }
 
-    public KBestHaplotype(final KBestHaplotype p, final BaseEdge edge, final int totalOutgoingMultiplicity) {
+    public KBestHaplotype(final KBestHaplotype p, final E edge, final int totalOutgoingMultiplicity) {
         super(p, edge);
         score = p.score() + MathUtils.log10(edge.getMultiplicity()) - MathUtils.log10(totalOutgoingMultiplicity);
         isReference &= edge.isRef();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.jgrapht.alg.CycleDetector;
 
@@ -12,11 +14,11 @@ import java.util.stream.Collectors;
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotypeFinder {
+public final class KBestHaplotypeFinder<V extends BaseVertex, E extends BaseEdge> {
 
-    private final SeqGraph graph;
-    final Set<SeqVertex> sinks;
-    final Set<SeqVertex> sources;
+    private final BaseGraph<V, E> graph;
+    final Set<V> sinks;
+    final Set<V> sources;
 
     /**
      * Constructs a new best haplotypes finder.
@@ -30,7 +32,7 @@ public final class KBestHaplotypeFinder {
      *     <li>any of {@code sources}' or any {@code sinks}' member is not a vertex in {@code graph}.</li>
      * </ul>
      */
-    public KBestHaplotypeFinder(final SeqGraph graph, final Set<SeqVertex> sources, final Set<SeqVertex> sinks) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph, final Set<V> sources, final Set<V> sinks) {
         Utils.nonNull(graph, "graph cannot be null");
         Utils.nonNull(sources, "sources cannot be null");
         Utils.nonNull(sinks, "sinks cannot be null");
@@ -50,44 +52,44 @@ public final class KBestHaplotypeFinder {
     /**
      * Constructor for the special case of a single source and sink
      */
-    public KBestHaplotypeFinder(final SeqGraph graph, final SeqVertex source, final SeqVertex sink) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph, final V source, final V sink) {
         this(graph, Collections.singleton(source), Collections.singleton(sink));
     }
 
     /**
      * Constructor for the default case of all sources and sinks
      */
-    public KBestHaplotypeFinder(final SeqGraph graph) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph) {
         this(graph, graph.getSources(), graph.getSinks());
     }
 
     /**
      * Implement Dijkstra's algorithm as described in https://en.wikipedia.org/wiki/K_shortest_path_routing
      */
-    public List<KBestHaplotype> findBestHaplotypes(final int maxNumberOfHaplotypes) {
-        final List<KBestHaplotype> result = new ArrayList<>();
-        final PriorityQueue<KBestHaplotype> queue = new PriorityQueue<>(Comparator.comparingDouble(KBestHaplotype::score).reversed());
-        sources.forEach(source -> queue.add(new KBestHaplotype(source, graph)));
+    public List<KBestHaplotype<V, E>> findBestHaplotypes(final int maxNumberOfHaplotypes) {
+        final List<KBestHaplotype<V, E>> result = new ArrayList<>();
+        final PriorityQueue<KBestHaplotype<V, E>> queue = new PriorityQueue<>(Comparator.comparingDouble(KBestHaplotype<V, E>::score).reversed());
+        sources.forEach(source -> queue.add(new KBestHaplotype<>(source, graph)));
 
-        final Map<SeqVertex, MutableInt> vertexCounts = graph.vertexSet().stream()
+        final Map<V, MutableInt> vertexCounts = graph.vertexSet().stream()
                 .collect(Collectors.toMap(v -> v, v -> new MutableInt(0)));
 
         while (!queue.isEmpty() && result.size() < maxNumberOfHaplotypes) {
-            final KBestHaplotype pathToExtend = queue.poll();
-            final SeqVertex vertexToExtend = pathToExtend.getLastVertex();
+            final KBestHaplotype<V, E> pathToExtend = queue.poll();
+            final V vertexToExtend = pathToExtend.getLastVertex();
             if (sinks.contains(vertexToExtend)) {
                 result.add(pathToExtend);
             } else {
                 if (vertexCounts.get(vertexToExtend).getAndIncrement() < maxNumberOfHaplotypes) {
-                    final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+                    final Set<E> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
                     int totalOutgoingMultiplicity = 0;
                     for (final BaseEdge edge : outgoingEdges) {
                         totalOutgoingMultiplicity += edge.getMultiplicity();
                     }
 
-                    for (final BaseEdge edge : outgoingEdges) {
-                        final SeqVertex targetVertex = graph.getEdgeTarget(edge);
-                        queue.add(new KBestHaplotype(pathToExtend, edge, totalOutgoingMultiplicity));
+                    for (final E edge : outgoingEdges) {
+                        final V targetVertex = graph.getEdgeTarget(edge);
+                        queue.add(new KBestHaplotype<>(pathToExtend, edge, totalOutgoingMultiplicity));
                     }
                 }
             }
@@ -95,7 +97,7 @@ public final class KBestHaplotypeFinder {
         return result;
     }
 
-    public List<KBestHaplotype> findBestHaplotypes() {
+    public List<KBestHaplotype<V, E>> findBestHaplotypes() {
        return findBestHaplotypes(Integer.MAX_VALUE);
     }
 
@@ -103,13 +105,13 @@ public final class KBestHaplotypeFinder {
      * Removes edges that produces cycles and also dead vertices that do not lead to any sink vertex.
      * @return never {@code null}.
      */
-    private static SeqGraph removeCyclesAndVerticesThatDontLeadToSinks(final SeqGraph original, final Collection<SeqVertex> sources, final Set<SeqVertex> sinks) {
-        final Set<BaseEdge> edgesToRemove = new HashSet<>(original.edgeSet().size());
-        final Set<SeqVertex> vertexToRemove = new HashSet<>(original.vertexSet().size());
+    private BaseGraph<V, E> removeCyclesAndVerticesThatDontLeadToSinks(final BaseGraph<V, E> original, final Collection<V> sources, final Set<V> sinks) {
+        final Set<E> edgesToRemove = new HashSet<>(original.edgeSet().size());
+        final Set<V> vertexToRemove = new HashSet<>(original.vertexSet().size());
 
         boolean foundSomePath = false;
-        for (final SeqVertex source : sources) {
-            final Set<SeqVertex> parentVertices = new HashSet<>(original.vertexSet().size());
+        for (final V source : sources) {
+            final Set<V> parentVertices = new HashSet<>(original.vertexSet().size());
             foundSomePath = findGuiltyVerticesAndEdgesToRemoveCycles(original, source, sinks, edgesToRemove, vertexToRemove, parentVertices) || foundSomePath;
         }
 
@@ -118,7 +120,7 @@ public final class KBestHaplotypeFinder {
 
         Utils.validate(!(edgesToRemove.isEmpty() && vertexToRemove.isEmpty()), "cannot find a way to remove the cycles");
 
-        final SeqGraph result = original.clone();
+        final BaseGraph<V, E> result = original.clone();
         result.removeAllEdges(edgesToRemove);
         result.removeAllVertices(vertexToRemove);
         return result;
@@ -138,22 +140,22 @@ public final class KBestHaplotypeFinder {
      * @return {@code true} to indicate that the some sink vertex is reachable by {@code currentVertex},
      *  {@code false} otherwise.
      */
-    private static boolean findGuiltyVerticesAndEdgesToRemoveCycles(final SeqGraph graph,
-                                                                    final SeqVertex currentVertex,
-                                                                    final Set<SeqVertex> sinks,
-                                                                    final Set<BaseEdge> edgesToRemove,
-                                                                    final Set<SeqVertex> verticesToRemove,
-                                                                    final Set<SeqVertex> parentVertices) {
+    private boolean findGuiltyVerticesAndEdgesToRemoveCycles(final BaseGraph<V, E> graph,
+                                                                    final V currentVertex,
+                                                                    final Set<V> sinks,
+                                                                    final Set<E> edgesToRemove,
+                                                                    final Set<V> verticesToRemove,
+                                                                    final Set<V> parentVertices) {
         if (sinks.contains(currentVertex)) {
             return true;
         }
 
-        final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
+        final Set<E> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
         parentVertices.add(currentVertex);
 
         boolean reachesSink = false;
-        for (final BaseEdge edge : outgoingEdges) {
-            final SeqVertex child = graph.getEdgeTarget(edge);
+        for (final E edge : outgoingEdges) {
+            final V child = graph.getEdgeTarget(edge);
             if (parentVertices.contains(child)) {
                 edgesToRemove.add(edge);
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.jgrapht.alg.CycleDetector;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
@@ -177,11 +177,11 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * @return  non-null sequence of bases corresponding to this path
      */
     public byte[] getBases() {
-        if( getEdges().isEmpty() ) { return graph.getAdditionalSequence(lastVertex); }
+        if( getEdges().isEmpty() ) { return graph.getAdditionalSequence(lastVertex, true); }
 
-        byte[] bases = graph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)));
+        byte[] bases = graph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)), true);
         for( final E e : edgesInOrder ) {
-            bases = ArrayUtils.addAll(bases, graph.getAdditionalSequence(graph.getEdgeTarget(e)));
+            bases = ArrayUtils.addAll(bases, graph.getAdditionalSequence(graph.getEdgeTarget(e), false));
         }
         return bases;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -502,7 +502,9 @@ public final class ReadThreadingAssembler {
 
         printDebugGraphTransform(initialSeqGraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.2.initial_seqgraph.dot");
         if (generateSeqGraph) {
-            initialSeqGraph.cleanNonRefPaths(); // TODO -- I don't this is possible by construction
+            // This step is likely necessary because though non-reference paths have been removed at several points above, it is still possible
+            // that the pruning steps taken on SeqGraph might result pruning edges that are necessary for a given path to connect to the reference path.
+            initialSeqGraph.cleanNonRefPaths();
         } else {
             rtgraph.cleanNonRefPaths();
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -4,8 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.variant.variantcontext.Allele;
-import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
@@ -14,7 +12,6 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResul
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResultSet;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadErrorCorrector;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
-import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
@@ -39,6 +36,7 @@ public final class ReadThreadingAssembler {
     private final List<Integer> kmerSizes;
     private final boolean dontIncreaseKmerSizesForCycles;
     private final boolean allowNonUniqueKmersInRef;
+    private final boolean generateSeqGraph;
     private final int numPruningSamples;
     private final int numBestHaplotypesPerGraph;
 
@@ -69,13 +67,14 @@ public final class ReadThreadingAssembler {
                                   final boolean dontIncreaseKmerSizesForCycles, final boolean allowNonUniqueKmersInRef,
                                   final int numPruningSamples, final int pruneFactor, final boolean useAdaptivePruning,
                                   final double initialErrorRateForPruning, final double pruningLogOddsThreshold,
-                                  final int maxUnprunedVariants) {
+                                  final int maxUnprunedVariants, final boolean generateSeqGraph) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
         this.kmerSizes = kmerSizes;
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;
         this.pruneFactor = pruneFactor;
+        this.generateSeqGraph = generateSeqGraph;
         chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants) :
                 new LowWeightChainPruner<>(pruneFactor);
         numBestHaplotypesPerGraph = maxAllowedPathsForReadThreadingAssembler;
@@ -83,7 +82,7 @@ public final class ReadThreadingAssembler {
 
     @VisibleForTesting
     ReadThreadingAssembler(final int maxAllowedPathsForReadThreadingAssembler, final List<Integer> kmerSizes, final int pruneFactor) {
-        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, Integer.MAX_VALUE);
+        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, Integer.MAX_VALUE, true);
     }
 
     @VisibleForTesting
@@ -129,7 +128,8 @@ public final class ReadThreadingAssembler {
             correctedReads = assemblyRegion.getReads();
         }
 
-        final List<SeqGraph> nonRefGraphs = new LinkedList<>();
+        final List<ReadThreadingGraph> nonRefRTGraphs = new LinkedList<>();
+        final List<SeqGraph> nonRefSeqGraphs = new LinkedList<>();
         final AssemblyResultSet resultSet = new AssemblyResultSet();
         resultSet.setRegionForGenotyping(assemblyRegion);
         resultSet.setFullReferenceWithPadding(fullReferenceWithPadding);
@@ -137,41 +137,56 @@ public final class ReadThreadingAssembler {
         final SimpleInterval activeRegionExtendedLocation = assemblyRegion.getExtendedSpan();
         refHaplotype.setGenomeLocation(activeRegionExtendedLocation);
         resultSet.add(refHaplotype);
-        final Map<SeqGraph,AssemblyResult> assemblyResultByGraph = new HashMap<>();
+        final Map<ReadThreadingGraph,AssemblyResult> assemblyResultByRTGraph = new HashMap<>();
+        final Map<SeqGraph,AssemblyResult> assemblyResultBySeqGraph = new HashMap<>();
         // create the graphs by calling our subclass assemble method
         for ( final AssemblyResult result : assemble(correctedReads, refHaplotype, header, aligner) ) {
             if ( result.getStatus() == AssemblyResult.Status.ASSEMBLED_SOME_VARIATION ) {
                 // do some QC on the graph
-                sanityCheckGraph(result.getGraph(), refHaplotype);
-                // add it to graphs with meaningful non-reference features
-                assemblyResultByGraph.put(result.getGraph(),result);
-                nonRefGraphs.add(result.getGraph());
+                if (generateSeqGraph) {
+                    sanityCheckGraph(result.getSeqGraph(), refHaplotype);
+                    // add it to graphs with meaningful non-reference features
+                    assemblyResultBySeqGraph.put(result.getSeqGraph(),result);
+                    nonRefSeqGraphs.add(result.getSeqGraph());
+                } else {
+                    sanityCheckGraph(result.getThreadingGraph(), refHaplotype);
+                    // add it to graphs with meaningful non-reference features
+                    assemblyResultByRTGraph.put(result.getThreadingGraph(),result);
+                    nonRefRTGraphs.add(result.getThreadingGraph());
+                }
+
             }
         }
 
         // add assembled alt haplotypes to the {@code resultSet}
-        findBestPaths(nonRefGraphs, refHaplotype, refLoc, activeRegionExtendedLocation, assemblyResultByGraph, resultSet, aligner);
+        if (generateSeqGraph) {
+            findBestPaths(nonRefSeqGraphs, refHaplotype, refLoc, activeRegionExtendedLocation, assemblyResultBySeqGraph, resultSet, aligner);
+        } else {
+            findBestPaths(nonRefRTGraphs, refHaplotype, refLoc, activeRegionExtendedLocation, assemblyResultByRTGraph, resultSet, aligner);
+        }
 
         // print the graphs if the appropriate debug option has been turned on
-        if ( graphOutputPath != null ) { printGraphs(nonRefGraphs); }
+        if ( graphOutputPath != null ) { printGraphs(nonRefSeqGraphs); }
 
         return resultSet;
     }
 
-    private List<Haplotype> findBestPaths(final Collection<SeqGraph> graphs, final Haplotype refHaplotype, final SimpleInterval refLoc, final SimpleInterval activeRegionWindow,
-                                          final Map<SeqGraph, AssemblyResult> assemblyResultByGraph, final AssemblyResultSet assemblyResultSet, final SmithWatermanAligner aligner) {
+    private <V extends  BaseVertex, E extends BaseEdge, T extends BaseGraph<V, E>>
+    List<Haplotype> findBestPaths(final Collection<T> graphs, final Haplotype refHaplotype, final SimpleInterval refLoc, final SimpleInterval activeRegionWindow,
+                                          final Map<T, AssemblyResult> assemblyResultByGraph, final AssemblyResultSet assemblyResultSet, final SmithWatermanAligner aligner) {
         // add the reference haplotype separately from all the others to ensure that it is present in the list of haplotypes
         final Set<Haplotype> returnHaplotypes = new LinkedHashSet<>();
 
         final int activeRegionStart = refHaplotype.getAlignmentStartHapwrtRef();
         int failedCigars = 0;
 
-        for( final SeqGraph graph : graphs ) {
-            final SeqVertex source = graph.getReferenceSourceVertex();
-            final SeqVertex sink = graph.getReferenceSinkVertex();
+        for( final BaseGraph<V, E> graph : graphs ) {
+            final V source = graph.getReferenceSourceVertex();
+            final V sink = graph.getReferenceSinkVertex();
             Utils.validateArg( source != null && sink != null, () -> "Both source and sink cannot be null but got " + source + " and sink " + sink + " for graph " + graph);
 
-            for (final KBestHaplotype kBestHaplotype : new KBestHaplotypeFinder(graph,source,sink).findBestHaplotypes(numBestHaplotypesPerGraph)) {
+            for (final KBestHaplotype<V, E> kBestHaplotype :
+                    new KBestHaplotypeFinder<V, E>(graph,source,sink).findBestHaplotypes(numBestHaplotypesPerGraph)) {
                 final Haplotype h = kBestHaplotype.haplotype();
                 if( !returnHaplotypes.contains(h) ) {
                     if (kBestHaplotype.isReference()) {
@@ -257,6 +272,21 @@ public final class ReadThreadingAssembler {
         }
     }
 
+    private AssemblyResult getResultSetForRTGraph(final ReadThreadingGraph rtGraph) {
+
+        // The graph has degenerated in some way, so the reference source and/or sink cannot be id'd.  Can
+        // happen in cases where for example the reference somehow manages to acquire a cycle, or
+        // where the entire assembly collapses back into the reference sequence.
+        if ( rtGraph.getReferenceSourceVertex() == null || rtGraph.getReferenceSinkVertex() == null ) {
+            return new AssemblyResult(AssemblyResult.Status.JUST_ASSEMBLED_REFERENCE, null, rtGraph);
+        }
+
+        rtGraph.removePathsNotConnectedToRef();
+
+        return new AssemblyResult(AssemblyResult.Status.ASSEMBLED_SOME_VARIATION, null, rtGraph);
+    }
+
+    // Performs the various transformations necessary on a sequence graph
     private AssemblyResult cleanupSeqGraph(final SeqGraph seqGraph) {
         printDebugGraphTransform(seqGraph, "sequenceGraph.1.dot");
 
@@ -454,25 +484,48 @@ public final class ReadThreadingAssembler {
 
         printDebugGraphTransform(rtgraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.1.cleaned_readthreading_graph.dot");
 
-        final SeqGraph initialSeqGraph = rtgraph.toSequenceGraph();
-        if (debugGraphTransformations) {
-            initialSeqGraph.printGraph(new File(debugGraphOutputPath, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.1.initial_seqgraph.dot"), 10000);
-        }
+        // Either return an assembly result with a sequence graph or with an unchanged sequence graph deptending on the kmer duplication behavior
+        if (generateSeqGraph) {
+            final SeqGraph initialSeqGraph = rtgraph.toSequenceGraph();
+            if (debugGraphTransformations) {
+                rtgraph.printGraph(new File(debugGraphOutputPath, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.1.initial_seqgraph.dot"), 10000);
+            }
 
-        // if the unit tests don't want us to cleanup the graph, just return the raw sequence graph
-        if ( justReturnRawGraph ) {
-            return new AssemblyResult(AssemblyResult.Status.ASSEMBLED_SOME_VARIATION, initialSeqGraph, null);
-        }
+            // if the unit tests don't want us to cleanup the graph, just return the raw sequence graph
+            if (justReturnRawGraph) {
+                return new AssemblyResult(AssemblyResult.Status.ASSEMBLED_SOME_VARIATION, initialSeqGraph, null);
+            }
 
-        if ( debug ) {
-            logger.info("Using kmer size of " + rtgraph.getKmerSize() + " in read threading assembler");
-        }
-        printDebugGraphTransform(initialSeqGraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.2.initial_seqgraph.dot");
-        initialSeqGraph.cleanNonRefPaths(); // TODO -- I don't this is possible by construction
+            if (debug) {
+                logger.info("Using kmer size of " + rtgraph.getKmerSize() + " in read threading assembler");
+            }
+            printDebugGraphTransform(initialSeqGraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.2.initial_seqgraph.dot");
+            initialSeqGraph.cleanNonRefPaths(); // TODO -- I don't this is possible by construction
 
-        final AssemblyResult cleaned = cleanupSeqGraph(initialSeqGraph);
-        final AssemblyResult.Status status = cleaned.getStatus();
-        return new AssemblyResult(status, cleaned.getGraph(), rtgraph);
+            final AssemblyResult cleaned = cleanupSeqGraph(initialSeqGraph);
+            final AssemblyResult.Status status = cleaned.getStatus();
+            return new AssemblyResult(status, cleaned.getSeqGraph(), rtgraph);
+
+        } else {
+            if (debugGraphTransformations) {
+                rtgraph.printGraph(new File(debugGraphOutputPath, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.1.initial_seqgraph.dot"), 10000);
+            }
+
+            // if the unit tests don't want us to cleanup the graph, just return the raw sequence graph
+            if (justReturnRawGraph) {
+                return new AssemblyResult(AssemblyResult.Status.ASSEMBLED_SOME_VARIATION, null, rtgraph);
+            }
+
+            if (debug) {
+                logger.info("Using kmer size of " + rtgraph.getKmerSize() + " in read threading assembler");
+            }
+            printDebugGraphTransform(rtgraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.2.initial_seqgraph.dot");
+            rtgraph.cleanNonRefPaths(); // TODO -- I don't this is possible by construction
+
+            final AssemblyResult cleaned = getResultSetForRTGraph(rtgraph);
+            final AssemblyResult.Status status = cleaned.getStatus();
+            return new AssemblyResult(status, null , cleaned.getThreadingGraph());
+        }
     }
 
     @Override
@@ -484,12 +537,12 @@ public final class ReadThreadingAssembler {
      * Print the generated graphs to the graphWriter
      * @param graphs a non-null list of graphs to print out
      */
-    private void printGraphs(final List<SeqGraph> graphs) {
+    private <T extends BaseGraph<?, ?>> void printGraphs(final List<T> graphs) {
         final int writeFirstGraphWithSizeSmallerThan = 50;
 
         try ( final PrintStream graphWriter = new PrintStream(graphOutputPath) ) {
             graphWriter.println("digraph assemblyGraphs {");
-            for ( final SeqGraph graph : graphs ) {
+            for ( final T graph : graphs ) {
                 if ( debugGraphTransformations && graph.getKmerSize() >= writeFirstGraphWithSizeSmallerThan ) {
                     logger.info("Skipping writing of graph with kmersize " + graph.getKmerSize());
                     continue;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -310,9 +310,8 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
             return;
         }
 
-        // determine the kmer size we'll use, and capture the set of nonUniques for that kmer size
-        final NonUniqueResult result = determineKmerSizeAndNonUniques(kmerSize, kmerSize);
-        nonUniqueKmers = result.nonUniques;
+        // Capture the set of non-unique kmers for the given kmer size (if applicable)
+        nonUniqueKmers = determineNonUniques(kmerSize);
 
         if ( DEBUG_NON_UNIQUE_CALC ) {
             logger.info("using " + kmerSize + " kmer size for this assembly with the following non-uniques");
@@ -426,15 +425,6 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
             this.danglingPathString = danglingPathString;
             this.referencePathString = referencePathString;
             this.cigar = cigar;
-        }
-    }
-
-    /** structure that keeps track of the non-unique kmers for a given kmer size */
-    private static final class NonUniqueResult {
-        final Set<Kmer> nonUniques;
-
-        private NonUniqueResult(final Set<Kmer> nonUniques) {
-            this.nonUniques = nonUniques;
         }
     }
 
@@ -872,7 +862,7 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      *
      * @param start   the reference vertex to start from
      * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
-     * @param blacklistedEdges edges to ignore in the traversal down; useful to exclude the non-reference dangling paths
+     * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
      * @return the path (non-null, non-empty)
      */
     private List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
@@ -992,44 +982,30 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * among all sequences added to the current graph.  Will always return a result for maxKmerSize if
      * all smaller kmers had non-unique kmers.
      *
-     * @param minKmerSize the minimum kmer size to consider when constructing the graph
-     * @param maxKmerSize the maximum kmer size to consider
+     * @param kmerSize the kmer size to check for non-unique kmers of
      * @return a non-null NonUniqueResult
      */
-    private NonUniqueResult determineKmerSizeAndNonUniques(final int minKmerSize, final int maxKmerSize) {
+    private Set<Kmer> determineNonUniques(final int kmerSize) {
         final Collection<SequenceForKmers> withNonUniques = getAllPendingSequences();
         final Set<Kmer> nonUniqueKmers = new HashSet<>();
 
-        // go through the sequences and determine which kmers aren't unique within each read
-        for (int kmerSize = minKmerSize ; kmerSize <= maxKmerSize; kmerSize++) {
-            // clear out set of non-unique kmers
-            nonUniqueKmers.clear();
+        // loop over all sequences that have non-unique kmers in them from the previous iterator
+        final Iterator<SequenceForKmers> it = withNonUniques.iterator();
+        while ( it.hasNext() ) {
+            final SequenceForKmers sequenceForKmers = it.next();
 
-            // loop over all sequences that have non-unique kmers in them from the previous iterator
-            final Iterator<SequenceForKmers> it = withNonUniques.iterator();
-            while ( it.hasNext() ) {
-                final SequenceForKmers sequenceForKmers = it.next();
-
-                // determine the non-unique kmers for this sequence
-                final Collection<Kmer> nonUniquesFromSeq = determineNonUniqueKmers(sequenceForKmers, kmerSize);
-                if ( nonUniquesFromSeq.isEmpty() ) {
-                    // remove this sequence from future consideration
-                    it.remove();
-                } else {
-                    // keep track of the non-uniques for this kmerSize, and keep it in the list of sequences that have non-uniques
-                    nonUniqueKmers.addAll(nonUniquesFromSeq);
-                }
-            }
-
-            if ( nonUniqueKmers.isEmpty() )
-                // this kmerSize produces no non-unique sequences, so go ahead and use it for our assembly
-            {
-                break;
+            // determine the non-unique kmers for this sequence
+            final Collection<Kmer> nonUniquesFromSeq = determineNonUniqueKmers(sequenceForKmers, kmerSize);
+            if ( nonUniquesFromSeq.isEmpty() ) {
+                // remove this sequence from future consideration
+                it.remove();
+            } else {
+                // keep track of the non-uniques for this kmerSize, and keep it in the list of sequences that have non-uniques
+                nonUniqueKmers.addAll(nonUniquesFromSeq);
             }
         }
 
-        // necessary because the loop breaks with kmerSize = max + 1
-        return new NonUniqueResult(nonUniqueKmers);
+        return nonUniqueKmers;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -986,26 +986,9 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * @return a non-null NonUniqueResult
      */
     private Set<Kmer> determineNonUniques(final int kmerSize) {
-        final Collection<SequenceForKmers> withNonUniques = getAllPendingSequences();
-        final Set<Kmer> nonUniqueKmers = new HashSet<>();
-
-        // loop over all sequences that have non-unique kmers in them from the previous iterator
-        final Iterator<SequenceForKmers> it = withNonUniques.iterator();
-        while ( it.hasNext() ) {
-            final SequenceForKmers sequenceForKmers = it.next();
-
-            // determine the non-unique kmers for this sequence
-            final Collection<Kmer> nonUniquesFromSeq = determineNonUniqueKmers(sequenceForKmers, kmerSize);
-            if ( nonUniquesFromSeq.isEmpty() ) {
-                // remove this sequence from future consideration
-                it.remove();
-            } else {
-                // keep track of the non-uniques for this kmerSize, and keep it in the list of sequences that have non-uniques
-                nonUniqueKmers.addAll(nonUniquesFromSeq);
-            }
-        }
-
-        return nonUniqueKmers;
+        return getAllPendingSequences().stream()
+                .flatMap(seq -> determineNonUniqueKmers(seq, kmerSize).stream())
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -232,6 +232,42 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         }
     }
 
+
+    /*
+     * Minimal test that the non-seq graph haplotype detection code is equivalent using either seq graphs or kmer graphs
+     *
+     *  NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
+     *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
+     *        sites, which is illustrated by this test. Use this mode at your own risk.
+     */
+    @Test(dataProvider="HaplotypeCallerTestInputs", enabled = false)
+    public void testGVCFModeIsConsistentWithPastResultsUsingKmerGraphs(final String inputFileName, final String referenceFileName) throws Exception {
+        Utils.resetRandomGenerator();
+
+        final File output = createTempFile("testGVCFModeIsConsistentWithPastResults", ".g.vcf");
+        final File expected = new File(TEST_FILES_DIR, "expected.testGVCFMode.gatk4.g.vcf");
+
+        final String outputPath = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected.getAbsolutePath() : output.getAbsolutePath();
+
+        final String[] args = {
+                "-I", inputFileName,
+                "-R", referenceFileName,
+                "-L", "20:10000000-10100000",
+                "-O", outputPath,
+                "-ERC", "GVCF",
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "--disable-sequence-graph-simplification",
+                "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"
+        };
+
+        runCommandLine(args);
+
+        // Test for an exact match against past results
+        if ( ! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(output, expected);
+        }
+    }
+
     /*
      * Test that in GVCF mode we're consistent with past GATK4 results using AS_ annotations
      *

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
@@ -99,9 +99,9 @@ public class CommonSuffixMergerUnitTest extends GATKBaseTest {
     };
 
     public static void assertSameHaplotypes(final String name, final SeqGraph actual, final SeqGraph original) {
-        final List<Haplotype> sortedOriginalKBestHaplotypes = new KBestHaplotypeFinder(original).findBestHaplotypes().stream()
+        final List<Haplotype> sortedOriginalKBestHaplotypes = new KBestHaplotypeFinder<>(original).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
-        final List<Haplotype> sortedActualKBestHaplotypes = new KBestHaplotypeFinder(actual).findBestHaplotypes().stream()
+        final List<Haplotype> sortedActualKBestHaplotypes = new KBestHaplotypeFinder<>(actual).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
         try {
             Assert.assertEquals(sortedActualKBestHaplotypes, sortedOriginalKBestHaplotypes);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -260,7 +260,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
             assembler.setDebugGraphTransformations(true);
             assembler.setDebugGraphOutputPath(createTempDir("debugGraphs"));
             final SeqGraph graph = assembler.assemble(reads, refHaplotype, header, SmithWatermanJavaAligner
-                    .getInstance()).get(0).getGraph();
+                    .getInstance()).get(0).getSeqGraph();
             if ( DEBUG ) graph.printGraph(new File("test.dot"), 0);
             return graph;
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
@@ -381,7 +381,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         final SeqGraph seqGraph = rtgraph.toSequenceGraph();
         seqGraph.simplifyGraph();
 
-        final List<String> paths = new KBestHaplotypeFinder(seqGraph).findBestHaplotypes().stream()
+        final List<String> paths = new KBestHaplotypeFinder<>(seqGraph).findBestHaplotypes().stream()
                 .map(kBestHaplotype -> new String(kBestHaplotype.getBases()))
                 .distinct()
                 .sorted()


### PR DESCRIPTION
This is an experimental feature that is intended to help with ongoing debruijn graph work. Currently there are differences in how the KBestHaplotypeFinder parses non-seq graphs that result in poor behavior at complicated sites. 

Resolves #5956 