### PR TITLE
Prototype of JunctionTree based haplotype finding

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/testutils/TestingReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/testutils/TestingReadThreadingGraph.java
@@ -1,7 +1,9 @@
-package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
+package org.broadinstitute.hellbender.testutils;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.*;
@@ -66,7 +68,7 @@ public final class TestingReadThreadingGraph extends ReadThreadingGraph {
         final Matcher pathMatcher = PATH_PATTERN.matcher(pathString);
 
         boolean referenceFound = false;
-        final Map<String,MultiDeBruijnVertex> vertexById = new HashMap<>();
+        final Map<String, MultiDeBruijnVertex> vertexById = new HashMap<>();
 
         // Loop between path strings and add them one by one.
         while (pathMatcher.find()) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
@@ -1,9 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraphInterface;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.AbstractReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
 
 /**
@@ -11,7 +9,7 @@ import org.broadinstitute.hellbender.utils.Utils;
  */
 public final class AssemblyResult {
     private final Status status;
-    private final ReadThreadingGraphInterface threadingGraph;
+    private final AbstractReadThreadingGraph threadingGraph;
     private final SeqGraph graph;
 
     /**
@@ -19,7 +17,7 @@ public final class AssemblyResult {
      * @param status the status, cannot be null
      * @param graph the resulting graph of the assembly, can only be null if result is failed
      */
-    public AssemblyResult(final Status status, final SeqGraph graph, final ReadThreadingGraphInterface threadingGraph) {
+    public AssemblyResult(final Status status, final SeqGraph graph, final AbstractReadThreadingGraph threadingGraph) {
         Utils.nonNull(status, "status cannot be null");
         Utils.validateArg( status == Status.FAILED || (graph != null || threadingGraph != null) , "graph is null but status is " + status);
 
@@ -28,7 +26,7 @@ public final class AssemblyResult {
         this.threadingGraph = threadingGraph;
     }
 
-    public ReadThreadingGraphInterface getThreadingGraph() {
+    public AbstractReadThreadingGraph getThreadingGraph() {
         return threadingGraph;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraphInterface;
 import org.broadinstitute.hellbender.utils.Utils;
 
 /**
@@ -10,7 +11,7 @@ import org.broadinstitute.hellbender.utils.Utils;
  */
 public final class AssemblyResult {
     private final Status status;
-    private final ReadThreadingGraph threadingGraph;
+    private final ReadThreadingGraphInterface threadingGraph;
     private final SeqGraph graph;
 
     /**
@@ -18,7 +19,7 @@ public final class AssemblyResult {
      * @param status the status, cannot be null
      * @param graph the resulting graph of the assembly, can only be null if result is failed
      */
-    public AssemblyResult(final Status status, final SeqGraph graph, final ReadThreadingGraph threadingGraph) {
+    public AssemblyResult(final Status status, final SeqGraph graph, final ReadThreadingGraphInterface threadingGraph) {
         Utils.nonNull(status, "status cannot be null");
         Utils.validateArg( status == Status.FAILED || (graph != null || threadingGraph != null) , "graph is null but status is " + status);
 
@@ -27,7 +28,7 @@ public final class AssemblyResult {
         this.threadingGraph = threadingGraph;
     }
 
-    public ReadThreadingGraph getThreadingGraph() {
+    public ReadThreadingGraphInterface getThreadingGraph() {
         return threadingGraph;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResult.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -19,7 +20,7 @@ public final class AssemblyResult {
      */
     public AssemblyResult(final Status status, final SeqGraph graph, final ReadThreadingGraph threadingGraph) {
         Utils.nonNull(status, "status cannot be null");
-        Utils.validateArg( status == Status.FAILED || graph != null, "graph is null but status is " + status);
+        Utils.validateArg( status == Status.FAILED || (graph != null || threadingGraph != null) , "graph is null but status is " + status);
 
         this.status = status;
         this.graph = graph;
@@ -34,12 +35,12 @@ public final class AssemblyResult {
         return status;
     }
 
-    public SeqGraph getGraph() {
+    public SeqGraph getSeqGraph() {
         return graph;
     }
 
     public int getKmerSize() {
-        return graph.getKmerSize();
+        return graph == null? threadingGraph.getKmerSize() : graph.getKmerSize();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
@@ -5,8 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraphInterface;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.AbstractReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.EventMap;
@@ -434,7 +433,7 @@ public final class AssemblyResultSet {
      *
      * @return {@code null} if there is no read-threading-graph amongst assembly results with that kmerSize.
      */
-    public ReadThreadingGraphInterface getUniqueReadThreadingGraph(final int kmerSize) {
+    public AbstractReadThreadingGraph getUniqueReadThreadingGraph(final int kmerSize) {
         final AssemblyResult assemblyResult = assemblyResultByKmerSize.get(kmerSize);
         if (assemblyResult == null) {
             return null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
@@ -204,7 +204,7 @@ public final class AssemblyResultSet {
 
         for (final Map.Entry<Haplotype,AssemblyResult> e : assemblyResultByHaplotype.entrySet()) {
             final AssemblyResult as = e.getValue();
-            final int kmerSize = as.getGraph().getKmerSize();
+            final int kmerSize = as.getKmerSize();
             if (kmerSizeToCount.containsKey(kmerSize)) {
                 kmerSizeToCount.put(kmerSize,kmerSizeToCount.get(kmerSize) + 1);
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSet.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraphInterface;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.EventMap;
@@ -433,7 +434,7 @@ public final class AssemblyResultSet {
      *
      * @return {@code null} if there is no read-threading-graph amongst assembly results with that kmerSize.
      */
-    public ReadThreadingGraph getUniqueReadThreadingGraph(final int kmerSize) {
+    public ReadThreadingGraphInterface getUniqueReadThreadingGraph(final int kmerSize) {
         final AssemblyResult assemblyResult = assemblyResultByKmerSize.get(kmerSize);
         if (assemblyResult == null) {
             return null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -242,8 +242,8 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         if (originalAlleleCount > practicalAlleleCount) {
             final List<Allele> allelesToKeep = whichAllelesToKeepBasedonHapScores(alleleMapper, practicalAlleleCount);
             alleleMapper.keySet().retainAll(allelesToKeep);
-            logger.warn(String.format("Removed alt alleles where ploidy is %d and original allele count is %d, whereas after trimming the allele count becomes %d. Alleles kept are:%s",
-                    ploidy, originalAlleleCount, practicalAlleleCount, allelesToKeep));
+            logger.warn(String.format("At position %s removed alt alleles where ploidy is %d and original allele count is %d, whereas after trimming the allele count becomes %d. Alleles kept are:%s",
+                    new SimpleInterval(mergedVC).toString(), ploidy, originalAlleleCount, practicalAlleleCount, allelesToKeep));
             return removeExcessAltAllelesFromVC(mergedVC, allelesToKeep);
         } else {
             return mergedVC;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -36,7 +36,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBrujinGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -36,7 +36,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !useLinkedDeBrujinGraph);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBrujinGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !useLinkedDeBrujinGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -22,7 +22,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, !disableSeqGraphConstruciton);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -150,6 +150,17 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Argument(fullName="max-unpruned-variants", doc = "Maximum number of variants in graph the adaptive pruner will allow", optional = true)
     public int maxUnprunedVariants = 100;
 
+    /**
+     * Disables graph simplification into a seq graph. This is experimental and may cause performance issues for the KBestHaplotypeFinder
+     *
+     * NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
+     *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
+     *        sites. Use this mode at your own risk.
+     */
+    @Hidden
+    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified debrujin graph", optional = true)
+    public boolean disableSeqGraphConstruciton = false;
+
     @Advanced
     @Argument(fullName="debug-assembly", shortName="debug", doc="Print out verbose debug information about each assembly region", optional = true)
     public boolean debugAssembly;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -151,14 +151,14 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     public int maxUnprunedVariants = 100;
 
     /**
-     * Disables graph simplification into a seq graph. This is experimental and may cause performance issues for the KBestHaplotypeFinder
+     * Disables graph simplification into a seq graph. This is experimental and may cause performance issues for the GraphBasedKBestHaplotypeFinder
      *
      * NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
      *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
      *        sites. Use this mode at your own risk.
      */
     @Hidden
-    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified debrujin graph", optional = true)
+    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified de Bruijn graph", optional = true)
     public boolean disableSeqGraphConstruciton = false;
 
     @Advanced

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -151,15 +151,15 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     public int maxUnprunedVariants = 100;
 
     /**
-     * Disables graph simplification into a seq graph. This is experimental and may cause performance issues for the GraphBasedKBestHaplotypeFinder
+     * Disables graph simplification into a seq graph, opts to construct a proper De Brujin graph with potential loops
      *
-     * NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
+     * NOTE: --linked-de-bruijn-graph is currently an experimental feature that does not directly match with
      *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
      *        sites. Use this mode at your own risk.
      */
     @Hidden
-    @Argument(fullName="disable-sequence-graph-simplification", doc = "If enabled, haplotype caller will detect haplotypes on the unmodified de Bruijn graph", optional = true)
-    public boolean disableSeqGraphConstruciton = false;
+    @Argument(fullName="linked-de-bruijn-graph", doc = "If enabled, the Assembly Engine will construct a Linked De Brujin graph to recover better haplotypes", optional = true)
+    public boolean useLinkedDeBrujinGraph = false;
 
     @Advanced
     @Argument(fullName="debug-assembly", shortName="debug", doc="Print out verbose debug information about each assembly region", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -137,10 +137,10 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     /**
      * Pull out the additional sequence implied by traversing this node in the graph
      * @param v the vertex from which to pull out the additional base sequence
-     * @param isSource if true, treat v as a source vertex regardless of graph in degree
+     * @param isSource if true, treat v as a source vertex regardless of in-degree
      * @return  non-null byte array
      */
-    public final byte[] getAdditionalSequence( final V v, final boolean isSource) {
+    public static final byte[] getAdditionalSequence( final BaseVertex v, final boolean isSource) {
         Utils.nonNull(v, "Attempting to pull sequence from a null vertex.");
         return v.getAdditionalSequence(isSource);
     }
@@ -190,14 +190,14 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     /**
      * @return the reference source vertex pulled from the graph, can be null if it doesn't exist in the graph
      */
-    public final V getReferenceSourceVertex( ) {
+    public V getReferenceSourceVertex( ) {
         return vertexSet().stream().filter(v -> isRefSource(v)).findFirst().orElse(null);
     }
 
     /**
      * @return the reference sink vertex pulled from the graph, can be null if it doesn't exist in the graph
      */
-    public final V getReferenceSinkVertex( ) {
+    public V getReferenceSinkVertex( ) {
         return vertexSet().stream().filter(v -> isRefSink(v)).findFirst().orElse(null);
     }
 
@@ -262,7 +262,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
      * @param includeStop   should the ending vertex be included in the path
      * @return              byte[] array holding the reference bases, this can be null if there are no nodes between the starting and ending vertex (insertions for example)
      */
-    public final byte[] getReferenceBytes( final V fromVertex, final V toVertex, final boolean includeStart, final boolean includeStop ) {
+    public byte[] getReferenceBytes( final V fromVertex, final V toVertex, final boolean includeStart, final boolean includeStop ) {
         Utils.nonNull(fromVertex, "Starting vertex in requested path cannot be null.");
         Utils.nonNull(toVertex, "From vertex in requested path cannot be null.");
 
@@ -409,9 +409,16 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
             graphWriter.println(String.format("\t%s [label=\"%s\",shape=box]", v.toString(), new String(getAdditionalSequence(v)) + v.getAdditionalInfo()));
         }
 
+        getExtraGraphFileLines().forEach(graphWriter::println);
+
         if ( writeHeader ) {
             graphWriter.println("}");
         }
+    }
+
+    // Extendable method intended to allow for adding extra material to the graph
+    public List<String> getExtraGraphFileLines() {
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -135,6 +135,17 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
     }
 
     /**
+     * Pull out the additional sequence implied by traversing this node in the graph
+     * @param v the vertex from which to pull out the additional base sequence
+     * @param isSource if true, treat v as a source vertex regardless of graph in degree
+     * @return  non-null byte array
+     */
+    public final byte[] getAdditionalSequence( final V v, final boolean isSource) {
+        Utils.nonNull(v, "Attempting to pull sequence from a null vertex.");
+        return v.getAdditionalSequence(isSource);
+    }
+
+    /**
      * @param v the vertex to test
      * @return  true if this vertex is a reference source
      */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/GraphBasedKBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/GraphBasedKBestHaplotypeFinder.java
@@ -1,0 +1,91 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.jgrapht.alg.CycleDetector;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Efficient algorithm to obtain the list of best haplotypes given the {@link BaseGraph instance}.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public class GraphBasedKBestHaplotypeFinder<V extends BaseVertex, E extends BaseEdge> extends KBestHaplotypeFinder<V, E> {
+
+    public final Comparator<KBestHaplotype<V, E>> K_BEST_HAPLOTYPE_COMPARATOR = Comparator.comparingDouble(KBestHaplotype<V, E>::score)
+            .reversed()
+            .thenComparing(KBestHaplotype<V, E>::getBases, BaseUtils.BASES_COMPARATOR.reversed()); // This is an arbitrary deterministic tie breaker.
+
+    /**
+     * Constructs a new best haplotypes finder.
+     *
+     * @param graph the graph to search.
+     * @param sources source vertices for all haplotypes.
+     * @param sinks sink vertices for all haplotypes.
+     *
+     * @throws IllegalArgumentException if <ul>
+     *     <li>any of {@code graph}, {@code sources} or {@code sinks} is {@code null} or</li>
+     *     <li>any of {@code sources}' or any {@code sinks}' member is not a vertex in {@code graph}.</li>
+     * </ul>
+     */
+    public GraphBasedKBestHaplotypeFinder(final BaseGraph<V, E> graph, final Set<V> sources, final Set<V> sinks) {
+        super(sinks, sources, graph);
+    }
+
+    /**
+     * Constructor for the special case of a single source and sink
+     */
+    public GraphBasedKBestHaplotypeFinder(final BaseGraph<V, E> graph, final V source, final V sink) {
+        this(graph, Collections.singleton(source), Collections.singleton(sink));
+    }
+
+    /**
+     * Constructor for the default case of all sources and sinks
+     */
+    public GraphBasedKBestHaplotypeFinder(final BaseGraph<V, E> graph) {
+        this(graph, graph.getSources(), graph.getSinks());
+    }
+
+    @Override
+    public boolean keepCycles() {
+        return false;
+    }
+
+    /**
+     * Implement Dijkstra's algorithm as described in https://en.wikipedia.org/wiki/K_shortest_path_routing
+     */
+    @Override
+    public List<KBestHaplotype<V, E>> findBestHaplotypes(final int maxNumberOfHaplotypes) {
+        final List<KBestHaplotype<V, E>> result = new ArrayList<>();
+        final PriorityQueue<KBestHaplotype<V, E>> queue = new PriorityQueue<>(K_BEST_HAPLOTYPE_COMPARATOR);
+        sources.forEach(source -> queue.add(new KBestHaplotype<>(source, graph)));
+
+        final Map<V, MutableInt> vertexCounts = graph.vertexSet().stream()
+                .collect(Collectors.toMap(v -> v, v -> new MutableInt(0)));
+
+        while (!queue.isEmpty() && result.size() < maxNumberOfHaplotypes) {
+            final KBestHaplotype<V, E> pathToExtend = queue.poll();
+            final V vertexToExtend = pathToExtend.getLastVertex();
+            if (sinks.contains(vertexToExtend)) {
+                result.add(pathToExtend);
+            } else {
+                if (vertexCounts.get(vertexToExtend).getAndIncrement() < maxNumberOfHaplotypes) {
+                    final Set<E> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+                    int totalOutgoingMultiplicity = 0;
+                    for (final BaseEdge edge : outgoingEdges) {
+                        totalOutgoingMultiplicity += edge.getMultiplicity();
+                    }
+
+                    for (final E edge : outgoingEdges) {
+                        queue.add(new KBestHaplotype<>(pathToExtend, edge, totalOutgoingMultiplicity));
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JTBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JTBestHaplotype.java
@@ -1,0 +1,233 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
+
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.JunctionTreeLinkedDeBruinGraph;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A best haplotype object for being used with junction trees.
+ *
+ * Each path holds a list of all the junction trees describing its current path. This list consists of pointers to nodes
+ * in the junction trees corresponding to the paths that have already been taken by the JTBestHaplotype object.
+ *
+ * In order to invoke the junction trees simply call {@link #getApplicableNextEdgesBasedOnJunctionTrees} which will return a list
+ * of cloned path objects corresponding to each path present in the eldest tree. This method handles popping old trees with insufficient
+ * data off of the list as well as incrementing all of the trees in the list to point at the next element based on the chosen path.
+ */
+public class JTBestHaplotype<V extends BaseVertex, E extends BaseEdge> extends KBestHaplotype<V, E> {
+    private JunctionTreeManager junctionTreeManager; // An object for storing and managing operations on the queue of junction trees active for this path
+    private int decisionEdgesTakenSinceLastJunctionTreeEvidence;
+
+    // NOTE, this constructor is used by JunctionTreeKBestHaplotypeFinder, in both cases paths are chosen by non-junction tree paths
+    public JTBestHaplotype(final JTBestHaplotype<V, E> previousPath, final List<E> edgesToExtend, final double edgePenalty) {
+        super(previousPath, edgesToExtend, edgePenalty);
+        junctionTreeManager = new JunctionTreeManager(previousPath.junctionTreeManager);
+        decisionEdgesTakenSinceLastJunctionTreeEvidence = junctionTreeManager.hasJunctionTreeEvidence() ? 0 : previousPath.decisionEdgesTakenSinceLastJunctionTreeEvidence;
+    }
+
+    // Constructor to be used for internal calls from {@link #getApplicableNextEdgesBasedOnJunctionTrees()}
+    private JTBestHaplotype(final JTBestHaplotype<V, E> previousPath, final List<E> chain, final int edgeMultiplicity, final int totalOutgoingMultiplicity, final boolean thisPathBasedOnJT) {
+        super(previousPath, chain, computeLogPenaltyScore( edgeMultiplicity, totalOutgoingMultiplicity));
+        junctionTreeManager = new JunctionTreeManager(previousPath.junctionTreeManager);
+        junctionTreeManager.traverseEdgeForAllTrees(chain.get(chain.size() - 1));
+        // I'm aware that the chain is only an estimate of the proper length, especially if we got here due to being under the weight threshold for a given tree... the chain lenght is a heuristic as it is...
+        decisionEdgesTakenSinceLastJunctionTreeEvidence = thisPathBasedOnJT ? 0 : previousPath.decisionEdgesTakenSinceLastJunctionTreeEvidence + 1;
+    }
+
+    // JTBestHaplotype constructor for construction an entirely new haplotype builder.
+    public JTBestHaplotype(final V initialVertex, final BaseGraph<V,E> graph) {
+        super(initialVertex, graph);
+        junctionTreeManager = new JunctionTreeManager();
+        decisionEdgesTakenSinceLastJunctionTreeEvidence = 0;
+    }
+
+    public boolean hasJunctionTreeEvidence() {
+        return junctionTreeManager.hasJunctionTreeEvidence();
+    }
+
+    // returns true if there is a symbolic edge pointing to the reference end or if there is insufficient node data
+    public boolean hasStoppingEvidence(final int weightThreshold) {
+
+        // Traverse the non-empty trees until we find one with evidence over our threshold. If we ever find a symbolic end vertex then we stop.
+        for (JunctionTreeLinkedDeBruinGraph.ThreadingNode tree : junctionTreeManager.removeEmptyNodesAndReturnIterator()) {
+            int totalOut = getTotalOutForBranch(tree);
+
+            // Are any of these vertexes symbolic stops?
+            if (tree.getChildrenNodes().values().stream()
+                    .anyMatch(JunctionTreeLinkedDeBruinGraph.ThreadingNode::isSymbolicEnd)) {
+                return true;
+            }
+            if ( totalOut >= weightThreshold) {
+                return false;
+            }
+        }
+
+        // None of our junction trees cover the stop vertex, close it
+        return true;
+    }
+
+    // Tally the total outgoing weight for a particular branch
+    private static int getTotalOutForBranch(final JunctionTreeLinkedDeBruinGraph.ThreadingNode eldestTree) {
+        return eldestTree == null ? 0 : eldestTree.getChildrenNodes().values().stream()
+                .mapToInt(JunctionTreeLinkedDeBruinGraph.ThreadingNode::getEvidenceCount).sum();
+    }
+
+    /**
+     * This method is the primary logic of deciding how to traverse junction paths and with what score.
+     *
+     * TODO this will likely change to use the eldest tree regardless of threshold passage
+     * This method checks the list of junction tree nodes, looking first at the eldest tree to perform the following:
+     *  - Checks the total outgoing weight, if its below weight threshold then the tree is popped and a new tree is considered
+     *  - For each path in the oldest tree clones this path with the chain edges added, taking the edge target for each path present in the tree.
+     *
+     * @param chain List of edges to add between the current path and the junction tree edge
+     * @param weightThreshold threshold of evidence under which old junction trees are discarded.
+     * @return A list of new RTBestHaplotypeObjects corresponding to each path chosen from the exisitng junction trees,
+     *         or an empty list if there is no path illuminated by junction trees.
+     */
+    //TODO for reviewer - is this the best way to structure this? I'm not sure how to decide about end nodes based on this, passing them back seesm wrong
+    @SuppressWarnings({"unchecked"})
+    public List<JTBestHaplotype<V, E>> getApplicableNextEdgesBasedOnJunctionTrees(final List<E> chain, final Set<E> outgoingEdges, final int weightThreshold) {
+        Set<MultiSampleEdge> edgesAccountedForByJunctionTrees = new HashSet<>(); // Since we check multiple junction trees for paths, keep track of which paths we have taken to adding duplicate paths to the graph
+        List<JTBestHaplotype<V, E>> output = new ArrayList<>();
+        for ( JunctionTreeLinkedDeBruinGraph.ThreadingNode tree : junctionTreeManager.removeEmptyNodesAndReturnIterator()) {
+            int totalOut = getTotalOutForBranch(tree);
+
+            // If the total evidence emerging from a given branch
+            for (Map.Entry<MultiSampleEdge, JunctionTreeLinkedDeBruinGraph.ThreadingNode> childNode : tree.getChildrenNodes().entrySet()) {
+                if (!outgoingEdges.contains(childNode.getKey())) {
+                    throw new GATKException("While constructing graph, there was an incongruity between a JunctionTree edge and the edge present on graph traversal");
+                }
+
+                // Don't add edges to the symbolic end vertex here at all, that's handled by {@link #hasStoppingEvidence()}, also don't add the same edge again if we pulled it in from a younger tree.
+                if (!childNode.getValue().isSymbolicEnd() && // ignore symbolic end branches, those are handled elsewhere
+                        !edgesAccountedForByJunctionTrees.contains(childNode.getKey())) {
+                    edgesAccountedForByJunctionTrees.add(childNode.getKey());
+                    JunctionTreeLinkedDeBruinGraph.ThreadingNode child = childNode.getValue();
+                    List<E> chainCopy = new ArrayList<>(chain);
+                    chainCopy.add((E) childNode.getKey());
+                    output.add(new JTBestHaplotype<>(this, chainCopy, child.getEvidenceCount(), totalOut, true));
+                }
+            }
+
+            // If there isn't enough outgoing evidence, then we poll the next oldest tree for evidence
+            // This is done to alleviate the problem that the oldest junction tree may have little evidence and drop connectivity
+            // information better represented by one of the younger trees in the path.
+            if (totalOut >= weightThreshold) {
+                return output;
+            }
+        }
+        // If we hit this point, then eldestTree == null, suggesting that none of the nodes exceeded our threshold for evidence (though some may have found evidence)
+        // Standard behavior from the old GraphBasedKBestHaplotypeFinder, base our next path on the edge weights instead
+        int totalOutgoingMultiplicity = 0;
+        for (final BaseEdge edge : outgoingEdges) {
+            totalOutgoingMultiplicity += edge.getMultiplicity();
+        }
+
+        // Add all valid edges to the graph
+        for (final E edge : outgoingEdges) {
+            // Don't traverse an edge if it only has reference evidence supporting it (unless there is no other evidence whatsoever)
+            if (!edgesAccountedForByJunctionTrees.contains((MultiSampleEdge) edge) &&
+                    totalOutgoingMultiplicity != 0 && edge.getMultiplicity() != 0) {
+
+                // TODO better justify this to myself and others
+                // only include ref edges with multiplicity of 1 (i.e. only the ref read spanned it) if there are no other choices at this site (from Junction trees or otherwise)
+                if ((edge.isRef() && edge.getMultiplicity() == 1) &&
+                        !(edgesAccountedForByJunctionTrees.isEmpty() && outgoingEdges.size() < 2)) { // no junction tree evidence and only one ref path to take
+                    continue;
+                }
+
+                List<E> chainCopy = new ArrayList<>(chain);
+                chainCopy.add(edge);
+                output.add(new JTBestHaplotype<>(this, chainCopy, edge.getMultiplicity(), totalOutgoingMultiplicity, false));
+            }
+        }
+        return output;
+    }
+
+    /**
+     * Return an accounting of how many edge decision (where there is a choice) have consecutively been based on the raw graph weights
+     * (as opposed to being based on junction tree evidence).
+     *
+     * @return number of decision edges
+     */
+    public int getDecisionEdgesTakenSinceLastJunctionTreeEvidence() {
+        return decisionEdgesTakenSinceLastJunctionTreeEvidence;
+    }
+
+    /**
+     * Add a junction tree (corresponding to the current vertex for traversal, note that if a tree has already been visited by this path then it is ignored)
+     * @param junctionTreeForNode Junction tree to add
+     */
+    public void addJunctionTree(final JunctionTreeLinkedDeBruinGraph.ThreadingTree junctionTreeForNode) {
+        if (junctionTreeManager.addJunctionTree(junctionTreeForNode)) {
+            decisionEdgesTakenSinceLastJunctionTreeEvidence = 0;
+        }
+    }
+
+    /**
+     * A helper class for managing the various junction tree operations that need to be done by JTBestHaplotypeFinder
+     *
+     * This class tracks traversing all active trees simultaneously so the right corresponding nodes are accounted for in every case.
+     * It also keeps track of the previously visited trees so we can save ourselves from double-counting evidence from a particular tree.
+     */
+    private class JunctionTreeManager {
+        Set<JunctionTreeLinkedDeBruinGraph.ThreadingTree> visitedTrees;
+        List<JunctionTreeLinkedDeBruinGraph.ThreadingNode> activeNodes;
+
+        protected JunctionTreeManager() {
+            visitedTrees = new HashSet<>();
+            activeNodes = new ArrayList<>(5);
+        }
+
+        protected JunctionTreeManager(JunctionTreeManager toCopy) {
+            this.visitedTrees = new HashSet<>(toCopy.visitedTrees);
+            this.activeNodes = new ArrayList<>(toCopy.activeNodes);
+        }
+
+        // Add a junction tree, ensuring that there is a valid tree in order to check.
+        // NOTE: this method filters out empty trees or trees that have already been visited on this path
+        // Return true if the tree was informative and was actually added
+        public boolean addJunctionTree(final JunctionTreeLinkedDeBruinGraph.ThreadingTree junctionTreeForNode) {
+            if (!visitedTrees.contains(junctionTreeForNode) && !junctionTreeForNode.getRootNode().hasNoEvidence()) {
+                visitedTrees.add(junctionTreeForNode);
+                activeNodes.add(junctionTreeForNode.getRootNode());
+                return true;
+            }
+            return false;
+        }
+
+        // method to handle incrementing all of the nodes in the tree simultaneously
+        public void traverseEdgeForAllTrees(E edgeTaken) {
+            activeNodes = activeNodes.stream()
+                    .filter(node -> node.getChildrenNodes().containsKey(edgeTaken))
+                    .map(node -> node.getChildrenNodes().get(edgeTaken))
+                    .filter(node -> !node.hasNoEvidence())
+                    .collect(Collectors.toList());
+        }
+
+        // Returns an iterable list of nodes that have sufficient data in the tree (performs pruning of empty nodes)
+        public Iterable<JunctionTreeLinkedDeBruinGraph.ThreadingNode> removeEmptyNodesAndReturnIterator() {
+            activeNodes = activeNodes.stream().filter(node -> getTotalOutForBranch(node) > 0).collect(Collectors.toList());
+            return activeNodes;
+        }
+
+        private JunctionTreeLinkedDeBruinGraph.ThreadingNode get(int i) {
+            return activeNodes.get(i);
+        }
+
+        private int size() {
+            return activeNodes == null ? 0 : activeNodes.size();
+        }
+
+        private void removeOldestTree() {
+            activeNodes.remove(0);
+        }
+
+        public boolean hasJunctionTreeEvidence() {
+            return !activeNodes.isEmpty();
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JunctionTreeKBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JunctionTreeKBestHaplotypeFinder.java
@@ -1,0 +1,191 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.JunctionTreeLinkedDeBruinGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class JunctionTreeKBestHaplotypeFinder<V extends BaseVertex, E extends BaseEdge> extends KBestHaplotypeFinder<V, E> {
+    public static final int DEFAULT_OUTGOING_JT_EVIDENCE_THRESHOLD_TO_BELEIVE = 3;
+    public static final int DEFAULT_MINIMUM_WEIGHT_FOR_JT_BRANCH_TO_NOT_BE_PRUNED = 2;
+    public static final int DEFAULT_MAX_ACCEPTABLE_DECISION_EDGES_WITHOUT_JT_GUIDANCE = 7;
+    public static final int DEFAULT_MAX_ACCEPTABLE_REPETITIONS_OF_A_KMER_IN_A_PATH = 10;
+    private int weightThreshold = DEFAULT_OUTGOING_JT_EVIDENCE_THRESHOLD_TO_BELEIVE;
+
+    // List for mapping vertexes that start chains of kmers that do not diverge, used to cut down on repeated graph traversal
+    Map<V, List<E>> graphKmerChainCache = new HashMap<>();
+
+    // Graph to be operated on, in this case cast as an JunctionTreeLinkedDeBruinGraph
+    JunctionTreeLinkedDeBruinGraph junctionTreeLinkedDeBruinGraph;
+
+    public JunctionTreeKBestHaplotypeFinder(final BaseGraph<V, E> graph, final Set<V> sources, Set<V> sinks, final int branchWeightThreshold) {
+        super(sinks, sources, graph);
+        Utils.validate(graph instanceof JunctionTreeLinkedDeBruinGraph, "JunctionTreeKBestHaplotypeFinder requires an JunctionTreeLinkedDeBruinGraph be provided");
+        junctionTreeLinkedDeBruinGraph = (JunctionTreeLinkedDeBruinGraph) graph;
+        ParamUtils.isPositive(weightThreshold, "Pruning Weight Threshold must be a positive number greater than 0");
+    }
+
+    /**
+     * Constructor for the special case of a single source and sink
+     */
+    public JunctionTreeKBestHaplotypeFinder(final BaseGraph<V, E> graph, final V source, final V sink) {
+        this(graph, Collections.singleton(source), Collections.singleton(sink), DEFAULT_OUTGOING_JT_EVIDENCE_THRESHOLD_TO_BELEIVE);
+    }
+
+    /**
+     * Constructor for the special case of a single source and sink
+     */
+    public JunctionTreeKBestHaplotypeFinder(final BaseGraph<V, E> graph, final V source, final V sink, final int branchWeightThreshold) {
+        this(graph, Collections.singleton(source), Collections.singleton(sink), branchWeightThreshold);
+    }
+
+    /**
+     * Constructor for the default case of all sources and sinks
+     */
+    public JunctionTreeKBestHaplotypeFinder(final BaseGraph<V, E> graph) {
+        this(graph, graph.getReferenceSourceVertex(), graph.getReferenceSinkVertex());
+    }
+
+    @Override
+    public boolean keepCycles() {
+        return true;
+    }
+
+    @VisibleForTesting
+    public JunctionTreeKBestHaplotypeFinder<V, E> setWeightThreshold(final int outgoingWeight) {
+        Utils.validate(weightThreshold > 0, "Pruning Weight Threshold must be a positive number greater than 0");
+        weightThreshold = outgoingWeight;
+        return this;
+    }
+
+    /**
+     * The primary engine for finding haplotypes based on junction trees.
+     *
+     * Best haplotypes are discovered by a modified Djikstra's algorithm. Paths are genearated from the reference start
+     * kmer and proceed forward until they encounter one of the following stop conditions and are treated accordingly:
+     *  (1) Encounter a kmer with a JunctionTree - In this case the junction tree is added to a JunctionTree queue maintained
+     *                                             by the KBestHaplotypePath.
+     *  (2) Encounter a kmer with out degree > 1 - In this case we consult the oldest JunctionTree in the experimental path,
+     *                                             and add new KBestHaplotypePaths to the Queue for each branch on the tree
+     *                                             for that node with weights calculated based on edge weight in the junction tree.
+     *                                             If the eldest tree has insufficient data then it is popped off the queue and a younger
+     *                                             tree is consulted, if no younger tree is consulted then the raw graph edge
+     *                                             weights for the fork are used to generate paths instead.
+     *  (3) Encounter a ReferenceSink - If a reference sink is encountered, close out the path and add it to the results. TODO this will be subjected to change
+     *
+     * Note: A cache is maintained of vertexes to contiguous sequences of paths in order to cut down on repeated traversal
+     *       of the same segments of the graph for each path.
+     *
+     * @param maxNumberOfHaplotypes maximum number of haplotypes to discover.
+     * @return A list of the best scoring haplotypes for hte GraphBasedKBestHaplotypeFinder
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public List<KBestHaplotype<V, E>> findBestHaplotypes(final int maxNumberOfHaplotypes) {
+        final List<JTBestHaplotype<V, E>> result = new ArrayList<>();
+        final PriorityQueue<JTBestHaplotype<V, E>> queue = new PriorityQueue<>(Comparator.comparingDouble(KBestHaplotype<V, E>::score).reversed());
+        sources.forEach(source -> queue.add(new JTBestHaplotype<>(source, graph)));
+
+        // Iterate over paths in the queue, unless we are out of paths of maxHaplotypes to find
+        while (!queue.isEmpty() && result.size() < maxNumberOfHaplotypes) {
+            final JTBestHaplotype<V, E> pathToExtend = queue.poll();
+
+            // This safeguards against infinite loops and degenerate excessively long paths, only allow 4 decisions without junction tree guidance
+            if (pathToExtend.getDecisionEdgesTakenSinceLastJunctionTreeEvidence() > DEFAULT_MAX_ACCEPTABLE_DECISION_EDGES_WITHOUT_JT_GUIDANCE) {
+                continue;
+            }
+            ////////////////////////////////////////////////////////////
+            // code to discover where the next interesting node is
+            ////////////////////////////////////////////////////////////
+            V vertexToExtend = pathToExtend.getLastVertex();
+            Set<E> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+
+            // Check if we have cached the current vertex in a contiguous sequence
+            final List<E> chain = graphKmerChainCache.computeIfAbsent(vertexToExtend, k -> new ArrayList<>());
+            // if not, step forward until a vertex meets one of conditions (1), (2), or (3) are met
+            if (chain.isEmpty()){
+                // Keep going until we reach a fork, reference sink, or fork
+                while ( outgoingEdges.size() == 1 && // Case (2)
+                        !junctionTreeLinkedDeBruinGraph.getJunctionTreeForNode((MultiDeBruijnVertex) vertexToExtend).isPresent() && // Case (1)
+                        !sinks.contains(vertexToExtend))// Case (3)
+                    {
+                    final E edge = outgoingEdges.iterator().next();
+                    // Defensive check for looping edges, don't extend the chain in such a way as to create loops, let other code handle that
+                    if (chain.contains(edge)) {
+                        break;
+                    }
+                    chain.add(edge);
+                    vertexToExtend = graph.getEdgeTarget(edge);
+                    outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+                }
+                // Cache the chain result
+                graphKmerChainCache.put(pathToExtend.getLastVertex(), chain);
+
+            } else {
+                // We have already expanded this part of the graph, use it.
+                vertexToExtend = graph.getEdgeTarget(chain.get(chain.size() - 1));
+                outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+            }
+            // vertexToExtend and outgoingEdges are necessarily at the next "interesting" point
+
+
+            ////////////////////////////////////////////////////////////
+            // code to decide what to do at that interesting node
+            ////////////////////////////////////////////////////////////
+            // In the event we have a junction tree on top of a vertex with outDegree > 1, we add this first before we traverse paths
+            junctionTreeLinkedDeBruinGraph.getJunctionTreeForNode((MultiDeBruijnVertex) vertexToExtend).ifPresent(pathToExtend::addJunctionTree);
+
+            //TODO this can probabaly be 100% consumed by getApplicableNextEdgesBasedOnJunctionTrees() as a check... that would simplify things somewhat
+            // If we are at a reference end then we close out the path
+            if (sinks.contains(vertexToExtend) && pathToExtend.hasStoppingEvidence(weightThreshold)) {
+                //TODO this will probably be resolved using a junction tree on that node and treating it as an edge to extend
+                //todo the proposal here would be to check if there is an active tree left for us at this point and if so keep going
+                if (chain.isEmpty()) {
+                    result.add(pathToExtend);
+                } else {
+                    result.add(new JTBestHaplotype<>(pathToExtend, chain, 0));
+                }
+            }
+            // NOTE: even if we are at the reference stop and there is evidence in the junction trees of a stop we still want to explore other edges potentially
+
+            // We must be at a point where the path diverges, use junction trees to resolve if possible
+            if (outgoingEdges.size() > 1) {
+                List<JTBestHaplotype<V, E>> jTPaths = pathToExtend.getApplicableNextEdgesBasedOnJunctionTrees(chain, outgoingEdges, weightThreshold);
+                if (jTPaths.isEmpty() && !sinks.contains(vertexToExtend)) {
+//                    throw new GATKException("Found no path based on the junction trees or exisiting paths, this should not have happened");
+                    System.out.println("Found nothing Queue has this many: "+queue.size()+"\nPath that failed to extend was junction tree: "+pathToExtend.getVertices());
+                }
+                queue.addAll(jTPaths);
+
+            // Otherwise just take the next node forward
+            } else {
+                // If there are no outgoing edges from this node, then just kill this branch from the queue
+                // NOTE: this branch in the future might be responsible for dangling end merging
+                if (outgoingEdges.size() > 0) {
+                    //TODO evaluate the expense of asking this quesion, there are ways to mitigate the cost. This particuar case is almost always triggered
+                    // Defensive check, if we see the same vertex
+                    final V finalVertexToExtend = vertexToExtend;
+                    if (!pathToExtend.hasJunctionTreeEvidence() &&
+                            pathToExtend.getVertices()
+                                    .stream()
+                                    .filter(v -> v.equals(finalVertexToExtend))
+                                    .count() > DEFAULT_MAX_ACCEPTABLE_REPETITIONS_OF_A_KMER_IN_A_PATH) {
+                        // do nothing
+                    } else {
+                        // otherwie add the path
+                        List<E> chainCopy = new ArrayList<>(chain);
+                        chainCopy.add(outgoingEdges.iterator().next());
+                        queue.add(new JTBestHaplotype<>(pathToExtend, chainCopy, 0));
+                    }
+                }
+            }
+        }
+
+        return result.stream().map(n -> (KBestHaplotype<V, E>) n).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
@@ -9,19 +10,19 @@ import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotype extends Path<SeqVertex,BaseEdge>{
+public final class KBestHaplotype<T extends BaseVertex, E extends BaseEdge> extends Path<T, E>{
     private double score;
     private boolean isReference;
 
     public double score() { return score; }
     public boolean isReference() { return isReference; }
 
-    public KBestHaplotype(final SeqVertex initialVertex, final BaseGraph<SeqVertex,BaseEdge> graph) {
+    public KBestHaplotype(final T initialVertex, final BaseGraph<T,E> graph) {
         super(initialVertex, graph);
         score = 0;
     }
 
-    public KBestHaplotype(final KBestHaplotype p, final BaseEdge edge, final int totalOutgoingMultiplicity) {
+    public KBestHaplotype(final KBestHaplotype p, final E edge, final int totalOutgoingMultiplicity) {
         super(p, edge);
         score = p.score() + MathUtils.log10(edge.getMultiplicity()) - MathUtils.log10(totalOutgoingMultiplicity);
         isReference &= edge.isRef();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotype.java
@@ -1,31 +1,41 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.utils.MathUtils;
-import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+
+import java.util.List;
 
 /**
  * Represents a result from a K-best haplotype search.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotype<T extends BaseVertex, E extends BaseEdge> extends Path<T, E>{
+public class KBestHaplotype<V extends BaseVertex, E extends BaseEdge> extends Path<V, E>{
     private double score;
     private boolean isReference;
 
     public double score() { return score; }
     public boolean isReference() { return isReference; }
 
-    public KBestHaplotype(final T initialVertex, final BaseGraph<T,E> graph) {
+    public KBestHaplotype(final V initialVertex, final BaseGraph<V,E> graph) {
         super(initialVertex, graph);
         score = 0;
     }
 
-    public KBestHaplotype(final KBestHaplotype p, final E edge, final int totalOutgoingMultiplicity) {
+    public KBestHaplotype(final KBestHaplotype<V, E> p, final E edge, final int totalOutgoingMultiplicity) {
         super(p, edge);
-        score = p.score() + MathUtils.log10(edge.getMultiplicity()) - MathUtils.log10(totalOutgoingMultiplicity);
+        score = p.score + computeLogPenaltyScore( edge.getMultiplicity(), totalOutgoingMultiplicity);
         isReference &= edge.isRef();
+    }
+
+    public static double computeLogPenaltyScore(int edgeMultiplicity, int totalOutgoingMultiplicity) {
+        return MathUtils.log10(edgeMultiplicity) - MathUtils.log10(totalOutgoingMultiplicity);
+    }
+
+    public KBestHaplotype(final KBestHaplotype<V, E> p, final List<E> edgesToExtend, final double edgePenalty) {
+        super(p, edgesToExtend);
+        score = p.score() + edgePenalty;
+        isReference &= edgesToExtend.get(edgesToExtend.size() - 1).isRef();
     }
 
     public final Haplotype haplotype() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
@@ -2,6 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.jgrapht.alg.CycleDetector;
 
@@ -13,14 +15,14 @@ import java.util.stream.Collectors;
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
-public final class KBestHaplotypeFinder {
+public final class KBestHaplotypeFinder<V extends BaseVertex, E extends BaseEdge> {
 
     public static final Comparator<KBestHaplotype> K_BEST_HAPLOTYPE_COMPARATOR = Comparator.comparingDouble(KBestHaplotype::score)
             .reversed()
-            .thenComparing(KBestHaplotype::getBases, BaseUtils.BASES_COMPARATOR.reversed()); // This is an arbitrary deterministic tie breaker. 
-    private final SeqGraph graph;
-    final Set<SeqVertex> sinks;
-    final Set<SeqVertex> sources;
+            .thenComparing(KBestHaplotype::getBases, BaseUtils.BASES_COMPARATOR.reversed()); // This is an arbitrary deterministic tie breaker.
+    private final BaseGraph<V, E> graph;
+    final Set<V> sinks;
+    final Set<V> sources;
 
     /**
      * Constructs a new best haplotypes finder.
@@ -34,7 +36,7 @@ public final class KBestHaplotypeFinder {
      *     <li>any of {@code sources}' or any {@code sinks}' member is not a vertex in {@code graph}.</li>
      * </ul>
      */
-    public KBestHaplotypeFinder(final SeqGraph graph, final Set<SeqVertex> sources, final Set<SeqVertex> sinks) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph, final Set<V> sources, final Set<V> sinks) {
         Utils.nonNull(graph, "graph cannot be null");
         Utils.nonNull(sources, "sources cannot be null");
         Utils.nonNull(sinks, "sinks cannot be null");
@@ -54,51 +56,51 @@ public final class KBestHaplotypeFinder {
     /**
      * Constructor for the special case of a single source and sink
      */
-    public KBestHaplotypeFinder(final SeqGraph graph, final SeqVertex source, final SeqVertex sink) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph, final V source, final V sink) {
         this(graph, Collections.singleton(source), Collections.singleton(sink));
     }
 
     /**
      * Constructor for the default case of all sources and sinks
      */
-    public KBestHaplotypeFinder(final SeqGraph graph) {
+    public KBestHaplotypeFinder(final BaseGraph<V, E> graph) {
         this(graph, graph.getSources(), graph.getSinks());
     }
 
     /**
      * Implement Dijkstra's algorithm as described in https://en.wikipedia.org/wiki/K_shortest_path_routing
      */
-    public List<KBestHaplotype> findBestHaplotypes(final int maxNumberOfHaplotypes) {
-        final List<KBestHaplotype> result = new ArrayList<>();
-        final PriorityQueue<KBestHaplotype> queue = new PriorityQueue<>(K_BEST_HAPLOTYPE_COMPARATOR);
-        sources.forEach(source -> queue.add(new KBestHaplotype(source, graph)));
+    public List<KBestHaplotype<V, E>> findBestHaplotypes(final int maxNumberOfHaplotypes) {
+        final List<KBestHaplotype<V, E>> result = new ArrayList<>();
+        final PriorityQueue<KBestHaplotype<V, E>> queue = new PriorityQueue<>(K_BEST_HAPLOTYPE_COMPARATOR).reversed());
+        sources.forEach(source -> queue.add(new KBestHaplotype<>(source, graph)));
 
-        final Map<SeqVertex, MutableInt> vertexCounts = graph.vertexSet().stream()
+        final Map<V, MutableInt> vertexCounts = graph.vertexSet().stream()
                 .collect(Collectors.toMap(v -> v, v -> new MutableInt(0)));
 
         while (!queue.isEmpty() && result.size() < maxNumberOfHaplotypes) {
-            final KBestHaplotype pathToExtend = queue.poll();
-            final SeqVertex vertexToExtend = pathToExtend.getLastVertex();
+            final KBestHaplotype<V, E> pathToExtend = queue.poll();
+            final V vertexToExtend = pathToExtend.getLastVertex();
             if (sinks.contains(vertexToExtend)) {
                 result.add(pathToExtend);
             } else {
                 if (vertexCounts.get(vertexToExtend).getAndIncrement() < maxNumberOfHaplotypes) {
-                    final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
+                    final Set<E> outgoingEdges = graph.outgoingEdgesOf(vertexToExtend);
                     int totalOutgoingMultiplicity = 0;
                     for (final BaseEdge edge : outgoingEdges) {
                         totalOutgoingMultiplicity += edge.getMultiplicity();
                     }
 
-                    for (final BaseEdge edge : outgoingEdges) {
-                        queue.add(new KBestHaplotype(pathToExtend, edge, totalOutgoingMultiplicity));
-                    }
+                    for (final E edge : outgoingEdges) {
+                        final V targetVertex = graph.getEdgeTarget(edge);
+                        queue.add(new KBestHaplotype<>(pathToExtend, edge, totalOutgoingMultiplicity));
                 }
             }
         }
         return result;
     }
 
-    public List<KBestHaplotype> findBestHaplotypes() {
+    public List<KBestHaplotype<V, E>> findBestHaplotypes() {
        return findBestHaplotypes(Integer.MAX_VALUE);
     }
 
@@ -106,13 +108,13 @@ public final class KBestHaplotypeFinder {
      * Removes edges that produces cycles and also dead vertices that do not lead to any sink vertex.
      * @return never {@code null}.
      */
-    private static SeqGraph removeCyclesAndVerticesThatDontLeadToSinks(final SeqGraph original, final Collection<SeqVertex> sources, final Set<SeqVertex> sinks) {
-        final Set<BaseEdge> edgesToRemove = new HashSet<>(original.edgeSet().size());
-        final Set<SeqVertex> vertexToRemove = new HashSet<>(original.vertexSet().size());
+    private BaseGraph<V, E> removeCyclesAndVerticesThatDontLeadToSinks(final BaseGraph<V, E> original, final Collection<V> sources, final Set<V> sinks) {
+        final Set<E> edgesToRemove = new HashSet<>(original.edgeSet().size());
+        final Set<V> vertexToRemove = new HashSet<>(original.vertexSet().size());
 
         boolean foundSomePath = false;
-        for (final SeqVertex source : sources) {
-            final Set<SeqVertex> parentVertices = new HashSet<>(original.vertexSet().size());
+        for (final V source : sources) {
+            final Set<V> parentVertices = new HashSet<>(original.vertexSet().size());
             foundSomePath = findGuiltyVerticesAndEdgesToRemoveCycles(original, source, sinks, edgesToRemove, vertexToRemove, parentVertices) || foundSomePath;
         }
 
@@ -121,7 +123,7 @@ public final class KBestHaplotypeFinder {
 
         Utils.validate(!(edgesToRemove.isEmpty() && vertexToRemove.isEmpty()), "cannot find a way to remove the cycles");
 
-        final SeqGraph result = original.clone();
+        final BaseGraph<V, E> result = original.clone();
         result.removeAllEdges(edgesToRemove);
         result.removeAllVertices(vertexToRemove);
         return result;
@@ -141,22 +143,22 @@ public final class KBestHaplotypeFinder {
      * @return {@code true} to indicate that the some sink vertex is reachable by {@code currentVertex},
      *  {@code false} otherwise.
      */
-    private static boolean findGuiltyVerticesAndEdgesToRemoveCycles(final SeqGraph graph,
-                                                                    final SeqVertex currentVertex,
-                                                                    final Set<SeqVertex> sinks,
-                                                                    final Set<BaseEdge> edgesToRemove,
-                                                                    final Set<SeqVertex> verticesToRemove,
-                                                                    final Set<SeqVertex> parentVertices) {
+    private boolean findGuiltyVerticesAndEdgesToRemoveCycles(final BaseGraph<V, E> graph,
+                                                                    final V currentVertex,
+                                                                    final Set<V> sinks,
+                                                                    final Set<E> edgesToRemove,
+                                                                    final Set<V> verticesToRemove,
+                                                                    final Set<V> parentVertices) {
         if (sinks.contains(currentVertex)) {
             return true;
         }
 
-        final Set<BaseEdge> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
+        final Set<E> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
         parentVertices.add(currentVertex);
 
         boolean reachesSink = false;
-        for (final BaseEdge edge : outgoingEdges) {
-            final SeqVertex child = graph.getEdgeTarget(edge);
+        for (final E edge : outgoingEdges) {
+            final V child = graph.getEdgeTarget(edge);
             if (parentVertices.contains(child)) {
                 edgesToRemove.add(edge);
             } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
@@ -206,11 +206,11 @@ public class Path<V extends BaseVertex, E extends BaseEdge> {
      * @return  non-null sequence of bases corresponding to this path
      */
     public byte[] getBases() {
-        if( getEdges().isEmpty() ) { return graph.getAdditionalSequence(lastVertex, true); }
+        if( getEdges().isEmpty() ) { return BaseGraph.getAdditionalSequence(lastVertex, true); }
 
-        byte[] bases = graph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)), true);
+        byte[] bases = BaseGraph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)), true);
         for( final E e : edgesInOrder ) {
-            bases = ArrayUtils.addAll(bases, graph.getAdditionalSequence(graph.getEdgeTarget(e), false));
+            bases = ArrayUtils.addAll(bases, BaseGraph.getAdditionalSequence(graph.getEdgeTarget(e), false));
         }
         return bases;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
@@ -20,23 +20,23 @@ import java.util.stream.Collectors;
  * class to keep track of paths
  *
  */
-public class Path<T extends BaseVertex, E extends BaseEdge> {
+public class Path<V extends BaseVertex, E extends BaseEdge> {
 
     // the last vertex seen in the path
-    private final T lastVertex;
+    private final V lastVertex;
 
     // the list of edges comprising the path
     private final List<E> edgesInOrder;
 
     // the graph from which this path originated
-    private final BaseGraph<T, E> graph;
+    private final BaseGraph<V, E> graph;
 
     /**
      * Create a new Path containing no edges and starting at initialVertex
      * @param initialVertex the starting vertex of the path
      * @param graph the graph this path will follow through
      */
-    public Path(final T initialVertex, final BaseGraph<T, E> graph) {
+    public Path(final V initialVertex, final BaseGraph<V, E> graph) {
         lastVertex = Utils.nonNull(initialVertex, "initialVertex cannot be null");
         this.graph = Utils.nonNull(graph, "graph cannot be null");
         Utils.validateArg(graph.containsVertex(initialVertex), () -> "Vertex " + initialVertex + " must be part of graph " + graph);
@@ -47,7 +47,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
     /**
      * Constructor that does not check arguments' validity i.e. doesn't check that edges are in order
      */
-    public Path(final List<E> edgesInOrder, final T lastVertex, final BaseGraph<T,E> graph) {
+    public Path(final List<E> edgesInOrder, final V lastVertex, final BaseGraph<V,E> graph) {
         this.lastVertex = lastVertex;
         this.graph = graph;
         this.edgesInOrder = edgesInOrder;
@@ -62,7 +62,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * @throws IllegalArgumentException if {@code p} or {@code edge} are {@code null}, or {@code edge} is
      * not part of {@code p}'s graph, or {@code edge} does not have as a source the last vertex in {@code p}.
      */
-    public Path(final Path<T,E> p, final E edge) {
+    public Path(final Path<V,E> p, final E edge) {
         Utils.nonNull(p, "Path cannot be null");
         Utils.nonNull(edge, "Edge cannot be null");
         Utils.validateArg(p.graph.containsEdge(edge), () -> "Graph must contain edge " + edge + " but it doesn't");
@@ -73,6 +73,34 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
         edgesInOrder = new ArrayList<>(p.length() + 1);
         edgesInOrder.addAll(p.edgesInOrder);
         edgesInOrder.add(edge);
+    }
+
+    /**
+     * Create a new Path extending p with edge
+     *
+     * @param p the path to extend.
+     * @param edges list of edges to extend. Does not check arguments' validity i.e. doesn't check that edges are in order
+     *
+     * @throws IllegalArgumentException if {@code p} or {@code edges} are {@code null} or empty, or {@code edges} is
+     * not part of {@code p}'s graph, or {@code edges} does not have as a source the last vertex in {@code p}.
+     */
+    public Path(final Path<V,E> p, final List<E> edges) {
+        Utils.nonNull(p, "Path cannot be null");
+        Utils.nonEmpty(edges, "Edge cannot be null");
+        edges.forEach(edge -> Utils.validateArg(p.graph.containsEdge(edge), () -> "Graph must contain edge " + edge + " but it doesn't"));
+        // Sanity check that the provided path is contiguous
+        V tmpVertex = p.lastVertex;
+        for (int i = 0; i < edges.size(); i++) {
+            if ( ! p.graph.getEdgeSource(edges.get(i)).equals(tmpVertex) ) {
+                throw new IllegalStateException("Edges added to path must be contiguous.");
+            } tmpVertex = p.graph.getEdgeTarget(edges.get(i));
+        }
+
+        graph = p.graph;
+        lastVertex = tmpVertex;
+        edgesInOrder = new ArrayList<>(p.length() + 1);
+        edgesInOrder.addAll(p.edgesInOrder);
+        edgesInOrder.addAll(edges);
     }
 
     /**
@@ -93,7 +121,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * @throws IllegalArgumentException if {@code p} or {@code edge} are {@code null}, or {@code edge} is
      * not part of {@code p}'s graph, or {@code edge} does not have as a target the first vertex in {@code p}.
      */
-    public Path(final E edge, final Path<T,E> p) {
+    public Path(final E edge, final Path<V,E> p) {
         Utils.nonNull(p, "Path cannot be null");
         Utils.nonNull(edge, "Edge cannot be null");
         Utils.validateArg(p.graph.containsEdge(edge), () -> "Graph must contain edge " + edge + " but it doesn't");
@@ -106,7 +134,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
     }
 
     @VisibleForTesting
-    boolean pathsAreTheSame(final Path<T,E> path) {
+    boolean pathsAreTheSame(final Path<V,E> path) {
         return edgesInOrder.equals(path.edgesInOrder);
     }
 
@@ -116,7 +144,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * @param v a non-null vertex
      * @return true if v occurs within this path, false otherwise
      */
-    public boolean containsVertex(final T v) {
+    public boolean containsVertex(final V v) {
         Utils.nonNull(v, "Vertex cannot be null");
         return v.equals(getFirstVertex()) || edgesInOrder.stream().map(graph::getEdgeTarget).anyMatch(v::equals);
     }
@@ -131,7 +159,7 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * Get the graph of this path
      * @return a non-null graph
      */
-    public BaseGraph<T, E> getGraph() {
+    public BaseGraph<V, E> getGraph() {
         return graph;
     }
 
@@ -148,8 +176,8 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * Get the list of vertices in this path in order defined by the edges of the path
      * @return a non-null, non-empty list of vertices
      */
-    public List<T> getVertices() {
-        final List<T> result = new ArrayList<>(edgesInOrder.size()+1);
+    public List<V> getVertices() {
+        final List<V> result = new ArrayList<>(edgesInOrder.size()+1);
         result.add(getFirstVertex());
         result.addAll(edgesInOrder.stream().map(graph::getEdgeTarget).collect(Collectors.toList()));
         return result;
@@ -159,13 +187,13 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * Get the final vertex of the path
      * @return a non-null vertex
      */
-    public T getLastVertex() { return lastVertex; }
+    public V getLastVertex() { return lastVertex; }
 
     /**
      * Get the first vertex in this path
      * @return a non-null vertex
      */
-    public T getFirstVertex() {
+    public V getFirstVertex() {
         if (edgesInOrder.isEmpty()) {
             return lastVertex;
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/Path.java
@@ -178,11 +178,11 @@ public class Path<T extends BaseVertex, E extends BaseEdge> {
      * @return  non-null sequence of bases corresponding to this path
      */
     public byte[] getBases() {
-        if( getEdges().isEmpty() ) { return graph.getAdditionalSequence(lastVertex); }
+        if( getEdges().isEmpty() ) { return graph.getAdditionalSequence(lastVertex, true); }
 
-        byte[] bases = graph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)));
+        byte[] bases = graph.getAdditionalSequence(graph.getEdgeSource(edgesInOrder.get(0)), true);
         for( final E e : edgesInOrder ) {
-            bases = ArrayUtils.addAll(bases, graph.getAdditionalSequence(graph.getEdgeTarget(e)));
+            bases = ArrayUtils.addAll(bases, graph.getAdditionalSequence(graph.getEdgeTarget(e), false));
         }
         return bases;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/AbstractReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/AbstractReadThreadingGraph.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KmerSearchableGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
+import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -27,17 +28,17 @@ import java.util.stream.Collectors;
 
 /**
  * Read threading graph class intended to contain duplicated code between {@link ReadThreadingGraph} and {@link JunctionTreeLinkedDeBruinGraph}.
- *
- *
  */
-public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruijnVertex, MultiSampleEdge> implements KmerSearchableGraph<MultiDeBruijnVertex,MultiSampleEdge> {
+public abstract class AbstractReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSampleEdge> implements KmerSearchableGraph<MultiDeBruijnVertex, MultiSampleEdge> {
     private static final long serialVersionUID = 1l;
     private static final String ANONYMOUS_SAMPLE = "XXX_UNNAMED_XXX";
     private static final boolean WRITE_GRAPH = false;
     private static final boolean DEBUG_NON_UNIQUE_CALC = false;
     private static final int MAX_CIGAR_COMPLEXITY = 3;
     private static final boolean INCREASE_COUNTS_BACKWARDS = true;
-    /** for debugging info printing */
+    /**
+     * for debugging info printing
+     */
     private static int counter = 0;
     /**
      * Sequences added for read threading before we've actually built the graph
@@ -49,44 +50,77 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     protected final Map<Kmer, MultiDeBruijnVertex> kmerToVertexMap = new LinkedHashMap<>();
     protected final boolean debugGraphTransformations;
     protected final byte minBaseQualityToUseInAssembly;
-    protected boolean startThreadingOnlyAtExistingVertex = false;
     protected List<MultiDeBruijnVertex> referencePath = null;
-
-    private int maxMismatchesInDanglingHead = -1;
-    protected boolean alreadyBuilt;
-    private boolean increaseCountsThroughBranches = false; // this may increase the branches without bounds
+    protected boolean alreadyBuilt = false;
     // --------------------------------------------------------------------------------
     // state variables, initialized in setToInitialState()
     // --------------------------------------------------------------------------------
-    protected Kmer refSource;
+    private Kmer refSource = null;
+    private boolean startThreadingOnlyAtExistingVertex = false;
+    private int maxMismatchesInDanglingHead = -1;
+    private boolean increaseCountsThroughBranches = false; // this may increase the branches without bounds
 
-    public ReadThreadingGraphInterface(int kmerSize, EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> edgeFactory) {
+    protected enum TraversalDirection {
+        downwards,
+        upwards
+    }
+
+    AbstractReadThreadingGraph(int kmerSize, EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> edgeFactory) {
         super(kmerSize, edgeFactory);
         debugGraphTransformations = false;
         minBaseQualityToUseInAssembly = 0;
     }
 
-
     /**
      * Create a new ReadThreadingAssembler using kmerSize for matching
+     *
      * @param kmerSize must be >= 1
      */
-    public ReadThreadingGraphInterface(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
+    public AbstractReadThreadingGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
         super(kmerSize, new MyEdgeFactory(numPruningSamples));
 
-        Utils.validateArg( kmerSize > 0, () -> "bad minkKmerSize " + kmerSize);
+        Utils.validateArg(kmerSize > 0, () -> "bad minkKmerSize " + kmerSize);
 
         this.debugGraphTransformations = debugGraphTransformations;
         this.minBaseQualityToUseInAssembly = minBaseQualityToUseInAssembly;
-
-        setToInitialState();
     }
 
+    /**
+     * Checks whether a kmer can be the threading start based on the current threading start location policy.
+     *
+     * @param kmer the query kmer.
+     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
+     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
+     */
+    protected abstract boolean isThreadingStart(final Kmer kmer, final boolean startThreadingOnlyAtExistingVertex);
+
+    // get the next kmerVertex for ChainExtension and validate if necessary.
+    protected abstract MultiDeBruijnVertex getNextKmerVertexForChainExtension(final Kmer kmer, final boolean isRef, final MultiDeBruijnVertex prevVertex);
+
+    // perform any necessary preprocessing on the graph (such as non-unique kmer determination) before the graph is constructed
+    protected abstract void preprocessReads();
+
+    // heuristic to decide if the graph should be thown away based on low complexity/poor assembly
+    public abstract boolean isLowQualityGraph();
+
+    // whether reads are needed after graph construction
+    protected abstract boolean shouldRemoveReadsAfterGraphConstruction();
+
+    // Method that will be called immediately before haplotype finding in the event there are alteations that must be made to the graph based on implementation
+    public abstract void postProcessForHaplotypeFinding(File debugGraphOutputPath, Locatable refHaplotype);
+
+    /**
+     * Define the behavior for how the graph should keep track of a potentially new kmer.
+     *
+     * @param kmer      (potentially) new kmer to track
+     * @param newVertex corresponding vertex for that kmer
+     */
+    protected abstract void trackKmer(Kmer kmer, MultiDeBruijnVertex newVertex);
 
     /**
      * Determine whether the provided cigar is okay to merge into the reference path
      *
-     * @param cigar    the cigar to analyze
+     * @param cigar                the cigar to analyze
      * @param requireFirstElementM if true, require that the first cigar element be an M operator in order for it to be okay
      * @param requireLastElementM  if true, require that the last cigar element be an M operator in order for it to be okay
      * @return true if it's okay to merge, false otherwise
@@ -97,17 +131,17 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         final int numElements = elements.size();
 
         // don't allow more than a couple of different ops
-        if ( numElements == 0 || numElements > MAX_CIGAR_COMPLEXITY ) {
+        if (numElements == 0 || numElements > MAX_CIGAR_COMPLEXITY) {
             return false;
         }
 
         // the first element must be an M
-        if ( requireFirstElementM && elements.get(0).getOperator() != CigarOperator.M ) {
+        if (requireFirstElementM && elements.get(0).getOperator() != CigarOperator.M) {
             return false;
         }
 
         // the last element must be an M
-        if ( requireLastElementM && elements.get(numElements - 1).getOperator() != CigarOperator.M ) {
+        if (requireLastElementM && elements.get(numElements - 1).getOperator() != CigarOperator.M) {
             return false;
         }
 
@@ -119,17 +153,17 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * calculates the longest suffix match between a sequence and a smaller kmer
      *
-     * @param seq         the (reference) sequence
-     * @param kmer        the smaller kmer sequence
-     * @param seqStart    the index (inclusive) on seq to start looking backwards from
+     * @param seq      the (reference) sequence
+     * @param kmer     the smaller kmer sequence
+     * @param seqStart the index (inclusive) on seq to start looking backwards from
      * @return the longest matching suffix
      */
     @VisibleForTesting
     static int longestSuffixMatch(final byte[] seq, final byte[] kmer, final int seqStart) {
-        for ( int len = 1; len <= kmer.length; len++ ) {
+        for (int len = 1; len <= kmer.length; len++) {
             final int seqI = seqStart - len + 1;
             final int kmerI = kmer.length - len;
-            if ( seqI < 0 || seq[seqI] != kmer[kmerI] ) {
+            if (seqI < 0 || seq[seqI] != kmer[kmerI]) {
                 return len - 1;
             }
         }
@@ -153,13 +187,13 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * @return the position of the starting vertex in seqForKmer, or -1 if it cannot find one
      */
     protected int findStart(final SequenceForKmers seqForKmers) {
-        if ( seqForKmers.isRef ) {
+        if (seqForKmers.isRef) {
             return 0;
         }
 
-        for ( int i = seqForKmers.start; i < seqForKmers.stop - kmerSize; i++ ) {
+        for (int i = seqForKmers.start; i < seqForKmers.stop - kmerSize; i++) {
             final Kmer kmer1 = new Kmer(seqForKmers.sequence, i, kmerSize);
-            if ( isThreadingStart(kmer1, startThreadingOnlyAtExistingVertex) ) {
+            if (isThreadingStart(kmer1, startThreadingOnlyAtExistingVertex)) {
                 return i;
             }
         }
@@ -168,25 +202,10 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     }
 
     /**
-     * Checks whether a kmer can be the threading start based on the current threading start location policy.
-     *
-     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
-     * @see #getThreadingStartOnlyAtExistingVertex()
-     *
-     * @param kmer the query kmer.
-     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
-     */
-    protected abstract boolean isThreadingStart(final Kmer kmer, final boolean startThreadingOnlyAtExistingVertex);
-
-    /**
-     * Perform any necessary steps in the constructor.
-     */
-    protected abstract void setToInitialState();
-
-    /**
      * Add the all bases in sequence to the graph
+     *
      * @param sequence a non-null sequence
-     * @param isRef is this the reference sequence?
+     * @param isRef    is this the reference sequence?
      */
     @VisibleForTesting
     public final void addSequence(final byte[] sequence, final boolean isRef) {
@@ -214,12 +233,12 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Add bases in sequence to this graph
      *
-     * @param seqName a useful seqName for this read, for debugging purposes
+     * @param seqName  a useful seqName for this read, for debugging purposes
      * @param sequence non-null sequence of bases
-     * @param start the first base offset in sequence that we should use for constructing the graph using this sequence, inclusive
-     * @param stop the last base offset in sequence that we should use for constructing the graph using this sequence, exclusive
-     * @param count the representative count of this sequence (to use as the weight)
-     * @param isRef is this the reference sequence.
+     * @param start    the first base offset in sequence that we should use for constructing the graph using this sequence, inclusive
+     * @param stop     the last base offset in sequence that we should use for constructing the graph using this sequence, exclusive
+     * @param count    the representative count of this sequence (to use as the weight)
+     * @param isRef    is this the reference sequence.
      */
     private void addSequence(final String seqName, final String sampleName, final byte[] sequence, final int start, final int stop, final int count, final boolean isRef) {
         // note that argument testing is taken care of in SequenceForKmers
@@ -234,11 +253,12 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
     /**
      * Thread sequence seqForKmers through the current graph, updating the graph as appropriate
+     *
      * @param seqForKmers a non-null sequence
      */
-    protected void threadSequence(final SequenceForKmers seqForKmers) {
+    private void threadSequence(final SequenceForKmers seqForKmers) {
         final int startPos = findStart(seqForKmers);
-        if ( startPos == -1 ) {
+        if (startPos == -1) {
             return;
         }
 
@@ -249,13 +269,13 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
             increaseCountsInMatchedKmers(seqForKmers, startingVertex, startingVertex.getSequence(), kmerSize - 2);
         }
 
-        if ( debugGraphTransformations ) {
+        if (debugGraphTransformations) {
             startingVertex.addRead(seqForKmers.name);
         }
 
         // keep track of information about the reference source
-        if ( seqForKmers.isRef ) {
-            if ( refSource != null ) {
+        if (seqForKmers.isRef) {
+            if (refSource != null) {
                 throw new IllegalStateException("Found two refSources! prev: " + refSource + ", new: " + startingVertex);
             }
             referencePath = new ArrayList<>(seqForKmers.sequence.length - kmerSize);
@@ -265,16 +285,16 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         // loop over all of the bases in sequence, extending the graph by one base at each point, as appropriate
         MultiDeBruijnVertex vertex = startingVertex;
-        for ( int i = startPos + 1; i <= seqForKmers.stop - kmerSize; i++ ) {
+        for (int i = startPos + 1; i <= seqForKmers.stop - kmerSize; i++) {
             vertex = extendChainByOne(vertex, seqForKmers.sequence, i, seqForKmers.count, seqForKmers.isRef);
-            if ( seqForKmers.isRef ) {
-                 referencePath.add(vertex);
+            if (seqForKmers.isRef) {
+                referencePath.add(vertex);
             }
-            if ( debugGraphTransformations ) {
+            if (debugGraphTransformations) {
                 vertex.addRead(seqForKmers.name);
             }
         }
-        if ( seqForKmers.isRef ) {
+        if (seqForKmers.isRef) {
             referencePath = Collections.unmodifiableList(referencePath);
         }
     }
@@ -282,8 +302,8 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Changes the threading start location policy.
      *
-     * @param value  {@code true} if threading will start only at existing vertices in the graph, {@code false} if
-     *  it can start at any unique kmer.
+     * @param value {@code true} if threading will start only at existing vertices in the graph, {@code false} if
+     *              it can start at any unique kmer.
      */
     public final void setThreadingStartOnlyAtExistingVertex(final boolean value) {
         startThreadingOnlyAtExistingVertex = value;
@@ -294,44 +314,41 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * been added to the graph.
      */
     public final void buildGraphIfNecessary() {
-        if ( alreadyBuilt ) {
+        if (alreadyBuilt) {
             return;
         }
 
         // Capture the set of non-unique kmers for the given kmer size (if applicable)
-        preprocessReadsIfNecessary();
+        preprocessReads();
 
-        if ( DEBUG_NON_UNIQUE_CALC ) {
+        if (DEBUG_NON_UNIQUE_CALC) {
             ReadThreadingGraph.logger.info("using " + kmerSize + " kmer size for this assembly with the following non-uniques");
         }
 
         // go through the pending sequences, and add them to the graph
-        for ( final List<SequenceForKmers> sequencesForSample : pending.values() ) {
-            for ( final SequenceForKmers sequenceForKmers : sequencesForSample ) {
+        for (final List<SequenceForKmers> sequencesForSample : pending.values()) {
+            for (final SequenceForKmers sequenceForKmers : sequencesForSample) {
                 threadSequence(sequenceForKmers);
-                if ( WRITE_GRAPH ) {
+                if (WRITE_GRAPH) {
                     printGraph(new File("threading." + counter++ + '.' + sequenceForKmers.name.replace(" ", "_") + ".dot"), 0);
                 }
             }
 
             // flush the single sample edge values from the graph
-            for ( final MultiSampleEdge e : edgeSet() ) {
+            for (final MultiSampleEdge e : edgeSet()) {
                 e.flushSingleSampleMultiplicity();
             }
         }
 
-        // clear
-        removePendingSequencesIfNecessary();
+        // clear the pending reads pile to conserve memory
+        if (shouldRemoveReadsAfterGraphConstruction()) {
+            pending.clear();
+        }
         alreadyBuilt = true;
         for (final MultiDeBruijnVertex v : kmerToVertexMap.values()) {
             v.setAdditionalInfo(v.getAdditionalInfo() + '+');
         }
     }
-
-    // perform any necessary preprocessing on the graph (such as non-unique kmer determination) before the graph is constructed
-    protected abstract void preprocessReadsIfNecessary();
-
-    protected abstract void removePendingSequencesIfNecessary();
 
     @Override
     public boolean removeVertex(final MultiDeBruijnVertex V) {
@@ -348,16 +365,14 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     public void removeSingletonOrphanVertices() {
         // Run through the graph and clean up singular orphaned nodes
         final Collection<MultiDeBruijnVertex> verticesToRemove = new LinkedList<>();
-        for( final MultiDeBruijnVertex v : vertexSet() ) {
-            if( inDegreeOf(v) == 0 && outDegreeOf(v) == 0 ) {
+        for (final MultiDeBruijnVertex v : vertexSet()) {
+            if (inDegreeOf(v) == 0 && outDegreeOf(v) == 0) {
                 verticesToRemove.add(v);
             }
         }
         removeVertex(null);
         removeAllVertices(verticesToRemove);
     }
-
-    public abstract boolean isLowComplexity();
 
     @VisibleForTesting
     void setIncreaseCountsThroughBranches(final boolean increaseCountsThroughBranches) {
@@ -367,23 +382,23 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Try to recover dangling tails
      *
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param pruneFactor             the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
      * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
+     * @param recoverAll              recover even branches with forks
      * @param aligner
      */
     public void recoverDanglingTails(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
         Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
         Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
 
-        if ( ! alreadyBuilt ) {
+        if (!alreadyBuilt) {
             throw new IllegalStateException("recoverDanglingTails requires the graph be already built");
         }
 
         int attempted = 0;
         int nRecovered = 0;
-        for ( final MultiDeBruijnVertex v : vertexSet() ) {
-            if ( outDegreeOf(v) == 0 && ! isRefSink(v) ) {
+        for (final MultiDeBruijnVertex v : vertexSet()) {
+            if (outDegreeOf(v) == 0 && !isRefSink(v)) {
                 attempted++;
                 nRecovered += recoverDanglingTail(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
             }
@@ -395,28 +410,28 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Try to recover dangling heads
      *
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param pruneFactor             the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
      * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
+     * @param recoverAll              recover even branches with forks
      * @param aligner
      */
     public void recoverDanglingHeads(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
         Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
         Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
-        if ( ! alreadyBuilt ) {
+        if (!alreadyBuilt) {
             throw new IllegalStateException("recoverDanglingHeads requires the graph be already built");
         }
 
         // we need to build a list of dangling heads because that process can modify the graph (and otherwise generate
         // a ConcurrentModificationException if we do it while iterating over the vertexes)
         final Collection<MultiDeBruijnVertex> danglingHeads = vertexSet().stream()
-                .filter(v -> inDegreeOf(v) == 0 && ! isRefSource(v))
+                .filter(v -> inDegreeOf(v) == 0 && !isRefSource(v))
                 .collect(Collectors.toList());
 
         // now we can try to recover the dangling heads
         int attempted = 0;
         int nRecovered = 0;
-        for ( final MultiDeBruijnVertex v : danglingHeads ) {
+        for (final MultiDeBruijnVertex v : danglingHeads) {
             attempted++;
             nRecovered += recoverDanglingHead(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
         }
@@ -427,14 +442,14 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Attempt to attach vertex with out-degree == 0 to the graph
      *
-     * @param vertex the vertex to recover
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param vertex                  the vertex to recover
+     * @param pruneFactor             the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
      * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
      * @param aligner
      * @return 1 if we successfully recovered the vertex and 0 otherwise
      */
     private int recoverDanglingTail(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        if ( outDegreeOf(vertex) != 0 ) {
+        if (outDegreeOf(vertex) != 0) {
             throw new IllegalStateException("Attempting to recover a dangling tail for " + vertex + " but it has out-degree > 0");
         }
 
@@ -442,7 +457,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         final DanglingChainMergeHelper danglingTailMergeResult = generateCigarAgainstDownwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
 
         // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
-        if ( danglingTailMergeResult == null || ! cigarIsOkayToMerge(danglingTailMergeResult.cigar, false, true) ) {
+        if (danglingTailMergeResult == null || !cigarIsOkayToMerge(danglingTailMergeResult.cigar, false, true)) {
             return 0;
         }
 
@@ -453,15 +468,15 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Attempt to attach vertex with in-degree == 0, or a vertex on its path, to the graph
      *
-     * @param vertex the vertex to recover
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param vertex                  the vertex to recover
+     * @param pruneFactor             the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
      * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
+     * @param recoverAll              recover even branches with forks
      * @param aligner
      * @return 1 if we successfully recovered a vertex and 0 otherwise
      */
     private int recoverDanglingHead(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        if ( inDegreeOf(vertex) != 0 ) {
+        if (inDegreeOf(vertex) != 0) {
             throw new IllegalStateException("Attempting to recover a dangling head for " + vertex + " but it has in-degree > 0");
         }
 
@@ -469,7 +484,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         final DanglingChainMergeHelper danglingHeadMergeResult = generateCigarAgainstUpwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
 
         // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
-        if ( danglingHeadMergeResult == null || ! cigarIsOkayToMerge(danglingHeadMergeResult.cigar, true, false) ) {
+        if (danglingHeadMergeResult == null || !cigarIsOkayToMerge(danglingHeadMergeResult.cigar, true, false)) {
             return 0;
         }
 
@@ -480,7 +495,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Actually merge the dangling tail if possible
      *
-     * @param danglingTailMergeResult   the result from generating a Cigar for the dangling tail against the reference
+     * @param danglingTailMergeResult the result from generating a Cigar for the dangling tail against the reference
      * @return 1 if merge was successful, 0 otherwise
      */
     @VisibleForTesting
@@ -488,11 +503,11 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         final List<CigarElement> elements = danglingTailMergeResult.cigar.getCigarElements();
         final CigarElement lastElement = elements.get(elements.size() - 1);
-        Utils.validateArg( lastElement.getOperator() == CigarOperator.M, "The last Cigar element must be an M");
+        Utils.validateArg(lastElement.getOperator() == CigarOperator.M, "The last Cigar element must be an M");
 
         final int lastRefIndex = danglingTailMergeResult.cigar.getReferenceLength() - 1;
         final int matchingSuffix = Math.min(longestSuffixMatch(danglingTailMergeResult.referencePathString, danglingTailMergeResult.danglingPathString, lastRefIndex), lastElement.getLength());
-        if ( matchingSuffix == 0 ) {
+        if (matchingSuffix == 0) {
             return 0;
         }
 
@@ -503,17 +518,17 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         // tail is a perfect match to the suffix of the reference path.  In this case we need to push the reference index to merge
         // down one position so that we don't incorrectly cut a base off of the deletion.
         final boolean firstElementIsDeletion = elements.get(0).getOperator() == CigarOperator.D;
-        final boolean mustHandleLeadingDeletionCase =  firstElementIsDeletion && (elements.get(0).getLength() + matchingSuffix == lastRefIndex + 1);
+        final boolean mustHandleLeadingDeletionCase = firstElementIsDeletion && (elements.get(0).getLength() + matchingSuffix == lastRefIndex + 1);
         final int refIndexToMerge = lastRefIndex - matchingSuffix + 1 + (mustHandleLeadingDeletionCase ? 1 : 0);
 
         // another edge condition occurs here: if Smith-Waterman places the whole tail into an insertion then it will try to
         // merge back to the LCA, which results in a cycle in the graph.  So we do not want to merge in such a case.
-        if ( refIndexToMerge == 0 ) {
+        if (refIndexToMerge == 0) {
             return 0;
         }
 
         // it's safe to merge now
-        addEdge(danglingTailMergeResult.danglingPath.get(altIndexToMerge), danglingTailMergeResult.referencePath.get(refIndexToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
+        addEdge(danglingTailMergeResult.danglingPath.get(altIndexToMerge), danglingTailMergeResult.referencePath.get(refIndexToMerge), ((MyEdgeFactory) getEdgeFactory()).createEdge(false, 1));
 
         return 1;
     }
@@ -521,7 +536,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Actually merge the dangling head if possible
      *
-     * @param danglingHeadMergeResult   the result from generating a Cigar for the dangling head against the reference
+     * @param danglingHeadMergeResult the result from generating a Cigar for the dangling head against the reference
      * @return 1 if merge was successful, 0 otherwise
      */
     @VisibleForTesting
@@ -529,25 +544,25 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         final List<CigarElement> elements = danglingHeadMergeResult.cigar.getCigarElements();
         final CigarElement firstElement = elements.get(0);
-        Utils.validateArg( firstElement.getOperator() == CigarOperator.M, "The first Cigar element must be an M");
+        Utils.validateArg(firstElement.getOperator() == CigarOperator.M, "The first Cigar element must be an M");
 
         final int indexesToMerge = bestPrefixMatch(danglingHeadMergeResult.referencePathString, danglingHeadMergeResult.danglingPathString, firstElement.getLength());
-        if ( indexesToMerge <= 0 ) {
+        if (indexesToMerge <= 0) {
             return 0;
         }
 
         // we can't push back the reference path
-        if ( indexesToMerge >= danglingHeadMergeResult.referencePath.size() - 1 ) {
+        if (indexesToMerge >= danglingHeadMergeResult.referencePath.size() - 1) {
             return 0;
         }
 
         // but we can manipulate the dangling path if we need to
-        if ( indexesToMerge >= danglingHeadMergeResult.danglingPath.size() &&
-                ! extendDanglingPathAgainstReference(danglingHeadMergeResult, indexesToMerge - danglingHeadMergeResult.danglingPath.size() + 2) ) {
+        if (indexesToMerge >= danglingHeadMergeResult.danglingPath.size() &&
+                !extendDanglingPathAgainstReference(danglingHeadMergeResult, indexesToMerge - danglingHeadMergeResult.danglingPath.size() + 2)) {
             return 0;
         }
 
-        addEdge(danglingHeadMergeResult.referencePath.get(indexesToMerge+1), danglingHeadMergeResult.danglingPath.get(indexesToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
+        addEdge(danglingHeadMergeResult.referencePath.get(indexesToMerge + 1), danglingHeadMergeResult.danglingPath.get(indexesToMerge), ((MyEdgeFactory) getEdgeFactory()).createEdge(false, 1));
 
         return 1;
     }
@@ -557,9 +572,9 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * provided vertex is the sink) and the reference path.
      *
      * @param aligner
-     * @param vertex   the sink of the dangling chain
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
-     * @param recoverAll recover even branches with forks
+     * @param vertex      the sink of the dangling chain
+     * @param pruneFactor the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param recoverAll  recover even branches with forks
      * @return a SmithWaterman object which can be null if no proper alignment could be generated
      */
     @VisibleForTesting
@@ -568,7 +583,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         // find the lowest common ancestor path between this vertex and the diverging master path if available
         final List<MultiDeBruijnVertex> altPath = findPathUpwardsToLowestCommonAncestor(vertex, pruneFactor, !recoverAll);
-        if ( altPath == null || isRefSource(altPath.get(0)) || altPath.size() < minTailPathLength + 1 ) // add 1 to include the LCA
+        if (altPath == null || isRefSource(altPath.get(0)) || altPath.size() < minTailPathLength + 1) // add 1 to include the LCA
         {
             return null;
         }
@@ -590,9 +605,9 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * provided vertex is the source) and the reference path.
      *
      * @param aligner
-     * @param vertex   the source of the dangling head
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
-     * @param recoverAll recover even branches with forks
+     * @param vertex      the source of the dangling head
+     * @param pruneFactor the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param recoverAll  recover even branches with forks
      * @return a SmithWaterman object which can be null if no proper alignment could be generated
      */
     @VisibleForTesting
@@ -600,7 +615,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         // find the highest common descendant path between vertex and the reference source if available
         final List<MultiDeBruijnVertex> altPath = findPathDownwardsToHighestCommonDescendantOfReference(vertex, pruneFactor, !recoverAll);
-        if ( altPath == null || isRefSink(altPath.get(0)) || altPath.size() < minDanglingBranchLength + 1 ) // add 1 to include the LCA
+        if (altPath == null || isRefSink(altPath.get(0)) || altPath.size() < minDanglingBranchLength + 1) // add 1 to include the LCA
         {
             return null;
         }
@@ -621,15 +636,15 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * Finds the path upwards in the graph from this vertex to the first diverging node, including that (lowest common ancestor) vertex.
      * Note that nodes are excluded if their pruning weight is less than the pruning factor.
      *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param vertex         the original vertex
+     * @param pruneFactor    the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
      * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
      * @return the path if it can be determined or null if this vertex either doesn't merge onto another path or
-     *  has an ancestor with multiple incoming edges before hitting the reference path
+     * has an ancestor with multiple incoming edges before hitting the reference path
      */
-    protected List<MultiDeBruijnVertex> findPathUpwardsToLowestCommonAncestor(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
+    private List<MultiDeBruijnVertex> findPathUpwardsToLowestCommonAncestor(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
         return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> inDegreeOf(v) != 1 || outDegreeOf(v) >= 2, v -> outDegreeOf(v) > 1, v -> incomingEdgeOf(v), e -> getEdgeSource(e))
-                :findPath(vertex, pruneFactor, v -> hasIncidentRefEdge(v) || inDegreeOf(v) == 0, v -> outDegreeOf(v) > 1 && hasIncidentRefEdge(v), this::getHeaviestIncomingEdge, e -> getEdgeSource(e));
+                : findPath(vertex, pruneFactor, v -> hasIncidentRefEdge(v) || inDegreeOf(v) == 0, v -> outDegreeOf(v) > 1 && hasIncidentRefEdge(v), this::getHeaviestIncomingEdge, e -> getEdgeSource(e));
     }
 
     private boolean hasIncidentRefEdge(final MultiDeBruijnVertex v) {
@@ -641,7 +656,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         return false;
     }
 
-    public MultiSampleEdge getHeaviestIncomingEdge(final MultiDeBruijnVertex v) {
+    private MultiSampleEdge getHeaviestIncomingEdge(final MultiDeBruijnVertex v) {
         final Set<MultiSampleEdge> incomingEdges = incomingEdgesOf(v);
         return incomingEdges.size() == 1 ? incomingEdges.iterator().next() :
                 incomingEdges.stream().max(Comparator.comparingInt(MultiSampleEdge::getMultiplicity)).get();
@@ -652,13 +667,13 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * However note that the path is reversed so that this vertex ends up at the end of the path.
      * Also note that nodes are excluded if their pruning weight is less than the pruning factor.
      *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
+     * @param vertex         the original vertex
+     * @param pruneFactor    the prune factor to use in ignoring chain pieces
      * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
      * @return the path if it can be determined or null if this vertex either doesn't merge onto the reference path or
-     *  has a descendant with multiple outgoing edges before hitting the reference path
+     * has a descendant with multiple outgoing edges before hitting the reference path
      */
-    protected List<MultiDeBruijnVertex> findPathDownwardsToHighestCommonDescendantOfReference(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
+    private List<MultiDeBruijnVertex> findPathDownwardsToHighestCommonDescendantOfReference(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
         return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) != 1, v -> isReferenceNode(v), v -> outgoingEdgeOf(v), e -> getEdgeTarget(e))
                 : findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) == 0, v -> isReferenceNode(v), this::getHeaviestOutgoingEdge, e -> getEdgeTarget(e));
     }
@@ -672,37 +687,36 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Finds a path starting from a given vertex and satisfying various predicates
      *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
-     * @param done test for whether a vertex is at the end of the path
-     * @param returnPath test for whether to return a found path based on its terminal vertex
-     * @param nextEdge function on vertices returning the next edge in the path
-     * @param nextNode function of edges returning the next vertex in the path
+     * @param vertex      the original vertex
+     * @param pruneFactor the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param done        test for whether a vertex is at the end of the path
+     * @param returnPath  test for whether to return a found path based on its terminal vertex
+     * @param nextEdge    function on vertices returning the next edge in the path
+     * @param nextNode    function of edges returning the next vertex in the path
      * @return a path, if one satisfying all predicates is found, {@code null} otherwise
      */
-    private  List<MultiDeBruijnVertex> findPath(final MultiDeBruijnVertex vertex, final int pruneFactor,
-                                            final Predicate<MultiDeBruijnVertex> done,
-                                            final Predicate<MultiDeBruijnVertex> returnPath,
-                                            final Function<MultiDeBruijnVertex, MultiSampleEdge> nextEdge,
-                                            final Function<MultiSampleEdge, MultiDeBruijnVertex> nextNode){
+    private List<MultiDeBruijnVertex> findPath(final MultiDeBruijnVertex vertex, final int pruneFactor,
+                                               final Predicate<MultiDeBruijnVertex> done,
+                                               final Predicate<MultiDeBruijnVertex> returnPath,
+                                               final Function<MultiDeBruijnVertex, MultiSampleEdge> nextEdge,
+                                               final Function<MultiSampleEdge, MultiDeBruijnVertex> nextNode) {
         final LinkedList<MultiDeBruijnVertex> path = new LinkedList<>();
         final Set<MultiDeBruijnVertex> visitedNodes = new HashSet<>(); // This code is necessary to
 
         MultiDeBruijnVertex v = vertex;
-        while ( ! done.test(v) ) {
+        while (!done.test(v)) {
             final MultiSampleEdge edge = nextEdge.apply(v);
             // if it has too low a weight, don't use it (or previous vertexes) for the path
-            if ( edge.getPruningMultiplicity() < pruneFactor ) {
+            if (edge.getPruningMultiplicity() < pruneFactor) {
                 // save the previously visited notes to protect us from riding forever 'neath the streets of boston
                 visitedNodes.addAll(path);
                 path.clear();
-            }
-            else {
+            } else {
                 path.addFirst(v);
             }
             v = nextNode.apply(edge);
             // Check that we aren't stuck in a loop
-            if ( path.contains(v) || visitedNodes.contains(v)) {
+            if (path.contains(v) || visitedNodes.contains(v)) {
                 System.err.println("Dangling End recovery killed because of a loop (findPath)");
                 return null;
             }
@@ -715,19 +729,19 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * Finds the path in the graph from this vertex to the reference sink, including this vertex
      *
-     * @param start   the reference vertex to start from
-     * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
+     * @param start           the reference vertex to start from
+     * @param direction       describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
      * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
      * @return the path (non-null, non-empty)
      */
     protected List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
-                                                       final TraversalDirection direction,
-                                                       final Optional<MultiSampleEdge> blacklistedEdge) {
+                                                         final TraversalDirection direction,
+                                                         final Optional<MultiSampleEdge> blacklistedEdge) {
 
         final List<MultiDeBruijnVertex> path = new ArrayList<>();
 
         MultiDeBruijnVertex v = start;
-        while ( v != null ) {
+        while (v != null) {
             path.add(v);
             v = (direction == TraversalDirection.downwards ? getNextReferenceVertex(v, true, blacklistedEdge) : getPrevReferenceVertex(v));
         }
@@ -738,21 +752,21 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     /**
      * The base sequence for the given path.
      *
-     * @param path the list of vertexes that make up the path
+     * @param path         the list of vertexes that make up the path
      * @param expandSource if true and if we encounter a source node, then expand (and reverse) the character sequence for that node
-     * @return  non-null sequence of bases corresponding to the given path
+     * @return non-null sequence of bases corresponding to the given path
      */
     @VisibleForTesting
     byte[] getBasesForPath(final List<MultiDeBruijnVertex> path, final boolean expandSource) {
         Utils.nonNull(path, "Path cannot be null");
 
         final StringBuilder sb = new StringBuilder();
-        for ( final MultiDeBruijnVertex v : path ) {
-            if ( expandSource && isSource(v) ) {
+        for (final MultiDeBruijnVertex v : path) {
+            if (expandSource && isSource(v)) {
                 final String seq = v.getSequenceString();
                 sb.append(new StringBuilder(seq).reverse().toString());
             } else {
-                sb.append((char)v.getSuffix());
+                sb.append((char) v.getSuffix());
             }
         }
 
@@ -763,8 +777,8 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * Finds the index of the best extent of the prefix match between the provided paths, for dangling head merging.
      * Assumes that path1.length >= maxIndex and path2.length >= maxIndex.
      *
-     * @param path1  the first path
-     * @param path2  the second path
+     * @param path1    the first path
+     * @param path2    the second path
      * @param maxIndex the maximum index to traverse (not inclusive)
      * @return the index of the ideal prefix match or -1 if it cannot find one, must be less than maxIndex
      */
@@ -773,9 +787,9 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         int mismatches = 0;
         int index = 0;
         int lastGoodIndex = -1;
-        while ( index < maxIndex ) {
-            if ( path1[index] != path2[index] ) {
-                if ( ++mismatches > maxMismatches ) {
+        while (index < maxIndex) {
+            if (path1[index] != path2[index]) {
+                if (++mismatches > maxMismatches) {
                     return -1;
                 }
                 lastGoodIndex = index;
@@ -790,7 +804,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * Determine the maximum number of mismatches permitted on the branch.
      * Unless it's preset (e.g. by unit tests) it should be the length of the branch divided by the kmer size.
      *
-     * @param lengthOfDanglingBranch  the length of the branch itself
+     * @param lengthOfDanglingBranch the length of the branch itself
      * @return positive integer
      */
     private int getMaxMismatches(final int lengthOfDanglingBranch) {
@@ -801,14 +815,14 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         final int indexOfLastDanglingNode = danglingHeadMergeResult.danglingPath.size() - 1;
         final int indexOfRefNodeToUse = indexOfLastDanglingNode + numNodesToExtend;
-        if ( indexOfRefNodeToUse >= danglingHeadMergeResult.referencePath.size() ) {
+        if (indexOfRefNodeToUse >= danglingHeadMergeResult.referencePath.size()) {
             return false;
         }
 
         final MultiDeBruijnVertex danglingSource = danglingHeadMergeResult.danglingPath.remove(indexOfLastDanglingNode);
         final StringBuilder sb = new StringBuilder();
         final byte[] refSourceSequence = danglingHeadMergeResult.referencePath.get(indexOfRefNodeToUse).getSequence();
-        for ( int i = 0; i < numNodesToExtend; i++ ) {
+        for (int i = 0; i < numNodesToExtend; i++) {
             sb.append((char) refSourceSequence[i]);
         }
         sb.append(danglingSource.getSequenceString());
@@ -820,7 +834,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         removeEdge(danglingSource, prevV);
 
         // extend the path
-        for ( int i = numNodesToExtend; i > 0; i-- ) {
+        for (int i = numNodesToExtend; i > 0; i--) {
             final MultiDeBruijnVertex newV = new MultiDeBruijnVertex(Arrays.copyOfRange(sequenceToExtend, i, i + kmerSize));
             addVertex(newV);
             final MultiSampleEdge newE = addEdge(newV, prevV);
@@ -836,31 +850,32 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
                                               final MultiDeBruijnVertex vertex,
                                               final byte[] originalKmer,
                                               final int offset) {
-        if ( offset == -1 ) {
+        if (offset == -1) {
             return;
         }
 
-        for ( final MultiSampleEdge edge : incomingEdgesOf(vertex) ) {
+        for (final MultiSampleEdge edge : incomingEdgesOf(vertex)) {
             final MultiDeBruijnVertex prev = getEdgeSource(edge);
             final byte suffix = prev.getSuffix();
             final byte seqBase = originalKmer[offset];
-            if ( suffix == seqBase && (increaseCountsThroughBranches || inDegreeOf(vertex) == 1) ) {
+            if (suffix == seqBase && (increaseCountsThroughBranches || inDegreeOf(vertex) == 1)) {
                 edge.incMultiplicity(seqForKmers.count);
-                increaseCountsInMatchedKmers(seqForKmers, prev, originalKmer, offset-1);
+                increaseCountsInMatchedKmers(seqForKmers, prev, originalKmer, offset - 1);
             }
         }
     }
 
     /**
      * Get the vertex for the kmer in sequence starting at start
+     *
      * @param sequence the sequence
-     * @param start the position of the kmer start
+     * @param start    the position of the kmer start
      * @return a non-null vertex
      */
     private MultiDeBruijnVertex getOrCreateKmerVertex(final byte[] sequence, final int start) {
         final Kmer kmer = new Kmer(sequence, start, kmerSize);
         final MultiDeBruijnVertex vertex = getKmerVertex(kmer, true);
-        return ( vertex != null ) ? vertex : createVertex(kmer);
+        return (vertex != null) ? vertex : createVertex(kmer);
     }
 
     /**
@@ -870,7 +885,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * @return a vertex for kmer, or null (either because it doesn't exist or is non-unique for graphs that have such a distinction)
      */
     protected MultiDeBruijnVertex getKmerVertex(final Kmer kmer, final boolean allowRefSource) {
-        if ( ! allowRefSource && kmer.equals(refSource) ) {
+        if (!allowRefSource && kmer.equals(refSource)) {
             return null;
         }
 
@@ -883,13 +898,13 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
      * @param kmer the kmer we want to create a vertex for
      * @return the non-null created vertex
      */
-    protected MultiDeBruijnVertex createVertex(final Kmer kmer) {
+    private MultiDeBruijnVertex createVertex(final Kmer kmer) {
         final MultiDeBruijnVertex newVertex = new MultiDeBruijnVertex(kmer.bases());
         final int prevSize = vertexSet().size();
         addVertex(newVertex);
 
         // make sure we aren't adding duplicates (would be a bug)
-        if ( vertexSet().size() != prevSize + 1) {
+        if (vertexSet().size() != prevSize + 1) {
             throw new IllegalStateException("Adding vertex " + newVertex + " to graph didn't increase the graph size");
         }
         trackKmer(kmer, newVertex);
@@ -898,31 +913,23 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     }
 
     /**
-     * Define the behavior for how the graph should keep track of a potentially new kmer.
-     *
-     * @param kmer (potentially) new kmer to track
-     * @param newVertex corresponding vertex for that kmer
-     */
-    protected abstract void trackKmer(Kmer kmer, MultiDeBruijnVertex newVertex);
-
-    /**
      * Workhorse routine of the assembler.  Given a sequence whose last vertex is anchored in the graph, extend
      * the graph one bp according to the bases in sequence.
      *
      * @param prevVertex a non-null vertex where sequence was last anchored in the graph
-     * @param sequence the sequence we're threading through the graph
-     * @param kmerStart the start of the current kmer in graph we'd like to add
-     * @param count the number of observations of this kmer in graph (can be > 1 for GGA)
-     * @param isRef is this the reference sequence?
+     * @param sequence   the sequence we're threading through the graph
+     * @param kmerStart  the start of the current kmer in graph we'd like to add
+     * @param count      the number of observations of this kmer in graph (can be > 1 for GGA)
+     * @param isRef      is this the reference sequence?
      * @return a non-null vertex connecting prevVertex to in the graph based on sequence
      */
     protected MultiDeBruijnVertex extendChainByOne(final MultiDeBruijnVertex prevVertex, final byte[] sequence, final int kmerStart, final int count, final boolean isRef) {
         final Set<MultiSampleEdge> outgoingEdges = outgoingEdgesOf(prevVertex);
 
         final int nextPos = kmerStart + kmerSize - 1;
-        for ( final MultiSampleEdge outgoingEdge : outgoingEdges ) {
+        for (final MultiSampleEdge outgoingEdge : outgoingEdges) {
             final MultiDeBruijnVertex target = getEdgeTarget(outgoingEdge);
-            if ( target.getSuffix() == sequence[nextPos] ) {
+            if (target.getSuffix() == sequence[nextPos]) {
                 // we've got a match in the chain, so simply increase the count of the edge by 1 and continue
                 outgoingEdge.incMultiplicity(count);
                 return target;
@@ -935,12 +942,9 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
 
         // either use our merge vertex, or create a new one in the chain
         final MultiDeBruijnVertex nextVertex = mergeVertex == null ? createVertex(kmer) : mergeVertex;
-        addEdge(prevVertex, nextVertex, ((MyEdgeFactory)getEdgeFactory()).createEdge(isRef, count));
+        addEdge(prevVertex, nextVertex, ((MyEdgeFactory) getEdgeFactory()).createEdge(isRef, count));
         return nextVertex;
     }
-
-    // get the next kmerVertex for ChainExtension and validate if necessary.
-    protected abstract MultiDeBruijnVertex getNextKmerVertexForChainExtension(final Kmer kmer, final boolean isRef, final MultiDeBruijnVertex prevVertex);
 
     /**
      * Add a read to the sequence graph.  Finds maximal consecutive runs of bases with sufficient quality
@@ -954,39 +958,41 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         final byte[] qualities = read.getBaseQualities();
 
         int lastGood = -1;
-        for( int end = 0; end <= sequence.length; end++ ) {
-            if ( end == sequence.length || ! baseIsUsableForAssembly(sequence[end], qualities[end]) ) {
+        for (int end = 0; end <= sequence.length; end++) {
+            if (end == sequence.length || !baseIsUsableForAssembly(sequence[end], qualities[end])) {
                 // the first good base is at lastGood, can be -1 if last base was bad
                 final int start = lastGood;
                 // the stop base is end - 1 (if we're not at the end of the sequence)
                 final int len = end - start;
 
-                if ( start != -1 && len >= kmerSize ) {
+                if (start != -1 && len >= kmerSize) {
                     // if the sequence is long enough to get some value out of, add it to the graph
                     final String name = read.getName() + '_' + start + '_' + end;
                     addSequence(name, ReadUtils.getSampleName(read, header), sequence, start, end, 1, false);
                 }
 
                 lastGood = -1; // reset the last good base
-            } else if ( lastGood == -1 ) {
+            } else if (lastGood == -1) {
                 lastGood = end; // we're at a good base, the last good one is us
             }
         }
     }
 
-    protected abstract boolean baseIsUsableForAssembly(byte base, byte qual);
-
-    // Method that will be called immediately before haplotype finding in the event there are alteations that must be made to the graph based on implementation
-    public abstract void postProcessForHaplotypeFinding(File debugGraphOutputPath, Locatable refHaplotype);
+    /**
+     * Determines whether a base can safely be used for assembly.
+     * Currently disallows Ns and/or those with low quality
+     *
+     * @param base  the base under consideration
+     * @param qual  the quality of that base
+     * @return true if the base can be used for assembly, false otherwise
+     */
+    protected boolean baseIsUsableForAssembly(final byte base, final byte qual) {
+        return base != BaseUtils.Base.N.base && qual >= minBaseQualityToUseInAssembly;
+    }
 
     @Override
     public MultiDeBruijnVertex findKmer(final Kmer k) {
         return kmerToVertexMap.get(k);
-    }
-
-    protected enum TraversalDirection {
-        downwards,
-        upwards
     }
 
     /**
@@ -995,7 +1001,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
     protected static final class MyEdgeFactory implements EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> {
         final int numPruningSamples;
 
-        protected MyEdgeFactory(final int numPruningSamples) {
+        MyEdgeFactory(final int numPruningSamples) {
             this.numPruningSamples = numPruningSamples;
         }
 
@@ -1004,7 +1010,7 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
             return new MultiSampleEdge(false, 1, numPruningSamples);
         }
 
-        public MultiSampleEdge createEdge(final boolean isRef, final int multiplicity) {
+        MultiSampleEdge createEdge(final boolean isRef, final int multiplicity) {
             return new MultiSampleEdge(isRef, multiplicity, numPruningSamples);
         }
     }
@@ -1020,10 +1026,10 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
         final Cigar cigar;
 
         DanglingChainMergeHelper(final List<MultiDeBruijnVertex> danglingPath,
-                                        final List<MultiDeBruijnVertex> referencePath,
-                                        final byte[] danglingPathString,
-                                        final byte[] referencePathString,
-                                        final Cigar cigar) {
+                                 final List<MultiDeBruijnVertex> referencePath,
+                                 final byte[] danglingPathString,
+                                 final byte[] referencePathString,
+                                 final Cigar cigar) {
             this.danglingPath = danglingPath;
             this.referencePath = referencePath;
             this.danglingPathString = danglingPathString;
@@ -1048,9 +1054,9 @@ public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruij
          */
         SequenceForKmers(final String name, final byte[] sequence, final int start, final int stop, final int count, final boolean ref) {
             Utils.nonNull(sequence, "Sequence is null ");
-            Utils.validateArg( start >= 0, () -> "Invalid start " + start);
-            Utils.validateArg( stop >= start, () -> "Invalid stop " + stop);
-            Utils.validateArg( count > 0, "Invalid count " + count);
+            Utils.validateArg(start >= 0, () -> "Invalid start " + start);
+            Utils.validateArg(stop >= start, () -> "Invalid stop " + stop);
+            Utils.validateArg(count > 0, "Invalid count " + count);
 
             this.name = name;
             this.sequence = sequence;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraph.java
@@ -1,0 +1,724 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import htsjdk.samtools.util.Locatable;
+import org.apache.commons.lang3.ArrayUtils;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Experimental version of the ReadThreadingGraph with support for threading reads to generate JunctionTrees for resolving
+ * connectivity information at longer ranges.
+ *
+ * Note that many of the non-DeBruin graph alterations that are made to ReadThreadingGraph are not made here:
+ * - Non-Unique kmers are not duplicated by this graph
+ * - Kmers are not Zipped together to form a SeqGraph
+ * - The reference path is stored in its entirety rather than being calculated on the fly
+ *
+ * For ease of debugging, this graph supports the method {@link #printSimplifiedGraph(File, int)}} which generates a SequenceGraph and
+ * adds the junction trees to the output .dot file.
+ */
+public class JunctionTreeLinkedDeBruinGraph extends ReadThreadingGraphInterface {
+    private static final long serialVersionUID = 1l;
+    private static final MultiDeBruijnVertex SYMBOLIC_END_VETEX = new MultiDeBruijnVertex(new byte[]{'_'});
+    private MultiSampleEdge SYMBOLIC_END_EDGE;
+
+    private Map<MultiDeBruijnVertex, ThreadingTree> readThreadingJunctionTrees = new HashMap<>();
+
+    // TODO should this be constructed here or elsewhere
+    private Set<Kmer> kmers = new HashSet<>();
+
+    public JunctionTreeLinkedDeBruinGraph(int kmerSize) {
+        this(kmerSize, false, (byte)6, 1);
+    }
+
+    /**
+     * Create a new ReadThreadingAssembler using kmerSize for matching
+     * @param kmerSize must be >= 1
+     */
+    JunctionTreeLinkedDeBruinGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
+        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
+    }
+
+    /**
+     * Find vertex and its position in seqForKmers where we should start assembling seqForKmers
+     *
+     * @param seqForKmers the sequence we want to thread into the graph
+     * @return the position of the starting vertex in seqForKmer, or -1 if it cannot find one
+     */
+
+    protected int findStartForJunctionThreading(final SequenceForKmers seqForKmers) {
+        for ( int i = seqForKmers.start; i < seqForKmers.stop - kmerSize; i++ ) {
+            final Kmer kmer1 = new Kmer(seqForKmers.sequence, i, kmerSize);
+            if ( kmerToVertexMap.containsKey(kmer1) ) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    @Override
+    protected void setToInitialState() {
+        // We don't clear pending here in order to later build the read threading
+        kmerToVertexMap.clear();
+        refSource = null;
+        alreadyBuilt = false;
+    }
+
+    @Override
+    // We don't need to track non-uniques here so this is a no-op
+    protected void preprocessReadsIfNecessary() {
+        return;
+    }
+
+    @Override
+    // We don't want to remove pending sequences as they are the data we need for read threading
+    protected void removePendingSequencesIfNecessary() {
+        return;
+    }
+
+    @Override
+    //TODO come up with some huristic for when we think one of these graphs is "too difficult" to call properly
+    public boolean isLowComplexity() {
+        return false;
+    }
+
+    /**
+     * Checks whether a kmer can be the threading start based on the current threading start location policy.
+     *
+     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
+     *
+     * @param kmer the query kmer.
+     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
+     */
+    protected boolean isThreadingStart(final Kmer kmer, final boolean startThreadingOnlyAtExistingVertex) {
+        Utils.nonNull(kmer);
+        return !startThreadingOnlyAtExistingVertex || kmers.contains(kmer);
+    }
+
+    /**
+     * Finds the path in the graph from this vertex to the reference sink, including this vertex
+     *
+     * @param start   the reference vertex to start from
+     * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
+     * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
+     * @return the path (non-null, non-empty)
+     */
+    @Override
+    protected List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
+                                                         final TraversalDirection direction,
+                                                         final Optional<MultiSampleEdge> blacklistedEdge) {
+        if ( direction == TraversalDirection.downwards ) {
+            return getReferencePathForwardFromKmer(start, blacklistedEdge);
+        } else {
+            return getReferencePathBackwardsForKmer(start);
+        }
+    }
+
+    // Since there are no non-unique kmers to worry about we just add it to our map
+    @Override
+    protected void trackKmer(Kmer kmer, MultiDeBruijnVertex newVertex) {
+        kmerToVertexMap.putIfAbsent(kmer, newVertex);
+    }
+
+    @VisibleForTesting
+    List<MultiDeBruijnVertex> getReferencePath(final TraversalDirection direction) {
+        return Collections.unmodifiableList(direction == TraversalDirection.downwards ? referencePath : Lists.reverse(referencePath));
+    }
+
+    @Override
+    protected boolean baseIsUsableForAssembly(byte base, byte qual) {
+        return base != BaseUtils.Base.N.base && qual >= minBaseQualityToUseInAssembly;
+    }
+
+    /**
+     * Extends the current vertex chain by one, making sure to build junction tree objects at each node with out-degree > 1.
+     *
+     * If a node has an in-degree > 1, then it has a junction tree added to the previous node.
+     *
+     * @param prevVertex Current vertex to extend off of
+     * @param sequence Sequence of kmers to extend
+     * @param kmerStart index of where the current kmer starts
+     * @return The next vertex in the sequence. Null if the corresponding edge doesn't exist.
+     */
+    protected MultiDeBruijnVertex extendJunctionThreadingByOne(final MultiDeBruijnVertex prevVertex, final byte[] sequence, final int kmerStart, final JunctionTreeThreadingHelper nodesHelper) {
+        final Set<MultiSampleEdge> outgoingEdges = outgoingEdgesOf(prevVertex);
+
+        final int nextPos = kmerStart + kmerSize - 1;
+        for (final MultiSampleEdge outgoingEdge : outgoingEdges) {
+            final MultiDeBruijnVertex target = getEdgeTarget(outgoingEdge);
+            if (target.getSuffix() == sequence[nextPos]) {
+                // Only want to create a new tree if we walk into a node that meets our junction tree criteria
+                // NOTE: we do this deciding on our path
+                nodesHelper.addTreeIfNecessary(prevVertex);
+
+                // If this node has an out-degree > 1, add the edge we took to existing trees
+                if (outgoingEdges.size() != 1) {
+                    nodesHelper.addEdgeToJunctionTreeNodes(outgoingEdge);
+                }
+
+                return target;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * NOTE: we override the old behavior here to allow for looping/nonunique references to be handled properly
+     *
+     * @return the reference source vertex pulled from the graph, can be null if it doesn't exist in the graph
+     */
+    @Override
+    public final MultiDeBruijnVertex getReferenceSourceVertex( ) {
+        return referencePath != null && !referencePath.isEmpty()? referencePath.get(0) : null;
+    }
+
+    /**
+     * NOTE: we override the old behavior here to allow for looping/nonunique references to be handled properly
+     *
+     * @return the reference sink vertex pulled from the graph, can be null if it doesn't exist in the graph
+     */
+    @Override
+    public final MultiDeBruijnVertex getReferenceSinkVertex( ) {
+        return referencePath != null && !referencePath.isEmpty()? referencePath.get(referencePath.size() - 1) : null;
+    }
+
+    /**
+     * This is a heruistic for deciding what the proper reference path is to align the dangling ends to. The last possible
+     * reference path emanating from the kmer (in the case of the root kmer for a dangling end being a repeated kmer
+     * from the reference) is chose (or the first in the case for dangling heads). This is based on the assumption that
+     * dangling tails worthy of recovering are often a result of the assembly window and thus we choose the last possible
+     * kmer as the option.
+     *
+     * //TODO both of these are a hack to emulate the current behavior when targetkmer isn't actually a reference kmer. The old behaior
+     * //TODO was to return a singleton list of targetKmer. The real solution is to walk back target kmer to the actual ref base
+     *
+     * @param targetKmer vertex corresponding to the root
+     * @return
+     */
+    private List<MultiDeBruijnVertex> getReferencePathForwardFromKmer(final MultiDeBruijnVertex targetKmer,
+                                                                      final Optional<MultiSampleEdge> blacklistedEdge) {
+        List<MultiDeBruijnVertex> extraSequence = new ArrayList<>(2);
+        MultiDeBruijnVertex vert = targetKmer;
+        int finalIndex = referencePath.lastIndexOf(vert);
+
+        while (finalIndex == -1 &&  vert != null) {
+            // If the current verex is not a reference vertex but exists, add it to our list of extra bases to append to the reference
+            extraSequence.add(vert);
+
+            final Set<MultiSampleEdge> outgoingEdges = outgoingEdgesOf(vert);
+
+            // singleton or empty set
+            final Set<MultiSampleEdge> blacklistedEdgeSet = blacklistedEdge.isPresent() ? Collections.singleton(blacklistedEdge.get()) : Collections.emptySet();
+
+            // walk forward while the path is unambiguous
+            final List<MultiSampleEdge> edges = outgoingEdges.stream().filter(e -> !blacklistedEdgeSet.contains(e)).limit(2).collect(Collectors.toList());
+
+            vert = edges.size() == 1 ? getEdgeTarget(edges.get(0)) : null;
+
+            // Defense against loops, kill the attempt if we are stuck in a loop
+            if (extraSequence.contains(vert)) {
+                System.err.println("Dangling End recovery killed because of a loop (getReferencePathForwardFromKmer)");
+                vert = null;
+            }
+
+            finalIndex = vert == null ? -1 : referencePath.lastIndexOf(vert);
+        }
+
+        // if we found extra sequence append it to the front of the
+        extraSequence.addAll(finalIndex != -1 ? referencePath.subList(finalIndex, referencePath.size()) : Collections.emptyList());
+        return extraSequence;
+    }
+
+    // TODO this behavior is frankly silly and needs to be fixed, there is no way upwards paths should be dangingling head recovered differently
+    private List<MultiDeBruijnVertex> getReferencePathBackwardsForKmer(final MultiDeBruijnVertex targetKmer) {
+        int firstIndex = referencePath.indexOf(targetKmer);
+        if (firstIndex == -1) return Collections.singletonList(targetKmer);
+        return Lists.reverse(referencePath.subList(0, firstIndex + 1));
+    }
+
+    // Generate a SeqGraph that is special
+    @Override
+    public SeqGraph toSequenceGraph() {
+        throw new UnsupportedOperationException("Cannot construct a sequence graph using JunctionTreeLinkedDeBruinGraph");
+    }
+
+    /**
+     * Print out the graph in the dot language for visualization for the graph after merging the graph into a seq graph.
+     * Junction trees will naively add junction trees to the corresponding zipped SeqGraph node for its root vertex.
+     *
+     * NOTE: this is intended for debugging complex assembly graphs while preserving junction tree data.
+     * @param destination File to write to
+     */
+    @VisibleForTesting
+    public final void printSimplifiedGraph(final File destination, final int pruneFactor) {
+        try (PrintStream stream = new PrintStream(new FileOutputStream(destination))) {
+            printSimplifiedGraph(stream, true, pruneFactor);
+        } catch ( final FileNotFoundException e ) {
+            throw new UserException.CouldNotReadInputFile(destination, e);
+        }
+    }
+    private final void printSimplifiedGraph(final PrintStream graphWriter, final boolean writeHeader, final int pruneFactor) {
+
+        /// LOCAL CLASS TO MANAGE PRINTING THE JUNCTION TREES ONTO THE SEQ GRAPH
+        class PrintingSeqGraph extends SeqGraph {
+            private static final long serialVersionUID = 1l;
+
+            private PrintingSeqGraph(int kmerSize) {
+                super(kmerSize);
+            }
+            private Map<MultiDeBruijnVertex, SeqVertex> vertexToOrigionalSeqVertex;
+            private Map<SeqVertex, SeqVertex> originalSeqVertexToMergedVerex;
+            @Override
+            // Extendable method intended to allow for adding extra material to the graph
+            public List<String> getExtraGraphFileLines() {
+                List<String> output = new ArrayList<>();
+                for( Map.Entry<MultiDeBruijnVertex, ThreadingTree> entry : readThreadingJunctionTrees.entrySet()) {
+                    // Resolving the chain of altered vertexes
+                    SeqVertex mergedSeqVertex = originalSeqVertexToMergedVerex.get(vertexToOrigionalSeqVertex.get(entry.getKey()));
+
+                    // adding the root node to the graph
+                    output.add(String.format("\t%s -> %s ", mergedSeqVertex.toString(), entry.getValue().rootNode.getDotName()) +
+                            String.format("[color=blue];"));
+                    output.add(String.format("\t%s [shape=point];", entry.getValue().rootNode.getDotName()));
+
+                    output.addAll(edgesForNodeRecursive(entry.getValue().rootNode));
+                }
+                return output;
+            }
+            // Helper class to be used for zipping linear chains for easy print outputting
+            private Map<SeqVertex, SeqVertex> zipLinearChainsWithVertexMapping() {
+                Map<SeqVertex, SeqVertex> vertexMapping = new HashMap<>();
+                // create the list of start sites [doesn't modify graph yet]
+                final Collection<SeqVertex> zipStarts = vertexSet().stream().filter(this::isLinearChainStart).collect(Collectors.toList());
+
+                if ( zipStarts.isEmpty() ) // nothing to do, as nothing could start a chain
+                {
+                    return vertexMapping;
+                }
+
+                // At this point, zipStarts contains all of the vertices in this graph that might start some linear
+                // chain of vertices.  We walk through each start, building up the linear chain of vertices and then
+                // zipping them up with mergeLinearChain, if possible
+                for ( final SeqVertex zipStart : zipStarts ) {
+                    final LinkedList<SeqVertex> linearChain = traceLinearChain(zipStart);
+
+                    SeqVertex mergedOne = mergeLinearChainVertex(linearChain);
+
+                    // Add all of the mapped vertexes to the map.
+                    if (mergedOne != null) {
+                        for (SeqVertex v : linearChain) {
+                            vertexMapping.put(v, mergedOne);
+                        }
+                    } else {
+                        // otherwise we indicate that nothing has changed
+                        for (SeqVertex v : linearChain) {
+                            vertexMapping.put(v, v);
+                        }
+                    }
+                }
+                return vertexMapping;
+            }
+        };
+
+        PrintingSeqGraph printingSeqGraph = new PrintingSeqGraph(kmerSize);
+
+        final Map<MultiDeBruijnVertex, SeqVertex> vertexToOrigionalSeqVertex = new HashMap<>();
+
+        // create all of the equivalent seq graph vertices
+        for ( final MultiDeBruijnVertex dv : vertexSet() ) {
+            final SeqVertex sv = new SeqVertex(dv.getAdditionalSequence(isSource(dv)));
+            sv.setAdditionalInfo(dv.getAdditionalInfo());
+            vertexToOrigionalSeqVertex.put(dv, sv);
+            printingSeqGraph.addVertex(sv);
+        }
+
+        // walk through the nodes and connect them to their equivalent seq vertices
+        for( final MultiSampleEdge e : edgeSet() ) {
+            final SeqVertex seqInV = vertexToOrigionalSeqVertex.get(getEdgeSource(e));
+            final SeqVertex seqOutV = vertexToOrigionalSeqVertex.get(getEdgeTarget(e));
+            printingSeqGraph.addEdge(seqInV, seqOutV, new BaseEdge(e.isRef(), e.getMultiplicity()));
+        }
+
+        final Map<SeqVertex, SeqVertex> originalSeqVertexToMergedVerex = printingSeqGraph.zipLinearChainsWithVertexMapping();
+        printingSeqGraph.originalSeqVertexToMergedVerex = originalSeqVertexToMergedVerex;
+        printingSeqGraph.vertexToOrigionalSeqVertex = vertexToOrigionalSeqVertex;
+
+
+        printingSeqGraph.printGraph(graphWriter, writeHeader, pruneFactor);
+    }
+
+    /**
+     * Walk along the reference path in the graph and pull out the corresponding bases
+     *
+     * NOTE: this attempts to generate the longest sequence of refernce bases in the event that fromVertex or toVertex are non-unique
+     *
+     * @param fromVertex    starting vertex
+     * @param toVertex      ending vertex
+     * @param includeStart  should the starting vertex be included in the path
+     * @param includeStop   should the ending vertex be included in the path
+     * @return              byte[] array holding the reference bases, this can be null if there are no nodes between the starting and ending vertex (insertions for example)
+     */
+    @Override
+    public byte[] getReferenceBytes( final MultiDeBruijnVertex fromVertex, final MultiDeBruijnVertex toVertex, final boolean includeStart, final boolean includeStop ) {
+        Utils.nonNull(fromVertex, "Starting vertex in requested path cannot be null.");
+        Utils.nonNull(toVertex, "From vertex in requested path cannot be null.");
+
+        byte[] bytes = null;
+        int fromIndex = referencePath.indexOf(fromVertex);
+        int toIndex = referencePath.lastIndexOf(toVertex);
+
+        if( includeStart ) {
+            bytes = ArrayUtils.addAll(bytes, getAdditionalSequence(fromVertex, true));
+        }
+        for (int i = fromIndex + 1; i < toIndex; i++) {
+            bytes = ArrayUtils.addAll(bytes, getAdditionalSequence(referencePath.get(i)));
+        }
+
+        if( includeStop ) {
+            bytes = ArrayUtils.addAll(bytes, getAdditionalSequence(toVertex));
+        }
+        return bytes;
+    }
+
+    @Override
+    // since we don't have to validate unique vertex merging we just find the vertex and pass
+    protected MultiDeBruijnVertex getNextKmerVertexForChainExtension(final Kmer kmer, final boolean isRef, final MultiDeBruijnVertex prevVertex) {
+        return kmerToVertexMap.get(kmer);
+    }
+
+    /**
+     * Generate the junction trees and prune them (optionally printing the graph stages as output)
+     *
+     * @param debugGraphOutputPath path for graph output files
+     * @param refHaplotype ref haplotype location
+     */
+    public void postProcessForHaplotypeFinding(final File debugGraphOutputPath, final Locatable refHaplotype) {
+        generateJunctionTrees();
+        if (debugGraphTransformations) {
+            printGraph(new File(debugGraphOutputPath, refHaplotype + "-sequenceGraph." + kmerSize + ".0.4.JT_unpruned.dot"), 10000);
+        }
+        pruneJunctionTrees(JunctionTreeKBestHaplotypeFinder.DEFAULT_MINIMUM_WEIGHT_FOR_JT_BRANCH_TO_NOT_BE_PRUNED);
+        if (debugGraphTransformations) {
+            printGraph(new File(debugGraphOutputPath, refHaplotype + "-sequenceGraph." + kmerSize + ".0.5.JT_pruned.dot"), 10000);
+        }
+    }
+
+
+    // Generate threading trees
+    public void generateJunctionTrees() {
+        Utils.validate(alreadyBuilt, "Assembly graph has not been constructed, please call BuildGraphIfNecessary() before trying to thread reads to the graph");
+        // Adding handle vertex to support symbolic end alleles
+        addVertex(SYMBOLIC_END_VETEX);
+        SYMBOLIC_END_EDGE = addEdge(getReferenceSinkVertex(), SYMBOLIC_END_VETEX);
+
+        readThreadingJunctionTrees = new HashMap<>();
+        pending.values().stream().flatMap(Collection::stream).forEach(this::threadSequenceForJuncitonTree);
+    }
+
+    /**
+     * Traverse all of the junction trees in the graph and remove branches supported by < minimumEdgeWeight edges recursively.
+     * This will also handle pruning of trees that are uninformative (i.e. empty roots).
+     *
+     * @param minimumEdgeWeight minimum edge weight below which branches are removed
+     */
+    public void pruneJunctionTrees(final int minimumEdgeWeight) {
+        readThreadingJunctionTrees.forEach((key, value) -> value.getRootNode().pruneNode(minimumEdgeWeight));
+        readThreadingJunctionTrees = Maps.filterValues( readThreadingJunctionTrees, ThreadingTree::isEmptyTree);
+    }
+
+    /**
+     * Takes a contiguous sequence of kmers and threads it through the graph, generating and subsequently adding to
+     * juncition trees at each relevant node.
+     *
+     * @param seqForKmers
+     */
+    public void threadSequenceForJuncitonTree(final SequenceForKmers seqForKmers) {
+        // Maybe handle this differently, the reference junction tree should be held seperatedly from everything else.
+        if (seqForKmers.isRef) {
+            return;
+        }
+
+        // List we will use to keep track of sequences
+        JunctionTreeThreadingHelper nodeHelper = new JunctionTreeThreadingHelper();
+
+        // Find the first kmer in the read that exists on the graph
+        final int startPos = findStartForJunctionThreading(seqForKmers);
+        if ( startPos == -1 ) {
+            return;
+        }
+
+        final MultiDeBruijnVertex startingVertex = kmerToVertexMap.get(new Kmer(seqForKmers.sequence, startPos, kmerSize));
+
+        // loop over all of the bases in sequence, extending the graph by one base at each point, as appropriate
+        MultiDeBruijnVertex lastVertex = startingVertex;
+        int kmersPastSinceLast = 0;
+        for ( int i = startPos + 1; i <= seqForKmers.stop - kmerSize; i++ ) {
+            final MultiDeBruijnVertex vertex;
+            if (kmersPastSinceLast == 0) {
+                vertex = extendJunctionThreadingByOne(lastVertex, seqForKmers.sequence, i, nodeHelper);
+            } else {
+                Kmer kmer = new Kmer(seqForKmers.sequence, i, kmerSize);
+                vertex = kmerToVertexMap.get(kmer);
+                // TODO this might cause problems
+                if (vertex != null) {
+                   attemptToResolveThreadingBetweenVertexes(lastVertex, nodeHelper, vertex);
+                }
+            }
+            // If for whatever reason vertex = null, then we have fallen off the corrected graph so we don't update anything
+            if (vertex != null) {
+                lastVertex = vertex;
+                kmersPastSinceLast = 0;
+            } else {
+                kmersPastSinceLast++;
+            }
+        }
+
+        // As a final step, if the last vetex happens to be the ref-stop vertex then we want to append a symbolic node to the junciton trees
+        if (lastVertex == getReferenceSinkVertex()) {
+            nodeHelper.addEdgeToJunctionTreeNodes(SYMBOLIC_END_EDGE);
+        }
+    }
+
+    // Extendable method intended to allow for adding extra material to the graph
+    public List<String> getExtraGraphFileLines() {
+        List<String> output = new ArrayList<>();
+        for( Map.Entry<MultiDeBruijnVertex, ThreadingTree> entry : readThreadingJunctionTrees.entrySet()) {
+            // adding the root node to the graph
+            output.add(String.format("\t%s -> %s ", entry.getKey().toString(), entry.getValue().rootNode.getDotName()) +
+            String.format("[color=blue];"));
+            output.add(String.format("\t%s [shape=point];", entry.getValue().rootNode.getDotName()));
+
+            output.addAll(edgesForNodeRecursive(entry.getValue().rootNode));
+        }
+        return output;
+    }
+
+    // Recursive search through a threading tree for nodes
+    private List<String> edgesForNodeRecursive(ThreadingNode node) {
+        List<String> output = new ArrayList<>();
+
+        for ( Map.Entry<MultiSampleEdge, ThreadingNode> childrenNode : node.childrenNodes.entrySet() ) {
+            output.add(String.format("\t%s -> %s ", node.getDotName(), childrenNode.getValue().getDotName() + String.format("[color=blue,label=\"%d\"];",childrenNode.getValue().count)));
+            output.add(String.format("\t%s [label=\"%s\",shape=plaintext]", childrenNode.getValue().getDotName(),
+                    new String(getEdgeTarget(childrenNode.getKey()).getAdditionalSequence(false))));
+            output.addAll(edgesForNodeRecursive(childrenNode.getValue()));
+        }
+        return output;
+    }
+
+    public Optional<ThreadingTree> getJunctionTreeForNode(MultiDeBruijnVertex vertex) {
+        return Optional.ofNullable(readThreadingJunctionTrees.get(vertex));
+    }
+
+    // TODO this needs to be filled out and resolved
+    // TODO as an extension, this should be made to intelligently pick nodes if there is a fork (possibly an expensive step)
+    private List<ThreadingNode> attemptToResolveThreadingBetweenVertexes(MultiDeBruijnVertex startingVertex, JunctionTreeThreadingHelper threadingNodes, MultiDeBruijnVertex vertex) {
+        threadingNodes.clear(); // Clear the nodes currently as they might cause issues down the line.
+        return Collections.emptyList();
+    }
+
+    @VisibleForTesting
+    // Test method for returning all existing junction trees.
+    public Map<MultiDeBruijnVertex, ThreadingTree> getReadThreadingJunctionTrees(boolean pruned) {
+        return pruned ? Maps.filterValues( Collections.unmodifiableMap(readThreadingJunctionTrees), n -> n.isEmptyTree())
+                : Collections.unmodifiableMap(readThreadingJunctionTrees);
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Classes associated with junction trees
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Class for storing a junction tree. A Juntion tree is a tree whose nodes correspond to edges in the graph where a
+     * traversal decision was made (i.e. the path forks and one edge was taken). Each node keeps track of a list of
+     * its children nodes, each of which stores a count of the evidence seen supporting the given edge.
+     */
+    public class ThreadingTree {
+        private ThreadingNode rootNode;
+
+        private ThreadingTree() {
+            rootNode = new ThreadingNode(null);
+        }
+
+        /**
+         * Returns the root node for this edge (ensuring that it has had its count intcremented to keep track of the total evidence spanning this tree.
+         *
+         * @return
+         */
+        private ThreadingNode getAndIncrementRootNode() {
+            rootNode.incrementCount();
+            return rootNode;
+        }
+
+        // Determines if this tree actually has any data associated with it
+        private boolean isEmptyTree() {
+            return !rootNode.childrenNodes.isEmpty();
+        }
+
+        // Returns the junction choices as a list of suffixes to follow (this is used for writing human readable tests)
+        @VisibleForTesting
+        List<String> getPathsPresentAsBaseChoiceStrings() {
+            return rootNode.getEdgesThroughNode().stream()
+                    .map(path -> path.stream()
+                                    .map(edge -> getEdgeTarget(edge).getSuffix())
+                                    .map(b -> Character.toString((char)b.byteValue()))
+                                    .collect(Collectors.joining()))
+                    .collect(Collectors.toList());
+
+        }
+
+        // getter for the root node, TODO to possibly be replaced when the graph gets hidden from prying eyes.
+        public ThreadingNode getRootNode() {
+            return rootNode;
+        }
+    }
+
+    // Linked node object for storing tree topography
+    public class ThreadingNode {
+        private Map<MultiSampleEdge, ThreadingNode> childrenNodes;
+        private MultiSampleEdge prevEdge; // This may be null if this node corresponds to the root of the graph
+        private int count = 0;
+
+        private ThreadingNode(MultiSampleEdge edge) {
+            prevEdge = edge;
+            childrenNodes = new HashMap<>(2);
+        }
+
+        /**
+         * Adds an edge to the tree if this node has not been traversed before, or increments the corresponding node
+         * if the edge already exists. Then returns the corresponding next node
+         *
+         * @param edge edge to add to this current node
+         * @return the node corresponding to the one that was added to this graph
+         */
+        private ThreadingNode addEdge(MultiSampleEdge edge) {
+            ThreadingNode nextNode = childrenNodes.computeIfAbsent(edge, k -> new ThreadingNode(edge));
+            nextNode.incrementCount();
+            return nextNode;
+        }
+
+        void incrementCount() {
+            count++;
+        }
+
+        private void incrementNode(List<MultiSampleEdge> edges, int index) {
+            incrementCount();
+            if (index < edges.size()) {
+                getNode(edges.get(index)).incrementNode(edges, index + 1);
+            }
+        }
+
+        private ThreadingNode getNode(MultiSampleEdge edge) {
+            ThreadingNode nextNode = childrenNodes.get(edge);
+            if (nextNode == null) {
+                nextNode = new ThreadingNode(edge);
+                childrenNodes.put(edge, nextNode);
+            }
+            return nextNode;
+        }
+
+        /**
+         * Helper method that returns a list of all the possible branching paths through the tree originiating from this node.
+         *
+         * NOTE: This method is intended for debugging and testing and thus may not be efficient for returning the list
+         *
+         * @return A list of potential paths originating from this node as observed
+         */
+        @VisibleForTesting
+        private List<List<MultiSampleEdge>> getEdgesThroughNode() {
+            List<List<MultiSampleEdge>> paths = new ArrayList<>();
+            if (childrenNodes.isEmpty()) {
+                paths.add(prevEdge == null ? new ArrayList<>() : Lists.newArrayList(prevEdge));
+            }
+
+            for (ThreadingNode childNode : childrenNodes.values()) {
+                for ( List<MultiSampleEdge> subPath : childNode.getEdgesThroughNode()) {
+                    List<MultiSampleEdge> pathRoot = (prevEdge == null ? new ArrayList<>() : Lists.newArrayList(prevEdge));
+                    pathRoot.addAll(subPath);
+                    paths.add(pathRoot);
+                }
+            }
+
+            return paths;
+        }
+
+        // Recursively prunes nodes based on the provided threshold, removing branches without sufficient support.
+        private void pruneNode(final int threshold) {
+            childrenNodes = Maps.filterValues( childrenNodes, node -> node.getEvidenceCount() >= threshold);
+            childrenNodes.forEach((edge, node) -> node.pruneNode(threshold));
+        }
+
+        // Returns a unique name based on the memory id that conforms to the restrictions placed on .dot file nodes
+        public String getDotName() {
+            return "TreadingNode_" + Integer.toHexString(hashCode());
+        }
+
+        // Getter for external tools to access a node
+        public Map<MultiSampleEdge, ThreadingNode> getChildrenNodes() {
+            return Collections.unmodifiableMap(childrenNodes);
+        }
+
+        // Returns true if there are no paths emanating from this node
+        public boolean hasNoEvidence() {
+            return childrenNodes.isEmpty();
+        }
+
+        // Return the count of total evidence supporting this node in the tree
+        public int getEvidenceCount() {
+            return count;
+        }
+
+        // Checks if this node is the symbolic end by determining if its previous edge ends on the symbolic edge
+        public boolean isSymbolicEnd() {
+            return prevEdge == SYMBOLIC_END_EDGE;
+        }
+    }
+
+    /**
+     * A convenient helper class designed to pull much of the direct interaction with junction trees in the threading code
+     * into a single place.
+     */
+    private class JunctionTreeThreadingHelper {
+        List<ThreadingNode> trackedNodes = new ArrayList<>(3);
+
+        // Helper method used to determine whether a vertex meets the criteria to hold a junction tree
+        // The current criteria, if any outgoing edge from a particular vertex leads to a vertex with inDegree > 1, then it warrants a tree. Or if it is the reference start vertex.
+        // NOTE: this check is necessary to handle the edge cases that may arise when a vertex has multiple exit paths but happens to lead to a vetex that needs a junction tree
+        private boolean vertexWarrantsJunctionTree(final MultiDeBruijnVertex vertex) {
+            return outgoingEdgesOf(vertex).stream().anyMatch(edge -> inDegreeOf(getEdgeTarget(edge)) > 1);
+        }
+
+        // Helper method that adds a single edge to all of the nodes in nodesToExtend.
+        private void addEdgeToJunctionTreeNodes(final MultiSampleEdge outgoingEdge) {
+            List<ThreadingNode> newNodes = trackedNodes.stream().map(n -> n.addEdge(outgoingEdge)).collect(Collectors.toList());
+            trackedNodes.clear();
+            trackedNodes.addAll(newNodes);
+        }
+
+        // removes all of the nodes currently on the tree for safety if there are gaps in a reads traversal
+        private void clear() {
+            trackedNodes.clear();
+        }
+
+        // Adds a junction tree prevVertex if the vertex warrants a junciton tree
+        private void addTreeIfNecessary(MultiDeBruijnVertex prevVertex) {
+            if (vertexWarrantsJunctionTree(prevVertex)) {
+                trackedNodes.add(readThreadingJunctionTrees.computeIfAbsent(prevVertex, k -> new ThreadingTree()).getAndIncrementRootNode());
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -79,7 +79,7 @@ public final class ReadThreadingAssembler {
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;
         this.pruneFactor = pruneFactor;
-        this.generateSeqGraph = generateSeqGraph;
+        this.generateSeqGraph = !generateSeqGraph;
         chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants) :
                 new LowWeightChainPruner<>(pruneFactor);
         numBestHaplotypesPerGraph = maxAllowedPathsForReadThreadingAssembler;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -72,14 +72,14 @@ public final class ReadThreadingAssembler {
                                   final boolean dontIncreaseKmerSizesForCycles, final boolean allowNonUniqueKmersInRef,
                                   final int numPruningSamples, final int pruneFactor, final boolean useAdaptivePruning,
                                   final double initialErrorRateForPruning, final double pruningLogOddsThreshold,
-                                  final int maxUnprunedVariants, final boolean generateSeqGraph) {
+                                  final int maxUnprunedVariants, final boolean useLinkedDebrujinGraphs) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
         this.kmerSizes = kmerSizes;
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;
         this.pruneFactor = pruneFactor;
-        this.generateSeqGraph = !generateSeqGraph;
+        this.generateSeqGraph = !useLinkedDebrujinGraphs;
         chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants) :
                 new LowWeightChainPruner<>(pruneFactor);
         numBestHaplotypesPerGraph = maxAllowedPathsForReadThreadingAssembler;
@@ -87,7 +87,7 @@ public final class ReadThreadingAssembler {
 
     @VisibleForTesting
     ReadThreadingAssembler(final int maxAllowedPathsForReadThreadingAssembler, final List<Integer> kmerSizes, final int pruneFactor) {
-        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, Integer.MAX_VALUE, true);
+        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, Integer.MAX_VALUE, false);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResul
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadErrorCorrector;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
 import org.broadinstitute.hellbender.utils.Histogram;
+import org.broadinstitute.hellbender.utils.Histogram;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -134,7 +135,7 @@ public final class ReadThreadingAssembler {
             correctedReads = assemblyRegion.getReads();
         }
 
-        final List<ReadThreadingGraph> nonRefRTGraphs = new LinkedList<>();
+        final List<ReadThreadingGraphInterface> nonRefRTGraphs = new LinkedList<>();
         final List<SeqGraph> nonRefSeqGraphs = new LinkedList<>();
         final AssemblyResultSet resultSet = new AssemblyResultSet();
         resultSet.setRegionForGenotyping(assemblyRegion);
@@ -143,7 +144,7 @@ public final class ReadThreadingAssembler {
         final SimpleInterval activeRegionExtendedLocation = assemblyRegion.getExtendedSpan();
         refHaplotype.setGenomeLocation(activeRegionExtendedLocation);
         resultSet.add(refHaplotype);
-        final Map<ReadThreadingGraph,AssemblyResult> assemblyResultByRTGraph = new HashMap<>();
+        final Map<ReadThreadingGraphInterface,AssemblyResult> assemblyResultByRTGraph = new HashMap<>();
         final Map<SeqGraph,AssemblyResult> assemblyResultBySeqGraph = new HashMap<>();
         // create the graphs by calling our subclass assemble method
         for ( final AssemblyResult result : assemble(correctedReads, refHaplotype, header, aligner) ) {
@@ -156,6 +157,7 @@ public final class ReadThreadingAssembler {
                     nonRefSeqGraphs.add(result.getSeqGraph());
                 } else {
                     sanityCheckGraph(result.getThreadingGraph(), refHaplotype);
+                    result.getThreadingGraph().postProcessForHaplotypeFinding(debugGraphOutputPath, refHaplotype.getLocation());
                     // add it to graphs with meaningful non-reference features
                     assemblyResultByRTGraph.put(result.getThreadingGraph(),result);
                     nonRefRTGraphs.add(result.getThreadingGraph());
@@ -196,9 +198,13 @@ public final class ReadThreadingAssembler {
             Utils.validateArg( source != null && sink != null, () -> "Both source and sink cannot be null but got " + source + " and sink " + sink + " for graph " + graph);
 
             for (final KBestHaplotype<V, E> kBestHaplotype :
-                    new KBestHaplotypeFinder<V, E>(graph,source,sink).findBestHaplotypes(numBestHaplotypesPerGraph)) {
+                    (generateSeqGraph ?
+                            new GraphBasedKBestHaplotypeFinder<>(graph,source,sink) :
+                            new JunctionTreeKBestHaplotypeFinder<>(graph,source,sink, JunctionTreeKBestHaplotypeFinder.DEFAULT_OUTGOING_JT_EVIDENCE_THRESHOLD_TO_BELEIVE))
+                            .findBestHaplotypes(numBestHaplotypesPerGraph)) {
                 final Haplotype h = kBestHaplotype.haplotype();
                 if( !returnHaplotypes.contains(h) ) {
+                    // TODO this score seems to be irrelevant at this point...
                     if (kBestHaplotype.isReference()) {
                         refHaplotype.setScore(kBestHaplotype.score());
                     }
@@ -281,7 +287,7 @@ public final class ReadThreadingAssembler {
         }
     }
 
-    private AssemblyResult getResultSetForRTGraph(final ReadThreadingGraph rtGraph) {
+    private AssemblyResult getResultSetForRTGraph(final ReadThreadingGraphInterface rtGraph) {
 
         // The graph has degenerated in some way, so the reference source and/or sink cannot be id'd.  Can
         // happen in cases where for example the reference somehow manages to acquire a cycle, or
@@ -447,7 +453,9 @@ public final class ReadThreadingAssembler {
             return null;
         }
 
-        final ReadThreadingGraph rtgraph = new ReadThreadingGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
+        // TODO figure out how you want to hook this in
+        final ReadThreadingGraphInterface rtgraph = generateSeqGraph ? new ReadThreadingGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples) :
+                new JunctionTreeLinkedDeBruinGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
 
         rtgraph.setThreadingStartOnlyAtExistingVertex(!recoverDanglingBranches);
 
@@ -467,8 +475,8 @@ public final class ReadThreadingAssembler {
         // and unnecessarily abort assembly
         chainPruner.pruneLowWeightChains(rtgraph);
 
-        // sanity check: make sure there are no cycles in the graph
-        if ( rtgraph.hasCycles() ) {
+        // sanity check: make sure there are no cycles in the graph, unless we are in experimental mode
+        if ( generateSeqGraph && rtgraph.hasCycles() ) {
             if ( debug ) {
                 logger.info("Not using kmer size of " + kmerSize + " in read threading assembler because it contains a cycle");
             }
@@ -491,7 +499,7 @@ public final class ReadThreadingAssembler {
         return result;
     }
 
-    private AssemblyResult getAssemblyResult(final Haplotype refHaplotype, final int kmerSize, final ReadThreadingGraph rtgraph, final SmithWatermanAligner aligner) {
+    private AssemblyResult getAssemblyResult(final Haplotype refHaplotype, final int kmerSize, final ReadThreadingGraphInterface rtgraph, final SmithWatermanAligner aligner) {
         if (debugGraphTransformations) {
             printDebugGraphTransform(rtgraph, refHaplotype.getLocation() + "-sequenceGraph." + kmerSize + ".0.0.raw_readthreading_graph.dot");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -310,9 +310,8 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
             return;
         }
 
-        // determine the kmer size we'll use, and capture the set of nonUniques for that kmer size
-        final NonUniqueResult result = determineKmerSizeAndNonUniques(kmerSize, kmerSize);
-        nonUniqueKmers = result.nonUniques;
+        // Capture the set of non-unique kmers for the given kmer size (if applicable)
+        nonUniqueKmers = determineNonUniques(kmerSize);
 
         if ( DEBUG_NON_UNIQUE_CALC ) {
             logger.info("using " + kmerSize + " kmer size for this assembly with the following non-uniques");
@@ -426,15 +425,6 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
             this.danglingPathString = danglingPathString;
             this.referencePathString = referencePathString;
             this.cigar = cigar;
-        }
-    }
-
-    /** structure that keeps track of the non-unique kmers for a given kmer size */
-    private static final class NonUniqueResult {
-        final Set<Kmer> nonUniques;
-
-        private NonUniqueResult(final Set<Kmer> nonUniques) {
-            this.nonUniques = nonUniques;
         }
     }
 
@@ -872,7 +862,7 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      *
      * @param start   the reference vertex to start from
      * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
-     * @param blacklistedEdges edges to ignore in the traversal down; useful to exclude the non-reference dangling paths
+     * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
      * @return the path (non-null, non-empty)
      */
     private List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
@@ -992,44 +982,30 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * among all sequences added to the current graph.  Will always return a result for maxKmerSize if
      * all smaller kmers had non-unique kmers.
      *
-     * @param minKmerSize the minimum kmer size to consider when constructing the graph
-     * @param maxKmerSize the maximum kmer size to consider
+     * @param kmerSize the kmer size to check for non-unique kmers of
      * @return a non-null NonUniqueResult
      */
-    private NonUniqueResult determineKmerSizeAndNonUniques(final int minKmerSize, final int maxKmerSize) {
+    private Set<Kmer> determineNonUniques(final int kmerSize) {
         final Collection<SequenceForKmers> withNonUniques = getAllPendingSequences();
         final Set<Kmer> nonUniqueKmers = new HashSet<>();
 
-        // go through the sequences and determine which kmers aren't unique within each read
-        for (int kmerSize = minKmerSize ; kmerSize <= maxKmerSize; kmerSize++) {
-            // clear out set of non-unique kmers
-            nonUniqueKmers.clear();
+        // loop over all sequences that have non-unique kmers in them from the previous iterator
+        final Iterator<SequenceForKmers> it = withNonUniques.iterator();
+        while ( it.hasNext() ) {
+            final SequenceForKmers sequenceForKmers = it.next();
 
-            // loop over all sequences that have non-unique kmers in them from the previous iterator
-            final Iterator<SequenceForKmers> it = withNonUniques.iterator();
-            while ( it.hasNext() ) {
-                final SequenceForKmers sequenceForKmers = it.next();
-
-                // determine the non-unique kmers for this sequence
-                final Collection<Kmer> nonUniquesFromSeq = determineNonUniqueKmers(sequenceForKmers, kmerSize);
-                if ( nonUniquesFromSeq.isEmpty() ) {
-                    // remove this sequence from future consideration
-                    it.remove();
-                } else {
-                    // keep track of the non-uniques for this kmerSize, and keep it in the list of sequences that have non-uniques
-                    nonUniqueKmers.addAll(nonUniquesFromSeq);
-                }
-            }
-
-            if ( nonUniqueKmers.isEmpty() )
-                // this kmerSize produces no non-unique sequences, so go ahead and use it for our assembly
-            {
-                break;
+            // determine the non-unique kmers for this sequence
+            final Collection<Kmer> nonUniquesFromSeq = determineNonUniqueKmers(sequenceForKmers, kmerSize);
+            if ( nonUniquesFromSeq.isEmpty() ) {
+                // remove this sequence from future consideration
+                it.remove();
+            } else {
+                // keep track of the non-uniques for this kmerSize, and keep it in the list of sequences that have non-uniques
+                nonUniqueKmers.addAll(nonUniquesFromSeq);
             }
         }
 
-        // necessary because the loop breaks with kmerSize = max + 1
-        return new NonUniqueResult(nonUniqueKmers);
+        return nonUniqueKmers;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -1,80 +1,33 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
 
 import com.google.common.annotations.VisibleForTesting;
-import htsjdk.samtools.Cigar;
-import htsjdk.samtools.CigarElement;
-import htsjdk.samtools.CigarOperator;
-import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.Locatable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KmerSearchableGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.read.ReadUtils;
-import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
-import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAlignment;
 import org.jgrapht.EdgeFactory;
 
 import java.io.File;
 import java.util.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * Note: not final but only intendent to be subclassed for testing.
+ * Note: not final but only intended to be subclassed for testing.
  */
-public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSampleEdge> implements KmerSearchableGraph<MultiDeBruijnVertex,MultiSampleEdge> {
+public class ReadThreadingGraph extends ReadThreadingGraphInterface {
 
-    private static final Logger logger = LogManager.getLogger(ReadThreadingGraph.class);
+    protected static final Logger logger = LogManager.getLogger(ReadThreadingGraph.class);
 
-    private static final String ANONYMOUS_SAMPLE = "XXX_UNNAMED_XXX";
-    private static final boolean WRITE_GRAPH = false;
-    private static final boolean DEBUG_NON_UNIQUE_CALC = false;
-
-    private static final int MAX_CIGAR_COMPLEXITY = 3;
     private static final long serialVersionUID = 1l;
-    private int maxMismatchesInDanglingHead = -1;
-
-    private boolean alreadyBuilt;
-
-    private boolean startThreadingOnlyAtExistingVertex = false;
-
-    /** for debugging info printing */
-    private static int counter = 0;
-
-    /**
-     * Sequences added for read threading before we've actually built the graph
-     */
-    private final Map<String, List<SequenceForKmers>> pending = new LinkedHashMap<>();
 
     /**
      * A set of non-unique kmers that cannot be used as merge points in the graph
      */
-    private Set<Kmer> nonUniqueKmers;
-
-    /**
-     * A map from kmers -> their corresponding vertex in the graph
-     */
-    private final Map<Kmer, MultiDeBruijnVertex> uniqueKmers = new LinkedHashMap<>();
-
-    private final boolean debugGraphTransformations;
-    private final byte minBaseQualityToUseInAssembly;
-
-    private static final boolean INCREASE_COUNTS_BACKWARDS = true;
-    private boolean increaseCountsThroughBranches = false; // this may increase the branches without bounds
-
-    // --------------------------------------------------------------------------------
-    // state variables, initialized in resetToInitialState()
-    // --------------------------------------------------------------------------------
-    private Kmer refSource;
+    protected Set<Kmer> nonUniqueKmers;
 
     /**
      * Constructs an empty read-threading-grpah provided the kmerSize.
@@ -92,48 +45,10 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * <p>
      *     Note: only used for testing.
      * </p>
-     * @param s the string representation of the graph {@code null}.
      */
     @VisibleForTesting
     protected ReadThreadingGraph(final int kmerSizeFromString, final EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> edgeFactory) {
         super(kmerSizeFromString, new MyEdgeFactory(1));
-        debugGraphTransformations = false;
-        minBaseQualityToUseInAssembly = 0;
-    }
-
-    @VisibleForTesting
-    protected void setAlreadyBuilt() {
-        alreadyBuilt = true;
-    }
-
-    @VisibleForTesting
-    void setMaxMismatchesInDanglingHead(final int maxMismatchesInDanglingHead) {
-        this.maxMismatchesInDanglingHead = maxMismatchesInDanglingHead;
-    }
-
-    /**
-     * Return the collection of outgoing vertices that expand this vertex with a particular base.
-     *
-     * @param v original vertex.
-     * @param b expanding base.
-     * @return never null, but perhaps an empty set. You cannot assume that you can modify the result.
-     */
-    @VisibleForTesting
-    Set<MultiDeBruijnVertex> getNextVertices(final MultiDeBruijnVertex v, final byte b) {
-        Utils.nonNull(v, "the input vertex cannot be null");
-        Utils.validateArg(vertexSet().contains(v), "the vertex must be present in the graph");
-        final List<MultiDeBruijnVertex> result = new LinkedList<>();
-        for (final MultiDeBruijnVertex w : outgoingVerticesOf(v)) {
-            if (w.getSuffix() == b) {
-                result.add(w);
-            }
-        }
-        switch (result.size()) {
-            case 0: return Collections.emptySet();
-            case 1: return Collections.singleton(result.get(0));
-            default:
-                    return new HashSet<>(result);
-        }
     }
 
     /**
@@ -141,228 +56,32 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * @param kmerSize must be >= 1
      */
     ReadThreadingGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
-        super(kmerSize, new MyEdgeFactory(numPruningSamples));
-
-        Utils.validateArg( kmerSize > 0, () -> "bad minkKmerSize " + kmerSize);
-
-        this.debugGraphTransformations = debugGraphTransformations;
-        this.minBaseQualityToUseInAssembly = minBaseQualityToUseInAssembly;
-
-        resetToInitialState();
+        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
     }
 
     /**
      * Reset this assembler to its initial state, so we can create another assembly with a different set of reads
      */
-    private void resetToInitialState() {
+    @Override
+    protected void setToInitialState() {
         pending.clear();
         nonUniqueKmers = null;
-        uniqueKmers.clear();
+        kmerToVertexMap.clear();
         refSource = null;
         alreadyBuilt = false;
     }
 
     /**
-     * Add the all bases in sequence to the graph
-     * @param sequence a non-null sequence
-     * @param isRef is this the reference sequence?
+     * Since we want to duplicate non-unique kmers in the graph code we must determine what those kmers are
      */
-    @VisibleForTesting
-    public final void addSequence(final byte[] sequence, final boolean isRef) {
-        addSequence("anonymous", sequence, isRef);
-    }
-
-    /**
-     * Add all bases in sequence to this graph
-     *
-     * @see #addSequence(String, String, byte[], int, int, int, boolean) for full information
-     */
-    public final void addSequence(final String seqName, final byte[] sequence, final boolean isRef) {
-        addSequence(seqName, sequence, 1, isRef);
-    }
-
-    /**
-     * Add all bases in sequence to this graph
-     *
-     * @see #addSequence(String, String, byte[], int, int, int, boolean) for full information
-     */
-    public final void addSequence(final String seqName, final byte[] sequence, final int count, final boolean isRef) {
-        addSequence(seqName, ANONYMOUS_SAMPLE, sequence, 0, sequence.length, count, isRef);
-    }
-
-    /**
-     * Add bases in sequence to this graph
-     *
-     * @param seqName a useful seqName for this read, for debugging purposes
-     * @param sequence non-null sequence of bases
-     * @param start the first base offset in sequence that we should use for constructing the graph using this sequence, inclusive
-     * @param stop the last base offset in sequence that we should use for constructing the graph using this sequence, exclusive
-     * @param count the representative count of this sequence (to use as the weight)
-     * @param isRef is this the reference sequence.
-     */
-    private void addSequence(final String seqName, final String sampleName, final byte[] sequence, final int start, final int stop, final int count, final boolean isRef) {
-        // note that argument testing is taken care of in SequenceForKmers
-        if ( alreadyBuilt ) {
-            throw new IllegalStateException("Graph already built");
-        }
-
-        // get the list of sequences for this sample
-        List<SequenceForKmers> sampleSequences = pending.get(sampleName);
-        if ( sampleSequences == null ) { // need to create
-            sampleSequences = new LinkedList<>();
-            pending.put(sampleName, sampleSequences);
-        }
-
-        // add the new sequence to the list of sequences for sample
-        sampleSequences.add(new SequenceForKmers(seqName, sequence, start, stop, count, isRef));
-    }
-
-    /**
-     * Thread sequence seqForKmers through the current graph, updating the graph as appropriate
-     * @param seqForKmers a non-null sequence
-     */
-    private void threadSequence(final SequenceForKmers seqForKmers) {
-        final int uniqueStartPos = findStart(seqForKmers);
-        if ( uniqueStartPos == -1 ) {
-            return;
-        }
-
-        final MultiDeBruijnVertex startingVertex = getOrCreateKmerVertex(seqForKmers.sequence, uniqueStartPos);
-
-        // increase the counts of all edges incoming into the starting vertex supported by going back in sequence
-        if (INCREASE_COUNTS_BACKWARDS) {
-            increaseCountsInMatchedKmers(seqForKmers, startingVertex, startingVertex.getSequence(), kmerSize - 2);
-        }
-
-        if ( debugGraphTransformations ) {
-            startingVertex.addRead(seqForKmers.name);
-        }
-
-        // keep track of information about the reference source
-        if ( seqForKmers.isRef ) {
-            if ( refSource != null ) {
-                throw new IllegalStateException("Found two refSources! prev: " + refSource + ", new: " + startingVertex);
-            }
-            refSource = new Kmer(seqForKmers.sequence, seqForKmers.start, kmerSize);
-        }
-
-        // loop over all of the bases in sequence, extending the graph by one base at each point, as appropriate
-        MultiDeBruijnVertex vertex = startingVertex;
-        for ( int i = uniqueStartPos + 1; i <= seqForKmers.stop - kmerSize; i++ ) {
-            vertex = extendChainByOne(vertex, seqForKmers.sequence, i, seqForKmers.count, seqForKmers.isRef);
-            if ( debugGraphTransformations ) {
-                vertex.addRead(seqForKmers.name);
-            }
-        }
-    }
-
-    /**
-     * Find vertex and its position in seqForKmers where we should start assembling seqForKmers
-     *
-     * @param seqForKmers the sequence we want to thread into the graph
-     * @return the position of the starting vertex in seqForKmer, or -1 if it cannot find one
-     */
-    private int findStart(final SequenceForKmers seqForKmers) {
-        if ( seqForKmers.isRef ) {
-            return 0;
-        }
-
-        for ( int i = seqForKmers.start; i < seqForKmers.stop - kmerSize; i++ ) {
-            final Kmer kmer1 = new Kmer(seqForKmers.sequence, i, kmerSize);
-            if ( isThreadingStart(kmer1) ) {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    /**
-     * Checks whether a kmer can be the threading start based on the current threading start location policy.
-     *
-     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
-     * @see #getThreadingStartOnlyAtExistingVertex()
-     *
-     * @param kmer the query kmer.
-     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
-     */
-    private boolean isThreadingStart(final Kmer kmer) {
-        Utils.nonNull(kmer);
-        return startThreadingOnlyAtExistingVertex ? uniqueKmers.containsKey(kmer) : !nonUniqueKmers.contains(kmer);
-    }
-
-    /**
-     * Changes the threading start location policy.
-     *
-     * @param value  {@code true} if threading will start only at existing vertices in the graph, {@code false} if
-     *  it can start at any unique kmer.
-     */
-    public final void setThreadingStartOnlyAtExistingVertex(final boolean value) {
-        startThreadingOnlyAtExistingVertex = value;
-    }
-
-    /**
-     * Build the read threaded assembly graph if it hasn't already been constructed from the sequences that have
-     * been added to the graph.
-     */
-    public final void buildGraphIfNecessary() {
-        if ( alreadyBuilt ) {
-            return;
-        }
-
-        // Capture the set of non-unique kmers for the given kmer size (if applicable)
+    @Override
+    protected void preprocessReadsIfNecessary() {
         nonUniqueKmers = determineNonUniques(kmerSize);
+    }
 
-        if ( DEBUG_NON_UNIQUE_CALC ) {
-            logger.info("using " + kmerSize + " kmer size for this assembly with the following non-uniques");
-        }
-
-        // go through the pending sequences, and add them to the graph
-        for ( final List<SequenceForKmers> sequencesForSample : pending.values() ) {
-            for ( final SequenceForKmers sequenceForKmers : sequencesForSample ) {
-                threadSequence(sequenceForKmers);
-                if ( WRITE_GRAPH ) {
-                    printGraph(new File("threading." + counter++ + '.' + sequenceForKmers.name.replace(" ", "_") + ".dot"), 0);
-                }
-            }
-
-            // flush the single sample edge values from the graph
-            for ( final MultiSampleEdge e : edgeSet() ) {
-                e.flushSingleSampleMultiplicity();
-            }
-        }
-
-        // clear
+    @Override
+    protected void removePendingSequencesIfNecessary() {
         pending.clear();
-        alreadyBuilt = true;
-        for (final MultiDeBruijnVertex v : uniqueKmers.values()) {
-            v.setAdditionalInfo(v.getAdditionalInfo() + '+');
-        }
-    }
-
-
-    @Override
-    public boolean removeVertex(final MultiDeBruijnVertex V) {
-        final boolean result = super.removeVertex(V);
-        if (result) {
-            final byte[] sequence = V.getSequence();
-            final Kmer kmer = new Kmer(sequence);
-            uniqueKmers.remove(kmer);
-        }
-        return result;
-    }
-
-    @Override
-    public void removeSingletonOrphanVertices() {
-        // Run through the graph and clean up singular orphaned nodes
-        final Collection<MultiDeBruijnVertex> verticesToRemove = new LinkedList<>();
-        for( final MultiDeBruijnVertex v : vertexSet() ) {
-            if( inDegreeOf(v) == 0 && outDegreeOf(v) == 0 ) {
-                verticesToRemove.add(v);
-            }
-        }
-        removeVertex(null);
-        removeAllVertices(verticesToRemove);
     }
 
     /**
@@ -371,8 +90,17 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      *
      * @return true if the graph has low complexity, false otherwise
      */
+    @Override
     public boolean isLowComplexity() {
-        return nonUniqueKmers.size() * 4 > uniqueKmers.size();
+        return nonUniqueKmers.size() * 4 > kmerToVertexMap.size();
+    }
+
+    // only add the new kmer to the map if it exists and isn't in our non-unique kmer list
+    @Override
+    protected void trackKmer(final Kmer kmer, final MultiDeBruijnVertex newVertex) {
+        if ( ! nonUniqueKmers.contains(kmer) && ! kmerToVertexMap.containsKey(kmer) ) {
+            kmerToVertexMap.put(kmer, newVertex);
+        }
     }
 
     @Override
@@ -380,601 +108,17 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
         return (ReadThreadingGraph) super.clone();
     }
 
-    @VisibleForTesting
-    void setIncreaseCountsThroughBranches(final boolean increaseCountsThroughBranches) {
-        this.increaseCountsThroughBranches = increaseCountsThroughBranches;
-    }
-
     /**
-     * Edge factory that encapsulates the numPruningSamples assembly parameter
-     */
-    private static final class MyEdgeFactory implements EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> {
-        final int numPruningSamples;
-
-        private MyEdgeFactory(final int numPruningSamples) {
-            this.numPruningSamples = numPruningSamples;
-        }
-
-        @Override
-        public MultiSampleEdge createEdge(final MultiDeBruijnVertex sourceVertex, final MultiDeBruijnVertex targetVertex) {
-            return new MultiSampleEdge(false, 1, numPruningSamples);
-        }
-
-        public MultiSampleEdge createEdge(final boolean isRef, final int multiplicity) {
-            return new MultiSampleEdge(isRef, multiplicity, numPruningSamples);
-        }
-    }
-
-    /**
-     * Class to keep track of the important dangling chain merging data
-     */
-    static final class DanglingChainMergeHelper {
-        final List<MultiDeBruijnVertex> danglingPath;
-        final List<MultiDeBruijnVertex> referencePath;
-        final byte[] danglingPathString;
-        final byte[] referencePathString;
-        final Cigar cigar;
-
-        DanglingChainMergeHelper(final List<MultiDeBruijnVertex> danglingPath,
-                                        final List<MultiDeBruijnVertex> referencePath,
-                                        final byte[] danglingPathString,
-                                        final byte[] referencePathString,
-                                        final Cigar cigar) {
-            this.danglingPath = danglingPath;
-            this.referencePath = referencePath;
-            this.danglingPathString = danglingPathString;
-            this.referencePathString = referencePathString;
-            this.cigar = cigar;
-        }
-    }
-
-    /**
-     * Keeps track of the information needed to add a sequence to the read threading assembly graph
-     */
-    static final class SequenceForKmers {
-        final String name;
-        final byte[] sequence;
-        final int start;
-        final int stop;
-        final int count;
-        final boolean isRef;
-
-        /**
-         * Create a new sequence for creating kmers
-         */
-        SequenceForKmers(final String name, final byte[] sequence, final int start, final int stop, final int count, final boolean ref) {
-            Utils.nonNull(sequence, "Sequence is null ");
-            Utils.validateArg( start >= 0, () -> "Invalid start " + start);
-            Utils.validateArg( stop >= start, () -> "Invalid stop " + stop);
-            Utils.validateArg( count > 0, "Invalid count " + count);
-
-            this.name = name;
-            this.sequence = sequence;
-            this.start = start;
-            this.stop = stop;
-            this.count = count;
-            isRef = ref;
-        }
-    }
-
-    /**
-     * Try to recover dangling tails
+     * Checks whether a kmer can be the threading start based on the current threading start location policy.
      *
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
-     * @param aligner
-     */
-    public void recoverDanglingTails(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
-        Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
-
-        if ( ! alreadyBuilt ) {
-            throw new IllegalStateException("recoverDanglingTails requires the graph be already built");
-        }
-
-        int attempted = 0;
-        int nRecovered = 0;
-        for ( final MultiDeBruijnVertex v : vertexSet() ) {
-            if ( outDegreeOf(v) == 0 && ! isRefSink(v) ) {
-                attempted++;
-                nRecovered += recoverDanglingTail(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
-            }
-        }
-
-        logger.debug(String.format("Recovered %d of %d dangling tails", nRecovered, attempted));
-    }
-
-
-    /**
-     * Try to recover dangling heads
+     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
      *
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
-     * @param aligner
+     * @param kmer the query kmer.
+     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
      */
-    public void recoverDanglingHeads(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
-        Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
-        if ( ! alreadyBuilt ) {
-            throw new IllegalStateException("recoverDanglingHeads requires the graph be already built");
-        }
-
-        // we need to build a list of dangling heads because that process can modify the graph (and otherwise generate
-        // a ConcurrentModificationException if we do it while iterating over the vertexes)
-        final Collection<MultiDeBruijnVertex> danglingHeads = vertexSet().stream()
-                .filter(v -> inDegreeOf(v) == 0 && ! isRefSource(v))
-                .collect(Collectors.toList());
-
-        // now we can try to recover the dangling heads
-        int attempted = 0;
-        int nRecovered = 0;
-        for ( final MultiDeBruijnVertex v : danglingHeads ) {
-            attempted++;
-            nRecovered += recoverDanglingHead(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
-        }
-
-        logger.debug(String.format("Recovered %d of %d dangling heads", nRecovered, attempted));
-    }
-
-    /**
-     * Attempt to attach vertex with out-degree == 0 to the graph
-     *
-     * @param vertex the vertex to recover
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param aligner
-     * @return 1 if we successfully recovered the vertex and 0 otherwise
-     */
-    private int recoverDanglingTail(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        if ( outDegreeOf(vertex) != 0 ) {
-            throw new IllegalStateException("Attempting to recover a dangling tail for " + vertex + " but it has out-degree > 0");
-        }
-
-        // generate the CIGAR string from Smith-Waterman between the dangling tail and reference paths
-        final DanglingChainMergeHelper danglingTailMergeResult = generateCigarAgainstDownwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
-
-        // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
-        if ( danglingTailMergeResult == null || ! cigarIsOkayToMerge(danglingTailMergeResult.cigar, false, true) ) {
-            return 0;
-        }
-
-        // merge
-        return mergeDanglingTail(danglingTailMergeResult);
-    }
-
-    /**
-     * Attempt to attach vertex with in-degree == 0, or a vertex on its path, to the graph
-     *
-     * @param vertex the vertex to recover
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
-     * @param recoverAll recover even branches with forks
-     * @param aligner
-     * @return 1 if we successfully recovered a vertex and 0 otherwise
-     */
-    private int recoverDanglingHead(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
-        if ( inDegreeOf(vertex) != 0 ) {
-            throw new IllegalStateException("Attempting to recover a dangling head for " + vertex + " but it has in-degree > 0");
-        }
-
-        // generate the CIGAR string from Smith-Waterman between the dangling tail and reference paths
-        final DanglingChainMergeHelper danglingHeadMergeResult = generateCigarAgainstUpwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
-
-        // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
-        if ( danglingHeadMergeResult == null || ! cigarIsOkayToMerge(danglingHeadMergeResult.cigar, true, false) ) {
-            return 0;
-        }
-
-        // merge
-        return mergeDanglingHead(danglingHeadMergeResult);
-    }
-
-    /**
-     * Determine whether the provided cigar is okay to merge into the reference path
-     *
-     * @param cigar    the cigar to analyze
-     * @param requireFirstElementM if true, require that the first cigar element be an M operator in order for it to be okay
-     * @param requireLastElementM  if true, require that the last cigar element be an M operator in order for it to be okay
-     * @return true if it's okay to merge, false otherwise
-     */
-    @VisibleForTesting
-    static boolean cigarIsOkayToMerge(final Cigar cigar, final boolean requireFirstElementM, final boolean requireLastElementM) {
-        final List<CigarElement> elements = cigar.getCigarElements();
-        final int numElements = elements.size();
-
-        // don't allow more than a couple of different ops
-        if ( numElements == 0 || numElements > MAX_CIGAR_COMPLEXITY ) {
-            return false;
-        }
-
-        // the first element must be an M
-        if ( requireFirstElementM && elements.get(0).getOperator() != CigarOperator.M ) {
-            return false;
-        }
-
-        // the last element must be an M
-        if ( requireLastElementM && elements.get(numElements - 1).getOperator() != CigarOperator.M ) {
-            return false;
-        }
-
-        // note that there are checks for too many mismatches in the dangling branch later in the process
-
-        return true;
-    }
-
-    /**
-     * Actually merge the dangling tail if possible
-     *
-     * @param danglingTailMergeResult   the result from generating a Cigar for the dangling tail against the reference
-     * @return 1 if merge was successful, 0 otherwise
-     */
-    @VisibleForTesting
-    final int mergeDanglingTail(final DanglingChainMergeHelper danglingTailMergeResult) {
-
-        final List<CigarElement> elements = danglingTailMergeResult.cigar.getCigarElements();
-        final CigarElement lastElement = elements.get(elements.size() - 1);
-        Utils.validateArg( lastElement.getOperator() == CigarOperator.M, "The last Cigar element must be an M");
-
-        final int lastRefIndex = danglingTailMergeResult.cigar.getReferenceLength() - 1;
-        final int matchingSuffix = Math.min(longestSuffixMatch(danglingTailMergeResult.referencePathString, danglingTailMergeResult.danglingPathString, lastRefIndex), lastElement.getLength());
-        if ( matchingSuffix == 0 ) {
-            return 0;
-        }
-
-        final int altIndexToMerge = Math.max(danglingTailMergeResult.cigar.getReadLength() - matchingSuffix - 1, 0);
-
-        // there is an important edge condition that we need to handle here: Smith-Waterman correctly calculates that there is a
-        // deletion, that deletion is left-aligned such that the LCA node is part of that deletion, and the rest of the dangling
-        // tail is a perfect match to the suffix of the reference path.  In this case we need to push the reference index to merge
-        // down one position so that we don't incorrectly cut a base off of the deletion.
-        final boolean firstElementIsDeletion = elements.get(0).getOperator() == CigarOperator.D;
-        final boolean mustHandleLeadingDeletionCase =  firstElementIsDeletion && (elements.get(0).getLength() + matchingSuffix == lastRefIndex + 1);
-        final int refIndexToMerge = lastRefIndex - matchingSuffix + 1 + (mustHandleLeadingDeletionCase ? 1 : 0);
-
-        // another edge condition occurs here: if Smith-Waterman places the whole tail into an insertion then it will try to
-        // merge back to the LCA, which results in a cycle in the graph.  So we do not want to merge in such a case.
-        if ( refIndexToMerge == 0 ) {
-            return 0;
-        }
-
-        // it's safe to merge now
-        addEdge(danglingTailMergeResult.danglingPath.get(altIndexToMerge), danglingTailMergeResult.referencePath.get(refIndexToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
-
-        return 1;
-    }
-
-
-    /**
-     * calculates the longest suffix match between a sequence and a smaller kmer
-     *
-     * @param seq         the (reference) sequence
-     * @param kmer        the smaller kmer sequence
-     * @param seqStart    the index (inclusive) on seq to start looking backwards from
-     * @return the longest matching suffix
-     */
-    @VisibleForTesting
-    static int longestSuffixMatch(final byte[] seq, final byte[] kmer, final int seqStart) {
-        for ( int len = 1; len <= kmer.length; len++ ) {
-            final int seqI = seqStart - len + 1;
-            final int kmerI = kmer.length - len;
-            if ( seqI < 0 || seq[seqI] != kmer[kmerI] ) {
-                return len - 1;
-            }
-        }
-        return kmer.length;
-    }
-
-    /**
-     * Actually merge the dangling head if possible
-     *
-     * @param danglingHeadMergeResult   the result from generating a Cigar for the dangling head against the reference
-     * @return 1 if merge was successful, 0 otherwise
-     */
-    @VisibleForTesting
-    int mergeDanglingHead(final DanglingChainMergeHelper danglingHeadMergeResult) {
-
-        final List<CigarElement> elements = danglingHeadMergeResult.cigar.getCigarElements();
-        final CigarElement firstElement = elements.get(0);
-        Utils.validateArg( firstElement.getOperator() == CigarOperator.M, "The first Cigar element must be an M");
-
-        final int indexesToMerge = bestPrefixMatch(danglingHeadMergeResult.referencePathString, danglingHeadMergeResult.danglingPathString, firstElement.getLength());
-        if ( indexesToMerge <= 0 ) {
-            return 0;
-        }
-
-        // we can't push back the reference path
-        if ( indexesToMerge >= danglingHeadMergeResult.referencePath.size() - 1 ) {
-            return 0;
-        }
-
-        // but we can manipulate the dangling path if we need to
-        if ( indexesToMerge >= danglingHeadMergeResult.danglingPath.size() &&
-                ! extendDanglingPathAgainstReference(danglingHeadMergeResult, indexesToMerge - danglingHeadMergeResult.danglingPath.size() + 2) ) {
-            return 0;
-        }
-
-        addEdge(danglingHeadMergeResult.referencePath.get(indexesToMerge+1), danglingHeadMergeResult.danglingPath.get(indexesToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
-
-        return 1;
-    }
-
-    /**
-     * Generates the CIGAR string from the Smith-Waterman alignment of the dangling path (where the
-     * provided vertex is the sink) and the reference path.
-     *
-     * @param aligner
-     * @param vertex   the sink of the dangling chain
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param recoverAll recover even branches with forks
-     * @return a SmithWaterman object which can be null if no proper alignment could be generated
-     */
-    @VisibleForTesting
-    final DanglingChainMergeHelper generateCigarAgainstDownwardsReferencePath(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, SmithWatermanAligner aligner) {
-        final int minTailPathLength = Math.max(1, minDanglingBranchLength); // while heads can be 0, tails absolutely cannot
-
-        // find the lowest common ancestor path between this vertex and the diverging master path if available
-        final List<MultiDeBruijnVertex> altPath = findPathUpwardsToLowestCommonAncestor(vertex, pruneFactor, !recoverAll);
-        if ( altPath == null || isRefSource(altPath.get(0)) || altPath.size() < minTailPathLength + 1 ) // add 1 to include the LCA
-        {
-            return null;
-        }
-
-        // now get the reference path from the LCA
-        final List<MultiDeBruijnVertex> refPath = getReferencePath(altPath.get(0), TraversalDirection.downwards, Optional.ofNullable(getHeaviestIncomingEdge(altPath.get(1))));
-
-        // create the Smith-Waterman strings to use
-        final byte[] refBases = getBasesForPath(refPath, false);
-        final byte[] altBases = getBasesForPath(altPath, false);
-
-        // run Smith-Waterman to determine the best alignment (and remove trailing deletions since they aren't interesting)
-        final SmithWatermanAlignment alignment = aligner.align(refBases, altBases, SmithWatermanAligner.STANDARD_NGS, SWOverhangStrategy.LEADING_INDEL);
-        return new DanglingChainMergeHelper(altPath, refPath, altBases, refBases, AlignmentUtils.removeTrailingDeletions(alignment.getCigar()));
-    }
-
-    /**
-     * Generates the CIGAR string from the Smith-Waterman alignment of the dangling path (where the
-     * provided vertex is the source) and the reference path.
-     *
-     * @param aligner
-     * @param vertex   the source of the dangling head
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param recoverAll recover even branches with forks
-     * @return a SmithWaterman object which can be null if no proper alignment could be generated
-     */
-    @VisibleForTesting
-    final DanglingChainMergeHelper generateCigarAgainstUpwardsReferencePath(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, SmithWatermanAligner aligner) {
-
-        // find the highest common descendant path between vertex and the reference source if available
-        final List<MultiDeBruijnVertex> altPath = findPathDownwardsToHighestCommonDescendantOfReference(vertex, pruneFactor, !recoverAll);
-        if ( altPath == null || isRefSink(altPath.get(0)) || altPath.size() < minDanglingBranchLength + 1 ) // add 1 to include the LCA
-        {
-            return null;
-        }
-
-        // now get the reference path from the LCA
-        final List<MultiDeBruijnVertex> refPath = getReferencePath(altPath.get(0), TraversalDirection.upwards, Optional.empty());
-
-        // create the Smith-Waterman strings to use
-        final byte[] refBases = getBasesForPath(refPath, true);
-        final byte[] altBases = getBasesForPath(altPath, true);
-
-        // run Smith-Waterman to determine the best alignment (and remove trailing deletions since they aren't interesting)
-        final SmithWatermanAlignment alignment = aligner.align(refBases, altBases, SmithWatermanAligner.STANDARD_NGS, SWOverhangStrategy.LEADING_INDEL);
-        return new DanglingChainMergeHelper(altPath, refPath, altBases, refBases, AlignmentUtils.removeTrailingDeletions(alignment.getCigar()));
-    }
-
-    /**
-     * Finds the path upwards in the graph from this vertex to the first diverging node, including that (lowest common ancestor) vertex.
-     * Note that nodes are excluded if their pruning weight is less than the pruning factor.
-     *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
-     * @return the path if it can be determined or null if this vertex either doesn't merge onto another path or
-     *  has an ancestor with multiple incoming edges before hitting the reference path
-     */
-    private List<MultiDeBruijnVertex> findPathUpwardsToLowestCommonAncestor(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
-        return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> inDegreeOf(v) != 1 || outDegreeOf(v) >= 2, v -> outDegreeOf(v) > 1, v -> incomingEdgeOf(v), e -> getEdgeSource(e))
-                :findPath(vertex, pruneFactor, v -> hasIncidentRefEdge(v) || inDegreeOf(v) == 0, v -> outDegreeOf(v) > 1 && hasIncidentRefEdge(v), this::getHeaviestIncomingEdge, e -> getEdgeSource(e));
-    }
-
-    private boolean hasIncidentRefEdge(final MultiDeBruijnVertex v) {
-        for (final MultiSampleEdge edge : incomingEdgesOf(v)) {
-            if (edge.isRef()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private MultiSampleEdge getHeaviestIncomingEdge(final MultiDeBruijnVertex v) {
-        final Set<MultiSampleEdge> incomingEdges = incomingEdgesOf(v);
-        return incomingEdges.size() == 1 ? incomingEdges.iterator().next() :
-                incomingEdges.stream().max(Comparator.comparingInt(MultiSampleEdge::getMultiplicity)).get();
-    }
-
-    /**
-     * Finds the path downwards in the graph from this vertex to the reference sequence, including the highest common descendant vertex.
-     * However note that the path is reversed so that this vertex ends up at the end of the path.
-     * Also note that nodes are excluded if their pruning weight is less than the pruning factor.
-     *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
-     * @return the path if it can be determined or null if this vertex either doesn't merge onto the reference path or
-     *  has a descendant with multiple outgoing edges before hitting the reference path
-     */
-    private List<MultiDeBruijnVertex> findPathDownwardsToHighestCommonDescendantOfReference(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
-        return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) != 1, v -> isReferenceNode(v), v -> outgoingEdgeOf(v), e -> getEdgeTarget(e))
-                : findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) == 0, v -> isReferenceNode(v), this::getHeaviestOutgoingEdge, e -> getEdgeTarget(e));
-    }
-
-    private MultiSampleEdge getHeaviestOutgoingEdge(final MultiDeBruijnVertex v) {
-        final Set<MultiSampleEdge> outgoing = outgoingEdgesOf(v);
-        return outgoing.size() == 1 ? outgoing.iterator().next() :
-                outgoing.stream().max(Comparator.comparingInt(MultiSampleEdge::getMultiplicity)).get();
-    }
-
-    /**
-     * Finds a path starting from a given vertex and satisfying various predicates
-     *
-     * @param vertex   the original vertex
-     * @param pruneFactor  the prune factor to use in ignoring chain pieces
-     * @param done test for whether a vertex is at the end of the path
-     * @param returnPath test for whether to return a found path based on its terminal vertex
-     * @param nextEdge function on vertices returning the next edge in the path
-     * @param nextNode function of edges returning the next vertex in the path
-     * @return a path, if one satisfying all predicates is found, {@code null} otherwise
-     */
-    private  List<MultiDeBruijnVertex> findPath(final MultiDeBruijnVertex vertex, final int pruneFactor,
-                                            final Predicate<MultiDeBruijnVertex> done,
-                                            final Predicate<MultiDeBruijnVertex> returnPath,
-                                            final Function<MultiDeBruijnVertex, MultiSampleEdge> nextEdge,
-                                            final Function<MultiSampleEdge, MultiDeBruijnVertex> nextNode){
-        final LinkedList<MultiDeBruijnVertex> path = new LinkedList<>();
-
-        MultiDeBruijnVertex v = vertex;
-        while ( ! done.test(v) ) {
-            final MultiSampleEdge edge = nextEdge.apply(v);
-            // if it has too low a weight, don't use it (or previous vertexes) for the path
-            if ( edge.getPruningMultiplicity() < pruneFactor ) {
-                path.clear();
-            }// otherwise it is safe to use
-            else {
-                path.addFirst(v);
-            }
-            v = nextNode.apply(edge);
-        }
-        path.addFirst(v);
-
-        return returnPath.test(v) ? path : null;
-    }
-
-    private enum TraversalDirection {
-        downwards,
-        upwards
-    }
-
-    /**
-     * Finds the path in the graph from this vertex to the reference sink, including this vertex
-     *
-     * @param start   the reference vertex to start from
-     * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
-     * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
-     * @return the path (non-null, non-empty)
-     */
-    private List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
-                                                       final TraversalDirection direction,
-                                                       final Optional<MultiSampleEdge> blacklistedEdge) {
-
-        final List<MultiDeBruijnVertex> path = new ArrayList<>();
-
-        MultiDeBruijnVertex v = start;
-        while ( v != null ) {
-            path.add(v);
-            v = (direction == TraversalDirection.downwards ? getNextReferenceVertex(v, true, blacklistedEdge) : getPrevReferenceVertex(v));
-        }
-
-        return path;
-    }
-
-    /**
-     * The base sequence for the given path.
-     *
-     * @param path the list of vertexes that make up the path
-     * @param expandSource if true and if we encounter a source node, then expand (and reverse) the character sequence for that node
-     * @return  non-null sequence of bases corresponding to the given path
-     */
-    @VisibleForTesting
-    byte[] getBasesForPath(final List<MultiDeBruijnVertex> path, final boolean expandSource) {
-        Utils.nonNull(path, "Path cannot be null");
-
-        final StringBuilder sb = new StringBuilder();
-        for ( final MultiDeBruijnVertex v : path ) {
-            if ( expandSource && isSource(v) ) {
-                final String seq = v.getSequenceString();
-                sb.append(new StringBuilder(seq).reverse().toString());
-            } else {
-                sb.append((char)v.getSuffix());
-            }
-        }
-
-        return sb.toString().getBytes();
-    }
-
-    /**
-     * Finds the index of the best extent of the prefix match between the provided paths, for dangling head merging.
-     * Assumes that path1.length >= maxIndex and path2.length >= maxIndex.
-     *
-     * @param path1  the first path
-     * @param path2  the second path
-     * @param maxIndex the maximum index to traverse (not inclusive)
-     * @return the index of the ideal prefix match or -1 if it cannot find one, must be less than maxIndex
-     */
-    private int bestPrefixMatch(final byte[] path1, final byte[] path2, final int maxIndex) {
-        final int maxMismatches = getMaxMismatches(maxIndex);
-        int mismatches = 0;
-        int index = 0;
-        int lastGoodIndex = -1;
-        while ( index < maxIndex ) {
-            if ( path1[index] != path2[index] ) {
-                if ( ++mismatches > maxMismatches ) {
-                    return -1;
-                }
-                lastGoodIndex = index;
-            }
-            index++;
-        }
-        // if we got here then we hit the max index
-        return lastGoodIndex;
-    }
-
-    /**
-     * Determine the maximum number of mismatches permitted on the branch.
-     * Unless it's preset (e.g. by unit tests) it should be the length of the branch divided by the kmer size.
-     *
-     * @param lengthOfDanglingBranch  the length of the branch itself
-     * @return positive integer
-     */
-    private int getMaxMismatches(final int lengthOfDanglingBranch) {
-        return maxMismatchesInDanglingHead > 0 ? maxMismatchesInDanglingHead : Math.max(1, (lengthOfDanglingBranch / kmerSize));
-    }
-
-    private boolean extendDanglingPathAgainstReference(final DanglingChainMergeHelper danglingHeadMergeResult, final int numNodesToExtend) {
-
-        final int indexOfLastDanglingNode = danglingHeadMergeResult.danglingPath.size() - 1;
-        final int indexOfRefNodeToUse = indexOfLastDanglingNode + numNodesToExtend;
-        if ( indexOfRefNodeToUse >= danglingHeadMergeResult.referencePath.size() ) {
-            return false;
-        }
-
-        final MultiDeBruijnVertex danglingSource = danglingHeadMergeResult.danglingPath.remove(indexOfLastDanglingNode);
-        final StringBuilder sb = new StringBuilder();
-        final byte[] refSourceSequence = danglingHeadMergeResult.referencePath.get(indexOfRefNodeToUse).getSequence();
-        for ( int i = 0; i < numNodesToExtend; i++ ) {
-            sb.append((char) refSourceSequence[i]);
-        }
-        sb.append(danglingSource.getSequenceString());
-        final byte[] sequenceToExtend = sb.toString().getBytes();
-
-        // clean up the source and edge
-        final MultiSampleEdge sourceEdge = getHeaviestOutgoingEdge(danglingSource);
-        MultiDeBruijnVertex prevV = getEdgeTarget(sourceEdge);
-        removeEdge(danglingSource, prevV);
-
-        // extend the path
-        for ( int i = numNodesToExtend; i > 0; i-- ) {
-            final MultiDeBruijnVertex newV = new MultiDeBruijnVertex(Arrays.copyOfRange(sequenceToExtend, i, i + kmerSize));
-            addVertex(newV);
-            final MultiSampleEdge newE = addEdge(newV, prevV);
-            newE.setMultiplicity(sourceEdge.getMultiplicity());
-            danglingHeadMergeResult.danglingPath.add(newV);
-            prevV = newV;
-        }
-
-        return true;
+    protected boolean isThreadingStart(final Kmer kmer, final boolean startThreadingOnlyAtExistingVertex) {
+        Utils.nonNull(kmer);
+        return startThreadingOnlyAtExistingVertex ? kmerToVertexMap.containsKey(kmer) : !nonUniqueKmers.contains(kmer);
     }
 
     /**
@@ -1042,147 +186,13 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
         return super.toSequenceGraph();
     }
 
-    private void increaseCountsInMatchedKmers(final SequenceForKmers seqForKmers,
-                                              final MultiDeBruijnVertex vertex,
-                                              final byte[] originalKmer,
-                                              final int offset) {
-        if ( offset == -1 ) {
-            return;
-        }
-
-        for ( final MultiSampleEdge edge : incomingEdgesOf(vertex) ) {
-            final MultiDeBruijnVertex prev = getEdgeSource(edge);
-            final byte suffix = prev.getSuffix();
-            final byte seqBase = originalKmer[offset];
-            if ( suffix == seqBase && (increaseCountsThroughBranches || inDegreeOf(vertex) == 1) ) {
-                edge.incMultiplicity(seqForKmers.count);
-                increaseCountsInMatchedKmers(seqForKmers, prev, originalKmer, offset-1);
-            }
-        }
-    }
-
     /**
-     * Get the vertex for the kmer in sequence starting at start
-     * @param sequence the sequence
-     * @param start the position of the kmer start
-     * @return a non-null vertex
-     */
-    private MultiDeBruijnVertex getOrCreateKmerVertex(final byte[] sequence, final int start) {
-        final Kmer kmer = new Kmer(sequence, start, kmerSize);
-        final MultiDeBruijnVertex vertex = getUniqueKmerVertex(kmer, true);
-        return ( vertex != null ) ? vertex : createVertex(kmer);
-    }
-
-    /**
-     * Get the unique vertex for kmer, or null if not possible.
-     *
-     * @param allowRefSource if true, we will allow kmer to match the reference source vertex
-     * @return a vertex for kmer, or null if it's not unique
-     */
-    private MultiDeBruijnVertex getUniqueKmerVertex(final Kmer kmer, final boolean allowRefSource) {
-        if ( ! allowRefSource && kmer.equals(refSource) ) {
-            return null;
-        }
-
-        return uniqueKmers.get(kmer);
-    }
-
-
-    /**
-     * Create a new vertex for kmer.  Add it to the uniqueKmers map if appropriate.
-     *
-     * kmer must not have a entry in unique kmers, or an error will be thrown
-     *
-     * @param kmer the kmer we want to create a vertex for
-     * @return the non-null created vertex
-     */
-    private MultiDeBruijnVertex createVertex(final Kmer kmer) {
-        final MultiDeBruijnVertex newVertex = new MultiDeBruijnVertex(kmer.bases());
-        final int prevSize = vertexSet().size();
-        addVertex(newVertex);
-
-        // make sure we aren't adding duplicates (would be a bug)
-        if ( vertexSet().size() != prevSize + 1) {
-            throw new IllegalStateException("Adding vertex " + newVertex + " to graph didn't increase the graph size");
-        }
-
-        // add the vertex to the unique kmer map, if it is in fact unique
-        if ( ! nonUniqueKmers.contains(kmer) && ! uniqueKmers.containsKey(kmer) ) // TODO -- not sure this last test is necessary
-        {
-            uniqueKmers.put(kmer, newVertex);
-        }
-
-        return newVertex;
-    }
-
-    /**
-     * Workhorse routine of the assembler.  Given a sequence whose last vertex is anchored in the graph, extend
-     * the graph one bp according to the bases in sequence.
-     *
-     * @param prevVertex a non-null vertex where sequence was last anchored in the graph
-     * @param sequence the sequence we're threading through the graph
-     * @param kmerStart the start of the current kmer in graph we'd like to add
-     * @param count the number of observations of this kmer in graph (can be > 1 for GGA)
-     * @param isRef is this the reference sequence?
-     * @return a non-null vertex connecting prevVertex to in the graph based on sequence
-     */
-    private MultiDeBruijnVertex extendChainByOne(final MultiDeBruijnVertex prevVertex, final byte[] sequence, final int kmerStart, final int count, final boolean isRef) {
-        final Set<MultiSampleEdge> outgoingEdges = outgoingEdgesOf(prevVertex);
-
-        final int nextPos = kmerStart + kmerSize - 1;
-        for ( final MultiSampleEdge outgoingEdge : outgoingEdges ) {
-            final MultiDeBruijnVertex target = getEdgeTarget(outgoingEdge);
-            if ( target.getSuffix() == sequence[nextPos] ) {
-                // we've got a match in the chain, so simply increase the count of the edge by 1 and continue
-                outgoingEdge.incMultiplicity(count);
-                return target;
-            }
-        }
-
-        // none of our outgoing edges had our unique suffix base, so we check for an opportunity to merge back in
-        final Kmer kmer = new Kmer(sequence, kmerStart, kmerSize);
-        final MultiDeBruijnVertex uniqueMergeVertex = getUniqueKmerVertex(kmer, false);
-
-        if ( isRef && uniqueMergeVertex != null ) {
-            throw new IllegalStateException("Found a unique vertex to merge into the reference graph " + prevVertex + " -> " + uniqueMergeVertex);
-        }
-
-        // either use our unique merge vertex, or create a new one in the chain
-        final MultiDeBruijnVertex nextVertex = uniqueMergeVertex == null ? createVertex(kmer) : uniqueMergeVertex;
-        addEdge(prevVertex, nextVertex, ((MyEdgeFactory)getEdgeFactory()).createEdge(isRef, count));
-        return nextVertex;
-    }
-
-    /**
-     * Add a read to the sequence graph.  Finds maximal consecutive runs of bases with sufficient quality
-     * and applies {@see addSequence} to these subreads if they are longer than the kmer size.
-     *
-     * @param read a non-null read
+     * Get the set of non-unique kmers in this graph.  For debugging purposes
+     * @return a non-null set of kmers
      */
     @VisibleForTesting
-    void addRead(final GATKRead read, final SAMFileHeader header) {
-        final byte[] sequence = read.getBases();
-        final byte[] qualities = read.getBaseQualities();
-
-        int lastGood = -1;
-        for( int end = 0; end <= sequence.length; end++ ) {
-            if ( end == sequence.length || ! baseIsUsableForAssembly(sequence[end], qualities[end]) ) {
-                // the first good base is at lastGood, can be -1 if last base was bad
-                final int start = lastGood;
-                // the stop base is end - 1 (if we're not at the end of the sequence)
-                final int len = end - start;
-
-                if ( start != -1 && len >= kmerSize ) {
-                    // if the sequence is long enough to get some value out of, add it to the graph
-                    final String name = read.getName() + '_' + start + '_' + end;
-                    addSequence(name, ReadUtils.getSampleName(read, header), sequence, start, end, 1, false);
-                }
-
-                lastGood = -1; // reset the last good base
-            } else if ( lastGood == -1 ) {
-                lastGood = end; // we're at a good base, the last good one is us
-            }
-        }
+    Set<Kmer> getNonUniqueKmers() {
+        return nonUniqueKmers;
     }
 
     /**
@@ -1193,29 +203,28 @@ public class ReadThreadingGraph extends BaseGraph<MultiDeBruijnVertex, MultiSamp
      * @param qual  the quality of that base
      * @return true if the base can be used for assembly, false otherwise
      */
-    private boolean baseIsUsableForAssembly(final byte base, final byte qual) {
+    @Override
+    protected boolean baseIsUsableForAssembly(final byte base, final byte qual) {
         return base != BaseUtils.Base.N.base && qual >= minBaseQualityToUseInAssembly;
     }
 
-    /**
-     * Get the set of non-unique kmers in this graph.  For debugging purposes
-     * @return a non-null set of kmers
-     */
-    @VisibleForTesting
-    Set<Kmer> getNonUniqueKmers() {
-        return nonUniqueKmers;
+    @Override
+    protected MultiDeBruijnVertex getNextKmerVertexForChainExtension(final Kmer kmer, final boolean isRef, final MultiDeBruijnVertex prevVertex) {
+        final MultiDeBruijnVertex uniqueMergeVertex = getKmerVertex(kmer, false);
+
+        Utils.validate(!(isRef && uniqueMergeVertex != null), "Found a unique vertex to merge into the reference graph " + prevVertex + " -> " + uniqueMergeVertex);
+
+        return uniqueMergeVertex;
+    }
+
+    @Override
+    public void postProcessForHaplotypeFinding(final File debugGraphOutputPath, final Locatable refHaplotype) {
+        return; // There is no processing required for this graph so simply return
     }
 
     @Override
     public String toString() {
         return "ReadThreadingAssembler{kmerSize=" + kmerSize + '}';
     }
-
-
-    @Override
-    public MultiDeBruijnVertex findKmer(final Kmer k) {
-        return uniqueKmers.get(k);
-    }
-
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphInterface.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphInterface.java
@@ -1,0 +1,1063 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.Locatable;
+import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.BaseGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KmerSearchableGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
+import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAlignment;
+import org.jgrapht.EdgeFactory;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Read threading graph class intended to contain duplicated code between {@link ReadThreadingGraph} and {@link JunctionTreeLinkedDeBruinGraph}.
+ *
+ *
+ */
+public abstract class ReadThreadingGraphInterface extends BaseGraph<MultiDeBruijnVertex, MultiSampleEdge> implements KmerSearchableGraph<MultiDeBruijnVertex,MultiSampleEdge> {
+    private static final long serialVersionUID = 1l;
+    private static final String ANONYMOUS_SAMPLE = "XXX_UNNAMED_XXX";
+    private static final boolean WRITE_GRAPH = false;
+    private static final boolean DEBUG_NON_UNIQUE_CALC = false;
+    private static final int MAX_CIGAR_COMPLEXITY = 3;
+    private static final boolean INCREASE_COUNTS_BACKWARDS = true;
+    /** for debugging info printing */
+    private static int counter = 0;
+    /**
+     * Sequences added for read threading before we've actually built the graph
+     */
+    protected final Map<String, List<SequenceForKmers>> pending = new LinkedHashMap<>();
+    /**
+     * A map from kmers -> their corresponding vertex in the graph
+     */
+    protected final Map<Kmer, MultiDeBruijnVertex> kmerToVertexMap = new LinkedHashMap<>();
+    protected final boolean debugGraphTransformations;
+    protected final byte minBaseQualityToUseInAssembly;
+    protected boolean startThreadingOnlyAtExistingVertex = false;
+    protected List<MultiDeBruijnVertex> referencePath = null;
+
+    private int maxMismatchesInDanglingHead = -1;
+    protected boolean alreadyBuilt;
+    private boolean increaseCountsThroughBranches = false; // this may increase the branches without bounds
+    // --------------------------------------------------------------------------------
+    // state variables, initialized in setToInitialState()
+    // --------------------------------------------------------------------------------
+    protected Kmer refSource;
+
+    public ReadThreadingGraphInterface(int kmerSize, EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> edgeFactory) {
+        super(kmerSize, edgeFactory);
+        debugGraphTransformations = false;
+        minBaseQualityToUseInAssembly = 0;
+    }
+
+
+    /**
+     * Create a new ReadThreadingAssembler using kmerSize for matching
+     * @param kmerSize must be >= 1
+     */
+    public ReadThreadingGraphInterface(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
+        super(kmerSize, new MyEdgeFactory(numPruningSamples));
+
+        Utils.validateArg( kmerSize > 0, () -> "bad minkKmerSize " + kmerSize);
+
+        this.debugGraphTransformations = debugGraphTransformations;
+        this.minBaseQualityToUseInAssembly = minBaseQualityToUseInAssembly;
+
+        setToInitialState();
+    }
+
+
+    /**
+     * Determine whether the provided cigar is okay to merge into the reference path
+     *
+     * @param cigar    the cigar to analyze
+     * @param requireFirstElementM if true, require that the first cigar element be an M operator in order for it to be okay
+     * @param requireLastElementM  if true, require that the last cigar element be an M operator in order for it to be okay
+     * @return true if it's okay to merge, false otherwise
+     */
+    @VisibleForTesting
+    static boolean cigarIsOkayToMerge(final Cigar cigar, final boolean requireFirstElementM, final boolean requireLastElementM) {
+        final List<CigarElement> elements = cigar.getCigarElements();
+        final int numElements = elements.size();
+
+        // don't allow more than a couple of different ops
+        if ( numElements == 0 || numElements > MAX_CIGAR_COMPLEXITY ) {
+            return false;
+        }
+
+        // the first element must be an M
+        if ( requireFirstElementM && elements.get(0).getOperator() != CigarOperator.M ) {
+            return false;
+        }
+
+        // the last element must be an M
+        if ( requireLastElementM && elements.get(numElements - 1).getOperator() != CigarOperator.M ) {
+            return false;
+        }
+
+        // note that there are checks for too many mismatches in the dangling branch later in the process
+
+        return true;
+    }
+
+    /**
+     * calculates the longest suffix match between a sequence and a smaller kmer
+     *
+     * @param seq         the (reference) sequence
+     * @param kmer        the smaller kmer sequence
+     * @param seqStart    the index (inclusive) on seq to start looking backwards from
+     * @return the longest matching suffix
+     */
+    @VisibleForTesting
+    static int longestSuffixMatch(final byte[] seq, final byte[] kmer, final int seqStart) {
+        for ( int len = 1; len <= kmer.length; len++ ) {
+            final int seqI = seqStart - len + 1;
+            final int kmerI = kmer.length - len;
+            if ( seqI < 0 || seq[seqI] != kmer[kmerI] ) {
+                return len - 1;
+            }
+        }
+        return kmer.length;
+    }
+
+    @VisibleForTesting
+    protected void setAlreadyBuilt() {
+        alreadyBuilt = true;
+    }
+
+    @VisibleForTesting
+    void setMaxMismatchesInDanglingHead(final int maxMismatchesInDanglingHead) {
+        this.maxMismatchesInDanglingHead = maxMismatchesInDanglingHead;
+    }
+
+    /**
+     * Find vertex and its position in seqForKmers where we should start assembling seqForKmers
+     *
+     * @param seqForKmers the sequence we want to thread into the graph
+     * @return the position of the starting vertex in seqForKmer, or -1 if it cannot find one
+     */
+    protected int findStart(final SequenceForKmers seqForKmers) {
+        if ( seqForKmers.isRef ) {
+            return 0;
+        }
+
+        for ( int i = seqForKmers.start; i < seqForKmers.stop - kmerSize; i++ ) {
+            final Kmer kmer1 = new Kmer(seqForKmers.sequence, i, kmerSize);
+            if ( isThreadingStart(kmer1, startThreadingOnlyAtExistingVertex) ) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Checks whether a kmer can be the threading start based on the current threading start location policy.
+     *
+     * @see #setThreadingStartOnlyAtExistingVertex(boolean)
+     * @see #getThreadingStartOnlyAtExistingVertex()
+     *
+     * @param kmer the query kmer.
+     * @return {@code true} if we can start thread the sequence at this kmer, {@code false} otherwise.
+     */
+    protected abstract boolean isThreadingStart(final Kmer kmer, final boolean startThreadingOnlyAtExistingVertex);
+
+    /**
+     * Perform any necessary steps in the constructor.
+     */
+    protected abstract void setToInitialState();
+
+    /**
+     * Add the all bases in sequence to the graph
+     * @param sequence a non-null sequence
+     * @param isRef is this the reference sequence?
+     */
+    @VisibleForTesting
+    public final void addSequence(final byte[] sequence, final boolean isRef) {
+        addSequence("anonymous", sequence, isRef);
+    }
+
+    /**
+     * Add all bases in sequence to this graph
+     *
+     * @see #addSequence(String, String, byte[], int, int, int, boolean) for full information
+     */
+    public final void addSequence(final String seqName, final byte[] sequence, final boolean isRef) {
+        addSequence(seqName, sequence, 1, isRef);
+    }
+
+    /**
+     * Add all bases in sequence to this graph
+     *
+     * @see #addSequence(String, String, byte[], int, int, int, boolean) for full information
+     */
+    public final void addSequence(final String seqName, final byte[] sequence, final int count, final boolean isRef) {
+        addSequence(seqName, ANONYMOUS_SAMPLE, sequence, 0, sequence.length, count, isRef);
+    }
+
+    /**
+     * Add bases in sequence to this graph
+     *
+     * @param seqName a useful seqName for this read, for debugging purposes
+     * @param sequence non-null sequence of bases
+     * @param start the first base offset in sequence that we should use for constructing the graph using this sequence, inclusive
+     * @param stop the last base offset in sequence that we should use for constructing the graph using this sequence, exclusive
+     * @param count the representative count of this sequence (to use as the weight)
+     * @param isRef is this the reference sequence.
+     */
+    private void addSequence(final String seqName, final String sampleName, final byte[] sequence, final int start, final int stop, final int count, final boolean isRef) {
+        // note that argument testing is taken care of in SequenceForKmers
+        Utils.validate(!alreadyBuilt, "Attempting to add sequence to a graph that has already been built");
+
+        // get the list of sequences for this sample
+        List<SequenceForKmers> sampleSequences = pending.computeIfAbsent(sampleName, s -> new LinkedList<>());
+
+        // add the new sequence to the list of sequences for sample
+        sampleSequences.add(new SequenceForKmers(seqName, sequence, start, stop, count, isRef));
+    }
+
+    /**
+     * Thread sequence seqForKmers through the current graph, updating the graph as appropriate
+     * @param seqForKmers a non-null sequence
+     */
+    protected void threadSequence(final SequenceForKmers seqForKmers) {
+        final int startPos = findStart(seqForKmers);
+        if ( startPos == -1 ) {
+            return;
+        }
+
+        final MultiDeBruijnVertex startingVertex = getOrCreateKmerVertex(seqForKmers.sequence, startPos);
+
+        // increase the counts of all edges incoming into the starting vertex supported by going back in sequence
+        if (INCREASE_COUNTS_BACKWARDS) {
+            increaseCountsInMatchedKmers(seqForKmers, startingVertex, startingVertex.getSequence(), kmerSize - 2);
+        }
+
+        if ( debugGraphTransformations ) {
+            startingVertex.addRead(seqForKmers.name);
+        }
+
+        // keep track of information about the reference source
+        if ( seqForKmers.isRef ) {
+            if ( refSource != null ) {
+                throw new IllegalStateException("Found two refSources! prev: " + refSource + ", new: " + startingVertex);
+            }
+            referencePath = new ArrayList<>(seqForKmers.sequence.length - kmerSize);
+            referencePath.add(startingVertex);
+            refSource = new Kmer(seqForKmers.sequence, seqForKmers.start, kmerSize);
+        }
+
+        // loop over all of the bases in sequence, extending the graph by one base at each point, as appropriate
+        MultiDeBruijnVertex vertex = startingVertex;
+        for ( int i = startPos + 1; i <= seqForKmers.stop - kmerSize; i++ ) {
+            vertex = extendChainByOne(vertex, seqForKmers.sequence, i, seqForKmers.count, seqForKmers.isRef);
+            if ( seqForKmers.isRef ) {
+                 referencePath.add(vertex);
+            }
+            if ( debugGraphTransformations ) {
+                vertex.addRead(seqForKmers.name);
+            }
+        }
+        if ( seqForKmers.isRef ) {
+            referencePath = Collections.unmodifiableList(referencePath);
+        }
+    }
+
+    /**
+     * Changes the threading start location policy.
+     *
+     * @param value  {@code true} if threading will start only at existing vertices in the graph, {@code false} if
+     *  it can start at any unique kmer.
+     */
+    public final void setThreadingStartOnlyAtExistingVertex(final boolean value) {
+        startThreadingOnlyAtExistingVertex = value;
+    }
+
+    /**
+     * Build the read threaded assembly graph if it hasn't already been constructed from the sequences that have
+     * been added to the graph.
+     */
+    public final void buildGraphIfNecessary() {
+        if ( alreadyBuilt ) {
+            return;
+        }
+
+        // Capture the set of non-unique kmers for the given kmer size (if applicable)
+        preprocessReadsIfNecessary();
+
+        if ( DEBUG_NON_UNIQUE_CALC ) {
+            ReadThreadingGraph.logger.info("using " + kmerSize + " kmer size for this assembly with the following non-uniques");
+        }
+
+        // go through the pending sequences, and add them to the graph
+        for ( final List<SequenceForKmers> sequencesForSample : pending.values() ) {
+            for ( final SequenceForKmers sequenceForKmers : sequencesForSample ) {
+                threadSequence(sequenceForKmers);
+                if ( WRITE_GRAPH ) {
+                    printGraph(new File("threading." + counter++ + '.' + sequenceForKmers.name.replace(" ", "_") + ".dot"), 0);
+                }
+            }
+
+            // flush the single sample edge values from the graph
+            for ( final MultiSampleEdge e : edgeSet() ) {
+                e.flushSingleSampleMultiplicity();
+            }
+        }
+
+        // clear
+        removePendingSequencesIfNecessary();
+        alreadyBuilt = true;
+        for (final MultiDeBruijnVertex v : kmerToVertexMap.values()) {
+            v.setAdditionalInfo(v.getAdditionalInfo() + '+');
+        }
+    }
+
+    // perform any necessary preprocessing on the graph (such as non-unique kmer determination) before the graph is constructed
+    protected abstract void preprocessReadsIfNecessary();
+
+    protected abstract void removePendingSequencesIfNecessary();
+
+    @Override
+    public boolean removeVertex(final MultiDeBruijnVertex V) {
+        final boolean result = super.removeVertex(V);
+        if (result) {
+            final byte[] sequence = V.getSequence();
+            final Kmer kmer = new Kmer(sequence);
+            kmerToVertexMap.remove(kmer);
+        }
+        return result;
+    }
+
+    @Override
+    public void removeSingletonOrphanVertices() {
+        // Run through the graph and clean up singular orphaned nodes
+        final Collection<MultiDeBruijnVertex> verticesToRemove = new LinkedList<>();
+        for( final MultiDeBruijnVertex v : vertexSet() ) {
+            if( inDegreeOf(v) == 0 && outDegreeOf(v) == 0 ) {
+                verticesToRemove.add(v);
+            }
+        }
+        removeVertex(null);
+        removeAllVertices(verticesToRemove);
+    }
+
+    public abstract boolean isLowComplexity();
+
+    @VisibleForTesting
+    void setIncreaseCountsThroughBranches(final boolean increaseCountsThroughBranches) {
+        this.increaseCountsThroughBranches = increaseCountsThroughBranches;
+    }
+
+    /**
+     * Try to recover dangling tails
+     *
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
+     * @param recoverAll recover even branches with forks
+     * @param aligner
+     */
+    public void recoverDanglingTails(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
+        Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
+        Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
+
+        if ( ! alreadyBuilt ) {
+            throw new IllegalStateException("recoverDanglingTails requires the graph be already built");
+        }
+
+        int attempted = 0;
+        int nRecovered = 0;
+        for ( final MultiDeBruijnVertex v : vertexSet() ) {
+            if ( outDegreeOf(v) == 0 && ! isRefSink(v) ) {
+                attempted++;
+                nRecovered += recoverDanglingTail(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
+            }
+        }
+
+        ReadThreadingGraph.logger.debug(String.format("Recovered %d of %d dangling tails", nRecovered, attempted));
+    }
+
+    /**
+     * Try to recover dangling heads
+     *
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
+     * @param recoverAll recover even branches with forks
+     * @param aligner
+     */
+    public void recoverDanglingHeads(final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
+        Utils.validateArg(pruneFactor >= 0, () -> "pruneFactor must be non-negative but was " + pruneFactor);
+        Utils.validateArg(minDanglingBranchLength >= 0, () -> "minDanglingBranchLength must be non-negative but was " + minDanglingBranchLength);
+        if ( ! alreadyBuilt ) {
+            throw new IllegalStateException("recoverDanglingHeads requires the graph be already built");
+        }
+
+        // we need to build a list of dangling heads because that process can modify the graph (and otherwise generate
+        // a ConcurrentModificationException if we do it while iterating over the vertexes)
+        final Collection<MultiDeBruijnVertex> danglingHeads = vertexSet().stream()
+                .filter(v -> inDegreeOf(v) == 0 && ! isRefSource(v))
+                .collect(Collectors.toList());
+
+        // now we can try to recover the dangling heads
+        int attempted = 0;
+        int nRecovered = 0;
+        for ( final MultiDeBruijnVertex v : danglingHeads ) {
+            attempted++;
+            nRecovered += recoverDanglingHead(v, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
+        }
+
+        ReadThreadingGraph.logger.debug(String.format("Recovered %d of %d dangling heads", nRecovered, attempted));
+    }
+
+    /**
+     * Attempt to attach vertex with out-degree == 0 to the graph
+     *
+     * @param vertex the vertex to recover
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
+     * @param aligner
+     * @return 1 if we successfully recovered the vertex and 0 otherwise
+     */
+    private int recoverDanglingTail(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
+        if ( outDegreeOf(vertex) != 0 ) {
+            throw new IllegalStateException("Attempting to recover a dangling tail for " + vertex + " but it has out-degree > 0");
+        }
+
+        // generate the CIGAR string from Smith-Waterman between the dangling tail and reference paths
+        final DanglingChainMergeHelper danglingTailMergeResult = generateCigarAgainstDownwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
+
+        // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
+        if ( danglingTailMergeResult == null || ! cigarIsOkayToMerge(danglingTailMergeResult.cigar, false, true) ) {
+            return 0;
+        }
+
+        // merge
+        return mergeDanglingTail(danglingTailMergeResult);
+    }
+
+    /**
+     * Attempt to attach vertex with in-degree == 0, or a vertex on its path, to the graph
+     *
+     * @param vertex the vertex to recover
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param minDanglingBranchLength the minimum length of a dangling branch for us to try to merge it
+     * @param recoverAll recover even branches with forks
+     * @param aligner
+     * @return 1 if we successfully recovered a vertex and 0 otherwise
+     */
+    private int recoverDanglingHead(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, final SmithWatermanAligner aligner) {
+        if ( inDegreeOf(vertex) != 0 ) {
+            throw new IllegalStateException("Attempting to recover a dangling head for " + vertex + " but it has in-degree > 0");
+        }
+
+        // generate the CIGAR string from Smith-Waterman between the dangling tail and reference paths
+        final DanglingChainMergeHelper danglingHeadMergeResult = generateCigarAgainstUpwardsReferencePath(vertex, pruneFactor, minDanglingBranchLength, recoverAll, aligner);
+
+        // if the CIGAR is too complex (or couldn't be computed) then we do not allow the merge into the reference path
+        if ( danglingHeadMergeResult == null || ! cigarIsOkayToMerge(danglingHeadMergeResult.cigar, true, false) ) {
+            return 0;
+        }
+
+        // merge
+        return mergeDanglingHead(danglingHeadMergeResult);
+    }
+
+    /**
+     * Actually merge the dangling tail if possible
+     *
+     * @param danglingTailMergeResult   the result from generating a Cigar for the dangling tail against the reference
+     * @return 1 if merge was successful, 0 otherwise
+     */
+    @VisibleForTesting
+    final int mergeDanglingTail(final DanglingChainMergeHelper danglingTailMergeResult) {
+
+        final List<CigarElement> elements = danglingTailMergeResult.cigar.getCigarElements();
+        final CigarElement lastElement = elements.get(elements.size() - 1);
+        Utils.validateArg( lastElement.getOperator() == CigarOperator.M, "The last Cigar element must be an M");
+
+        final int lastRefIndex = danglingTailMergeResult.cigar.getReferenceLength() - 1;
+        final int matchingSuffix = Math.min(longestSuffixMatch(danglingTailMergeResult.referencePathString, danglingTailMergeResult.danglingPathString, lastRefIndex), lastElement.getLength());
+        if ( matchingSuffix == 0 ) {
+            return 0;
+        }
+
+        final int altIndexToMerge = Math.max(danglingTailMergeResult.cigar.getReadLength() - matchingSuffix - 1, 0);
+
+        // there is an important edge condition that we need to handle here: Smith-Waterman correctly calculates that there is a
+        // deletion, that deletion is left-aligned such that the LCA node is part of that deletion, and the rest of the dangling
+        // tail is a perfect match to the suffix of the reference path.  In this case we need to push the reference index to merge
+        // down one position so that we don't incorrectly cut a base off of the deletion.
+        final boolean firstElementIsDeletion = elements.get(0).getOperator() == CigarOperator.D;
+        final boolean mustHandleLeadingDeletionCase =  firstElementIsDeletion && (elements.get(0).getLength() + matchingSuffix == lastRefIndex + 1);
+        final int refIndexToMerge = lastRefIndex - matchingSuffix + 1 + (mustHandleLeadingDeletionCase ? 1 : 0);
+
+        // another edge condition occurs here: if Smith-Waterman places the whole tail into an insertion then it will try to
+        // merge back to the LCA, which results in a cycle in the graph.  So we do not want to merge in such a case.
+        if ( refIndexToMerge == 0 ) {
+            return 0;
+        }
+
+        // it's safe to merge now
+        addEdge(danglingTailMergeResult.danglingPath.get(altIndexToMerge), danglingTailMergeResult.referencePath.get(refIndexToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
+
+        return 1;
+    }
+
+    /**
+     * Actually merge the dangling head if possible
+     *
+     * @param danglingHeadMergeResult   the result from generating a Cigar for the dangling head against the reference
+     * @return 1 if merge was successful, 0 otherwise
+     */
+    @VisibleForTesting
+    int mergeDanglingHead(final DanglingChainMergeHelper danglingHeadMergeResult) {
+
+        final List<CigarElement> elements = danglingHeadMergeResult.cigar.getCigarElements();
+        final CigarElement firstElement = elements.get(0);
+        Utils.validateArg( firstElement.getOperator() == CigarOperator.M, "The first Cigar element must be an M");
+
+        final int indexesToMerge = bestPrefixMatch(danglingHeadMergeResult.referencePathString, danglingHeadMergeResult.danglingPathString, firstElement.getLength());
+        if ( indexesToMerge <= 0 ) {
+            return 0;
+        }
+
+        // we can't push back the reference path
+        if ( indexesToMerge >= danglingHeadMergeResult.referencePath.size() - 1 ) {
+            return 0;
+        }
+
+        // but we can manipulate the dangling path if we need to
+        if ( indexesToMerge >= danglingHeadMergeResult.danglingPath.size() &&
+                ! extendDanglingPathAgainstReference(danglingHeadMergeResult, indexesToMerge - danglingHeadMergeResult.danglingPath.size() + 2) ) {
+            return 0;
+        }
+
+        addEdge(danglingHeadMergeResult.referencePath.get(indexesToMerge+1), danglingHeadMergeResult.danglingPath.get(indexesToMerge), ((MyEdgeFactory)getEdgeFactory()).createEdge(false, 1));
+
+        return 1;
+    }
+
+    /**
+     * Generates the CIGAR string from the Smith-Waterman alignment of the dangling path (where the
+     * provided vertex is the sink) and the reference path.
+     *
+     * @param aligner
+     * @param vertex   the sink of the dangling chain
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param recoverAll recover even branches with forks
+     * @return a SmithWaterman object which can be null if no proper alignment could be generated
+     */
+    @VisibleForTesting
+    DanglingChainMergeHelper generateCigarAgainstDownwardsReferencePath(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, SmithWatermanAligner aligner) {
+        final int minTailPathLength = Math.max(1, minDanglingBranchLength); // while heads can be 0, tails absolutely cannot
+
+        // find the lowest common ancestor path between this vertex and the diverging master path if available
+        final List<MultiDeBruijnVertex> altPath = findPathUpwardsToLowestCommonAncestor(vertex, pruneFactor, !recoverAll);
+        if ( altPath == null || isRefSource(altPath.get(0)) || altPath.size() < minTailPathLength + 1 ) // add 1 to include the LCA
+        {
+            return null;
+        }
+
+        // now get the reference path from the LCA
+        final List<MultiDeBruijnVertex> refPath = getReferencePath(altPath.get(0), TraversalDirection.downwards, Optional.ofNullable(getHeaviestIncomingEdge(altPath.get(1))));
+
+        // create the Smith-Waterman strings to use
+        final byte[] refBases = getBasesForPath(refPath, false);
+        final byte[] altBases = getBasesForPath(altPath, false);
+
+        // run Smith-Waterman to determine the best alignment (and remove trailing deletions since they aren't interesting)
+        final SmithWatermanAlignment alignment = aligner.align(refBases, altBases, SmithWatermanAligner.STANDARD_NGS, SWOverhangStrategy.LEADING_INDEL);
+        return new DanglingChainMergeHelper(altPath, refPath, altBases, refBases, AlignmentUtils.removeTrailingDeletions(alignment.getCigar()));
+    }
+
+    /**
+     * Generates the CIGAR string from the Smith-Waterman alignment of the dangling path (where the
+     * provided vertex is the source) and the reference path.
+     *
+     * @param aligner
+     * @param vertex   the source of the dangling head
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param recoverAll recover even branches with forks
+     * @return a SmithWaterman object which can be null if no proper alignment could be generated
+     */
+    @VisibleForTesting
+    DanglingChainMergeHelper generateCigarAgainstUpwardsReferencePath(final MultiDeBruijnVertex vertex, final int pruneFactor, final int minDanglingBranchLength, final boolean recoverAll, SmithWatermanAligner aligner) {
+
+        // find the highest common descendant path between vertex and the reference source if available
+        final List<MultiDeBruijnVertex> altPath = findPathDownwardsToHighestCommonDescendantOfReference(vertex, pruneFactor, !recoverAll);
+        if ( altPath == null || isRefSink(altPath.get(0)) || altPath.size() < minDanglingBranchLength + 1 ) // add 1 to include the LCA
+        {
+            return null;
+        }
+
+        // now get the reference path from the LCA
+        final List<MultiDeBruijnVertex> refPath = getReferencePath(altPath.get(0), TraversalDirection.upwards, Optional.empty());
+
+        // create the Smith-Waterman strings to use
+        final byte[] refBases = getBasesForPath(refPath, true);
+        final byte[] altBases = getBasesForPath(altPath, true);
+
+        // run Smith-Waterman to determine the best alignment (and remove trailing deletions since they aren't interesting)
+        final SmithWatermanAlignment alignment = aligner.align(refBases, altBases, SmithWatermanAligner.STANDARD_NGS, SWOverhangStrategy.LEADING_INDEL);
+        return new DanglingChainMergeHelper(altPath, refPath, altBases, refBases, AlignmentUtils.removeTrailingDeletions(alignment.getCigar()));
+    }
+
+    /**
+     * Finds the path upwards in the graph from this vertex to the first diverging node, including that (lowest common ancestor) vertex.
+     * Note that nodes are excluded if their pruning weight is less than the pruning factor.
+     *
+     * @param vertex   the original vertex
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
+     * @return the path if it can be determined or null if this vertex either doesn't merge onto another path or
+     *  has an ancestor with multiple incoming edges before hitting the reference path
+     */
+    protected List<MultiDeBruijnVertex> findPathUpwardsToLowestCommonAncestor(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
+        return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> inDegreeOf(v) != 1 || outDegreeOf(v) >= 2, v -> outDegreeOf(v) > 1, v -> incomingEdgeOf(v), e -> getEdgeSource(e))
+                :findPath(vertex, pruneFactor, v -> hasIncidentRefEdge(v) || inDegreeOf(v) == 0, v -> outDegreeOf(v) > 1 && hasIncidentRefEdge(v), this::getHeaviestIncomingEdge, e -> getEdgeSource(e));
+    }
+
+    private boolean hasIncidentRefEdge(final MultiDeBruijnVertex v) {
+        for (final MultiSampleEdge edge : incomingEdgesOf(v)) {
+            if (edge.isRef()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public MultiSampleEdge getHeaviestIncomingEdge(final MultiDeBruijnVertex v) {
+        final Set<MultiSampleEdge> incomingEdges = incomingEdgesOf(v);
+        return incomingEdges.size() == 1 ? incomingEdges.iterator().next() :
+                incomingEdges.stream().max(Comparator.comparingInt(MultiSampleEdge::getMultiplicity)).get();
+    }
+
+    /**
+     * Finds the path downwards in the graph from this vertex to the reference sequence, including the highest common descendant vertex.
+     * However note that the path is reversed so that this vertex ends up at the end of the path.
+     * Also note that nodes are excluded if their pruning weight is less than the pruning factor.
+     *
+     * @param vertex   the original vertex
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces
+     * @param giveUpAtBranch stop trying to find a path if a vertex with multiple incoming or outgoing edge is found
+     * @return the path if it can be determined or null if this vertex either doesn't merge onto the reference path or
+     *  has a descendant with multiple outgoing edges before hitting the reference path
+     */
+    protected List<MultiDeBruijnVertex> findPathDownwardsToHighestCommonDescendantOfReference(final MultiDeBruijnVertex vertex, final int pruneFactor, final boolean giveUpAtBranch) {
+        return giveUpAtBranch ? findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) != 1, v -> isReferenceNode(v), v -> outgoingEdgeOf(v), e -> getEdgeTarget(e))
+                : findPath(vertex, pruneFactor, v -> isReferenceNode(v) || outDegreeOf(v) == 0, v -> isReferenceNode(v), this::getHeaviestOutgoingEdge, e -> getEdgeTarget(e));
+    }
+
+    private MultiSampleEdge getHeaviestOutgoingEdge(final MultiDeBruijnVertex v) {
+        final Set<MultiSampleEdge> outgoing = outgoingEdgesOf(v);
+        return outgoing.size() == 1 ? outgoing.iterator().next() :
+                outgoing.stream().max(Comparator.comparingInt(MultiSampleEdge::getMultiplicity)).get();
+    }
+
+    /**
+     * Finds a path starting from a given vertex and satisfying various predicates
+     *
+     * @param vertex   the original vertex
+     * @param pruneFactor  the prune factor to use in ignoring chain pieces if edge multiplicity is < pruneFactor
+     * @param done test for whether a vertex is at the end of the path
+     * @param returnPath test for whether to return a found path based on its terminal vertex
+     * @param nextEdge function on vertices returning the next edge in the path
+     * @param nextNode function of edges returning the next vertex in the path
+     * @return a path, if one satisfying all predicates is found, {@code null} otherwise
+     */
+    private  List<MultiDeBruijnVertex> findPath(final MultiDeBruijnVertex vertex, final int pruneFactor,
+                                            final Predicate<MultiDeBruijnVertex> done,
+                                            final Predicate<MultiDeBruijnVertex> returnPath,
+                                            final Function<MultiDeBruijnVertex, MultiSampleEdge> nextEdge,
+                                            final Function<MultiSampleEdge, MultiDeBruijnVertex> nextNode){
+        final LinkedList<MultiDeBruijnVertex> path = new LinkedList<>();
+        final Set<MultiDeBruijnVertex> visitedNodes = new HashSet<>(); // This code is necessary to
+
+        MultiDeBruijnVertex v = vertex;
+        while ( ! done.test(v) ) {
+            final MultiSampleEdge edge = nextEdge.apply(v);
+            // if it has too low a weight, don't use it (or previous vertexes) for the path
+            if ( edge.getPruningMultiplicity() < pruneFactor ) {
+                // save the previously visited notes to protect us from riding forever 'neath the streets of boston
+                visitedNodes.addAll(path);
+                path.clear();
+            }
+            else {
+                path.addFirst(v);
+            }
+            v = nextNode.apply(edge);
+            // Check that we aren't stuck in a loop
+            if ( path.contains(v) || visitedNodes.contains(v)) {
+                System.err.println("Dangling End recovery killed because of a loop (findPath)");
+                return null;
+            }
+        }
+        path.addFirst(v);
+
+        return returnPath.test(v) ? path : null;
+    }
+
+    /**
+     * Finds the path in the graph from this vertex to the reference sink, including this vertex
+     *
+     * @param start   the reference vertex to start from
+     * @param direction describes which direction to move in the graph (i.e. down to the reference sink or up to the source)
+     * @param blacklistedEdge edge to ignore in the traversal down; useful to exclude the non-reference dangling paths
+     * @return the path (non-null, non-empty)
+     */
+    protected List<MultiDeBruijnVertex> getReferencePath(final MultiDeBruijnVertex start,
+                                                       final TraversalDirection direction,
+                                                       final Optional<MultiSampleEdge> blacklistedEdge) {
+
+        final List<MultiDeBruijnVertex> path = new ArrayList<>();
+
+        MultiDeBruijnVertex v = start;
+        while ( v != null ) {
+            path.add(v);
+            v = (direction == TraversalDirection.downwards ? getNextReferenceVertex(v, true, blacklistedEdge) : getPrevReferenceVertex(v));
+        }
+
+        return path;
+    }
+
+    /**
+     * The base sequence for the given path.
+     *
+     * @param path the list of vertexes that make up the path
+     * @param expandSource if true and if we encounter a source node, then expand (and reverse) the character sequence for that node
+     * @return  non-null sequence of bases corresponding to the given path
+     */
+    @VisibleForTesting
+    byte[] getBasesForPath(final List<MultiDeBruijnVertex> path, final boolean expandSource) {
+        Utils.nonNull(path, "Path cannot be null");
+
+        final StringBuilder sb = new StringBuilder();
+        for ( final MultiDeBruijnVertex v : path ) {
+            if ( expandSource && isSource(v) ) {
+                final String seq = v.getSequenceString();
+                sb.append(new StringBuilder(seq).reverse().toString());
+            } else {
+                sb.append((char)v.getSuffix());
+            }
+        }
+
+        return sb.toString().getBytes();
+    }
+
+    /**
+     * Finds the index of the best extent of the prefix match between the provided paths, for dangling head merging.
+     * Assumes that path1.length >= maxIndex and path2.length >= maxIndex.
+     *
+     * @param path1  the first path
+     * @param path2  the second path
+     * @param maxIndex the maximum index to traverse (not inclusive)
+     * @return the index of the ideal prefix match or -1 if it cannot find one, must be less than maxIndex
+     */
+    private int bestPrefixMatch(final byte[] path1, final byte[] path2, final int maxIndex) {
+        final int maxMismatches = getMaxMismatches(maxIndex);
+        int mismatches = 0;
+        int index = 0;
+        int lastGoodIndex = -1;
+        while ( index < maxIndex ) {
+            if ( path1[index] != path2[index] ) {
+                if ( ++mismatches > maxMismatches ) {
+                    return -1;
+                }
+                lastGoodIndex = index;
+            }
+            index++;
+        }
+        // if we got here then we hit the max index
+        return lastGoodIndex;
+    }
+
+    /**
+     * Determine the maximum number of mismatches permitted on the branch.
+     * Unless it's preset (e.g. by unit tests) it should be the length of the branch divided by the kmer size.
+     *
+     * @param lengthOfDanglingBranch  the length of the branch itself
+     * @return positive integer
+     */
+    private int getMaxMismatches(final int lengthOfDanglingBranch) {
+        return maxMismatchesInDanglingHead > 0 ? maxMismatchesInDanglingHead : Math.max(1, (lengthOfDanglingBranch / kmerSize));
+    }
+
+    private boolean extendDanglingPathAgainstReference(final DanglingChainMergeHelper danglingHeadMergeResult, final int numNodesToExtend) {
+
+        final int indexOfLastDanglingNode = danglingHeadMergeResult.danglingPath.size() - 1;
+        final int indexOfRefNodeToUse = indexOfLastDanglingNode + numNodesToExtend;
+        if ( indexOfRefNodeToUse >= danglingHeadMergeResult.referencePath.size() ) {
+            return false;
+        }
+
+        final MultiDeBruijnVertex danglingSource = danglingHeadMergeResult.danglingPath.remove(indexOfLastDanglingNode);
+        final StringBuilder sb = new StringBuilder();
+        final byte[] refSourceSequence = danglingHeadMergeResult.referencePath.get(indexOfRefNodeToUse).getSequence();
+        for ( int i = 0; i < numNodesToExtend; i++ ) {
+            sb.append((char) refSourceSequence[i]);
+        }
+        sb.append(danglingSource.getSequenceString());
+        final byte[] sequenceToExtend = sb.toString().getBytes();
+
+        // clean up the source and edge
+        final MultiSampleEdge sourceEdge = getHeaviestOutgoingEdge(danglingSource);
+        MultiDeBruijnVertex prevV = getEdgeTarget(sourceEdge);
+        removeEdge(danglingSource, prevV);
+
+        // extend the path
+        for ( int i = numNodesToExtend; i > 0; i-- ) {
+            final MultiDeBruijnVertex newV = new MultiDeBruijnVertex(Arrays.copyOfRange(sequenceToExtend, i, i + kmerSize));
+            addVertex(newV);
+            final MultiSampleEdge newE = addEdge(newV, prevV);
+            newE.setMultiplicity(sourceEdge.getMultiplicity());
+            danglingHeadMergeResult.danglingPath.add(newV);
+            prevV = newV;
+        }
+
+        return true;
+    }
+
+    private void increaseCountsInMatchedKmers(final SequenceForKmers seqForKmers,
+                                              final MultiDeBruijnVertex vertex,
+                                              final byte[] originalKmer,
+                                              final int offset) {
+        if ( offset == -1 ) {
+            return;
+        }
+
+        for ( final MultiSampleEdge edge : incomingEdgesOf(vertex) ) {
+            final MultiDeBruijnVertex prev = getEdgeSource(edge);
+            final byte suffix = prev.getSuffix();
+            final byte seqBase = originalKmer[offset];
+            if ( suffix == seqBase && (increaseCountsThroughBranches || inDegreeOf(vertex) == 1) ) {
+                edge.incMultiplicity(seqForKmers.count);
+                increaseCountsInMatchedKmers(seqForKmers, prev, originalKmer, offset-1);
+            }
+        }
+    }
+
+    /**
+     * Get the vertex for the kmer in sequence starting at start
+     * @param sequence the sequence
+     * @param start the position of the kmer start
+     * @return a non-null vertex
+     */
+    private MultiDeBruijnVertex getOrCreateKmerVertex(final byte[] sequence, final int start) {
+        final Kmer kmer = new Kmer(sequence, start, kmerSize);
+        final MultiDeBruijnVertex vertex = getKmerVertex(kmer, true);
+        return ( vertex != null ) ? vertex : createVertex(kmer);
+    }
+
+    /**
+     * Get the unique vertex for kmer, or null if not possible.
+     *
+     * @param allowRefSource if true, we will allow kmer to match the reference source vertex
+     * @return a vertex for kmer, or null (either because it doesn't exist or is non-unique for graphs that have such a distinction)
+     */
+    protected MultiDeBruijnVertex getKmerVertex(final Kmer kmer, final boolean allowRefSource) {
+        if ( ! allowRefSource && kmer.equals(refSource) ) {
+            return null;
+        }
+
+        return kmerToVertexMap.get(kmer);
+    }
+
+    /**
+     * Create a new vertex for kmer.  Add it to the kmerToVertexMap map if appropriate.
+     *
+     * @param kmer the kmer we want to create a vertex for
+     * @return the non-null created vertex
+     */
+    protected MultiDeBruijnVertex createVertex(final Kmer kmer) {
+        final MultiDeBruijnVertex newVertex = new MultiDeBruijnVertex(kmer.bases());
+        final int prevSize = vertexSet().size();
+        addVertex(newVertex);
+
+        // make sure we aren't adding duplicates (would be a bug)
+        if ( vertexSet().size() != prevSize + 1) {
+            throw new IllegalStateException("Adding vertex " + newVertex + " to graph didn't increase the graph size");
+        }
+        trackKmer(kmer, newVertex);
+
+        return newVertex;
+    }
+
+    /**
+     * Define the behavior for how the graph should keep track of a potentially new kmer.
+     *
+     * @param kmer (potentially) new kmer to track
+     * @param newVertex corresponding vertex for that kmer
+     */
+    protected abstract void trackKmer(Kmer kmer, MultiDeBruijnVertex newVertex);
+
+    /**
+     * Workhorse routine of the assembler.  Given a sequence whose last vertex is anchored in the graph, extend
+     * the graph one bp according to the bases in sequence.
+     *
+     * @param prevVertex a non-null vertex where sequence was last anchored in the graph
+     * @param sequence the sequence we're threading through the graph
+     * @param kmerStart the start of the current kmer in graph we'd like to add
+     * @param count the number of observations of this kmer in graph (can be > 1 for GGA)
+     * @param isRef is this the reference sequence?
+     * @return a non-null vertex connecting prevVertex to in the graph based on sequence
+     */
+    protected MultiDeBruijnVertex extendChainByOne(final MultiDeBruijnVertex prevVertex, final byte[] sequence, final int kmerStart, final int count, final boolean isRef) {
+        final Set<MultiSampleEdge> outgoingEdges = outgoingEdgesOf(prevVertex);
+
+        final int nextPos = kmerStart + kmerSize - 1;
+        for ( final MultiSampleEdge outgoingEdge : outgoingEdges ) {
+            final MultiDeBruijnVertex target = getEdgeTarget(outgoingEdge);
+            if ( target.getSuffix() == sequence[nextPos] ) {
+                // we've got a match in the chain, so simply increase the count of the edge by 1 and continue
+                outgoingEdge.incMultiplicity(count);
+                return target;
+            }
+        }
+
+        // none of our outgoing edges had our unique suffix base, so we check for an opportunity to merge back in
+        final Kmer kmer = new Kmer(sequence, kmerStart, kmerSize);
+        final MultiDeBruijnVertex mergeVertex = getNextKmerVertexForChainExtension(kmer, isRef, prevVertex);
+
+        // either use our merge vertex, or create a new one in the chain
+        final MultiDeBruijnVertex nextVertex = mergeVertex == null ? createVertex(kmer) : mergeVertex;
+        addEdge(prevVertex, nextVertex, ((MyEdgeFactory)getEdgeFactory()).createEdge(isRef, count));
+        return nextVertex;
+    }
+
+    // get the next kmerVertex for ChainExtension and validate if necessary.
+    protected abstract MultiDeBruijnVertex getNextKmerVertexForChainExtension(final Kmer kmer, final boolean isRef, final MultiDeBruijnVertex prevVertex);
+
+    /**
+     * Add a read to the sequence graph.  Finds maximal consecutive runs of bases with sufficient quality
+     * and applies {@see addSequence} to these subreads if they are longer than the kmer size.
+     *
+     * @param read a non-null read
+     */
+    @VisibleForTesting
+    void addRead(final GATKRead read, final SAMFileHeader header) {
+        final byte[] sequence = read.getBases();
+        final byte[] qualities = read.getBaseQualities();
+
+        int lastGood = -1;
+        for( int end = 0; end <= sequence.length; end++ ) {
+            if ( end == sequence.length || ! baseIsUsableForAssembly(sequence[end], qualities[end]) ) {
+                // the first good base is at lastGood, can be -1 if last base was bad
+                final int start = lastGood;
+                // the stop base is end - 1 (if we're not at the end of the sequence)
+                final int len = end - start;
+
+                if ( start != -1 && len >= kmerSize ) {
+                    // if the sequence is long enough to get some value out of, add it to the graph
+                    final String name = read.getName() + '_' + start + '_' + end;
+                    addSequence(name, ReadUtils.getSampleName(read, header), sequence, start, end, 1, false);
+                }
+
+                lastGood = -1; // reset the last good base
+            } else if ( lastGood == -1 ) {
+                lastGood = end; // we're at a good base, the last good one is us
+            }
+        }
+    }
+
+    protected abstract boolean baseIsUsableForAssembly(byte base, byte qual);
+
+    // Method that will be called immediately before haplotype finding in the event there are alteations that must be made to the graph based on implementation
+    public abstract void postProcessForHaplotypeFinding(File debugGraphOutputPath, Locatable refHaplotype);
+
+    @Override
+    public MultiDeBruijnVertex findKmer(final Kmer k) {
+        return kmerToVertexMap.get(k);
+    }
+
+    protected enum TraversalDirection {
+        downwards,
+        upwards
+    }
+
+    /**
+     * Edge factory that encapsulates the numPruningSamples assembly parameter
+     */
+    protected static final class MyEdgeFactory implements EdgeFactory<MultiDeBruijnVertex, MultiSampleEdge> {
+        final int numPruningSamples;
+
+        protected MyEdgeFactory(final int numPruningSamples) {
+            this.numPruningSamples = numPruningSamples;
+        }
+
+        @Override
+        public MultiSampleEdge createEdge(final MultiDeBruijnVertex sourceVertex, final MultiDeBruijnVertex targetVertex) {
+            return new MultiSampleEdge(false, 1, numPruningSamples);
+        }
+
+        public MultiSampleEdge createEdge(final boolean isRef, final int multiplicity) {
+            return new MultiSampleEdge(isRef, multiplicity, numPruningSamples);
+        }
+    }
+
+    /**
+     * Class to keep track of the important dangling chain merging data
+     */
+    static final class DanglingChainMergeHelper {
+        final List<MultiDeBruijnVertex> danglingPath;
+        final List<MultiDeBruijnVertex> referencePath;
+        final byte[] danglingPathString;
+        final byte[] referencePathString;
+        final Cigar cigar;
+
+        DanglingChainMergeHelper(final List<MultiDeBruijnVertex> danglingPath,
+                                        final List<MultiDeBruijnVertex> referencePath,
+                                        final byte[] danglingPathString,
+                                        final byte[] referencePathString,
+                                        final Cigar cigar) {
+            this.danglingPath = danglingPath;
+            this.referencePath = referencePath;
+            this.danglingPathString = danglingPathString;
+            this.referencePathString = referencePathString;
+            this.cigar = cigar;
+        }
+    }
+
+    /**
+     * Keeps track of the information needed to add a sequence to the read threading assembly graph
+     */
+    static final class SequenceForKmers {
+        final String name;
+        final byte[] sequence;
+        final int start;
+        final int stop;
+        final int count;
+        final boolean isRef;
+
+        /**
+         * Create a new sequence for creating kmers
+         */
+        SequenceForKmers(final String name, final byte[] sequence, final int start, final int stop, final int count, final boolean ref) {
+            Utils.nonNull(sequence, "Sequence is null ");
+            Utils.validateArg( start >= 0, () -> "Invalid start " + start);
+            Utils.validateArg( stop >= start, () -> "Invalid stop " + stop);
+            Utils.validateArg( count > 0, "Invalid count " + count);
+
+            this.name = name;
+            this.sequence = sequence;
+            this.start = start;
+            this.stop = stop;
+            this.count = count;
+            isRef = ref;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/TestingReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/TestingReadThreadingGraph.java
@@ -1,11 +1,10 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -136,6 +135,31 @@ public final class TestingReadThreadingGraph extends ReadThreadingGraph {
                 }
                 lastVertex = nextVertex;
             }
+        }
+    }
+
+    /**
+     * Return the collection of outgoing vertices that expand this vertex with a particular base.
+     *
+     * @param v original vertex.
+     * @param b expanding base.
+     * @return never null, but perhaps an empty set. You cannot assume that you can modify the result.
+     */
+    @VisibleForTesting
+    Set<MultiDeBruijnVertex> getNextVertices(final MultiDeBruijnVertex v, final byte b) {
+        Utils.nonNull(v, "the input vertex cannot be null");
+        Utils.validateArg(vertexSet().contains(v), "the vertex must be present in the graph");
+        final List<MultiDeBruijnVertex> result = new LinkedList<>();
+        for (final MultiDeBruijnVertex w : outgoingVerticesOf(v)) {
+            if (w.getSuffix() == b) {
+                result.add(w);
+            }
+        }
+        switch (result.size()) {
+            case 0: return Collections.emptySet();
+            case 1: return Collections.singleton(result.get(0));
+            default:
+                return new HashSet<>(result);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanJavaAligner.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/smithwaterman/SmithWatermanJavaAligner.java
@@ -58,6 +58,8 @@ public final class SmithWatermanJavaAligner implements SmithWatermanAligner {
     public SmithWatermanAlignment align(final byte[] reference, final byte[] alternate, final SWParameters parameters, final SWOverhangStrategy overhangStrategy) {
         long startTime = System.nanoTime();
 
+        new String(reference);
+
         if ( reference == null || reference.length == 0 || alternate == null || alternate.length == 0 ) {
             throw new IllegalArgumentException("Non-null, non-empty sequences are required for the Smith-Waterman calculation");
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyResultSetUnitTest.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.TestingReadThreadingGraph;
+import org.broadinstitute.hellbender.testutils.TestingReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.RandomDNA;
 import org.broadinstitute.hellbender.utils.SimpleInterval;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -97,10 +97,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         }
     }
 
-    /*
-     * Test that in VCF mode we're consistent with past GATK4 results
-     */
-    @Test(dataProvider="HaplotypeCallerTestInputs")
+    @Test(dataProvider="HaplotypeCallerTestInputs", enabled = false)
     public void testVCFModeWithExperimentalAssemblyEngineCode(final String inputFileName, final String referenceFileName) throws Exception {
         Utils.resetRandomGenerator();
 
@@ -185,8 +182,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-R", referenceFileName,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
-                "-pairHMM", "AVX_LOGLESS_CACHING",
-                "--disable-sequence-graph-simplification"
+                "-pairHMM", "AVX_LOGLESS_CACHING"
         };
 
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -231,6 +231,42 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         }
     }
 
+
+    /*
+     * Minimal test that the non-seq graph haplotype detection code is equivalent using either seq graphs or kmer graphs
+     *
+     *  NOTE: --disable-sequence-graph-simplification is currently an experimental feature that does not directly match with
+     *        the regular HaplotypeCaller. Specifically the haplotype finding code does not perform correctly at complicated
+     *        sites, which is illustrated by this test. Use this mode at your own risk.
+     */
+    @Test(dataProvider="HaplotypeCallerTestInputs", enabled = false)
+    public void testGVCFModeIsConsistentWithPastResultsUsingKmerGraphs(final String inputFileName, final String referenceFileName) throws Exception {
+        Utils.resetRandomGenerator();
+
+        final File output = createTempFile("testGVCFModeIsConsistentWithPastResults", ".g.vcf");
+        final File expected = new File(TEST_FILES_DIR, "expected.testGVCFMode.gatk4.g.vcf");
+
+        final String outputPath = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected.getAbsolutePath() : output.getAbsolutePath();
+
+        final String[] args = {
+                "-I", inputFileName,
+                "-R", referenceFileName,
+                "-L", "20:10000000-10100000",
+                "-O", outputPath,
+                "-ERC", "GVCF",
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "--disable-sequence-graph-simplification",
+                "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"
+        };
+
+        runCommandLine(args);
+
+        // Test for an exact match against past results
+        if ( ! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(output, expected);
+        }
+    }
+
     /*
      * Test that in GVCF mode we're consistent with past GATK4 results using AS_ annotations
      *

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -99,6 +99,36 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
 
     /*
      * Test that in VCF mode we're consistent with past GATK4 results
+     */
+    @Test(dataProvider="HaplotypeCallerTestInputs")
+    public void testVCFModeWithExperimentalAssemblyEngineCode(final String inputFileName, final String referenceFileName) throws Exception {
+        Utils.resetRandomGenerator();
+
+        final File output = createTempFile("testVCFModeIsConsistentWithPastResults", ".vcf");
+        final File expected = new File(TEST_FILES_DIR, "expected.testVCFMode.gatk4.vcf");
+
+        final String outputPath = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected.getAbsolutePath() : output.getAbsolutePath();
+
+        final String[] args = {
+                "-I", inputFileName,
+                "-R", referenceFileName,
+                "-L", "20:10000000-10100000",
+                "-O", outputPath,
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "--disable-sequence-graph-simplification",
+                "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false"
+        };
+
+        runCommandLine(args);
+
+        // Test for an exact match against past results
+        if ( ! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(output, expected);
+        }
+    }
+
+    /*
+     * Test that in VCF mode we're consistent with past GATK4 results
      *
      * Test currently throws an exception due to lack of support for allele-specific annotations in VCF mode
      */
@@ -156,6 +186,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-pairHMM", "AVX_LOGLESS_CACHING",
+                "--disable-sequence-graph-simplification"
         };
 
         runCommandLine(args);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
@@ -1,15 +1,11 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
-import htsjdk.samtools.SAMFileHeader;
 import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.random.RandomGeneratorFactory;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.BaseUtils;
-import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanJavaAligner;
 import org.testng.Assert;
@@ -168,7 +164,7 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         seqGraph.removePathsNotConnectedToRef();
         seqGraph.simplifyGraph();
 
-        final List<KBestHaplotype> bestPaths = new KBestHaplotypeFinder(seqGraph).findBestHaplotypes(10);
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new GraphBasedKBestHaplotypeFinder<>(seqGraph).findBestHaplotypes(10);
 
         final OptionalInt altIndex = IntStream.range(0, bestPaths.size()).filter(n -> bestPaths.get(n).haplotype().basesMatch(alt)).findFirst();
         Assert.assertTrue(altIndex.isPresent());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
@@ -99,9 +99,9 @@ public class CommonSuffixMergerUnitTest extends GATKBaseTest {
     };
 
     public static void assertSameHaplotypes(final String name, final SeqGraph actual, final SeqGraph original) {
-        final List<Haplotype> sortedOriginalKBestHaplotypes = new KBestHaplotypeFinder(original).findBestHaplotypes().stream()
+        final List<Haplotype> sortedOriginalKBestHaplotypes = new KBestHaplotypeFinder<>(original).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
-        final List<Haplotype> sortedActualKBestHaplotypes = new KBestHaplotypeFinder(actual).findBestHaplotypes().stream()
+        final List<Haplotype> sortedActualKBestHaplotypes = new KBestHaplotypeFinder<>(actual).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
         try {
             Assert.assertEquals(sortedActualKBestHaplotypes, sortedOriginalKBestHaplotypes);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixMergerUnitTest.java
@@ -93,15 +93,15 @@ public class CommonSuffixMergerUnitTest extends GATKBaseTest {
     /**
      * Compares KBestHaplotype solutions, first by the haplotype base sequence and the by their score.
      */
-    private static final Comparator<KBestHaplotype> KBESTHAPLOTYPE_COMPARATOR = (o1,o2) -> {
+    private static final Comparator<KBestHaplotype<SeqVertex, BaseEdge>> KBESTHAPLOTYPE_COMPARATOR = (o1,o2) -> {
         final int baseCmp = new String(o1.getBases()).compareTo(new String(o2.getBases()));
         return baseCmp != 0 ? baseCmp : - Double.compare(o1.score(), o2.score());
     };
 
     public static void assertSameHaplotypes(final String name, final SeqGraph actual, final SeqGraph original) {
-        final List<Haplotype> sortedOriginalKBestHaplotypes = new KBestHaplotypeFinder<>(original).findBestHaplotypes().stream()
+        final List<Haplotype> sortedOriginalKBestHaplotypes = new GraphBasedKBestHaplotypeFinder<>(original).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
-        final List<Haplotype> sortedActualKBestHaplotypes = new KBestHaplotypeFinder<>(actual).findBestHaplotypes().stream()
+        final List<Haplotype> sortedActualKBestHaplotypes = new GraphBasedKBestHaplotypeFinder<>(actual).findBestHaplotypes().stream()
                 .sorted(KBESTHAPLOTYPE_COMPARATOR).map(KBestHaplotype::haplotype).collect(Collectors.toList());
         try {
             Assert.assertEquals(sortedActualKBestHaplotypes, sortedOriginalKBestHaplotypes);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/GraphBasedKBestHaplotypeFinderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/GraphBasedKBestHaplotypeFinderUnitTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.stream.IntStream;
 
-public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
+public final class GraphBasedKBestHaplotypeFinderUnitTest extends GATKBaseTest {
 
     @Test
     public void testScore(){
@@ -38,11 +38,11 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         g.addEdge(v2, v3);
         g.addEdge(v2, v4);
         g.addEdge(v2, v5);
-        final KBestHaplotypeFinder finder = new KBestHaplotypeFinder(g);
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder = new GraphBasedKBestHaplotypeFinder<>(g);
         Assert.assertEquals(finder.sources.size(), 1);
         Assert.assertEquals(finder.sinks.size(), 3);
-        final List<KBestHaplotype> haplotypes = finder.findBestHaplotypes();
-        final KBestHaplotype ACG = haplotypes.stream().filter(h -> h.haplotype().basesMatch("ACG".getBytes())).findFirst().get();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> haplotypes = finder.findBestHaplotypes();
+        final KBestHaplotype<SeqVertex, BaseEdge> ACG = haplotypes.stream().filter(h -> h.haplotype().basesMatch("ACG".getBytes())).findFirst().get();
         Assert.assertEquals(ACG.score(), -0.47712125471966244);
     }
 
@@ -61,7 +61,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         g.addEdge(v2, v3);
         g.addEdge(v3, v2); //cycle
         g.addEdge(v3, v4);
-        final KBestHaplotypeFinder finder = new KBestHaplotypeFinder(g);
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder = new GraphBasedKBestHaplotypeFinder<>(g);
         Assert.assertEquals(finder.sources.size(), 1);
         Assert.assertEquals(finder.sinks.size(), 1);
     }
@@ -74,15 +74,15 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         g.addVertex(v1);   //source
         g.addVertex(v2);
         g.addEdge(v1, v2);
-        final KBestHaplotypeFinder finder = new KBestHaplotypeFinder(g);
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder = new GraphBasedKBestHaplotypeFinder<>(g);
         Assert.assertEquals(finder.sources.size(), 1);
         Assert.assertEquals(finder.sinks.size(), 1);
 
-        final KBestHaplotypeFinder finder2 = new KBestHaplotypeFinder(g, Collections.emptySet(), Collections.singleton(v2));
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder2 = new GraphBasedKBestHaplotypeFinder<>(g, Collections.emptySet(), Collections.singleton(v2));
         Assert.assertEquals(finder2.sources.size(), 0);
         Assert.assertEquals(finder2.sinks.size(), 1);
 
-        final KBestHaplotypeFinder finder3 = new KBestHaplotypeFinder(g, Collections.singleton(v1), Collections.emptySet());
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge>finder3 = new GraphBasedKBestHaplotypeFinder<>(g, Collections.singleton(v1), Collections.emptySet());
         Assert.assertEquals(finder3.sources.size(), 1);
         Assert.assertEquals(finder3.sinks.size(), 0);
         Assert.assertTrue(finder3.findBestHaplotypes().isEmpty());
@@ -106,11 +106,11 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         g.addEdge(v3, v2);//cycle
         g.addEdge(v2, v5);
         g.addEdge(v1, v4);
-        final KBestHaplotypeFinder finder1 = new KBestHaplotypeFinder(g);
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder1 = new GraphBasedKBestHaplotypeFinder<>(g);
         Assert.assertEquals(finder1.sources.size(), 1);
         Assert.assertEquals(finder1.sinks.size(), 2);
 
-        final KBestHaplotypeFinder finder2 = new KBestHaplotypeFinder(g, v1, v4); //v5 is a dead node (can't reach the sink v4)
+        final KBestHaplotypeFinder<SeqVertex, BaseEdge> finder2 = new GraphBasedKBestHaplotypeFinder<>(g, v1, v4); //v5 is a dead node (can't reach the sink v4)
         Assert.assertEquals(finder2.sources.size(), 1);
         Assert.assertEquals(finder2.sinks.size(), 1);
     }
@@ -155,7 +155,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         final Set<SeqVertex> ends = createVertices(graph, nEndNodes, middleBottom, null);
 
         final int expectedNumOfPaths = nStartNodes * nBranchesPerBubble * nEndNodes;
-        final List<KBestHaplotype> haplotypes = new KBestHaplotypeFinder(graph, starts, ends).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> haplotypes = new GraphBasedKBestHaplotypeFinder<>(graph, starts, ends).findBestHaplotypes();
         Assert.assertEquals(haplotypes.size(), expectedNumOfPaths);
         IntStream.range(1, haplotypes.size()).forEach(n -> Assert.assertTrue(haplotypes.get(n-1).score() >= haplotypes.get(n).score()));
     }
@@ -245,7 +245,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         }
 
         // enumerate all possible paths
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph).findBestHaplotypes();
         Assert.assertEquals(paths.size(), 1);
         Assert.assertEquals(new String(paths.get(0).getBases()), Utils.join("", frags), "Path doesn't have the expected sequence");
     }
@@ -385,7 +385,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         graph.addEdges(() -> new BaseEdge(false, 1), top, alt, bot);
 
         @SuppressWarnings("all")
-        final List<KBestHaplotype> bestPaths = new KBestHaplotypeFinder(graph,top,bot).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new GraphBasedKBestHaplotypeFinder<>(graph,top,bot).findBestHaplotypes();
         Assert.assertEquals(bestPaths.size(), 2);
         final Path<SeqVertex,BaseEdge> refPath = bestPaths.get(0);
         final Path<SeqVertex,BaseEdge> altPath = bestPaths.get(1);
@@ -445,7 +445,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         graph.addEdges(() -> new BaseEdge(true, 65), midAndTopExt, refEnd);
 
         @SuppressWarnings("all")
-        final List<KBestHaplotype> bestPaths = new KBestHaplotypeFinder(graph,refStart,refEnd).findBestHaplotypes(2);
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new GraphBasedKBestHaplotypeFinder<>(graph,refStart,refEnd).findBestHaplotypes(2);
         Assert.assertEquals(bestPaths.size(), 2);
         final Path<SeqVertex,BaseEdge> refPath = bestPaths.get(0);
         final Path<SeqVertex,BaseEdge> altPath = bestPaths.get(1);
@@ -468,7 +468,7 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         graph.addEdges(() -> new BaseEdge(false, 1), top, alt, bot);
 
         @SuppressWarnings("all")
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph, top, bot).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph, top, bot).findBestHaplotypes();
 
         Assert.assertEquals(paths.size(), 2);
 
@@ -504,11 +504,11 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         graph.addEdges(() -> new MultiSampleEdge(true, 1, 1), refSource, k1, k2, k3, k4, k5, k6, k7, k8, refEnd);
 
         @SuppressWarnings("all")
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph, refSource, refEnd).findBestHaplotypes();
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph, refSource, refEnd).findBestHaplotypes();
 
         Assert.assertEquals(paths.size(), 1);
 
-        final Path<SeqVertex,BaseEdge> refPath = paths.get(0);
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> refPath = paths.get(0);
 
         final String refString = "AAATTTGGGCCCTT";
 
@@ -539,12 +539,12 @@ public final class KBestHaplotypeFinderUnitTest extends GATKBaseTest {
         graph.addEdges(() -> new MultiSampleEdge(false, 1, 3), k2, v3, v4, v5, v6, v7, k8);
 
         @SuppressWarnings("all")
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph, refSource, refEnd).findBestHaplotypes();
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph, refSource, refEnd).findBestHaplotypes();
 
         Assert.assertEquals(paths.size(), 2);
 
-        final Path<SeqVertex,BaseEdge> refPath = paths.get(0);
-        final Path<SeqVertex,BaseEdge> altPath = paths.get(1);
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> refPath = paths.get(0);
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> altPath = paths.get(1);
 
         final String refString = "AAATTTGGGCCCTT";
         final String altString = "AAATTTGCGCCCTT";

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JunctionTreeKBestHaplotypeFinderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/JunctionTreeKBestHaplotypeFinderUnitTest.java
@@ -1,0 +1,1102 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
+
+import com.google.common.base.Strings;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.JunctionTreeLinkedDeBruinGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
+import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
+import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanJavaAligner;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class JunctionTreeKBestHaplotypeFinderUnitTest extends GATKBaseTest {
+
+    public static byte[] getBytes(final String alignment) {
+        return alignment.replace("-","").getBytes();
+    }
+
+    @DataProvider (name = "loopingReferences")
+    public static Object[][] loopingReferencesRecoverablehaplotypes() {
+        return new Object[][]{
+                new Object[]{"GACACACAGTCA", 3, 8, true}, //ACA and CAC are repeated, 9 is enough bases to span the path
+                new Object[]{"GACACACAGTCA", 3, 5, false}, //ACA and CAC are repeated, 8 is not
+                new Object[]{"GACACTCACGCACGG", 3, 6, true}, //CAC repeated thrice, showing that the loops are handled somewhat sanely
+                new Object[]{"GACATCGACGG", 3, 11, false}, //GAC repeated twice, starting with GAC, can it recover the reference if it starts on a repeated kmer (should not be recoverable based on our decisions)
+                new Object[]{"GACATCGACGG", 3, 6, false}, //With non-unique reference start we fall over for looping structures
+                new Object[]{"GACATCGACGG", 3, 6, false}, //reads too short to be resolvable
+                new Object[]{"GACATCACATC", 3, 8, true}, //final kmer ATC is repeated, can we recover the reference for repating final kmer
+
+                // Some less complicated cases
+                new Object[]{"ACTGTGGGGGGGGGGGGCCGCG", 5, 14, true}, //Just long enough to be resolvable
+                new Object[]{"ACTGTGGGGGGGGGGGGCCGCG", 5, 12, false}, //Just too short to be resolvable
+
+                new Object[]{"ACTGTTCTCTCTCTCTCCCGCG", 5, 14, true}, //Just long enough to be resolvable
+                new Object[]{"ACTGTTCTCTCTCTCTCCCGCG", 5, 9, false}, //Just too short to be resolvable
+        };
+    }
+
+    @Test (dataProvider = "loopingReferences")
+    public void testRecoveryOfLoopingReferenceSequences(final String ref, final int kmerSize, final int readlength, final boolean resolvable) {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        // Add "reads" to the graph
+        for (int i = 0; i + readlength <= ref.length(); i ++) {
+            assembler.addSequence("anonymous", Arrays.copyOfRange(getBytes(ref), i, i + readlength), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+
+        // For all of these loops we expect to recover at least the reference haplotype
+        Assert.assertTrue(bestPaths.contains(ref));
+
+        if (resolvable) {
+            Assert.assertEquals(bestPaths.size(), 1);
+        } else {
+            Assert.assertTrue(bestPaths.size() > 1);
+        }
+    }
+
+    @Test (enabled = false) //TODO this test needs to be reconsidered, this is the "baby thrown out with the bathwater" for ignoring reference weight edges wherever possible,
+    // todo                             this loop becomes unresolvable because there is no evidence for the path out of the loop so the chain stops expanding after a point
+    // Asserting that for a very degenerate looping case (the only weight resides in the loop (which could happen due to non-unique kmers for unmerged dangling ends)
+    // note that this particular case is recovered by virtue of the fact that the reference path itself has weight
+    // This test asserts that ref path weight is still taken into accoun
+    public void testDegenerateLoopingCase() {
+        final String ref = "GACACTCACGCACGG";
+        final int kmerSize = 3;
+        final int readlength = 6;
+
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        // Add "reads" to the graph
+        for (int i = 0; i + readlength < ref.length(); i ++) {
+            assembler.addSequence("anonymous", Arrays.copyOfRange(getBytes(ref), i, i + readlength), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+
+        // For all of these loops we expect to recover at least the reference haplotype
+        Assert.assertTrue(bestPaths.contains(ref));
+
+        Assert.assertEquals(bestPaths.size(), 5);
+
+    }
+
+    @Test
+    // This test demonstrates a potential source of infinite looping, specifically the chain extension
+    public void testDegernerateLoopingDanglingEndInChainGatheringCode() {
+        final String ref = "GACACTCACGCACGGCC";
+        final String alt = "GACACTCACCCCCCCCC"; // the alt ends with a looping and un-escpaed string that is repetative, this will make a path that has no hope of escape (RUN!)
+        final int kmerSize = 5;
+        final int readlength = 8;
+
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        // Add "reads" to the graph
+        for (int i = 0; i + readlength < ref.length(); i ++) {
+            assembler.addSequence("anonymous", Arrays.copyOfRange(getBytes(alt), i, i + readlength), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+        assembler.pruneJunctionTrees(1);
+
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+
+        Assert.assertTrue(true, "This case could have infinitely looped because the junction trees were all uninformative and pruned on the poly-C branch. There is no condition to stop because the junction tree was removed by pruning");
+    }
+
+    @Test
+    // Asserting that for a very degenerate looping case (the only weight resides in the loop (which could happen due to non-unique kmers for unmerged dangling ends)
+    // note that this particular case is recovered by virtue of the fact that the reference path itself has weight
+    public void testDegernerateLoopingDanglingEnd() {
+        final String ref = "GACACTCACGCACGGCC";
+        final String alt = "GACACTCACCCCCCCCC"; // the alt ends with a looping and un-escpaed string that is repetative, this will make a path that has no hope of escape (RUN!)
+        final int kmerSize = 5;
+        final int readlength = 8;
+
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        // Add "reads" to the graph
+        for (int i = 0; i + readlength < ref.length(); i ++) {
+            assembler.addSequence("anonymous", Arrays.copyOfRange(getBytes(alt), i, i + readlength), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+
+        // For this graph structure, there is no evidence whatsoever that a path follow the reference, unfortunately this means we can currently not recover the loop in the alt
+        Assert.assertTrue(bestPaths.isEmpty());
+
+    }
+
+    @Test
+    // Due to there being no JT covering the reference, we assert that we are only finding the read supported alt path despite the reference path being a reasonable start path
+    public void testJunctionTreeRefusesToFollowReferencePathUnlessThereIsNoChoice() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(4);
+        String ref = "AAAACAC"+"CCGA"+"ATGTGGGG"+"A"+"GGGTT"; // the first site has an interesting graph structure and the second site is used to ensure the graph isinterestingg
+
+        // A simple snip het
+        String read1 = "AAAACAC"+"TCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the below read
+        String read2 = "AAAACAC"+"TCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the above read
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(read1), false);
+        assembler.addSequence("anonymous", getBytes(read2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+
+        Assert.assertEquals(bestPaths.size(), 1);
+        Assert.assertEquals(new String(bestPaths.get(0).getBytes()), read1);
+    }
+
+    // TODO this test will soon be obsolete, we will change path termination to be based on loops soon enough (disabled because the number was bumped up to 7 rather than 4 which broke this test)
+    @Test (enabled = false)
+    // This test asserts the current behavior towards junction tree ending because of insufficient junction tree data, if we are past our point of junction tree evidence we will fail
+    // to find paths, thus this test documents the limitations therein.
+    public void testPathTerminationBasedOnDistanceFromLastHaplotype() {
+        final JunctionTreeLinkedDeBruinGraph assembler1 = new JunctionTreeLinkedDeBruinGraph(6);
+        final JunctionTreeLinkedDeBruinGraph assembler2 = new JunctionTreeLinkedDeBruinGraph(6);
+
+        String ref =  "AAACAC"+"C"+"ATGGCGG"+"A"+"GGAGTT"+"T"+"GCTCGAA"+"G"+"GGCGTA"+"C"+"CCTACCT"; // the first site has an interesting graph structure and the second site is used to ensure the graph isinterestingg
+        String alt1 = "AAACAC"+"A"+"ATGGCGG"+"T"+"GGAGTT"+"G"+"GCTCGAA"+"A"+"GGCGTA"+"G"+"CCTACCT";
+        String alt2 = "AAACAC"+"A"+"ATGGCGG"+"T"+"GGAGTT"+"G"+"GCTCGAA"+"A"+"GGCGTA"+"C"+"CCTACCT"; //No expansion of the last path
+
+        assembler1.addSequence("anonymous", getBytes(ref), true);
+        assembler2.addSequence("anonymous", getBytes(ref), true);
+        // Add short sequences of reads to generate the appropriate alt paths
+        for (int i = 0; i + 6 < ref.length(); i ++) {
+            assembler1.addSequence("anonymous", Arrays.copyOfRange(getBytes(alt1), i, i + 7), false);
+            assembler2.addSequence("anonymous", Arrays.copyOfRange(getBytes(alt2), i, i + 7), false);
+        }
+
+        assembler1.buildGraphIfNecessary();
+        assembler2.buildGraphIfNecessary();
+        assembler1.generateJunctionTrees();
+        assembler2.generateJunctionTrees();
+        // Assert that the trees are all pointless
+        assembler1.getReadThreadingJunctionTrees(false).values().forEach(tree -> Assert.assertTrue(tree.getRootNode().hasNoEvidence()));
+        assembler2.getReadThreadingJunctionTrees(false).values().forEach(tree -> Assert.assertTrue(tree.getRootNode().hasNoEvidence()));
+
+        // We had to close out our paths because none of the junction trees are informative and there are 4 decisions to make
+        final List<String> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(assembler1).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+        Assert.assertEquals(bestPaths.size(), 0);
+
+        // We didn't have to close out our paths because there were < 4 decisions made without junction trees, thus we do recover the path
+        final List<String> bestPaths2 = new JunctionTreeKBestHaplotypeFinder<>(assembler2).setWeightThreshold(1)
+                .findBestHaplotypes(5).stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toList());
+        Assert.assertEquals(bestPaths2.size(), 1);
+    }
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testPerfectlyPhasedHaplotypeRecoveryRef() {
+        int readlength = 20;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AAACAAG"+"G"+"TTGGGTTCG"+"A"+"GCGGGGTTC"+"T"+"CTCGAAGT"+"T"+"CTTGGTAATAT"+"A"+"GGGGGCCCC"; // Reference with 5 sites all separated by at least kmer size
+        String alt1 = "AAACAAG"+"T"+"TTGGGTTCG"+"G"+"GCGGGGTTC"+"A"+"CTCGAAGT"+"C"+"CTTGGTAATAT"+"G"+"GGGGGCCCC"; // Alt with different values for all sites
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(alt1.substring(i, i + readlength)), false);
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 10);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes();
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 2);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that
+        Assert.assertTrue(foundHaplotypes.contains(alt1));
+        Assert.assertTrue(foundHaplotypes.contains(ref));
+    }
+
+    @Test
+    // This test is intended to illustrate a problem we know causes probems for junction trees, namely that despite there being
+    // evidence for a particular path, if there is insufficient evidence we simply end up with combinatorial expansion like before
+    public void testInsufficientJunctionTreeDataCausingCombinatorialExpansion() {
+        int readlength = 20;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AAACAAG"+"G"+"TTGGGTTCG"+"A"+"GCGGGGTTC"+"T"+"CTCGAAGT"+"T"+"CTTGGTAATAT"+"A"+"GGGGGCCCC"; // Reference with 5 sites all separated by at least kmer size
+        String alt1 = "AAACAAG"+"T"+"TTGGGTTCG"+"G"+"GCGGGGTTC"+"A"+"CTCGAAGT"+"C"+"CTTGGTAATAT"+"G"+"GGGGGCCCC"; // Alt with different values for all sites
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+
+        assembler.addSequence("anonymous", getBytes(alt1), false);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 10);
+
+        JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes();
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 32); // 2^5 paths from combinatorial expansion
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that
+        Assert.assertTrue(foundHaplotypes.contains(alt1));
+        Assert.assertTrue(foundHaplotypes.contains(ref));
+
+    }
+
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testPerfectlyPhasedHaplotypeRecoveryTwoAlts() {
+        int readlength = 20;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AAACAAG"+"G"+"TTGGGTTCG"+"A"+"GCGGGGTTC"+"T"+"CTCGAAGT"+"T"+"CTTGGTAATAT"+"A"+"GGGGGCCCC"; // Reference with 5 sites all separated by at least kmer size
+        String alt1 = "AAACAAG"+"T"+"TTGGGTTCG"+"G"+"GCGGGGTTC"+"A"+"CTCGAAGT"+"C"+"CTTGGTAATAT"+"G"+"GGGGGCCCC"; // Alt with different values for all sites
+        String alt2 = "AAACAAG"+"T"+"TTGGGTTCG"+"G"+"GCGGGGTTC"+"C"+"CTCGAAGT"+"C"+"CTTGGTAATAT"+"G"+"GGGGGCCCC"; // Alt with one different value from alt1
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(alt1.substring(i, i + readlength)), false);
+            assembler.addSequence("anonymous", getBytes(alt2.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 6);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes();
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 2);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that
+        Assert.assertTrue(foundHaplotypes.contains(alt1));
+        Assert.assertTrue(foundHaplotypes.contains(alt2));
+    }
+
+    @Test
+    // Asserting that the reference end base is handled with care... This code has the tendency to cut early
+    // TODO this test is disabled
+    public void testNonUniqueRefStopPosition() {
+        int readlength = 15;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AACTTGGGTGTGTGAAACCCGGGTTGTGTGTGAA"; // The sequence GTGTGTGAA is repeated
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i <= ref.length(); i+=2) {
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + readlength <= ref.length() ? i + readlength : ref.length())), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(3);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes(5);
+
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that the correct reference haplotype actually existed
+        Assert.assertTrue(foundHaplotypes.contains(ref));
+        // Asserting that we did NOT find the haplotype with 0 loops of the repeat:
+        Assert.assertFalse(foundHaplotypes.contains("AACTTGGGTGTGTG"));
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 1);
+    }
+
+    @Test
+    public void testNonUniqueRefStopPositionNoStopJTToResolveIt() {
+        int readlength = 15;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AACTTGGGTGTGTGAAACCCGGGTTGTGTGTGAA"; // The sequence GTGTGTGAA is repeated
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < ref.length() - 2; i++) { //the - 2 means that we don't span to the end
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 1);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes(5);
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that the correct reference haplotype actually existed
+        Assert.assertTrue(foundHaplotypes.contains(ref));
+        // Asserting that we did NOT find the haplotype with 0 loops of the repeat:
+        Assert.assertFalse(foundHaplotypes.contains("AACTTGGGTGTGTG"));
+        //TODO maybe assert something about the lenght... unclear
+    }
+
+    @Test
+    // Test asserting that the behavior is reasonable when there is read data past the reference end kmer
+    public void testReferenceEndWithErrorSpanningPastEndBase() {
+        int readlength = 15;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AACTGGGTT"  +  "GCGCGCGTTACCCGT"; // The sequence GTGTGTGAA is repeated
+        String alt = "AACTGGGTT"+"T"+"GCGCGCGTTACCCGTTT"; // Alt contig with error spanning past the end of the reference sequence
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < alt.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(alt.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 1); //TODO this will become 2 once the change is implemented
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes(5);
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 1);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that we did NOT find the reference haplotype itself
+        Assert.assertFalse(foundHaplotypes.contains(ref));
+        // Asserting that we did find the alt haplotype minus the ending bases
+        Assert.assertTrue(foundHaplotypes.contains("AACTGGGTT"+"T"+"GCGCGCGTTACCCGT"));
+    }
+
+    @Test
+    // Test asserting that the behavior is reasonable when there is read data past the reference end kmer
+    public void testFullReferencePathRecoveryDespiteReadsNotReachingLastBase() {
+        int readlength = 15;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AACTGGGTT"  +  "GCGCGCGTTACCCGT"; // The sequence GTGTGTGAA is repeated
+        String alt = "AACTGGGTT"+"T"+"GCGCGCGTTACCC"; // Alt contig that doesn't reach the end of the reference
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < alt.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(alt.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 1);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes(5);
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 1);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that we did NOT find the reference haplotype itself
+        Assert.assertFalse(foundHaplotypes.contains(ref));
+        // Asserting that we did find the alt haplotype minus the ending bases
+        Assert.assertTrue(foundHaplotypes.contains("AACTGGGTT"+"T"+"GCGCGCGTTACCCGT"));
+    }
+
+    @Test
+    // The read evidence at the loop is short (15 bases) and consequently doesn't span the entire loop.
+    public void testOfLoopingReferenceReadsTooShortToRecoverIt() {
+        int readlength = 15;
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(7);
+        String ref = "AAACTTTCGCGGGCCCTTAAACCCGCCCTTAAACCCGCCCTTAAACCGCTGTAAGAAA"; // The sequence GCCCTTAAACCC (12 bases) is repeated
+
+        // Generate some reads that do not span the entire active region
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        for (int i = 0; i + readlength < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + readlength)), false);
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + readlength)), false);
+        }
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes(5); //NOTE we only ask for 5 haplotypes here since the graph might loop forever...
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 5);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        // Asserting that the correct reference haplotype actually existed
+        Assert.assertTrue(foundHaplotypes.contains(ref));
+        // Asserting that we did NOT find the haplotype with 0 loops of the repeat:
+        Assert.assertFalse(foundHaplotypes.contains("AAACTTTCGCGGGCCCTTAAACCGCTGTAAGAAA"));
+    }
+
+    // TODO this is a lingering and very serious problem that we aim to resolve shortly somehow, unclear as to exaclty how right now
+    @Test (enabled = false)
+    // This test illustrates a current known issue with the new algorithm, where old junction trees with subranchees that don't have a lot of data
+    // are used in place of younger trees that might cointain evidence of new paths. This particular test shows that a variant might be dropped as a result.
+    public void testOrphanedSubBranchDueToLackingOldJunctionTree() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(6);
+
+        String ref        = "AAAACAC"+"T"+"ATGTGGGG"+"A"+"GGGTTAA"+"A"+"GTCTGAA";
+        String haplotype1 = "AAAACAC"+"G"+"ATGTGGGG"+"T"+"GGGTTAA"+"A"+"GTCTGAA";
+        String haplotype2 = "AAAACAC"+"G"+"ATGTGGGG"+"T"+"GGGTTAA"+"C"+"GTCTGAA";
+        int longReadLength = 20;
+        int shortReadLength = 10;
+
+        // Add the reference a few times to get it into the junction trees
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+
+        // Add haplotype 1 reads that are long enough to catch the last variant site from the first junction tree (22)
+        for (int i = 0; i + longReadLength < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(haplotype1.substring(i, i + longReadLength)), false);
+        }
+
+        // Add haplotype 2 reads that are long enough to leapfrog the entire haplotype but insufficient to establish the G->T->C path on the first tree
+        for (int i = 0; i + shortReadLength < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(haplotype2.substring(i, i + shortReadLength)), false);
+        }
+
+        assembler.generateJunctionTrees();
+
+        final List<String> haplotypes = new JunctionTreeKBestHaplotypeFinder<>(assembler).setWeightThreshold(2)
+                .findBestHaplotypes(5).stream().map(h -> new String(h.getBases())).collect(Collectors.toList());
+
+        // Assert that the reference haplotype is recovered
+        Assert.assertTrue(haplotypes.contains(ref));
+        // Assert that haplotype1 is recovered
+        Assert.assertTrue(haplotypes.contains(haplotype1));
+        // Assert that haplotype2 is recovered
+        // NOTE: this gets dropped because the oldest junction tree on the T->A path has data for haplotype1 but not haplotype2
+        Assert.assertTrue(haplotypes.contains(haplotype2));
+    }
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testEdgeCaseInvolvingHighInDegreeAndOutDegreeChars() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(4);
+        String ref = "AAAACAC"+"CCGA"+"ATGTGGGG"+"A"+"GGGTT"; // the first site has an interesting graph structure and the second site is used to ensurethe graph is intersting
+
+        // A simple snip het
+        String refRead1 = "AAAACAC"+"CCGA"+"ATGTGGGG"+"A"+"GGGTT";
+        String read1 = "AAAACAC"+"CCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the below read
+        String read2 = "AAAACAC"+"TCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the above read
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead1), false);
+        assembler.addSequence("anonymous", getBytes(read1), false);
+        assembler.addSequence("anonymous", getBytes(read2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 6);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        finder.setWeightThreshold(0);
+        Assert.assertEquals(finder.sources.size(), 1);
+        Assert.assertEquals(finder.sinks.size(), 1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes();
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 3);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        Assert.assertTrue(foundHaplotypes.contains(refRead1));
+        Assert.assertTrue(foundHaplotypes.contains(read1));
+        Assert.assertTrue(foundHaplotypes.contains(read2));
+    }
+
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testGraphRecoveryWhenTreeContainsRepeatedKmers() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "AAATCTTCGGGGGGGGGGGGGGTTTCTGGG"; // the first site has an interesting graph structure and the second site is used to ensurethe graph is intersting
+
+        // A simple snip het
+        String refRead = "AAATCTTCGGGGGGGGGGGGGGTTTCTGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        finder.setWeightThreshold(0);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder.findBestHaplotypes();
+
+        // We assert that we found all of the haplotypes present in reads and nothing else
+        Assert.assertEquals(haplotypes.size(), 1);
+        Set<String> foundHaplotypes = haplotypes.stream().map(haplotype -> new String(haplotype.getBases())).collect(Collectors.toSet());
+        Assert.assertTrue(foundHaplotypes.contains(refRead));
+    }
+
+    @Test
+    public void testSimpleJunctionTreeIncludeRefInJunctionTreeTwoSites() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGGAAAT" + "T" + "TCCGGC" + "T" + "CGTTTA"; //Two variant sites in close proximity
+
+        // A simple snip het
+        String altAARead1 = "GGGAAAT" + "A" + "TCCGGC" + "A" + "CGTTTA"; // Replaces a T with an A, then a T with a A
+        String altAARead2 = "GGGAAAT" + "A" + "TCCGGC" + "A" + "CGTTTA"; // Replaces a T with an A, then a T with a A
+        String altTCRead1 = "GGGAAAT" + "T" + "TCCGGC" + "C" + "CGTTTA"; // Keeps the T, then replaces a T with a C
+        String altTCRead2 = "GGGAAAT" + "T" + "TCCGGC" + "C" + "CGTTTA"; // Keeps the T, then replaces a T with a C
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(altAARead1), false);
+        assembler.addSequence("anonymous", getBytes(altAARead2), false);
+        assembler.addSequence("anonymous", getBytes(altTCRead1), false);
+        assembler.addSequence("anonymous", getBytes(altTCRead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+        assembler.pruneJunctionTrees(0);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder1 = new JunctionTreeKBestHaplotypeFinder<>(assembler);
+        Assert.assertEquals(finder1.sources.size(), 1);
+        Assert.assertEquals(finder1.sinks.size(), 1);
+
+        List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = finder1.findBestHaplotypes(10);
+        System.out.println();
+    }
+
+    // Disabled until multi-sink/source edges are supported
+    @Test (enabled = false)
+    public void testDeadNode(){
+        final JunctionTreeLinkedDeBruinGraph g = new JunctionTreeLinkedDeBruinGraph(3);
+        final MultiDeBruijnVertex v1 = new MultiDeBruijnVertex("a".getBytes());
+        final MultiDeBruijnVertex v2 = new MultiDeBruijnVertex("b".getBytes());
+        final MultiDeBruijnVertex v3 = new MultiDeBruijnVertex("c".getBytes());
+        final MultiDeBruijnVertex v4 = new MultiDeBruijnVertex("d".getBytes());
+        final MultiDeBruijnVertex v5 = new MultiDeBruijnVertex("e".getBytes());
+        g.addVertex(v1);   //source
+        g.addVertex(v2);
+        g.addVertex(v3);
+        g.addVertex(v4);  //sink
+        g.addVertex(v5);  //sink
+        g.addEdge(v1, v2);
+        g.addEdge(v2, v3);
+        g.addEdge(v3, v2);//cycle
+        g.addEdge(v2, v5);
+        g.addEdge(v1, v4);
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder1 = new JunctionTreeKBestHaplotypeFinder<>(g);
+        Assert.assertEquals(finder1.sources.size(), 1);
+        Assert.assertEquals(finder1.sinks.size(), 2);
+
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder2 = new JunctionTreeKBestHaplotypeFinder<>(g, v1, v4); //v5 is a dead node (can't reach the sink v4)
+        Assert.assertEquals(finder2.sources.size(), 1);
+        Assert.assertEquals(finder2.sinks.size(), 1);
+    }
+
+    @DataProvider(name = "BasicPathFindingData")
+    public Object[][] makeBasicPathFindingData() {
+        final List<Object[]> tests = new ArrayList<>();
+        for ( final int nStartNodes : Arrays.asList(1, 2, 3) ) {
+            for ( final int nBranchesPerBubble : Arrays.asList(2, 3) ) {
+                for ( final int nEndNodes : Arrays.asList(1, 2, 3) ) {
+                    tests.add(new Object[]{nStartNodes, nBranchesPerBubble, nEndNodes});
+                }
+            }
+        }
+        return tests.toArray(new Object[][]{});
+    }
+
+    private static int weight = 1;
+    final Set<MultiDeBruijnVertex> createVertices(final JunctionTreeLinkedDeBruinGraph graph, final int n, final MultiDeBruijnVertex source, final MultiDeBruijnVertex target) {
+        final List<String> seqs = Arrays.asList("A", "C", "G", "T");
+        final Set<MultiDeBruijnVertex> vertices = new LinkedHashSet<>();
+        for ( int i = 0; i < n; i++ ) {
+            final MultiDeBruijnVertex v = new MultiDeBruijnVertex(seqs.get(i).getBytes());
+            graph.addVertex(v);
+            vertices.add(v);
+            if ( source != null ) graph.addEdge(source, v, new MultiSampleEdge(false, weight++, 1));
+            if ( target != null ) graph.addEdge(v, target, new MultiSampleEdge(false, weight++, 1));
+        }
+        return vertices;
+    }
+
+
+    @Test(dataProvider = "BasicPathFindingData")
+    public void testBasicPathFindingNoJunctionTrees(final int nStartNodes, final int nBranchesPerBubble, final int nEndNodes) {
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(11);
+
+        final MultiDeBruijnVertex middleTop = new MultiDeBruijnVertex("GTAC".getBytes());
+        final MultiDeBruijnVertex middleBottom = new MultiDeBruijnVertex("ACTG".getBytes());
+        graph.addVertices(middleTop, middleBottom);
+        final Set<MultiDeBruijnVertex> starts = createVertices(graph, nStartNodes, null, middleTop);
+        @SuppressWarnings("unused")
+        final Set<MultiDeBruijnVertex> bubbles = createVertices(graph, nBranchesPerBubble, middleTop, middleBottom);
+        final Set<MultiDeBruijnVertex> ends = createVertices(graph, nEndNodes, middleBottom, null);
+
+        final int expectedNumOfPaths = nStartNodes * nBranchesPerBubble * nEndNodes;
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> haplotypes = new JunctionTreeKBestHaplotypeFinder<>(graph, starts, ends, JunctionTreeKBestHaplotypeFinder.DEFAULT_OUTGOING_JT_EVIDENCE_THRESHOLD_TO_BELEIVE).findBestHaplotypes();
+        Assert.assertEquals(haplotypes.size(), expectedNumOfPaths);
+        IntStream.range(1, haplotypes.size()).forEach(n -> Assert.assertTrue(haplotypes.get(n-1).score() >= haplotypes.get(n).score()));
+    }
+
+
+    @DataProvider(name = "BasicBubbleDataProvider")
+    public Object[][] makeBasicBubbleDataProvider() {
+        final List<Object[]> tests = new ArrayList<>();
+        for ( final int refBubbleLength : Arrays.asList(1, 5, 10) ) {
+            for ( final int altBubbleLength : Arrays.asList(1, 5, 10) ) {
+                tests.add(new Object[]{refBubbleLength, altBubbleLength});
+            }
+        }
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "BasicBubbleDataProvider")
+    public void testBasicBubbleData(final int refBubbleLength, final int altBubbleLength) {
+        // Construct the assembly graph
+        JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(4);
+        final String preRef = "ATGG";
+        final String postRef = "GCGGC";
+
+        final String ref = preRef + Strings.repeat("A", refBubbleLength) + postRef;
+        final String alt = preRef + Strings.repeat("A", altBubbleLength-1) + "T" + postRef;
+
+        graph.addSequence("anonomyous", ref.getBytes(),  true);
+        for (int i = 0; i < 5; i++) graph.addSequence("anonomyous", ref.getBytes(), 1, false);
+        for (int i = 0; i < 10; i++) graph.addSequence("anonomyous", alt.getBytes(), 1, false);
+
+        graph.buildGraphIfNecessary();
+        graph.generateJunctionTrees();
+
+        // Construct the test path
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(graph).findBestHaplotypes(5);
+        Assert.assertEquals(bestPaths.size(), 2);
+        KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge> path = bestPaths.get(0);
+
+        // Construct the actual cigar string implied by the test path
+        Cigar expectedCigar = new Cigar();
+        expectedCigar.add(new CigarElement(preRef.length(), CigarOperator.M));
+        if( refBubbleLength > altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength - altBubbleLength, CigarOperator.D));
+            expectedCigar.add(new CigarElement(altBubbleLength, CigarOperator.M));
+        } else if ( refBubbleLength < altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+            expectedCigar.add(new CigarElement(altBubbleLength - refBubbleLength, CigarOperator.I));
+        } else {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+        }
+        expectedCigar.add(new CigarElement(postRef.length(), CigarOperator.M));
+
+        Assert.assertEquals(path.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(), AlignmentUtils.consolidateCigar(expectedCigar).toString(), "Cigar string mismatch");
+    }
+
+    @DataProvider(name = "TripleBubbleDataProvider")
+    public Object[][] makeTripleBubbleDataProvider() {
+        final List<Object[]> tests = new ArrayList<>();
+        for ( final int refBubbleLength : Arrays.asList(1, 5, 10) ) {
+            for ( final int altBubbleLength : Arrays.asList(1, 5, 10) ) {
+                for ( final boolean offRefEnding : Arrays.asList(true, false) ) {
+                    for ( final boolean offRefBeginning : Arrays.asList(false) ) {
+                        tests.add(new Object[]{refBubbleLength, altBubbleLength, offRefBeginning, offRefEnding});
+                    }
+                }
+            }
+        }
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "TripleBubbleDataProvider")
+    //TODO figure out what to do here as this test doesn't apply
+    public void testTripleBubbleData(final int refBubbleLength, final int altBubbleLength, final boolean offRefBeginning, final boolean offRefEnding) {
+        // Construct the assembly graph
+        SeqGraph graph = new SeqGraph(11);
+        final String preAltOption = "ATCGATCGATCGATCGATCG";
+        final String postAltOption = "CCCC";
+        final String preRef = "ATGG";
+        final String postRef = "GGCCG";
+        final String midRef1 = "TTCCT";
+        final String midRef2 = "CCCAAAAAAAAAAAA";
+
+        SeqVertex preV = new SeqVertex(preAltOption);
+        SeqVertex v = new SeqVertex(preRef);
+        SeqVertex v2Ref = new SeqVertex(Strings.repeat("A", refBubbleLength));
+        SeqVertex v2Alt = new SeqVertex(Strings.repeat("A", altBubbleLength - 1) + "T");
+        SeqVertex v4Ref = new SeqVertex(Strings.repeat("C", refBubbleLength));
+        SeqVertex v4Alt = new SeqVertex(Strings.repeat("C", altBubbleLength - 1) + "T");
+        SeqVertex v6Ref = new SeqVertex(Strings.repeat("G", refBubbleLength));
+        SeqVertex v6Alt = new SeqVertex(Strings.repeat("G", altBubbleLength - 1) + "T");
+        SeqVertex v3 = new SeqVertex(midRef1);
+        SeqVertex v5 = new SeqVertex(midRef2);
+        SeqVertex v7 = new SeqVertex(postRef);
+        SeqVertex postV = new SeqVertex(postAltOption);
+
+        final String ref = preRef + v2Ref.getSequenceString() + midRef1 + v4Ref.getSequenceString() + midRef2 + v6Ref.getSequenceString() + postRef;
+
+        graph.addVertex(preV);
+        graph.addVertex(v);
+        graph.addVertex(v2Ref);
+        graph.addVertex(v2Alt);
+        graph.addVertex(v3);
+        graph.addVertex(v4Ref);
+        graph.addVertex(v4Alt);
+        graph.addVertex(v5);
+        graph.addVertex(v6Ref);
+        graph.addVertex(v6Alt);
+        graph.addVertex(v7);
+        graph.addVertex(postV);
+        graph.addEdge(preV, v, new BaseEdge(false, 1));
+        graph.addEdge(v, v2Ref, new BaseEdge(true, 10));
+        graph.addEdge(v2Ref, v3, new BaseEdge(true, 10));
+        graph.addEdge(v, v2Alt, new BaseEdge(false, 5));
+        graph.addEdge(v2Alt, v3, new BaseEdge(false, 5));
+        graph.addEdge(v3, v4Ref, new BaseEdge(true, 10));
+        graph.addEdge(v4Ref, v5, new BaseEdge(true, 10));
+        graph.addEdge(v3, v4Alt, new BaseEdge(false, 5));
+        graph.addEdge(v4Alt, v5, new BaseEdge(false, 5));
+        graph.addEdge(v5, v6Ref, new BaseEdge(true, 11));
+        graph.addEdge(v6Ref, v7, new BaseEdge(true, 11));
+        graph.addEdge(v5, v6Alt, new BaseEdge(false, 55));
+        graph.addEdge(v6Alt, v7, new BaseEdge(false, 55));
+        graph.addEdge(v7, postV, new BaseEdge(false, 1));
+
+        // Construct the test path
+        Path<SeqVertex,BaseEdge> path = new Path<>( (offRefBeginning ? preV : v), graph);
+        if( offRefBeginning )
+            path = new Path<>(path, graph.getEdge(preV, v));
+        path = new Path<>(path, graph.getEdge(v, v2Alt));
+        path = new Path<>(path, graph.getEdge(v2Alt, v3));
+        path = new Path<>(path, graph.getEdge(v3, v4Ref));
+        path = new Path<>(path, graph.getEdge(v4Ref, v5));
+        path = new Path<>(path, graph.getEdge(v5, v6Alt));
+        path = new Path<>(path, graph.getEdge(v6Alt, v7));
+        if( offRefEnding )
+            path = new Path<>(path, graph.getEdge(v7,postV));
+
+        // Construct the actual cigar string implied by the test path
+        Cigar expectedCigar = new Cigar();
+        if( offRefBeginning ) {
+            expectedCigar.add(new CigarElement(preAltOption.length(), CigarOperator.I));
+        }
+        expectedCigar.add(new CigarElement(preRef.length(), CigarOperator.M));
+        // first bubble
+        if( refBubbleLength > altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength - altBubbleLength, CigarOperator.D));
+            expectedCigar.add(new CigarElement(altBubbleLength, CigarOperator.M));
+        } else if ( refBubbleLength < altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+            expectedCigar.add(new CigarElement(altBubbleLength - refBubbleLength, CigarOperator.I));
+        } else {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+        }
+        expectedCigar.add(new CigarElement(midRef1.length(), CigarOperator.M));
+        // second bubble is ref path
+        expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+        expectedCigar.add(new CigarElement(midRef2.length(), CigarOperator.M));
+        // third bubble
+        if( refBubbleLength > altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength - altBubbleLength, CigarOperator.D));
+            expectedCigar.add(new CigarElement(altBubbleLength, CigarOperator.M));
+        } else if ( refBubbleLength < altBubbleLength ) {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+            expectedCigar.add(new CigarElement(altBubbleLength - refBubbleLength, CigarOperator.I));
+        } else {
+            expectedCigar.add(new CigarElement(refBubbleLength, CigarOperator.M));
+        }
+        expectedCigar.add(new CigarElement(postRef.length(), CigarOperator.M));
+        if( offRefEnding ) {
+            expectedCigar.add(new CigarElement(postAltOption.length(), CigarOperator.I));
+        }
+
+        Assert.assertEquals(path.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(),
+                AlignmentUtils.consolidateCigar(expectedCigar).toString(),
+                "Cigar string mismatch: ref = " + ref + " alt " + new String(path.getBases()));
+    }
+
+    @Test (enabled = false)
+    //TODO this test illustrates a problem with junction trees and dangling end recovery, namely the path that the JT points to
+    //TODO is a dead end after dangling tail recovery. This needs to be resolved with either SmithWaterman or by coopting the threading code
+    public void testIntraNodeInsertionDeletion() {
+        // Construct the assembly graph
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(5);
+        final String ref = "TTTT" + "CCCCCGGG" + "TTT";
+        final String alt = "TTTT" + "AAACCCCC" + "TTT";
+
+        graph.addSequence("anonymous", getBytes(ref), true);
+        graph.addSequence("anonymous", getBytes(ref), false);
+        graph.addSequence("anonymous", getBytes(alt), false);
+        graph.buildGraphIfNecessary();
+        graph.recoverDanglingHeads(0, 0,  true, SmithWatermanJavaAligner.getInstance());
+        graph.recoverDanglingTails(0, 0,  true, SmithWatermanJavaAligner.getInstance());
+        graph.generateJunctionTrees();
+
+        @SuppressWarnings("all")
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(graph).findBestHaplotypes();
+        Assert.assertEquals(bestPaths.size(), 2);
+        final Path<MultiDeBruijnVertex,MultiSampleEdge> refPath = bestPaths.get(0);
+        final Path<MultiDeBruijnVertex,MultiSampleEdge> altPath = bestPaths.get(1);
+
+        Assert.assertEquals(refPath.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(), "15M");
+        Assert.assertEquals(altPath.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(), "4M3I5M3D3M");
+    }
+
+    @Test (enabled = false) //TODO this is disabled due to the k max paths per node optimization not being implemented yet
+    /*
+     This is a test of what can go awry if path pruning is based on the number of incoming edges to a given vertex.
+     An illustration of the graph in this test:
+               / ----- top \
+              /(33)         \
+     refStart -(32) -- mid -- midExt ---------------------------- refEnd
+              \(34)        / (1)                               /
+               \ ---- bot /- (33) botExt - (15) - botExtTop - /
+                                        \ (18)               /
+                                         \ ------ botExtBot /
+
+      The expected best paths are (refStart->top->midExt->refEnd), and (refStart->mid->midExt->refEnd) because the bottom
+      path is penalized for two extra forks despite it greedily looking the best at the start.
+
+      Because the old behavior used to base pruning on the number of incoming edges < K, the edge (bot->midExt) would be created
+      first, then (top -> midExt) but (mid -> midExt) would never be created because midExt already has 2 incoming edges.
+      */
+
+    public void testDegeneratePathPruningOptimizationCase() {
+        // Construct an assembly graph demonstrating this issue
+        final SeqGraph graph = new SeqGraph(11);
+        final SeqVertex top = new SeqVertex("T");
+        final SeqVertex mid = new SeqVertex("C");
+        final SeqVertex midAndTopExt = new SeqVertex("GGG");
+        final SeqVertex bot = new SeqVertex("G");
+        final SeqVertex botExt = new SeqVertex("AAA");
+        final SeqVertex botExtTop = new SeqVertex("A");
+        final SeqVertex botExtBot = new SeqVertex("T");
+
+        // Ref source and sink vertexes
+        final SeqVertex refStart = new SeqVertex("CCCCCGGG");
+        final SeqVertex refEnd = new SeqVertex("TTTT");
+
+        graph.addVertices(top, bot, mid, midAndTopExt, bot, botExt, botExtTop, botExtBot, refStart, refEnd);
+        // First "diamond" with 3 mostly equivalent cost paths
+        graph.addEdges(() -> new BaseEdge(false, 34), refStart, bot, botExt);
+        graph.addEdges(() -> new BaseEdge(true, 33), refStart, top, midAndTopExt);
+        graph.addEdges(() -> new BaseEdge(false, 32), refStart, mid, midAndTopExt);
+
+        // The best looking path reconnects with a very poor edge multiplicity to midAndTopExt (This is this is what casues the bug)
+        graph.addEdges(() -> new BaseEdge(false, 1), bot, midAndTopExt);
+        // There is another diamond at bot ext that will end up discounting that path from being in the k best
+        graph.addEdges(() -> new BaseEdge(false, 15), botExt, botExtTop, refEnd);
+        graph.addEdges(() -> new BaseEdge(false, 18), botExt, botExtBot, refEnd);
+
+        // Wheras the path is smooth sailing from refEnd
+        graph.addEdges(() -> new BaseEdge(true, 65), midAndTopExt, refEnd);
+
+        @SuppressWarnings("all")
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new JunctionTreeKBestHaplotypeFinder<>(graph,refStart,refEnd).findBestHaplotypes(2);
+        Assert.assertEquals(bestPaths.size(), 2);
+        final Path<SeqVertex,BaseEdge> refPath = bestPaths.get(0);
+        final Path<SeqVertex,BaseEdge> altPath = bestPaths.get(1);
+
+        Assert.assertEquals(refPath.getVertices().toArray(new SeqVertex[0]), new SeqVertex[]{refStart, top, midAndTopExt, refEnd});
+        Assert.assertEquals(altPath.getVertices().toArray(new SeqVertex[0]), new SeqVertex[]{refStart, mid, midAndTopExt, refEnd});
+    }
+
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    //TODO this test will make a good base for testing later realignment if the leading Ns are cut back down
+    public void testHardSWPath() {
+        // Construct the assembly graph
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(11);
+        String ref = "NNNNNNNNNNN"+"TGTGTGTGTGTGTGACAGAGAGAGAGAGAGAGAGAGAGAGAGAGA"+"NNN"; // Alt with one different value from alt1
+        String alt = "NNNNNNNNNNN"+"ACAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGA"+"NNN"; // Alt with one different value from alt1
+
+        // Generate some reads that do not span the entire active region
+        graph.addSequence("anonymous", getBytes(ref), true);
+        graph.addSequence("anonymous", getBytes(ref), false);
+        graph.addSequence("anonymous", getBytes(alt), false);
+        graph.buildGraphIfNecessary();
+        graph.recoverDanglingHeads(0, 2, true, SmithWatermanJavaAligner.getInstance());
+        graph.generateJunctionTrees();
+
+        @SuppressWarnings("all")
+        final JunctionTreeKBestHaplotypeFinder<MultiDeBruijnVertex, MultiSampleEdge> finder = new JunctionTreeKBestHaplotypeFinder<>(graph);
+        finder.setWeightThreshold(1);
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = finder.findBestHaplotypes();
+
+        Assert.assertEquals(paths.size(), 2);
+
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> refPath = paths.get(0);
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> altPath = paths.get(1);
+
+        logger.warn("RefPath : " + refPath + " cigar " + refPath.calculateCigar(ref.getBytes(),
+                SmithWatermanJavaAligner.getInstance()));
+        logger.warn("AltPath : " + altPath + " cigar " + altPath.calculateCigar(ref.getBytes(),
+                SmithWatermanJavaAligner.getInstance()));
+
+        Assert.assertEquals(refPath.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(), "59M");
+        Assert.assertEquals(altPath.calculateCigar(ref.getBytes(), SmithWatermanJavaAligner.getInstance()).toString(), "11M6I48M");
+    }
+
+    @Test
+    public void testKmerGraphSimpleReferenceRecovery() {
+        // Construct the assembly graph
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(5);
+        final MultiDeBruijnVertex refSource = new MultiDeBruijnVertex( "AAATT".getBytes() );
+        final MultiDeBruijnVertex k1 = new MultiDeBruijnVertex( "AATTT".getBytes() );
+        final MultiDeBruijnVertex k2 = new MultiDeBruijnVertex( "ATTTG".getBytes() );
+        final MultiDeBruijnVertex k3 = new MultiDeBruijnVertex( "TTTGG".getBytes() );
+        final MultiDeBruijnVertex k4 = new MultiDeBruijnVertex( "TTGGG".getBytes() );
+        final MultiDeBruijnVertex k5 = new MultiDeBruijnVertex( "TGGGC".getBytes() );
+        final MultiDeBruijnVertex k6 = new MultiDeBruijnVertex( "GGGCC".getBytes() );
+        final MultiDeBruijnVertex k7 = new MultiDeBruijnVertex( "GGCCC".getBytes() );
+        final MultiDeBruijnVertex k8 = new MultiDeBruijnVertex( "GCCCT".getBytes() );
+        final MultiDeBruijnVertex refEnd = new MultiDeBruijnVertex( "CCCTT".getBytes() );
+        graph.addVertices(refSource, k1, k2, k3, k4, k5, k6, k7, k8, refEnd);
+        graph.addEdges(() -> new MultiSampleEdge(true, 1, 1), refSource, k1, k2, k3, k4, k5, k6, k7, k8, refEnd);
+
+        @SuppressWarnings("all")
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new JunctionTreeKBestHaplotypeFinder<>(graph, refSource, refEnd).findBestHaplotypes();
+
+        Assert.assertEquals(paths.size(), 1);
+
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> refPath = paths.get(0);
+
+        final String refString = "AAATTTGGGCCCTT";
+
+        Assert.assertEquals(refPath.getBases(), refString.getBytes());
+    }
+
+    @Test
+    public void testKmerGraphSimpleReferenceRecoveryWithSNP() {
+        // Construct the assembly graph
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(5);
+        final MultiDeBruijnVertex refSource = new MultiDeBruijnVertex( "AAATT".getBytes() );
+        final MultiDeBruijnVertex k1 = new MultiDeBruijnVertex( "AATTT".getBytes() );
+        final MultiDeBruijnVertex k2 = new MultiDeBruijnVertex( "ATTTG".getBytes() );
+        final MultiDeBruijnVertex k3 = new MultiDeBruijnVertex( "TTTGG".getBytes() );
+        final MultiDeBruijnVertex k4 = new MultiDeBruijnVertex( "TTGGG".getBytes() );
+        final MultiDeBruijnVertex k5 = new MultiDeBruijnVertex( "TGGGC".getBytes() );
+        final MultiDeBruijnVertex k6 = new MultiDeBruijnVertex( "GGGCC".getBytes() );
+        final MultiDeBruijnVertex k7 = new MultiDeBruijnVertex( "GGCCC".getBytes() );
+        final MultiDeBruijnVertex k8 = new MultiDeBruijnVertex( "GCCCT".getBytes() );
+        final MultiDeBruijnVertex refEnd = new MultiDeBruijnVertex( "CCCTT".getBytes() );
+        final MultiDeBruijnVertex v3 = new MultiDeBruijnVertex( "TTTGC".getBytes() );
+        final MultiDeBruijnVertex v4 = new MultiDeBruijnVertex( "TTGCG".getBytes() );
+        final MultiDeBruijnVertex v5 = new MultiDeBruijnVertex( "TGCGC".getBytes() );
+        final MultiDeBruijnVertex v6 = new MultiDeBruijnVertex( "GCGCC".getBytes() );
+        final MultiDeBruijnVertex v7 = new MultiDeBruijnVertex( "CGCCC".getBytes() );
+        graph.addVertices(refSource, k1, k2, k3, k4, k5, k6, k7, k8, refEnd, v3, v4, v5, v6, v7);
+        graph.addEdges(() -> new MultiSampleEdge(true, 1, 4), refSource, k1, k2, k3, k4, k5, k6, k7, k8, refEnd);
+        graph.addEdges(() -> new MultiSampleEdge(false, 1, 3), k2, v3, v4, v5, v6, v7, k8);
+
+        @SuppressWarnings("all")
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new JunctionTreeKBestHaplotypeFinder<>(graph, refSource, refEnd).findBestHaplotypes();
+
+        Assert.assertEquals(paths.size(), 1);
+
+        final Path<MultiDeBruijnVertex, MultiSampleEdge> altPath = paths.get(0);
+
+        final String altString = "AAATTTGCGCCCTT";
+
+        Assert.assertEquals(altPath.getBases(), altString.getBytes());
+    }
+
+    // -----------------------------------------------------------------
+    //
+    // Systematic tests to ensure that we get the correct SW result for
+    // a variety of variants in the ref vs alt bubble
+    //
+    // -----------------------------------------------------------------
+
+    @DataProvider(name = "SystematicRefAltSWTestData")
+    public Object[][] makeSystematicRefAltSWTestData() {
+        final List<Object[]> tests = new ArrayList<>();
+
+        final List<List<String>> allDiffs = Arrays.asList(
+                Arrays.asList("G", "C", "1M"),
+                Arrays.asList("G", "", "1D"),
+                Arrays.asList("", "C", "1I"),
+                Arrays.asList("AAA", "CGT", "3M"),
+                Arrays.asList("TAT", "CAC", "3M"),
+                Arrays.asList("GCTG", "GTCG", "4M"),
+                Arrays.asList("AAAAA", "", "5D"),
+                Arrays.asList("", "AAAAA", "5I"),
+                Arrays.asList("AAAAACC", "CCGGGGGG", "5D2M6I")
+        );
+
+        for ( final String prefix : Arrays.asList("", "X", "XXXXXXXXXXXXX")) {
+            for ( final String end : Arrays.asList("", "X", "XXXXXXXXXXXXX")) {
+                for ( final List<String> diffs : allDiffs )
+                    tests.add(new Object[]{prefix, end, diffs.get(0), diffs.get(1), diffs.get(2)});
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+
+    /**
+     * Convenience constructor for testing that creates a path through vertices in graph
+     */
+    private static <T extends BaseVertex, E extends BaseEdge> Path<T,E> makePath(final List<T> vertices, final BaseGraph<T, E> graph) {
+        Path<T,E> path = new Path<>(vertices.get(0), graph);
+        for ( int i = 1; i < vertices.size(); i++ ) {
+            path = new Path<>(path, graph.getEdge(path.getLastVertex(), vertices.get(i)));
+        }
+        return path;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/SharedVertexSequenceSplitterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/SharedVertexSequenceSplitterUnitTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.testng.Assert;
@@ -182,7 +181,7 @@ public class SharedVertexSequenceSplitterUnitTest extends GATKBaseTest {
                 graph.addEdge(vi, bot, new BaseEdge(vi == first, edgeWeight++));
         }
 
-        final List<KBestHaplotype> originalPaths = new KBestHaplotypeFinder(graph.clone()).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> originalPaths = new GraphBasedKBestHaplotypeFinder<>(graph.clone()).findBestHaplotypes();
         final Set<Haplotype> haplotypes = originalPaths.stream()
                 .map(KBestHaplotype::haplotype).collect(Collectors.toSet());
 
@@ -193,7 +192,7 @@ public class SharedVertexSequenceSplitterUnitTest extends GATKBaseTest {
         splitter.updateGraph(top, bot);
         if ( PRINT_GRAPHS ) graph.printGraph(new File(Utils.join("_", strings) + "_" + hasTop + "_" + hasBot + ".updated.dot"), 0);
 
-        final List<KBestHaplotype> splitPaths = new KBestHaplotypeFinder(graph).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> splitPaths = new GraphBasedKBestHaplotypeFinder<>(graph).findBestHaplotypes();
         splitPaths.forEach(p -> Assert.assertTrue(haplotypes.contains(p.haplotype())));
 
         final List<String> sortedOriginalPaths = originalPaths.stream().map(p -> p.haplotype().getBaseString()).distinct().sorted().collect(Collectors.toList());
@@ -216,10 +215,10 @@ public class SharedVertexSequenceSplitterUnitTest extends GATKBaseTest {
      *
      * @return never {@code null}, perhaps an empty list.
      */
-    private static List<KBestHaplotype> unique(final List<KBestHaplotype> haplotpyes) {
+    private static List<KBestHaplotype<SeqVertex, BaseEdge>> unique(final List<KBestHaplotype<SeqVertex, BaseEdge>> haplotpyes) {
         final Set<String> haplotypes = new HashSet<>();
-        final List<KBestHaplotype> result = new ArrayList<>();
-        for (final KBestHaplotype kbh : haplotpyes) {
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> result = new ArrayList<>();
+        for (final KBestHaplotype<SeqVertex, BaseEdge> kbh : haplotpyes) {
             if (haplotypes.add(new String(kbh.getBases()))) {
                 result.add(kbh);
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraphUnitTest.java
@@ -389,9 +389,6 @@ public class JunctionTreeLinkedDeBruinGraphUnitTest extends BaseTest {
         Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
         Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
 
-        //TODO remove
-        assembler.printGraph(new File("/Users/emeryj/hellbender/gatk/withJT.dot"), 0);
-
         List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
         List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
         // Perfectly phased variants (site 2 has 2 mismatches to the reference)
@@ -448,9 +445,6 @@ public class JunctionTreeLinkedDeBruinGraphUnitTest extends BaseTest {
         JunctionTreeLinkedDeBruinGraph.ThreadingTree insideTree = junctionTrees.get(assembler.findKmer(new Kmer("TAAAT")));
         Assert.assertNotNull(outsideTree); // Make sure we actually have tree data for that site
         Assert.assertNotNull(insideTree); // Make sure we actually have tree data for that site
-
-        //TODO remove
-        assembler.printGraph(new File("/Users/emeryj/hellbender/gatk/withJT.dot"), 0);
 
         List<String> insideChoices = insideTree.getPathsPresentAsBaseChoiceStrings();
         Assert.assertEquals(insideChoices.size(), 2);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruinGraphUnitTest.java
@@ -1,0 +1,1087 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.TextCigarCodec;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.testutils.BaseTest;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
+import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanJavaAligner;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class JunctionTreeLinkedDeBruinGraphUnitTest extends BaseTest {
+
+    @DataProvider (name = "loopingReferences")
+    public static Object[][] loopingReferences() {
+        return new Object[][]{
+                new Object[]{"GACACACAGTCA", 3}, //ACA and CAC are repeated
+                new Object[]{"GACACTCACGCACGG", 3}, //CAC repeated twice, showing that the loops are handled somewhat sanely
+                new Object[]{"GACATCGACGG", 3}, //GAC repeated twice, starting with GAC, can it recover the reference if it starts on a repeated kmer
+                new Object[]{"GACATCACATC", 3} //final kmer ATC is repeated, can we recover the reference for repating final kmer
+        };
+    }
+
+    @Test (dataProvider = "loopingReferences")
+    public void testRecoveryOfLoopingReferenceSequences(final String ref, final int kmerSize) {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.buildGraphIfNecessary();
+        List<MultiDeBruijnVertex> refVertexes = assembler.getReferencePath(ReadThreadingGraph.TraversalDirection.downwards);
+        final StringBuilder builder = new StringBuilder(refVertexes.get(0).getSequenceString());
+        refVertexes.stream().skip(1).forEach(v -> builder.append(v.getSuffixString()));
+        Assert.assertEquals(builder.toString(), ref);
+    }
+
+    @Test
+    // This test is intended to assert that a potentially dangerous infinite loop is closed
+    public void testDanglingEndRecoveryInfiniteHeadLoop() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        final String ref = "AACTGGGCTAGAGAGCGTT";
+        final String loopingDanglingHead = "TTCGAAGGTCGAAG"; // "TCGAA" is repeated, causing dangling head recovery to fail
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+        // Coverage = 3, thus above the prune factor of 2
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHead), false);
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHead), false);
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHead), false);
+
+        // This graph should have generated 3 junction trees (one at GAAAA, one at TCGGG, and one at AATCG)
+        assembler.buildGraphIfNecessary();
+
+        //Try dangling head recovery (this might have infinitely looped if we are not careful)
+        assembler.recoverDanglingHeads(2, 0, true, SmithWatermanAligner.getAligner(SmithWatermanAligner.Implementation.JAVA));
+
+        Assert.assertTrue(true, "If we reached here than the above code didn't infinitely loop");
+    }
+
+    @Test
+    // As above, pruning the dangling end recovery path can cause the infinite loop recovery to fall over
+    public void testDanglingEndRecoveryInfiniteHeadLoopWithPruning() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        final String ref = "AACTGGGCTAGAGAGCGTT";
+        final String loopingDanglingHead = "TTCGAAGGTCGAA"; // "TCGAA" is repeated, causing dangling head recovery to fail
+        final String loopingDanglingHeadShortened = "TTCGAAGGTC"; // "TCGAA" is repeated, causing dangling head recovery to fail
+
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHead), false);
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHead), false);
+        // Now the some of the kimers in the infinite loop should have < 3 coverage, causing pruning to kick in
+        assembler.addSequence("loopingUnconecetedHead", getBytes(loopingDanglingHeadShortened), false);
+
+        // This graph should have generated 3 junction trees (one at GAAAA, one at TCGGG, and one at AATCG)
+        assembler.buildGraphIfNecessary();
+
+        //Try dangling head recovery (this might have infinitely looped if we are not careful)
+        assembler.recoverDanglingHeads(3, 0, true, SmithWatermanAligner.getAligner(SmithWatermanAligner.Implementation.JAVA));
+
+        Assert.assertTrue(true, "If we reached here than the above code didn't infinitely loop");
+    }
+
+    @Test
+    public void testJunctionTreePaperTestExample() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "ACTGATTTCGATGCGATGCGATGCCACGGTGG"; // a loop of length 3 in the middle
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(ref), false);
+
+        // This graph should have generated 3 junction trees (one at GAAAA, one at TCGGG, and one at AATCG)
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("TCGAT"))).isPresent());
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("GCGAT"))).isPresent());
+
+        Assert.assertEquals(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("TCGAT"))).get().getPathsPresentAsBaseChoiceStrings().get(0), "GGC_");
+    }
+
+    @Test
+    public void testGraphPruningSanityCheck() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "TTTTTAAAAACCCCCGGGGGATATATCGCGCG"; // the first site has an interesting graph structure and the second site is used to ensurethe graph is intersting
+
+        String altRead1 = "TTTTTGAAAACCCTCGGGGGATAAATCGCGCG"; // 3 SNPs
+        String altRead2 = "TTTTTGAAAACCCTCGGGGG";
+        String altRead3 = "TTTTTGAAAACCCTCG";
+        String altRead4 = "TTTTTGAAAA";
+        String altRead5 = "TTTTTG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(altRead1), false);
+        assembler.addSequence("anonymous", getBytes(altRead2), false);
+        assembler.addSequence("anonymous", getBytes(altRead3), false);
+        assembler.addSequence("anonymous", getBytes(altRead4), false);
+        assembler.addSequence("anonymous", getBytes(altRead5), false);
+
+        // This graph should have generated 3 junction trees (one at GAAAA, one at TCGGG, and one at AATCG)
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("GAAAA"))).isPresent());
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("TCGGG"))).isPresent());
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("AATCG"))).isPresent());
+
+        Assert.assertEquals(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("GAAAA"))).get().getPathsPresentAsBaseChoiceStrings().get(0), "TA_");
+
+        // Now we prune requiring at least 2 bases of support (which should kill all but the first graph and then only the first two nodes of the first graph)
+        assembler.pruneJunctionTrees(2);
+
+        Assert.assertTrue(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("GAAAA"))).isPresent());
+        Assert.assertFalse(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("TCGGG"))).isPresent());
+        Assert.assertFalse(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("AATCG"))).isPresent());
+
+        Assert.assertEquals(assembler.getJunctionTreeForNode(assembler.findKmer( new Kmer("GAAAA"))).get().getPathsPresentAsBaseChoiceStrings().get(0), "T");
+    }
+
+    @Test
+    // The simplest case where we expect two uninformative junction trees to be constructed
+    public void testSimpleJunctionTreeExample() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGGGAAATTTCCCGGGG";
+
+        // A simple snip het
+        String refRead1 = "GGGAAATTTCC";
+        String refRead2 = "GAAATTTCCCGGG";
+        String altRead1 = "GGAAATGTC";
+        String altRead2 = "GGAAATGTCCCGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead1), false);
+        assembler.addSequence("anonymous", getBytes(refRead2), false);
+        assembler.addSequence("anonymous", getBytes(altRead1), false);
+        assembler.addSequence("anonymous", getBytes(altRead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("GTCCC")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("TTCCC")));
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(tree1Choices, Collections.singletonList(""));
+        Assert.assertEquals(tree2Choices, Collections.singletonList(""));
+
+        // Since the remaining graphs are empty prune them and assert as much
+        junctionTrees = assembler.getReadThreadingJunctionTrees(true);
+        Assert.assertEquals(junctionTrees.size(), 0);
+    }
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testEdgeCaseInvolvingHighInDegreeAndOutDegreeCars() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(4);
+        String ref = "AAAACAC"+"CCGA"+"ATGTGGGG"+"A"+"GGGTT"; // the first site has an interesting graph structure and the second site is used to ensurethe graph is intersting
+
+        // A simple snip het
+        String refRead1 = "AAAACAC"+"CCGA"+"ATGTGGGG"+"A"+"GGGTT";
+        String read1 = "AAAACAC"+"CCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the below read
+        String read2 = "AAAACAC"+"TCGA"+"CTGTGGGG"+"C"+"GGGTT"; // CGAC merges with the above read
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead1), false);
+        assembler.addSequence("anonymous", getBytes(read1), false);
+        assembler.addSequence("anonymous", getBytes(read2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 6);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("CCGA")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("TCGA")));
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(new HashSet<>(tree1Choices), new HashSet<>(Arrays.asList("AA_","CC_"))); // The AA and CC correspond to taking A and C out of the current nodes.
+        Assert.assertEquals(tree2Choices, Collections.singletonList("C_"));
+    }
+
+
+    @Test
+    // This is a test enforcing that the behavior around nodes are both outDegree > 1 while also having downstream children with inDegree > 1.
+    // We are asserting that the JunctionTree generated by this case lives on the node itself
+    public void testGraphRecoveryWhenKmerIsRepeated() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "AAATCTTCGGGGGGGGGGGGGGTTTCTGGG"; // the first site has an interesting graph structure and the second site is used to ensurethe graph is intersting
+
+        // A simple snip het
+        String refRead = "AAATCTTCGGGGGGGGGGGGGGTTTCTGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("CGGGG")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("GGGGG")));
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(tree1Choices, Collections.singletonList("GGGGGGGGGT_"));
+
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(new HashSet<>(tree2Choices), new HashSet<>(Arrays.asList(
+                 "GGGGGGGGGT_"
+                ,"GGGGGGGGT_"
+                ,"GGGGGGGT_"
+                ,"GGGGGGT_"
+                ,"GGGGGT_"
+                ,"GGGGT_"
+                ,"GGGT_"
+                ,"GGT_"
+                ,"GT_"
+                ,"T_")));
+    }
+
+    @Test
+    // The simplest case where we expect two uninformative junction trees to be constructed
+    public void testPruneGraph() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGGGAAATTTCCCGGGG";
+
+        // A simple snip het
+        String refRead1 = "GGGAAATTTCC";
+        String refRead2 = "GAAATTTCCCGGG";
+        String altRead1 = "GGAAATGTC";
+        String altRead2 = "GGAAATGTCCCGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(refRead1), false);
+        assembler.addSequence("anonymous", getBytes(refRead2), false);
+        assembler.addSequence("anonymous", getBytes(altRead1), false);
+        assembler.addSequence("anonymous", getBytes(altRead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        assembler.pruneJunctionTrees(0);
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 0);
+    }
+
+    @Test
+    public void testSimpleJunctionTreeIncludeRefInJunctionTreeNoStopEnd() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGGGAAATTTCCCGGGG"; // Ref starts 1 base before/after any of the reads
+
+        // A simple snip het
+        String altARead1 = "GGGAAATATCC"; // Replaces a T with an A
+        String altARead2 = "GAAATATCCCGGG";
+        String altTRead1 = "GGAAATGTC"; // Replaces a T with a G
+        String altTRead2 = "GGAAATGTCCCGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(altTRead1), false);
+        assembler.addSequence("anonymous", getBytes(altTRead2), false);
+        assembler.addSequence("anonymous", getBytes(altARead1), false);
+        assembler.addSequence("anonymous", getBytes(altARead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("ATCCC")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("GTCCC")));
+        //NOTE there is no "TTCCC" edge here because it only existed as a reference path
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(tree1Choices, Collections.singletonList(""));
+        Assert.assertEquals(tree2Choices, Collections.singletonList(""));
+    }
+
+    @Test
+    // NOTE this test is less useful now that the starting JT has been removed
+    public void testSimpleJunctionTreeIncludeRefInJunctionTreeNoWithStartEndChanges() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGGAAATTTCCCGGG"; // Reads span to the start/stop of the ref, thus we have to worry about symbolic alleles
+
+        // A simple snip het
+        String altARead1 = "GGGAAATATCC"; // Replaces a T with an A
+        String altARead2 = "GAAATATCCCGGG";
+        String altTRead1 = "GGAAATGTC"; // Replaces a T with a G
+        String altTRead2 = "GGAAATGTCCCGGG";
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(altTRead1), false);
+        assembler.addSequence("anonymous", getBytes(altTRead2), false);
+        assembler.addSequence("anonymous", getBytes(altARead1), false);
+        assembler.addSequence("anonymous", getBytes(altARead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree starttree = junctionTrees.get(assembler.findKmer(new Kmer("GGGAA")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("ATCCC")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("GTCCC")));
+        //NOTE there is no "TTCCC" edge here because it only existed as a reference path
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(tree1Choices, Collections.singletonList("_"));
+        Assert.assertEquals(tree2Choices, Collections.singletonList("_"));
+    }
+
+    @Test
+    public void testSimpleJunctionTreeIncludeRefInJunctionTreeTwoSites() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "GGAAAT"+"T"+"TCCGGC"+"T"+"CGTTTAG"; //Two variant sites in close proximity
+
+        // A simple snip het
+        String altAARead1 = "GAAAT"+"A"+"TCCGGC"+"A"+"CGTTTA"; // Replaces a T with an A, then a T with a A
+        String altAARead2 = "GAAAT"+"A"+"TCCGGC"+"A"+"CGTTTA"; // Replaces a T with an A, then a T with a A
+        String altTCRead1 = "GAAAT"+"T"+"TCCGGC"+"C"+"CGTTTA"; // Keeps the T, then replaces a T with a C
+        String altTCRead2 = "GAAAT"+"T"+"TCCGGC"+"C"+"CGTTTA"; // Keeps the T, then replaces a T with a C
+
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(altAARead1), false);
+        assembler.addSequence("anonymous", getBytes(altAARead2), false);
+        assembler.addSequence("anonymous", getBytes(altTCRead1), false);
+        assembler.addSequence("anonymous", getBytes(altTCRead2), false);
+
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(true);
+        Assert.assertEquals(junctionTrees.size(), 2);
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree1 = junctionTrees.get(assembler.findKmer(new Kmer("ATCCG")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree tree2 = junctionTrees.get(assembler.findKmer(new Kmer("TTCCG")));
+        //NOTE there is no "TTCCC" edge here because it only existed as a reference path
+        Assert.assertNotNull(tree1); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(tree2); // Make sure we actually have tree data for that site
+
+        //TODO remove
+        assembler.printGraph(new File("/Users/emeryj/hellbender/gatk/withJT.dot"), 0);
+
+        List<String> tree1Choices = tree1.getPathsPresentAsBaseChoiceStrings();
+        List<String> tree2Choices = tree2.getPathsPresentAsBaseChoiceStrings();
+        // Perfectly phased variants (site 2 has 2 mismatches to the reference)
+        Assert.assertEquals(tree1Choices, Collections.singletonList("A"));
+        Assert.assertEquals(tree2Choices, Collections.singletonList("C"));
+    }
+
+    @Test
+    public void testSimpleJuncionTreeLoopingReference() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "ATGGTTAGGGGAAATTTAAATTTAAAGCGCCCCCG"; // AAATT, AATTT, ATTTA, TTTAA, and TTAAA are all repeated in a loop
+
+        assembler.addSequence("reference", getBytes(ref), true);
+        for (int i = 0; i + 20 < ref.length(); i++) {
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + 20)), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2); //
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree outsideTree = junctionTrees.get(assembler.findKmer(new Kmer("GAAAT")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree insideTree = junctionTrees.get(assembler.findKmer(new Kmer("TAAAT")));
+        Assert.assertNotNull(outsideTree); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(insideTree); // Make sure we actually have tree data for that site
+
+        List<String> insideChoices = insideTree.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(insideChoices.size(), 1);
+        Assert.assertTrue(insideChoices.contains("G"));
+
+        List<String> outsideChoices = outsideTree.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(outsideChoices.size(), 1);
+        Assert.assertTrue(outsideChoices.contains("TG"));
+    }
+
+    @Test
+    public void testSimpleJuncionTreeThriceLoopingReference() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(5);
+        String ref = "ATGGTTAGGGGAAATTTAAATTTAAATTTAAAGCGCCCCCG"; // AAATT, AATTT, ATTTA, TTTAA, and TTAAA are all repeated in a loop
+
+        assembler.addSequence("reference", getBytes(ref), true);
+        for (int i = 0; i + 23 < ref.length(); i++) {
+            // 20 bases should be exactly enough to recover the whole path through the loop (from GGAAAT to TTAAAG)
+            assembler.addSequence("anonymous", getBytes(ref.substring(i, i + 23)), false);
+        }
+        assembler.buildGraphIfNecessary();
+        assembler.generateJunctionTrees();
+
+        Map<MultiDeBruijnVertex, JunctionTreeLinkedDeBruinGraph.ThreadingTree> junctionTrees = assembler.getReadThreadingJunctionTrees(false);
+        Assert.assertEquals(junctionTrees.size(), 2); //
+
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree outsideTree = junctionTrees.get(assembler.findKmer(new Kmer("GAAAT")));
+        JunctionTreeLinkedDeBruinGraph.ThreadingTree insideTree = junctionTrees.get(assembler.findKmer(new Kmer("TAAAT")));
+        Assert.assertNotNull(outsideTree); // Make sure we actually have tree data for that site
+        Assert.assertNotNull(insideTree); // Make sure we actually have tree data for that site
+
+        //TODO remove
+        assembler.printGraph(new File("/Users/emeryj/hellbender/gatk/withJT.dot"), 0);
+
+        List<String> insideChoices = insideTree.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(insideChoices.size(), 2);
+        Assert.assertTrue(insideChoices.contains("TG"));
+        Assert.assertTrue(insideChoices.contains("G"));
+
+        List<String> outsideChoices = outsideTree.getPathsPresentAsBaseChoiceStrings();
+        Assert.assertEquals(outsideChoices.size(), 1);
+        Assert.assertTrue(outsideChoices.contains("TTG"));
+    }
+
+    private static final boolean DEBUG = false;
+
+    public static byte[] getBytes(final String alignment) {
+        return alignment.replace("-","").getBytes();
+    }
+
+    private void assertNonUniqueKmersInvolveLoops(final JunctionTreeLinkedDeBruinGraph assembler, String... nonUniques) {
+        final Set<String> actual = new HashSet<>();
+        assembler.buildGraphIfNecessary();
+        for (String kmer : nonUniques) {
+            MultiDeBruijnVertex vertex = assembler.findKmer(new Kmer(kmer));
+            Assert.assertTrue(assembler.incomingEdgesOf(vertex).size() > 1 || assembler.outgoingEdgesOf(vertex).size() > 1);
+        }
+    }
+
+    @Test
+    public void testSimpleHaplotypeRethreading() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(11);
+        final String ref   = "CATGCACTTTAAAACTTGCCTTTTTAACAAGACTTCCAGATG";
+        final String alt   = "CATGCACTTTAAAACTTGCCGTTTTAACAAGACTTCCAGATG";
+        assembler.addSequence("anonymous", getBytes(ref), true);
+        assembler.addSequence("anonymous", getBytes(alt), false);
+        assembler.buildGraphIfNecessary();
+        Assert.assertNotEquals(ref.length() - 11 + 1, assembler.vertexSet().size(), "the number of vertex in the graph is the same as if there was no alternative sequence");
+        Assert.assertEquals(ref.length() - 11 + 1 + 11, assembler.vertexSet().size(), "the number of vertex in the graph is not the same as if there is an alternative sequence");
+        MultiDeBruijnVertex startAlt = assembler.findKmer(new Kmer(alt.getBytes(),20,11));
+        Assert.assertNotNull(startAlt);
+    }
+
+    @Test(enabled = ! DEBUG)
+    public void testNonUniqueMiddle() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(3);
+        final String ref   = "GACACACAGTCA";
+        final String read1 = "GACAC---GTCA";
+        final String read2 =   "CAC---GTCA";
+        assembler.addSequence(getBytes(ref), true);
+        assembler.addSequence(getBytes(read1), false);
+        assembler.addSequence(getBytes(read2), false);
+        assertNonUniqueKmersInvolveLoops(assembler, "ACA", "CAC");
+    }
+
+    @Test(enabled = ! DEBUG)
+    public void testReadsCreateNonUnique() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(3);
+        final String ref   = "GCAC--GTCA"; // CAC is unique
+        final String read1 = "GCACACGTCA"; // makes CAC non unique because it has a duplication
+        final String read2 =    "CACGTCA"; // shouldn't be allowed to match CAC as start
+        assembler.addSequence(getBytes(ref), true);
+        assembler.addSequence(getBytes(read1), false);
+        assembler.addSequence(getBytes(read2), false);
+//        assembler.convertToSequenceGraph().printGraph(new File("test.dot"), 0);
+
+        assertNonUniqueKmersInvolveLoops(assembler, "CAC");
+        //assertSingleBubble(assembler, ref, "CAAAATCGGG");
+    }
+
+    @Test(enabled = ! DEBUG)
+    // NOTE that now we do still count the reference as edge multiplicity
+    public void testCountingOfStartEdges() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(3);
+        final String ref   = "NNNGTCAAA"; // ref has some bases before start
+        final String read1 =    "GTCAAA"; // starts at first non N base
+
+        assembler.addSequence(getBytes(ref), true);
+        assembler.addSequence(getBytes(read1), false);
+        assembler.buildGraphIfNecessary();
+//        assembler.printGraph(new File("test.dot"), 0);
+
+        for ( final MultiSampleEdge edge : assembler.edgeSet() ) {
+            final MultiDeBruijnVertex source = assembler.getEdgeSource(edge);
+            final MultiDeBruijnVertex target = assembler.getEdgeTarget(edge);
+            final boolean headerVertex = source.getSuffix() == 'N' || target.getSuffix() == 'N';
+            if ( headerVertex ) {
+                Assert.assertEquals(edge.getMultiplicity(), 1, "Bases in the unique reference header should have multiplicity of 0");
+            } else {
+                Assert.assertEquals(edge.getMultiplicity(), 2, "Should have multiplicity of 1 for any edge outside the ref header but got " + edge + " " + source + " -> " + target);
+            }
+        }
+    }
+
+    @Test(enabled = !DEBUG)
+    public void testCountingOfStartEdgesWithMultiplePrefixes() {
+        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(3);
+        assembler.setIncreaseCountsThroughBranches(true);
+        final String ref   = "NNNGTCAXX"; // ref has some bases before start
+        final String alt1  = "NNNCTCAXX"; // alt1 has SNP right after N
+        final String read  =     "TCAXX"; // starts right after SNP, but merges right before branch
+
+        assembler.addSequence(getBytes(ref), true);
+        assembler.addSequence(getBytes(alt1), false);
+        assembler.addSequence(getBytes(read), false);
+        assembler.buildGraphIfNecessary();
+        assembler.printGraph(createTempFile("test",".dot"), 0);
+
+        final List<String> oneCountVertices = Arrays.asList("NNN", "NNC", "NCT", "NNG", "NGT");
+        final List<String> twoCountVertices = Arrays.asList("CTC", "TCA", "GTC");
+
+        for ( final MultiSampleEdge edge : assembler.edgeSet() ) {
+            final MultiDeBruijnVertex source = assembler.getEdgeSource(edge);
+            final MultiDeBruijnVertex target = assembler.getEdgeTarget(edge);
+            final int expected;
+//            if (source.getSequenceString().equals("GTC") && target.getSequenceString().equals("TCA")) {
+//                expected = 1;
+//            } else {
+                expected = oneCountVertices.contains(target.getSequenceString()) ? 1 : ((twoCountVertices.contains(target.getSequenceString()) ? 2 : 3));
+//            }
+            Assert.assertEquals(edge.getMultiplicity(), expected, "Bases at edge " + edge + " from " + source + " to " + target + " has bad multiplicity");
+        }
+    }
+
+    @Test(enabled = !DEBUG)
+    public void testCyclesInGraph() {
+
+        // b37 20:12655200-12655850
+        final String ref = "CAATTGTCATAGAGAGTGACAAATGTTTCAAAAGCTTATTGACCCCAAGGTGCAGCGGTGCACATTAGAGGGCACCTAAGACAGCCTACAGGGGTCAGAAAAGATGTCTCAGAGGGACTCACACCTGAGCTGAGTTGTGAAGGAAGAGCAGGATAGAATGAGCCAAAGATAAAGACTCCAGGCAAAAGCAAATGAGCCTGAGGGAAACTGGAGCCAAGGCAAGAGCAGCAGAAAAGAGCAAAGCCAGCCGGTGGTCAAGGTGGGCTACTGTGTATGCAGAATGAGGAAGCTGGCCAAGTAGACATGTTTCAGATGATGAACATCCTGTATACTAGATGCATTGGAACTTTTTTCATCCCCTCAACTCCACCAAGCCTCTGTCCACTCTTGGTACCTCTCTCCAAGTAGACATATTTCAGATCATGAACATCCTGTGTACTAGATGCATTGGAAATTTTTTCATCCCCTCAACTCCACCCAGCCTCTGTCCACACTTGGTACCTCTCTCTATTCATATCTCTGGCCTCAAGGAGGGTATTTGGCATTAGTAAATAAATTCCAGAGATACTAAAGTCAGATTTTCTAAGACTGGGTGAATGACTCCATGGAAGAAGTGAAAAAGAGGAAGTTGTAATAGGGAGACCTCTTCGG";
+
+        // SNP at 20:12655528 creates a cycle for small kmers
+        final String alt = "CAATTGTCATAGAGAGTGACAAATGTTTCAAAAGCTTATTGACCCCAAGGTGCAGCGGTGCACATTAGAGGGCACCTAAGACAGCCTACAGGGGTCAGAAAAGATGTCTCAGAGGGACTCACACCTGAGCTGAGTTGTGAAGGAAGAGCAGGATAGAATGAGCCAAAGATAAAGACTCCAGGCAAAAGCAAATGAGCCTGAGGGAAACTGGAGCCAAGGCAAGAGCAGCAGAAAAGAGCAAAGCCAGCCGGTGGTCAAGGTGGGCTACTGTGTATGCAGAATGAGGAAGCTGGCCAAGTAGACATGTTTCAGATGATGAACATCCTGTGTACTAGATGCATTGGAACTTTTTTCATCCCCTCAACTCCACCAAGCCTCTGTCCACTCTTGGTACCTCTCTCCAAGTAGACATATTTCAGATCATGAACATCCTGTGTACTAGATGCATTGGAAATTTTTTCATCCCCTCAACTCCACCCAGCCTCTGTCCACACTTGGTACCTCTCTCTATTCATATCTCTGGCCTCAAGGAGGGTATTTGGCATTAGTAAATAAATTCCAGAGATACTAAAGTCAGATTTTCTAAGACTGGGTGAATGACTCCATGGAAGAAGTGAAAAAGAGGAAGTTGTAATAGGGAGACCTCTTCGG";
+
+        final List<GATKRead> reads = new ArrayList<>();
+        for ( int index = 0; index < alt.length() - 100; index += 20 ) {
+            reads.add(ArtificialReadUtils.createArtificialRead(Arrays.copyOfRange(alt.getBytes(), index, index + 100), Utils.dupBytes((byte) 30, 100), 100 + "M"));
+        }
+
+        // test that there are cycles detected for small kmer
+        final JunctionTreeLinkedDeBruinGraph rtgraph25 = new JunctionTreeLinkedDeBruinGraph(25);
+        rtgraph25.addSequence("ref", ref.getBytes(), true);
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        for ( final GATKRead read : reads ) {
+            rtgraph25.addRead(read, header);
+        }
+        rtgraph25.buildGraphIfNecessary();
+        Assert.assertTrue(rtgraph25.hasCycles());
+
+        // test that there are no cycles detected for large kmer
+        final JunctionTreeLinkedDeBruinGraph rtgraph75 = new JunctionTreeLinkedDeBruinGraph(75);
+        rtgraph75.addSequence("ref", ref.getBytes(), true);
+        for ( final GATKRead read : reads ) {
+            rtgraph75.addRead(read, header);
+        }
+        rtgraph75.buildGraphIfNecessary();
+        Assert.assertFalse(rtgraph75.hasCycles());
+    }
+
+    @Test(enabled = !DEBUG)
+    // Test showing that if a read gets completely clipped in the ReadThreadingAssembler, that the assembly will not crash
+    public void testEmptyReadBeingAddedToGraph() {
+
+        // b37 20:12655200-12655850
+        final String ref = "CAATTGTCATAGAGAGTGACAAATGTTTCAAAAGCTTATTGACCCCAAGGTGCAGCGGTGCACATTAGAGGGCACCTAAGACAGCCTACAGGGGTCAGAAAAGATGTCTCAGAGGGACTCACACCTGAGCTGAGTTGTGAAGGAAGAGCAGGATAGAATGAGCCAAAGATAAAGACTCCAGGCAAAAGCAAATGAGCCTGAGGGAAACTGGAGCCAAGGCAAGAGCAGCAGAAAAGAGCAAAGCCAGCCGGTGGTCAAGGTGGGCTACTGTGTATGCAGAATGAGGAAGCTGGCCAAGTAGACATGTTTCAGATGATGAACATCCTGTATACTAGATGCATTGGAACTTTTTTCATCCCCTCAACTCCACCAAGCCTCTGTCCACTCTTGGTACCTCTCTCCAAGTAGACATATTTCAGATCATGAACATCCTGTGTACTAGATGCATTGGAAATTTTTTCATCCCCTCAACTCCACCCAGCCTCTGTCCACACTTGGTACCTCTCTCTATTCATATCTCTGGCCTCAAGGAGGGTATTTGGCATTAGTAAATAAATTCCAGAGATACTAAAGTCAGATTTTCTAAGACTGGGTGAATGACTCCATGGAAGAAGTGAAAAAGAGGAAGTTGTAATAGGGAGACCTCTTCGG";
+
+        // SNP at 20:12655528 creates a cycle for small kmers
+        final String alt = "CAATTGTCATAGAGAGTGACAAATGTTTCAAAAGCTTATTGACCCCAAGGTGCAGCGGTGCACATTAGAGGGCACCTAAGACAGCCTACAGGGGTCAGAAAAGATGTCTCAGAGGGACTCACACCTGAGCTGAGTTGTGAAGGAAGAGCAGGATAGAATGAGCCAAAGATAAAGACTCCAGGCAAAAGCAAATGAGCCTGAGGGAAACTGGAGCCAAGGCAAGAGCAGCAGAAAAGAGCAAAGCCAGCCGGTGGTCAAGGTGGGCTACTGTGTATGCAGAATGAGGAAGCTGGCCAAGTAGACATGTTTCAGATGATGAACATCCTGTGTACTAGATGCATTGGAACTTTTTTCATCCCCTCAACTCCACCAAGCCTCTGTCCACTCTTGGTACCTCTCTCCAAGTAGACATATTTCAGATCATGAACATCCTGTGTACTAGATGCATTGGAAATTTTTTCATCCCCTCAACTCCACCCAGCCTCTGTCCACACTTGGTACCTCTCTCTATTCATATCTCTGGCCTCAAGGAGGGTATTTGGCATTAGTAAATAAATTCCAGAGATACTAAAGTCAGATTTTCTAAGACTGGGTGAATGACTCCATGGAAGAAGTGAAAAAGAGGAAGTTGTAATAGGGAGACCTCTTCGG";
+
+        final List<GATKRead> reads = new ArrayList<>();
+        for ( int index = 0; index < alt.length() - 100; index += 20 ) {
+            reads.add(ArtificialReadUtils.createArtificialRead(Arrays.copyOfRange(alt.getBytes(), index, index + 100), Utils.dupBytes((byte) 30, 100), 100 + "M"));
+        }
+        reads.add(ReadUtils.emptyRead(reads.get(0)));
+
+        // test that there are cycles detected for small kmer
+        final JunctionTreeLinkedDeBruinGraph rtgraph25 = new JunctionTreeLinkedDeBruinGraph(25);
+        rtgraph25.addSequence("ref", ref.getBytes(), true);
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        for ( final GATKRead read : reads ) {
+            rtgraph25.addRead(read, header);
+        }
+        rtgraph25.buildGraphIfNecessary();
+    }
+
+    @Test(enabled = false)
+    // TODO determine what is causing null bases here
+    public void testNsInReadsAreNotUsedForGraph() {
+
+        final int length = 100;
+        final byte[] ref = Utils.dupBytes((byte) 'A', length);
+
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(25);
+        rtgraph.addSequence("ref", ref, true);
+
+        // add reads with Ns at any position
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        for ( int i = 0; i < length; i++ ) {
+            final byte[] bases = ref.clone();
+            bases[i] = 'N';
+            final GATKRead read = ArtificialReadUtils.createArtificialRead(bases, Utils.dupBytes((byte) 30, length), length + "M");
+            rtgraph.addRead(read, header);
+        }
+        rtgraph.buildGraphIfNecessary();
+
+        //final SeqGraph graph = rtgraph.toSequenceGraph();
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(rtgraph, rtgraph.getReferenceSourceVertex(), rtgraph.getReferenceSinkVertex()).findBestHaplotypes();
+        Assert.assertEquals(paths.size(), 1);
+    }
+
+// TODO -- update to use determineKmerSizeAndNonUniques directly
+//    @DataProvider(name = "KmerSizeData")
+//    public Object[][] makeKmerSizeDataProvider() {
+//        List<Object[]> tests = new ArrayList<Object[]>();
+//
+//        // this functionality can be adapted to provide input data for whatever you might want in your data
+//        tests.add(new Object[]{3, 3, 3, Arrays.asList("ACG"), Arrays.asList()});
+//        tests.add(new Object[]{3, 4, 3, Arrays.asList("CAGACG"), Arrays.asList()});
+//
+//        tests.add(new Object[]{3, 3, 3, Arrays.asList("AAAAC"), Arrays.asList("AAA")});
+//        tests.add(new Object[]{3, 4, 4, Arrays.asList("AAAAC"), Arrays.asList()});
+//        tests.add(new Object[]{3, 5, 4, Arrays.asList("AAAAC"), Arrays.asList()});
+//        tests.add(new Object[]{3, 4, 3, Arrays.asList("CAAA"), Arrays.asList()});
+//        tests.add(new Object[]{3, 4, 4, Arrays.asList("CAAAA"), Arrays.asList()});
+//        tests.add(new Object[]{3, 5, 4, Arrays.asList("CAAAA"), Arrays.asList()});
+//        tests.add(new Object[]{3, 5, 5, Arrays.asList("ACGAAAAACG"), Arrays.asList()});
+//
+//        for ( int maxSize = 3; maxSize < 20; maxSize++ ) {
+//            for ( int dupSize = 3; dupSize < 20; dupSize++ ) {
+//                final int expectedSize = Math.min(maxSize, dupSize);
+//                final String dup = Utils.dupString("C", dupSize);
+//                final List<String> nonUnique = dupSize > maxSize ? Arrays.asList(Utils.dupString("C", maxSize)) : Collections.<String>emptyList();
+//                tests.add(new Object[]{3, maxSize, expectedSize, Arrays.asList("ACGT", "A" + dup + "GT"), nonUnique});
+//                tests.add(new Object[]{3, maxSize, expectedSize, Arrays.asList("A" + dup + "GT", "ACGT"), nonUnique});
+//            }
+//        }
+//
+//        return tests.toArray(new Object[][]{});
+//    }
+//
+//    /**
+//     * Example testng test using MyDataProvider
+//     */
+//    @Test(dataProvider = "KmerSizeData")
+//    public void testDynamicKmerSizing(final int min, final int max, final int expectKmer, final List<String> seqs, final List<String> expectedNonUniques) {
+//        final JunctionTreeLinkedDeBruinGraph assembler = new JunctionTreeLinkedDeBruinGraph(min, max);
+//        for ( String seq : seqs ) assembler.addSequence(seq.getBytes(), false);
+//        assembler.buildGraphIfNecessary();
+//        Assert.assertEquals(assembler.getKmerSize(), expectKmer);
+//        assertNonUniqueKmersInvolveLoops(assembler, expectedNonUniques.toArray(new String[]{}));
+//    }
+
+    @DataProvider(name = "DanglingTails")
+    public Object[][] makeDanglingTailsData() {
+        List<Object[]> tests = new ArrayList<>();
+
+        // add 1M to the expected CIGAR because it includes the previous (common) base too
+        tests.add(new Object[]{"AAAAAAAAAA", "CAAA", "5M", true, 3});                  // incomplete haplotype
+        tests.add(new Object[]{"AAAAAAAAAA", "CAAAAAAAAAA", "1M1I10M", true, 10});     // insertion
+        tests.add(new Object[]{"CCAAAAAAAAAA", "AAAAAAAAAA", "1M2D10M", true, 10});    // deletion
+        tests.add(new Object[]{"AAAAAAAA", "CAAAAAAA", "9M", true, 7});                // 1 snp
+        tests.add(new Object[]{"AAAAAAAA", "CAAGATAA", "9M", true, 2});                // several snps
+        tests.add(new Object[]{"AAAAA", "C", "1M4D1M", false, -1});                    // funky SW alignment
+        tests.add(new Object[]{"AAAAA", "CA", "1M3D2M", false, 1});                    // very little data
+        tests.add(new Object[]{"AAAAAAA", "CAAAAAC", "8M", true, -1});                 // ends in mismatch
+        tests.add(new Object[]{"AAAAAA", "CGAAAACGAA", "1M2I4M2I2M", false, 0});       // alignment is too complex
+        tests.add(new Object[]{"AAAAA", "XXXXX", "1M5I", false, -1});                  // insertion
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "DanglingTails")
+    public void testDanglingTails(final String refEnd,
+                                  final String altEnd,
+                                  final String cigar,
+                                  final boolean cigarIsGood,
+                                  final int mergePointDistanceFromSink) {
+
+        final int kmerSize = 15;
+
+        // construct the haplotypes
+        final String commonPrefix = "AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT";
+        final String ref = commonPrefix + refEnd;
+        final String alt = commonPrefix + altEnd;
+
+        // create the graph and populate it
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        rtgraph.addSequence("ref", ref.getBytes(), true);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(alt.getBytes(), Utils.dupBytes((byte) 30, alt.length()), alt.length() + "M");
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        rtgraph.addRead(read, header);
+        rtgraph.buildGraphIfNecessary();
+
+        // confirm that we have just a single dangling tail
+        MultiDeBruijnVertex altSink = null;
+        for ( final MultiDeBruijnVertex v : rtgraph.vertexSet() ) {
+            if ( rtgraph.isSink(v) && !rtgraph.isReferenceNode(v) ) {
+                Assert.assertTrue(altSink == null, "We found more than one non-reference sink");
+                altSink = v;
+            }
+        }
+
+        Assert.assertTrue(altSink != null, "We did not find a non-reference sink");
+
+        // confirm that the SW alignment agrees with our expectations
+        final JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstDownwardsReferencePath(altSink, 0, 4, false, SmithWatermanJavaAligner
+                .getInstance());
+
+        if ( result == null ) {
+            Assert.assertFalse(cigarIsGood);
+            return;
+        }
+
+        Assert.assertTrue(cigar.equals(result.cigar.toString()), "SW generated cigar = " + result.cigar.toString());
+
+        // confirm that the goodness of the cigar agrees with our expectations
+        Assert.assertEquals(JunctionTreeLinkedDeBruinGraph.cigarIsOkayToMerge(result.cigar, false, true), cigarIsGood);
+
+        // confirm that the tail merging works as expected
+        if ( cigarIsGood ) {
+            final int mergeResult = rtgraph.mergeDanglingTail(result);
+            Assert.assertTrue(mergeResult == 1 || mergePointDistanceFromSink == -1);
+
+            // confirm that we created the appropriate edge
+            if ( mergePointDistanceFromSink >= 0 ) {
+                MultiDeBruijnVertex v = altSink;
+                for ( int i = 0; i < mergePointDistanceFromSink; i++ ) {
+                    if ( rtgraph.inDegreeOf(v) != 1 )
+                        Assert.fail("Encountered vertex with multiple edges");
+                    v = rtgraph.getEdgeSource(rtgraph.incomingEdgeOf(v));
+                }
+                Assert.assertTrue(rtgraph.outDegreeOf(v) > 1);
+            }
+        }
+    }
+
+    @Test (enabled = false)
+    //TODO this test will need to be reenabled when dangling head recovery is handled with the JTBesthaplotypeFinder
+    public void testForkedDanglingEnds() {
+
+        final int kmerSize = 15;
+
+        // construct the haplotypes
+        final String commonPrefix = "AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT";
+        final String refEnd = "GCTAGCTAATCG";
+        final String altEnd1 = "ACTAGCTAATCG";
+        final String altEnd2 = "ACTAGATAATCG";
+        final String ref = commonPrefix + refEnd;
+        final String alt1 = commonPrefix + altEnd1;
+        final String alt2 = commonPrefix + altEnd2;
+
+        // create the graph and populate it
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        rtgraph.addSequence("ref", ref.getBytes(), true);
+        final GATKRead read1 = ArtificialReadUtils.createArtificialRead(alt1.getBytes(), Utils.dupBytes((byte) 30, alt1.length()), alt1.length() + "M");
+        final GATKRead read2 = ArtificialReadUtils.createArtificialRead(alt2.getBytes(), Utils.dupBytes((byte) 30, alt2.length()), alt2.length() + "M");
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        rtgraph.addRead(read1, header);
+        rtgraph.addRead(read2, header);
+        rtgraph.buildGraphIfNecessary();
+
+        Assert.assertEquals(rtgraph.getSinks().size(), 3);
+
+        for (final MultiDeBruijnVertex altSink : rtgraph.getSinks()) {
+            if (rtgraph.isReferenceNode(altSink)) {
+                continue;
+            }
+
+            // confirm that the SW alignment agrees with our expectations
+            final JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstDownwardsReferencePath(altSink,
+                    0, 4, true, SmithWatermanJavaAligner.getInstance());
+            Assert.assertNotNull(result);
+            Assert.assertTrue(JunctionTreeLinkedDeBruinGraph.cigarIsOkayToMerge(result.cigar, false, true));
+
+            // confirm that the tail merging works as expected
+            final int mergeResult = rtgraph.mergeDanglingTail(result);
+            Assert.assertTrue(mergeResult == 1);
+        }
+
+        final List<String> paths = new JunctionTreeKBestHaplotypeFinder<>(rtgraph).findBestHaplotypes().stream()
+                .map(kBestHaplotype -> new String(kBestHaplotype.getBases()))
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(paths.size(), 3);
+        Assert.assertEquals(paths, Arrays.asList(ref, alt1, alt2).stream().sorted().collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testWholeTailIsInsertion() {
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(10);
+        final JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper result = new JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper(null, null, "AXXXXX".getBytes(), "AAAAAA".getBytes(), TextCigarCodec.decode("5I1M"));
+        final int mergeResult = rtgraph.mergeDanglingTail(result);
+        Assert.assertEquals(mergeResult, 0);
+    }
+
+    @Test
+    public void testGetBasesForPath() {
+
+        final int kmerSize = 4;
+        final String testString = "AATGGGGCAATACTA";
+
+        final JunctionTreeLinkedDeBruinGraph graph = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        graph.addSequence(testString.getBytes(), true);
+        graph.buildGraphIfNecessary();
+
+        final List<MultiDeBruijnVertex> vertexes = new ArrayList<>();
+        MultiDeBruijnVertex v = graph.getReferenceSourceVertex();
+        while ( v != null ) {
+            vertexes.add(v);
+            v = graph.getNextReferenceVertex(v);
+        }
+
+        final String resultForTails = new String(graph.getBasesForPath(vertexes, false));
+        Assert.assertEquals(resultForTails, testString.substring(kmerSize - 1));
+        final String resultForHeads = new String(graph.getBasesForPath(vertexes, true));
+        Assert.assertEquals(resultForHeads, "GTAAGGGCAATACTA");  // because the source node will be reversed
+    }
+
+    @DataProvider(name = "DanglingHeads")
+    public Object[][] makeDanglingHeadsData() {
+        List<Object[]> tests = new ArrayList<>();
+
+        // add 1M to the expected CIGAR because it includes the last (common) base too
+        tests.add(new Object[]{"XXTXXXXAACCGGTTACGT", "AAYCGGTTACGT", "8M", true});        // 1 snp
+        tests.add(new Object[]{"XXXAACCGGTTACGT", "XAAACCGGTTACGT", "7M", false});         // 1 snp
+        tests.add(new Object[]{"XXTXXXXAACCGGTTACGT", "XAACGGTTACGT", "4M1D4M", false});   // deletion
+        tests.add(new Object[]{"XXTXXXXAACCGGTTACGT", "AYYCGGTTACGT", "8M", true});        // 2 snps
+        tests.add(new Object[]{"XXTXXXXAACCGGTTACGTAA", "AYCYGGTTACGTAA", "9M", true});    // 2 snps
+        tests.add(new Object[]{"XXXTXXXAACCGGTTACGT", "AYCGGTTACGT", "7M", true});         // very little data
+        tests.add(new Object[]{"XXTXXXXAACCGGTTACGT", "YCCGGTTACGT", "6M", true});         // begins in mismatch
+
+        //TODO these tests are diffiuclt to evaluate, as GraphBasedKBestHaplotypeFinder currently cannot handle looping sequence which poses a problem for testing explicitly looping refrence behavior
+//        tests.add(new Object[]{"XXTXXXXAACCGGTTACGTTTACGT", "AAYCGGTTACGT", "8M", true});        // dangling head hanging off of a non-unique reference kmer
+//        tests.add(new Object[]{"XXTXXXXAACCGGTTACGTCGGTTACGT", "AAYCGGTTACGT", "8M", true});
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "DanglingHeads")
+    public void testDanglingHeads(final String ref,
+                                  final String alt,
+                                  final String cigar,
+                                  final boolean shouldBeMerged) {
+
+        final int kmerSize = 5;
+
+        // create the graph and populate it
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        rtgraph.addSequence("ref", ref.getBytes(), true);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(alt.getBytes(), Utils.dupBytes((byte) 30, alt.length()), alt.length() + "M");
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        rtgraph.addRead(read, header);
+        rtgraph.setMaxMismatchesInDanglingHead(10);
+        rtgraph.buildGraphIfNecessary();
+
+        // confirm that we have just a single dangling head
+        MultiDeBruijnVertex altSource = null;
+        for ( final MultiDeBruijnVertex v : rtgraph.vertexSet() ) {
+            if ( rtgraph.isSource(v) && !rtgraph.isReferenceNode(v) ) {
+                Assert.assertTrue(altSource == null, "We found more than one non-reference source");
+                altSource = v;
+            }
+        }
+
+        Assert.assertTrue(altSource != null, "We did not find a non-reference source");
+
+        // confirm that the SW alignment agrees with our expectations
+        final JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstUpwardsReferencePath(altSource, 0, 1, false, SmithWatermanJavaAligner
+                .getInstance());
+
+        if ( result == null ) {
+            Assert.assertFalse(shouldBeMerged);
+            return;
+        }
+
+        Assert.assertTrue(cigar.equals(result.cigar.toString()), "SW generated cigar = " + result.cigar.toString());
+
+        // confirm that the tail merging works as expected
+        final int mergeResult = rtgraph.mergeDanglingHead(result);
+        Assert.assertTrue(mergeResult > 0 || !shouldBeMerged);
+
+        // confirm that we created the appropriate bubble in the graph only if expected
+        rtgraph.cleanNonRefPaths();
+//        final SeqGraph seqGraph = rtgraph.toSequenceGraph();
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(rtgraph, rtgraph.getReferenceSourceVertex(), rtgraph.getReferenceSinkVertex()).findBestHaplotypes();
+        Assert.assertEquals(paths.size(), shouldBeMerged ? 2 : 1);
+    }
+
+    @Test(dataProvider = "DanglingHeads", enabled = false)
+    //TODO this test will need to be enabled when we change the dangling end recovery logic, as of right now definitionally we are
+    //TODO incapable of recovering dangling heads and that will have to change eventually
+    public void testDanglingHeadsWithJTBestHaplotypeFinder(final String ref,
+                                  final String alt,
+                                  final String cigar,
+                                  final boolean shouldBeMerged) {
+
+        final int kmerSize = 5;
+
+        // create the graph and populate it
+        final JunctionTreeLinkedDeBruinGraph rtgraph = new JunctionTreeLinkedDeBruinGraph(kmerSize);
+        rtgraph.addSequence("ref", ref.getBytes(), true);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(alt.getBytes(), Utils.dupBytes((byte) 30, alt.length()), alt.length() + "M");
+        final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
+        rtgraph.addRead(read, header);
+        rtgraph.setMaxMismatchesInDanglingHead(10);
+        rtgraph.buildGraphIfNecessary();
+
+        // confirm that we have just a single dangling head
+        MultiDeBruijnVertex altSource = null;
+        for ( final MultiDeBruijnVertex v : rtgraph.vertexSet() ) {
+            if ( rtgraph.isSource(v) && !rtgraph.isReferenceNode(v) ) {
+                Assert.assertTrue(altSource == null, "We found more than one non-reference source");
+                altSource = v;
+            }
+        }
+
+        Assert.assertTrue(altSource != null, "We did not find a non-reference source");
+
+        // confirm that the SW alignment agrees with our expectations
+        final JunctionTreeLinkedDeBruinGraph.DanglingChainMergeHelper result = rtgraph.generateCigarAgainstUpwardsReferencePath(altSource, 0, 1, false, SmithWatermanJavaAligner
+                .getInstance());
+
+        if ( result == null ) {
+            Assert.assertFalse(shouldBeMerged);
+            return;
+        }
+
+        Assert.assertTrue(cigar.equals(result.cigar.toString()), "SW generated cigar = " + result.cigar.toString());
+
+        // confirm that the tail merging works as expected
+        final int mergeResult = rtgraph.mergeDanglingHead(result);
+        Assert.assertTrue(mergeResult > 0 || !shouldBeMerged);
+
+        // confirm that we created the appropriate bubble in the graph only if expected
+        rtgraph.cleanNonRefPaths();
+//        final SeqGraph seqGraph = rtgraph.toSequenceGraph();
+        final List<KBestHaplotype<MultiDeBruijnVertex, MultiSampleEdge>> paths = new JunctionTreeKBestHaplotypeFinder<>(rtgraph, rtgraph.getReferenceSourceVertex(), rtgraph.getReferenceSinkVertex()).findBestHaplotypes();
+        Assert.assertEquals(paths.size(), shouldBeMerged ? 2 : 1);
+    }
+
+    /**
+     * Find the ending position of the longest uniquely matching
+     * run of bases of kmer in seq.
+     *
+     * for example, if seq = ACGT and kmer is NAC, this function returns 1,2 as we have the following
+     * match:
+     *
+     *  0123
+     * .ACGT
+     * NAC..
+     *
+     * @param seq a non-null sequence of bytes
+     * @param kmer a non-null kmer
+     * @return the ending position and length where kmer matches uniquely in sequence, or null if no
+     *         unique longest match can be found
+     */
+    private static Pair<Integer, Integer> findLongestUniqueSuffixMatch(final byte[] seq, final byte[] kmer) {
+        int longestPos = -1;
+        int length = 0;
+        boolean foundDup = false;
+
+        for ( int i = 0; i < seq.length; i++ ) {
+            final int matchSize = JunctionTreeLinkedDeBruinGraph.longestSuffixMatch(seq, kmer, i);
+            if ( matchSize > length ) {
+                longestPos = i;
+                length = matchSize;
+                foundDup = false;
+            } else if ( matchSize == length ) {
+                foundDup = true;
+            }
+        }
+
+        return foundDup ? null : Pair.of(longestPos, length);
+    }
+
+    /**
+     * Example testng test using MyDataProvider
+     */
+    @Test(dataProvider = "findLongestUniqueMatchData")
+    public void testfindLongestUniqueMatch(final String seq, final String kmer, final int start, final int length) {
+        // adaptor this code to do whatever testing you want given the arguments start and size
+        final Pair<Integer, Integer> actual = findLongestUniqueSuffixMatch(seq.getBytes(), kmer.getBytes());
+        if ( start == -1 )
+            Assert.assertNull(actual);
+        else {
+            Assert.assertNotNull(actual);
+            Assert.assertEquals((int)actual.getLeft(), start);
+            Assert.assertEquals((int)actual.getRight(), length);
+        }
+    }
+
+    @DataProvider(name = "findLongestUniqueMatchData")
+    public Object[][] makefindLongestUniqueMatchData() {
+        List<Object[]> tests = new ArrayList<>();
+
+        { // test all edge conditions
+            final String ref = "ACGT";
+            for ( int start = 0; start < ref.length(); start++ ) {
+                for ( int end = start + 1; end <= ref.length(); end++ ) {
+                    final String kmer = ref.substring(start, end);
+                    tests.add(new Object[]{ref, kmer, end - 1, end - start});
+                    tests.add(new Object[]{ref, "N" + kmer, end - 1, end - start});
+                    tests.add(new Object[]{ref, "NN" + kmer, end - 1, end - start});
+                    tests.add(new Object[]{ref, kmer + "N", -1, 0});
+                    tests.add(new Object[]{ref, kmer + "NN", -1, 0});
+                }
+            }
+        }
+
+        { // multiple matches
+            final String ref = "AACCGGTT";
+            for ( final String alt : Arrays.asList("A", "C", "G", "T") )
+                tests.add(new Object[]{ref, alt, -1, 0});
+            tests.add(new Object[]{ref, "AA", 1, 2});
+            tests.add(new Object[]{ref, "CC", 3, 2});
+            tests.add(new Object[]{ref, "GG", 5, 2});
+            tests.add(new Object[]{ref, "TT", 7, 2});
+        }
+
+        { // complex matches that have unique substrings of lots of parts of kmer in the ref
+            final String ref = "ACGTACGTACGT";
+            tests.add(new Object[]{ref, "ACGT", -1, 0});
+            tests.add(new Object[]{ref, "TACGT", -1, 0});
+            tests.add(new Object[]{ref, "GTACGT", -1, 0});
+            tests.add(new Object[]{ref, "CGTACGT", -1, 0});
+            tests.add(new Object[]{ref, "ACGTACGT", -1, 0});
+            tests.add(new Object[]{ref, "TACGTACGT", 11, 9});
+            tests.add(new Object[]{ref, "NTACGTACGT", 11, 9});
+            tests.add(new Object[]{ref, "GTACGTACGT", 11, 10});
+            tests.add(new Object[]{ref, "NGTACGTACGT", 11, 10});
+            tests.add(new Object[]{ref, "CGTACGTACGT", 11, 11});
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -260,7 +260,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
             assembler.setDebugGraphTransformations(true);
             assembler.setDebugGraphOutputPath(createTempDir("debugGraphs"));
             final SeqGraph graph = assembler.assemble(reads, refHaplotype, header, SmithWatermanJavaAligner
-                    .getInstance()).get(0).getGraph();
+                    .getInstance()).get(0).getSeqGraph();
             if ( DEBUG ) graph.printGraph(new File("test.dot"), 0);
             return graph;
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -11,10 +11,7 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResultSet;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KBestHaplotype;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KBestHaplotypeFinder;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqVertex;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
@@ -276,10 +273,10 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
     private void assertSingleBubble(final TestAssembler assembler, final String one, final String two) {
         final SeqGraph graph = assembler.assemble();
         graph.simplifyGraph();
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph).findBestHaplotypes();
         Assert.assertEquals(paths.size(), 2);
         final Set<String> expected = new HashSet<>(Arrays.asList(one, two));
-        for ( final KBestHaplotype path : paths ) {
+        for ( final KBestHaplotype<SeqVertex, BaseEdge> path : paths ) {
             final String seq = new String(path.getBases());
             Assert.assertTrue(expected.contains(seq));
             expected.remove(seq);
@@ -343,7 +340,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
         Assert.assertNotNull(graph.getReferenceSourceVertex());
         Assert.assertNotNull(graph.getReferenceSinkVertex());
 
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph).findBestHaplotypes();
         Assert.assertEquals(paths.size(), 1);
     }
 
@@ -389,7 +386,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
         assembler.addSequence(ReadThreadingGraphUnitTest.getBytes(read2), false);
 
         final SeqGraph graph = assembler.assemble();
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph).findBestHaplotypes();
         Assert.assertEquals(paths.size(), 2);
         final byte[] refPath = paths.get(0).getBases().length == ref.length() ? paths.get(0).getBases() : paths.get(1).getBases();
         final byte[] altPath = paths.get(0).getBases().length == ref.length() ? paths.get(1).getBases() : paths.get(0).getBases();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
@@ -5,12 +5,8 @@ import htsjdk.samtools.TextCigarCodec;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.Kmer;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KBestHaplotype;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.KBestHaplotypeFinder;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.MultiSampleEdge;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.SeqGraph;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
@@ -206,7 +202,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         rtgraph.buildGraphIfNecessary();
 
         final SeqGraph graph = rtgraph.toSequenceGraph();
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(graph, graph.getReferenceSourceVertex(), graph.getReferenceSinkVertex()).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(graph, graph.getReferenceSourceVertex(), graph.getReferenceSinkVertex()).findBestHaplotypes();
         Assert.assertEquals(paths.size(), 1);
     }
 
@@ -381,7 +377,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         final SeqGraph seqGraph = rtgraph.toSequenceGraph();
         seqGraph.simplifyGraph();
 
-        final List<String> paths = new KBestHaplotypeFinder<>(seqGraph).findBestHaplotypes().stream()
+        final List<String> paths = new GraphBasedKBestHaplotypeFinder<>(seqGraph).findBestHaplotypes().stream()
                 .map(kBestHaplotype -> new String(kBestHaplotype.getBases()))
                 .distinct()
                 .sorted()
@@ -484,7 +480,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         // confirm that we created the appropriate bubble in the graph only if expected
         rtgraph.cleanNonRefPaths();
         final SeqGraph seqGraph = rtgraph.toSequenceGraph();
-        final List<KBestHaplotype> paths = new KBestHaplotypeFinder(seqGraph, seqGraph.getReferenceSourceVertex(), seqGraph.getReferenceSinkVertex()).findBestHaplotypes();
+        final List<KBestHaplotype<SeqVertex, BaseEdge>> paths = new GraphBasedKBestHaplotypeFinder<>(seqGraph, seqGraph.getReferenceSourceVertex(), seqGraph.getReferenceSinkVertex()).findBestHaplotypes();
         Assert.assertEquals(paths.size(), shouldBeMerged ? 2 : 1);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
@@ -381,7 +381,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         final SeqGraph seqGraph = rtgraph.toSequenceGraph();
         seqGraph.simplifyGraph();
 
-        final List<String> paths = new KBestHaplotypeFinder(seqGraph).findBestHaplotypes().stream()
+        final List<String> paths = new KBestHaplotypeFinder<>(seqGraph).findBestHaplotypes().stream()
                 .map(kBestHaplotype -> new String(kBestHaplotype.getBases()))
                 .distinct()
                 .sorted()


### PR DESCRIPTION
This is a prototype of the basic infrastructure that must go in to make the junction tree based Haplotype finding work. I have pulled out a toggle for the HaplotypeCaller that that enables a separate ReadThreadingAssembler codepath for haplotype finding. Right now when this mode is enabled `ExperimentalReadThreadingAssembler` is used in conjunction with `JuncitonTreeKBestHalotypeFinder` to extract only haplotypes that show up in our junction trees with evidence of > 3 reads. This still poses problems with dangling end recovery as definitionally those branches never include complete junction tree data. 

I will continue to work on this branch (as it is in a somewhat rough state still) but I would like to at least get some eyes on it before i get too deep in the weeds to at least validate the structural approach I have chosen. 

Currently known issues in this branch: 
 - Tests are failing due to resolution of non-unique reference sink vertexes, I would solicit help as to how best to resolve the case where junction trees point to both a reference stop allele and a continued path.
- There is at least one very degenerate edge case that might cause the code to hang, I would also ask after what is the best way to close out of looping assembly structures that never have reads to close them (i.e. a "dangling end" hom-var that happens to point to a non-unique reference base). 
- Probably after discussion the threshold for discarding junction trees will be changed to instead use paths from the discarded tree first. 

Resolves #5925