### PR TITLE
Optional empty intervals in GATK tools, useful for scattered jobs

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -603,11 +603,11 @@ task M2 {
 
         if [[ ! -z "~{variants_for_contamination}" ]]; then
             gatk --java-options "-Xmx~{command_mem}m" GetPileupSummaries -R ~{ref_fasta} -I ~{tumor_bam} ~{"--interval-set-rule INTERSECTION -L " + intervals} \
-                -V ~{variants_for_contamination} -L ~{variants_for_contamination} -O tumor-pileups.table
+                --allow-empty-intervals -V ~{variants_for_contamination} -L ~{variants_for_contamination} -O tumor-pileups.table
 
             if [[ ! -z "~{normal_bam}" ]]; then
                 gatk --java-options "-Xmx~{command_mem}m" GetPileupSummaries -R ~{ref_fasta} -I ~{normal_bam} ~{"--interval-set-rule INTERSECTION -L " + intervals} \
-                    -V ~{variants_for_contamination} -L ~{variants_for_contamination} -O normal-pileups.table
+                    --allow-empty-intervals -V ~{variants_for_contamination} -L ~{variants_for_contamination} -O normal-pileups.table
             fi
         fi
     >>>

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/IntervalOverlapReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/IntervalOverlapReadFilter.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine.filters;
 
 import htsjdk.samtools.util.OverlapDetector;
-import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
@@ -14,7 +13,6 @@ import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
-import java.lang.annotation.Documented;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,7 +66,7 @@ public final class IntervalOverlapReadFilter extends ReadFilter {
             warning.warn("You are using the IntervalOverlapReadFilter to subset your input, this is a very slow operation and it will usually be preferable to use the '-L' command or provide an interval list file for a sorted and indexed input file");
             // first load the intervals
             final GenomeLocParser genomeLocParser = new GenomeLocParser(this.samHeader.getSequenceDictionary());
-            final GenomeLocSortedSet intervals = IntervalUtils.loadIntervals(intervalStrings, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser);
+            final GenomeLocSortedSet intervals = IntervalUtils.loadIntervals(intervalStrings, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser, false);
             // then initializes the overlap detector with the loaded intervals
             this.detector = OverlapDetector.create(intervals.toList());
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/IntervalUtils.java
@@ -218,7 +218,8 @@ public final class IntervalUtils {
             final IntervalSetRule intervalSetRule,
             final IntervalMergingRule intervalMergingRule,
             final int padding,
-            final GenomeLocParser genomeLocParser) {
+            final GenomeLocParser genomeLocParser,
+            final boolean allowEmptyResult) {
         Utils.nonNull(intervalStrings);
         List<GenomeLoc> allIntervals = new ArrayList<>();
         for ( final String intervalString : intervalStrings) {
@@ -229,7 +230,7 @@ public final class IntervalUtils {
                 intervals = getIntervalsWithFlanks(genomeLocParser, intervals, padding);
             }
 
-            allIntervals = mergeListsBySetOperator(intervals, allIntervals, intervalSetRule);
+            allIntervals = mergeListsBySetOperator(intervals, allIntervals, intervalSetRule, allowEmptyResult);
         }
 
         return sortAndMergeIntervals(genomeLocParser, allIntervals, intervalMergingRule);
@@ -391,9 +392,10 @@ public final class IntervalUtils {
      * @param setOne a list of genomeLocs, in order (cannot be NULL)
      * @param setTwo a list of genomeLocs, also in order (cannot be NULL)
      * @param rule the rule to use for merging, i.e. union, intersection, etc
+     * @param allowEmptyResult
      * @return a list, correctly merged using the specified rule
      */
-    public static List<GenomeLoc> mergeListsBySetOperator(final List<GenomeLoc> setOne, final List<GenomeLoc> setTwo, final IntervalSetRule rule) {
+    public static List<GenomeLoc> mergeListsBySetOperator(final List<GenomeLoc> setOne, final List<GenomeLoc> setTwo, final IntervalSetRule rule, boolean allowEmptyResult) {
         // shortcut, if either set is zero, return the other set
         if (setOne == null || setOne.isEmpty() || setTwo == null || setTwo.isEmpty()) {
             return Collections.unmodifiableList((setOne == null || setOne.isEmpty()) ? setTwo : setOne);
@@ -434,7 +436,7 @@ public final class IntervalUtils {
         }
 
         //if we have an empty list, throw an exception.  If they specified intersection and there are no items, this is bad.
-        if (retList.isEmpty()) {
+        if (!allowEmptyResult && retList.isEmpty()) {
             throw new UserException.EmptyIntersection("There was an empty intersection");
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/IntervalOverlappingIterator.java
@@ -43,13 +43,14 @@ public class IntervalOverlappingIterator<T extends Locatable> implements Iterato
     public IntervalOverlappingIterator(Iterator<T> iterator, List<SimpleInterval> intervals,
         SAMSequenceDictionary dictionary) {
         Utils.nonNull(iterator);
-        Utils.nonEmpty(intervals);
         Utils.nonNull(dictionary);
         this.iterator = iterator;
         this.intervals = intervals.iterator();
         this.dictionary = dictionary;
-        currentInterval = this.intervals.next();
-        advance();
+        if (!intervals.isEmpty()) { // if intervals are empty, next remains null and we have a trivial, empty iterator
+            currentInterval = this.intervals.next();
+            advance();
+        }
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -124,6 +124,22 @@ public final class IntervalArgumentCollectionTest extends GATKBaseTest {
         iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
     }
 
+    /**
+     * Asserts that the interval set rule is applied first, then the interval ordering rule. This would give an error because the overlap is empty
+     * if not for the allowEmptyIntervals argument.
+     * @param iac
+     */
+    @Test(dataProvider = "optionalOrNot")
+    public void testIntervalSetAndMergingOverlapWithEmptyIntervalsAllowed(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:1-100");
+        iac.addToIntervalStrings("1:101-200");
+        iac.addToIntervalStrings("1:90-110");
+        iac.allowEmptyIntervals = true;
+        iac.intervalSetRule = IntervalSetRule.INTERSECTION;
+        iac.intervalMergingRule = IntervalMergingRule.ALL;
+        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
+    }
+
     @Test(dataProvider = "optionalOrNot")
     public void testIntervalSetRuleIntersection(IntervalArgumentCollection iac){
         iac.addToIntervalStrings("1:1-100");
@@ -148,10 +164,27 @@ public final class IntervalArgumentCollectionTest extends GATKBaseTest {
         iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
     }
 
+    @Test(dataProvider = "optionalOrNot")
+    public void testAllExcludedWithEmptyIntervalsAllowed(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:10-20");
+        iac.excludeIntervalStrings.add("1:1-200");
+        iac.allowEmptyIntervals = true;
+        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
+    }
+
     @Test(dataProvider = "optionalOrNot", expectedExceptions= CommandLineException.BadArgumentValue.class)
     public void testNoIntersection(IntervalArgumentCollection iac){
         iac.addToIntervalStrings("1:10-20");
         iac.addToIntervalStrings("1:50-200");
+        iac.intervalSetRule = IntervalSetRule.INTERSECTION;
+        iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
+    }
+
+    @Test(dataProvider = "optionalOrNot")
+    public void testNoIntersectionWithEmptyIntervalsAllowed(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:10-20");
+        iac.addToIntervalStrings("1:50-200");
+        iac.allowEmptyIntervals = true;
         iac.intervalSetRule = IntervalSetRule.INTERSECTION;
         iac.getIntervals(hg19GenomeLocParser.getSequenceDictionary());
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/contamination/GetPileupSummariesIntegrationTest.java
@@ -76,4 +76,26 @@ public class GetPileupSummariesIntegrationTest extends CommandLineProgramTest {
         runCommandLine(args);
     }
 
+    // This tool is often run as part of a scattered Mutect2 workflow.  It is possible that a scattered job may be over some interval,
+    // the mitochondria or Y chromosome, for example, that does not overlap any variant in the -V input.  Therefore, we test that the
+    // --allow-empty-intervals argument prevents errors in such a scatter and returns an empty table
+    @Test
+    public void testEmptyScatter() {
+        final File output = createTempFile("output", ".table");
+        final String[] args = {
+                "-I", NA12878.getAbsolutePath(),
+                "-V", thousandGenomes,
+                "-L", thousandGenomes,
+                "-L", "21",
+                "--interval-set-rule", "INTERSECTION",
+                "-allow-empty-intervals",
+                "-O", output.getAbsolutePath()
+        };
+        runCommandLine(args);
+
+        final ImmutablePair<String, List<PileupSummary>> sampleAndResult = PileupSummary.readFromFile(output);
+
+        final List<PileupSummary> result = sampleAndResult.getRight();
+        Assert.assertTrue(result.isEmpty());
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/IntervalUtilsUnitTest.java
@@ -387,11 +387,11 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         }
 
         List<GenomeLoc> ret;
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, IntervalSetRule.UNION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, IntervalSetRule.UNION, false);
         Assert.assertEquals(ret.size(), 100);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, null);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, null, false);
         Assert.assertEquals(ret.size(), 100);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, IntervalSetRule.INTERSECTION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, listEveryTwoFromOne, IntervalSetRule.INTERSECTION, false);
         Assert.assertEquals(ret.size(), 0);
     }
 
@@ -409,11 +409,11 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         }
 
         List<GenomeLoc> ret;
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.UNION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.UNION, false);
         Assert.assertEquals(ret.size(), 150);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, null);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, null, false);
         Assert.assertEquals(ret.size(), 150);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.INTERSECTION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.INTERSECTION, false);
         Assert.assertEquals(ret.size(), 50);
     }
 
@@ -432,11 +432,11 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         }
 
         List<GenomeLoc> ret;
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.UNION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.UNION, false);
         Assert.assertEquals(ret.size(), 40);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, null);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, null, false);
         Assert.assertEquals(ret.size(), 40);
