### PR TITLE
fix SyntaxWarning while run gatk with python3.8

### DIFF
--- a/gatk
+++ b/gatk
@@ -77,7 +77,7 @@ def main(args):
     signal.signal(signal.SIGINT, signal_handler)
 
     try:
-        if len(args) is 0 or (len(args) is 1 and (args[0] == "--help" or args[0] == "-h")):
+        if len(args) == 0 or (len(args) == 1 and (args[0] == "--help" or args[0] == "-h")):
             print("")
             print(" Usage template for all tools (uses --spark-runner LOCAL when used with a Spark tool)")
             print("    gatk AnyTool toolArgs")
@@ -114,7 +114,7 @@ def main(args):
             print("                 Java options MUST be passed inside a single string with space-separated values.")
             sys.exit(0)
 
-        if len(args) is 1 and args[0] == "--list":
+        if len(args) == 1 and args[0] == "--list":
             args[0] = "--help"  # if we're invoked with --list, invoke the GATK with --help
 
         dryRun = "--dry-run" in args
@@ -305,11 +305,11 @@ def cacheJarOnGCS(jar, dryRun):
         gcsjar = staging + name + "_"+ jarmd5 + ext
 
         try:
-            if call(["gsutil", "-q", "stat", gcsjar]) is 0:
+            if call(["gsutil", "-q", "stat", gcsjar]) == 0:
                     sys.stderr.write("\nfound cached jar: " + gcsjar + "\n")
                     return gcsjar
             else:
-                if call(["gsutil", "cp", jar, gcsjar]) is 0:
+                if call(["gsutil", "cp", jar, gcsjar]) == 0:
                     sys.stderr.write("\nuploaded " + jar + " -> " + gcsjar + "\n")
                     return gcsjar
                 else:
@@ -464,11 +464,11 @@ def convertSparkSubmitToDataprocArgs(sparkConfArgs, sparkArgs):
     except IndexError:
         raise GATKLaunchException("Found an argument: " + arg + "with no matching value.")
 
-    if not len(properties) is 0:
+    if not len(properties) == 0:
         dataprocargs.append("--properties")
         dataprocargs.append(",".join(properties))
 
-    if not len(filesToAdd) is 0:
+    if not len(filesToAdd) == 0:
         dataprocargs.append("--files")
         dataprocargs.append(",".join(filesToAdd))
 


### PR DESCRIPTION
` The warning advises users to use equality tests (== and !=) instead`

[bpo-34850](https://bugs.python.org/issue34850)