### PR TITLE
Fix Mitochondria Mode documentation in FilterMutectCalls

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/M2FiltersArgumentCollection.java
@@ -39,7 +39,7 @@ public class M2FiltersArgumentCollection {
     /**
      * Mitochondria mode includes the filter{@link ChimericOriginalAlignmentFilter} and {@link PolymorphicNuMTFilter},
      * and excludes the filters {@link ClusteredEventsFilter}, {@link MultiallelicFilter}, {@link PolymeraseSlippageFilter},
-     * {@link FilteredHaplotypeFilter}, and {@link GermlineFilter}
+     * {@link FilteredHaplotypeFilter}, {@link FragmentLengthFilter}, and {@link GermlineFilter}
      */
     @Argument(fullName = M2ArgumentCollection.MITOCHONDRIA_MODE_LONG_NAME, optional = true, doc = "Set filters to mitochondrial defaults")
     public boolean mitochondria = false;


### PR DESCRIPTION
Mitochondria mode documentation in FilterMutectCalls was missing a filter that is excluded, as can be seen here: https://github.com/broadinstitute/gatk/blob/master/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/Mutect2FilteringEngine.java#L237