### PR TITLE
Fix non-determinism in HaplotypeCaller

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/KBestHaplotypeFinder.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.jgrapht.alg.CycleDetector;
 
@@ -66,7 +67,8 @@ public final class KBestHaplotypeFinder {
      */
     public List<KBestHaplotype> findBestHaplotypes(final int maxNumberOfHaplotypes) {
         final List<KBestHaplotype> result = new ArrayList<>();
-        final PriorityQueue<KBestHaplotype> queue = new PriorityQueue<>(Comparator.comparingDouble(KBestHaplotype::score).reversed());
+        final PriorityQueue<KBestHaplotype> queue = new PriorityQueue<>(Comparator.comparingDouble(KBestHaplotype::score).reversed()
+                .thenComparing(KBestHaplotype::getBases, BaseUtils.BASES_COMPARATOR));
         sources.forEach(source -> queue.add(new KBestHaplotype(source, graph)));
 
         final Map<SeqVertex, MutableInt> vertexCounts = graph.vertexSet().stream()
@@ -86,7 +88,6 @@ public final class KBestHaplotypeFinder {
                     }
 
                     for (final BaseEdge edge : outgoingEdges) {
-                        final SeqVertex targetVertex = graph.getEdgeTarget(edge);
                         queue.add(new KBestHaplotype(pathToExtend, edge, totalOutgoingMultiplicity));
                     }
                 }


### PR DESCRIPTION
* Fixing a non-deterministic point in HaplotypeCaller's KBestHaplotypeFinder
 * It uses a priority queue to compare scores, if there are ties the tie breaking is arbitrary and seems to be different depending on circumstances of the run.
 * For some as of yet unknown reason reading from a gs path vs a local path can cause this to be triggered.
 * Adding a tie breaker which uses the entirety of the bases in the Path in cases where the score is tied, this is unique per path.