### PR TITLE
BaseRecalibratorSpark fails on a cluster due to system classloader issue

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
@@ -84,13 +84,16 @@ public final class Resource {
      */
     public static File getResourceContentsAsFile(final String resourcePath) throws IOException {
         final File tmpResourceFile = File.createTempFile("tmp_read_resource_", ".config");
-        final InputStream systemResourceAsStream = ClassLoader.getSystemResourceAsStream(resourcePath);
+        InputStream resourceAsStream = ClassLoader.getSystemResourceAsStream(resourcePath);
 
-        if (systemResourceAsStream == null) {
-            throw new GATKException("Null value when trying to read system resource.  Cannot find: " + resourcePath);
+        if (resourceAsStream == null) {
+            resourceAsStream = Resource.class.getClassLoader().getResourceAsStream(resourcePath);
+            if (resourceAsStream == null) {
+                throw new GATKException("Null value when trying to read resource.  Cannot find: " + resourcePath);
+            }
         }
 
-        FileUtils.copyInputStreamToFile(systemResourceAsStream,
+        FileUtils.copyInputStreamToFile(resourceAsStream,
                 tmpResourceFile);
         return tmpResourceFile;
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/Resource.java
@@ -84,13 +84,11 @@ public final class Resource {
      */
     public static File getResourceContentsAsFile(final String resourcePath) throws IOException {
         final File tmpResourceFile = File.createTempFile("tmp_read_resource_", ".config");
-        InputStream resourceAsStream = ClassLoader.getSystemResourceAsStream(resourcePath);
+        // use current classloader rather than system classloader to support dynamic environments like Spark executors
+        final InputStream resourceAsStream = Resource.class.getClassLoader().getResourceAsStream(resourcePath);
 
         if (resourceAsStream == null) {
-            resourceAsStream = Resource.class.getClassLoader().getResourceAsStream(resourcePath);
-            if (resourceAsStream == null) {
-                throw new GATKException("Null value when trying to read resource.  Cannot find: " + resourcePath);
-            }
+            throw new GATKException("Null value when trying to read resource.  Cannot find: " + resourcePath);
         }
 
         FileUtils.copyInputStreamToFile(resourceAsStream,


### PR DESCRIPTION
The problem is that Spark executors can't rely on the system classloader to load resources. This change falls back to the current classloader if the resource can't be loaded from the system classloader. I've tested it successfully on a cluster.

