### PR TITLE
Update disq to 0.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ final barclayVersion = System.getProperty('barclay.version','2.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.3')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
-final disqVersion = System.getProperty('disq.version','0.3.3')
+final disqVersion = System.getProperty('disq.version','0.3.4')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','1.1.2.2')
 final testNGVersion = '6.11'
 // Using the shaded version to avoid conflicts between its protobuf dependency


### PR DESCRIPTION
* Upating disq 0.3.3 -> 0.3.4
* This release makes use of new features in htsjdk 2.21.0 which were previously part of disq itself.