### PR TITLE
Assert that ELBO did not become NaN during each step of inference

### DIFF
--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
@@ -392,6 +392,7 @@ class HybridInferenceTask(InferenceTask):
             try:
                 for _ in progress_bar:
                     loss = self.continuous_model_step_func() / self.elbo_normalization_factor
+                    assert not np.isnan(loss), "The optimization step for ELBO update returned a NaN"
                     self.i_advi += 1
 
                     try:


### PR DESCRIPTION
gCNV does not fail if the ELBO becomes NaN and just finishes the maximum number of allowed iterations. This check would save some time and lead to less cryptic errors downstream