-        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.INTERSECTION);
+        ret = IntervalUtils.mergeListsBySetOperator(listEveryTwoFromTwo, allSites, IntervalSetRule.INTERSECTION, false);
         Assert.assertEquals(ret.size(), 20);
     }
 
@@ -452,7 +452,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         source2.add(hg19GenomeLocParser.createGenomeLoc("1", 16, 18));
         source2.add(hg19GenomeLocParser.createGenomeLoc("1", 22, 24));
 
-        List<GenomeLoc> ret = IntervalUtils.mergeListsBySetOperator(source1, source2, IntervalSetRule.INTERSECTION);
+        List<GenomeLoc> ret = IntervalUtils.mergeListsBySetOperator(source1, source2, IntervalSetRule.INTERSECTION, false);
         Assert.assertEquals(ret.size(), 2);
     }
 
@@ -1130,7 +1130,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
         List<String> intervalArgs = new ArrayList<>(1);
         intervalArgs.add(gatkIntervalFile.getAbsolutePath());
 
-        IntervalUtils.loadIntervals(intervalArgs, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser);
+        IntervalUtils.loadIntervals(intervalArgs, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser, false);
     }
 
     @Test(expectedExceptions={UserException.MalformedFile.class, UserException.MalformedGenomeLoc.class}, dataProvider="invalidIntervalTestData")
