### PR TITLE
update public key for installing R in docker (key just expired)

### DIFF
--- a/scripts/docker/gatkbase/Dockerfile
+++ b/scripts/docker/gatkbase/Dockerfile
@@ -43,7 +43,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN java -version
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu xenial/" && \
     apt-get update && \
     apt-get install -y --force-yes \


### PR DESCRIPTION
Master is broken.

E.g.

```
Fetched 217 kB in 1s (163 kB/s)
Reading package lists...
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
W: GPG error: https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157
W: The repository 'https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease' is not signed.
W: There is no public key available for the following key IDs:
6B05F25D762E3157  

```