### PR TITLE
change spark.yarn.executor.memoryOverhead to 

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ You can download and run pre-built versions of GATK4 from the following places:
       -- \
       --spark-runner SPARK --spark-master <master_url> \
       --num-executors 5 --executor-cores 2 --executor-memory 4g \
-      --conf spark.yarn.executor.memoryOverhead=600
+      --conf spark.executor.memoryOverhead=600
     ```
 
 * You can also omit the "--num-executors" argument to enable [dynamic allocation](https://spark.apache.org/docs/latest/job-scheduling.html#dynamic-resource-allocation) if you configure the cluster properly (see the Spark website for instructions).

--- a/gatk
+++ b/gatk
@@ -50,7 +50,7 @@ DEFAULT_SPARK_ARGS = {
     "spark.driver.maxResultSize" : "0",
     "spark.driver.userClassPathFirst" : "false",
     "spark.io.compression.codec" : "lzf",
-    "spark.yarn.executor.memoryOverhead" : "600",
+    "spark.executor.memoryOverhead" : "600",
     "spark.driver.extraJavaOptions" : EXTRA_JAVA_OPTIONS_SPARK,
     "spark.executor.extraJavaOptions" : EXTRA_JAVA_OPTIONS_SPARK
 }

--- a/scripts/sv/run_whole_pipeline.sh
+++ b/scripts/sv/run_whole_pipeline.sh
@@ -94,8 +94,6 @@ case ${GATK_SV_TOOL} in
         ;;
 esac
 
-#   --conf spark.yarn.executor.memoryOverhead=5000 \
-
 "${GATK_DIR}/gatk" ${GATK_SV_TOOL} \
     ${TOOL_OPTIONS} ${SV_ARGS} \
     -- \

--- a/scripts/sv/stepByStep/discoverVariants.sh
+++ b/scripts/sv/stepByStep/discoverVariants.sh
@@ -26,4 +26,4 @@ REF_TWOBIT="${MASTER_NODE}$4"
     --cluster "${CLUSTER_NAME}" \
     --driver-memory 30G \
     --executor-memory 8G \
-    --conf spark.yarn.executor.memoryOverhead=5000
+    --conf spark.executor.memoryOverhead=5000

--- a/scripts/sv/stepByStep/scanBam.sh
+++ b/scripts/sv/stepByStep/scanBam.sh
@@ -39,4 +39,4 @@ ALTS_KILL_LIST=$(echo "${REF_TWOBIT}" | sed 's/.2bit$/.kill.alts/')
     --num-executors 20 \
     --driver-memory 30G \
     --executor-memory 30G \
-    --conf spark.yarn.executor.memoryOverhead=5000
+    --conf spark.executor.memoryOverhead=5000

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkContextFactory.java
@@ -49,7 +49,7 @@ public final class SparkContextFactory {
             .put("spark.driver.maxResultSize", "0")
             .put("spark.driver.userClassPathFirst", "true")
             .put("spark.io.compression.codec", "lzf")
-            .put("spark.yarn.executor.memoryOverhead", "600")
+            .put("spark.executor.memoryOverhead", "600")
             .build();
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
@@ -84,7 +84,7 @@ import java.io.IOException;
  *   --executor-memory 32G \
  *   --num-executors 4 \
  *   --executor-cores 30 \
- *   --conf spark.yarn.executor.memoryOverhead=132000
+ *   --conf spark.executor.memoryOverhead=132000
  * </pre>
  *
  * <p>Note that the microbe BWA image must be copied to the same path on every worker node. The microbe FASTA

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
@@ -97,7 +97,7 @@ import scala.Tuple2;
  *   --executor-memory 32G \
  *   --num-executors 4 \
  *   --executor-cores 15 \
- *   --conf spark.yarn.executor.memoryOverhead=32000
+ *   --conf spark.executor.memoryOverhead=32000
  * </pre>
  *
  * <p>Note that the host BWA image must be copied to the same path on every worker node. The host k-mer file

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSpark.java
@@ -133,7 +133,7 @@ import java.util.List;
  *   --executor-memory 32G \
  *   --num-executors 4 \
  *   --executor-cores 30 \
- *   --conf spark.yarn.executor.memoryOverhead=132000
+ *   --conf spark.executor.memoryOverhead=132000
  * </pre>
  *
  * <p>Note that the host and microbe BWA images must be copied to the same paths on every worker node. The microbe FASTA,

--- a/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
@@ -121,9 +121,9 @@ public interface GATKConfig extends Mutable, Accessible {
     String spark_io_compression_codec();
 
     @SystemProperty
-    @Key("spark.yarn.executor.memoryOverhead")
+    @Key("spark.executor.memoryOverhead")
     @DefaultValue("600")
-    int spark_yarn_executor_memoryOverhead();
+    int spark_executor_memoryOverhead();
 
     @SystemProperty
     @Key("spark.driver.extraJavaOptions")

--- a/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
@@ -49,7 +49,7 @@ samjdk.compression_level = 2
 
 spark.kryoserializer.buffer.max = 512m
 spark.io.compression.codec = lzf
-spark.yarn.executor.memoryOverhead = 600
+spark.executor.memoryOverhead = 600
 
 spark.driver.maxResultSize = 0
 spark.driver.userClassPathFirst = true


### PR DESCRIPTION
spark.executor.memoryOverhead as warned by Spark 2.3

a trivial change.