### PR TITLE
Clarified the readme to warn users to set their Gradle JVM properly in Intellij.

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ We use [git-lfs](https://git-lfs.github.com/) to version and distribute test dat
 
 * Make sure that the Java version is set correctly by going to File -> "Project Structure" -> "Project". Check that the "Project SDK" is set to your Java 1.8 JDK, and "Project language level" to 8 (you may need to add your Java 8 JDK under "Platform Settings" -> SDKs if it isn't there already). Then click "Apply"/"Ok".
 
+* If you are still having issues building the GATK you may need to manually set the Gradle JVM. In order to do that find the wrench icon in the gradle tab in intellij and change the "Gradle JVM" argument to point to Java 1.8.
+
 #### <a name="debugging">Setting up debugging in IntelliJ</a>
 
 * Follow the instructions above for creating an IntelliJ project for GATK

--- a/README.md
+++ b/README.md
@@ -457,15 +457,13 @@ We use [git-lfs](https://git-lfs.github.com/) to version and distribute test dat
 
 * Select "Use auto-import" and "Use default gradle wrapper".
 
-* Make sure the Gradle JVM points to Java 1.8 
+* Make sure the Gradle JVM points to Java 1.8. You may need to set this manually after creating the project, to do so find the gradle settings by clicking the wrench icon in the gradle tab on the right bar, from there edit "Gradle JVM" argument to point to Java 1.8.
 
 * Click "Finish"
 
 * After downloading project dependencies, IntelliJ should open a new window with your GATK project
 
 * Make sure that the Java version is set correctly by going to File -> "Project Structure" -> "Project". Check that the "Project SDK" is set to your Java 1.8 JDK, and "Project language level" to 8 (you may need to add your Java 8 JDK under "Platform Settings" -> SDKs if it isn't there already). Then click "Apply"/"Ok".
-
-* If you are still having issues building the GATK you may need to manually set the Gradle JVM. In order to do that find the wrench icon in the gradle tab in intellij and change the "Gradle JVM" argument to point to Java 1.8.
 
 #### <a name="debugging">Setting up debugging in IntelliJ</a>
 


### PR DESCRIPTION
Saving wisdom that wasn't previously easy to find in the README. 