@@ -1154,7 +1154,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
 
         // loadIntervals() will validate all intervals against the sequence dictionary in our genomeLocParser,
         // and should throw for all intervals in our invalidIntervalTestData set
-        IntervalUtils.loadIntervals(intervalArgs, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser);
+        IntervalUtils.loadIntervals(intervalArgs, IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, genomeLocParser, false);
     }
 
     // TODO - remove once a corrected version of the exome interval list is released.
@@ -1260,7 +1260,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
 
     @Test( dataProvider = "loadintervals")
     public void loadIntervalsTest(List<String> intervals, IntervalSetRule setRule, int padding, List<GenomeLoc> results){
-        GenomeLocSortedSet loadedIntervals = IntervalUtils.loadIntervals(intervals, setRule, IntervalMergingRule.ALL, padding, hg19GenomeLocParser);
+        GenomeLocSortedSet loadedIntervals = IntervalUtils.loadIntervals(intervals, setRule, IntervalMergingRule.ALL, padding, hg19GenomeLocParser, false);
         Assert.assertEquals(loadedIntervals, results);
     }
 
@@ -1276,7 +1276,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "loadIntervalsFromFeatureFileData")
     public void testLoadIntervalsFromFeatureFile( final File featureFile, final List<GenomeLoc> expectedIntervals ) {
-        final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Collections.singletonList(featureFile.getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Collections.singletonList(featureFile.getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser, false);
         Assert.assertEquals(actualIntervals, expectedIntervals, "Wrong intervals loaded from Feature file " + featureFile.getAbsolutePath());
     }
 
@@ -1286,7 +1286,7 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
             final Path jimfsRootPath = fs.getRootDirectories().iterator().next();
             final Path jimfsCopy = Files.copy(featureFile.toPath(), jimfsRootPath.resolve(featureFile.getName()));
             final String jimfsPathString = jimfsCopy.toAbsolutePath().toUri().toString();
-            final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Collections.singletonList(jimfsPathString), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+            final GenomeLocSortedSet actualIntervals = IntervalUtils.loadIntervals(Collections.singletonList(jimfsPathString), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser, false);
             Assert.assertEquals(actualIntervals, expectedIntervals, "Wrong intervals loaded from Feature file " + jimfsPathString);
         }
     }
