### PR TITLE
Remove Beta label from some Spark tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountBasesSpark.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -48,7 +47,6 @@ import java.io.PrintStream;
         programGroup = CoverageAnalysisProgramGroup.class
 )
 @DocumentedFeature
-@BetaFeature
 public final class CountBasesSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -47,7 +46,6 @@ import java.util.List;
  * </pre>
  */
 @DocumentedFeature
-@BetaFeature
 @CommandLineProgramProperties(
         summary = "Counts reads in the input SAM/BAM",
         oneLineSummary = "Counts reads in the input SAM/BAM",

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountVariantsSpark.java
@@ -4,7 +4,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
@@ -22,7 +21,6 @@ import java.util.List;
         oneLineSummary = "CountVariants on Spark",
         programGroup = VariantEvaluationProgramGroup.class)
 @DocumentedFeature
-@BetaFeature
 public final class CountVariantsSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
@@ -3,7 +3,6 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -43,7 +42,6 @@ import java.io.PrintStream;
  *     -O statistics.txt
  * </pre>
  */
-@BetaFeature
 @DocumentedFeature
 @CommandLineProgramProperties(
         summary = "Spark tool to accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set," +

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
@@ -15,7 +15,6 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 @CommandLineProgramProperties(summary = "Print reads from the input BAM", oneLineSummary = "PrintReads on Spark", programGroup = ReadDataManipulationProgramGroup.class)
 @DocumentedFeature
-@BetaFeature
 public final class PrintReadsSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintVariantsSpark.java
@@ -43,7 +43,6 @@ import java.io.IOException;
         oneLineSummary = "Prints out variants from the input VCF.",
         programGroup = VariantManipulationProgramGroup.class)
 @DocumentedFeature
-@BetaFeature
 public final class PrintVariantsSpark extends VariantWalkerSpark {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Now that Disq runs tests on 'large' BAM and VCF files (https://github.com/disq-bio/disq/pull/103), we can remove the Beta label from some more of the Spark tools.