### PR TITLE
Assembly-based realignment filter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStart.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStart.java
@@ -7,9 +7,11 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -24,10 +26,18 @@ import java.util.List;
  */
 public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalker {
     private List<VariantContext> currentVariants = new ArrayList<>();
-    private ReferenceContext spanningReferenceContext;
+    private int firstCurrentVariantStart;
+    private int lastCurrentVariantStart;
+    private List<ReadsContext> currentReadsContexts = new ArrayList<>();
     private OverlapDetector<SimpleInterval> overlapDetector;
 
     public static final String IGNORE_VARIANTS_THAT_START_OUTSIDE_INTERVAL = "ignore-variants-starting-outside-interval";
+
+    public static final String COMBINE_VARIANTS_DISTANCE = "combine-variants-distance";
+
+    public static final String MAX_COMBINED_DISTANCE = "max-distance";
+
+    public static final String REFERENCE_WINDOW_PADDING = "ref-padding";
 
     /**
      * this option has no effect unless intervals are specified.
@@ -39,6 +49,33 @@ public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalke
             doc = "Restrict variant output to sites that start within provided intervals (only applies when an interval is specified)",
             optional = true)
     private boolean ignoreIntervalsOutsideStart = false;
+
+    @Advanced
+    @Argument(fullName = COMBINE_VARIANTS_DISTANCE, doc = "Maximum distance for variants to be grouped together", optional = true)
+    protected int distanceToCombineVariants = defaultDistanceToGroupVariants();
+
+    @Advanced
+    @Argument(fullName = MAX_COMBINED_DISTANCE, doc = "Maximum distance for variants to be grouped together", optional = true)
+    protected int maxCombinedDistance = defaultMaxGroupedSpan();
+
+    @Advanced
+    @Argument(fullName = REFERENCE_WINDOW_PADDING, doc = "Number of bases on either side to expand spanning reference window", optional = true)
+    protected int referenceWindowPadding = defaultReferenceWindowPadding();
+
+    // override to group variants that start nearby but not at the same locus
+    protected int defaultDistanceToGroupVariants() {
+        return 0;
+    }
+
+    // override to change reference padding
+    protected int defaultReferenceWindowPadding() {
+        return 1;
+    }
+
+    // override to cap the size span of combined variants
+    protected int defaultMaxGroupedSpan() {
+        return Integer.MAX_VALUE;
+    }
 
     @Override
     public boolean requiresReference() {
@@ -61,20 +98,20 @@ public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalke
 
         // Collecting all the reads that start at a particular base into one.
         if (currentVariants.isEmpty()) {
-            currentVariants.add(variant);
+            firstCurrentVariantStart = variant.getStart();
         } else if (!currentVariants.get(0).contigsMatch(variant)
-                || currentVariants.get(0).getStart() < variant.getStart()) {
+                || lastCurrentVariantStart < variant.getStart() - distanceToCombineVariants
+                || firstCurrentVariantStart < variant.getStart() - maxCombinedDistance) {
             // Emptying any sites which should emit a new VC since the last one
-            apply(new ArrayList<>(currentVariants), spanningReferenceContext);
+            apply(new ArrayList<>(currentVariants), currentReadsContexts);
             currentVariants.clear();
-            currentVariants.add(variant);
-        } else {
-            currentVariants.add(variant);
+            currentReadsContexts.clear();
+            firstCurrentVariantStart = variant.getStart();
         }
-        if (referenceContext.hasBackingDataSource()){
-            referenceContext.setWindow(1, 1);
-        }
-        spanningReferenceContext = getExpandedReferenceContext(currentVariants, spanningReferenceContext, referenceContext);
+
+        currentVariants.add(variant);
+        currentReadsContexts.add(readsContext);
+        lastCurrentVariantStart = variant.getStart();
     }
 
     /**
@@ -83,28 +120,32 @@ public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalke
      * This is the primary traversal for any MultiVariantWalkerGroupedOnStart walkers. Will traverse over input variant contexts
      * and call #apply() exactly once for each unique reference start position. All variants starting at each locus
      * across source files will be grouped and passed as a list of VariantContext objects.
-     *
-     * @param variantContexts  VariantContexts from driving variants with matching start positon
+     *  @param variantContexts  VariantContexts from driving variants with matching start positon
      *                         NOTE: This will never be empty
      * @param referenceContext  ReferenceContext object covering the reference of the longest spanning VariantContext
-     *                          with one base on either end as window padding.
+     * @param readsContexts
      */
-    public abstract void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext);
+    public abstract void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext, final List<ReadsContext> readsContexts);
+
+    public void apply(List<VariantContext> variantContexts, final List<ReadsContext> readsContexts) {
+        apply(variantContexts, makeSpanningReferenceContext(variantContexts, referenceWindowPadding), readsContexts);
+    }
 
     /**
      * Helper method that ensures the reference context it returns is adequate to span the length of all the accumulated
-     * VariantContexts. It makes the assumption that all variant contexts in currentVariants start at the same location and
-     * that currentReferenceContext corresponds to the correct span for the longest variantContexts the first N-1 VariantContexts
-     * and that newReferenceContext corresponds to the correct span for the Nth item.
+     * VariantContexts. It assumes that all variant contexts in currentVariants have the same contig.
      */
