### PR TITLE
Added check for null sequence dictionaries 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/SequenceDictionaryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SequenceDictionaryUtils.java
@@ -146,6 +146,8 @@ public final class SequenceDictionaryUtils {
                                              final SAMSequenceDictionary dict2,
                                              final boolean requireSuperset,
                                              final boolean checkContigOrdering ) {
+        Utils.nonNull(dict1, "Something went wrong with sequence dictionary detection, check that "+name1+" has a valid sequence dictionary");
+        Utils.nonNull(dict2, "Something went wrong with sequence dictionary detection, check that "+name2+" has a valid sequence dictionary");
 
         final SequenceDictionaryCompatibility type = compareDictionaries(dict1, dict2, checkContigOrdering);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
@@ -1,16 +1,23 @@
 package org.broadinstitute.hellbender.engine;
 
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -34,5 +41,28 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
         for (VariantContext v: results.getRight()) {
             Assert.assertFalse(v.hasGenotypes());
         }
+    }
+
+    @Test (expectedExceptions = java.lang.IllegalArgumentException.class)
+    // test asserting that if the reference dictionary exists but is not valid we get a more helpful exception than a null pointer exception
+    public void testBrokenReferenceDictionaryErrorMessage() throws IOException {
+        createTempFile("reference", ".dict"); // file because we want an empty file that "exists" for the reference
+        File out = createTempFile("GTStrippedOutput", "vcf");
+
+        Path refCopy = Files.copy(IOUtils.getPath(hg19_chr1_1M_Reference), createTempPath("reference", ".fasta"), StandardCopyOption.REPLACE_EXISTING);
+        Path indexCopy = Files.copy(ReferenceSequenceFileFactory.getFastaIndexFileName(IOUtils.getPath(hg19_chr1_1M_Reference)), ReferenceSequenceFileFactory.getFastaIndexFileName(refCopy));
+        File emptyDict = new File(ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(refCopy).toString());
+        IOUtils.deleteOnExit(indexCopy);
+
+        emptyDict.createNewFile();
+        IOUtils.deleteOnExit(emptyDict.toPath());
+
+        String[] args = new String[] {
+                "-R", refCopy.toString(),
+                "-I", TEST_DIRECTORY + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10000000-10000020.with.unmapped.bam",
+                "-O", out.getAbsolutePath()
+        };
+
+        runCommandLine(Arrays.asList(args), Mutect2.class.getSimpleName());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
@@ -46,7 +46,6 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
     @Test (expectedExceptions = java.lang.IllegalArgumentException.class)
     // test asserting that if the reference dictionary exists but is not valid we get a more helpful exception than a null pointer exception
     public void testBrokenReferenceDictionaryErrorMessage() throws IOException {
-        createTempFile("reference", ".dict"); // file because we want an empty file that "exists" for the reference
         File out = createTempFile("GTStrippedOutput", "vcf");
 
         Path refCopy = Files.copy(IOUtils.getPath(hg19_chr1_1M_Reference), createTempPath("reference", ".fasta"), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
As a compromise fix, I have added a check to the validation code that asserts the dictionaries actually exist to save ourselves the potential null-pointer exceptions. @droazen 

Fixes #6142 