### PR TITLE
Added QC metrics to the Germline CNV workflow

### DIFF
--- a/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
+++ b/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
@@ -30,6 +30,7 @@
   "CNVGermlineCaseScatteredWorkflow.gcnv_max_advi_iter_subsequent_epochs": 1,
   "CNVGermlineCaseScatteredWorkflow.gcnv_max_copy_number": 3,
   "CNVGermlineCaseScatteredWorkflow.gcnv_max_calling_iters": 1,
+  "CNVGermlineCaseScatteredWorkflow.maximum_number_events_per_sample": 120,
   "CNVGermlineCaseScatteredWorkflow.ref_fasta_dict": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_germline_workflows_test_files/Homo_sapiens_assembly19.truncated.dict",
   "CNVGermlineCaseScatteredWorkflow.ref_fasta_fai": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_germline_workflows_test_files/Homo_sapiens_assembly19.truncated.fasta.fai",
   "CNVGermlineCaseScatteredWorkflow.ref_fasta": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/cnv_germline_workflows_test_files/Homo_sapiens_assembly19.truncated.fasta"

--- a/scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
+++ b/scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
@@ -34,5 +34,6 @@
   "CNVGermlineCohortWorkflow.maximum_mappability": 1.0,
   "CNVGermlineCohortWorkflow.minimum_segmental_duplication_content": 0.0,
   "CNVGermlineCohortWorkflow.maximum_segmental_duplication_content": 1.0,
-  "CNVGermlineCohortWorkflow.low_count_filter_count_threshold": 0
+  "CNVGermlineCohortWorkflow.low_count_filter_count_threshold": 0,
+  "CNVGermlineCohortWorkflow.maximum_number_events_per_sample": 120
 }

--- a/scripts/cnv_wdl/germline/README.md
+++ b/scripts/cnv_wdl/germline/README.md
@@ -26,6 +26,7 @@ The reference used must be the same between PoN and case samples.
 - ``CNVGermlineCohortWorkflow.ref_fasta_dict`` -- Path to reference dict file.
 - ``CNVGermlineCohortWorkflow.ref_fasta_fai`` -- Path to reference fasta fai file.
 - ``CNVGermlineCohortWorkflow.ref_fasta`` -- Path to reference fasta file.
+- ``CNVGermlineCohortWorkflow.maximum_number_events_per_sample`` -- Maximum number of events threshold for doing sample QC (recommended for WES is ~100)
 
 In additional, there are optional workflow-level and task-level parameters that may be set by advanced users; for example:
 
@@ -49,6 +50,7 @@ The reference, number of intervals per scatter, and bins (if specified) must be 
 - ``CNVGermlineCaseWorkflow.ref_fasta_dict`` -- Path to reference dict file.
 - ``CNVGermlineCaseWorkflow.ref_fasta_fai`` -- Path to reference fasta fai file.
 - ``CNVGermlineCaseWorkflow.ref_fasta`` -- Path to reference fasta file.
+- ``CNVGermlineCohortWorkflow.maximum_number_events_per_sample`` -- Maximum number of events threshold for doing sample QC (recommended for WES is ~100)
 
 In additional, there are several task-level parameters that may be set by advanced users as above.
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -191,6 +191,7 @@ workflow CNVGermlineCaseScatteredWorkflow {
         Array[Array[File]] gcnv_tracking_tars = CNVGermlineCaseWorkflow.gcnv_tracking_tars
         Array[Array[File]] genotyped_intervals_vcf = CNVGermlineCaseWorkflow.genotyped_intervals_vcf
         Array[Array[File]] genotyped_segments_vcf = CNVGermlineCaseWorkflow.genotyped_segments_vcf
+        Array[Array[File]] qc_status_files = CNVGermlineCaseWorkflow.qc_status_files
     }
 }
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -103,6 +103,11 @@ workflow CNVGermlineCaseScatteredWorkflow {
     Int ref_copy_number_autosomal_contigs
     Array[String]? allosomal_contigs
 
+    ##########################
+    #### arguments for QC ####
+    ##########################
+    Int maximum_number_events_per_sample
+
     call SplitInputArray as SplitInputBamsList {
         input:
             input_array = normal_bams,
@@ -178,7 +183,8 @@ workflow CNVGermlineCaseScatteredWorkflow {
                 gcnv_caller_external_admixing_rate = gcnv_caller_external_admixing_rate,
                 gcnv_disable_annealing = gcnv_disable_annealing,
                 ref_copy_number_autosomal_contigs = ref_copy_number_autosomal_contigs,
-                allosomal_contigs = allosomal_contigs 
+                allosomal_contigs = allosomal_contigs,
+                maximum_number_events_per_sample = maximum_number_events_per_sample
         }
     }
 
@@ -192,6 +198,7 @@ workflow CNVGermlineCaseScatteredWorkflow {
         Array[Array[File]] genotyped_intervals_vcf = CNVGermlineCaseWorkflow.genotyped_intervals_vcf
         Array[Array[File]] genotyped_segments_vcf = CNVGermlineCaseWorkflow.genotyped_segments_vcf
         Array[Array[File]] qc_status_files = CNVGermlineCaseWorkflow.qc_status_files
+        Array[Array[String]] qc_status_strings = CNVGermlineCaseWorkflow.qc_status_strings
     }
 }
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
@@ -233,6 +233,14 @@ workflow CNVGermlineCaseWorkflow {
         }
     }
 
