### PR TITLE
Added the ability for Indels to be recovered from dangling heads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -38,7 +38,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
                 useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph,
-                enableLegacyGraphCycleDetection, minMachingBasesToDanglngEndRecovery);
+                enableLegacyGraphCycleDetection, minMatchingBasesToDanglingEndRecovery);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -37,7 +37,8 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph, enableLegacyGraphCycleDetection);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph,
+                enableLegacyGraphCycleDetection, minMachingBasesToDanglngEndRecovery);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -23,7 +23,8 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph, enableLegacyGraphCycleDetection);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph,
+                enableLegacyGraphCycleDetection, minMachingBasesToDanglngEndRecovery);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -24,7 +24,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
                 !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph,
-                enableLegacyGraphCycleDetection, minMachingBasesToDanglngEndRecovery);
+                enableLegacyGraphCycleDetection, minMatchingBasesToDanglingEndRecovery);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -186,6 +186,10 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Argument(fullName = CAPTURE_ASSEMBLY_FAILURE_BAM_LONG_NAME, doc = "Write a BAM called assemblyFailure.bam capturing all of the reads that were in the active region when the assembler failed for any reason", optional = true)
     public boolean captureAssemblyFailureBAM = false;
 
+    @Hidden
+    @Argument(fullName = "num-matching-prefix-bases-in-end-to-recover", doc = "Sets the number of bases that must exactly match in a dangling end for it to be recoverd", optional = true)
+    public int minMachingBasesToDanglngEndRecovery = 3;
+
     //---------------------------------------------------------------------------------------------------------------
     //
     // Read Error Corrector Related Parameters

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -187,8 +187,8 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     public boolean captureAssemblyFailureBAM = false;
 
     @Hidden
-    @Argument(fullName = "num-matching-prefix-bases-in-end-to-recover", doc = "Sets the number of bases that must exactly match in a dangling end for it to be recoverd", optional = true)
-    public int minMachingBasesToDanglngEndRecovery = 3;
+    @Argument(fullName = "num-matching-bases-in-dangling-end-to-recover", doc = "Sets the number of exactly matching bases in the suffix of a dangling tail and the prefix for a dangling head necessary in order to recover the path. (-1 indicates legacy behavior)", optional = true)
+    public int minMatchingBasesToDanglingEndRecovery = -1;
 
     //---------------------------------------------------------------------------------------------------------------
     //

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/AbstractReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/AbstractReadThreadingGraph.java
@@ -588,7 +588,7 @@ public abstract class AbstractReadThreadingGraph extends BaseGraph<MultiDeBruijn
 
         final int lastRefIndex = danglingTailMergeResult.cigar.getReferenceLength() - 1;
         final int matchingSuffix = Math.min(longestSuffixMatch(danglingTailMergeResult.referencePathString, danglingTailMergeResult.danglingPathString, lastRefIndex), lastElement.getLength());