@@ -1296,17 +1296,17 @@ public final class IntervalUtilsUnitTest extends GATKBaseTest {
     // So we'll blow up with MalformedGenomeLoc and not anything related to files
     @Test(expectedExceptions = UserException.MalformedGenomeLoc.class)
     public void testLoadIntervalsFromNonExistentFile() {
-        IntervalUtils.loadIntervals(Arrays.asList(GATKBaseTest.getSafeNonExistentFile("non_existent_file.vcf").getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(GATKBaseTest.getSafeNonExistentFile("non_existent_file.vcf").getAbsolutePath()), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser, false);
     }
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)
     public void testLoadIntervalsFromUnrecognizedFormatFile() {
-        IntervalUtils.loadIntervals(Arrays.asList(INTERVAL_TEST_DATA + "unrecognized_format_file.xyz"), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(INTERVAL_TEST_DATA + "unrecognized_format_file.xyz"), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser, false);
     }
 
     @Test(expectedExceptions = UserException.MalformedFile.class)
     public void loadIntervalsEmptyFile(){
-        IntervalUtils.loadIntervals(Arrays.asList(emptyIntervals), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser);
+        IntervalUtils.loadIntervals(Arrays.asList(emptyIntervals), IntervalSetRule.UNION, IntervalMergingRule.ALL, 0, hg19GenomeLocParser, false);
     }
 
     @Test(dataProvider = "genomeLocsFromLocatablesData",expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
Justin Rhoades of the blood biopsy team noticed a bug in the Mutect2 pipeline: if the number of scatters was sufficiently high, the last chunk of intervals did not contain any autosomal contigs, and therefore `GetPileupSummaries` was run on an empty interval for that scatter, throwing an error.  For the pipeline there is no reason not to allow this empty interval and consequent empty output because it gets merged with other output later in the pipeline.

It also seems that this is a generic feature of scattered jobs -- empty intersection of intervals need not imply a user error.  Therefore, I added an argument to `IntervalArgumentCollection` to allow empty intervals.

Since the change to the Mutect2 pipeline is tiny the primary need in code review is to judge whether the changes to `IntervalArgumentCollection` are acceptable.  @lbergelson could you look at this PR?