### PR TITLE
Fix to Allele Fraction annotation bug

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
@@ -49,20 +49,17 @@ public final class AlleleFraction extends GenotypeAnnotation {
         if ( g == null || !g.isCalled() || g.hasExtendedAttribute(getKeyNames().get(0))) {  //don't overwrite AF based on Bayesian estimate if it already exists
             return;
         }
-
-        for ( final Genotype genotype : genotypes ) {
-           if ( genotype.hasAD() ) {
-                final int[] AD = genotype.getAD();
-                final double[] allAlleleFractions = MathUtils.normalizeSumToOne(Arrays.stream(AD).mapToDouble(x -> x).toArray());
-                gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
-            }
-            // if there is no AD value calculate it now using likelihoods
-            else if (likelihoods != null) {
-                DepthPerAlleleBySample adCalc = new DepthPerAlleleBySample();
-                final int[] AD = adCalc.annotateWithLikelihoods(vc, g, new LinkedHashSet<>(vc.getAlleles()), likelihoods);
-                final double[] allAlleleFractions = MathUtils.normalizeSumToOne(Arrays.stream(AD).mapToDouble(x -> x*1.0).toArray());
-                gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
-            }
+       if ( g.hasAD() ) {
+            final int[] AD = g.getAD();
+            final double[] allAlleleFractions = MathUtils.normalizeFromRealSpace(Arrays.stream(AD).mapToDouble(x -> x).toArray());
+            gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
+        }
+        // if there is no AD value calculate it now using likelihoods
+        else if (likelihoods != null) {
+            DepthPerAlleleBySample adCalc = new DepthPerAlleleBySample();
+            final int[] AD = adCalc.annotateWithLikelihoods(vc, g, new LinkedHashSet<>(vc.getAlleles()), likelihoods);
+            final double[] allAlleleFractions = MathUtils.normalizeFromRealSpace(Arrays.stream(AD).mapToDouble(x -> x*1.0).toArray());
+            gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
@@ -51,14 +51,14 @@ public final class AlleleFraction extends GenotypeAnnotation {
         }
        if ( g.hasAD() ) {
             final int[] AD = g.getAD();
-            final double[] allAlleleFractions = MathUtils.normalizeFromRealSpace(Arrays.stream(AD).mapToDouble(x -> x).toArray());
+            final double[] allAlleleFractions = MathUtils.normalizeSumToOne(Arrays.stream(AD).mapToDouble(x -> x).toArray());
             gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
         }
         // if there is no AD value calculate it now using likelihoods
         else if (likelihoods != null) {
             DepthPerAlleleBySample adCalc = new DepthPerAlleleBySample();
             final int[] AD = adCalc.annotateWithLikelihoods(vc, g, new LinkedHashSet<>(vc.getAlleles()), likelihoods);
-            final double[] allAlleleFractions = MathUtils.normalizeFromRealSpace(Arrays.stream(AD).mapToDouble(x -> x*1.0).toArray());
+            final double[] allAlleleFractions = MathUtils.normalizeSumToOne(Arrays.stream(AD).mapToDouble(x -> x*1.0).toArray());
             gb.attribute(getKeyNames().get(0), Arrays.copyOfRange(allAlleleFractions, 1, allAlleleFractions.length)); //omit the first entry of the array corresponding to the reference
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFractionGenotypeAnnotationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFractionGenotypeAnnotationUnitTest.java
@@ -7,10 +7,10 @@ import htsjdk.variant.variantcontext.GenotypeBuilder;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedAlleleList;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
 import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
-import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
@@ -88,11 +88,11 @@ public class AlleleFractionGenotypeAnnotationUnitTest extends GATKBaseTest {
 
         final Map<String, List<GATKRead>> readsBySample = ImmutableMap.of("1", sample1Reads, "2", sample2Reads);
         final IndexedSampleList sampleList = new IndexedSampleList(Arrays.asList("1", "2"));
-        final ReadLikelihoods<Allele> readLikelihoods = new ReadLikelihoods<Allele>(sampleList, new IndexedAlleleList<>(AC), readsBySample);
+        final AlleleLikelihoods<GATKRead, Allele> alleleLikelihoods = new AlleleLikelihoods<GATKRead, Allele>(sampleList, new IndexedAlleleList<>(AC), readsBySample);
 
         //setup likelihood matrix
-        final LikelihoodMatrix<Allele> matrix1 = readLikelihoods.sampleMatrix(0);
-        final LikelihoodMatrix<Allele> matrix2 = readLikelihoods.sampleMatrix(1);
+        final LikelihoodMatrix<GATKRead, Allele> matrix1 = alleleLikelihoods.sampleMatrix(0);
+        final LikelihoodMatrix<GATKRead, Allele> matrix2 = alleleLikelihoods.sampleMatrix(1);
         final double MATCH_LIKELIHOOD = -1.0;
         final double MISMATCH_LIKELIHOOD = -100.0;
         for (int i=0; i<nRef+nAlt; i++) {
@@ -104,16 +104,16 @@ public class AlleleFractionGenotypeAnnotationUnitTest extends GATKBaseTest {
         }
 
         return new Object[][] {
-                {vc, gAC, readLikelihoods, new double[]{(double)nAlt/(double)(nAlt + nRef)}},
-                {vc, gAA, readLikelihoods, new double[]{0.0}},
+                {vc, gAC, alleleLikelihoods, new double[]{(double)nAlt/(double)(nAlt + nRef)}},
+                {vc, gAA, alleleLikelihoods, new double[]{0.0}},
         };
     }
 
     @Test(dataProvider = "testUsingReadsDataProvider")
-    public void testUsingRead(final VariantContext vc, final Genotype g, final ReadLikelihoods<Allele> readLikelihoods, final double[] expectedAF) {
+    public void testUsingRead(final VariantContext vc, final Genotype g, final AlleleLikelihoods<GATKRead, Allele> alleleLikelihoods, final double[] expectedAF) {
         final GenotypeBuilder gb = new GenotypeBuilder();
 
-        new AlleleFraction().annotate(null, vc, g, gb, readLikelihoods);
+        new AlleleFraction().annotate(null, vc, g, gb, alleleLikelihoods);
 
 
         double[] af = (double[])gb.make().getAnyAttribute(GATKVCFConstants.ALLELE_FRACTION_KEY);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFractionGenotypeAnnotationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFractionGenotypeAnnotationUnitTest.java
@@ -1,0 +1,122 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator;
+
+import com.google.common.collect.ImmutableMap;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.genotyper.IndexedAlleleList;
+import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
+import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
+import org.broadinstitute.hellbender.utils.genotyper.ReadLikelihoods;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class AlleleFractionGenotypeAnnotationUnitTest extends GATKBaseTest {
+
+    @DataProvider(name = "testUsingADDataProvider")
+    public Object[][] testUsingADDataProvider() {
+        final Allele A = Allele.create("A", true);
+        final Allele C = Allele.create("C");
+
+        final List<Allele> AA = Arrays.asList(A, A);
+        final List<Allele> AC = Arrays.asList(A, C);
+
+        final Genotype gAC = new GenotypeBuilder("1", AC).AD(new int[]{5,5}).make();
+        final Genotype gAA = new GenotypeBuilder("2", AA).AD(new int[]{10,0}).make();
+
+        final VariantContext vc = new VariantContextBuilder("test", "20", 10, 10, AC).genotypes(Arrays.asList(gAA, gAC)).make();
+
+        return new Object[][] {
+                {vc, gAC, new double[]{0.5}},
+                {vc, gAA, new double[]{0.0}}
+            };
+    }
+
+    @Test(dataProvider = "testUsingADDataProvider")
+    public void testUsingAD(final VariantContext vc, final Genotype g, final double[] expectedAF) {
+        final GenotypeBuilder gb = new GenotypeBuilder();
+
+        new AlleleFraction().annotate(null, vc, g, gb, null);
+
+
+        double[] af = (double[])gb.make().getAnyAttribute(GATKVCFConstants.ALLELE_FRACTION_KEY);
+        Assert.assertEquals(af, expectedAF);
+    }
+
+    @DataProvider(name = "testUsingReadsDataProvider")
+    public Object[][] testUsingReadsDataProvider() {
+        final Allele A = Allele.create("A", true);
+        final Allele C = Allele.create("C");
+
+        final List<Allele> AA = Arrays.asList(A, A);
+        final List<Allele> AC = Arrays.asList(A, C);
+
+        final Genotype gAC = new GenotypeBuilder("1", AC).make();
+        final Genotype gAA = new GenotypeBuilder("2", AA).make();
+
+        final VariantContext vc = new VariantContextBuilder("test", "20", 10, 10, AC).genotypes(Arrays.asList(gAA, gAC)).make();
+
+        final byte[] qual = new byte[]{30,30,30,30};
+        final String refBases = "AAAA";
+        final String altBases = "AACA";
+
+        final GATKRead refRead = ArtificialReadUtils.createArtificialRead(refBases.getBytes(), qual, "4M");
+        final GATKRead altRead = ArtificialReadUtils.createArtificialRead(altBases.getBytes(), qual, "4M");
+
+        final int nRef=7;
+        final int nAlt=3;
+
+        final List<GATKRead> sample1Reads = new ArrayList<>(Collections.nCopies(nRef, refRead));
+        sample1Reads.addAll(Collections.nCopies(nAlt, altRead));
+
+        final List<GATKRead> sample2Reads = Collections.nCopies(nRef + nAlt, refRead);
+
+        final Map<String, List<GATKRead>> readsBySample = ImmutableMap.of("1", sample1Reads, "2", sample2Reads);
+        final IndexedSampleList sampleList = new IndexedSampleList(Arrays.asList("1", "2"));
+        final ReadLikelihoods<Allele> readLikelihoods = new ReadLikelihoods<Allele>(sampleList, new IndexedAlleleList<>(AC), readsBySample);
+
+        //setup likelihood matrix
+        final LikelihoodMatrix<Allele> matrix1 = readLikelihoods.sampleMatrix(0);
+        final LikelihoodMatrix<Allele> matrix2 = readLikelihoods.sampleMatrix(1);
+        final double MATCH_LIKELIHOOD = -1.0;
+        final double MISMATCH_LIKELIHOOD = -100.0;
+        for (int i=0; i<nRef+nAlt; i++) {
+            matrix1.set(0, i,i<nRef? MATCH_LIKELIHOOD : MISMATCH_LIKELIHOOD);
+            matrix1.set(1, i, i<nRef? MISMATCH_LIKELIHOOD : MATCH_LIKELIHOOD);
+
+            matrix2.set(0, i, MATCH_LIKELIHOOD);
+            matrix2.set(1, i, MISMATCH_LIKELIHOOD);
+        }
+
+        return new Object[][] {
+                {vc, gAC, readLikelihoods, new double[]{(double)nAlt/(double)(nAlt + nRef)}},
+                {vc, gAA, readLikelihoods, new double[]{0.0}},
+        };
+    }
+
+    @Test(dataProvider = "testUsingReadsDataProvider")
+    public void testUsingRead(final VariantContext vc, final Genotype g, final ReadLikelihoods<Allele> readLikelihoods, final double[] expectedAF) {
+        final GenotypeBuilder gb = new GenotypeBuilder();
+
+        new AlleleFraction().annotate(null, vc, g, gb, readLikelihoods);
+
+
+        double[] af = (double[])gb.make().getAnyAttribute(GATKVCFConstants.ALLELE_FRACTION_KEY);
+        Assert.assertEquals(af, expectedAF);
+    }
+}


### PR DESCRIPTION
Fixes bug in AlleleFraction annotator when run on multisample vcf.  In this situation, the AFs calculated for the final (right-most) sample in the vcf are used for all samples, instead of correctly putting the AFs associated with each sample in that sample's genotype annotations.  

Bug came from user on forum: https://gatkforums.broadinstitute.org/gatk/discussion/24579/plz-check-my-result-from-variantannotator/p1