-    @VisibleForTesting
-    final static ReferenceContext getExpandedReferenceContext(List<VariantContext> currentVariants,
-                                                              ReferenceContext currentReferenceContext,
-                                                              ReferenceContext newReferenceContext) {
-        if ((currentReferenceContext==null)||(currentVariants.size() == 1 || newReferenceContext.getWindow().getEnd() > currentReferenceContext.getWindow().getEnd())) {
-            return newReferenceContext;
-        }
-        return currentReferenceContext;
+    private ReferenceContext makeSpanningReferenceContext(final List<VariantContext> variantContexts, final int referenceWindowPadding) {
+        Utils.nonEmpty(variantContexts, "Must have at least one current variant context");
+        final List<String> contigs = variantContexts.stream().map(VariantContext::getContig).distinct().collect(Collectors.toList());
+        Utils.validate(contigs.size() == 1, "variant contexts should all have the same contig");
+        final int minStart = variantContexts.stream().mapToInt(VariantContext::getStart).min().getAsInt();
+        final int maxEnd = variantContexts.stream().mapToInt(VariantContext::getEnd).max().getAsInt();
+        final SimpleInterval combinedInterval = new SimpleInterval(contigs.get(0), minStart, maxEnd);
+
+        final ReferenceContext combinedReferenceContext = new ReferenceContext(reference, combinedInterval);
+        combinedReferenceContext.setWindow(referenceWindowPadding,referenceWindowPadding);
+        return combinedReferenceContext;
     }
 
     /**
@@ -147,7 +188,7 @@ public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalke
             logger.warn("Error: The requested interval contained no data in source VCF files");
 
         } else {
-            apply(currentVariants, spanningReferenceContext);
+            apply(currentVariants, currentReadsContexts);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/CombineGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/CombineGVCFs.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.DbsnpArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
 import org.broadinstitute.hellbender.engine.MultiVariantWalkerGroupedOnStart;
+import org.broadinstitute.hellbender.engine.ReadsContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
@@ -140,7 +141,7 @@ public final class CombineGVCFs extends MultiVariantWalkerGroupedOnStart {
     private ReferenceContext storedReferenceContext;
 
     @Override
-    public void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext) {
+    public void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext, final List<ReadsContext> readsContexts) {
         // Check that the input variant contexts do not contain MNPs as these may not be properly merged
         for (final VariantContext ctx : variantContexts) {
             if (GATKVariantContextUtils.isUnmixedMnpIgnoringNonRef(ctx)) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/RealignmentArgumentCollection.java
@@ -8,21 +8,15 @@ public class RealignmentArgumentCollection {
     public static final double DEFAULT_DROP_RATIO = 0.2;
     public static final double DEFAULT_SEED_SPLIT_FACTOR = 0.5;
     public static final int DEFAULT_MAX_REASONABLE_FRAGMENT_LENGTH = 100000;
-    public static final int DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE = 20;
-    public static final double DEFAULT_MIN_MISMATCH_RATIO = 2.5;
-    public static final int DEFAULT_NUM_REGULAR_CONTIGS = 25;
+    public static final double DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE_PER_BASE = 0.2;
+    public static final double DEFAULT_MIN_MISMATCH_DIFFERENCE_PER_BASE = 0.02;
+    public static final int DEFAULT_NUM_REGULAR_CONTIGS = 250000;
 
     /**
      * BWA-mem index image created by {@link BwaMemIndexImageCreator}
      */
     @Argument(fullName = "bwa-mem-index-image", shortName = "index", doc = "BWA-mem index image")
     public String bwaMemIndexImage;
-
-    /**
-     * Turn off the default mate-aware realignment
-     */
-    @Argument(fullName = "dont-use-mates", doc = "Realign individual reads without using their mates", optional = true)
-    public boolean dontUseMates = false;
 
     /**
      * Maximum fragment length to be considered a reasonable pair alignment
@@ -33,14 +27,14 @@ public class RealignmentArgumentCollection {
     /**
      * Minimum difference between best and second-best alignment for a read to be considered well-mapped
      */
-    @Argument(fullName = "min-aligner-score-difference", doc = "Minimum difference between best and second-best alignment for a read to be considered well-mapped", optional = true)
-    public int minAlignerScoreDifference = DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE;
+    @Argument(fullName = "min-aligner-score-difference-per-base", doc = "Minimum difference between best and second-best alignment for a read to be considered well-mapped", optional = true)
+    public double minAlignerScoreDifferencePerBase = DEFAULT_MIN_ALIGNER_SCORE_DIFFERENCE_PER_BASE;
 
     /**
      * Minimum ratio between the number of mismatches in the second best and best alignments
      */
-    @Argument(fullName = "min-mismatch-ratio", doc = "Minimum ratio between the number of mismatches in the second best and best alignments", optional = true)
-    public double minMismatchRatio = DEFAULT_MIN_MISMATCH_RATIO;
+    @Argument(fullName = "min-mismatch-difference-per-base", doc = "Minimum ratio between the number of mismatches in the second best and best alignments", optional = true)
+    public double minMismatchDifferencePerBase = DEFAULT_MIN_MISMATCH_DIFFERENCE_PER_BASE;
 
     /**
      * Number of regular i.e. non-alt contigs

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -118,7 +118,6 @@ public final class GATKVCFConstants {
     public static final String SEQUENCING_QUAL_KEY =  "SEQQ";
     public static final String POLYMERASE_SLIPPAGE_QUAL_KEY =  "STRQ";
     public static final String STRAND_QUAL_KEY =  "STRANDQ";
-    public static final String REALIGNMENT_COUNTS_KEY =   "RCNTS";
     public static final String CONTAMINATION_QUAL_KEY =  "CONTQ";
     public static final String READ_ORIENTATION_QUAL_KEY =  "ROQ";
     public static final String ORIGINAL_CONTIG_MISMATCH_KEY =       "OCM";
@@ -128,6 +127,9 @@ public final class GATKVCFConstants {
     public static final String MEDIAN_MAPPING_QUALITY_KEY = "MMQ";
     public static final String MEDIAN_FRAGMENT_LENGTH_KEY = "MFRL";
     public static final String MEDIAN_READ_POSITON_KEY = "MPOS";
+    public static final String UNITIG_SIZES_KEY = "UNITIGS";
+    public static final String ALIGNMENT_SCORE_DIFFERENCE_KEY = "ALIGN_DIFF";
+    public static final String JOINT_ALIGNMENT_COUNT_KEY = "NALIGNS";
 
     // Methylation-specific INFO Keys
     public static final String UNCONVERTED_BASE_COVERAGE_KEY =      "UNCONVERTED_BASE_COV";

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -218,7 +218,6 @@ public class GATKVCFHeaderLines {
         // M2-related info lines
         addInfoLine(new VCFInfoHeaderLine(EVENT_COUNT_IN_HAPLOTYPE_KEY, 1, VCFHeaderLineType.Integer, "Number of events in this haplotype"));
         addInfoLine(new VCFInfoHeaderLine(NORMAL_LOG_10_ODDS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Normal log 10 likelihood ratio of diploid het or hom alt genotypes"));
-        addInfoLine(new VCFInfoHeaderLine(REALIGNMENT_COUNTS_KEY, 2, VCFHeaderLineType.Integer, "Number of reads passing and failing realignment."));
         addInfoLine(new VCFInfoHeaderLine(TUMOR_LOG_10_ODDS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Log 10 likelihood ratio score of variant existing versus not existing"));
         addFormatLine(new VCFFormatHeaderLine(TUMOR_LOG_10_ODDS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Log 10 likelihood ratio score of variant existing versus not existing"));
         addInfoLine(new VCFInfoHeaderLine(IN_PON_KEY, 0, VCFHeaderLineType.Flag, "site found in panel of normals"));
@@ -237,5 +236,8 @@ public class GATKVCFHeaderLines {
         addInfoLine(new FragmentLength().getDescriptions().get(0));
         addInfoLine(new MappingQuality().getDescriptions().get(0));
         addInfoLine(new ReadPosition().getDescriptions().get(0));
+        addInfoLine(new VCFInfoHeaderLine(UNITIG_SIZES_KEY, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "Sizes of reassembled unitigs"));
+        addInfoLine(new VCFInfoHeaderLine(JOINT_ALIGNMENT_COUNT_KEY, 1, VCFHeaderLineType.Integer, "Number of joint alignments"));
+        addInfoLine(new VCFInfoHeaderLine(ALIGNMENT_SCORE_DIFFERENCE_KEY, 1, VCFHeaderLineType.Integer, "Difference in alignment score between best and next-best alignment"));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStartUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStartUnitTest.java
@@ -7,7 +7,6 @@ import htsjdk.variant.vcf.VCFConstants;
 import org.apache.commons.collections.IteratorUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -16,7 +15,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,54 +25,10 @@ public class MultiVariantWalkerGroupedOnStartUnitTest extends GATKBaseTest {
     public static final Allele REF = Allele.create("A", true);
     public static final Allele ALT = Allele.create("C", false);
 
-    // This test is disabled until mocking classes with mockito is allowed in GATK4.
-    @Test(enabled = false )
-    public void testGetExpandedReferenceContext() {
-        ReferenceContext referenceContext1 = Mockito.mock(ReferenceContext.class);
-        when(referenceContext1.getWindow()).thenReturn(new SimpleInterval("20",1000,1100));
-        when(referenceContext1.getBases()).thenReturn(new byte[]{'A'});
-
-        ReferenceContext referenceContext2 = Mockito.mock(ReferenceContext.class);
-        when(referenceContext2.getWindow()).thenReturn(new SimpleInterval("20",1000,1050));
-        when(referenceContext2.getBases()).thenReturn(new byte[]{'C'});
-
-        ReferenceContext referenceContext3 = Mockito.mock(ReferenceContext.class);
-        when(referenceContext3.getWindow()).thenReturn(new SimpleInterval("20",1050,1100));
-        when(referenceContext3.getBases()).thenReturn(new byte[]{'G'});
-
-        ReferenceContext referenceContext4 = Mockito.mock(ReferenceContext.class);
-        when(referenceContext4.getWindow()).thenReturn(new SimpleInterval("20",1050,1150));
-        when(referenceContext4.getBases()).thenReturn(new byte[]{'T'});
-
-        List<VariantContext> VCs = new ArrayList<>();
-        VariantContext A = new VariantContextBuilder().loc("20",1001,1099).alleles(Arrays.asList(REF, Allele.NON_REF_ALLELE)).attribute(VCFConstants.END_KEY, 1099).make();
-
-        VCs.add(A);
-        ReferenceContext contextState = MultiVariantWalkerGroupedOnStart.getExpandedReferenceContext(VCs, null, referenceContext1);
-        Assert.assertEquals(contextState.getWindow().getEnd(),1100);
-        Assert.assertEquals(contextState.getBases()[0],'A');
-
-        VCs.add(A);
-        contextState = MultiVariantWalkerGroupedOnStart.getExpandedReferenceContext(VCs, contextState, referenceContext1);
-        Assert.assertEquals(contextState.getWindow().getEnd(),1100);
-        Assert.assertEquals(contextState.getBases()[0],'A');
-
-        VCs.clear();
-        VCs.add(A);
-        contextState = MultiVariantWalkerGroupedOnStart.getExpandedReferenceContext(VCs, contextState, referenceContext4);
-        Assert.assertEquals(contextState.getWindow().getEnd(),1150);
-        Assert.assertEquals(contextState.getBases()[0],'T');
-
-        VCs.add(A);
-        contextState = MultiVariantWalkerGroupedOnStart.getExpandedReferenceContext(VCs, contextState, referenceContext3);
-        Assert.assertEquals(contextState.getWindow().getEnd(),1150);
-        Assert.assertEquals(contextState.getBases()[0],'T');
-    }
-
     private final class DummyExampleGroupingMultiVariantWalker extends MultiVariantWalkerGroupedOnStart {
         List<List<VariantContext>> seenVariants = new ArrayList<>();
         @Override
-        public void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext) {
+        public void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext, final List<ReadsContext> readsContexts) {
             seenVariants.add(variantContexts);
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifactsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifactsIntegrationTest.java
@@ -27,6 +27,7 @@ public class FilterAlignmentArtifactsIntegrationTest extends CommandLineProgramT
         final File filteredVcf = createTempFile("filtered", ".vcf");
 
         final String[] args = {
+                "-R", b37Reference,
                 "-I", tumorBam.getAbsolutePath(),
                 "-V", truthVcf.getAbsolutePath(),
                 "-L", "20",
@@ -37,4 +38,5 @@ public class FilterAlignmentArtifactsIntegrationTest extends CommandLineProgramT
 
         runCommandLine(args);
     }
+
 }


### PR DESCRIPTION
Closes #6030.

@takutosato This a complete rewrite of the realignment filter, so I would review `FilterAlignmentArtifacts` and its engine from scratch, not from the diff.

There's still a bit of tuning to be done, but it's already far superior to the old version and I want to be using the release jar as much as possible for MC3.