### PR TITLE
fixed a bug where normal p value argument in FilterMutectCalls was static

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/M2FiltersArgumentCollection.java
@@ -178,7 +178,7 @@ public class M2FiltersArgumentCollection {
     public double initialLogPriorOfVariantVersusArtifact = DEFAULT_INITIAL_LOG_PRIOR_OF_VARIANT_VERSUS_ARTIFACT;
 
     @Argument(fullName = NORMAL_P_VALUE_THRESHOLD_LONG_NAME, optional = true, doc = "P value threshold for normal artifact filter")
-    public static final double normalPileupPValueThreshold = DEFAULT_NORMAL_P_VALUE_THRESHOLD;
+    public double normalPileupPValueThreshold = DEFAULT_NORMAL_P_VALUE_THRESHOLD;
 
     @Argument(fullName = MIN_POLYMERASE_SLIPPAGE_LENGTH, optional = true, doc = "Minimum number of reference bases in an STR to suspect polymerase slippage")
     public int minSlippageLength = DEFAULT_MIN_SLIPPAGE_LENGTH;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/Mutect2FilteringEngine.java
@@ -206,7 +206,7 @@ public class Mutect2FilteringEngine {
         filters.add(new StrandArtifactFilter());
         filters.add(new ContaminationFilter(MTFAC.contaminationTables, MTFAC.contaminationEstimate));
         filters.add(new PanelOfNormalsFilter());
-        filters.add(new NormalArtifactFilter());
+        filters.add(new NormalArtifactFilter(MTFAC.normalPileupPValueThreshold));
         filters.add(new NRatioFilter(MTFAC.nRatio));
         filters.add(new StrictStrandBiasFilter(MTFAC.minReadsOnEachStrand));
         filters.add(new ReadPositionFilter(MTFAC.minMedianReadPosition));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/NormalArtifactFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/NormalArtifactFilter.java
@@ -16,6 +16,11 @@ public class NormalArtifactFilter extends Mutect2VariantFilter {
     private static final double MIN_NORMAL_ARTIFACT_RATIO = 0.1;    // don't call normal artifact if allele fraction in normal is much smaller than allele fraction in tumor
     private static final int IMPUTED_NORMAL_BASE_QUALITY = 30;  // only used if normal base quality annotation fails somehow
 
+    private final double normalPileupPValueThreshold;
+    public NormalArtifactFilter(final double normalPileupPValueThreshold) {
+        this.normalPileupPValueThreshold = normalPileupPValueThreshold;
+    }
+
     @Override
     public ErrorType errorType() { return ErrorType.ARTIFACT; }
 
@@ -50,7 +55,7 @@ public class NormalArtifactFilter extends Mutect2VariantFilter {
         final double normalPValue = 1 - new BinomialDistribution(null, normalDepth, QualityUtils.qualToErrorProb(medianRefBaseQuality))
                 .cumulativeProbability(normalAltDepth - 1);
 
-        return normalPValue < M2FiltersArgumentCollection.normalPileupPValueThreshold ? 1.0 : normalArtifactProbability;
+        return normalPValue < normalPileupPValueThreshold ? 1.0 : normalArtifactProbability;
     }
 
     @Override


### PR DESCRIPTION
@takutosato Silly error on my part.  Made the argument parser crash whenever the argument was set to a non-default value.

@Closes #5978.