### PR TITLE
Increase number of iterations in calculateContamination to 30

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/ContaminationModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/contamination/ContaminationModel.java
@@ -211,7 +211,7 @@ public class ContaminationModel {
         final DoubleUnaryOperator objective = c -> modelLogLikelihood(segments, c, errorRate, mafs);
 
         final List<UnivariatePointValuePair> optima = CONTAMINATION_INITIAL_GUESSES.stream()
-                .map(initial -> OptimizationUtils.max(objective, 0, 0.5, initial, 1.0e-4, 1.0e-4, 20))
+                .map(initial -> OptimizationUtils.max(objective, 0, 0.5, initial, 1.0e-4, 1.0e-4, 30))
                 .collect(Collectors.toList());
 
         return Collections.max(optima, Comparator.comparingDouble(UnivariatePointValuePair::getValue)).getPoint();


### PR DESCRIPTION
I found a sample that fails when CalculateContamination is run.

The exception I get is:
org.apache.commons.math3.exception.TooManyEvaluationsException: illegal state: maximal count (20) exceeded: evaluations
	at org.apache.commons.math3.optim.BaseOptimizer$MaxEvalCallback.trigger(BaseOptimizer.java:242)
	at org.apache.commons.math3.util.Incrementor.incrementCount(Incrementor.java:155)
	at org.apache.commons.math3.optim.BaseOptimizer.incrementEvaluationCount(BaseOptimizer.java:191)
	at org.apache.commons.math3.optim.univariate.UnivariateOptimizer.computeObjectiveValue(UnivariateOptimizer.java:148)
	at org.apache.commons.math3.optim.univariate.BrentOptimizer.doOptimize(BrentOptimizer.java:225)
	at org.apache.commons.math3.optim.univariate.BrentOptimizer.doOptimize(BrentOptimizer.java:43)
	at org.apache.commons.math3.optim.BaseOptimizer.optimize(BaseOptimizer.java:153)
	at org.apache.commons.math3.optim.univariate.UnivariateOptimizer.optimize(UnivariateOptimizer.java:70)
	at org.broadinstitute.hellbender.utils.OptimizationUtils.max(OptimizationUtils.java:40)
	at org.broadinstitute.hellbender.tools.walkers.contamination.ContaminationModel.lambda$calculateContamination$13(ContaminationModel.java:214)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at org.broadinstitute.hellbender.tools.walkers.contamination.ContaminationModel.calculateContamination(ContaminationModel.java:215)
	at org.broadinstitute.hellbender.tools.walkers.contamination.ContaminationModel.<init>(ContaminationModel.java:67)
	at org.broadinstitute.hellbender.tools.walkers.contamination.CalculateContamination.doWork(CalculateContamination.java:127)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.runTool(CommandLineProgram.java:139)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMainPostParseArgs(CommandLineProgram.java:191)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:210)
	at org.broadinstitute.hellbender.Main.runCommandLineProgram(Main.java:163)
	at org.broadinstitute.hellbender.Main.mainEntry(Main.java:206)
	at org.broadinstitute.hellbender.Main.main(Main.java:292)


By increasing the maxEvaluations in calculateContamination from 20 to 30 this no longer throws an exception.  Ideally I'd like to have a more principled way to decide on this upper bound.