### PR TITLE
Removed erroneous short argument names in R scripts for CNV plotting.

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.R
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.R
@@ -5,13 +5,13 @@ library(optparse)
 library(data.table)
 
 option_list = list(
-    make_option(c("--sample_name", "-sample_name"), dest="sample_name", action="store"),
-    make_option(c("--standardized_copy_ratios_file", "-standardized_copy_ratios_file"), dest="standardized_copy_ratios_file", action="store"),
-    make_option(c("--denoised_copy_ratios_file", "-denoised_copy_ratios_file"), dest="denoised_copy_ratios_file", action="store"),
-    make_option(c("--contig_names", "-contig_names"), dest="contig_names", action="store"),         #string with elements separated by "CONTIG_DELIMITER"
-    make_option(c("--contig_lengths", "-contig_lengths"), dest="contig_lengths", action="store"),   #string with elements separated by "CONTIG_DELIMITER"
-    make_option(c("--output_dir", "-output_dir"), dest="output_dir", action="store"),
-    make_option(c("--output_prefix", "-output_prefix"), dest="output_prefix", action="store"))
+    make_option(c("--sample_name"), dest="sample_name", action="store"),
+    make_option(c("--standardized_copy_ratios_file"), dest="standardized_copy_ratios_file", action="store"),
+    make_option(c("--denoised_copy_ratios_file"), dest="denoised_copy_ratios_file", action="store"),
+    make_option(c("--contig_names"), dest="contig_names", action="store"),      #string with elements separated by "CONTIG_DELIMITER"
+    make_option(c("--contig_lengths"), dest="contig_lengths", action="store"),  #string with elements separated by "CONTIG_DELIMITER"
+    make_option(c("--output_dir"), dest="output_dir", action="store"),
+    make_option(c("--output_prefix"), dest="output_prefix", action="store"))
 
 opt = parse_args(OptionParser(option_list=option_list))
 

--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.R
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.R
@@ -5,13 +5,14 @@ library(optparse)
 library(data.table)
 
 option_list = list(
-make_option(c("--sample_name", "-sample_name"), dest="sample_name", action="store"),
-make_option(c("--denoised_copy_ratios_file", "-denoised_copy_ratios_file"), dest="denoised_copy_ratios_file", action="store"),
-make_option(c("--allelic_counts_file", "-allelic_counts_file"), dest="allelic_counts_file", action="store"),
-make_option(c("--modeled_segments_file", "-modeled_segments_file"), dest="modeled_segments_file", action="store"),
-make_option(c("--contig_names", "-contig_names"), dest="contig_names", action="store"),         #string with elements separated by "CONTIG_DELIMITER"
-make_option(c("--contig_lengths", "-contig_lengths"), dest="contig_lengths", action="store"),   #string with elements separated by "CONTIG_DELIMITER"
-make_option(c("--output_file", "-output_file"), dest="output_file", action="store"))
+    make_option(c("--sample_name"), dest="sample_name", action="store"),
+    make_option(c("--denoised_copy_ratios_file"), dest="denoised_copy_ratios_file", action="store"),
+    make_option(c("--allelic_counts_file"), dest="allelic_counts_file", action="store"),
+    make_option(c("--modeled_segments_file"), dest="modeled_segments_file", action="store"),
+    make_option(c("--contig_names"), dest="contig_names", action="store"),      #string with elements separated by "CONTIG_DELIMITER"
+    make_option(c("--contig_lengths"), dest="contig_lengths", action="store"),  #string with elements separated by "CONTIG_DELIMITER"
+    make_option(c("--output_file"), dest="output_file", action="store"))
+
 opt = parse_args(OptionParser(option_list=option_list))
 
 sample_name = opt[["sample_name"]]


### PR DESCRIPTION
I think the erroneous calls to the optparse `make_option` method got ported over accidentally from the original versions of these scripts.  These calls don't cause any issues with optparse 1.3.2 (which is the version currently in the GATK Docker image), but could possibly cause issues with later versions (and might be responsible for an issue noted by @knoblett).