### PR TITLE
Disable CNNVariantPipelineTest.testTrainingReadModel until failures are resolved.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantPipelineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantPipelineTest.java
@@ -69,7 +69,8 @@ public class CNNVariantPipelineTest extends GATKBaseTest {
         new Main().instanceMain(args.getArgsArray());
     }
 
-    @Test(groups = {"python"}, dependsOnMethods = {"testGenerateReadTensors"})
+    // Disabled until https://github.com/broadinstitute/gatk/issues/6307 is resolved
+    @Test(enabled=false, groups = {"python"}, dependsOnMethods = {"testGenerateReadTensors"})
     public void testTrainingReadModel() {
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add("CNNVariantTrain")


### PR DESCRIPTION
See https://github.com/broadinstitute/gatk/issues/6307. This is causing quite a few branches to fail intermittently.