### PR TITLE
 Fixed a bug in hardClipCigar function that caused incorrect cigar calculation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
@@ -628,7 +628,7 @@ public final class ClippingOp {
      * @param oldCigar original cigar
      * @param newCigar new cigar (with hard/soft clipping)
      * @return int the offset (from 0 between the alignment start on the old and on the new cigar)
-    */
+     */
     private int calculateAlignmentStartShift(final Cigar oldCigar, final Cigar newCigar) {
         final int newShift = calcHardSoftOffset(newCigar);
         final int oldShift = calcHardSoftOffset(oldCigar);
@@ -637,8 +637,9 @@ public final class ClippingOp {
 
     /**
      * Calculates how much the alignment should be shifted when hard/soft clipping is applied
-    * to the cigar
-     * @param oldCigar the original CIGAR
+     * to the cigar
+     *
+     * @param oldCigar            the original CIGAR
      * @param newReadBasesClipped - number of bases of the read clipped
      * @return int - the offset between the alignment starts in the oldCigar and in
      * the cigar after applying clipping
@@ -649,12 +650,15 @@ public final class ClippingOp {
         int refBasesClipped = 0; // A measure of the reference offset between the oldCigar and the clippedCigar
 
         boolean finalElement = false;
+
         for (final CigarElement e : oldCigar.getCigarElements()) {
 
             int curRefLength = e.getLength();
             int curReadLength = e.getOperator().consumesReadBases() ? e.getLength() : 0;
 
             // needed only if the clipping ended on N or D
+            // TODO: unclear if a single pass is enough to deal with BOTH and N and a D after the clipping...
+
             if (finalElement) {
                 if (!e.getOperator().consumesReadBases() && e.getOperator().consumesReferenceBases()) {
                     refBasesClipped += curRefLength;
@@ -662,13 +666,10 @@ public final class ClippingOp {
                 break;
             }
 
-            final boolean truncated;
-            if (readBasesClipped + curReadLength > newReadBasesClipped) {
+            final boolean truncated = readBasesClipped + curReadLength > newReadBasesClipped;
+            if (truncated) {
                 curReadLength = newReadBasesClipped - readBasesClipped;
                 curRefLength = curReadLength;
-                truncated = true;
-            } else {
-                truncated= false;
             }
 
             if (!e.getOperator().consumesReferenceBases()) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ClippingOp.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Nucleotide;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
@@ -133,7 +134,7 @@ public final class ClippingOp {
 
     private void applyWriteNs(final GATKRead readCopied) {
         final byte[] newBases = readCopied.getBases();       //this makes a copy so we can modify in place
-        overwriteFromStartToStop(newBases, (byte) 'N');
+        overwriteFromStartToStop(newBases, Nucleotide.N.encodeAsByte());
         readCopied.setBases(newBases);
     }
 
@@ -440,9 +441,9 @@ public final class ClippingOp {
                 // we're still clipping or just finished perfectly
                 if (index + shift == stop + 1) {
                     newCigar.add(new CigarElement(totalHardClipCount, CigarOperator.HARD_CLIP));
-                }
+
                 // element goes beyond what we need to clip
-                else if (index + shift > stop + 1) {
+                } else if (index + shift > stop + 1) {
                     final int elementLengthAfterChopping = cigarElement.getLength() - (stop - index + 1);
                     newCigar.add(new CigarElement(totalHardClipCount, CigarOperator.HARD_CLIP));
                     newCigar.add(new CigarElement(elementLengthAfterChopping, cigarElement.getOperator()));

--- a/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/clipping/ReadClipper.java
@@ -502,6 +502,7 @@ public class ReadClipper {
             throw new GATKException(String.format("Trying to clip the middle of the read: start %d, stop %d, cigar: %s", start, stop, read.getCigar().toString()));
         }
         this.addOp(new ClippingOp(start, stop));
+
         final GATKRead clippedRead = clipRead(clippingOp, runAsserts);
         this.ops = null;
         return clippedRead;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -446,7 +446,7 @@ public final class ArtificialReadUtils {
 
     public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar, final String name) {
         final int length = cigar.getReadLength();
-        final Random random = new Random(TestUtil.RANDOM_SEED);
+        final Random random = Utils.getRandomGenerator();
         final byte qual = 30;
         final byte [] bases = SequenceUtil.getRandomBases(random, length);
         final byte [] quals = Utils.dupBytes(qual, length);

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.SequenceUtil;
-import htsjdk.samtools.util.TestUtil;
 import htsjdk.variant.variantcontext.Allele;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.hellbender.exceptions.GATKException;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -445,9 +445,9 @@ public final class ArtificialReadUtils {
 
     public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar, final String name) {
         final int length = cigar.getReadLength();
-        final Random random = Utils.getRandomGenerator();
+        final byte base = 'A';
         final byte qual = 30;
-        final byte [] bases = SequenceUtil.getRandomBases(random, length);
+        final byte [] bases = Utils.dupBytes(base, length);
         final byte [] quals = Utils.dupBytes(qual, length);
         return createArtificialSAMRecord(header, name, 0, 10000, bases, quals, cigar.toString());
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialReadUtils.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
+import htsjdk.samtools.util.SequenceUtil;
+import htsjdk.samtools.util.TestUtil;
 import htsjdk.variant.variantcontext.Allele;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -438,16 +440,16 @@ public final class ArtificialReadUtils {
     }
 
     public static SAMRecord createArtificialSAMRecord(final byte[] bases, final byte[] qual, final String cigar) {
-        SAMFileHeader header = createArtificialSamHeader();
+        final SAMFileHeader header = createArtificialSamHeader();
         return createArtificialSAMRecord(header, "default_read", 0, 10000, bases, qual, cigar);
     }
 
     public static SAMRecord createArtificialSAMRecord(final SAMFileHeader header, final Cigar cigar, final String name) {
-        int length = cigar.getReadLength();
-        byte base = 'A';
-        byte qual = 30;
-        byte [] bases = Utils.dupBytes(base, length);
-        byte [] quals = Utils.dupBytes(qual, length);
+        final int length = cigar.getReadLength();
+        final Random random = new Random(TestUtil.RANDOM_SEED);
+        final byte qual = 30;
+        final byte [] bases = SequenceUtil.getRandomBases(random, length);
+        final byte [] quals = Utils.dupBytes(qual, length);
         return createArtificialSAMRecord(header, name, 0, 10000, bases, quals, cigar.toString());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ClippingOpUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ClippingOpUnitTest.java
@@ -50,7 +50,11 @@ public final class ClippingOpUnitTest extends GATKBaseTest {
                 {"10H60M", "10H50M10S", 0},
                 {"10H10S50M", "10H20S40M", 10},
                 {"10X60M", "20S50M", 20},
-                {"10I40N20M","10S20M",40}
+                {"10I40N20M","10S20M",40},
+
+                {"5M5D5M","5S5M",10},
+                {"5M5D5N5M","5S5M",15},
+                {"5M5D5M","6S4M",11}
         };
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ClippingOpUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ClippingOpUnitTest.java
@@ -54,7 +54,10 @@ public final class ClippingOpUnitTest extends GATKBaseTest {
 
                 {"5M5D5M","5S5M",10},
                 {"5M5D5N5M","5S5M",15},
-                {"5M5D5M","6S4M",11}
+                {"5M5D5M","6S4M",11},
+
+                {"5M5D5S5H","15S5H",10},
+
         };
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -1,43 +1,52 @@
 package org.broadinstitute.hellbender.utils.clipping;
 
-import htsjdk.samtools.*;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.TextCigarCodec;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.testutils.ReadClipperTestUtils;
 import org.broadinstitute.hellbender.utils.BaseUtils;
 import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.testutils.ReadClipperTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.broadinstitute.hellbender.utils.read.ReadUtils.getSoftEnd;
 import static org.broadinstitute.hellbender.utils.read.ReadUtils.getSoftStart;
 
 public final class ReadClipperUnitTest extends GATKBaseTest {
     private List<Cigar> cigarList;
-    private final int maximumCigarElements = 9;                                                                                           // 6 is the minimum necessary number to try all combinations of cigar types with guarantee of clipping an element with length = 2
+    // 9 is the minimum necessary number to try all combinations of cigar types with guarantee of clipping an element with length = 2
+    private final int maximumCigarElements = 9;
 
     @BeforeClass
     public void init() {
         cigarList = ReadClipperTestUtils.generateCigarList(maximumCigarElements);
-        Cigar additionalCigar = TextCigarCodec.decode("2M3I5M");
+        final Cigar additionalCigar = TextCigarCodec.decode("2M3I5M");
         cigarList.add(additionalCigar);
     }
 
     @Test
     public void testHardClipBothEndsByReferenceCoordinates() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int alnStart = read.getStart();
-            int alnEnd = read.getEnd();
-            int readLength = alnStart - alnEnd;
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int alnStart = read.getStart();
+            final int alnEnd = read.getEnd();
+            final int readLength = alnStart - alnEnd;
             for (int i = 0; i < readLength / 2; i++) {
-                GATKRead clippedRead = ReadClipper.hardClipBothEndsByReferenceCoordinates(read, alnStart + i, alnEnd - i);
+                final GATKRead clippedRead = ReadClipper.hardClipBothEndsByReferenceCoordinates(read, alnStart + i, alnEnd - i);
                 Assert.assertTrue(clippedRead.getStart() >= alnStart + i, String.format("Clipped alignment start is less than original read (minus %d): %s -> %s", i, read.getCigar().toString(), clippedRead.getCigar().toString()));
                 Assert.assertTrue(clippedRead.getEnd() <= alnEnd + i, String.format("Clipped alignment end is greater than original read (minus %d): %s -> %s", i, read.getCigar().toString(), clippedRead.getCigar().toString()));
                 assertUnclippedLimits(read, clippedRead);
@@ -47,19 +56,18 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testHardClipByReadCoordinates() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
 
-            int readLength = read.getLength();
+            final int readLength = read.getLength();
             for (int i = 0; i < readLength; i++) {
-                GATKRead clipLeft = ReadClipper.hardClipByReadCoordinates(read, 0, i);
+                final GATKRead clipLeft = ReadClipper.hardClipByReadCoordinates(read, 0, i);
                 Assert.assertTrue(clipLeft.getLength() <= readLength - i, String.format("Clipped read length is greater than original read length (minus %d): %s -> %s", i, read.getCigar().toString(), clipLeft.getCigar().toString()));
                 assertRefAlignmentConsistent(clipLeft);
                 assertReadLengthConsistent(clipLeft);
                 assertReadClippingConsistent(read, clipLeft, i + 1);
 
-
-                GATKRead clipRight = ReadClipper.hardClipByReadCoordinates(read, i, readLength - 1);
+                final GATKRead clipRight = ReadClipper.hardClipByReadCoordinates(read, i, readLength - 1);
                 Assert.assertTrue(clipRight.getLength() <= i, String.format("Clipped read length is greater than original read length (minus %d): %s -> %s", i, read.getCigar().toString(), clipRight.getCigar().toString()));
                 assertRefAlignmentConsistent(clipRight);
                 assertReadLengthConsistent(clipRight);
@@ -83,10 +91,10 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "ClippedReadLengthData")
     public void testHardClipReadLengthIsRight(final int originalReadLength, final int nToClip) {
-        GATKRead read = ReadClipperTestUtils.makeReadFromCigar(originalReadLength + "M");
+        final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(originalReadLength + "M");
         read.getLength(); // provoke the caching of the read length
         final int expectedReadLength = originalReadLength - nToClip;
-        GATKRead clipped = ReadClipper.hardClipByReadCoordinates(read, 0, nToClip - 1);
+        final GATKRead clipped = ReadClipper.hardClipByReadCoordinates(read, 0, nToClip - 1);
         Assert.assertEquals(clipped.getLength(), expectedReadLength,
                 String.format("Clipped read length %d with cigar %s not equal to the expected read length %d after clipping %d bases from the left from a %d bp read with cigar %s",
                         clipped.getLength(), clipped.getCigar(), expectedReadLength, nToClip, read.getLength(), read.getCigar()));
@@ -94,23 +102,20 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testHardClipByReferenceCoordinates() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int start = getSoftStart(read);
-            int aln_start = read.getStart();
-            int aln_end = read.getEnd();
-
-            int stop = getSoftEnd(read);
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int start = getSoftStart(read);
+            final int stop = getSoftEnd(read);
 
             for (int i = start; i <= stop; i++) {
-                GATKRead clipLeft = (new ReadClipper(read)).hardClipByReferenceCoordinates(-1, i);
+                final GATKRead clipLeft = (new ReadClipper(read)).hardClipByReferenceCoordinates(-1, i);
                 if (!clipLeft.isEmpty()) {
                     Assert.assertTrue(clipLeft.getStart() >= Math.min(read.getEnd(), i + 1), String.format("Clipped alignment start (%d) is less the expected (%d): %s -> %s", clipLeft.getStart(), i + 1, read.getCigar().toString(), clipLeft.getCigar().toString()));
                     assertRefAlignmentConsistent(clipLeft);
                     assertReadLengthConsistent(clipLeft);
                 }
 
-                GATKRead clipRight = (new ReadClipper(read)).hardClipByReferenceCoordinates(i, -1);
+                final GATKRead clipRight = (new ReadClipper(read)).hardClipByReferenceCoordinates(i, -1);
                 if (!clipRight.isEmpty() && clipRight.getStart() <= clipRight.getEnd()) {             // alnStart > alnEnd if the entire read is a soft clip now. We can't test those.
                     Assert.assertTrue(clipRight.getEnd() <= Math.max(read.getStart(), i - 1), String.format("Clipped alignment end (%d) is greater than expected (%d): %s -> %s", clipRight.getEnd(), i - 1, read.getCigar().toString(), clipRight.getCigar().toString()));
                     assertRefAlignmentConsistent(clipRight);
@@ -122,13 +127,13 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testHardClipByReferenceCoordinatesLeftTail() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int alnStart = read.getStart();
-            int alnEnd = read.getEnd();
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int alnStart = read.getStart();
+            final int alnEnd = read.getEnd();
             if (getSoftStart(read) == alnStart) {                                                                      // we can't test left clipping if the read has hanging soft clips on the left side
                 for (int i = alnStart; i <= alnEnd; i++) {
-                    GATKRead clipLeft = ReadClipper.hardClipByReferenceCoordinatesLeftTail(read, i);
+                    final GATKRead clipLeft = ReadClipper.hardClipByReferenceCoordinatesLeftTail(read, i);
 
                     if (!clipLeft.isEmpty()) {
                         Assert.assertTrue(clipLeft.getStart() >= i + 1, String.format("Clipped alignment start (%d) is less the expected (%d): %s -> %s", clipLeft.getStart(), i + 1, read.getCigar().toString(), clipLeft.getCigar().toString()));
@@ -142,13 +147,13 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testHardClipByReferenceCoordinatesRightTail() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int alnStart = read.getStart();
-            int alnEnd = read.getEnd();
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int alnStart = read.getStart();
+            final int alnEnd = read.getEnd();
             if (getSoftEnd(read) == alnEnd) {                                                                          // we can't test right clipping if the read has hanging soft clips on the right side
                 for (int i = alnStart; i <= alnEnd; i++) {
-                    GATKRead clipRight = ReadClipper.hardClipByReferenceCoordinatesRightTail(read, i);
+                    final GATKRead clipRight = ReadClipper.hardClipByReferenceCoordinatesRightTail(read, i);
                     if (!clipRight.isEmpty() && clipRight.getStart() <= clipRight.getEnd()) {         // alnStart > alnEnd if the entire read is a soft clip now. We can't test those.
                         Assert.assertTrue(clipRight.getEnd() <= i - 1, String.format("Clipped alignment end (%d) is greater than expected (%d): %s -> %s", clipRight.getEnd(), i - 1, read.getCigar().toString(), clipRight.getCigar().toString()));
                         assertRefAlignmentConsistent(clipRight);
@@ -165,10 +170,10 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
         final byte HIGH_QUAL = 30;
 
         /* create a read for every cigar permutation */
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int readLength = read.getLength();
-            byte[] quals = new byte[readLength];
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int readLength = read.getLength();
+            final byte[] quals = new byte[readLength];
 
             for (int nLowQualBases = 0; nLowQualBases < readLength; nLowQualBases++) {
 
@@ -177,7 +182,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
                 for (int addLeft = 0; addLeft < nLowQualBases; addLeft++)
                     quals[addLeft] = LOW_QUAL;
                 read.setBaseQualities(quals);
-                GATKRead clipLeft = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
+                final GATKRead clipLeft = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
                 checkClippedReadsForLowQualEnds(read, clipLeft, LOW_QUAL, nLowQualBases);
 
                 /* create a read with nLowQualBases in the right tail */
@@ -185,7 +190,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
                 for (int addRight = 0; addRight < nLowQualBases; addRight++)
                     quals[readLength - addRight - 1] = LOW_QUAL;
                 read.setBaseQualities(quals);
-                GATKRead clipRight = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
+                final GATKRead clipRight = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
                 checkClippedReadsForLowQualEnds(read, clipRight, LOW_QUAL, nLowQualBases);
 
                 /* create a read with nLowQualBases on both tails */
@@ -196,7 +201,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
                         quals[readLength - addBoth - 1] = LOW_QUAL;
                     }
                     read.setBaseQualities(quals);
-                    GATKRead clipBoth = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
+                    final GATKRead clipBoth = ReadClipper.hardClipLowQualEnds(read, LOW_QUAL);
                     checkClippedReadsForLowQualEnds(read, clipBoth, LOW_QUAL, 2*nLowQualBases);
                 }
             }
@@ -205,11 +210,11 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testHardClipSoftClippedBases() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            GATKRead clippedRead = ReadClipper.hardClipSoftClippedBases(read);
-            CigarCounter original = new CigarCounter(read);
-            CigarCounter clipped = new CigarCounter(clippedRead);
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final GATKRead clippedRead = ReadClipper.hardClipSoftClippedBases(read);
+            final CigarCounter original = new CigarCounter(read);
+            final CigarCounter clipped = new CigarCounter(clippedRead);
 
             assertUnclippedLimits(read, clippedRead);  // Make sure limits haven't changed
             original.assertHardClippingSoftClips(clipped); // Make sure we have only clipped SOFT_CLIPS
@@ -218,17 +223,17 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test(enabled = false)
     public void testHardClipLeadingInsertions() {
-        for (Cigar cigar : cigarList) {
+        for (final Cigar cigar : cigarList) {
             if (startsWithInsertion(cigar)) {
-                GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-                GATKRead clippedRead = ReadClipper.hardClipLeadingInsertions(read);
+                final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+                final GATKRead clippedRead = ReadClipper.hardClipLeadingInsertions(read);
 
                 assertUnclippedLimits(read, clippedRead);        // Make sure limits haven't changed
 
                 int expectedLength = read.getLength() - leadingCigarElementLength(read.getCigar(), CigarOperator.INSERTION);
-                if (cigarHasElementsDifferentThanInsertionsAndHardClips(read.getCigar()))
+                if (cigarHasElementsDifferentThanInsertionsAndHardClips(read.getCigar())) {
                     expectedLength -= leadingCigarElementLength(CigarUtils.invertCigar(read.getCigar()), CigarOperator.INSERTION);
-
+                }
                 if (!clippedRead.isEmpty()) {
                     Assert.assertEquals(expectedLength, clippedRead.getLength(), String.format("%s -> %s", read.getCigar().toString(), clippedRead.getCigar().toString()));  // check that everything else is still there
                     Assert.assertFalse(startsWithInsertion(clippedRead.getCigar()));                                                                                   // check that the insertions are gone
@@ -240,7 +245,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testRevertSoftClippedBases() {
-        for (Cigar cigar : cigarList) {
+        for (final Cigar cigar : cigarList) {
             final int leadingSoftClips = leadingCigarElementLength(cigar, CigarOperator.SOFT_CLIP);
             final int tailSoftClips = leadingCigarElementLength(CigarUtils.invertCigar(cigar), CigarOperator.SOFT_CLIP);
 
@@ -262,7 +267,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testRevertSoftClippedBasesWithThreshold() {
-        for (Cigar cigar : cigarList) {
+        for (final Cigar cigar : cigarList) {
             final int leadingSoftClips = leadingCigarElementLength(cigar, CigarOperator.SOFT_CLIP);
             final int tailSoftClips = leadingCigarElementLength(CigarUtils.invertCigar(cigar), CigarOperator.SOFT_CLIP);
 
@@ -281,11 +286,11 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @DataProvider(name = "RevertSoftClipsBeforeContig")
     public Object[][] makeRevertSoftClipsBeforeContig() {
-        List<Object[]> tests = new ArrayList<>();
+        final List<Object[]> tests = new ArrayList<>();
 
         // this functionality can be adapted to provide input data for whatever you might want in your data
-        for ( int softStart : Arrays.asList(-10, -1, 0) ) {
-            for ( int alignmentStart : Arrays.asList(1, 10) ) {
+        for ( final int softStart : Arrays.asList(-10, -1, 0) ) {
+            for ( final int alignmentStart : Arrays.asList(1, 10) ) {
                 tests.add(new Object[]{softStart, alignmentStart});
             }
         }
@@ -314,15 +319,15 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
         Assert.assertEquals(reverted.getCigar().toString(), expectedCigar);
     }
 
-    private void assertNoLowQualBases(GATKRead read, byte low_qual) {
+    private void assertNoLowQualBases(final GATKRead read, final byte low_qual) {
         if (!read.isEmpty()) {
-            byte[] quals = read.getBaseQualities();
+            final byte[] quals = read.getBaseQualities();
             for (int i = 0; i < quals.length; i++)
                 Assert.assertFalse(quals[i] <= low_qual, String.format("Found low qual (%d) base after hard clipping. Position: %d -- %s", low_qual, i, read.getCigar().toString()));
         }
     }
 
-    private void checkClippedReadsForLowQualEnds(GATKRead read, GATKRead clippedRead, byte lowQual, int nLowQualBases) {
+    private void checkClippedReadsForLowQualEnds(final GATKRead read, final GATKRead clippedRead, final byte lowQual, final int nLowQualBases) {
         assertNoLowQualBases(clippedRead, lowQual);  // Make sure the low qualities are gone
     }
 
@@ -345,12 +350,10 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     *
     * @param clippedRead input read
     * */
-    private void assertRefAlignmentConsistent(final GATKRead clippedRead){
-        int cigarRefLength = clippedRead.getCigar().getReferenceLength();
-        int readRefLength = clippedRead.getLengthOnReference();
-        if (clippedRead.isUnmapped()) {
-            readRefLength = 0 ;
-        }
+    private void assertRefAlignmentConsistent(final GATKRead clippedRead) {
+        final int cigarRefLength = clippedRead.getCigar().getReferenceLength();
+        final int readRefLength = clippedRead.isUnmapped() ? 0 : clippedRead.getLengthOnReference();
+
         Assert.assertEquals(cigarRefLength, readRefLength);
     }
 
@@ -360,8 +363,8 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
      * @param clippedRead input read
      * */
     private void assertReadLengthConsistent(final GATKRead clippedRead){
-        int cigarReadLength = clippedRead.getCigar().getReadLength();
-        int readReadLength = clippedRead.getLength();
+        final int cigarReadLength = clippedRead.getCigar().getReadLength();
+        final int readReadLength = clippedRead.getLength();
         Assert.assertEquals(cigarReadLength, readReadLength);
     }
 
@@ -375,46 +378,16 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     private void assertReadClippingConsistent(final GATKRead original,
                                               final GATKRead clipped,
                                               final int clipping) {
-        int clip_diff = original.getLength() - clipped.getLength();
+        final int clip_diff = original.getLength() - clipped.getLength();
         Assert.assertEquals(clip_diff, clipping);
     }
 
-    /**
-     * Asserts that reference clipping was as requested
-     *
-     * @param original Original read
-     * @param clipped clipped read
-     * @param clipped_left number of bases clipped from alignment to ref on the left
-     * @param clipped_right umber of bases clipped from alignment to ref on the right
-     * */
-    private void assertRefClippingConsistent(final GATKRead original,
-                                             final GATKRead clipped,
-                                             final int clipped_left,
-                                             final int clipped_right){
-
-        if (original.getLengthOnReference() - clipped_left - clipped_right <= 0 ){
-            if (clipped.getLengthOnReference() == 0 )
-                return;
-            Assert.assertTrue(clipped.isUnmapped());
-            return;
-        }
-        int delta_left = clipped.getStart() - original.getStart();
-        Assert.assertEquals(delta_left, clipped_left);
-        int original_end = original.getEnd() ;
-        int clipped_end = clipped.getEnd() ;
-        int delta_right = original_end - clipped_end;
-        Assert.assertEquals(delta_right, clipped_right);
-
-
-    }
-
-
-    private boolean startsWithInsertion(Cigar cigar) {
+    private boolean startsWithInsertion(final Cigar cigar) {
         return leadingCigarElementLength(cigar, CigarOperator.INSERTION) > 0;
     }
 
-    private int leadingCigarElementLength(Cigar cigar, CigarOperator operator) {
-        for (CigarElement cigarElement : cigar.getCigarElements()) {
+    private int leadingCigarElementLength(final Cigar cigar, final CigarOperator operator) {
+        for (final CigarElement cigarElement : cigar.getCigarElements()) {
             if (cigarElement.getOperator() == operator)
                 return cigarElement.getLength();
             if (cigarElement.getOperator() != CigarOperator.HARD_CLIP)
@@ -423,42 +396,43 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
         return 0;
     }
 
-    private boolean cigarHasElementsDifferentThanInsertionsAndHardClips(Cigar cigar) {
-        for (CigarElement cigarElement : cigar.getCigarElements())
+    private boolean cigarHasElementsDifferentThanInsertionsAndHardClips(final Cigar cigar) {
+        for (final CigarElement cigarElement : cigar.getCigarElements())
             if (cigarElement.getOperator() != CigarOperator.INSERTION && cigarElement.getOperator() != CigarOperator.HARD_CLIP)
                 return true;
         return false;
     }
 
     private class CigarCounter {
-        private Map<CigarOperator, Integer> counter;
+        final private Map<CigarOperator, Integer> counter;
 
-        Integer getCounterForOp(CigarOperator operator) {
+        Integer getCounterForOp(final CigarOperator operator) {
             return counter.get(operator);
         }
 
-        CigarCounter(GATKRead read) {
-            CigarOperator[] operators = CigarOperator.values();
+        CigarCounter(final GATKRead read) {
+            final CigarOperator[] operators = CigarOperator.values();
             counter = new LinkedHashMap<>(operators.length);
 
-            for (CigarOperator op : operators)
+            for (final CigarOperator op : operators)
                 counter.put(op, 0);
 
-            for (CigarElement cigarElement : read.getCigar().getCigarElements())
+            for (final CigarElement cigarElement : read.getCigar().getCigarElements())
                 counter.put(cigarElement.getOperator(), counter.get(cigarElement.getOperator()) + cigarElement.getLength());
         }
 
-        boolean assertHardClippingSoftClips(CigarCounter clipped) {
-            for (CigarOperator op : counter.keySet()) {
+        boolean assertHardClippingSoftClips(final CigarCounter clipped) {
+            for (final CigarOperator op : counter.keySet()) {
                 if (op == CigarOperator.HARD_CLIP || op == CigarOperator.SOFT_CLIP) {
-                    int counterTotal = counter.get(CigarOperator.HARD_CLIP) + counter.get(CigarOperator.SOFT_CLIP);
-                    int clippedHard = clipped.getCounterForOp(CigarOperator.HARD_CLIP);
-                    int clippedSoft = clipped.getCounterForOp(CigarOperator.SOFT_CLIP);
+                    final int counterTotal = counter.get(CigarOperator.HARD_CLIP) + counter.get(CigarOperator.SOFT_CLIP);
+                    final int clippedHard = clipped.getCounterForOp(CigarOperator.HARD_CLIP);
+                    final int clippedSoft = clipped.getCounterForOp(CigarOperator.SOFT_CLIP);
 
                     Assert.assertEquals(counterTotal, clippedHard);
                     Assert.assertEquals(clippedSoft, 0);
-                } else
+                } else {
                     Assert.assertEquals(counter.get(op), clipped.getCounterForOp(op));
+                }
             }
             return true;
         }
@@ -467,21 +441,21 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     @Test
     public void testRevertEntirelySoftClippedReads() {
-        GATKRead read = ReadClipperTestUtils.makeReadFromCigar("2H1S3H");
-        GATKRead clippedRead = ReadClipper.revertSoftClippedBases(read);
+        final GATKRead read = ReadClipperTestUtils.makeReadFromCigar("2H1S3H");
+        final GATKRead clippedRead = ReadClipper.revertSoftClippedBases(read);
         Assert.assertEquals(clippedRead.getStart(), getSoftStart(read));
     }
 
 
     @Test
     public void testSoftClipBothEndsByReferenceCoordinates() {
-        for (Cigar cigar : cigarList) {
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int alnStart = read.getStart();
-            int alnEnd = read.getEnd();
-            int readLength = alnStart - alnEnd;
+        for (final Cigar cigar : cigarList) {
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int alnStart = read.getStart();
+            final int alnEnd = read.getEnd();
+            final int readLength = alnStart - alnEnd;
             for (int i = 0; i < readLength / 2; i++) {
-                GATKRead clippedRead = ReadClipper.softClipBothEndsByReferenceCoordinates(read, alnStart + i, alnEnd - i);
+                final GATKRead clippedRead = ReadClipper.softClipBothEndsByReferenceCoordinates(read, alnStart + i, alnEnd - i);
                 Assert.assertTrue(clippedRead.getStart() >= alnStart + i, String.format("Clipped alignment start is less than original read (minus %d): %s -> %s", i, read.getCigar().toString(), clippedRead.getCigar().toString()));
                 Assert.assertTrue(clippedRead.getEnd() <= alnEnd + i, String.format("Clipped alignment end is greater than original read (minus %d): %s -> %s", i, read.getCigar().toString(), clippedRead.getCigar().toString()));
                 assertUnclippedLimits(read, clippedRead);
@@ -495,11 +469,11 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
         final SAMFileHeader header = new SAMFileHeader();
         header.setSequenceDictionary(hg19GenomeLocParser.getSequenceDictionary());
 
-        GATKRead read = ReadClipperTestUtils.makeReadFromCigar("8M");
-        ReadClipper clipper = new ReadClipper(read);
-        ClippingOp op = new ClippingOp(0, 7);
+        final GATKRead read = ReadClipperTestUtils.makeReadFromCigar("8M");
+        final ReadClipper clipper = new ReadClipper(read);
+        final ClippingOp op = new ClippingOp(0, 7);
         clipper.addOp(op);
-        GATKRead softResult = clipper.clipRead(ClippingRepresentation.SOFTCLIP_BASES);
+        final GATKRead softResult = clipper.clipRead(ClippingRepresentation.SOFTCLIP_BASES);
         Assert.assertEquals(softResult.getCigar().toString(), "7S1M");
     }
 
@@ -508,20 +482,20 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     //Test pending resolution of issue #2022
     @Test (enabled = false)
     public void testSoftClipByReferenceCoordinates() {
-        for (Cigar cigar : cigarList) {
+        for (final Cigar cigar : cigarList) {
             if(cigar.isValid(null, -1) != null) {
                 continue;
             }
-            GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
-            int start = getSoftStart(read);
-            int stop = getSoftEnd(read);
+            final GATKRead read = ReadClipperTestUtils.makeReadFromCigar(cigar);
+            final int start = getSoftStart(read);
+            final int stop = getSoftEnd(read);
 
             for (int i = start; i <= stop; i++) {
-                GATKRead clipLeft = (new ReadClipper(read.copy())).softClipByReferenceCoordinates(-1, i);
+                final GATKRead clipLeft = (new ReadClipper(read.copy())).softClipByReferenceCoordinates(-1, i);
                 if (!clipLeft.isEmpty()) {
                     Assert.assertTrue(clipLeft.getStart() >= Math.min(read.getEnd(), i + 1), String.format("Clipped alignment start (%d) is less the expected (%d): %s -> %s", clipLeft.getStart(), i + 1, read.getCigar().toString(), clipLeft.getCigar().toString()));
                 }
-                GATKRead clipRight = (new ReadClipper(read.copy())).softClipByReferenceCoordinates(i, -1);
+                final GATKRead clipRight = (new ReadClipper(read.copy())).softClipByReferenceCoordinates(i, -1);
                 if (!clipRight.isEmpty() && clipRight.getStart() <= clipRight.getEnd()) {             // alnStart > alnEnd if the entire read is a soft clip now. We can't test those.
                     Assert.assertTrue(clipRight.getEnd() <= Math.max(read.getStart(), i - 1), String.format("Clipped alignment end (%d) is greater than expected (%d): %s -> %s", clipRight.getEnd(), i - 1, read.getCigar().toString(), clipRight.getCigar().toString()));
                 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -529,7 +529,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
         // It's important that the read be AT the start of the contig for this test, so that
         // we clip away ALL of the reverted soft-clipped bases, resulting in an empty read.
         originalRead.setPosition(originalRead.getContig(), 1);
-        
+
         final GATKRead clippedRead = ReadClipper.revertSoftClippedBases(originalRead);
 
         Assert.assertEquals(clippedRead.getLength(), 0);
@@ -542,7 +542,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
 
     //test fix for https://github.com/broadinstitute/gatk/issues/6139
     @DataProvider()
-    Object[][] cigarsToClipData(){
+    Object[][] cigarsToClipData() {
         return new Object[][]{
                 new Object[]{"20M", 6},
                 new Object[]{"3M2I20M", 4},
@@ -561,21 +561,21 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     }
 
     //test fix for https://github.com/broadinstitute/gatk/issues/6139
-    @Test (dataProvider="cigarsToClipData")
+    @Test(dataProvider = "cigarsToClipData")
     public void testHardClipSoftClippedBasesClipsTheCorrectAmount(final String cigarString, final int alignmentOffset) {
-        final int nBasesToClip=6;
+        final int nBasesToClip = 6;
         final int start = 100;
         final GATKRead originalRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(cigarString));
-        BaseUtils.fillWithRandomBases(originalRead.getBasesNoCopy(),0,originalRead.getLength());
+        BaseUtils.fillWithRandomBases(originalRead.getBasesNoCopy(), 0, originalRead.getLength());
         originalRead.setPosition(originalRead.getContig(), start);
 
-        final GATKRead clippedRead = ReadClipper.hardClipByReadCoordinates(originalRead, 0, nBasesToClip-1);
+        final GATKRead clippedRead = ReadClipper.hardClipByReadCoordinates(originalRead, 0, nBasesToClip - 1);
         Assert.assertEquals(
                 clippedRead.getCigar().getReadLength() + AlignmentUtils.getNumHardClippedBases(clippedRead),
                 originalRead.getCigar().getReadLength() + AlignmentUtils.getNumHardClippedBases((originalRead))
                 , " Clipped cigar: " + clippedRead.getCigar());
-        Assert.assertEquals(clippedRead.getStart(),start + alignmentOffset, " Clipped cigar: " + clippedRead.getCigar());
-        Assert.assertEquals(clippedRead.getBasesNoCopy(),Arrays.copyOfRange(originalRead.getBases(),nBasesToClip,originalRead.getBasesNoCopy().length));
-        Assert.assertEquals(clippedRead.getBaseQualitiesNoCopy(),Arrays.copyOfRange(originalRead.getBaseQualitiesNoCopy(),nBasesToClip,originalRead.getBaseQualitiesNoCopy().length));
+        Assert.assertEquals(clippedRead.getStart(), start + alignmentOffset, " Clipped cigar: " + clippedRead.getCigar());
+        Assert.assertEquals(clippedRead.getBasesNoCopy(), Arrays.copyOfRange(originalRead.getBases(), nBasesToClip, originalRead.getBasesNoCopy().length));
+        Assert.assertEquals(clippedRead.getBaseQualitiesNoCopy(), Arrays.copyOfRange(originalRead.getBaseQualitiesNoCopy(), nBasesToClip, originalRead.getBaseQualitiesNoCopy().length));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -29,7 +29,8 @@ import static org.broadinstitute.hellbender.utils.read.ReadUtils.getSoftStart;
 public final class ReadClipperUnitTest extends GATKBaseTest {
     private List<Cigar> cigarList;
     // 9 is the minimum necessary number to try all combinations of cigar types with guarantee of clipping an element with length = 2
-    private final int maximumCigarElements = 9;
+    // and there are already 3 cigar elements on the basic cigar
+    private final int maximumCigarElements = 6;
 
     @BeforeClass
     public void init() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -541,7 +541,7 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     }
 
     //test fix for https://github.com/broadinstitute/gatk/issues/6139
-    @DataProvider(name="test-hard-clip-clips-right-amount")
+    @DataProvider()
     Object[][] cigarsToClipData(){
         return new Object[][]{
                 new Object[]{"20M", 6},
@@ -550,6 +550,10 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
                 new Object[]{"3M2D20M", 8},
                 new Object[]{"3M10N20M", 16},
                 new Object[]{"6M2D10M", 8},
+                new Object[]{"6M1D1N10M", 8},
+                new Object[]{"6M1N1D10M", 8},
+                new Object[]{"6M1D1N1D10M", 9},
+                new Object[]{"5M1D1N1D10M", 9},
                 new Object[]{"10M2D10M", 6},
                 new Object[]{"3S10M", 3},
                 new Object[]{"3H10M", 6}
@@ -557,20 +561,21 @@ public final class ReadClipperUnitTest extends GATKBaseTest {
     }
 
     //test fix for https://github.com/broadinstitute/gatk/issues/6139
-    @Test (dataProvider="test-hard-clip-clips-right-amount")
+    @Test (dataProvider="cigarsToClipData")
     public void testHardClipSoftClippedBasesClipsTheCorrectAmount(final String cigarString, final int alignmentOffset) {
+        final int nBasesToClip=6;
         final int start = 100;
         final GATKRead originalRead = ArtificialReadUtils.createArtificialRead(TextCigarCodec.decode(cigarString));
         BaseUtils.fillWithRandomBases(originalRead.getBasesNoCopy(),0,originalRead.getLength());
         originalRead.setPosition(originalRead.getContig(), start);
 
-        final GATKRead clippedRead = ReadClipper.hardClipByReadCoordinates(originalRead, 0, 5);
+        final GATKRead clippedRead = ReadClipper.hardClipByReadCoordinates(originalRead, 0, nBasesToClip-1);
         Assert.assertEquals(
                 clippedRead.getCigar().getReadLength() + AlignmentUtils.getNumHardClippedBases(clippedRead),
                 originalRead.getCigar().getReadLength() + AlignmentUtils.getNumHardClippedBases((originalRead))
                 , " Clipped cigar: " + clippedRead.getCigar());
         Assert.assertEquals(clippedRead.getStart(),start + alignmentOffset, " Clipped cigar: " + clippedRead.getCigar());
-        Assert.assertEquals(clippedRead.getBasesNoCopy(),Arrays.copyOfRange(originalRead.getBases(),6,originalRead.getBasesNoCopy().length));
-        Assert.assertEquals(clippedRead.getBaseQualitiesNoCopy(),Arrays.copyOfRange(originalRead.getBaseQualitiesNoCopy(),6,originalRead.getBaseQualitiesNoCopy().length));
+        Assert.assertEquals(clippedRead.getBasesNoCopy(),Arrays.copyOfRange(originalRead.getBases(),nBasesToClip,originalRead.getBasesNoCopy().length));
+        Assert.assertEquals(clippedRead.getBaseQualitiesNoCopy(),Arrays.copyOfRange(originalRead.getBaseQualitiesNoCopy(),nBasesToClip,originalRead.getBaseQualitiesNoCopy().length));
     }
 }


### PR DESCRIPTION
Problem was ocurring in the presence of insertions and deletions. fixes #6139

1. Changed ReadClipper unit tests:
  - The tests in many cases assumed that the unclipped alignment locations do not    change when the read is clipped. This is not true: for example if start for cigar
   1M1I3M is 100, the unclipped start for 2H3M is 99. All assertUnclipped calls were
   removed
   - Alignment now check that the read length remains to be consistent with the CIGAR, that the aligned bases span are consistent with the CIGAR and that the number of clipped bases from the read is consistent with the requested clipping
2. Hard clipping in ClippingOps was buggy, thus we introduced new tests for it.
3. Text was refactored for readability
4. Clipping in ClippingOps did not treat insertions and deletions in the clipped parts of the CIGAR correctly. This was fixed
5. Alignment re-calculation after clipping did not work correctly if the initial CIGAR contained insertions and deletions
6. Hard clipping applied to the hard clipped read did not behave correctly

