### PR TITLE
Added secret arguments to ReadThreadingAssembler to track found haplotype counts and kmers used.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -711,6 +711,8 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             }
         }
 
+        // Write assembly region debug output if present
+        assemblyEngine.printDebugHistograms();
 
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -46,7 +46,6 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
                 useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
-        assemblyEngine.setDebugHaplotypeMode(debugHaplotypeDiscovery);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -46,12 +46,16 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
                 useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
+        assemblyEngine.setDebugHaplotypeMode(debugHaplotypeDiscovery);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);
 
         if ( graphOutput != null ) {
             assemblyEngine.setGraphWriter(new File(graphOutput));
+        }
+        if ( haplotypeHistogramOutput != null ) {
+            assemblyEngine.setDebugHistogramOutput(new File(haplotypeHistogramOutput));
         }
 
         return assemblyEngine;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -24,7 +24,6 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
                 !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
-        assemblyEngine.setDebugHaplotypeMode(debugHaplotypeDiscovery);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -24,6 +24,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
                 !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
+        assemblyEngine.setDebugHaplotypeMode(debugHaplotypeDiscovery);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);
         assemblyEngine.setMinDanglingBranchLength(minDanglingBranchLength);
@@ -31,6 +32,11 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
         if ( graphOutput != null ) {
             assemblyEngine.setGraphWriter(new File(graphOutput));
         }
+        if ( haplotypeHistogramOutput != null ) {
+            assemblyEngine.setDebugHistogramOutput(new File(haplotypeHistogramOutput));
+        }
+
+
 
         return assemblyEngine;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -166,10 +166,6 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Argument(fullName="graph-output", shortName="graph", doc="Write debug assembly graph information to this file", optional = true)
     public String graphOutput = null;
 
-    @Hidden
-    @Argument(fullName="debug-haplotype-discovery", doc="Write debug histogram for haplotype discovery", optional = true)
-    public boolean debugHaplotypeDiscovery = false;
-
     /**
      * This argument is meant for debugging and is not immediately useful for normal analysis use.
      */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -167,6 +167,17 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     public String graphOutput = null;
 
     @Hidden
