### PR TITLE
Remove the one-space indentation of last line

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -1322,4 +1322,3 @@ task Funcotate {
          File funcotated_output_file_index = "${output_file_index}"
      }
 }
-

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -1321,4 +1321,4 @@ task Funcotate {
          File funcotated_output_file = "${output_file}"
          File funcotated_output_file_index = "${output_file_index}"
      }
- }
+}


### PR DESCRIPTION
Reason: With the indentation before the closing bracket, the task Funcotate is ignored by tools such as dxWDL.