### PR TITLE
fixed edge case of small region in  orientation bias model

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/ArtifactPriorCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/ArtifactPriorCollection.java
@@ -22,7 +22,7 @@ public class ArtifactPriorCollection {
     public ArtifactPriorCollection(final String sample){
         this.sample = sample;
         for (final String kmer : F1R2FilterConstants.ALL_KMERS){
-            map.put(kmer, new ArtifactPrior(kmer, new double[F1R2FilterConstants.NUM_STATES], 0, 0));
+            map.put(kmer, new ArtifactPrior(kmer, LearnReadOrientationModelEngine.getFlatPrior(F1R2FilterUtils.getMiddleBase(kmer)), 0, 0));
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelEngine.java
@@ -142,7 +142,8 @@ public class LearnReadOrientationModelEngine {
     // Learn the prior probabilities for the artifact states by the EM algorithm
     public ArtifactPrior learnPriorForArtifactStates() {
         // Initialize the prior for artifact
-        double[] statePrior = getFlatPrior(refAllele);
+        final double[] pseudocounts = getFlatPrior(refAllele);
+        double[] statePrior = Arrays.copyOf(pseudocounts, F1R2FilterConstants.NUM_STATES);
         double l2Distance;
 
         do {
@@ -150,7 +151,7 @@ public class LearnReadOrientationModelEngine {
 
             // Responsibilities are updated by side effect to save space
             takeEstep(statePrior);
-            statePrior = takeMstep();
+            statePrior = takeMstep(pseudocounts);
 
             // TODO: make sure EM increases the likelihood
             // newLikelihood >= oldLikelihood : "M step must increase the likelihood";
@@ -220,7 +221,7 @@ public class LearnReadOrientationModelEngine {
      * We do so by maximizing the expectation of the complete data likelihood with respect to the posterior
      * for the artifact states from the E-step
      */
-    private double[] takeMstep() {
+    private double[] takeMstep(final double[] pseudocounts) {
         // First we compute the effective counts of each state, N_k in the docs. We do this separately over alt and ref sites
         final double[] effectiveAltCountsFromDesignMatrix = MathUtils.sumArrayFunction(0, altDesignMatrix.size(), n -> altResponsibilities.getRow(n));
         double[] effectiveAltCountsFromHistograms = new double[F1R2FilterConstants.NUM_STATES];
@@ -245,7 +246,7 @@ public class LearnReadOrientationModelEngine {
                 i -> MathArrays.scale(refHistogram.get(i + 1).getValue(), refResponsibilities.getRow(i)));
 
         effectiveCounts = new ArrayRealVector(MathArrays.ebeAdd(effectiveAltCounts, effectiveRefCounts));
-        return effectiveCounts.mapMultiply(1.0/numExamples).toArray();
+        return MathUtils.normalizeSumToOne(effectiveCounts.add(new ArrayRealVector(pseudocounts)).toArray());
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelEngineUnitTest.java
@@ -31,7 +31,7 @@ import java.util.stream.IntStream;
 import static org.broadinstitute.hellbender.tools.walkers.readorientation.F1R2FilterConstants.ALL_KMERS;
 
 public class LearnReadOrientationModelEngineUnitTest extends CommandLineProgramTest {
-    private static final double EPSILON = 1e-3;
+    private static final double EPSILON = 1e-2;
 
     protected final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -118,12 +118,11 @@ public class LearnReadOrientationModelEngineUnitTest extends CommandLineProgramT
                 F1R2FilterConstants.DEFAULT_MAX_DEPTH, logger);
         final ArtifactPrior artifactPrior = engine.learnPriorForArtifactStates();
 
-        final double epsilon = 1e-3;
         IntStream.range(0, F1R2FilterConstants.DEFAULT_MAX_DEPTH).mapToDouble(i -> MathUtils.sum(engine.getRefResonsibilities(i)))
-                .forEach(s -> Assert.assertEquals(s, 1.0, epsilon));
+                .forEach(s -> Assert.assertEquals(s, 1.0, EPSILON));
         IntStream.range(0, numAltExamples).mapToDouble(i -> MathUtils.sum(engine.getAltResonsibilities(i)))
-                .forEach(s -> Assert.assertEquals(s, 1.0, epsilon));
-        Assert.assertEquals(engine.getEffectiveCounts().getL1Norm(), numExamples, epsilon);
+                .forEach(s -> Assert.assertEquals(s, 1.0, EPSILON));
+        Assert.assertEquals(engine.getEffectiveCounts().getL1Norm(), numExamples, EPSILON);
 
         Assert.assertEquals(engine.getEffectiveCounts(artifactState), (double) numAltExamples, EPSILON);
         Assert.assertEquals(engine.getEffectiveCounts(ArtifactState.HOM_REF), (double) numRefExamples, EPSILON);


### PR DESCRIPTION
@takutosato Here's the bug fix I mentioned.  The idea is to use prior pseudocounts in case there are no effective counts from the data.