### PR TITLE
Logging exceptions during deletion instead of throwing

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/io/DeleteRecursivelyOnExitPathHook.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/DeleteRecursivelyOnExitPathHook.java
@@ -15,7 +15,7 @@ import java.util.LinkedHashSet;
  * This class should be considered an implementation detail of {@link IOUtils#deleteOnExit(Path)} and not used directly.
  */
 class DeleteRecursivelyOnExitPathHook {
-    private static Logger LOG = LogManager.getLogger(DeleteRecursivelyOnExitPathHook.class);
+    private static final Logger LOG = LogManager.getLogger(DeleteRecursivelyOnExitPathHook.class);
     private static LinkedHashSet<Path> paths = new LinkedHashSet<>();
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(DeleteRecursivelyOnExitPathHook::runHooks));

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/DeleteRecursivelyOnExitPathHook.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/DeleteRecursivelyOnExitPathHook.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.io;
 
-import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,6 +15,7 @@ import java.util.LinkedHashSet;
  * This class should be considered an implementation detail of {@link IOUtils#deleteOnExit(Path)} and not used directly.
  */
 class DeleteRecursivelyOnExitPathHook {
+    private static Logger LOG = LogManager.getLogger(DeleteRecursivelyOnExitPathHook.class);
     private static LinkedHashSet<Path> paths = new LinkedHashSet<>();
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(DeleteRecursivelyOnExitPathHook::runHooks));
@@ -54,8 +56,9 @@ class DeleteRecursivelyOnExitPathHook {
         for (Path path : toBeDeleted) {
             try {
                 IOUtils.deleteRecursively(path);
-            } catch (SecurityException e) {
+            } catch (final Exception e) {
                 // do nothing if cannot be deleted, because it is a shutdown hook
+                LOG.debug(() -> "Could not recursively delete " + path.toString() + " during JVM shutdown because we encountered the following exception:", e);
             }
         }
     }


### PR DESCRIPTION
* When running recursive deletion file hooks we now catch all exceptions and log them at DEBUG level instead of letting them propagate.
* This should reduce confusion when test have deletion failures.