### PR TITLE
Added an explicit override to RMSMappingQuality annotation to enable old code fallback.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -134,7 +134,8 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
                 throw new UserException.BadInput("Presence of '-"+getDeprecatedRawKeyName()+"' annotation is detected. This GATK version expects key "
                         + getRawKeyName() + " with a tuple of sum of squared MQ values and total reads over variant "
                         + "genotypes as the value. This could indicate that the provided input was produced with an older version of GATK. " +
-                        "Use the argument '--"+RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT+"' to override and attempt the deprecated MQ calculation.");
+                        "Use the argument '--"+RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT+"' to override and attempt the deprecated MQ calculation. There " +
+                        "may be differences in how newer GATK versions calculate DP and MQ that may result in worse MQ results. Use at your own risk.");
             }
 
             rawMQdata = vc.getAttributeAsString(getDeprecatedRawKeyName(), null);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -10,7 +10,9 @@ import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.ReducibleAnnotation;
@@ -55,6 +57,10 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
     public static final int NUM_LIST_ENTRIES = 2;
     public static final int SUM_OF_SQUARES_INDEX = 0;
     public static final int TOTAL_DEPTH_INDEX = 1;
+    public static final String RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT = "allow-old-rms-mapping-quality-annotation-data";
+
+    @Argument(fullName = RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT, doc="Override to allow old RMSMappingQuality annotatated VCFs to function", optional=true)
+    public boolean allowOlderRawKeyValues = false;
 
     @Override
     public String getRawKeyName() { return GATKVCFConstants.RAW_MAPPING_QUALITY_WITH_DEPTH_KEY;}   //new key for the two-value MQ data to prevent version mismatch catastrophes
@@ -124,6 +130,13 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
             rawMQdata = vc.getAttributeAsString(getRawKeyName(), null);
         }
         else if (vc.hasAttribute(getDeprecatedRawKeyName())) {
+            if (!allowOlderRawKeyValues) {
+                throw new UserException.BadInput("Presence of '-"+getDeprecatedRawKeyName()+"' annotation is detected. This GATK version expects key "
+                        + getRawKeyName() + " with an long tuple of sum of squared MQ values and total reads over variant "
+                        + "genotypes as the value. This could indicate that the provided input was produced with an older version of GATK. " +
+                        "Use the argument '--"+RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT+"' to override and attempt the deprecated MQ calculation.");
+            }
+
             rawMQdata = vc.getAttributeAsString(getDeprecatedRawKeyName(), null);
             //the original version of ReblockGVCF produces a different MQ format -- try to handle that gracefully here just in case those files go through GenotypeGVCFs
             if (vc.hasAttribute("MQ_DP")) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -59,7 +59,7 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
     public static final int TOTAL_DEPTH_INDEX = 1;
     public static final String RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT = "allow-old-rms-mapping-quality-annotation-data";
 
-    @Argument(fullName = RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT, doc="Override to allow old RMSMappingQuality annotatated VCFs to function", optional=true)
+    @Argument(fullName = RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT, doc="Override to allow old RMSMappingQuality annotated VCFs to function", optional=true)
     public boolean allowOlderRawKeyValues = false;
 
     @Override
@@ -132,7 +132,7 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
         else if (vc.hasAttribute(getDeprecatedRawKeyName())) {
             if (!allowOlderRawKeyValues) {
                 throw new UserException.BadInput("Presence of '-"+getDeprecatedRawKeyName()+"' annotation is detected. This GATK version expects key "
-                        + getRawKeyName() + " with an long tuple of sum of squared MQ values and total reads over variant "
+                        + getRawKeyName() + " with a tuple of sum of squared MQ values and total reads over variant "
                         + "genotypes as the value. This could indicate that the provided input was produced with an older version of GATK. " +
                         "Use the argument '--"+RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT+"' to override and attempt the deprecated MQ calculation.");
             }
@@ -151,7 +151,7 @@ public final class RMSMappingQuality extends InfoFieldAnnotation implements Stan
             }
             else {
                 logger.warn("MQ annotation data is not properly formatted. This GATK version expects key "
-                        + getRawKeyName() + " with an long tuple of sum of squared MQ values and total reads over variant "
+                        + getRawKeyName() + " with a tuple of sum of squared MQ values and total reads over variant "
                         + "genotypes as the value. Attempting to use deprecated MQ calculation.");
                 final long numOfReads = getNumOfReads(vc, null);
                 rawMQdata = Math.round(Double.parseDouble(rawMQdata)) + "," + numOfReads;   //deprecated format was double so it needs to be converted to long

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBImport;
+import org.broadinstitute.hellbender.tools.walkers.annotator.RMSMappingQuality;
 import org.broadinstitute.hellbender.utils.GATKProtectedVariantContextUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -326,6 +327,7 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.addReference(new File(reference))
                 .addArgument("V", input)
+                .addArgument(RMSMappingQuality.RMS_MAPPING_QUALITY_OLD_BEHAVIOR_OVERRIDE_ARGUMENT)
                 .addOutput(output);
 
         additionalArguments.forEach(args::add);


### PR DESCRIPTION
After spending some time to resolve this users issue, https://gatkforums.broadinstitute.org/gatk/discussion/24134/gatk4-rmsmappingquality-results-differ-between-v4-0-0-0-and-v4-1-1-0/p1, it became clear that the issue was that the user simply mismatched her versions of gatk, which seems to have caused their MQ annotations to tank. The user didn't notice the warnings of this fact until we had already nearly found the issue by debugging. I propose that we upgrade the warning to an exception with explicit override to make it harder for this issue to slip past people in the future. 