### PR TITLE
Fix some GATK doc issues

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/stratifications/AlleleFrequency.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/stratifications/AlleleFrequency.java
@@ -16,7 +16,6 @@ import java.util.List;
  * Either uses a constant 0.005 frequency grid, and projects the AF INFO field value or logit scale from -30 to 30.
  * Requires that AF be present in every ROD, otherwise this stratification throws an exception
  */
-@DocumentedFeature(groupName= "tools", summary = "Stratify by  eval RODs by the allele frequency of the alternate allele") // , extraDocs = {VariantEval.class})
 public class AlleleFrequency extends VariantStratifier {
 
     public enum StratifyingScale {

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
@@ -88,7 +88,6 @@
         <div class="accordion" id="index">
             <#assign seq = ["engine", "tools", "other", "utilities"]>
             <#list seq as supercat>
-                <br />
                 <#list groups?sort_by("name") as group>
                     <#if group.supercat == supercat>
                         <@emitGroup group=group/>


### PR DESCRIPTION
The current top-level index document has a bogus tool category called "tools" in it (see https://software.broadinstitute.org/gatk/documentation/tooldocs/current/). This is created by the  `@DocumentedFeature` annotation on the AlleleFrequency stratifier class. We don't actually have a category for this, and most are not documented. If at some point we want to add those, we can do so with a real category, but for now this removes the annotation.

There are also some unnatural line breaks in the index, which are removed here. The html doc could use some more maintenance cleanup, but this fixes those two obvious issues.