### PR TITLE
Fixed CNV plotting script to allow spaces in input filenames.

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/CNVPlottingLibrary.R
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/CNVPlottingLibrary.R
@@ -3,7 +3,7 @@ ReadTSV = function(tsv_file) {
     # however, the standard 'fread("grep ...")' causes issues with the default Docker container, so we use a temporary file.
     # See https://github.com/broadinstitute/gatk/issues/4140.
     temp_file = tempfile()
-    system(sprintf("grep -v ^@ %s > %s", tsv_file, temp_file))
+    system(sprintf('grep -v ^@ "%s" > %s', tsv_file, temp_file))
     return(suppressWarnings(fread(temp_file, sep="\t", stringsAsFactors=FALSE, header=TRUE, check.names=FALSE, data.table=FALSE, showProgress=FALSE, verbose=FALSE)))
 }
 


### PR DESCRIPTION
Encountered this when doing some work on Google Colab, where your Google Drive is frustratingly named `/content/gdrive/My Drive/Colab Notebooks/`.  It's possible that other funky business could still break this, but it's an improvement.