### PR TITLE
Fix some typos in the allele subsetting code

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleSubsettingUtils.java
@@ -141,7 +141,6 @@ public final class AlleleSubsettingUtils {
             Set<String> keys = g.getExtendedAttributes().keySet();
             for (final String key : keys) {
                 final VCFFormatHeaderLine headerLine = outputHeader.getFormatHeaderLine(key);
-                final int nonRefIndex = allelesToKeep.contains(Allele.NON_REF_ALLELE) ? allelesToKeep.indexOf(Allele.NON_REF_ALLELE) : -1;
                 gb.attribute(key, ReferenceConfidenceVariantContextMerger.generateAnnotationValueVector(headerLine.getCountType(),
                             GATKProtectedVariantContextUtils.attributeToList(g.getAnyAttribute(key)), relevantIndices));
             }
@@ -155,7 +154,7 @@ public final class AlleleSubsettingUtils {
      *
      * @param vc                    original variant context
      * @param builder               variant context builder with subset of original variant context's alleles
-     * @param keepOriginalChrCounts keep the orignal chromosome counts before subsetting
+     * @param keepOriginalChrCounts keep the original chromosome counts before subsetting
      * @return variant context builder with updated INFO field attribute values
      */
     public static void addInfoFieldAnnotations(final VariantContext vc, final VariantContextBuilder builder,
@@ -171,14 +170,14 @@ public final class AlleleSubsettingUtils {
         // don't have to subset, the original vc has the same number and hence, the same alleles
         boolean keepOriginal = (vc.getAlleles().size() == alleles.size());
 
-        List<Integer> alleleIndecies = builder.getAlleles().stream().map(a -> vc.getAlleleIndex(a)).collect(Collectors.toList());
+        List<Integer> alleleIndices = builder.getAlleles().stream().map(vc::getAlleleIndex).collect(Collectors.toList());
         if (keepOriginalChrCounts) {
             if (vc.hasAttribute(VCFConstants.ALLELE_COUNT_KEY))
                 builder.attribute(GATKVCFConstants.ORIGINAL_AC_KEY, keepOriginal ?
-                        vc.getAttribute(VCFConstants.ALLELE_COUNT_KEY) : alleleIndecies.stream().filter(i -> i > 0).map(j -> vc.getAttributeAsList(VCFConstants.ALLELE_COUNT_KEY).get(j - 1)).collect(Collectors.toList()).get(0));
+                        vc.getAttribute(VCFConstants.ALLELE_COUNT_KEY) : alleleIndices.stream().filter(i -> i > 0).map(j -> vc.getAttributeAsList(VCFConstants.ALLELE_COUNT_KEY).get(j - 1)).collect(Collectors.toList()).get(0));
             if (vc.hasAttribute(VCFConstants.ALLELE_FREQUENCY_KEY))
                 builder.attribute(GATKVCFConstants.ORIGINAL_AF_KEY, keepOriginal ?
-                        vc.getAttribute(VCFConstants.ALLELE_FREQUENCY_KEY) : alleleIndecies.stream().filter(i -> i > 0).map(j -> vc.getAttributeAsList(VCFConstants.ALLELE_FREQUENCY_KEY).get(j - 1)).collect(Collectors.toList()).get(0));
+                        vc.getAttribute(VCFConstants.ALLELE_FREQUENCY_KEY) : alleleIndices.stream().filter(i -> i > 0).map(j -> vc.getAttributeAsList(VCFConstants.ALLELE_FREQUENCY_KEY).get(j - 1)).collect(Collectors.toList()).get(0));
             if (vc.hasAttribute(VCFConstants.ALLELE_NUMBER_KEY)) {
                 builder.attribute(GATKVCFConstants.ORIGINAL_AN_KEY, vc.getAttribute(VCFConstants.ALLELE_NUMBER_KEY));
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/IndexedSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/IndexedSet.java
@@ -243,7 +243,7 @@ public final class IndexedSet<E> extends AbstractSet<E> {
      *
      * @throws IllegalArgumentException if {@code other} is {@code null}.
      *
-     * @return {@code true} iff {@other} is not {@code null}, and contains exactly the same elements
+     * @return {@code true} iff {@code other} is not {@code null}, and contains exactly the same elements
      * (as compared using {@link Object#equals} a this set with matching indices.
      */
     public boolean equals(final IndexedSet<?> other) {
@@ -296,7 +296,7 @@ public final class IndexedSet<E> extends AbstractSet<E> {
      */
     public int indexOf(final Object o) {
         Utils.nonNull(o, "the query object cannot be null");
-        return indexByElement.containsKey(o) ? indexByElement.get(o) : -1;
+        return indexByElement.getOrDefault(o, -1);
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/Permutation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/Permutation.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.utils.collections;
 import java.util.List;
 
 /**
- * Represent a permutation of a ordered set or list of elements.
+ * Represent a permutation of an ordered set or list of elements.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleList.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 //Note: Names in this interface are unusual because of name clash in a subclass.
 // For example the name of AlleleList.alleleCount() cannot be simply size(), as would be usual,
-// because {@link ReadLikelohoods} implements AlleleList and SampleList and then size() would be ambiguous.
+// because {@link ReadLikelihoods} implements AlleleList and SampleList and then size() would be ambiguous.
 public interface AlleleList<A extends Allele>{
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleList.java
@@ -7,7 +7,7 @@ import org.broadinstitute.hellbender.utils.collections.IndexedSet;
 import java.util.Collection;
 
 /**
- * Allele list implementation using and indexed-set.
+ * Allele list implementation using an indexed-set.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */


### PR DESCRIPTION
I fixed some typos/intellij warnings in the AlleleSubsettingUtils and related files.