### PR TITLE
Copy temporary files early in gcnvkernel to avoid inadvertent temporary directory cleanup.

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/case_denoising_calling.py
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/case_denoising_calling.py
@@ -156,6 +156,12 @@ if __name__ == "__main__":
     # check gcnvkernel version in the input model path
     gcnvkernel.io_commons.check_gcnvkernel_version_from_path(args.input_model_path)
 
+    # copy the intervals to the calls path
+    # (we do this early to avoid inadvertent cleanup of temporary files)
+    gcnvkernel.io_commons.assert_output_path_writable(args.output_calls_path)
+    shutil.copy(os.path.join(args.input_model_path, gcnvkernel.io_consts.default_interval_list_filename),
+                os.path.join(args.output_calls_path, gcnvkernel.io_consts.default_interval_list_filename))
+
     # load modeling interval list from the model
     logging.info("Loading modeling interval list from the provided model...")
     modeling_interval_list = gcnvkernel.io_intervals_and_counts.load_interval_list_tsv_file(
@@ -215,10 +221,6 @@ if __name__ == "__main__":
     gcnvkernel.io_denoising_calling.SampleDenoisingAndCallingPosteriorsWriter(
         denoising_config, calling_config, shared_workspace, task.continuous_model, task.continuous_model_approx,
         args.output_calls_path)()
-
-    # save a copy of targets in the calls path
-    shutil.copy(os.path.join(args.input_model_path, gcnvkernel.io_consts.default_interval_list_filename),
-                os.path.join(args.output_calls_path, gcnvkernel.io_consts.default_interval_list_filename))
 
     # save optimizer state
     if hasattr(args, 'output_opt_path'):

--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/cohort_denoising_calling.py
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/cohort_denoising_calling.py
@@ -102,6 +102,15 @@ if __name__ == "__main__":
 
     logger.info("THEANO_FLAGS environment variable has been set to: {theano_flags}".format(theano_flags=theano_flags))
 
+    # copy the intervals to the model and calls paths
+    # (we do this early to avoid inadvertent cleanup of temporary files)
+    gcnvkernel.io_commons.assert_output_path_writable(args.output_model_path)
+    shutil.copy(args.modeling_interval_list,
+                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_interval_list_filename))
+    gcnvkernel.io_commons.assert_output_path_writable(args.output_calls_path)
+    shutil.copy(args.modeling_interval_list,
+                os.path.join(args.output_calls_path, gcnvkernel.io_consts.default_interval_list_filename))
+
     # load modeling interval list
     modeling_interval_list = gcnvkernel.io_intervals_and_counts.load_interval_list_tsv_file(args.modeling_interval_list)
 
@@ -183,18 +192,10 @@ if __name__ == "__main__":
         shared_workspace, main_task.continuous_model, main_task.continuous_model_approx,
         args.output_model_path)()
 
-    # save a copy of targets in the model path
-    shutil.copy(args.modeling_interval_list,
-                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_interval_list_filename))
-
     # save calls
     gcnvkernel.io_denoising_calling.SampleDenoisingAndCallingPosteriorsWriter(
         main_denoising_config, main_calling_config, shared_workspace, main_task.continuous_model,
         main_task.continuous_model_approx, args.output_calls_path)()
-
-    # save a copy of targets in the calls path
-    shutil.copy(args.modeling_interval_list,
-                os.path.join(args.output_calls_path, gcnvkernel.io_consts.default_interval_list_filename))
 
     # save optimizer state
     if hasattr(args, 'output_opt_path'):

--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/cohort_determine_ploidy_and_depth.py
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/cohort_determine_ploidy_and_depth.py
@@ -82,6 +82,14 @@ if __name__ == "__main__":
 
     logger.info("THEANO_FLAGS environment variable has been set to: {theano_flags}".format(theano_flags=theano_flags))
 
+    # copy the intervals and ploidy priors to the model path
+    # (we do this early to avoid inadvertent cleanup of temporary files)
+    gcnvkernel.io_commons.assert_output_path_writable(args.output_model_path)
+    shutil.copy(args.interval_list,
+                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_interval_list_filename))
+    shutil.copy(args.contig_ploidy_prior_table,
+                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_contig_ploidy_prior_tsv_filename))
+
     # read contig ploidy prior map from file
     contig_ploidy_prior_map = gcnvkernel.io_ploidy.get_contig_ploidy_prior_map_from_tsv_file(
         args.contig_ploidy_prior_table)
@@ -120,9 +128,3 @@ if __name__ == "__main__":
     gcnvkernel.io_ploidy.SamplePloidyWriter(ploidy_config, ploidy_workspace,
                                             ploidy_task.continuous_model, ploidy_task.continuous_model_approx,
                                             args.output_calls_path)()
-
-    # save a copy of interval list and ploidy priors as well
-    shutil.copy(args.interval_list,
-                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_interval_list_filename))
-    shutil.copy(args.contig_ploidy_prior_table,
-                os.path.join(args.output_model_path, gcnvkernel.io_consts.default_contig_ploidy_prior_tsv_filename))


### PR DESCRIPTION
See https://gatkforums.broadinstitute.org/gatk/discussion/24650/cohort-mode-of-germlinecnvcaller-filenotfounderror.