### PR TITLE
Added trimming to the Allele removal code in the genotyping engine

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -371,7 +371,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
 
     @VisibleForTesting
     static protected VariantContext makeAnnotatedCall(byte[] ref, SimpleInterval refLoc, FeatureContext tracker, SAMFileHeader header, VariantContext mergedVC, int mergedAllelesListSizeBeforePossibleTrimming, ReadLikelihoods<Allele> readAlleleLikelihoods, VariantContext call, VariantAnnotatorEngine annotationEngine) {
-        final SimpleInterval locus = new SimpleInterval(mergedVC.getContig());
+        final SimpleInterval locus = new SimpleInterval(mergedVC);
         final SimpleInterval refLocInterval= new SimpleInterval(refLoc);
         final ReferenceDataSource refData = new ReferenceMemorySource(new ReferenceBases(ref, refLocInterval), header.getSequenceDictionary());
         final ReferenceContext referenceContext = new ReferenceContext(refData, locus, refLocInterval);
@@ -379,7 +379,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         final VariantContext untrimmedResult =  annotationEngine.annotateContext(call, tracker, referenceContext, readAlleleLikelihoods, a -> true);
 
         // NOTE: We choose to reverseTrimAlleles() here as opposed to when we actually do the trimming because otherwise we would have to resolve
-        //       the mismatching readAlleleLikelihoods object which is keyed to the old, possibly incorrectly trimmed alleles. 
+        //       the mismatching readAlleleLikelihoods object which is keyed to the old, possibly incorrectly trimmed alleles.
         return untrimmedResult.getAlleles().size() == mergedAllelesListSizeBeforePossibleTrimming ? untrimmedResult
                 : GATKVariantContextUtils.reverseTrimAlleles(untrimmedResult);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngineUnitTest.java
@@ -311,6 +311,7 @@ public final class HaplotypeCallerGenotypingEngineUnitTest extends GATKBaseTest 
     @Test
     public void testMakeAnnotatedCallTrimmingAlleles(){
         List<Allele> alleles = Arrays.asList(Allele.create("AGGGGGGGGG", true), Allele.create("TGGGGGGGGG", false));
+        List<Allele> mergedAlleles = Arrays.asList(Allele.create("AGGGGGGGGG", true), Allele.create("TGGGGGGGGG", false), Allele.create("A", false));
         ReadLikelihoods<Allele> likelihoods = new ReadLikelihoods(SampleList.EMPTY_LIST, new IndexedAlleleList(alleles), new HashMap<>());
 
         // Both a deletion and SNPs are present at this site
@@ -323,6 +324,7 @@ public final class HaplotypeCallerGenotypingEngineUnitTest extends GATKBaseTest 
                 new FeatureContext(),
                 ArtificialReadUtils.createArtificialSamHeader(),
                 originalVC,
+                mergedAlleles.size(),
                 likelihoods,
                 originalVC,
                 new VariantAnnotatorEngine(Collections.emptyList(), null, features, false, true));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngineUnitTest.java
@@ -309,10 +309,11 @@ public final class HaplotypeCallerGenotypingEngineUnitTest extends GATKBaseTest 
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testMakeAnnotatedCallTrimmingAlleles(){
         List<Allele> alleles = Arrays.asList(Allele.create("AGGGGGGGGG", true), Allele.create("TGGGGGGGGG", false));
         List<Allele> mergedAlleles = Arrays.asList(Allele.create("AGGGGGGGGG", true), Allele.create("TGGGGGGGGG", false), Allele.create("A", false));
-        ReadLikelihoods<Allele> likelihoods = new ReadLikelihoods(SampleList.EMPTY_LIST, new IndexedAlleleList(alleles), new HashMap<>());
+        ReadLikelihoods<Allele> likelihoods = new ReadLikelihoods<Allele>(SampleList.EMPTY_LIST, new IndexedAlleleList<Allele>(alleles), new HashMap<>());
 
         // Both a deletion and SNPs are present at this site
         final VariantContext originalVC = new VariantContextBuilder("source", "1", 1000000, 1000009, alleles).make();


### PR DESCRIPTION
I have tested that this explicitly works on the users data. I decided it was simplest to just check for mis-trimming at the very last stage. I'm a little weary about the change of the locus for the ref context from being the culledVC to being the mergedVC. 

Fixes #5994