### PR TITLE
Mutect2 warns but does not fail when three or more reads have the same name

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -90,7 +90,7 @@ public class SomaticGenotypingEngine {
         if (MTAC.likelihoodArgs.phredScaledGlobalReadMismappingRate > 0) {
             logReadLikelihoods.normalizeLikelihoods(NaturalLogUtils.qualToLogErrorProb(MTAC.likelihoodArgs.phredScaledGlobalReadMismappingRate));
         }
-        final AlleleLikelihoods<Fragment, Haplotype> logFragmentLikelihoods = logReadLikelihoods.groupEvidence(MTAC.independentMates ? read -> read : GATKRead::getName, Fragment::create);
+        final AlleleLikelihoods<Fragment, Haplotype> logFragmentLikelihoods = logReadLikelihoods.groupEvidence(MTAC.independentMates ? read -> read : GATKRead::getName, Fragment::createAndAvoidFailure);
 
         for( final int loc : startPosKeySet ) {
             final List<VariantContext> eventsAtThisLoc = AssemblyBasedCallerUtils.getVariantContextsFromActiveHaplotypes(loc, haplotypes, false);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -464,8 +464,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final File bam = new File(toolsTestDir + "mutect/repeated_reads.bam");
         final File outputVcf = createTempFile("output", ".vcf");
 
-        runMutect2(bam, outputVcf, "20:10018000-10020000", b37Reference, Optional.empty(),
-                args -> args.addBooleanArgument(M2ArgumentCollection.INDEPENDENT_MATES_LONG_NAME, true));
+        runMutect2(bam, outputVcf, "20:10018000-10020000", b37Reference, Optional.empty());
     }
 
     // basic test on a small chunk of NA12878 mitochondria.  This is not a validation, but rather a sanity check


### PR DESCRIPTION
@takutosato We have seen samples with a handful of cases and I would rather not force users to run with `--independent-mates` just to avoid an error at a few sites.