### PR TITLE
Adding links to download java 8 to the ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ releases of the toolkit.
 
 ## <a name="requirements">Requirements</a>
 * To run GATK:
-    * Java 8
+    * Java 8 is needed to run or build GATK. 
+    We recommend either of the following:
+        * OpenJDK 8 with Hotspot from [AdoptOpenJdk](https://adoptopenjdk.net/)
+        * [OracleJDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+    which requires an Oracle account to download and comes with restrictive [license conditions](https://www.oracle.com/downloads/licenses/javase-license1.html).
     * Python 2.6 or greater (required to run the `gatk` frontend script)
     * Python 3.6.2, along with a set of additional Python packages, is required to run some tools and workflows.
       See [Python Dependencies](#python) for more information.


### PR DESCRIPTION
* Java 8 doesn't come by default on many machines now.  Updating the
README with advice about where to download a java8 jdk.
* Part of https://github.com/broadinstitute/gatk/issues/6024