### PR TITLE
Fixes for IndexFeatureFile error reporting.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
@@ -78,11 +78,11 @@ public final class IndexFeatureFile extends CommandLineProgram {
         try {
             index.write(indexPath);
         } catch (final IOException e) {
-            throw new UserException.CouldNotCreateOutputFile("Could not write index to file " + indexPath.toAbsolutePath(), e);
+            throw new UserException.CouldNotCreateOutputFile("Could not write index to file " + indexPath, e);
         }
 
-        logger.info("Successfully wrote index to " + indexPath.toAbsolutePath());
-        return indexPath.toAbsolutePath().toString();
+        logger.info("Successfully wrote index to " + indexPath);
+        return indexPath.toString();
     }
 
     private Path determineFileName(final Index index) {


### PR DESCRIPTION
We shouldn't call toAbsolutePath on our Paths since it resolves paths that are not already absolute to a (implementation dependent) default location, which will often return an incorrect result for non-default file systems.

This is the cosmetic part of the fix for https://github.com/broadinstitute/gatk/issues/6348. The actual fix requires an htsjdk that has https://github.com/samtools/htsjdk/pull/1449.