### PR TITLE
Default autosomal coverage and renamed output for mt pipeline

### DIFF
--- a/scripts/m2_cromwell_tests/test_mitochondria_m2_wdl.json
+++ b/scripts/m2_cromwell_tests/test_mitochondria_m2_wdl.json
@@ -2,6 +2,7 @@
   "MitochondriaPipeline.wgs_aligned_input_bam_or_cram": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/NA12878.alignedHg38.duplicateMarked.baseRealigned.bam",
   "MitochondriaPipeline.wgs_aligned_input_bam_or_cram_index": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/NA12878.alignedHg38.duplicateMarked.baseRealigned.bam.bai",
   "MitochondriaPipeline.autosomal_coverage": 30,
+  "MitochondriaPipeline.sample_name": "NA12878",
   "MitochondriaPipeline.mt_dict": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/mitochondria_references/Homo_sapiens_assembly38.chrM.dict",
   "MitochondriaPipeline.mt_fasta": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/mitochondria_references/Homo_sapiens_assembly38.chrM.fasta",
   "MitochondriaPipeline.mt_fasta_index": "/home/travis/build/broadinstitute/gatk/src/test/resources/large/mitochondria_references/Homo_sapiens_assembly38.chrM.fasta.fai",

--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -10,6 +10,7 @@ workflow AlignAndCall {
   input {
     File unmapped_bam
     Float? autosomal_coverage
+    String sample_name
 
     File mt_dict
     File mt_fasta
@@ -160,6 +161,7 @@ workflow AlignAndCall {
       raw_vcf = LiftoverAndCombineVcfs.final_vcf,
       raw_vcf_index = LiftoverAndCombineVcfs.final_vcf_index,
       raw_vcf_stats = MergeStats.stats,
+      sample_name = sample_name,
       ref_fasta = mt_fasta,
       ref_fai = mt_fasta_index,
       ref_dict = mt_dict,
@@ -449,6 +451,7 @@ task Filter {
     File raw_vcf_stats
     Boolean compress
     Float? vaf_cutoff
+    String sample_name
 
     String? m2_extra_filtering_args
     Int max_alt_allele_count
@@ -466,7 +469,7 @@ task Filter {
     Int? preemptible_tries
   }
 
-  String output_vcf = "output" + if compress then ".vcf.gz" else ".vcf"
+  String output_vcf = sample_name + if compress then ".vcf.gz" else ".vcf"
   String output_vcf_index = output_vcf + if compress then ".tbi" else ".idx"
   Float ref_size = size(ref_fasta, "GB") + size(ref_fai, "GB")
   Int disk_size = ceil(size(raw_vcf, "GB") + ref_size) + 20

--- a/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json
+++ b/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json
@@ -2,6 +2,7 @@
   "MitochondriaPipeline.wgs_aligned_input_bam_or_cram": "input_bam_here",
   "MitochondriaPipeline.wgs_aligned_input_bam_or_cram_index": "input_bam_index_here",
   "MitochondriaPipeline.autosomal_coverage": autosomal_median_coverage_here,
+  "MitochondriaPipeline.sample_name": "SAMPLE_NAME",
   "MitochondriaPipeline.mt_dict": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.dict",
   "MitochondriaPipeline.mt_fasta": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.fasta",
   "MitochondriaPipeline.mt_fasta_index": "gs://broad-references/hg38/v0/chrM/Homo_sapiens_assembly38.chrM.fasta.fai",

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -11,8 +11,9 @@ workflow MitochondriaPipeline {
   input {
     File wgs_aligned_input_bam_or_cram
     File wgs_aligned_input_bam_or_cram_index
+    String sample_name
     String contig_name = "chrM"
-    Float? autosomal_coverage
+    Float autosomal_coverage = 30
 
     # Read length used for optimization only. If this is too small CollectWgsMetrics might fail, but the results are not
     # affected by this number. Default is 151.
@@ -70,6 +71,7 @@ workflow MitochondriaPipeline {
     vaf_filter_threshold: "Hard threshold for filtering low VAF sites"
     f_score_beta: "F-Score beta balances the filtering strategy between recall and precision. The relative weight of recall to precision."
     contig_name: "Name of mitochondria contig in reference that wgs_aligned_input_bam_or_cram is aligned to"
+    sample_name: "Name of file in final output vcf"
   }
 
   call SubsetBamToChrM {
@@ -94,6 +96,7 @@ workflow MitochondriaPipeline {
     input:
       unmapped_bam = RevertSam.unmapped_bam,
       autosomal_coverage = autosomal_coverage,
+      sample_name = sample_name,
       mt_dict = mt_dict,
       mt_fasta = mt_fasta,
       mt_fasta_index = mt_fasta_index,


### PR DESCRIPTION
Kristen requested some small changes for the mitochondria pipeline. This renames the output vcf with the name of the sample and puts a default value for autosomal_median_coverage (meaning you'll now get the NuMT filter even if you don't provide the actual autosomal coverage). Happy to discuss if that's the right thing to do or if we really want to force people to put a value for autosomal coverage.