### PR TITLE
Added epsilons to overdispersion in gCNV models to avoid NaNs.

### DIFF
--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
@@ -362,7 +362,7 @@ def _get_std_tsv_filename(path: str, var_name: str):
 def _get_singleton_slice_along_axis(array: np.ndarray, axis: int, index: int):
     slc = [slice(None)] * array.ndim
     slc[axis] = index
-    return slc
+    return tuple(slc)
 
 
 def write_mean_field_sample_specific_params(sample_index: int,
@@ -391,8 +391,8 @@ def write_mean_field_sample_specific_params(sample_index: int,
                                                 "variables to disk".format(var_name)
         mu_all = approx_mu_map[var_name]
         std_all = approx_std_map[var_name]
-        mu_slice = mu_all[_get_singleton_slice_along_axis(mu_all, var_sample_axis, sample_index)]
-        std_slice = std_all[_get_singleton_slice_along_axis(mu_all, var_sample_axis, sample_index)]
+        mu_slice = np.atleast_1d(mu_all[_get_singleton_slice_along_axis(mu_all, var_sample_axis, sample_index)])
+        std_slice = np.atleast_1d(std_all[_get_singleton_slice_along_axis(mu_all, var_sample_axis, sample_index)])
 
         mu_out_file_name = _get_mu_tsv_filename(sample_posterior_path, var_name)
         write_ndarray_to_tsv(mu_out_file_name, mu_slice, extra_comment_lines=extra_comment_lines)

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
@@ -12,6 +12,9 @@ _log_2_pi = 1.837877066409345  # np.log(2 * np.pi)
 _10_inv_log_10 = 4.342944819032518  # 10 / np.log(10)
 
 
+eps = 1E-10
+
+
 def get_normalized_prob_vector(prob_vector: np.ndarray, prob_sum_tol: float) -> np.ndarray:
     """Normalizes the probability vector of a categorical RV to unity.
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
@@ -914,14 +914,14 @@ class HHMMClassAndCopyNumberBasicCaller:
     """This class updates copy number and interval class posteriors according to the following hierarchical
     hidden Markov model:
 
-        class_prior_k --► (tau_1) --► (tau_2) --► (tau_3) --► ...
+        class_prior_k --> (tau_1) --> (tau_2) --> (tau_3) --> ...
                              |           |           |
                              |           |           |
-                             ▼           ▼           ▼
-                           (c_s1) --►  (c_s2) --►  (c_s3) --► ...
+                             v           v           v
+                           (c_s1) -->  (c_s2) -->  (c_s3) --> ...
                              |           |           |
                              |           |           |
-                             ▼           ▼           ▼
+                             v           v           v
                             n_s1        n_s2        n_s3
 
         The posterior probability of `tau` and `c_s`, q(tau) and q(c_s) respectively, are obtained via

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
@@ -25,7 +25,7 @@ from ..tasks.inference_task_base import HybridInferenceParameters
 
 _logger = logging.getLogger(__name__)
 
-_eps = 1E-10
+_eps = commons.eps
 
 
 class DenoisingModelConfig:

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
@@ -12,13 +12,12 @@ from pymc3 import Normal, Deterministic, DensityDist, Bound, Exponential
 from . import commons
 from .fancy_model import GeneralizedContinuousModel
 from .. import config, types
-from ..structs.interval import Interval
 from ..structs.metadata import IntervalListMetadata, SampleMetadataCollection
 from ..tasks.inference_task_base import HybridInferenceParameters
 
 _logger = logging.getLogger(__name__)
 
-_eps = 1E-10
+_eps = commons.eps
 
 
 class PloidyModelConfig:

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
@@ -18,6 +18,8 @@ from ..tasks.inference_task_base import HybridInferenceParameters
 
 _logger = logging.getLogger(__name__)
 
+_eps = 1E-10
+
 
 class PloidyModelConfig:
     """Germline contig ploidy model hyper-parameters."""
@@ -208,7 +210,7 @@ class PloidyModel(GeneralizedContinuousModel):
         n_sj = ploidy_workspace.n_sj
         ploidy_k = ploidy_workspace.int_ploidy_values_k
         q_ploidy_sjk = tt.exp(ploidy_workspace.log_q_ploidy_sjk)
-        eps = ploidy_config.mapping_error_rate
+        eps_mapping = ploidy_config.mapping_error_rate
 
         register_as_global = self.register_as_global
         register_as_sample_specific = self.register_as_sample_specific
@@ -233,7 +235,8 @@ class PloidyModel(GeneralizedContinuousModel):
         register_as_sample_specific(psi_s, sample_axis=0)
 
         # convert "unexplained variance" to negative binomial over-dispersion
-        alpha_sj = tt.inv((tt.exp(psi_j.dimshuffle('x', 0) + psi_s.dimshuffle(0, 'x')) - 1.0))
+        alpha_sj = tt.maximum(tt.inv((tt.exp(psi_j.dimshuffle('x', 0) + psi_s.dimshuffle(0, 'x')) - 1.0)),
+                              _eps)
 
         # mean ploidy per contig per sample
         mean_ploidy_sj = tt.sum(tt.exp(ploidy_workspace.log_q_ploidy_sjk)
@@ -249,9 +252,9 @@ class PloidyModel(GeneralizedContinuousModel):
         mu_num_sjk = (t_j.dimshuffle('x', 0, 'x') * mean_bias_j.dimshuffle('x', 0, 'x')
                       * ploidy_k.dimshuffle('x', 'x', 0))
         mu_den_sjk = gamma_rest_sj.dimshuffle(0, 1, 'x') + mu_num_sjk
-        eps_j = eps * t_j / tt.sum(t_j)  # average number of reads erroneously mapped to contig j
-        mu_sjk = ((1.0 - eps) * (mu_num_sjk / mu_den_sjk)
-                  + eps_j.dimshuffle('x', 0, 'x')) * n_s.dimshuffle(0, 'x', 'x')
+        eps_mapping_j = eps_mapping * t_j / tt.sum(t_j)  # average number of reads erroneously mapped to contig j
+        mu_sjk = ((1.0 - eps_mapping) * (mu_num_sjk / mu_den_sjk)
+                  + eps_mapping_j.dimshuffle('x', 0, 'x')) * n_s.dimshuffle(0, 'x', 'x')
 
         def _get_logp_sjk(_n_sj):
             _logp_sjk = commons.negative_binomial_logp(

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
@@ -139,7 +139,7 @@ class HybridInferenceTask(InferenceTask):
     """The hybrid inference framework is applicable to PGMs with the following general structure:
 
         +--------------+           +----------------+
-        | discrete RVs + --------► + continuous RVs |
+        | discrete RVs + --------> + continuous RVs |
         +--------------+           +----------------+
 
     Note that discrete RVs do not have any continuous parents. The inference is approximately

--- a/src/main/python/org/broadinstitute/hellbender/setup_gcnvkernel.py
+++ b/src/main/python/org/broadinstitute/hellbender/setup_gcnvkernel.py
@@ -32,7 +32,7 @@ setup(
     description='GATK gCNV computational kernel',
     long_description=open('gcnvkernel/README.txt').read(),
     install_requires=[
-        "theano == 0.9.0",
+        "theano == 1.0.4",
         "pymc3 == 3.1",
         "numpy >= 1.13.1",
         "scipy >= 0.19.1",

--- a/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-contig-ploidy-model.tar.gz
+++ b/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-contig-ploidy-model.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e05448d2e06c020c9468016127e6d06213c700451566b4f32677532adf81ef24
-size 1214
+oid sha256:a667caea27776a91ae612f57769fd79fde2850fe7d98ce9903c787bccbad1a1e
+size 1221

--- a/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-gcnv-model-0.tar.gz
+++ b/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-gcnv-model-0.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1b81fdb5b6a3ecb0610fad0019a9c7b4f47d8f31dac91d70c6ca4b6deb280ea
-size 5007
+oid sha256:dcad7edb5752c9012f3d69b932c09bf6c9b552e3785a8b1c1256aa65ecb38de0
+size 4995

--- a/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-gcnv-model-1.tar.gz
+++ b/src/test/resources/large/cnv_germline_workflows_test_files/wes-do-gc-gcnv-model-1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c2df0059fb62336a2fd88290ae09bd1bbf2fa03fffc88fc40703a51f3acf9a9
-size 5153
+oid sha256:74fdf99dbcc233878045812ebc891ce2923f08a9ab87daec1fa483b8afdb02ea
+size 5164


### PR DESCRIPTION
Closes #4824 (at least for underflow of overdispersion)
Closes #6226 
Closes #6227

Along with some other minor fixes.

I've done some manual testing and this change is most likely harmless, but ideally we'd have some better automated testing to cover this sort of minor model change...  Extremely conscientious users might want to rebuild models just to be safe, which we can mention in the release notes.