### PR TITLE
Fix NPE in VariantEval when run with no intervals/reference

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
@@ -306,6 +306,7 @@ public class VariantEval extends MultiVariantWalker {
     Map<FeatureInput<VariantContext>, String> inputToNameMap = new HashMap<>();
 
     private final OneShotLogger territoryUnknownWarningLogger = new OneShotLogger(logger);
+    private int referencePositionsCoveredByVariants = 0;
 
     /**
      * Initialize the stratifications, evaluations, evaluation contexts, and reporting object
@@ -491,6 +492,7 @@ public class VariantEval extends MultiVariantWalker {
 
     @Override
     public void apply(VariantContext variant, ReadsContext readsContext, ReferenceContext referenceContext, FeatureContext featureContext) {
+        referencePositionsCoveredByVariants += variant.getLengthOnReference();
         aggr.addVariant(variant, readsContext, referenceContext, featureContext);
     }
 
@@ -821,11 +823,16 @@ public class VariantEval extends MultiVariantWalker {
         return sampleDB;
     }
 
+    /**
+     *
+     * Get the size of the input intervals or the input reference or the number of reference positions covered by variants.
+     */
     public long getnProcessedLoci() {
         if(getTraversalIntervals() == null) {
-            territoryUnknownWarningLogger.warn("No reference or intervals were provided so it is not clear how much genomic " +
-                    "territory the input covered. Values that rely on the size of the input territory will not be correct.");
-            return 0;
+            territoryUnknownWarningLogger.warn("No reference or intervals were provided so it is not clear how much " +
+                    "genomic territory the input covered. Values that are calculated based on the size of the input " +
+                    "territory will not be meaningful.");
+            return referencePositionsCoveredByVariants;
         } else {
             return getTraversalIntervals().stream().mapToLong(SimpleInterval::size).sum();
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval.java
@@ -417,17 +417,17 @@ public class VariantEval extends MultiVariantWalker {
     }
 
     private void assertThatTerritoryIsSpecifiedIfNecessary() {
-        final Set<String> evaluatorsWichRequireTerritory = stratManager.values()
+        final Set<String> evaluatorsWhichRequireTerritory = stratManager.values()
                 .stream()
                 .flatMap(ctx -> ctx.getVariantEvaluators().stream())
                 .filter(Objects::nonNull)
                 .filter(VariantEvaluator::requiresTerritoryToBeSpecified)
                 .map(VariantEvaluator::getSimpleName)
                 .collect(Collectors.toSet());
-        if(!evaluatorsWichRequireTerritory.isEmpty() && getTraversalIntervals() == null){
+        if(!evaluatorsWhichRequireTerritory.isEmpty() && getTraversalIntervals() == null){
             throw new UserException("You specified evaluators which require a covered territory to be specified.  " +
                     "\nPlease specify intervals or a reference file or disable all of the following evaluators:" +
-                    evaluatorsWichRequireTerritory.stream()
+                    evaluatorsWhichRequireTerritory.stream()
                             .collect(Collectors.joining(", ")));
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/CountVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/CountVariants.java
@@ -92,7 +92,7 @@ public class CountVariants extends VariantEvaluator implements StandardEval {
         // This is really not correct.  What we really want here is a polymorphic vs. monomorphic count (i.e. on the Genotypes).
         // So in order to maintain consistency with the previous implementation (and the intention of the original author), I've
         // added in a proxy check for monomorphic status here.
-        // Protect against case when vc only as no-calls too - can happen if we strafity by sample and sample as a single no-call.
+        // Protect against the case when vc only has no-calls too - can happen if we stratify by sample and sample as a single no-call.
        if ( getWalker().ignoreAC0Sites() && vc1.isMonomorphicInSamples() ) {
             nRefLoci++;
         } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/CountVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/CountVariants.java
@@ -191,4 +191,9 @@ public class CountVariants extends VariantEvaluator implements StandardEval {
         indelRatePerBp = perLocusRInverseRate(nDeletions + nInsertions + nComplex);
         insertionDeletionRatio = ratio(nInsertions, nDeletions);
     }
+
+    @Override
+    public boolean requiresTerritoryToBeSpecified() {
+        return true;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/MultiallelicSummary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/MultiallelicSummary.java
@@ -142,4 +142,9 @@ public class MultiallelicSummary extends VariantEvaluator implements StandardEva
         SNPNoveltyRate = Utils.formattedPercent(all - known, all);
         indelNoveltyRate = Utils.formattedPercent(all - known, all);
     }
+
+    @Override
+    public boolean requiresTerritoryToBeSpecified() {
+        return true;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantEvaluator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantEvaluator.java
@@ -107,4 +107,12 @@ public abstract class VariantEvaluator implements Comparable<VariantEvaluator> {
     public boolean supportsCombine() {
         return false;
     }
+
+    /**
+     * Subclasses must overload this to return true if they require an input to include a calling territory, either
+     * an interval list or a reference.
+     */
+    public boolean requiresTerritoryToBeSpecified() {
+        return false;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantSummary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/VariantSummary.java
@@ -248,4 +248,9 @@ public class VariantSummary extends VariantEvaluator implements StandardEval {
         SNPDPPerSample = depthPerSample.meanValue(Type.SNP);
         IndelDPPerSample = depthPerSample.meanValue(Type.INDEL);
     }
+
+    @Override
+    public boolean requiresTerritoryToBeSpecified() {
+        return true;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/stratifications/manager/StratificationManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/stratifications/manager/StratificationManager.java
@@ -4,7 +4,17 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalIntegrationTest.java
@@ -666,4 +666,16 @@ public class VariantEvalIntegrationTest extends CommandLineProgramTest {
                 new File(getToolTestDataDir() + "expected/" + "testPrintMissingComp" + ".expected.txt"));
     }
 
+    @Test
+    public void testCountWithNoReferenceOrIntervals() {
+        //Test for https://github.com/broadinstitute/gatk/issues/6212 just make sure we don't crash.
+        final String vcf = getTestFilePath("/CEU.trio.callsForVE.vcf");
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+                args.addOutput( createTempFile("out",".stuff"))
+                        .addArgument("eval", vcf)
+                        .addArgument("EV", "CountVariants");
+
+        runCommandLine(args);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/TestEvaluatorWhichRequiresReferenceButDoesntSayItDoes.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/TestEvaluatorWhichRequiresReferenceButDoesntSayItDoes.java
@@ -1,0 +1,18 @@
+package org.broadinstitute.hellbender.tools.walkers.varianteval.evaluators;
+
+import org.broadinstitute.hellbender.tools.walkers.varianteval.VariantEval;
+
+/**
+ * A test evaluator which calls {@link VariantEval#getnProcessedLoci} but doesn't override {@link VariantEvaluator#requiresTerritoryToBeSpecified()}
+ */
+public class TestEvaluatorWhichRequiresReferenceButDoesntSayItDoes extends VariantEvaluator {
+    @Override
+    public int getComparisonOrder() {
+        return 1;
+    }
+
+    @Override
+    public void finalizeEvaluation() {
+        getWalker().getnProcessedLoci();
+    }
+}


### PR DESCRIPTION
* Fixes an NPE that happened when using certain evaluators with VariantEval and not specifying a reference or intervals
* Fixes https://github.com/broadinstitute/gatk/issues/6212