+    call CNVTasks.CollectSampleQualityMetrics {
+        input:
+            genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf,
+            entity_ids = CollectCounts.entity_id,
+            gatk_docker = gatk_docker,
+            preemptible_attempts = preemptible_attempts
+    }
+
     output {
         File preprocessed_intervals = PreprocessIntervals.preprocessed_intervals
         Array[File] read_counts_entity_id = CollectCounts.entity_id
@@ -242,6 +250,7 @@ workflow CNVGermlineCaseWorkflow {
         Array[File] gcnv_tracking_tars = GermlineCNVCallerCaseMode.gcnv_tracking_tar
         Array[File] genotyped_intervals_vcf = PostprocessGermlineCNVCalls.genotyped_intervals_vcf
         Array[File] genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf
+        Array[File] qc_status_files = CollectSampleQualityMetrics.qc_status_files
     }
 }
 

--- a/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
@@ -113,6 +113,11 @@ workflow CNVGermlineCaseWorkflow {
     Int ref_copy_number_autosomal_contigs
     Array[String]? allosomal_contigs
 
+    ##########################
+    #### arguments for QC ####
+    ##########################
+    Int maximum_number_events_per_sample
+
     Array[Pair[String, String]] normal_bams_and_bais = zip(normal_bams, normal_bais)
 
     call CNVTasks.PreprocessIntervals {
@@ -231,14 +236,14 @@ workflow CNVGermlineCaseWorkflow {
                 gatk_docker = gatk_docker,
                 preemptible_attempts = preemptible_attempts
         }
-    }
 
-    call CNVTasks.CollectSampleQualityMetrics {
-        input:
-            genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf,
-            entity_ids = CollectCounts.entity_id,
-            gatk_docker = gatk_docker,
-            preemptible_attempts = preemptible_attempts
+        call CNVTasks.CollectSampleQualityMetrics {
+            input:
+                genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf,
+                entity_id = CollectCounts.entity_id[sample_index],
+                maximum_number_events = maximum_number_events_per_sample,
+                preemptible_attempts = preemptible_attempts
+        }
     }
 
     output {
@@ -250,7 +255,8 @@ workflow CNVGermlineCaseWorkflow {
         Array[File] gcnv_tracking_tars = GermlineCNVCallerCaseMode.gcnv_tracking_tar
         Array[File] genotyped_intervals_vcf = PostprocessGermlineCNVCalls.genotyped_intervals_vcf
         Array[File] genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf
-        Array[File] qc_status_files = CollectSampleQualityMetrics.qc_status_files
+        Array[File] qc_status_files = CollectSampleQualityMetrics.qc_status_file
+        Array[String] qc_status_strings = CollectSampleQualityMetrics.qc_status_string
     }
 }
 

--- a/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
@@ -326,6 +326,21 @@ workflow CNVGermlineCohortWorkflow {
         }
     }
 
+    call CNVTasks.CollectSampleQualityMetrics {
+        input:
+            genotyped_segments_vcf = PostprocessGermlineCNVCalls.genotyped_segments_vcf,
+            entity_ids = CollectCounts.entity_id,
+            gatk_docker = gatk_docker,
+            preemptible_attempts = preemptible_attempts
+    }
+
+    call CNVTasks.CollectModelQualityMetrics {
+        input:
+            gcnv_model_tars = GermlineCNVCallerCohortMode.gcnv_model_tar,
+            gatk_docker = gatk_docker,
+            preemptible_attempts = preemptible_attempts
+    }
+
     output {
         File preprocessed_intervals = PreprocessIntervals.preprocessed_intervals
         Array[File] read_counts_entity_ids = CollectCounts.entity_id
@@ -339,6 +354,8 @@ workflow CNVGermlineCohortWorkflow {
         Array[File] gcnv_tracking_tars = GermlineCNVCallerCohortMode.gcnv_tracking_tar
         Array[File] genotyped_intervals_vcfs = PostprocessGermlineCNVCalls.genotyped_intervals_vcf
         Array[File] genotyped_segments_vcfs = PostprocessGermlineCNVCalls.genotyped_segments_vcf
+        Array[File] sample_qc_status_files = CollectSampleQualityMetrics.qc_status_files
+        File model_qc_status = CollectModelQualityMetrics.qc_status
     }
 }
 


### PR DESCRIPTION
This adds two new tasks that perform QC checks on gCNV output, namely:
- Check that number of events in segments VCFs does not exceed preset value
- Check that not all PCs are used by the model (even if one of the shards fails, the QC status will be negative)

Both tasks output *qc_status.txt file, for each sample and model respectively, and the file will contain string "PASS", or a string describing the fail condition