### PR TITLE
Simplified genotype likelihood calculation (no change in output)

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleLikelihoodMatrixMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/AlleleLikelihoodMatrixMapper.java
@@ -90,13 +90,6 @@ public class AlleleLikelihoodMatrixMapper<A extends Allele> {
                 Utils.validateArg(evidenceIndex >= 0, "readIndex");
                 return original.getEvidence(evidenceIndex);
             }
-
-            @Override
-            public void copyAlleleLikelihoods(final int alleleIndex, final double[] dest, final int offset) {
-                Utils.validateArg(alleleIndex >= 0, "alleleIndex");
-                Utils.nonNull(dest);
-                original.copyAlleleLikelihoods(permutation.fromIndex(alleleIndex), dest, offset);
-            }
         };
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
@@ -661,7 +661,9 @@ public final class GenotypeAlleleCounts implements Comparable<GenotypeAlleleCoun
 
 
     public void forEachAlleleIndexAndCount(final IntBiConsumer action) {
-        new IndexRange(0, distinctAlleleCount).forEach(n -> action.accept(sortedAlleleCounts[2*n], sortedAlleleCounts[2*n+1]));
+        for (int n = 0; n < distinctAlleleCount; n++) {
+            action.accept(sortedAlleleCounts[2*n], sortedAlleleCounts[2*n+1]);
+        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculator.java
@@ -2,22 +2,23 @@ package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeLikelihoods;
+import org.apache.commons.lang.mutable.MutableDouble;
+import org.apache.commons.math3.util.FastMath;
+import org.broadinstitute.hellbender.utils.IndexRange;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
 
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.PriorityQueue;
+import java.util.function.Consumer;
 
 /**
  * Helper to calculate genotype likelihoods given a ploidy and an allele count (number of possible distinct alleles).
  */
-public final class GenotypeLikelihoodCalculator {
-
-    /**
-     * Maximum number of components (or distinct alleles) for any genotype with this calculator ploidy and allele count.
-     */
-    private int maximumDistinctAllelesInGenotype;
+public final class GenotypeLikelihoodCalculator implements Iterable<GenotypeAlleleCounts>{
 
     /**
      * Offset table for this calculator.
@@ -46,14 +47,7 @@ public final class GenotypeLikelihoodCalculator {
      */
     private final int genotypeCount;
 
-    /**
-     * Number of genotyping alleles for this calculator.
-     */
     private final int alleleCount;
-
-    /**
-     * Ploidy for this calculator.
-     */
     private final int ploidy;
 
     /**
@@ -67,75 +61,23 @@ public final class GenotypeLikelihoodCalculator {
      */
     private GenotypeAlleleCounts lastOverheadCounts;
 
-    /**
-     * Buffer used as a temporary container for likelihood components for genotypes stratified by alleles, allele frequency and reads.
-     *
-     * <p>To improve performance we use a 1-dimensional array to implement a 3-dimensional one as some of those dimension
-     * have typically very low depths (allele and allele frequency)</p>
-     *
-     * <p>
-     *     The value contained in position <code>[a][f][r] == log10Lk(read[r] | allele[a]) + log10(f) </code>. Exception is
-     *     for f == 0 whose value is undefined (in practice 0.0) and never used.
-     * </p>
-     *
-     * <p>
-     *     It is indexed by read, then by allele and then by the number of copies of the allele. For the latter
-     *     there are as many entries as the ploidy of the calculator + 1 (to accommodate zero copies although is
-     *     never used in practice).
-     * </p>
-     */
-    private double[] readAlleleLikelihoodByAlleleCount = null;
-
-    /**
-     * Buffer used as a temporary container for likelihood components for genotypes stratified by reads.
-     *
-     * <p>
-     *     It is indexed by genotype index and then by read index. The read capacity is increased as needed by calling
-     *     {@link #ensureReadCapacity(int) ensureReadCapacity}.
-     * </p>
-     */
-    private final double[][] readLikelihoodsByGenotypeIndex;
-
+    private static final int INITIAL_READ_CAPACITY = 10;
     /**
      * Indicates how many reads the calculator supports.
      *
-     * <p>This figure is increased dynamically as per the
-     * calculation request calling {@link #ensureReadCapacity(int) ensureReadCapacity}.<p/>
+     * This figure is increased dynamically by {@link #ensureReadCapacity(int) ensureReadCapacity}.
      */
-    private int readCapacity = -1;
+    private int readCapacity = INITIAL_READ_CAPACITY;
 
     /**
-     * Buffer field use as a temporal container for sorted allele counts when calculating the likelihood of a
-     * read in a genotype.
-     * <p>
-     *      This array follows the same format as {@link GenotypeAlleleCounts#sortedAlleleCounts}. Each component in the
-     *      genotype takes up two positions in the array where the first indicate the allele index and the second its frequency in the
-     *      genotype. Only non-zero frequency alleles are represented, taking up the first positions of the array.
-     * </p>
+     * Buffer field used as a temporary container when one value per read is stored.
      *
-     * <p>
-     *     This array is sized so that it can accommodate the maximum possible number of distinct alleles in any
-     *     genotype supported by the calculator, value stored in {@link #maximumDistinctAllelesInGenotype}.
-     * </p>
+     * In the multiallelic calculation we accumulate the likelihood contribution of each read one allele at a time.  That is,
+     * for genotype containing alleles A, B, C, we first fill the buffer with the likelihood contributions from allele A, then
+     * we make a second pass and add the contributions from allele B, then allele C.  Traversing each allele row of the
+     * likelihoods array in this manner is cache-friendly.
      */
-    private final int[] genotypeAllelesAndCounts;
-
-    /**
-     * Buffer field use as a temporal container for component likelihoods when calculating the likelihood of a
-     * read in a genotype. It is stratified by read and the allele component of the genotype likelihood... that is
-     * the part of the likelihood sum that correspond to a particular allele in the genotype.
-     *
-     * <p>
-     *     It is implemented in a 1-dimensional array since typically one of the dimensions is rather small. Its size
-     *     is equal to {@link #readCapacity} times {@link #maximumDistinctAllelesInGenotype}.
-     * </p>
-     *
-     * <p>
-     *     More concretely [r][i] == log10Lk(read[r] | allele[i]) + log(freq[i]) where allele[i] is the ith allele
-     *     in the genotype of interest and freq[i] is the number of times it occurs in that genotype.
-     * </p>
-     */
-    private double[] readGenotypeLikelihoodComponents;
+    private double[] perReadBuffer = new double[INITIAL_READ_CAPACITY];
 
     /**
      * Creates a new calculator providing its ploidy and number of genotyping alleles.
@@ -150,34 +92,16 @@ public final class GenotypeLikelihoodCalculator {
         this.ploidy = ploidy;
         genotypeCount = this.alleleFirstGenotypeOffsetByPloidy[ploidy][alleleCount];
         alleleHeap = new PriorityQueue<>(ploidy, Comparator.<Integer>naturalOrder().reversed());
-        readLikelihoodsByGenotypeIndex = new double[genotypeCount][];
-        // The number of possible components is limited by distinct allele count and ploidy.
-        maximumDistinctAllelesInGenotype = Math.min(ploidy, alleleCount);
-        genotypeAllelesAndCounts = new int[maximumDistinctAllelesInGenotype * 2];
     }
 
     /**
      * Makes sure that temporal arrays and matrices are prepared for a number of reads to process.
      * @param requestedCapacity number of read that need to be processed.
      */
-    public void ensureReadCapacity(final int requestedCapacity) {
-        Utils.validateArg(requestedCapacity >= 0, "capacity may not be negative");
-        if (readCapacity == -1) { // first time call.
-            final int minimumCapacity = Math.max(requestedCapacity, 10); // Never go too small, 10 is the minimum.
-            readAlleleLikelihoodByAlleleCount = new double[minimumCapacity * alleleCount * (ploidy+1)];
-            for (int i = 0; i < genotypeCount; i++) {
-                readLikelihoodsByGenotypeIndex[i] = new double[minimumCapacity];
-            }
-            readGenotypeLikelihoodComponents = new double[ploidy * minimumCapacity];
-            readCapacity = minimumCapacity;
-        } else if (readCapacity < requestedCapacity) {
-            final int doubleCapacity = (requestedCapacity << 1);
-            readAlleleLikelihoodByAlleleCount = new double[doubleCapacity * alleleCount * (ploidy+1)];
-            for (int i = 0; i < genotypeCount; i++) {
-                readLikelihoodsByGenotypeIndex[i] = new double[doubleCapacity];
-            }
-            readGenotypeLikelihoodComponents = new double[maximumDistinctAllelesInGenotype * doubleCapacity];
-            readCapacity = doubleCapacity;
+    private void ensureReadCapacity(final int requestedCapacity) {
+        if (readCapacity < requestedCapacity) {
+            readCapacity = 2 * requestedCapacity;
+            perReadBuffer = new double[readCapacity];
         }
     }
 
@@ -213,7 +137,7 @@ public final class GenotypeLikelihoodCalculator {
     /**
      * Returns the genotype associated to a particular likelihood index.
      *
-     * <p>If {@code index} is larger than {@link GenotypeLikelihoodCalculators#MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY},
+     * <p>If {@code index} is larger than {@link GenotypeLikelihoodCalculators#MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR},
      *  this method will reconstruct that genotype-allele-count iteratively from the largest strongly referenced count available.
      *  or the last requested index genotype.
      *  </p>
@@ -227,11 +151,11 @@ public final class GenotypeLikelihoodCalculator {
     public GenotypeAlleleCounts genotypeAlleleCountsAt(final int index) {
         Utils.validateArg(index >= 0 && index < genotypeCount, () -> "invalid likelihood index: " + index + " >= " + genotypeCount
                     + " (genotype count for nalleles = " + alleleCount + " and ploidy " + ploidy);
-        if (index < GenotypeLikelihoodCalculators.MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY) {
+        if (index < GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR) {
             return genotypeAlleleCounts[index];
         } else if (lastOverheadCounts == null || lastOverheadCounts.index() > index) {
-            final GenotypeAlleleCounts result = genotypeAlleleCounts[GenotypeLikelihoodCalculators.MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY - 1].copy();
-            result.increase(index - GenotypeLikelihoodCalculators.MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY + 1);
+            final GenotypeAlleleCounts result = genotypeAlleleCounts[GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR - 1].copy();
+            result.increase(index - GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR + 1);
             lastOverheadCounts = result;
             return result.copy();
         } else {
@@ -241,193 +165,107 @@ public final class GenotypeLikelihoodCalculator {
     }
 
     /**
-     * Calculate the likelihoods given the list of alleles and the likelihood map.
+     * Calculate the log10Likelihoods given the list of alleles and the likelihood map.
      *
-     * @param likelihoods the likelihood matrix all alleles vs all reads.
+     * @param log10Likelihoods the likelihood matrix all alleles vs all reads.
      *
-     * @throws IllegalArgumentException if {@code alleleList} is {@code null} or {@code likelihoods} is {@code null}
+     * @throws IllegalArgumentException if {@code alleleList} is {@code null} or {@code log10Likelihoods} is {@code null}
      *     or the alleleList size does not match the allele-count of this calculator, or there are missing allele vs
-     *     read combinations in {@code likelihoods}.
+     *     read combinations in {@code log10Likelihoods}.
      *
      * @return never {@code null}.
      */
-    public <EVIDENCE, A extends Allele> GenotypeLikelihoods genotypeLikelihoods(final LikelihoodMatrix<EVIDENCE, A> likelihoods) {
-        Utils.nonNull(likelihoods);
-        Utils.validateArg(likelihoods.numberOfAlleles() == alleleCount, "mismatch between allele list and alleleCount");
-        final int readCount = likelihoods.evidenceCount();
+    public <EVIDENCE, A extends Allele> GenotypeLikelihoods genotypeLikelihoods(final LikelihoodMatrix<EVIDENCE, A> log10Likelihoods) {
+        Utils.nonNull(log10Likelihoods);
+        Utils.validateArg(log10Likelihoods.numberOfAlleles() == alleleCount, "mismatch between allele list and alleleCount");
+        final int readCount = log10Likelihoods.evidenceCount();
         ensureReadCapacity(readCount);
 
-        /// [x][y][z] = z * LnLk(Read_x | Allele_y)
-        final double[] readLikelihoodComponentsByAlleleCount
-                = readLikelihoodComponentsByAlleleCount(likelihoods);
-        final double[][] genotypeLikelihoodByRead = genotypeLikelihoodByRead(readLikelihoodComponentsByAlleleCount,readCount);
-        final double[] readLikelihoodsByGenotypeIndex = genotypeLikelihoods(genotypeLikelihoodByRead, readCount);
-        return GenotypeLikelihoods.fromLog10Likelihoods(readLikelihoodsByGenotypeIndex);
-    }
+        final double[][] log10LikelihoodsByAlleleAndRead = log10Likelihoods.copyAlleleLikelihoods();
+        final boolean triallelicGenotypesPossible = alleleCount > 2 && ploidy > 2;
 
-    /**
-     * Calculates the final genotype likelihood array out of the likelihoods for each genotype per read.
-     *
-     * @param readLikelihoodsByGenotypeIndex <i>[g][r]</i> likelihoods for each genotype <i>g</i> and <i>r</i>.
-     * @param readCount number of reads in the input likelihood arrays in {@code genotypeLikelihoodByRead}.
-     * @return never {@code null}, one position per genotype where the <i>i</i> entry is the likelihood of the ith
-     *   genotype (0-based).
-     */
-    private double[] genotypeLikelihoods(final double[][] readLikelihoodsByGenotypeIndex, final int readCount) {
+        // non-log space likelihoods for multiallelic computation
+        final double[][] likelihoodsByAlleleAndRead = triallelicGenotypesPossible ? log10Likelihoods.copyAlleleLikelihoods() : null;
+        final MutableDouble multiallelicNormalization = new MutableDouble(0);
+        if (triallelicGenotypesPossible) {
+            makeNormalizedNonLogLikelihoods(readCount, likelihoodsByAlleleAndRead, multiallelicNormalization);
+        }
+
         final double[] result = new double[genotypeCount];
-        final double denominator = readCount * MathUtils.log10(ploidy);
-        // instead of dividing each read likelihood by ploidy ( so subtract log10(ploidy) )
-         // we multiply them all and the divide by ploidy^readCount (so substract readCount * log10(ploidy) )
-        for (int g = 0; g < genotypeCount; g++) {
-            result[g] = MathUtils.sum(readLikelihoodsByGenotypeIndex[g], 0, readCount) - denominator;
-        }
-        return result;
-    }
 
-    /**
-     * Calculates the likelihood component of each read on each genotype.
-     *
-     * @param readLikelihoodComponentsByAlleleCount [a][f][r] likelihood stratified by allele <i>a</i>, frequency in genotype <i>f</i> and
-     *                                              read <i>r</i>.
-     * @param readCount number of reads in {@code readLikelihoodComponentsByAlleleCount}.
-     * @return never {@code null}.
-     */
-    private double[][] genotypeLikelihoodByRead(final double[] readLikelihoodComponentsByAlleleCount, final int readCount) {
-
-        // Here we don't use the convenience of {@link #genotypeAlleleCountsAt(int)} within the loop to spare instantiations of
-        // GenotypeAlleleCounts class when we are dealing with many genotypes.
-        GenotypeAlleleCounts alleleCounts = genotypeAlleleCounts[0];
-
-        for (int genotypeIndex = 0; genotypeIndex < genotypeCount; genotypeIndex++) {
-            final double[] readLikelihoods = this.readLikelihoodsByGenotypeIndex[genotypeIndex];
+        Utils.stream(iterator()).forEach(alleleCounts -> {
             final int componentCount = alleleCounts.distinctAlleleCount();
-            switch (componentCount) {
-                case 1: //
-                    singleComponentGenotypeLikelihoodByRead(alleleCounts, readLikelihoods, readLikelihoodComponentsByAlleleCount, readCount);
-                    break;
-                case 2:
-                    twoComponentGenotypeLikelihoodByRead(alleleCounts,readLikelihoods,readLikelihoodComponentsByAlleleCount, readCount);
-                    break;
-                default:
-                    manyComponentGenotypeLikelihoodByRead(alleleCounts,readLikelihoods,readLikelihoodComponentsByAlleleCount, readCount);
+            final int genotypeIndex = alleleCounts.index();
+            if (componentCount == 1) {
+                // homozygous case: log P(reads|AAAAA. . .) = sum_{reads} log P(read|A)
+                final int allele = alleleCounts.alleleIndexAt(0);
+                result[genotypeIndex] = MathUtils.sum(log10LikelihoodsByAlleleAndRead[allele]);
+            } else if (componentCount == 2) {
+                // biallelic het case: log P(reads | nA copies of A, nB copies of B) = sum_{reads} log[(nA * P(read | A) + nB * P(read | B))] -log(ploidy)
+                final double[] logLks1 = log10LikelihoodsByAlleleAndRead[alleleCounts.alleleIndexAt(0)];
+                final int freq1 = alleleCounts.alleleCountAt(0);
+                final double log10Freq1 = MathUtils.log10(freq1);
+                final double[] logLks2  = log10LikelihoodsByAlleleAndRead[alleleCounts.alleleIndexAt(1)];
+                final double log10Freq2 = MathUtils.log10(ploidy - freq1);
+
+                result[genotypeIndex] = new IndexRange(0, readCount).sum(r -> MathUtils.approximateLog10SumLog10(logLks1[r] + log10Freq1, logLks2[r] + log10Freq2))
+                        - readCount * MathUtils.log10(ploidy);
+            } else {
+                // the multiallelic case is conceptually the same as the biallelic case but done in non-log space
+                // We implement in a cache-friendly way by adding nA * P(read|A) to the per-read buffer for all reads (inner loop), and all alleles (outer loop)
+                Arrays.fill(perReadBuffer,0, readCount, 0);
+                alleleCounts.forEachAlleleIndexAndCount((a, f) -> new IndexRange(0, readCount).forEach(r -> perReadBuffer[r] += f * likelihoodsByAlleleAndRead[a][r]));
+                result[genotypeIndex] = new IndexRange(0, readCount).sum(r -> FastMath.log10(perReadBuffer[r])) - readCount * MathUtils.log10(ploidy) + multiallelicNormalization.doubleValue();
             }
-            if (genotypeIndex < genotypeCount - 1) {
-                alleleCounts = nextGenotypeAlleleCounts(alleleCounts);
-            }
-        }
-        return readLikelihoodsByGenotypeIndex;
+        });
+        return GenotypeLikelihoods.fromLog10Likelihoods(result);
     }
 
-    private GenotypeAlleleCounts nextGenotypeAlleleCounts(final GenotypeAlleleCounts alleleCounts) {
-        final int index = alleleCounts.index();
-        final GenotypeAlleleCounts result;
-        final int cmp = index - GenotypeLikelihoodCalculators.MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY + 1;
-        if (cmp < 0) {
-            result = genotypeAlleleCounts[index + 1];
-        } else if (cmp == 0) {
-            result = genotypeAlleleCounts[index].copy();
-            result.increase();
-        } else {
-            alleleCounts.increase();
-            result = alleleCounts;
-        }
-        return result;
-    }
-
-    /**
-     * General genotype likelihood component by read calculator. It does not make any assumption in the exact
-     * number of alleles present in the genotype.
-     */
-    private void manyComponentGenotypeLikelihoodByRead(final GenotypeAlleleCounts genotypeAlleleCounts,
-                                                       final double[] likelihoodByRead,
-                                                       final double[]readLikelihoodComponentsByAlleleCount,
-                                                       final int readCount) {
-
-        // First we collect the allele likelihood component for all reads and place it
-        // in readGenotypeLikelihoodComponents for the final calculation per read.
-        genotypeAlleleCounts.copyAlleleCounts(genotypeAllelesAndCounts,0);
-        final int componentCount = genotypeAlleleCounts.distinctAlleleCount();
-        final int alleleDataSize = (ploidy + 1) * readCount;
-        for (int c = 0,cc = 0; c < componentCount; c++) {
-            final int alleleIndex = genotypeAllelesAndCounts[cc++];
-            final int alleleCount = genotypeAllelesAndCounts[cc++];
-            // alleleDataOffset will point to the index of the first read likelihood for that allele and allele count.
-            int alleleDataOffset = alleleDataSize * alleleIndex + alleleCount * readCount;
-            for (int r = 0, readDataOffset = c; r < readCount; r++, readDataOffset += maximumDistinctAllelesInGenotype) {
-                readGenotypeLikelihoodComponents[readDataOffset] = readLikelihoodComponentsByAlleleCount[alleleDataOffset++];
+    private void makeNormalizedNonLogLikelihoods(int readCount, double[][] likelihoodsByAlleleAndRead, final MutableDouble multiallelicNormalization) {
+        // fill the per-read buffer with the maximum log-likelihood per read
+        Arrays.fill(perReadBuffer, 0, readCount, Double.NEGATIVE_INFINITY);
+        for (int a = 0; a < alleleCount; a++) {
+            for (int r = 0; r < readCount; r++) {
+                perReadBuffer[r] = FastMath.max(perReadBuffer[r], likelihoodsByAlleleAndRead[a][r]);
             }
         }
 
-        // Calculate the likelihood per read.
-        for (int r = 0, readDataOffset = 0; r < readCount; r++, readDataOffset += maximumDistinctAllelesInGenotype) {
-            likelihoodByRead[r] = MathUtils.approximateLog10SumLog10(readGenotypeLikelihoodComponents, readDataOffset, readDataOffset + componentCount);
+        // subtract these maxima
+        for (int a = 0; a < alleleCount; a++) {
+            for (int r = 0; r < readCount; r++) {
+                likelihoodsByAlleleAndRead[a][r] -= perReadBuffer[r];
+            }
         }
+        // switch to non-log now that we have moved to numerically safe zero-max space
+        new IndexRange(0, alleleCount).forEach(a -> MathUtils.applyToArrayInPlace(likelihoodsByAlleleAndRead[a], x -> Math.pow(10.0, x)));
+
+        // the normalization is the sum of all the subtracted-off maximum log likelihoods
+        multiallelicNormalization.setValue(MathUtils.sum(perReadBuffer, 0, readCount));
     }
 
-    /**
-     * Calculates the likelihood component by read for a given genotype allele count assuming that there are
-     * exactly two alleles present in the genotype (with arbitrary non-zero counts each).
-     */
-    private void twoComponentGenotypeLikelihoodByRead(final GenotypeAlleleCounts genotypeAlleleCounts,
-                                                      final double[] likelihoodByRead,
-                                                      final double[] readLikelihoodComponentsByAlleleCount,
-                                                      final int readCount) {
-        final int allele0 = genotypeAlleleCounts.alleleIndexAt(0);
-        final int freq0 = genotypeAlleleCounts.alleleCountAt(0);
-        final int allele1 = genotypeAlleleCounts.alleleIndexAt(1);
-        final int freq1 = ploidy - freq0; // no need to get it from genotypeAlleleCounts.
-        int allele0LnLkOffset = readCount * ((ploidy + 1) * allele0 + freq0);
-        int allele1LnLkOffset = readCount * ((ploidy + 1) * allele1 + freq1);
-        for (int r = 0; r < readCount; r++) {
-            final double lnLk0 = readLikelihoodComponentsByAlleleCount[allele0LnLkOffset++];
-            final double lnLk1 = readLikelihoodComponentsByAlleleCount[allele1LnLkOffset++];
-            likelihoodByRead[r] = MathUtils.approximateLog10SumLog10(lnLk0, lnLk1);
-        }
-    }
+    @Override
+    public Iterator<GenotypeAlleleCounts> iterator() {
+        return new Iterator<GenotypeAlleleCounts>() {
+            private int genotypeIndex = 0;
+            private final GenotypeAlleleCounts increasingAlleleCounts = genotypeCount < GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR ?
+                    null : genotypeAlleleCounts[GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR - 1].copy();
 
-    /**
-     * Calculates the likelihood component by read for a given genotype allele count assuming that there are
-     * exactly one allele present in the genotype.
-     */
-    private void singleComponentGenotypeLikelihoodByRead(final GenotypeAlleleCounts genotypeAlleleCounts,
-                                                         final double[] likelihoodByRead, final double[] readLikelihoodComponentsByAlleleCount, final int readCount) {
-        final int allele = genotypeAlleleCounts.alleleIndexAt(0);
-        // the count of the only component must be = ploidy.
-        int offset = (allele * (ploidy + 1) + ploidy) * readCount;
-        for (int r = 0; r < readCount; r++) {
-            likelihoodByRead[r] =
-                    readLikelihoodComponentsByAlleleCount[offset++];
-        }
-    }
+            @Override
+            public boolean hasNext() {
+                return genotypeIndex < genotypeCount;
+            }
 
-    /**
-     * Returns a 3rd matrix with the likelihood components.
-     *
-     * <pre>
-     *     result[y][z][x] :=  z * lnLk ( read_x | allele_y ).
-     * </pre>
-     *
-     * @return never {@code null}.
-     */
-    private <EVIDENCE, A extends Allele> double[] readLikelihoodComponentsByAlleleCount(final LikelihoodMatrix<EVIDENCE, A> likelihoods) {
-        final int readCount = likelihoods.evidenceCount();
-        final int alleleDataSize = readCount * (ploidy + 1);
-
-        // frequency1Offset = readCount to skip the useless frequency == 0. So now we are at the start frequency == 1
-        // frequency1Offset += alleleDataSize to skip to the next allele index data location (+ readCount) at each iteration.
-        for (int a = 0, frequency1Offset = readCount; a < alleleCount; a++, frequency1Offset += alleleDataSize) {
-            likelihoods.copyAlleleLikelihoods(a, readAlleleLikelihoodByAlleleCount, frequency1Offset);
-
-            // p = 2 because the frequency == 1 we already have it.
-            for (int frequency = 2, destinationOffset = frequency1Offset + readCount; frequency <= ploidy; frequency++) {
-                final double log10frequency = MathUtils.log10(frequency);
-                for (int r = 0, sourceOffset = frequency1Offset; r < readCount; r++) {
-                    readAlleleLikelihoodByAlleleCount[destinationOffset++] =
-                            readAlleleLikelihoodByAlleleCount[sourceOffset++] + log10frequency;
+            @Override
+            public GenotypeAlleleCounts next() {
+                if (genotypeIndex < GenotypeLikelihoodCalculators.MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR) {
+                    return genotypeAlleleCounts[genotypeIndex++];
+                } else {
+                    increasingAlleleCounts.increase();
+                    genotypeIndex++;
+                    return increasingAlleleCounts;
                 }
             }
-        }
-        return readAlleleLikelihoodByAlleleCount;
+        };
     }
 
     /**
@@ -522,13 +360,7 @@ public final class GenotypeLikelihoodCalculator {
         final int[] result = new int[resultLength];
         final int[] sortedAlleleCounts = new int[Math.max(ploidy, alleleCount) << 1];
         alleleHeap.clear();
-        GenotypeAlleleCounts alleleCounts = genotypeAlleleCounts[0];
-        for (int i = 0; i < resultLength; i++) {
-            genotypeIndexMapPerGenotypeIndex(i,alleleCounts, oldToNewAlleleIndexMap, result, sortedAlleleCounts);
-            if (i < resultLength - 1) {
-                alleleCounts = nextGenotypeAlleleCounts(alleleCounts);
-            }
-        }
+        Utils.stream(iterator()).limit(resultLength).forEach(gac -> genotypeIndexMapPerGenotypeIndex(gac.index(), gac, oldToNewAlleleIndexMap, result, sortedAlleleCounts));
         return result;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculators.java
@@ -31,9 +31,13 @@ public final class GenotypeLikelihoodCalculators {
     private int maximumPloidy = 2; // its initial value is the initial capacity of the shared tables.
 
     /**
-     * Maximum possible number of genotypes that this calculator can handle.
+     * Maximum possible number of {@link GenotypeAlleleCounts} a {@link GenotypeLikelihoodCalculator} of fixed ploidy
+     * and allele count may cache in an array, allowing for fast random access of genotypes.
+     *
+     * Iterating over all genotypes via the {@code increase} method is always fast, but accessing the allele counts
+     * for a particular genotype index, eg the one with the greatest likelihood, is slow without a cache.
      */
-    public static final int MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY = 1000;
+    public static final int MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR = 1000;
 
     /**
      * Mark to indicate genotype-count overflow due to a large number of allele and ploidy;
@@ -238,7 +242,7 @@ public final class GenotypeLikelihoodCalculators {
         Utils.validateArg(ploidy >= 0, () -> "the requested ploidy cannot be negative: " + ploidy);
         Utils.validateArg(alleleCount >= 0, () -> "the requested maximum allele cannot be negative: " + alleleCount);
         final int length = genotypeOffsetTable[ploidy][alleleCount];
-        final int strongRefLength = length == GENOTYPE_COUNT_OVERFLOW ? MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY : Math.min(length, MAXIMUM_STRONG_REF_GENOTYPE_PER_PLOIDY);
+        final int strongRefLength = length == GENOTYPE_COUNT_OVERFLOW ? MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR : Math.min(length, MAXIMUM_NUMBER_OF_CACHED_GENOTYPE_ALLELE_COUNTS_PER_CALCULATOR);
         final GenotypeAlleleCounts[] result = new GenotypeAlleleCounts[strongRefLength];
         result[0] = GenotypeAlleleCounts.first(ploidy);
         for (int genotypeIndex = 1; genotypeIndex < strongRefLength; genotypeIndex++) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SubsettedLikelihoodMatrix.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SubsettedLikelihoodMatrix.java
@@ -73,9 +73,4 @@ public class SubsettedLikelihoodMatrix<EVIDENCE extends Locatable, A extends All
 
     @Override
     public EVIDENCE getEvidence(final int evidenceIndex) { return matrix.getEvidence(evidenceIndex); }
-
-    @Override
-    public void copyAlleleLikelihoods(final int alleleIndex, final double[] dest, final int offset) {
-        throw new UnsupportedOperationException("Subsetted likelihood matrices are not meant to be copied.");
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
@@ -1298,12 +1298,5 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
             Utils.validIndex(evidenceIndex, sampleEvidence.size());
             return sampleEvidence.get(evidenceIndex);
         }
-
-        @Override
-        public void copyAlleleLikelihoods(final int alleleIndex, final double[] dest, final int offset) {
-            Utils.nonNull(dest);
-            Utils.validIndex(alleleIndex, valuesBySampleIndex[sampleIndex].length);
-            System.arraycopy(valuesBySampleIndex[sampleIndex][alleleIndex], 0, dest, offset, numberOfEvidences[sampleIndex]);
-        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/LikelihoodMatrix.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/LikelihoodMatrix.java
@@ -107,10 +107,18 @@ public interface LikelihoodMatrix<EVIDENCE,A extends Allele> extends AlleleList<
 
 
     /**
-     * Copies the likelihood of all the evidence for a given allele into an array from a particular offset.
-     * @param alleleIndex the targeted allele
-     * @param dest the destination array.
-     * @param offset the copy offset within the destination allele
+     * Copies the likelihood of all the evidence for a given allele into a 2D array
      */
-    public void copyAlleleLikelihoods(final int alleleIndex, final double[] dest, final int offset);
+    default double[][] copyAlleleLikelihoods() {
+        final int alleleCount = numberOfAlleles();
+        final int evidenceCount = evidenceCount();
+        final double[][] result = new double[alleleCount][evidenceCount];
+        for (int a = 0; a < alleleCount; a++) {
+            for (int e = 0; e < evidenceCount; e++) {
+                result[a][e] = get(a,e);
+            }
+        }
+
+        return result;
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeLikelihoodCalculatorUnitTest.java
@@ -135,7 +135,7 @@ public final class GenotypeLikelihoodCalculatorUnitTest {
             return 0;
         else {
             return calculateGenotypeCount(ploidy - 1, alleleCount) +
-                        calculateGenotypeCount(ploidy, alleleCount - 1);
+                    calculateGenotypeCount(ploidy, alleleCount - 1);
         }
     }
 
@@ -157,7 +157,7 @@ public final class GenotypeLikelihoodCalculatorUnitTest {
         for (final int i : PLOIDY)
             for (final int j : MAXIMUM_ALLELE)
                 for (final int[] k : READ_COUNTS)
-                result[index++] = new Object[] { i, j, k };
+                    result[index++] = new Object[] { i, j, k };
         return result;
     }
 
@@ -167,7 +167,7 @@ public final class GenotypeLikelihoodCalculatorUnitTest {
         int index = 0;
         for (final int i : PLOIDY)
             for (final int j : MAXIMUM_ALLELE)
-                    result[index++] = new Object[] { i, j };
+                result[index++] = new Object[] { i, j };
         return result;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMUnitTest.java
@@ -583,11 +583,6 @@ public final class PairHMMUnitTest extends GATKBaseTest {
             public GATKRead getEvidence(int evidenceIndex) {
                 throw new UnsupportedOperationException();
             }
-
-            @Override
-            public void copyAlleleLikelihoods(int alleleIndex, double[] dest, int offset) {
-                throw new UnsupportedOperationException();
-            }
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/VectorPairHMMUnitTest.java
@@ -175,11 +175,6 @@ public final class VectorPairHMMUnitTest extends GATKBaseTest {
             public GATKRead getEvidence(int evidenceIndex) {
                 throw new UnsupportedOperationException();
             }
-
-            @Override
-            public void copyAlleleLikelihoods(int alleleIndex, double[] dest, int offset) {
-                throw new UnsupportedOperationException();
-            }
         };
     }
 


### PR DESCRIPTION
@jamesemery Could you review this?  I think you may appreciate it.  It took several tries, but I was finally able to write a stripped-down version of the code that actually slightly outperforms the old version.  What I realized after a lot of profiling the old code and various failed rewrites was that cache-friendliness is the critical thing here.  It turns out that this can be achieved without too many buffers, without precomputing the log frequencies, and without storing 2D and 3D arrays as flattened 1D arrays.