### PR TITLE
Refactor two VariantEval methods to allow subclasses to override

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
@@ -414,7 +414,7 @@ public class VariantEval extends MultiVariantWalker {
             for ( Class<? extends VariantEvaluator> ec : evaluationClasses )
                 if ( vs.getIncompatibleEvaluators().contains(ec) )
                     throw new CommandLineException.BadArgumentValue("ST and ET",
-                            "The selected stratification " + vs.getName() + 
+                            "The selected stratification " + vs.getName() +
                                     " and evaluator " + ec.getSimpleName() +
                                     " are incompatible due to combinatorial memory requirements." +
                                     " Please disable one");
@@ -427,9 +427,19 @@ public class VariantEval extends MultiVariantWalker {
 
         logger.info("Creating " + stratManager.size() + " combinatorial stratification states");
         for ( int i = 0; i < stratManager.size(); i++ ) {
-            EvaluationContext ec = new EvaluationContext(this, evaluationObjects);
+            EvaluationContext ec = createEvaluationContext(evaluationObjects);
             stratManager.set(i, ec);
         }
+    }
+
+    /**
+     * Create the EvaluationContext (new instance) for the provided set of VariantEvaluators.
+     *
+     * @param evaluationObjects The list of VariantEvaluator classes
+     * @return The EvaluationContext for this set of VariantEvaluator classes
+     */
+    protected EvaluationContext createEvaluationContext(final Set<Class<? extends VariantEvaluator>> evaluationObjects) {
+        return new EvaluationContext(this, evaluationObjects);
     }
 
     private class PositionAggregator {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantEvaluator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantEvaluator.java
@@ -11,6 +11,10 @@ public abstract class VariantEvaluator implements Comparable<VariantEvaluator> {
     private VariantEval walker;
     private final String simpleName;
 
+    protected VariantEvaluator(String simpleName) {
+        this.simpleName = simpleName;
+    }
+
     protected VariantEvaluator() {
         this.simpleName = getClass().getSimpleName();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/util/EvaluationContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/util/EvaluationContext.java
@@ -10,13 +10,14 @@ import org.broadinstitute.hellbender.tools.walkers.varianteval.evaluators.Varian
 import org.broadinstitute.hellbender.tools.walkers.varianteval.stratifications.manager.StratificationManager;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-public final class EvaluationContext {
+public class EvaluationContext {
     // NOTE: must be hashset to avoid O(log n) cost of iteration in the very frequently called apply function
     final VariantEval walker;
-    private final ArrayList<VariantEvaluator> evaluationInstances;
+    private final List<VariantEvaluator> evaluationInstances;
     private final Set<Class<? extends VariantEvaluator>> evaluationClasses;
 
     public EvaluationContext(final VariantEval walker, final Set<Class<? extends VariantEvaluator>> evaluationClasses) {
@@ -26,7 +27,7 @@ public final class EvaluationContext {
     private EvaluationContext(final VariantEval walker, final Set<Class<? extends VariantEvaluator>> evaluationClasses, final boolean doInitialize) {
         this.walker = walker;
         this.evaluationClasses = evaluationClasses;
-        this.evaluationInstances = new ArrayList<VariantEvaluator>(evaluationClasses.size());
+        this.evaluationInstances = new ArrayList<>(evaluationClasses.size());
 
         for ( final Class<? extends VariantEvaluator> c : evaluationClasses ) {
             try {
@@ -42,12 +43,30 @@ public final class EvaluationContext {
     }
 
     /**
+     * Return a list of instances of each VariantEvaluator (see getEvaluationClasses).  Note: elements of this list can be null.
+     *
+     * @return The list of VariantEvaluator instances
+     */
+    public List<VariantEvaluator> getEvaluationInstances() {
+        return evaluationInstances;
+    }
+
+    /**
+     * Returns a set of VariantEvaluator classes to be used
+     *
+     * @return The set of VariantEvaluator classes to be used
+     */
+    public Set<Class<? extends VariantEvaluator>> getEvaluationClasses() {
+        return evaluationClasses;
+    }
+
+    /**
      * Returns a sorted set of VariantEvaluators
      *
-     * @return
+     * @return A sorted set of VariantEvaluator instances
      */
     public final TreeSet<VariantEvaluator> getVariantEvaluators() {
-        return new TreeSet<VariantEvaluator>(evaluationInstances);
+        return new TreeSet<>(evaluationInstances);
     }
 
     public final void apply(ReferenceContext referenceContext, ReadsContext readsContext, FeatureContext featureContext, VariantContext comp, VariantContext eval) {


### PR DESCRIPTION
We have a tool, VariantQC, that extends VariantEval.  This PR is a minor refactor to expose the code that creates the list of VariantStratifier and VariantEvaluator objects as protected methods, so subclasses could modify them.  This should have no functional difference on VariantEval itself.  We're hoping to use these changes in order to adapt our tool in response to reviewers, so if there is any way to push these changes we would appreciate it.

