### PR TITLE
 Changed cr.igv.seg output of ModelSegments to give log2 Segment_Mean.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
@@ -146,7 +146,7 @@ import java.util.stream.Stream;
  *         and the corresponding entry rows that can be plotted using IGV (see
  *         <a href="https://software.broadinstitute.org/software/igv/SEG">
  *             https://software.broadinstitute.org/software/igv/SEG</a>).
- *         The posterior medians of the copy ratio and minor-allele fraction are given in the SEGMENT_MEAN
+ *         The posterior medians of the log2 copy ratio and minor-allele fraction are given in the SEGMENT_MEAN
  *         columns in the .cr.igv.seg and .af.igv.seg files, respectively.
  *     </li>
  *     <li>
@@ -552,7 +552,7 @@ public final class ModelSegments extends CommandLineProgram {
                                 metadata.getSampleName(),
                                 s.getInterval(),
                                 s.getNumPointsCopyRatio(),
-                                Math.pow(2., s.getLog2CopyRatioSimplePosteriorSummary().getDecile50())))
+                                s.getLog2CopyRatioSimplePosteriorSummary().getDecile50()))
                         .collect(Collectors.toList()));
         final LegacySegmentCollection alleleFractionLegacySegments = new LegacySegmentCollection(
                 metadata,

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/CalledLegacySegmentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/CalledLegacySegmentCollection.java
@@ -95,7 +95,7 @@ public final class CalledLegacySegmentCollection extends AbstractSampleLocatable
     @Override
     public void write(final File outputFile) {
         Utils.nonNull(outputFile);
-        try (final RecordWriter recordWriter = new RecordWriter(new FileWriter(outputFile, true))) {
+        try (final RecordWriter recordWriter = new RecordWriter(new FileWriter(outputFile))) {
             recordWriter.writeAllRecords(getRecords());
         } catch (final IOException e) {
             throw new UserException.CouldNotCreateOutputFile(outputFile, e);

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/LegacySegmentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/LegacySegmentCollection.java
@@ -80,7 +80,7 @@ public final class LegacySegmentCollection extends AbstractSampleLocatableCollec
     @Override
     public void write(final File outputFile) {
         Utils.nonNull(outputFile);
-        try (final RecordWriter recordWriter = new RecordWriter(new FileWriter(outputFile, true))) {
+        try (final RecordWriter recordWriter = new RecordWriter(new FileWriter(outputFile))) {
             recordWriter.writeAllRecords(getRecords());
         } catch (final IOException e) {
             throw new UserException.CouldNotCreateOutputFile(outputFile, e);


### PR DESCRIPTION
Also changed LegacySegmentCollection and CalledLegacySegmentCollection writers to overwrite instead of append.  (This was fixed for AbstractRecordCollection writers in an earlier PR but was missed in these collections that override the default writer.)

See https://gatkforums.broadinstitute.org/gatk/discussion/24048/a-few-things-need-help-about-output-of-command-modelsegments#latest for some context.  In principle, IGV should be able to handle linear scaling, but it scales automatically for seg files and I'm not sure if you can get around it without some additional steps.  Seems easier to just output log2 copy ratios.  (Perhaps we initially output linear copy ratios to maintain backwards compatibility with previous versions of GATK CNV?  If so, the *LegacySegmentCollections seem to be pulling double duty, since we use them to provide IGV compatibility.  In any case, we are currently inconsistent between ModelSegments and CallCopyRatioSegments, as I noted in the forum post.) 

@LeeTL1220 any objections?  If downstream scripts are consuming the IGV output of ModelSegments, they should be adjusted if necessary.