+    @Argument(fullName="debug-haplotype-discovery", doc="Write debug histogram for haplotype discovery", optional = true)
+    public boolean debugHaplotypeDiscovery = false;
+
+    /**
+     * This argument is meant for debugging and is not immediately useful for normal analysis use.
+     */
+    @Hidden
+    @Argument(fullName="haplotype-debug-histogram-output", doc="Write debug assembly graph information to this file", optional = true)
+    public String haplotypeHistogramOutput = null;
+
+    @Hidden
     @Argument(fullName = CAPTURE_ASSEMBLY_FAILURE_BAM_LONG_NAME, doc = "Write a BAM called assemblyFailure.bam capturing all of the reads that were in the active region when the assembler failed for any reason", optional = true)
     public boolean captureAssemblyFailureBAM = false;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResul
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResultSet;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadErrorCorrector;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
+import org.broadinstitute.hellbender.utils.Histogram;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -54,6 +55,7 @@ public final class ReadThreadingAssembler {
 
     private boolean debug = false;
     private boolean debugGraphTransformations = false;
+    private boolean debugHaplotypeFinding = false;
     private boolean recoverDanglingBranches = true;
     private boolean recoverAllDanglingBranches = false;
     private int minDanglingBranchLength = 0;
@@ -64,6 +66,9 @@ public final class ReadThreadingAssembler {
 
     private File debugGraphOutputPath = null;  //Where to write debug graphs, if unset it defaults to the current working dir
     private File graphOutputPath = null;
+    private File graphHaplotypeHistogramPath = null;
+    private Histogram haplotypeHistogram = null;
+    private Histogram kmersUsedHistogram = null;
 
     public ReadThreadingAssembler(final int maxAllowedPathsForReadThreadingAssembler, final List<Integer> kmerSizes,
                                   final boolean dontIncreaseKmerSizesForCycles, final boolean allowNonUniqueKmersInRef,
@@ -146,6 +151,10 @@ public final class ReadThreadingAssembler {
                 // add it to graphs with meaningful non-reference features
                 assemblyResultByGraph.put(result.getGraph(),result);
                 nonRefGraphs.add(result.getGraph());
+
+                if (debugHaplotypeFinding) {
+                    haplotypeHistogram.add((double)result.getKmerSize());
+                }
             }
         }
 
@@ -154,6 +163,7 @@ public final class ReadThreadingAssembler {
 
         // print the graphs if the appropriate debug option has been turned on
         if ( graphOutputPath != null ) { printGraphs(nonRefGraphs); }
+        if ( debugHaplotypeFinding ) { haplotypeHistogram.add((double)resultSet.getHaplotypeCount()); }
 
         return resultSet;
     }
@@ -513,6 +523,26 @@ public final class ReadThreadingAssembler {
         }
     }
 
+    /**
+     * Print the generated graphs to the graphWriter
+     */
+    public void printDebugHistograms() {
+        if (graphHaplotypeHistogramPath != null) {
+
+
+            try (final PrintStream histogramWriter = new PrintStream(graphOutputPath)) {
+                histogramWriter.println("Histogram over the number of haplotypes recovered per active region:");
+                histogramWriter.println(haplotypeHistogram.toString());
+
+                histogramWriter.println("\nHistogram over the average kmer size used for assembly:");
+                histogramWriter.println(kmersUsedHistogram.toString());
+
+            } catch (IOException e) {
+                throw new UserException.CouldNotCreateOutputFile(graphOutputPath, e);
+            }
+        }
+    }
+
     // -----------------------------------------------------------------------------------------------
     //
     // getter / setter routines for generic assembler properties
@@ -545,8 +575,14 @@ public final class ReadThreadingAssembler {
 
     public boolean isRecoverDanglingBranches() { return recoverDanglingBranches; }
 
-    public void setDebugGraphTransformations(final boolean debugGraphTransformations) {
-        this.debugGraphTransformations = debugGraphTransformations;
+    public void setDebugHaplotypeMode(final boolean debugGraphTransformations) {
+        this.debugHaplotypeFinding = debugGraphTransformations;
+        this.haplotypeHistogram = new Histogram(1.0);
+        this.kmersUsedHistogram = new Histogram(1.0);
+    }
+
+    public void setDebugGraphTransformations(final boolean debugHaplotypeFinding) {
+        this.debugGraphTransformations = debugHaplotypeFinding;
     }
 
     /**
@@ -576,5 +612,9 @@ public final class ReadThreadingAssembler {
 
     public void setRemovePathsNotConnectedToRef(final boolean removePathsNotConnectedToRef) {
         this.removePathsNotConnectedToRef = removePathsNotConnectedToRef;
+    }
+
+    public void setDebugHistogramOutput(final File file) {
+        this.graphHaplotypeHistogramPath = file;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -55,7 +55,6 @@ public final class ReadThreadingAssembler {
 
     private boolean debug = false;
     private boolean debugGraphTransformations = false;
-    private boolean debugHaplotypeFinding = false;
     private boolean recoverDanglingBranches = true;
     private boolean recoverAllDanglingBranches = false;
     private int minDanglingBranchLength = 0;
@@ -152,7 +151,7 @@ public final class ReadThreadingAssembler {
                 assemblyResultByGraph.put(result.getGraph(),result);
                 nonRefGraphs.add(result.getGraph());
 
-                if (debugHaplotypeFinding) {
+                if (graphHaplotypeHistogramPath != null) {
                     kmersUsedHistogram.add((double)result.getKmerSize());
                 }
             }
@@ -163,7 +162,7 @@ public final class ReadThreadingAssembler {
 
         // print the graphs if the appropriate debug option has been turned on
         if ( graphOutputPath != null ) { printGraphs(nonRefGraphs); }
-        if ( debugHaplotypeFinding ) { haplotypeHistogram.add((double)resultSet.getHaplotypeCount()); }
+        if ( graphHaplotypeHistogramPath != null ) { haplotypeHistogram.add((double)resultSet.getHaplotypeCount()); }
 
         return resultSet;
     }
@@ -575,7 +574,6 @@ public final class ReadThreadingAssembler {
     public boolean isRecoverDanglingBranches() { return recoverDanglingBranches; }
 
     public void setDebugHistogramOutput(final File file) {
-        this.debugHaplotypeFinding = true;
         this.graphHaplotypeHistogramPath = file;
         this.haplotypeHistogram = new Histogram(1.0);
         this.kmersUsedHistogram = new Histogram(1.0);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -574,8 +574,9 @@ public final class ReadThreadingAssembler {
 
     public boolean isRecoverDanglingBranches() { return recoverDanglingBranches; }
 
-    public void setDebugHaplotypeMode(final boolean debugGraphTransformations) {
-        this.debugHaplotypeFinding = debugGraphTransformations;
+    public void setDebugHistogramOutput(final File file) {
+        this.debugHaplotypeFinding = true;
+        this.graphHaplotypeHistogramPath = file;
         this.haplotypeHistogram = new Histogram(1.0);
         this.kmersUsedHistogram = new Histogram(1.0);
     }
@@ -611,9 +612,5 @@ public final class ReadThreadingAssembler {
 
     public void setRemovePathsNotConnectedToRef(final boolean removePathsNotConnectedToRef) {
         this.removePathsNotConnectedToRef = removePathsNotConnectedToRef;
-    }
-
-    public void setDebugHistogramOutput(final File file) {
-        this.graphHaplotypeHistogramPath = file;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -153,7 +153,7 @@ public final class ReadThreadingAssembler {
                 nonRefGraphs.add(result.getGraph());
 
                 if (debugHaplotypeFinding) {
-                    haplotypeHistogram.add((double)result.getKmerSize());
+                    kmersUsedHistogram.add((double)result.getKmerSize());
                 }
             }
         }
@@ -529,8 +529,7 @@ public final class ReadThreadingAssembler {
     public void printDebugHistograms() {
         if (graphHaplotypeHistogramPath != null) {
 
-
-            try (final PrintStream histogramWriter = new PrintStream(graphOutputPath)) {
+            try (final PrintStream histogramWriter = new PrintStream(graphHaplotypeHistogramPath)) {
                 histogramWriter.println("Histogram over the number of haplotypes recovered per active region:");
                 histogramWriter.println(haplotypeHistogram.toString());
 
@@ -538,7 +537,7 @@ public final class ReadThreadingAssembler {
                 histogramWriter.println(kmersUsedHistogram.toString());
 
             } catch (IOException e) {
-                throw new UserException.CouldNotCreateOutputFile(graphOutputPath, e);
+                throw new UserException.CouldNotCreateOutputFile(graphHaplotypeHistogramPath, e);
             }
         }
     }


### PR DESCRIPTION
This branch (or some variation therin) will be necessary to keep track of how well #5980 is doing at bringing down the number of found haplotypes.