### PR TITLE
Don't fail the build if we're in a git worktree folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,11 @@ def resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessag
     }
 }
 
+
+def looksLikeWereInAGitRepository(){
+    file(".git").isDirectory() || (file(".git").exists() && file(".git").text.startsWith("gitdir"))
+}
+
 // Ensure that we have the right JDK version, a clone of the git repository, and resolve any required git-lfs
 // resource files that are needed to run the build but are still lfs stub files.
 def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage) {
@@ -134,7 +139,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPre
                 "The ClassLoader obtained from the Java ToolProvider is null. "
                 + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
     }
-    if (!file(".git").isDirectory()) {
+    if (!looksLikeWereInAGitRepository()) {
         throw new GradleException("The GATK Github repository must be cloned using \"git clone\" to run the build. "
                 + "$buildPrerequisitesMessage")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,8 @@ def resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessag
     }
 }
 
-
+// Check that we're in a folder which git recognizes as a git repository.
+// This works for either a standard git clone or one created with `git worktree add`
 def looksLikeWereInAGitRepository(){
     file(".git").isDirectory() || (file(".git").exists() && file(".git").text.startsWith("gitdir"))
 }
@@ -140,8 +141,9 @@ def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPre
                 + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
     }
     if (!looksLikeWereInAGitRepository()) {
-        throw new GradleException("The GATK Github repository must be cloned using \"git clone\" to run the build. "
-                + "$buildPrerequisitesMessage")
+        throw new GradleException("This doesn't appear to be a git folder. " +
+                "The GATK Github repository must be cloned using \"git clone\" to run the build. " +
+                "\n$buildPrerequisitesMessage")
     }
     // Large runtime resource files must be present at build time to be compiled into the jar, so
     // try to resolve them to real files if any of them are stubs.


### PR DESCRIPTION
* Expand the way the build.gradle checks if we're in a git repo to also understand git-worktree checkouts

This is useful to me since I've been using `git worktree` to maintain copies of gatk for java 8 and 11 separately.  

Also, I recommend `git worktree` 