### PR TITLE
Yf fix GenotypeAlleleCount's toString

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
@@ -371,13 +371,12 @@ public final class GenotypeAlleleCounts implements Comparable<GenotypeAlleleCoun
             return "";
         }
         final StringBuilder sb = new StringBuilder(distinctAlleleCount * 3);
-        for (int i = 0; i < distinctAlleleCount; i += 2) {
+        for (int i = 0; i < distinctAlleleCount * 2; i += 2) {
             final int alleleIndex = sortedAlleleCounts[i];
             final int alleleCount = sortedAlleleCounts[i + 1];
             for (int j = 0; j < alleleCount; j++) {
                 sb.append(alleleIndex).append('/');
             }
-
         }
         sb.setLength(sb.length() - 1);
         return sb.toString();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCounts.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
 import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
 import org.broadinstitute.hellbender.utils.IndexRange;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -371,11 +372,12 @@ public final class GenotypeAlleleCounts implements Comparable<GenotypeAlleleCoun
             return "";
         }
         final StringBuilder sb = new StringBuilder(distinctAlleleCount * 3);
-        for (int i = 0; i < distinctAlleleCount * 2; i += 2) {
-            final int alleleIndex = sortedAlleleCounts[i];
-            final int alleleCount = sortedAlleleCounts[i + 1];
+        final int upperBound = distinctAlleleCount * 2;
+        for (int i = 0; i < upperBound;) {
+            final int alleleIndex = sortedAlleleCounts[i++];
+            final int alleleCount = sortedAlleleCounts[i++];
             for (int j = 0; j < alleleCount; j++) {
-                sb.append(alleleIndex).append('/');
+                sb.append(alleleIndex).append(Genotype.UNPHASED_ALLELE_SEPARATOR);
             }
         }
         sb.setLength(sb.length() - 1);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
@@ -7,10 +7,15 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
- * Test {@link org.broadinstitute.gatk.tools.walkers.genotyper.GenotypeAlleleCounts}
+ * Test {@link org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAlleleCounts}
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
@@ -413,4 +418,22 @@ public final class GenotypeAlleleCountsUnitTest {
         return result;
     }
 
+    @DataProvider
+    public Object[][] genotypeAlleleCountDataWithToStringOutput() {
+        return new Object[][]{
+                new Object[]{1, new String[]{"0", "1", "2"}},
+                new Object[]{2, new String[]{"0/0", "0/1", "1/1", "0/2", "1/2", "2/2"}},
+                new Object[]{3, new String[]{"0/0/0", "0/0/1", "0/1/1","1/1/1","0/0/2","0/1/2","1/1/2","0/2/2","1/2/2","2/2/2"}}};
+    }
+
+    @Test(dataProvider = "genotypeAlleleCountDataWithToStringOutput")
+    public void testToString(final int ploidy, final String[] expectedtoStrings) {
+        GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
+        int i = 0;
+        do {
+            Assert.assertEquals(current.toString(), expectedtoStrings[i],String.format("genotype index: %d",i));
+            i++;
+            current = current.next();
+        } while (i < expectedtoStrings.length);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
@@ -303,8 +303,7 @@ public final class GenotypeAlleleCountsUnitTest {
     }
 
     private void testNextOnePloidyIncrease() {
-        final GenotypeAlleleCounts first = GenotypeAlleleCounts.first(1);
-        GenotypeAlleleCounts next = first;
+        final GenotypeAlleleCounts next = GenotypeAlleleCounts.first(1);
 
         while (!next.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
             final GenotypeAlleleCounts current = next.copy();
@@ -344,7 +343,7 @@ public final class GenotypeAlleleCountsUnitTest {
             throw new IllegalArgumentException();
         }
 
-        GenotypeAlleleCounts next = GenotypeAlleleCounts.first(ploidy);
+        final GenotypeAlleleCounts next = GenotypeAlleleCounts.first(ploidy);
 
         while (!next.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
             final GenotypeAlleleCounts current = next.copy();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
@@ -14,6 +14,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.testng.Assert.assertEquals;
+
 /**
  * Test {@link org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAlleleCounts}
  *
@@ -67,30 +69,30 @@ public final class GenotypeAlleleCountsUnitTest {
     public void testFirst(final int ploidy) {
         final GenotypeAlleleCounts subject = GenotypeAlleleCounts.first(ploidy);
         Assert.assertNotNull(subject);
-        Assert.assertEquals(subject.ploidy(), ploidy);
-        Assert.assertEquals(subject.distinctAlleleCount(), 1);
-        Assert.assertEquals(subject.log10CombinationCount(), 0.0);
-        Assert.assertEquals(subject.alleleCountAt(0), ploidy);
-        Assert.assertEquals(subject.alleleCountFor(0), ploidy);
-        Assert.assertEquals(subject.alleleRankFor(0), 0);
-        Assert.assertEquals(subject.alleleRankFor(1), -2);
+        assertEquals(subject.ploidy(), ploidy);
+        assertEquals(subject.distinctAlleleCount(), 1);
+        assertEquals(subject.log10CombinationCount(), 0.0);
+        assertEquals(subject.alleleCountAt(0), ploidy);
+        assertEquals(subject.alleleCountFor(0), ploidy);
+        assertEquals(subject.alleleRankFor(0), 0);
+        assertEquals(subject.alleleRankFor(1), -2);
         Assert.assertTrue(subject.containsAllele(0));
         Assert.assertFalse(subject.containsAllele(1));
-        Assert.assertEquals(subject.alleleIndexAt(0), 0);
-        Assert.assertEquals(subject.maximumAlleleIndex(), 0);
-        Assert.assertEquals(subject.minimumAlleleIndex(), 0);
-        Assert.assertTrue(subject.compareTo(subject) == 0);
-        Assert.assertTrue(subject.equals(subject));
-        Assert.assertEquals(subject.index(), 0);
-        Assert.assertEquals(subject.asAlleleList(testAlleles), Collections.nCopies(ploidy, testAlleles.get(0)));
+        assertEquals(subject.alleleIndexAt(0), 0);
+        assertEquals(subject.maximumAlleleIndex(), 0);
+        assertEquals(subject.minimumAlleleIndex(), 0);
+        assertEquals(subject.compareTo(subject), 0);
+        assertEquals(subject, subject);
+        assertEquals(subject.index(), 0);
+        assertEquals(subject.asAlleleList(testAlleles), Collections.nCopies(ploidy, testAlleles.get(0)));
         for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
             final int[] expected = new int[maximumAlleleIndex + 1];
             expected[0] = ploidy;
-            Assert.assertEquals(subject.alleleCountsByIndex(maximumAlleleIndex), expected);
+            assertEquals(subject.alleleCountsByIndex(maximumAlleleIndex), expected);
         }
 
         Assert.assertNotNull(subject.toString());
-        Assert.assertEquals(subject.toUnphasedGenotypeString(), ploidy == 1 ? "0" : Strings.repeat("0/", ploidy-1) + "0");
+        assertEquals(subject.toUnphasedGenotypeString(), ploidy == 1 ? "0" : Strings.repeat("0/", ploidy-1) + "0");
     }
 
     @Test(dataProvider = "ploidyDataWithZero",dependsOnMethods = "testFirst")
@@ -116,65 +118,64 @@ public final class GenotypeAlleleCountsUnitTest {
     private void testNextZeroPloidy() {
         final GenotypeAlleleCounts first = GenotypeAlleleCounts.first(0);
         final GenotypeAlleleCounts next = first.next();
-        Assert.assertEquals(first, next);
-        Assert.assertEquals(first.compareTo(next), 0);
-        Assert.assertEquals(next.compareTo(first), 0);
-        Assert.assertEquals(next.distinctAlleleCount(), 0);
-        Assert.assertEquals(next.ploidy(), 0);
-        Assert.assertEquals(next.index(), 0);
-        Assert.assertEquals(next.asAlleleList(testAlleles), Collections.EMPTY_LIST);
+        assertEquals(first, next);
+        assertEquals(first.compareTo(next), 0);
+        assertEquals(next.compareTo(first), 0);
+        assertEquals(next.distinctAlleleCount(), 0);
+        assertEquals(next.ploidy(), 0);
+        assertEquals(next.index(), 0);
+        assertEquals(next.asAlleleList(testAlleles), Collections.EMPTY_LIST);
         for (int maximumAlleleIndex = 0; maximumAlleleIndex <= 10; maximumAlleleIndex++) {
             final int[] expected = new int[maximumAlleleIndex + 1];
-            Assert.assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
+            assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
         }
 
         first.increase();
-        Assert.assertEquals(first, next);
+        assertEquals(first, next);
     }
 
     private void testNextOnePloidy() {
        final GenotypeAlleleCounts ploidy2 = GenotypeAlleleCounts.first(2);
-       final GenotypeAlleleCounts first = GenotypeAlleleCounts.first(1);
-       GenotypeAlleleCounts current = first;
+        GenotypeAlleleCounts current = GenotypeAlleleCounts.first(1);
 
        while (!current.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
             final GenotypeAlleleCounts next = current.next();
-            Assert.assertEquals(next.log10CombinationCount(), 0.0);
-            Assert.assertEquals(next.minimumAlleleIndex(), next.maximumAlleleIndex());
-            Assert.assertEquals(next.minimumAlleleIndex(), current.minimumAlleleIndex() + 1);
-            Assert.assertEquals(next.alleleCountAt(0), 1);
-            Assert.assertEquals(next.alleleIndexAt(0), next.minimumAlleleIndex());
-            Assert.assertEquals(next.alleleRankFor(next.minimumAlleleIndex()), 0);
-            Assert.assertEquals(next.alleleRankFor(next.minimumAlleleIndex() + 1), -2);
-            Assert.assertEquals(next.alleleCountFor(next.minimumAlleleIndex()), 1);
-            Assert.assertEquals(next.alleleCountFor(next.minimumAlleleIndex() + 1), 0);
-            Assert.assertEquals(next.ploidy(), 1);
+            assertEquals(next.log10CombinationCount(), 0.0);
+            assertEquals(next.minimumAlleleIndex(), next.maximumAlleleIndex());
+            assertEquals(next.minimumAlleleIndex(), current.minimumAlleleIndex() + 1);
+            assertEquals(next.alleleCountAt(0), 1);
+            assertEquals(next.alleleIndexAt(0), next.minimumAlleleIndex());
+            assertEquals(next.alleleRankFor(next.minimumAlleleIndex()), 0);
+            assertEquals(next.alleleRankFor(next.minimumAlleleIndex() + 1), -2);
+            assertEquals(next.alleleCountFor(next.minimumAlleleIndex()), 1);
+            assertEquals(next.alleleCountFor(next.minimumAlleleIndex() + 1), 0);
+            assertEquals(next.ploidy(), 1);
 
-            int[] dest = new int[next.distinctAlleleCount()*2];
+            final int[] dest = new int[next.distinctAlleleCount()*2];
             next.copyAlleleCounts(dest, 0);
-            Assert.assertEquals(dest, new int[]{next.index(), 1});
+            assertEquals(dest, new int[]{next.index(), 1});
 
             Assert.assertTrue(next.compareTo(current) > 0);
             Assert.assertTrue(current.compareTo(next) < 0);
-            Assert.assertTrue(next.compareTo(next) == 0);
-            Assert.assertTrue(next.equals(next));
-            Assert.assertFalse(next.equals(null));
-            Assert.assertFalse(next.equals(next.toString()));
-            Assert.assertFalse(next.equals(ploidy2));
-            Assert.assertFalse(ploidy2.equals(next));
-            Assert.assertFalse(next.equals(current));
+           assertEquals(next.compareTo(next), 0);
+           assertEquals(next, next);
+           Assert.assertNotEquals(next, null);
+           Assert.assertNotEquals(next.toString(), next);
+           Assert.assertNotEquals(ploidy2, next);
+           Assert.assertNotEquals(next, ploidy2);
+           Assert.assertNotEquals(current, next);
             Assert.assertNotEquals(next.hashCode(), current.hashCode());
-            Assert.assertFalse(current.equals(next));
+           Assert.assertNotEquals(next, current);
 
-            Assert.assertEquals(next.index(), current.index() + 1);
-            Assert.assertEquals(next.ploidy(), current.ploidy());
+            assertEquals(next.index(), current.index() + 1);
+            assertEquals(next.ploidy(), current.ploidy());
 
-            Assert.assertEquals(next.asAlleleList(testAlleles), Collections.singletonList(testAlleles.get(next.maximumAlleleIndex())));
+            assertEquals(next.asAlleleList(testAlleles), Collections.singletonList(testAlleles.get(next.maximumAlleleIndex())));
 
            for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
                final int[] expected = new int[maximumAlleleIndex + 1];
                if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) expected[current.minimumAlleleIndex() + 1] = 1;
-               Assert.assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
+               assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
            }
            current = next;
        }
@@ -194,15 +195,15 @@ public final class GenotypeAlleleCountsUnitTest {
 
             // test log10CombinationCount
             if (ploidy == 2) {
-                Assert.assertEquals(next.log10CombinationCount(), next.distinctAlleleCount() == 2 ? Math.log10(2) : 0.0);
+                assertEquals(next.log10CombinationCount(), next.distinctAlleleCount() == 2 ? Math.log10(2) : 0.0);
             } else if (ploidy == 3) {
-                    Assert.assertEquals(next.log10CombinationCount(),
+                    assertEquals(next.log10CombinationCount(),
                             next.distinctAlleleCount() == 3 ? Math.log10(6) : (next.distinctAlleleCount() == 2 ? Math.log10(6) - Math.log10(2) : 0.0));
             } else {
                 if (next.distinctAlleleCount() == 1) {
-                    Assert.assertEquals(next.log10CombinationCount(), 0.0);
+                    assertEquals(next.log10CombinationCount(), 0.0);
                 } else if (next.distinctAlleleCount() == ploidy) {
-                    Assert.assertEquals(next.log10CombinationCount(), MathUtils.log10Factorial(ploidy));
+                    assertEquals(next.log10CombinationCount(), MathUtils.log10Factorial(ploidy));
                 }
             }
 
@@ -216,29 +217,29 @@ public final class GenotypeAlleleCountsUnitTest {
             final int[] actualAlleleCounts = new int[next.distinctAlleleCount()*2];
             next.copyAlleleCounts(actualAlleleCounts, 0);
 
-            Assert.assertEquals(alleleCountsAsList.stream().mapToInt(n->n).toArray(), actualAlleleCounts);
+            assertEquals(alleleCountsAsList.stream().mapToInt(n->n).toArray(), actualAlleleCounts);
 
-            Assert.assertEquals(absentAlleles.size(), MAXIMUM_ALLELE_INDEX + 1 - next.distinctAlleleCount());
-            next.forEachAlleleIndexAndCount((index, count) -> Assert.assertTrue(!absentAlleles.contains(index)));
+            assertEquals(absentAlleles.size(), MAXIMUM_ALLELE_INDEX + 1 - next.distinctAlleleCount());
+            next.forEachAlleleIndexAndCount((index, count) -> Assert.assertFalse(absentAlleles.contains(index)));
 
 
             if (current.distinctAlleleCount() == 1) {
-                Assert.assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex() + 1);
-                Assert.assertEquals(next.distinctAlleleCount(), 2);
-                Assert.assertEquals(next.minimumAlleleIndex(), 0);
+                assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex() + 1);
+                assertEquals(next.distinctAlleleCount(), 2);
+                assertEquals(next.minimumAlleleIndex(), 0);
             } else {
-                Assert.assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex());
-                Assert.assertEquals(next.minimumAlleleIndex(), current.alleleCountAt(0) > 1 ? 0
+                assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex());
+                assertEquals(next.minimumAlleleIndex(), current.alleleCountAt(0) > 1 ? 0
                         : current.alleleCountAt(0) == 1 ? current.minimumAlleleIndex() + 1 : current.minimumAlleleIndex());
             }
 
             // Checking on 0's new count and current.minAllele + 1 alleles.
-            Assert.assertEquals(next.alleleCountFor(0), current.alleleCountFor(current.minimumAlleleIndex()) - 1);
-            Assert.assertEquals(next.alleleCountFor(current.minimumAlleleIndex() + 1),
+            assertEquals(next.alleleCountFor(0), current.alleleCountFor(current.minimumAlleleIndex()) - 1);
+            assertEquals(next.alleleCountFor(current.minimumAlleleIndex() + 1),
                     current.alleleCountFor(current.minimumAlleleIndex() + 1) + 1);
 
             // Checks current.minAllele count
-            Assert.assertEquals(next.alleleCountFor(current.minimumAlleleIndex()),
+            assertEquals(next.alleleCountFor(current.minimumAlleleIndex()),
                     current.minimumAlleleIndex() == 0 ? current.alleleCountAt(0) - 1 : 0);
 
             int totalCountSum = 0;
@@ -248,23 +249,23 @@ public final class GenotypeAlleleCountsUnitTest {
                 final int index = next.alleleIndexAt(i);
                 expectedAlleleCountsByIndex[index] = count;
                 // Check consistency of alleleCountAt(x) and alleleCountFor(alleleIndexAt(x))
-                Assert.assertEquals(next.alleleCountFor(index), count);
+                assertEquals(next.alleleCountFor(index), count);
                 totalCountSum += count;
                 // Check on counts of, in theory, unaffected allele counts.
                 if (index > current.minimumAlleleIndex() + 1)
-                    Assert.assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
+                    assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
             }
             Assert.assertTrue(Arrays.equals(next.alleleCountsByIndex(Math.max(MAXIMUM_ALLELE_INDEX, next.maximumAlleleIndex())), expectedAlleleCountsByIndex));
-            Assert.assertEquals(totalCountSum, ploidy);
+            assertEquals(totalCountSum, ploidy);
 
             Assert.assertTrue(next.compareTo(current) > 0);
             Assert.assertTrue(current.compareTo(next) < 0);
-            Assert.assertTrue(next.compareTo(next) == 0);
-            Assert.assertTrue(next.equals(next));
-            Assert.assertFalse(next.equals(current));
-            Assert.assertFalse(current.equals(next));
-            Assert.assertEquals(next.index(), current.index() + 1);
-            Assert.assertEquals(next.ploidy(), ploidy);
+            assertEquals(next.compareTo(next), 0);
+            assertEquals(next, next);
+            Assert.assertNotEquals(current, next);
+            Assert.assertNotEquals(next, current);
+            assertEquals(next.index(), current.index() + 1);
+            assertEquals(next.ploidy(), ploidy);
 
             //Check asAlleleList.
             final List<Allele> expectedList = new ArrayList<>(ploidy);
@@ -273,7 +274,7 @@ public final class GenotypeAlleleCountsUnitTest {
                     expectedList.add(testAlleles.get(next.alleleIndexAt(i)));
                 }
             }
-            Assert.assertEquals(next.asAlleleList(testAlleles), expectedList);
+            assertEquals(next.asAlleleList(testAlleles), expectedList);
 
             current = next;
         }
@@ -283,15 +284,15 @@ public final class GenotypeAlleleCountsUnitTest {
         final GenotypeAlleleCounts first = GenotypeAlleleCounts.first(0);
         final GenotypeAlleleCounts next = first.copy();
         next.increase();
-        Assert.assertEquals(first, next);
-        Assert.assertEquals(first.compareTo(next), 0);
-        Assert.assertEquals(next.compareTo(first), 0);
-        Assert.assertEquals(next.distinctAlleleCount(), 0);
-        Assert.assertEquals(next.ploidy(), 0);
-        Assert.assertEquals(next.index(), 0);
+        assertEquals(first, next);
+        assertEquals(first.compareTo(next), 0);
+        assertEquals(next.compareTo(first), 0);
+        assertEquals(next.distinctAlleleCount(), 0);
+        assertEquals(next.ploidy(), 0);
+        assertEquals(next.index(), 0);
         for (int maximumAlleleIndex = 0; maximumAlleleIndex <= 10; maximumAlleleIndex++) {
             final int[] expected = new int[maximumAlleleIndex + 1];
-            Assert.assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
+            assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
         }
     }
 
@@ -302,30 +303,30 @@ public final class GenotypeAlleleCountsUnitTest {
         while (!next.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
             final GenotypeAlleleCounts current = next.copy();
             next.increase(1);
-            Assert.assertEquals(next.minimumAlleleIndex(), next.maximumAlleleIndex());
-            Assert.assertEquals(next.minimumAlleleIndex(), current.minimumAlleleIndex() + 1);
-            Assert.assertEquals(next.alleleCountAt(0), 1);
-            Assert.assertEquals(next.alleleIndexAt(0), next.minimumAlleleIndex());
-            Assert.assertEquals(next.alleleRankFor(next.minimumAlleleIndex()), 0);
-            Assert.assertEquals(next.alleleRankFor(next.minimumAlleleIndex() + 1), -2);
-            Assert.assertEquals(next.alleleCountFor(next.minimumAlleleIndex()), 1);
-            Assert.assertEquals(next.alleleCountFor(next.minimumAlleleIndex() + 1), 0);
-            Assert.assertEquals(next.ploidy(), 1);
+            assertEquals(next.minimumAlleleIndex(), next.maximumAlleleIndex());
+            assertEquals(next.minimumAlleleIndex(), current.minimumAlleleIndex() + 1);
+            assertEquals(next.alleleCountAt(0), 1);
+            assertEquals(next.alleleIndexAt(0), next.minimumAlleleIndex());
+            assertEquals(next.alleleRankFor(next.minimumAlleleIndex()), 0);
+            assertEquals(next.alleleRankFor(next.minimumAlleleIndex() + 1), -2);
+            assertEquals(next.alleleCountFor(next.minimumAlleleIndex()), 1);
+            assertEquals(next.alleleCountFor(next.minimumAlleleIndex() + 1), 0);
+            assertEquals(next.ploidy(), 1);
 
             Assert.assertTrue(next.compareTo(current) > 0);
             Assert.assertTrue(current.compareTo(next) < 0);
-            Assert.assertTrue(next.compareTo(next) == 0);
-            Assert.assertTrue(next.equals(next));
-            Assert.assertFalse(next.equals(current));
-            Assert.assertFalse(current.equals(next));
+            assertEquals(next.compareTo(next), 0);
+            assertEquals(next, next);
+            Assert.assertNotEquals(current, next);
+            Assert.assertNotEquals(next, current);
 
-            Assert.assertEquals(next.index(), current.index() + 1);
-            Assert.assertEquals(next.ploidy(), current.ploidy());
+            assertEquals(next.index(), current.index() + 1);
+            assertEquals(next.ploidy(), current.ploidy());
 
             for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
                 final int[] expected = new int[maximumAlleleIndex + 1];
                 if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) expected[current.minimumAlleleIndex() + 1] = 1;
-                Assert.assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
+                assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
             }
         }
     }
@@ -340,22 +341,22 @@ public final class GenotypeAlleleCountsUnitTest {
             final GenotypeAlleleCounts current = next.copy();
             next.increase();
             if (current.distinctAlleleCount() == 1) {
-                Assert.assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex() + 1);
-                Assert.assertEquals(next.distinctAlleleCount(), 2);
-                Assert.assertEquals(next.minimumAlleleIndex(), 0);
+                assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex() + 1);
+                assertEquals(next.distinctAlleleCount(), 2);
+                assertEquals(next.minimumAlleleIndex(), 0);
             } else {
-                Assert.assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex());
-                Assert.assertEquals(next.minimumAlleleIndex(), current.alleleCountAt(0) > 1 ? 0
+                assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex());
+                assertEquals(next.minimumAlleleIndex(), current.alleleCountAt(0) > 1 ? 0
                         : current.alleleCountAt(0) == 1 ? current.minimumAlleleIndex() + 1 : current.minimumAlleleIndex());
             }
 
             // Checking on 0's new count and current.minAllele + 1 alleles.
-            Assert.assertEquals(next.alleleCountFor(0), current.alleleCountFor(current.minimumAlleleIndex()) - 1);
-            Assert.assertEquals(next.alleleCountFor(current.minimumAlleleIndex() + 1),
+            assertEquals(next.alleleCountFor(0), current.alleleCountFor(current.minimumAlleleIndex()) - 1);
+            assertEquals(next.alleleCountFor(current.minimumAlleleIndex() + 1),
                     current.alleleCountFor(current.minimumAlleleIndex() + 1) + 1);
 
             // Checks current.minAllele count
-            Assert.assertEquals(next.alleleCountFor(current.minimumAlleleIndex()),
+            assertEquals(next.alleleCountFor(current.minimumAlleleIndex()),
                     current.minimumAlleleIndex() == 0 ? current.alleleCountAt(0) - 1 : 0);
 
             int totalCountSum = 0;
@@ -365,23 +366,23 @@ public final class GenotypeAlleleCountsUnitTest {
                 final int index = next.alleleIndexAt(i);
                 expectedAlleleCountsByIndex[index] = count;
                 // Check consistency of alleleCountAt(x) and alleleCountFor(alleleIndexAt(x))
-                Assert.assertEquals(next.alleleCountFor(index), count);
+                assertEquals(next.alleleCountFor(index), count);
                 totalCountSum += count;
                 // Check on counts of, in theory, unaffected allele counts.
                 if (index > current.minimumAlleleIndex() + 1)
-                    Assert.assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
+                    assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
             }
             Assert.assertTrue(Arrays.equals(next.alleleCountsByIndex(Math.max(MAXIMUM_ALLELE_INDEX, next.maximumAlleleIndex())), expectedAlleleCountsByIndex));
-            Assert.assertEquals(totalCountSum, ploidy);
+            assertEquals(totalCountSum, ploidy);
 
             Assert.assertTrue(next.compareTo(current) > 0);
             Assert.assertTrue(current.compareTo(next) < 0);
-            Assert.assertTrue(next.compareTo(next) == 0);
-            Assert.assertTrue(next.equals(next));
-            Assert.assertFalse(next.equals(current));
-            Assert.assertFalse(current.equals(next));
-            Assert.assertEquals(next.index(), current.index() + 1);
-            Assert.assertEquals(next.ploidy(), ploidy);
+            assertEquals(next.compareTo(next), 0);
+            assertEquals(next, next);
+            Assert.assertNotEquals(current, next);
+            Assert.assertNotEquals(next, current);
+            assertEquals(next.index(), current.index() + 1);
+            assertEquals(next.ploidy(), ploidy);
         }
     }
 
@@ -431,7 +432,7 @@ public final class GenotypeAlleleCountsUnitTest {
         GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
         int i = 0;
         do {
-            Assert.assertEquals(current.toString(), expectedtoStrings[i],String.format("genotype index: %d",i));
+            assertEquals(current.toString(), expectedtoStrings[i],String.format("genotype index: %d",i));
             i++;
             current = current.next();
         } while (i < expectedtoStrings.length);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
@@ -64,8 +64,7 @@ public final class GenotypeAlleleCountsUnitTest {
         first.copyAlleleCounts(new int[3], 4);
     }
 
-
-    @Test(dataProvider="ploidyData")
+    @Test(dataProvider = "ploidyData")
     public void testFirst(final int ploidy) {
         final GenotypeAlleleCounts subject = GenotypeAlleleCounts.first(ploidy);
         Assert.assertNotNull(subject);
@@ -92,27 +91,29 @@ public final class GenotypeAlleleCountsUnitTest {
         }
 
         Assert.assertNotNull(subject.toString());
-        assertEquals(subject.toUnphasedGenotypeString(), ploidy == 1 ? "0" : Strings.repeat("0/", ploidy-1) + "0");
+        assertEquals(subject.toUnphasedGenotypeString(), ploidy == 1 ? "0" : Strings.repeat("0/", ploidy - 1) + "0");
     }
 
-    @Test(dataProvider = "ploidyDataWithZero",dependsOnMethods = "testFirst")
+    @Test(dataProvider = "ploidyDataWithZero", dependsOnMethods = "testFirst")
     public void testNext(final int ploidy) {
-        if (ploidy == 0)
+        if (ploidy == 0) {
             testNextZeroPloidy();
-        else if (ploidy == 1)
+        } else if (ploidy == 1) {
             testNextOnePloidy();
-        else
+        } else {
             testPloidyTwoOrMore(ploidy);
+        }
     }
 
-    @Test(dataProvider = "ploidyDataWithZero",dependsOnMethods = "testNext")
+    @Test(dataProvider = "ploidyDataWithZero", dependsOnMethods = "testNext")
     public void testIncrease(final int ploidy) {
-        if (ploidy == 0)
+        if (ploidy == 0) {
             testNextZeroPloidyIncrease();
-        else if (ploidy == 1)
+        } else if (ploidy == 1) {
             testNextOnePloidyIncrease();
-        else
+        } else {
             testPloidyTwoOrMoreIncrease(ploidy);
+        }
     }
 
     private void testNextZeroPloidy() {
@@ -135,10 +136,10 @@ public final class GenotypeAlleleCountsUnitTest {
     }
 
     private void testNextOnePloidy() {
-       final GenotypeAlleleCounts ploidy2 = GenotypeAlleleCounts.first(2);
+        final GenotypeAlleleCounts ploidy2 = GenotypeAlleleCounts.first(2);
         GenotypeAlleleCounts current = GenotypeAlleleCounts.first(1);
 
-       while (!current.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
+        while (!current.containsAllele(MAXIMUM_ALLELE_INDEX + 1)) {
             final GenotypeAlleleCounts next = current.next();
             assertEquals(next.log10CombinationCount(), 0.0);
             assertEquals(next.minimumAlleleIndex(), next.maximumAlleleIndex());
@@ -151,39 +152,42 @@ public final class GenotypeAlleleCountsUnitTest {
             assertEquals(next.alleleCountFor(next.minimumAlleleIndex() + 1), 0);
             assertEquals(next.ploidy(), 1);
 
-            final int[] dest = new int[next.distinctAlleleCount()*2];
+            final int[] dest = new int[next.distinctAlleleCount() * 2];
             next.copyAlleleCounts(dest, 0);
             assertEquals(dest, new int[]{next.index(), 1});
 
             Assert.assertTrue(next.compareTo(current) > 0);
             Assert.assertTrue(current.compareTo(next) < 0);
-           assertEquals(next.compareTo(next), 0);
-           assertEquals(next, next);
-           Assert.assertNotEquals(next, null);
-           Assert.assertNotEquals(next.toString(), next);
-           Assert.assertNotEquals(ploidy2, next);
-           Assert.assertNotEquals(next, ploidy2);
-           Assert.assertNotEquals(current, next);
+            assertEquals(next.compareTo(next), 0);
+            assertEquals(next, next);
+            Assert.assertNotEquals(next, null);
+            Assert.assertNotEquals(next.toString(), next);
+            Assert.assertNotEquals(ploidy2, next);
+            Assert.assertNotEquals(next, ploidy2);
+            Assert.assertNotEquals(current, next);
             Assert.assertNotEquals(next.hashCode(), current.hashCode());
-           Assert.assertNotEquals(next, current);
+            Assert.assertNotEquals(next, current);
 
             assertEquals(next.index(), current.index() + 1);
             assertEquals(next.ploidy(), current.ploidy());
 
             assertEquals(next.asAlleleList(testAlleles), Collections.singletonList(testAlleles.get(next.maximumAlleleIndex())));
 
-           for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
-               final int[] expected = new int[maximumAlleleIndex + 1];
-               if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) expected[current.minimumAlleleIndex() + 1] = 1;
-               assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
-           }
-           current = next;
-       }
+            for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
+                final int[] expected = new int[maximumAlleleIndex + 1];
+                if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) {
+                    expected[current.minimumAlleleIndex() + 1] = 1;
+                }
+                assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
+            }
+            current = next;
+        }
     }
 
     private void testPloidyTwoOrMore(final int ploidy) {
-        if (ploidy < 2)
+        if (ploidy < 2) {
             throw new IllegalArgumentException();
+        }
 
         GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
 
@@ -197,8 +201,8 @@ public final class GenotypeAlleleCountsUnitTest {
             if (ploidy == 2) {
                 assertEquals(next.log10CombinationCount(), next.distinctAlleleCount() == 2 ? Math.log10(2) : 0.0);
             } else if (ploidy == 3) {
-                    assertEquals(next.log10CombinationCount(),
-                            next.distinctAlleleCount() == 3 ? Math.log10(6) : (next.distinctAlleleCount() == 2 ? Math.log10(6) - Math.log10(2) : 0.0));
+                assertEquals(next.log10CombinationCount(),
+                        next.distinctAlleleCount() == 3 ? Math.log10(6) : (next.distinctAlleleCount() == 2 ? Math.log10(6) - Math.log10(2) : 0.0));
             } else {
                 if (next.distinctAlleleCount() == 1) {
                     assertEquals(next.log10CombinationCount(), 0.0);
@@ -208,20 +212,20 @@ public final class GenotypeAlleleCountsUnitTest {
             }
 
             //test forEach
-            final List<Integer> alleleCountsAsList = new ArrayList<>(next.distinctAlleleCount()*2);
+            final List<Integer> alleleCountsAsList = new ArrayList<>(next.distinctAlleleCount() * 2);
             final Set<Integer> absentAlleles = new HashSet<>();
             next.forEachAlleleIndexAndCount((alleleIndex, alleleCount) -> {
                 alleleCountsAsList.add(alleleIndex);
-                alleleCountsAsList.add(alleleCount);});
+                alleleCountsAsList.add(alleleCount);
+            });
             next.forEachAbsentAlleleIndex(absentAlleles::add, MAXIMUM_ALLELE_INDEX + 1);
-            final int[] actualAlleleCounts = new int[next.distinctAlleleCount()*2];
+            final int[] actualAlleleCounts = new int[next.distinctAlleleCount() * 2];
             next.copyAlleleCounts(actualAlleleCounts, 0);
 
-            assertEquals(alleleCountsAsList.stream().mapToInt(n->n).toArray(), actualAlleleCounts);
+            assertEquals(alleleCountsAsList.stream().mapToInt(n -> n).toArray(), actualAlleleCounts);
 
             assertEquals(absentAlleles.size(), MAXIMUM_ALLELE_INDEX + 1 - next.distinctAlleleCount());
             next.forEachAlleleIndexAndCount((index, count) -> Assert.assertFalse(absentAlleles.contains(index)));
-
 
             if (current.distinctAlleleCount() == 1) {
                 assertEquals(next.maximumAlleleIndex(), current.maximumAlleleIndex() + 1);
@@ -252,8 +256,9 @@ public final class GenotypeAlleleCountsUnitTest {
                 assertEquals(next.alleleCountFor(index), count);
                 totalCountSum += count;
                 // Check on counts of, in theory, unaffected allele counts.
-                if (index > current.minimumAlleleIndex() + 1)
+                if (index > current.minimumAlleleIndex() + 1) {
                     assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
+                }
             }
             Assert.assertTrue(Arrays.equals(next.alleleCountsByIndex(Math.max(MAXIMUM_ALLELE_INDEX, next.maximumAlleleIndex())), expectedAlleleCountsByIndex));
             assertEquals(totalCountSum, ploidy);
@@ -325,15 +330,18 @@ public final class GenotypeAlleleCountsUnitTest {
 
             for (int maximumAlleleIndex = 0; maximumAlleleIndex <= MAXIMUM_ALLELE_INDEX; maximumAlleleIndex++) {
                 final int[] expected = new int[maximumAlleleIndex + 1];
-                if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) expected[current.minimumAlleleIndex() + 1] = 1;
+                if (maximumAlleleIndex >= current.minimumAlleleIndex() + 1) {
+                    expected[current.minimumAlleleIndex() + 1] = 1;
+                }
                 assertEquals(next.alleleCountsByIndex(maximumAlleleIndex), expected);
             }
         }
     }
 
     private void testPloidyTwoOrMoreIncrease(final int ploidy) {
-        if (ploidy < 2)
+        if (ploidy < 2) {
             throw new IllegalArgumentException();
+        }
 
         GenotypeAlleleCounts next = GenotypeAlleleCounts.first(ploidy);
 
@@ -369,8 +377,9 @@ public final class GenotypeAlleleCountsUnitTest {
                 assertEquals(next.alleleCountFor(index), count);
                 totalCountSum += count;
                 // Check on counts of, in theory, unaffected allele counts.
-                if (index > current.minimumAlleleIndex() + 1)
+                if (index > current.minimumAlleleIndex() + 1) {
                     assertEquals(next.alleleCountFor(index), current.alleleCountFor(index));
+                }
             }
             Assert.assertTrue(Arrays.equals(next.alleleCountsByIndex(Math.max(MAXIMUM_ALLELE_INDEX, next.maximumAlleleIndex())), expectedAlleleCountsByIndex));
             assertEquals(totalCountSum, ploidy);
@@ -400,22 +409,24 @@ public final class GenotypeAlleleCountsUnitTest {
         }
     }
 
-    private static final int[] PLOIDY = { 1, 2, 3, 7, 10};
-    private static final int[] PLOIDY_WITH_ZERO = { 0, 1, 2, 3, 7, 10};
+    private static final int[] PLOIDY = {1, 2, 3, 7, 10};
+    private static final int[] PLOIDY_WITH_ZERO = {0, 1, 2, 3, 7, 10};
 
-    @DataProvider(name="ploidyData")
+    @DataProvider(name = "ploidyData")
     public Object[][] ploidyData() {
         final Object[][] result = new Object[PLOIDY.length][];
-        for (int i = 0; i < PLOIDY.length; i++)
-            result[i] = new Object[] { PLOIDY[i ]};
+        for (int i = 0; i < PLOIDY.length; i++) {
+            result[i] = new Object[]{PLOIDY[i]};
+        }
         return result;
     }
 
-    @DataProvider(name="ploidyDataWithZero")
+    @DataProvider(name = "ploidyDataWithZero")
     public Object[][] ploidyDataWithZero() {
         final Object[][] result = new Object[PLOIDY_WITH_ZERO.length][];
-        for (int i = 0; i < PLOIDY_WITH_ZERO.length; i++)
-            result[i] = new Object[] { PLOIDY_WITH_ZERO[i ]};
+        for (int i = 0; i < PLOIDY_WITH_ZERO.length; i++) {
+            result[i] = new Object[]{PLOIDY_WITH_ZERO[i]};
+        }
         return result;
     }
 
@@ -424,7 +435,7 @@ public final class GenotypeAlleleCountsUnitTest {
         return new Object[][]{
                 new Object[]{1, new String[]{"0", "1", "2"}},
                 new Object[]{2, new String[]{"0/0", "0/1", "1/1", "0/2", "1/2", "2/2"}},
-                new Object[]{3, new String[]{"0/0/0", "0/0/1", "0/1/1","1/1/1","0/0/2","0/1/2","1/1/2","0/2/2","1/2/2","2/2/2"}}};
+                new Object[]{3, new String[]{"0/0/0", "0/0/1", "0/1/1", "1/1/1", "0/0/2", "0/1/2", "1/1/2", "0/2/2", "1/2/2", "2/2/2"}}};
     }
 
     @Test(dataProvider = "genotypeAlleleCountDataWithToStringOutput")
@@ -432,7 +443,7 @@ public final class GenotypeAlleleCountsUnitTest {
         GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
         int i = 0;
         do {
-            assertEquals(current.toString(), expectedtoStrings[i],String.format("genotype index: %d",i));
+            assertEquals(current.toString(), expectedtoStrings[i], String.format("genotype index: %d", i));
             i++;
             current = current.next();
         } while (i < expectedtoStrings.length);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeAlleleCountsUnitTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -430,22 +431,29 @@ public final class GenotypeAlleleCountsUnitTest {
         return result;
     }
 
-    @DataProvider
-    public Object[][] genotypeAlleleCountDataWithToStringOutput() {
+    private Object[][] genotypeAlleleCountDataWithToStringOutput() {
         return new Object[][]{
-                new Object[]{1, new String[]{"0", "1", "2"}},
-                new Object[]{2, new String[]{"0/0", "0/1", "1/1", "0/2", "1/2", "2/2"}},
+                new Object[]{1, new String[]{"0", "1", "2", "3", "4"}},
+                new Object[]{2, new String[]{"0/0", "0/1", "1/1", "0/2", "1/2", "2/2", "0/3", "1/3", "2/3", "3/3"}},
                 new Object[]{3, new String[]{"0/0/0", "0/0/1", "0/1/1", "1/1/1", "0/0/2", "0/1/2", "1/1/2", "0/2/2", "1/2/2", "2/2/2"}}};
     }
 
-    @Test(dataProvider = "genotypeAlleleCountDataWithToStringOutput")
-    public void testToString(final int ploidy, final String[] expectedtoStrings) {
-        GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
-        int i = 0;
-        do {
-            assertEquals(current.toString(), expectedtoStrings[i], String.format("genotype index: %d", i));
-            i++;
-            current = current.next();
-        } while (i < expectedtoStrings.length);
+    @DataProvider
+    public Iterator<Object[]> genotypeAlleleCountDataWithToStringOutputIterable() {
+        final List<Object[]> tests = new ArrayList<>();
+        for (final Object[] test : genotypeAlleleCountDataWithToStringOutput()) {
+            final Integer ploidy = (Integer) test[0];
+            GenotypeAlleleCounts current = GenotypeAlleleCounts.first(ploidy);
+            for (final String expectedGenotypeString : (String[]) test[1]) {
+                tests.add(new Object[]{current, expectedGenotypeString});
+                current = current.next();
+            }
+        }
+        return tests.iterator();
+    }
+
+    @Test(dataProvider = "genotypeAlleleCountDataWithToStringOutputIterable")
+    public void testToString(final GenotypeAlleleCounts gac, final String expectedtoString) {
+        assertEquals(gac.toString(), expectedtoString);
     }
 }


### PR DESCRIPTION
GenotypeAlleleCount's toString function was broken, leading to a misleading debugging information showing up in the debugger

This PR fixes the bug and adds tests for toString output.