### PR TITLE
Allow updates to an invalid sequence dictionary in a VCF

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
@@ -108,20 +108,24 @@ public final class UpdateVCFSequenceDictionary extends VariantWalker {
         getDefaultToolVCFHeaderLines().forEach(line -> outputHeader.addMetaDataLine(line));
         sourceDictionary = getBestAvailableSequenceDictionary();
 
+        // If -replace is set, do not need to access sequence dictionary is not checked for validity.
         // Warn and require opt-in via -replace if we're about to clobber a valid sequence
         // dictionary. Check the input file directly via the header rather than using the
         // engine, since it might dig one up from an index.
-        SAMSequenceDictionary oldDictionary =
-                inputHeader == null ? null : inputHeader.getSequenceDictionary();
-        if ( (oldDictionary != null && !oldDictionary.getSequences().isEmpty()) && !replace) {
-            throw new CommandLineException.BadArgumentValue(
-                    String.format(
-                            "The input variant file %s already contains a sequence dictionary. " +
-                            "Use %s to force the dictionary to be replaced.",
-                            getDrivingVariantsFeatureInput().getName(),
-                            REPLACE_ARGUMENT_NAME
-                    )
-            );
+        if (!replace) {
+            SAMSequenceDictionary oldDictionary =
+                    inputHeader == null ? null : inputHeader.getSequenceDictionary();
+            if (oldDictionary != null && !oldDictionary.getSequences().isEmpty())  {
+                throw new CommandLineException.BadArgumentValue(
+                        String.format(
+                                "The input variant file %s already contains a sequence dictionary. " +
+                                        "Use %s to force the dictionary to be replaced.",
+                                getDrivingVariantsFeatureInput().getName(),
+                                REPLACE_ARGUMENT_NAME
+                        )
+                );
+            }
+
         }
 
         outputHeader.setSequenceDictionary(sourceDictionary);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
@@ -108,9 +108,9 @@ public final class UpdateVCFSequenceDictionary extends VariantWalker {
         getDefaultToolVCFHeaderLines().forEach(line -> outputHeader.addMetaDataLine(line));
         sourceDictionary = getBestAvailableSequenceDictionary();
 
-        // If -replace is set, do not need to access sequence dictionary is not checked for validity.
-        // Warn and require opt-in via -replace if we're about to clobber a valid sequence
-        // dictionary. Check the input file directly via the header rather than using the
+        // If -replace is set, do not need to check the sequence dictionary for validity here -- it will still be
+        // checked in our normal sequence dictionary validation. Warn and require opt-in via -replace if we're about to
+        // clobber a valid sequence dictionary. Check the input file directly via the header rather than using the
         // engine, since it might dig one up from an index.
         if (!replace) {
             SAMSequenceDictionary oldDictionary =

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
@@ -31,6 +31,11 @@ import java.io.File;
  * variants in the target file. The dictionary lines start with '##contig='.
  * </p>
  *
+ * <p>
+ *     By specifying both --replace and --disable-sequence-dictionary-validation, one can force replace an invalid
+ *     sequence dictionary in a variant file with a valid sequence dictionary in another file.
+ * </p>
+ *
  * <h3>Usage example</h3>
  *
  * <h4>Use the contig dictionary from a BAM (SQ lines) to replace an existing dictionary in the header of a VCF.</h4>

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
@@ -111,6 +111,24 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
                 expectedSequenceDictionary.getSequences().stream().map(seq -> seq.getSequenceLength()).collect(Collectors.toList()));
     }
 
+    @Test
+    public void testBadContigSource() {
+
+        SAMSequenceDictionary actualSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(
+                Paths.get(new File(testDir, "exampleFASTA.dict").getAbsolutePath()));
+
+        SAMSequenceDictionary expectedSequenceDictionary = updateSequenceDictionary(
+                new File(testDir, "variantsWithDictBadContigLength.vcf"),
+                new File(testDir, "exampleFASTA.dict"),
+                null,
+                null,
+                true);
+        Assert.assertEquals(actualSequenceDictionary.getSequences().stream().map(seq -> seq.getSequenceLength()).collect(Collectors.toList()),
+                expectedSequenceDictionary.getSequences().stream().map(seq -> seq.getSequenceLength()).collect(Collectors.toList()));
+
+
+    }
+
     @Test(expectedExceptions=CommandLineException.class)
     public void testMasterDictionaryAmbiguous() {
         // specifying both a source dictionary and a master dictionary is ambiguous

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
@@ -51,9 +51,9 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
             final File inputReferenceFile,
             final String masterSequenceDictionary,
             final boolean replace,
-            final boolean dontValidate) throws FileNotFoundException, URISyntaxException {
+            final boolean disableSequenceDictionaryValidation) throws FileNotFoundException, URISyntaxException {
         final SAMSequenceDictionary resultingDictionary =
-                updateSequenceDictionary(inputVariantsFile, inputSourceFile, inputReferenceFile, masterSequenceDictionary, replace, dontValidate);
+                updateSequenceDictionary(inputVariantsFile, inputSourceFile, inputReferenceFile, masterSequenceDictionary, replace, disableSequenceDictionaryValidation);
 
         // get the original sequence dictionary from the source for comparison
         SAMSequenceDictionary sourceDictionary =
@@ -94,8 +94,8 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
             final File inputReferenceFile,
             final String masterSequenceDictionary,
             final boolean replace,
-            final boolean dontValidate) {
-        updateSequenceDictionary(inputVariantsFile, inputSourceFile, inputReferenceFile, masterSequenceDictionary, replace, dontValidate);
+            final boolean disableSequenceDictionaryValidation) {
+        updateSequenceDictionary(inputVariantsFile, inputSourceFile, inputReferenceFile, masterSequenceDictionary, replace, disableSequenceDictionaryValidation);
     }
 
     @Test
@@ -120,9 +120,7 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
 
     @Test(expectedExceptions= TribbleException.class)
     public void testBadContigLengthWithValidation() {
-        // throw an error if trying to force a replace with an invalid sequence dictionary if don't disable sequence validation
-
-        // specifying both a source dictionary and a master dictionary is ambiguous
+        // throw an error if trying to force a replace with an invalid sequence dictionary without disabling sequence validation
         updateSequenceDictionary(
                 new File(testDir, "variantsWithDictBadContigLength.vcf"),
                 new File(testDir, "exampleFASTA.dict"),
@@ -150,7 +148,7 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
         final File inputReferenceFile,
         final String masterSequenceDictionary,
         final boolean replace,
-        final boolean dontValidate)
+        final boolean disableSequenceDictionaryValidation)
     {
         ArgumentsBuilder argBuilder = new ArgumentsBuilder();
 
@@ -164,8 +162,8 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
         if (replace) {
             argBuilder.addArgument(UpdateVCFSequenceDictionary.REPLACE_ARGUMENT_NAME, Boolean.toString(replace));
         }
-        if (dontValidate) {
-            argBuilder.addArgument(StandardArgumentDefinitions.DISABLE_SEQUENCE_DICT_VALIDATION_NAME, Boolean.toString(dontValidate));
+        if (disableSequenceDictionaryValidation) {
+            argBuilder.addArgument(StandardArgumentDefinitions.DISABLE_SEQUENCE_DICT_VALIDATION_NAME, Boolean.toString(disableSequenceDictionaryValidation));
         }
         if (masterSequenceDictionary != null) {
             argBuilder.addArgument(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, masterSequenceDictionary);

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary/variantsWithDictBadContigLength.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary/variantsWithDictBadContigLength.vcf
@@ -1,0 +1,112 @@
+##fileformat=VCFv4.1
+##contig=<ID=1>
+##contig=<ID=10>
+##contig=<ID=11>
+##contig=<ID=12>
+##contig=<ID=13>
+##contig=<ID=14>
+##contig=<ID=15>
+##contig=<ID=16>
+##contig=<ID=17>
+##contig=<ID=18>
+##contig=<ID=19>
+##contig=<ID=2>
+##contig=<ID=20>
+##contig=<ID=21>
+##contig=<ID=22>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+##contig=<ID=7>
+##contig=<ID=8>
+##contig=<ID=9>
+##contig=<ID=GL000191.1>
+##contig=<ID=GL000192.1>
+##contig=<ID=GL000193.1>
+##contig=<ID=GL000194.1>
+##contig=<ID=GL000195.1>
+##contig=<ID=GL000196.1>
+##contig=<ID=GL000197.1>
+##contig=<ID=GL000198.1>
+##contig=<ID=GL000199.1>
+##contig=<ID=GL000200.1>
+##contig=<ID=GL000201.1>
+##contig=<ID=GL000202.1>
+##contig=<ID=GL000203.1>
+##contig=<ID=GL000204.1>
+##contig=<ID=GL000205.1>
+##contig=<ID=GL000206.1>
+##contig=<ID=GL000207.1>
+##contig=<ID=GL000208.1>
+##contig=<ID=GL000209.1>
+##contig=<ID=GL000210.1>
+##contig=<ID=GL000211.1>
+##contig=<ID=GL000212.1>
+##contig=<ID=GL000213.1>
+##contig=<ID=GL000214.1>
+##contig=<ID=GL000215.1>
+##contig=<ID=GL000216.1>
+##contig=<ID=GL000217.1>
+##contig=<ID=GL000218.1>
+##contig=<ID=GL000219.1>
+##contig=<ID=GL000220.1>
+##contig=<ID=GL000221.1>
+##contig=<ID=GL000222.1>
+##contig=<ID=GL000223.1>
+##contig=<ID=GL000224.1>
+##contig=<ID=GL000225.1>
+##contig=<ID=GL000226.1>
+##contig=<ID=GL000227.1>
+##contig=<ID=GL000228.1>
+##contig=<ID=GL000229.1>
+##contig=<ID=GL000230.1>
+##contig=<ID=GL000231.1>
+##contig=<ID=GL000232.1>
+##contig=<ID=GL000233.1>
+##contig=<ID=GL000234.1>
+##contig=<ID=GL000235.1>
+##contig=<ID=GL000236.1>
+##contig=<ID=GL000237.1>
+##contig=<ID=GL000238.1>
+##contig=<ID=GL000239.1>
+##contig=<ID=GL000240.1>
+##contig=<ID=GL000241.1>
+##contig=<ID=GL000242.1>
+##contig=<ID=GL000243.1>
+##contig=<ID=GL000244.1>
+##contig=<ID=GL000245.1>
+##contig=<ID=GL000246.1>
+##contig=<ID=GL000247.1>
+##contig=<ID=GL000248.1>
+##contig=<ID=GL000249.1>
+##contig=<ID=MT>
+##contig=<ID=X>
+##contig=<ID=Y>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	100	a	G	A	232.46	PASS	.
+1	199	b	GG	G	232.46	PASS	.
+1	200	c	G	A	232.46	PASS	.
+1	203	d	GGGG	G	232.46	PASS	.
+1	280	e	G	A	232.46	PASS	.
+1	284	f	GGG	G	232.46	PASS	.
+1	285	g	G	A	232.46	PASS	.
+1	286	h	G	A	232.46	PASS	.
+1	999	i	G	A	232.46	PASS	.
+1	1000	j	G	A	232.46	PASS	.
+1	1000	k	GGGG	G	232.46	PASS	.
+1	1076	l	G	A	232.46	PASS	.
+1	1150	m	G	A	232.46	PASS	.
+1	1176	n	G	A	232.46	PASS	.
+2	200	o	G	A	232.46	PASS	.
+2	525	p	G	A	232.46	PASS	.
+2	548	q	GGG	G	232.46	PASS	.
+2	640	r	G	A	232.46	PASS	.
+2	700	s	G	A	232.46	PASS	.
+3	1	t	G	A	232.46	PASS	.
+3	300	u	G	A	232.46	PASS	.
+3	300	v	GGGG	G	232.46	PASS	.
+3	400	w	G	A	232.46	PASS	.
+4	600	x	G	A	232.46	PASS	.
+4	775	y	G	A	232.46	PASS	.
+4	776	z	GGGG	G	232.46	PASS	.


### PR DESCRIPTION
I'm working on an imputation pipeline right now, and the contigs in the returned VCF header don't contain lengths. This fix to UpdateVCFSequenceDictionary allows me to force an update to the VCF's sequence dictionary so I have a valid VCF I can use with the rest of our tools when both --replace and --disable-sequence-dictionary-validation are set to true.

