### PR TITLE
implement heuristics that align haplotypes to reads without calling Smith-Waterman

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -699,6 +699,12 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
      */
     public void shutdown() {
         likelihoodCalculationEngine.close();
+
+        //print out alignments
+        System.out.println("TOTAL NUMBER OF ALIGNMENTS:" + aligner.getNumOfAlignments());
+        System.out.println("NO SW:" + aligner.noSW());
+        System.out.println("YES SW:" + aligner.yesSW());
+
         aligner.close();
         if ( haplotypeBAMWriter.isPresent() ) {
             haplotypeBAMWriter.get().close();
@@ -710,8 +716,6 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
                 throw new RuntimeIOException(e);
             }
         }
-
-
     }
 
     private Set<GATKRead> filterNonPassingReads( final AssemblyRegion activeRegion ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -1042,12 +1042,37 @@ public final class Utils {
      * @param query the query sequence
      */
     public static int lastIndexOf(final byte[] reference, final byte[] query) {
+
         int queryLength = query.length;
 
         // start search from the last possible matching position and search to the left
         for (int r = reference.length - queryLength; r >= 0; r--) {
             int q = 0;
             while (q < queryLength && reference[r+q] == query[q]) {
+                q++;
+            }
+            if (q == queryLength) {
+                return r;
+            }
+        }
+        return -1;
+    }
+
+    public static int lastIndexOfOneMismatch(final byte[] reference, final byte[] query)
+    {
+        int queryLength = query.length;
+
+        boolean oneMismatch;
+
+        // start search from the last possible matching position and search to the left
+        for (int r = reference.length - queryLength; r >= 0; r--) {
+            oneMismatch = false;
+            int q = 0;
+            while (q < queryLength && (reference[r+q] == query[q] || oneMismatch == false)) {
+                if (reference[r+q] != query[q])
+                {
+                    oneMismatch = true;
+                }
                 q++;
             }
             if (q == queryLength) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -74,6 +74,7 @@ public final class AlignmentUtils {
 
         // compute the smith-waterman alignment of read -> haplotype
         final SmithWatermanAlignment swPairwiseAlignment = aligner.align(haplotype.getBases(), originalRead.getBases(), CigarUtils.ALIGNMENT_TO_BEST_HAPLOTYPE_SW_PARAMETERS, SWOverhangStrategy.SOFTCLIP);
+
         if ( swPairwiseAlignment.getAlignmentOffset() == -1 ) {
             // sw can fail (reasons not clear) so if it happens just don't realign the read
             return originalRead;

--- a/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SWNativeAlignerWrapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SWNativeAlignerWrapper.java
@@ -25,6 +25,24 @@ public final class SWNativeAlignerWrapper implements SmithWatermanAligner {
         this.aligner = aligner;
     }
 
+
+    //methods for printing out number of SW/non-SW alignments. not needed
+    public int getNumOfAlignments()
+    {
+        System.out.println("SW native wrapper being used");
+        return 0;
+    }
+    public int noSW()
+    {
+        System.out.println("native SW being used");
+        return 0;
+    }
+    public int yesSW()
+    {
+        System.out.println("native SW being used");
+        return 0;
+    }
+
     @Override
     public SmithWatermanAlignment align(final byte[] reference, final byte[] alternate, final SWParameters parameters, final SWOverhangStrategy overhangStrategy){
         long startTime = System.nanoTime();

--- a/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanAligner.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanAligner.java
@@ -28,6 +28,11 @@ public interface SmithWatermanAligner extends Closeable {
      */
     SmithWatermanAlignment align(final byte[] ref, final byte[] alt, SWParameters parameters, SWOverhangStrategy overhangStrategy);
 
+    //methods for printing out number of SW/non-SW alignments
+    int getNumOfAlignments();
+    int noSW();
+    int yesSW();
+
     /**
      * Implementations may optionally implement close in order to release any resources that they are holding.
      *

--- a/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanIntelAligner.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanIntelAligner.java
@@ -45,6 +45,23 @@ public final class SmithWatermanIntelAligner implements SmithWatermanAligner {
         return alignerWrapper.align(reference, alternate, parameters, overhangStrategy);
     }
 
+    //methods for printing out number of SW/non-SW alignments. not needed for now
+    public int getNumOfAlignments()
+    {
+        System.out.println("Intel SW being used");
+        return 0;
+    }
+    public int noSW()
+    {
+        System.out.println("Intel SW being used");
+        return 0;
+    }
+    public int yesSW()
+    {
+        System.out.println("Intel SW being used");
+        return 0;
+    }
+
     /**
      * Close the aligner
      */

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -613,6 +613,75 @@ public final class UtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(result, expected);
     }
 
+    @Test
+    public void testLastIndexOfOneMismatchLastBoundaries() {
+        final String reference = "AAAACCCCTTTTGGGG";
+
+        // match right boundary of reference
+        String query = "TGAGG";
+        int result = Utils.lastIndexOfOneMismatch(reference.getBytes(), query.getBytes());
+        int expected = 11;
+        Assert.assertEquals(result, expected);
+
+        // match left boundary of reference
+        query = "AAGAC";
+        result = Utils.lastIndexOfOneMismatch(reference.getBytes(), query.getBytes());
+        expected = 0;
+        Assert.assertEquals(result, expected);
+    }
+
+    @Test
+    public void testLastIndexOfOneMismatchRandom() {
+        final int num_tests = 100;
+        final int referenceLength = 1000;
+        final int queryLength = 100;
+
+        byte [] reference = new byte[referenceLength];
+        byte [] query = new byte[queryLength];
+
+        final Random rng = Utils.getRandomGenerator();
+
+        for (int i = 0; i < num_tests; i++) {
+            randomByteString(rng, reference);
+            randomByteString(rng, query);
+
+            int index = -1;
+            // add one-off query to reference at a random location for 75% of the tests
+            if (i % 4 > 0) {
+                index = rng.nextInt(referenceLength - queryLength);
+                int mismatch = index + rng.nextInt(queryLength);
+                for (int j = 0; j < queryLength; j++) {
+                    if (index + j == mismatch)
+                    {
+                        if ((char)(query[j] & 0xFF) == 'A')
+                        {
+                            reference[index + j] = (byte)'G';
+                        }
+                        if ((char)(query[j] & 0xFF) == 'G')
+                        {
+                            reference[index + j] = (byte)'C';
+                        }
+                        if ((char)(query[j] & 0xFF) == 'C')
+                        {
+                            reference[index + j] = (byte)'T';
+                        }
+                        if ((char)(query[j] & 0xFF) == 'T')
+                        {
+                            reference[index + j] = (byte)'A';
+                        }
+                    }
+                    else {
+                        reference[index + j] = query[j];
+                    }
+                }
+            }
+
+            final int result = Utils.lastIndexOfOneMismatch(reference, query);
+            final int expected = index;
+            Assert.assertEquals(result, expected);
+        }
+    }
+
     private void randomByteString(Random rng, byte[] bytes) {
         for (int i = 0; i < bytes.length; i++) {
             bytes[i] = (byte)(rng.nextInt(94) + 32);


### PR DESCRIPTION
added counts for Smith-Waterman and non-Smith_Waterman calls
implemented oneMismatch heuristic that aligns reads to haplotypes given a read that only has 1 SNP
added tests for the oneMismatch heuristic