### PR TITLE
update htsjdk to 2.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.20.3-9-g03e9a32-SNAPSHOT')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.21.0')
 final picardVersion = System.getProperty('picard.version','2.21.1')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.3')

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.20.3')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.20.3-9-g03e9a32-SNAPSHOT')
 final picardVersion = System.getProperty('picard.version','2.21.1')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.3')

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.exceptions;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.ValidateVariants;
@@ -12,6 +13,7 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * <p/>
@@ -339,12 +341,6 @@ public class UserException extends RuntimeException {
         }
     }
 
-    /**
-     * <p/>
-     * Class UserException.MalformedFile
-     * <p/>
-     * For errors parsing files
-     */
     public static class IncompatibleSequenceDictionaries extends UserException {
         private static final long serialVersionUID = 0L;
 
@@ -370,6 +366,20 @@ public class UserException extends RuntimeException {
                             + "\nYou can use the ReorderSam utility to fix this problem: " + HelpConstants.forumPost("discussion/58/companion-utilities-reordersam")
                             + "\n  %s contigs = %s",
                     name, name, ReadUtils.prettyPrintSequenceRecords(dict)));
+        }
+    }
+
+    public static class SequenceDictionaryIsMissingContigLengths extends UserException {
+        private static final long serialVersionUID = 0L;
+
+        public SequenceDictionaryIsMissingContigLengths(String source, SAMSequenceDictionary dict){
+            super("GATK SequenceDictionaryValidation requires all contigs in the dictionary to have lengths associated with them.  " +
+                    "\nOne or more contigs in the dictionary from " + source + " are missing contig lengths." +
+                    "\nThe following contigs are missing lengths: " +
+                    dict.getSequences().stream()
+                            .filter( s -> s.getSequenceLength() == SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH)
+                            .map(SAMSequenceRecord::getSequenceName)
+                            .collect(Collectors.joining(",")));
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -379,6 +379,7 @@ public class UserException extends RuntimeException {
                     dict.getSequences().stream()
                             .filter( s -> s.getSequenceLength() == SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH)
                             .map(SAMSequenceRecord::getSequenceName)
+                            .limit(20)
                             .collect(Collectors.joining(",")));
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionary.java
@@ -211,7 +211,7 @@ public final class UpdateVCFSequenceDictionary extends VariantWalker {
             if (resultDictionary == null || resultDictionary.getSequences().isEmpty()) {
                 throw new CommandLineException.BadArgumentValue(
                     String.format(
-                        "The specified dictionary source has an empty or invalid sequence dictionary: %S",
+                        "The specified dictionary source has an empty or invalid sequence dictionary: %s",
                         dictionarySource)
                 );
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/UpdateVCFSequenceDictionaryIntegrationTest.java
@@ -8,6 +8,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 
 import org.testng.Assert;
@@ -45,7 +46,7 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
     }
 
     @Test(dataProvider="UpdateGoodSequenceDictionaryData")
-    private void testGoodUpdateSequenceDictionary(
+    public void testGoodUpdateSequenceDictionary(
             final File inputVariantsFile,
             final File inputSourceFile,
             final File inputReferenceFile,
@@ -88,7 +89,7 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
     }
 
     @Test(dataProvider="UpdateBadSequenceDictionaryData", expectedExceptions= CommandLineException.BadArgumentValue.class)
-    private void testBadUpdateSequenceDictionary(
+    public void testBadUpdateSequenceDictionary(
             final File inputVariantsFile,
             final File inputSourceFile,
             final File inputReferenceFile,
@@ -118,15 +119,15 @@ public class UpdateVCFSequenceDictionaryIntegrationTest extends CommandLineProgr
     }
 
 
-    @Test(expectedExceptions= TribbleException.class)
+    @Test(expectedExceptions = UserException.SequenceDictionaryIsMissingContigLengths.class)
     public void testBadContigLengthWithValidation() {
         // throw an error if trying to force a replace with an invalid sequence dictionary without disabling sequence validation
         updateSequenceDictionary(
+                new File(testDir, "variantsWithDict.vcf"),
                 new File(testDir, "variantsWithDictBadContigLength.vcf"),
-                new File(testDir, "exampleFASTA.dict"),
                 null,
                 null,
-                false,
+                true,
                 false);
     }
 


### PR DESCRIPTION
Upgrading htsjdk to 2.21.0.  

This includes a change that relaxes restrictions on loading vcfs with sequence dictionaries that are missing lengths.  This effected one of the tests which I changed a bit.  We could also implement blanket ban on sequence dictionaries with missing lengths in our sequence dictionary validation code, but we currently allow them for sam/bam as far as I can tell and have tests that take them into account.  