### PR TITLE
Add .java-version to gitignore to support jenv users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ funcotator_tmp
 #Eclipse files
 /bin/
 .project
+
+#JENV local file
+.java-version


### PR DESCRIPTION
Adding the jenv .java-version file to gitignore so that I'm not annoyed by seeing it in git status.