### PR TITLE
Propagate read group filters in ReadGroupBlackListReadFilter.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadGroupBlackListReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadGroupBlackListReadFilter.java
@@ -11,23 +11,27 @@ import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.*;
 
 /**
- * Keep records not matching the read group tag and exact match string.
+ * Keep records that don't match the specified filter string(s). Filter strings consist of a two character
+ * read group tag name such as "RG", "PU", etc., as defined by {@link SAMReadGroupRecord}, followed by a
+ * ":", and then the specific value to use for filtering.
  *
- * <p>For example, this filter value:
+ * <p>For example, this filter value uses the platform unit (PU) tag:
  *   <code>PU:1000G-mpimg-080821-1_1</code>
- * would filter out a read with the read group PU:1000G-mpimg-080821-1_1</p>
+ * to filter out reads with the read group platform unit value <code>1000G-mpimg-080821-1_1</code></p>
  */
 @DocumentedFeature(groupName= HelpConstants.DOC_CAT_READFILTERS, groupSummary=HelpConstants.DOC_CAT_READFILTERS_SUMMARY)
 public final class ReadGroupBlackListReadFilter extends ReadFilter implements Serializable {
     private static final long serialVersionUID = 1L;
     public static final String FILTER_ENTRY_SEPARATOR = ":";
 
-    @Argument(fullName= ReadFilterArgumentDefinitions.READ_GROUP_BLACK_LIST_LONG_NAME, doc="The name of the read group to filter out", optional=false)
+    @Argument(fullName=ReadFilterArgumentDefinitions.READ_GROUP_BLACK_LIST_LONG_NAME,
+            doc="A read group filter expression in the form \"attribute:value\", where \"attribute\" is "
+                    + "a two character read group attribute such as \"RG\" or \"PU\".",
+            optional=false)
     public List<String> blackList = new ArrayList<>();
 
     //most of the collection Entry classes are not serializable so just use a Map
@@ -41,11 +45,9 @@ public final class ReadGroupBlackListReadFilter extends ReadFilter implements Se
         super.setHeader(samFileHeader);
         parseReadGroupFilters();
     }
+
     /**
-     * Creates a filter using the lists of files with blacklisted read groups.
-     * Any entry can be a path to a file (ending with "list" or "txt" which
-     * will load blacklist from that file. This scheme works recursively
-     * (ie the file may contain names of further files etc).
+     * Creates a filter using the list of blacklisted read groups.
      */
     public ReadGroupBlackListReadFilter(final List<String> blackLists, final SAMFileHeader header) {
         super.setHeader(header);
@@ -56,7 +58,7 @@ public final class ReadGroupBlackListReadFilter extends ReadFilter implements Se
     private void parseReadGroupFilters() {
         final Map<String, Collection<String>> filters = new TreeMap<>();
         for (String blackList : this.blackList) {
-                addFilters(filters, blackList, null, 0);
+            addFilters(filters, blackList);
         }
         //merge all the new entries in to the blacklist
         filters.forEach((k, v) -> blacklistEntries.merge(k, v, (v1, v2) -> {
@@ -65,15 +67,15 @@ public final class ReadGroupBlackListReadFilter extends ReadFilter implements Se
         }));
     }
 
-    private void addFilters(final Map<String, Collection<String>> filters, final String filter, final File parentFile, final int parentLineNum) {
+    private void addFilters(final Map<String, Collection<String>> filters, final String filter) {
         final String[] split = filter.split(FILTER_ENTRY_SEPARATOR, 2);
-        checkValidFilterEntry(filter, parentFile, parentLineNum, split);
+        checkValidFilterEntry(filter, split);
 
         //Note: if we're here, we know that split has exactly 2 elements.
         filters.computeIfAbsent(split[0], k -> new TreeSet<>()).add(split[1]);
     }
 
-    private void checkValidFilterEntry(String filter, File parentFile, int parentLineNum, String[] split) {
+    private void checkValidFilterEntry(String filter, String[] split) {
         String message = null;
         if (split.length != 2) {
             message = "Invalid read group filter: " + filter;
@@ -82,9 +84,6 @@ public final class ReadGroupBlackListReadFilter extends ReadFilter implements Se
         }
 
         if (message != null) {
-            if (parentFile != null) {
-                message += ", " + parentFile.getAbsolutePath() + ":" + parentLineNum;
-            }
             message += ", format is <TAG>:<SUBSTRING>";
             throw new UserException(message);
         }


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/6299. Also removed obsolete code to populate read group filters from a file.