### PR TITLE
Added a new flag to ReadWalkers for start position filtering

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -443,14 +443,21 @@ public abstract class GATKTool extends CommandLineProgram {
                 factory = factory.enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES);
             }
 
-            reads = new ReadsDataSource(readArguments.getReadPaths(), readArguments.getReadIndexPaths(), factory, cloudPrefetchBuffer,
-                (cloudIndexPrefetchBuffer < 0 ? cloudPrefetchBuffer : cloudIndexPrefetchBuffer));
+            createReadsDataSource(factory);
         }
         else {
             reads = null;
         }
     }
 
+    /**
+     * Create the {@link ReadsDataSource} for this {@link GATKTool}.
+     * @param factory {@link SamReaderFactory} used to create the raw reads.
+     */
+    void createReadsDataSource(final SamReaderFactory factory) {
+        reads = new ReadsDataSource(readArguments.getReadPaths(), readArguments.getReadIndexPaths(), factory, cloudPrefetchBuffer,
+            (cloudIndexPrefetchBuffer < 0 ? cloudPrefetchBuffer : cloudIndexPrefetchBuffer), false, Collections.emptyList());
+    }
 
     private boolean bamIndexCachingShouldBeEnabled() {
         return intervalArgumentCollection.intervalsSpecified() && !disableBamIndexCaching;

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/SamRecordAlignmentStartIntervalFilteringIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/SamRecordAlignmentStartIntervalFilteringIterator.java
@@ -1,0 +1,157 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.CloseableIterator;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator that will filter the {@link SAMRecord}s from the given {@link CloseableIterator<SAMRecord>} by whether they appear
+ * in the given {@link Iterator<SimpleInterval>}.
+ * If a {@link SAMRecord} starts in any of the intervals given, then the record passes filtering and is emitted.
+ *
+ * NOTE:
+ *      Assumes that both the given {@link CloseableIterator<SAMRecord>} and {@link Iterator<SimpleInterval>} contain
+ *      sorted data.
+ * Created by jonn on 7/23/19.
+ */
+public class SamRecordAlignmentStartIntervalFilteringIterator implements CloseableIterator<SAMRecord> {
+
+    final private CloseableIterator<SAMRecord> samRecordIterator;
+    final private Iterator<SimpleInterval> intervalIterator;
+
+    private SAMSequenceDictionary sequenceDictionary;
+
+    private SimpleInterval currentInterval = null;
+
+    private SAMRecord next = null;
+
+    public SamRecordAlignmentStartIntervalFilteringIterator(
+            final SAMSequenceDictionary sequenceDictionary,
+            final Iterator<SimpleInterval> intervalIterator,
+            final CloseableIterator<SAMRecord> samRecordIterator) {
+
+        Utils.nonNull(sequenceDictionary, "Sequence dictionary cannot be null");
+        Utils.nonNull(intervalIterator, "Input interval iterator cannot be null");
+        Utils.nonNull(samRecordIterator, "Input sam record iterator cannot be null");
+        Utils.validate(intervalIterator.hasNext(), "Given intervals iterator should never be empty.");
+
+        this.sequenceDictionary = sequenceDictionary;
+        this.intervalIterator = intervalIterator;
+        this.samRecordIterator = samRecordIterator;
+
+        if (samRecordIterator.hasNext()) {
+            advanceCurrentInterval();
+            advanceIterators();
+        }
+    }
+
+    @Override
+    public void close() {
+        if ( samRecordIterator != null ) {
+            samRecordIterator.close();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    @Override
+    public SAMRecord next() {
+
+        if ( !hasNext() ) {
+            throw new NoSuchElementException();
+        }
+        final SAMRecord toReturn = next;
+        advanceIterators();
+        return toReturn;
+    }
+
+    private void advanceIterators() {
+        // Only continue if we have more data:
+        if ( !samRecordIterator.hasNext() ) {
+            next = null;
+            return;
+        }
+
+        // Get our record and the start position.
+        // These will be updated in the while loop below if they do not overlap our intervals:
+        SAMRecord samRecord = samRecordIterator.next();
+        SimpleInterval recordStart =
+                new SimpleInterval( samRecord.getContig(), samRecord.getStart(), samRecord.getStart() );
+
+        // Since we are sorted we can do the following to keep it fast:
+
+        // While we are not in an interval that contains the current samRecord, advance the sam records.
+        // If the sam records jump contigs, we jump contigs and try again.
+        while ( (currentInterval != null) && (!currentInterval.overlaps( recordStart )) ) {
+
+            // If our interval no longer can align with our record, we increment the interval:
+            if ( mustAdvanceIntervals(samRecord) ) {
+                advanceCurrentInterval();
+            }
+            else {
+                if ( !samRecordIterator.hasNext() ) {
+                    next = null;
+                    return;
+                }
+                samRecord = samRecordIterator.next();
+                recordStart = new SimpleInterval( samRecord.getContig(), samRecord.getStart(), samRecord.getStart() );
+            }
+        }
+
+        // We either have a containing interval or we're done:
+        if ( currentInterval == null ) {
+            next = null;
+        }
+        else {
+            next = samRecord;
+        }
+    }
+
+    /**
+     * Determines whether to advance the intervals iterator or the reads iterator.
+     * @param samRecord The current {@link SAMRecord} in the reads iterator.
+     * @return {@code true} if the interval iterator should be updated.  {@code false} if the reads iterator should be updated.
+     */
+    private boolean mustAdvanceIntervals(final SAMRecord samRecord) {
+
+        if ( !currentInterval.getContig().equals( samRecord.getContig() )) {
+            // Different contigs.
+            // We must figure out whether the reads are behind or the intervals are behind:
+
+            final int intervalContigIndex = sequenceDictionary.getSequenceIndex( currentInterval.getContig() );
+            final int readContigIndex = sequenceDictionary.getSequenceIndex( samRecord.getContig() );
+
+            if ( intervalContigIndex < readContigIndex ) {
+                return true;
+            }
+            else {
+                return false;
+            }
+        }
+
+        if ( !currentInterval.overlaps(samRecord) ) {
+            // The interval is on the same contig but does not overlap at all.
+            // Because the intervals and reads are in order, this means we need to move to the next interval.
+            return true;
+        }
+
+        return false;
+    }
+
+    private void advanceCurrentInterval() {
+        if (intervalIterator.hasNext()) {
+            currentInterval = intervalIterator.next();
+        } else {
+            // This code block should only get hit when there are no more intervals in the intervalIterator.
+            currentInterval = null;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadIterator.java
@@ -33,23 +33,6 @@ public class ArtificialReadIterator implements Iterator<GATKRead>, Iterable<GATK
      */
     protected boolean open = false;
 
-    /**
-     * create the fake iterator, given the mapping of chromosomes and read counts
-     *
-     * @param startingChr the starting chromosome
-     * @param endingChr   the ending chromosome
-     * @param readCount   the number of reads in each chromosome
-     * @param header      the associated header
-     */
-    ArtificialReadIterator( int startingChr, int endingChr, int readCount, SAMFileHeader header ) {
-        sChr = startingChr;
-        eChromosomeCount = (endingChr - startingChr) + 1;
-        rCount = readCount;
-        this.header = header;
-        unmappedReadCount = 0;
-        reset();
-    }
-
     protected void reset() {
         this.currentChromo = 0;
         this.currentRead = 1;
@@ -119,7 +102,7 @@ public class ArtificialReadIterator implements Iterator<GATKRead>, Iterable<GATK
             }
         }
         ++totalReadCount;
-        this.next = ArtificialReadUtils.createArtificialRead(this.header, String.valueOf(totalReadCount), currentChromo, currentRead, 50);
+        this.next = ArtificialReadUtils.createArtificialRead(this.header, String.valueOf(totalReadCount), currentChromo, currentRead, ArtificialReadUtils.DEFAULT_READ_LENGTH);
         ++currentRead;
         return true;
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/iterators/SamRecordAlignmentStartIntervalFilteringIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/iterators/SamRecordAlignmentStartIntervalFilteringIteratorUnitTest.java
@@ -1,0 +1,365 @@
+package org.broadinstitute.hellbender.utils.iterators;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.CloseableIterator;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadQueryIterator;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+/**
+ * Unit test class for {@link SamRecordAlignmentStartIntervalFilteringIterator}
+ * Created by jonn on 7/23/19.
+ */
+public class SamRecordAlignmentStartIntervalFilteringIteratorUnitTest extends GATKBaseTest {
+
+    //==================================================================================================================
+    // Private Static Members:
+
+    //==================================================================================================================
+    // Private Members:
+
+    /**
+     * Helper class to deal with converting artificial reads to {@link SAMRecord}s.
+     */
+    private class ArtificialReadQueryIteratorSamIteratorConverter implements CloseableIterator<SAMRecord> {
+
+        private ArtificialReadQueryIterator iterator;
+        private SAMFileHeader header;
+
+        public ArtificialReadQueryIteratorSamIteratorConverter(final SAMFileHeader header,
+                                                               final ArtificialReadQueryIterator it) {
+            this.header = header;
+            iterator = it;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public SAMRecord next() {
+            return iterator.next().convertToSAMRecord(header);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+    }
+
+    //==================================================================================================================
+    // Helper Methods:
+
+    //==================================================================================================================
+    // Data Providers:
+
+    @DataProvider
+    private Object[][] provideForTestIteratorEmptyIntervals() {
+        return new Object[][] {
+                {
+                        Collections.emptyList().iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, 5),
+                        Collections.emptyList(),
+                }
+        };
+    }
+
+    @DataProvider
+    private Object[][] provideForTestIterator() {
+
+        final int numReads = 5;
+        final SAMFileHeader header = ArtificialReadUtils.mappedReadIterator(1, 5, numReads).getHeader();
+
+        return new Object[][] {
+                // Checks for increasing number of reads on one contig with other contigs containing reads:
+                {
+                        Collections.singletonList(
+                            new SimpleInterval("1", 1, 1)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Collections.singletonList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 1, 2)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 1, 3)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 1, 4)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 1, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                // Check on user interval that extends past end of contig:
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 1, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                // Checks on interval with at least 1 read starting before it:
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 2, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 3, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 4, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 5, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Collections.singletonList(
+                                new SimpleInterval("1", 6, 1000)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Collections.emptyList(),
+                },
+                // Multi-interval tests:
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 1),
+                                new SimpleInterval("1", 2, 2),
+                                new SimpleInterval("1", 3, 3),
+                                new SimpleInterval("1", 4, 4),
+                                new SimpleInterval("1", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 1),
+                                new SimpleInterval("1", 3, 3),
+                                new SimpleInterval("1", 4, 4),
+                                new SimpleInterval("1", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 1),
+                                new SimpleInterval("1", 2, 2),
+                                new SimpleInterval("1", 3, 3),
+                                new SimpleInterval("1", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(5), 0, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 2, 2),
+                                new SimpleInterval("1", 4, 4)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                // Multi-Interval / Multi-Contig tests:
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 1),
+                                new SimpleInterval("2", 2, 2),
+                                new SimpleInterval("3", 3, 3),
+                                new SimpleInterval("4", 4, 4),
+                                new SimpleInterval("5", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads + 2), 1, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 2 + 3), 2, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 3 + 4), 3, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 4 + 5), 4, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 1),
+                                new SimpleInterval("2", 2, 3),
+                                new SimpleInterval("3", 3, 3),
+                                new SimpleInterval("4", 4, 5),
+                                new SimpleInterval("5", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads + 2), 1, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads + 3), 1, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 2 + 3), 2, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 3 + 4), 3, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 3 + 5), 3, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 4 + 5), 4, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+                {
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 2),
+                                new SimpleInterval("1", 3, 4),
+                                new SimpleInterval("3", 3, 3),
+                                new SimpleInterval("4", 1, 2),
+                                new SimpleInterval("5", 5, 5)
+                        ).iterator(),
+                        ArtificialReadUtils.mappedReadIterator(1, 5, numReads),
+                        Arrays.asList(
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(1), 0, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(2), 0, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(3), 0, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(4), 0, 4, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 2 + 3), 2, 3, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 3 + 1), 3, 1, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 3 + 2), 3, 2, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header),
+                                ArtificialReadUtils.createArtificialRead(header, String.valueOf(numReads * 4 + 5), 4, 5, ArtificialReadUtils.DEFAULT_READ_LENGTH).convertToSAMRecord(header)
+                        ),
+                },
+        };
+    }
+
+    //==================================================================================================================
+    // Tests:
+
+    @Test(dataProvider = "provideForTestIterator")
+    public void testIterator( final Iterator<SimpleInterval>    intervalIterator,
+                              final ArtificialReadQueryIterator artificialReadQueryIterator,
+                              final List<SAMRecord>             expected ) {
+
+        final ArtificialReadQueryIteratorSamIteratorConverter samIterator =
+                new ArtificialReadQueryIteratorSamIteratorConverter(
+                        artificialReadQueryIterator.getHeader(),
+                        artificialReadQueryIterator);
+
+        final SamRecordAlignmentStartIntervalFilteringIterator it =
+                new SamRecordAlignmentStartIntervalFilteringIterator(
+                        artificialReadQueryIterator.getHeader().getSequenceDictionary(),
+                        intervalIterator,
+                        samIterator );
+
+        final List<SAMRecord> records = new ArrayList<>();
+        while(it.hasNext()) {
+            records.add(it.next());
+        }
+
+        Assert.assertEquals( records, expected );
+    }
+
+    @Test(dataProvider = "provideForTestIteratorEmptyIntervals",
+            expectedExceptions = IllegalStateException.class)
+    public void testIteratorEmptyIntervals( final Iterator<SimpleInterval>   intervalIterator,
+                                            final ArtificialReadQueryIterator artificialReadQueryIterator,
+                                            final List<SAMRecord>            expected ) {
+
+        final ArtificialReadQueryIteratorSamIteratorConverter samIterator =
+                new ArtificialReadQueryIteratorSamIteratorConverter(
+                        artificialReadQueryIterator.getHeader(),
+                        artificialReadQueryIterator);
+
+        final SamRecordAlignmentStartIntervalFilteringIterator it =
+                new SamRecordAlignmentStartIntervalFilteringIterator(
+                        artificialReadQueryIterator.getHeader().getSequenceDictionary(),
+                        intervalIterator,
+                        samIterator );
+    }
+}
+
+


### PR DESCRIPTION
Added reads-must-start-within-intervals flag to ReadWalker to allow for
splitting of files over an interval set without seeing repeats.
This allows PrintReads to split files over an arbitrary number of
intervals and not get any repeated reads across all of the split data
files.

Added a new iterator type to filter reads by this interval.