### PR TITLE
ValidateVariants exception message improvement

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -326,7 +326,7 @@ public class UserException extends RuntimeException {
         public final ValidateVariants.ValidationType type;
 
         public FailsStrictValidation(String f, ValidateVariants.ValidationType type, String message) {
-            super(String.format("Input %s fails strict validation: %s of type:", f, message, type));
+            super(String.format("Input %s fails strict validation of type %s: %s", f, type, message));
             this.type = type;
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/ValidateVariantsIntegrationTest.java
@@ -37,7 +37,7 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
     }
 
     private static String excludeValidationTypesButString(ValidateVariants.ValidationType type) {
-        if (type.equals(ALL)) {
+        if (type == null || type.equals(ALL)) {
             return "";
         }
         final StringBuilder sbuilder = new StringBuilder();
@@ -160,6 +160,14 @@ public final class ValidateVariantsIntegrationTest extends CommandLineProgramTes
         );
 
         spec.executeTest("test bad chr counts #1", this);
+
+        IntegrationTestSpec spec2 = new IntegrationTestSpec(
+                baseTestStringWithoutReference(false, "validationExampleBad.vcf", false, null),
+                0,
+                UserException.FailsStrictValidation.class
+        );
+
+        spec2.executeTest("test bad chr counts #1", this);
     }
 
     @Test


### PR DESCRIPTION
I added a test according to #4642 , but can't reproduce the error.  The user also noted that the error message was badly formed, which is true because it ended with a colon.  Now it looks like:
"Input src/test/resources/org/broadinstitute/hellbender/tools/walkers/ValidateVariants/validationExampleBad.vcf fails strict validation of type CHR_COUNTS: the Allele Count (AC) tag is incorrect for the record at position 1:985447, 1 vs. 2"