### PR TITLE
Restart test jvm every few test classes

### DIFF
--- a/testsettings.gradle
+++ b/testsettings.gradle
@@ -9,7 +9,7 @@ tasks.withType(Test) {
      * anything else             : run the non-cloud tests
      */
     String TEST_TYPE = "$System.env.TEST_TYPE"
-
+    forkEvery 5
     useTestNG {
         if (TEST_TYPE == "cloud") {
             // run only the cloud tests

--- a/testsettings.gradle
+++ b/testsettings.gradle
@@ -9,7 +9,7 @@ tasks.withType(Test) {
      * anything else             : run the non-cloud tests
      */
     String TEST_TYPE = "$System.env.TEST_TYPE"
-    forkEvery 5
+    forkEvery 50
     useTestNG {
         if (TEST_TYPE == "cloud") {
             // run only the cloud tests

--- a/testsettings.gradle
+++ b/testsettings.gradle
@@ -9,7 +9,7 @@ tasks.withType(Test) {
      * anything else             : run the non-cloud tests
      */
     String TEST_TYPE = "$System.env.TEST_TYPE"
-    forkEvery 50
+    forkEvery 100
     useTestNG {
         if (TEST_TYPE == "cloud") {
             // run only the cloud tests


### PR DESCRIPTION
* Adding forkEvery 5 to cause the test jvm to be restarted every few test classes.
* This might fix a theoretical memory leak causing our builds to fail often.

This might help?