### PR TITLE
Cleanup GenomicsDB vid combine protobuf mapping overrides

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -729,7 +729,7 @@ public final class GenomicsDBImport extends GATKTool {
         GenomicsDBImporter importer;
         try {
             importer = new GenomicsDBImporter(importConfig);
-            // Modify importer directly from updateImportProtobufMapping.
+            // Modify importer directly from updateImportProtobufVidMapping.
             org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBUtils.updateImportProtobufVidMapping(importer);
             importer.executeImport(maxNumIntervalsToImportInParallel);
         } catch (final IOException e) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -729,6 +729,8 @@ public final class GenomicsDBImport extends GATKTool {
         GenomicsDBImporter importer;
         try {
             importer = new GenomicsDBImporter(importConfig);
+            // Modify importer directly from updateImportProtobufMapping.
+            org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBUtils.updateImportProtobufVidMapping(importer);
             importer.executeImport(maxNumIntervalsToImportInParallel);
         } catch (final IOException e) {
             throw new UserException("Error initializing GenomicsDBImporter", e);

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -30,20 +30,22 @@ import java.util.Map;
  */
 public class GenomicsDBUtils {
 
+    private static final String SUM = "sum";
     private static final String ELEMENT_WISE_SUM = "element_wise_sum";
     private static final String ELEMENT_WISE_FLOAT_SUM = "element_wise_float_sum";
-    private static final String SUM = "sum";
+    private static final String ELEMENT_WISE_INT_SUM = "element_wise_int_sum";
     private static final String HISTOGRAM_SUM = "histogram_sum";
-    private static final String STRAND_BIAS_TABLE_COMBINE = "strand_bias_table";
+    private static final String MOVE_TO_FORMAT = "move_to_FORMAT";
+
     private static final String GDB_TYPE_FLOAT = "float";
     private static final String GDB_TYPE_INT = "int";
-    // private static final String MOVE_TO_FORMAT = "move_to_FORMAT";
+
 
     /**
      * Info and Allele-specific fields that need to be treated differently
      * will have to be explicitly overridden in this method during import.
      * Note that the recommendation is to perform this operation during the import phase
-     * as only a very limited set of mappings can be changed during export.
+     * as only a limited set of mappings can be changed during export.
      *
      * @param importer
      */
@@ -77,7 +79,7 @@ public class GenomicsDBUtils {
         vidMapPB = updateINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList,
                 GATKVCFConstants.RAW_GENOTYPE_COUNT_KEY, ELEMENT_WISE_SUM);
         vidMapPB = updateAlleleSpecificINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList,
-                GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, STRAND_BIAS_TABLE_COMBINE);
+                GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, ELEMENT_WISE_INT_SUM);
 
         importer.updateProtobufVidMapping(vidMapPB);
     }
@@ -131,6 +133,8 @@ public class GenomicsDBUtils {
         } else {
             exportConfigurationBuilder.setGenerateArrayNameFromPartitionBounds(true);
         }
+
+
 
         return exportConfigurationBuilder.build();
     }
@@ -230,9 +234,11 @@ public class GenomicsDBUtils {
 
             GenomicsDBVidMapProto.FieldLengthDescriptorComponentPB.Builder lengthDescriptorComponentBuilder =
                     GenomicsDBVidMapProto.FieldLengthDescriptorComponentPB.newBuilder();
+
             infoBuilder.clearLength();
             infoBuilder.clearVcfDelimiter();
             infoBuilder.clearType();
+
             lengthDescriptorComponentBuilder.setVariableLengthDescriptor("R");
             infoBuilder.addLength(lengthDescriptorComponentBuilder.build());
             lengthDescriptorComponentBuilder.setVariableLengthDescriptor("var"); //ignored - can set anything here

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -34,10 +34,10 @@ public class GenomicsDBUtils {
     private static final String ELEMENT_WISE_FLOAT_SUM = "element_wise_float_sum";
     private static final String SUM = "sum";
     private static final String HISTOGRAM_SUM = "histogram_sum";
-    private static final String MOVE_TO_FORMAT = "move_to_FORMAT";
     private static final String STRAND_BIAS_TABLE_COMBINE = "strand_bias_table";
     private static final String GDB_TYPE_FLOAT = "float";
     private static final String GDB_TYPE_INT = "int";
+    // private static final String MOVE_TO_FORMAT = "move_to_FORMAT";
 
     /**
      * Info and Allele-specific fields that need to be treated differently

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -77,7 +77,7 @@ public class GenomicsDBUtils {
         vidMapPB = updateINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList,
                 GATKVCFConstants.RAW_GENOTYPE_COUNT_KEY, ELEMENT_WISE_SUM);
         vidMapPB = updateAlleleSpecificINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList,
-                GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, ELEMENT_WISE_FLOAT_SUM);
+                GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, STRAND_BIAS_TABLE_COMBINE);
 
         importer.updateProtobufVidMapping(vidMapPB);
     }
@@ -139,6 +139,22 @@ public class GenomicsDBUtils {
                                                                                               final String callsetJson, final String vidmapJson,
                                                                                               final String vcfHeader) {
         return createExportConfiguration(workspace, callsetJson, vidmapJson, vcfHeader, null);
+    }
+
+    /**
+     * Parse the vid json and create an in-memory Protobuf structure representing the
+     * information in the JSON file
+     *
+     * @param vidmapJson vid JSON file
+     * @return Protobuf object
+     */
+    public static GenomicsDBVidMapProto.VidMappingPB getProtobufVidMappingFromJsonFile(final String vidmapJson)
+            throws IOException {
+        final GenomicsDBVidMapProto.VidMappingPB.Builder vidMapBuilder = GenomicsDBVidMapProto.VidMappingPB.newBuilder();
+        try (final Reader reader = Files.newBufferedReader(IOUtils.getPath(vidmapJson))) {
+            JsonFormat.merge(reader, vidMapBuilder);
+        }
+        return vidMapBuilder.build();
     }
 
     /**
@@ -233,7 +249,7 @@ public class GenomicsDBUtils {
                 infoBuilder.setVCFFieldCombineOperation(ELEMENT_WISE_SUM);
                 if (newCombineOperation.equals(ELEMENT_WISE_FLOAT_SUM)) {
                     infoBuilder.addType(GDB_TYPE_FLOAT);
-                } else if (newCombineOperation.equals(STRAND_BIAS_TABLE_COMBINE)) {
+                } else {
                     infoBuilder.addType(GDB_TYPE_INT);
                 }
             }


### PR DESCRIPTION
Move vid combine protobuf mapping overrides from GenomicsDB ExportConfiguration to Import. Overrides can still be performed via ExportConfiguration, but recommended to modify the mappings during the import phase as not all mappings can be effectively modified during export/queries.

There is a whole bunch of hardcoded allele-specific fields whose vid mappings are hardcoded in GenomicsDB - see https://github.com/GenomicsDB/GenomicsDB/blob/master/src/main/java/org/genomicsdb/importer/Constants.java. There is no harm in specifying the mappings in gatk as well. But, at some point we should move the mappings from GenomicsDB to gatk, as these are gatk-specific annotations.