### PR TITLE
Renamed OutputMode.EMIT_ALL_SITES to EMIT_ALL_ACTIVE_SITES

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsEngine.java
@@ -392,8 +392,8 @@ public class GenotypeGVCFsEngine
 
         //whether to emit non-variant sites is not contained in genotypeArgs and must be passed to uac separately
         //Note: GATK3 uses OutputMode.EMIT_ALL_CONFIDENT_SITES when includeNonVariants is requested
-        //GATK4 uses EMIT_ALL_SITES to ensure LowQual sites are emitted.
-        uac.outputMode = includeNonVariants ? OutputMode.EMIT_ALL_SITES : OutputMode.EMIT_VARIANTS_ONLY;
+        //GATK4 uses EMIT_ALL_ACTIVE_SITES to ensure LowQual sites are emitted.
+        uac.outputMode = includeNonVariants ? OutputMode.EMIT_ALL_ACTIVE_SITES : OutputMode.EMIT_VARIANTS_ONLY;
         return uac;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -376,7 +376,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
     }
 
     protected boolean emitAllSites() {
-        return configuration.outputMode == OutputMode.EMIT_ALL_SITES;
+        return configuration.outputMode == OutputMode.EMIT_ALL_ACTIVE_SITES;
     }
 
     protected final boolean passesEmitThreshold(final double conf, final boolean bestGuessIsRef) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -182,13 +182,13 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
 
         // return a null call if we don't pass the confidence cutoff or the most likely allele frequency is zero
         // skip this if we are already looking at a vc with NON_REF as the first alt allele i.e. if we are in GenotypeGVCFs
-        if ( !passesEmitThreshold(phredScaledConfidence, outputAlternativeAlleles.siteIsMonomorphic) && !emitAllSites()
+        if ( !passesEmitThreshold(phredScaledConfidence, outputAlternativeAlleles.siteIsMonomorphic) && !emitAllActiveSites()
                 && noAllelesOrFirstAlleleIsNotNonRef(outputAlternativeAlleles.alleles) && givenAlleles.isEmpty()) {
             return null;
         }
 
         // return a null call if we aren't forcing site emission and the only alt allele is a spanning deletion
-        if (! emitAllSites() && outputAlternativeAlleles.alleles.size() == 1 && Allele.SPAN_DEL.equals(outputAlternativeAlleles.alleles.get(0))) {
+        if (! emitAllActiveSites() && outputAlternativeAlleles.alleles.size() == 1 && Allele.SPAN_DEL.equals(outputAlternativeAlleles.alleles.get(0))) {
             return null;
         }
 
@@ -375,7 +375,11 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
         return true;
     }
 
-    protected boolean emitAllSites() {
+    /**
+     * Whether or not all calls at any region over the activity threshold should be emitted regardless of confidence.
+     * This does not necessarily emit calls for all sites in a region (see {@link OutputMode}).
+     */
+    protected boolean emitAllActiveSites() {
         return configuration.outputMode == OutputMode.EMIT_ALL_ACTIVE_SITES;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
@@ -10,8 +10,8 @@ public enum OutputMode {
     /** produces calls at variant sites and confident reference sites */
     EMIT_ALL_CONFIDENT_SITES,
 
-    /** produces calls at any callable site regardless of confidence. This does not necessarily output calls for all
-     * sites in a region. This argument is intended only for point mutations (SNPs); it will not produce a
-     * comprehensive set of indels. */
+    /** Produces calls at any region over the activity threshold regardless of confidence. This does not necessarily
+     * output calls for all sites in a region. This argument is intended only for point mutations (SNPs); it will not
+     * produce a comprehensive set of indels. */
     EMIT_ALL_ACTIVE_SITES
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
@@ -10,7 +10,8 @@ public enum OutputMode {
     /** produces calls at variant sites and confident reference sites */
     EMIT_ALL_CONFIDENT_SITES,
 
-    /** produces calls at any callable site regardless of confidence; this argument is intended only for point
-     * mutations (SNPs); it will not produce a comprehensive set of indels. */
-    EMIT_ALL_SITES
+    /** produces calls at any callable site regardless of confidence. This does not necessarily output calls for all
+     * sites in a region. This argument is intended only for point mutations (SNPs); it will not produce a
+     * comprehensive set of indels. */
+    EMIT_ALL_ACTIVE_SITES
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/OutputMode.java
@@ -10,8 +10,9 @@ public enum OutputMode {
     /** produces calls at variant sites and confident reference sites */
     EMIT_ALL_CONFIDENT_SITES,
 
-    /** Produces calls at any region over the activity threshold regardless of confidence. This does not necessarily
-     * output calls for all sites in a region. This argument is intended only for point mutations (SNPs); it will not
-     * produce a comprehensive set of indels. */
+    /** Produces calls at any region over the activity threshold regardless of confidence. On occasion, this will output
+     * HOM_REF records where no call could be confidently made. This does not necessarily output calls for all sites in
+     * a region. This argument is intended only for point mutations (SNPs); it will not produce a comprehensive set of
+     * indels. */
     EMIT_ALL_ACTIVE_SITES
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/StandardCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/StandardCallerArgumentCollection.java
@@ -138,12 +138,12 @@ public class StandardCallerArgumentCollection implements Serializable {
     public OutputMode outputMode = OutputMode.EMIT_VARIANTS_ONLY;
 
     /**
-     * Advanced, experimental argument: if SNP likelihood model is specified, and if EMIT_ALL_SITES output mode is set, when we set this argument then we will also emit PLs at all sites.
+     * Advanced, experimental argument: if SNP likelihood model is specified, and if EMIT_ALL_ACTIVE_SITES output mode is set, when we set this argument then we will also emit PLs at all sites.
      * This will give a measure of reference confidence and a measure of which alt alleles are more plausible (if any).
      * WARNINGS:
      * - This feature will inflate VCF file size considerably.
      * - All SNP ALT alleles will be emitted with corresponding 10 PL values.
-     * - An error will be emitted if EMIT_ALL_SITES is not set, or if anything other than diploid SNP model is used
+     * - An error will be emitted if EMIT_ALL_ACTIVE_SITES is not set, or if anything other than diploid SNP model is used
      */
     @Advanced
     @Argument(fullName = "all-site-pls", doc = "Annotate all sites with PLs", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
@@ -197,7 +197,7 @@ public final class ReblockGVCF extends VariantWalker {
     private HaplotypeCallerGenotypingEngine createGenotypingEngine(SampleList samples) {
         final HaplotypeCallerArgumentCollection hcArgs = new HaplotypeCallerArgumentCollection();
         // create the genotyping engine
-        hcArgs.standardArgs.outputMode = OutputMode.EMIT_ALL_SITES;
+        hcArgs.standardArgs.outputMode = OutputMode.EMIT_ALL_ACTIVE_SITES;
         hcArgs.standardArgs.annotateAllSitesWithPLs = true;
         hcArgs.standardArgs.genotypeArgs = new GenotypeCalculationArgumentCollection(genotypeArgs);
         hcArgs.emitReferenceConfidence = ReferenceConfidenceMode.GVCF;   //this is important to force emission of all alleles at a multiallelic site


### PR DESCRIPTION
- Modified GenotypeGVCFsEngine.OutputMode enum documentation to reflect this change