-        if (matchingSuffix == 0 && matchingSuffix >= minMatchingBasesToDangingEndRecovery ) {
+        if (minMatchingBasesToDangingEndRecovery >= 0 ? matchingSuffix < minMatchingBasesToDangingEndRecovery : matchingSuffix == 0 ) {
             return 0;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraph.java
@@ -40,15 +40,15 @@ public class JunctionTreeLinkedDeBruijnGraph extends AbstractReadThreadingGraph 
     private final Set<Kmer> kmers = new HashSet<>();
 
     public JunctionTreeLinkedDeBruijnGraph(int kmerSize) {
-        this(kmerSize, false, (byte)6, 1);
+        this(kmerSize, false, (byte)6, 1, 3);
     }
 
     /**
      * Create a new ReadThreadingAssembler using kmerSize for matching
      * @param kmerSize must be >= 1
      */
-    JunctionTreeLinkedDeBruijnGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
-        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
+    JunctionTreeLinkedDeBruijnGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples, final int numDanglingMatchingPrefixBases) {
+        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, numDanglingMatchingPrefixBases);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraph.java
@@ -39,8 +39,9 @@ public class JunctionTreeLinkedDeBruijnGraph extends AbstractReadThreadingGraph 
     // TODO should this be constructed here or elsewhere
     private final Set<Kmer> kmers = new HashSet<>();
 
+    @VisibleForTesting
     public JunctionTreeLinkedDeBruijnGraph(int kmerSize) {
-        this(kmerSize, false, (byte)6, 1, 3);
+        this(kmerSize, false, (byte)6, 1, -1);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -66,7 +66,7 @@ public final class ReadThreadingAssembler {
     protected byte minBaseQualityToUseInAssembly = DEFAULT_MIN_BASE_QUALITY_TO_USE;
     private int pruneFactor;
     private final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> chainPruner;
-    private final int minMachingBasesToDanglngEndRecovery;
+    private int minMachingBasesToDanglngEndRecovery;
 
     private File debugGraphOutputPath = null;  //Where to write debug graphs, if unset it defaults to the current working dir
     private File graphOutputPath = null;
@@ -106,6 +106,12 @@ public final class ReadThreadingAssembler {
     @VisibleForTesting
     ReadThreadingAssembler() {
         this(DEFAULT_NUM_PATHS_PER_GRAPH, Arrays.asList(25), 2);
+    }
+
+    // this method should not be used, only exposed for testing purposes. This should be set in the constructor.
+    @VisibleForTesting
+    void setMinMachingBasesToDanglngEndRecovery(final int mimMatchingBases) {
+        this.minMachingBasesToDanglngEndRecovery = mimMatchingBases;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -66,7 +66,7 @@ public final class ReadThreadingAssembler {
     protected byte minBaseQualityToUseInAssembly = DEFAULT_MIN_BASE_QUALITY_TO_USE;
     private int pruneFactor;
     private final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> chainPruner;
-    private int minMachingBasesToDanglngEndRecovery;
+    private int minMatchingBasesToDanglingEndRecovery;
 
     private File debugGraphOutputPath = null;  //Where to write debug graphs, if unset it defaults to the current working dir
     private File graphOutputPath = null;
@@ -95,7 +95,7 @@ public final class ReadThreadingAssembler {
         chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants) :
                 new LowWeightChainPruner<>(pruneFactor);
         numBestHaplotypesPerGraph = maxAllowedPathsForReadThreadingAssembler;
-        this.minMachingBasesToDanglngEndRecovery = minMachingBasesToDanglngEndRecovery;
+        this.minMatchingBasesToDanglingEndRecovery = minMachingBasesToDanglngEndRecovery;
     }
 
     @VisibleForTesting
@@ -110,8 +110,8 @@ public final class ReadThreadingAssembler {
 
     // this method should not be used, only exposed for testing purposes. This should be set in the constructor.
     @VisibleForTesting
-    void setMinMachingBasesToDanglngEndRecovery(final int mimMatchingBases) {
-        this.minMachingBasesToDanglngEndRecovery = mimMatchingBases;
+    void setMinMatchingBasesToDanglingEndRecovery(final int mimMatchingBases) {
+        this.minMatchingBasesToDanglingEndRecovery = mimMatchingBases;
     }
 
     /**
@@ -618,8 +618,8 @@ public final class ReadThreadingAssembler {
         }
 
         // TODO figure out how you want to hook this in
-        final AbstractReadThreadingGraph rtgraph = generateSeqGraph ? new ReadThreadingGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, minMachingBasesToDanglngEndRecovery) :
-                new JunctionTreeLinkedDeBruijnGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, minMachingBasesToDanglngEndRecovery);
+        final AbstractReadThreadingGraph rtgraph = generateSeqGraph ? new ReadThreadingGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, minMatchingBasesToDanglingEndRecovery) :
+                new JunctionTreeLinkedDeBruijnGraph(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, minMatchingBasesToDanglingEndRecovery);
 
         rtgraph.setThreadingStartOnlyAtExistingVertex(!recoverDanglingBranches);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -36,7 +36,7 @@ public class ReadThreadingGraph extends AbstractReadThreadingGraph {
      * @throws IllegalArgumentException if (@code kmerSize) < 1.
      */
     public ReadThreadingGraph(final int kmerSize) {
-        this(kmerSize, false, (byte)6, 1);
+        this(kmerSize, false, (byte)6, 1, 3);
     }
 
     /**
@@ -56,8 +56,8 @@ public class ReadThreadingGraph extends AbstractReadThreadingGraph {
      * Create a new ReadThreadingAssembler using kmerSize for matching
      * @param kmerSize must be >= 1
      */
-    ReadThreadingGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples) {
-        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples);
+    ReadThreadingGraph(final int kmerSize, final boolean debugGraphTransformations, final byte minBaseQualityToUseInAssembly, final int numPruningSamples, final int numDanglingMatchingPrefixBases) {
+        super(kmerSize, debugGraphTransformations, minBaseQualityToUseInAssembly, numPruningSamples, numDanglingMatchingPrefixBases);
         nonUniqueKmers = null;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraph.java
@@ -36,7 +36,7 @@ public class ReadThreadingGraph extends AbstractReadThreadingGraph {
      * @throws IllegalArgumentException if (@code kmerSize) < 1.
      */
     public ReadThreadingGraph(final int kmerSize) {
-        this(kmerSize, false, (byte)6, 1, 3);
+        this(kmerSize, false, (byte)6, 1, -1);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/JunctionTreeLinkedDeBruijnGraphUnitTest.java
@@ -1049,7 +1049,7 @@ public class JunctionTreeLinkedDeBruijnGraphUnitTest extends BaseTest {
         Assert.assertTrue(cigar.equals(result.cigar.toString()), "SW generated cigar = " + result.cigar.toString());
 
         // confirm that the tail merging works as expected
-        final int mergeResult = rtgraph.mergeDanglingHead(result);
+        final int mergeResult = rtgraph.mergeDanglingHeadLegacy(result);
         Assert.assertTrue(mergeResult > 0 || !shouldBeMerged);
 
         // confirm that we created the appropriate bubble in the graph only if expected

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingGraphUnitTest.java
@@ -448,7 +448,7 @@ public final class ReadThreadingGraphUnitTest extends GATKBaseTest {
         final GATKRead read = ArtificialReadUtils.createArtificialRead(alt.getBytes(), Utils.dupBytes((byte) 30, alt.length()), alt.length() + "M");
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
         rtgraph.addRead(read, header);
-        rtgraph.setMaxMismatchesInDanglingHead(10);
+        //rtgraph.setMaxMismatchesInDanglingHead(10);
         rtgraph.buildGraphIfNecessary();
 
         // confirm that we have just a single dangling head

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
+import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.walkers.annotator.AnnotationUtils;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerArgumentCollection;
@@ -579,6 +580,42 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                         )}
         };
     }
+
+    @Test
+    public void testThing() {
+        Utils.resetRandomGenerator();
+
+        //NOTE: AlleleSpecific support in the VCF mode is implemented but bogus for now.
+        // This test should not be treated as a strict check of correctness.
+        final File output = createTempFile("testVCFModeIsConsistentWithPastResults", ".vcf");
+//        final File expected = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk4.alleleSpecific.vcf");
+
+//        final String outputPath = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected.getAbsolutePath() : output.getAbsolutePath();
+
+        final String[] args = {
+                "-R",
+                "gs://broad-dsp-spec-ops/scratch/andrea/mtb/Mycobacterium_tuberculosis_H37Rv.fasta",
+                "-I",
+                "gs://broad-dsp-spec-ops-cromwell-execution/MicrobialGenomePipeline/3625b1d1-38a1-40de-a810-23b347d51b14/call-AlignToRef/MicrobialAlignmentPipeline/87d3ba55-4497-474c-9232-44144c7c3ef4/call-AlignAndMarkDuplicates/D1CLVACXX.1.Solexa-125092.aligned.realigned.bam",
+                "-O", output.getAbsolutePath(),
+                "-L", "/Users/emeryj/hellbender/UserLiason/debugM2Graph/Mycobacterium_tuberculosis_H37Rv.intervals",
+                "--annotation","StrandBiasBySample",
+                "--num-matching-bases-in-dangling-end-to-recover",
+                "1",
+                "--max-reads-per-alignment-start",
+                "75",
+                "--max-mnp-distance",
+                "0"};
+
+        runCommandLine(args);
+
+        // Test for an exact match against past results
+//        if ( ! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+//            IntegrationTestSpec.assertEqualTextFiles(output, expected);
+//        }
+
+    }
+
 
     @Test(dataProvider = "vcfsForFiltering")
     public void testFilterMitochondria(File unfiltered, final double minAlleleFraction, final List<String> intervals, List<Set<String>> expectedFilters, List<List<String>> expectedASFilters)  {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -14,7 +14,6 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
-import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.walkers.annotator.AnnotationUtils;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyBasedCallerArgumentCollection;
@@ -580,42 +579,6 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                         )}
         };
     }
-
-    @Test
-    public void testThing() {
-        Utils.resetRandomGenerator();
-
-        //NOTE: AlleleSpecific support in the VCF mode is implemented but bogus for now.
-        // This test should not be treated as a strict check of correctness.
-        final File output = createTempFile("testVCFModeIsConsistentWithPastResults", ".vcf");
-//        final File expected = new File(TEST_FILES_DIR + "expected.testVCFMode.gatk4.alleleSpecific.vcf");
-
-//        final String outputPath = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected.getAbsolutePath() : output.getAbsolutePath();
-
-        final String[] args = {
-                "-R",
-                "gs://broad-dsp-spec-ops/scratch/andrea/mtb/Mycobacterium_tuberculosis_H37Rv.fasta",
-                "-I",
-                "gs://broad-dsp-spec-ops-cromwell-execution/MicrobialGenomePipeline/3625b1d1-38a1-40de-a810-23b347d51b14/call-AlignToRef/MicrobialAlignmentPipeline/87d3ba55-4497-474c-9232-44144c7c3ef4/call-AlignAndMarkDuplicates/D1CLVACXX.1.Solexa-125092.aligned.realigned.bam",
-                "-O", output.getAbsolutePath(),
-                "-L", "/Users/emeryj/hellbender/UserLiason/debugM2Graph/Mycobacterium_tuberculosis_H37Rv.intervals",
-                "--annotation","StrandBiasBySample",
-                "--num-matching-bases-in-dangling-end-to-recover",
-                "1",
-                "--max-reads-per-alignment-start",
-                "75",
-                "--max-mnp-distance",
-                "0"};
-
-        runCommandLine(args);
-
-        // Test for an exact match against past results
-//        if ( ! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
-//            IntegrationTestSpec.assertEqualTextFiles(output, expected);
-//        }
-
-    }
-
 
     @Test(dataProvider = "vcfsForFiltering")
     public void testFilterMitochondria(File unfiltered, final double minAlleleFraction, final List<String> intervals, List<Set<String>> expectedFilters, List<List<String>> expectedASFilters)  {


### PR DESCRIPTION
In helping @bhanugandham figure out why a particular site was failing it became apparent that merging dangling head code was failing to recover deletions in the dangling head. Furthermore there is some code in the dangling end recovery code that asserts a certain high standard of matching (usually 1 but sometimes dangling branch length/kmersize) `getMaxMismatches(final int lengthOfDanglingBranch)`. Both of these facts seem likely to cause dangling heads to be dropped despite their being still potentially informative, particularly the indel code. 

I have added the ability for the index recovery code to account for the cigar string when merging dangling ends. Addtionally rather than counting mismatches to reject the branch it simply requires a minimum matching end (which can be changed, I suspect this is where the lionshare of the differences come from).  Unfortunately changing the tests is non-trivial (as this happened to change the integration test results for HaplotypeCaller at a few sites) so I wanted to get this branch up to solicit advice a to whether it is worth pursuing this fix. @davidbenjamin @ldgauthier @droazen 