### PR TITLE
fixed Mutect2 bug that overfiltered by one variant

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilterMutectCalls.java
@@ -104,7 +104,7 @@ public final class FilterMutectCalls extends MultiplePassVariantWalker {
     private static final int NUMBER_OF_LEARNING_PASSES = 2;
 
     @Override
-    protected int numberOfPasses() { return NUMBER_OF_LEARNING_PASSES + 2; }    // {@coode NUMBER_OF_LEARNING_PASSES} passes for learning, one for the threshold, and one for calling
+    protected int numberOfPasses() { return NUMBER_OF_LEARNING_PASSES + 2; }    // {@code NUMBER_OF_LEARNING_PASSES} passes for learning, one for the threshold, and one for calling
 
     @Override
     public boolean requiresReference() { return true;}


### PR DESCRIPTION
@takutosato This fixes two sources of the bug:

* Threshold was equal to the error probability of the worst unfiltered variant, but filtering was based on `errorProbability > threshold - EPSILON`, which ends up filtering this variant.
* Threshold was adjusted *and* filtering parameters were changed on the last pass, which means that error probabilities could shift slightly relative to those used to set the threshold.