### PR TITLE
[WIP] Passing max alternate alleles and max genotypes from GenotypeGVCFs to GenomicsDB. 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
@@ -11,6 +11,8 @@ public final class GenomicsDBOptions {
     final private Path reference;
     final private boolean callGenotypes;
     final private int maxAlternateAlleles;
+    final private int maxGenotypeCount;
+    final private int MAX_GENOTYPES = 100000;
 
     public GenomicsDBOptions() {
         this(null, false, GenotypeLikelihoods.MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED);
@@ -20,16 +22,25 @@ public final class GenomicsDBOptions {
         this(reference, false, GenotypeLikelihoods.MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED);
     }
 
+    public GenomicsDBOptions(final Path reference, final boolean callGenotypes, final int maxAlternateAlleles) {
+        this.reference = reference;
+        this.callGenotypes = callGenotypes;
+        this.maxAlternateAlleles = maxAlternateAlleles;
+        this.maxGenotypeCount = MAX_GENOTYPES;
+    }
+
     /**
      *
      * @param reference     Path to a reference. May be null. Needed only for reading from GenomicsDB.
      * @param callGenotypes Indicates whether GenomicsDB should return called genotypes
      * @param maxAlternateAlleles The maximum number of alternative alleles to return in query results
+     * @param maxGenotypeCount The maximum number of genotypes to return in query results
      */
-    public GenomicsDBOptions(final Path reference, final boolean callGenotypes, final int maxAlternateAlleles) {
+    public GenomicsDBOptions(final Path reference, final boolean callGenotypes, final int maxAlternateAlleles, final int maxGenotypeCount) {
         this.reference = reference;
         this.callGenotypes = callGenotypes;
         this.maxAlternateAlleles = maxAlternateAlleles;
+        this.maxGenotypeCount = maxGenotypeCount;
     }
 
     public Path getReference() {
@@ -41,4 +52,6 @@ public final class GenomicsDBOptions {
     }
 
     public int getMaxAlternateAlleles() { return maxAlternateAlleles; }
+
+    public int getMaxGenotypeCount() { return maxGenotypeCount; }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -108,8 +108,9 @@ public class GenomicsDBUtils {
                         .setSitesOnlyQuery(false)
                         .setMaxDiploidAltAllelesThatCanBeGenotyped(GenotypeLikelihoods.MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED);
         if (genomicsDBOptions != null) {
-            exportConfigurationBuilder.setProduceGTField(genomicsDBOptions.doCallGenotypes()).
-                    setMaxDiploidAltAllelesThatCanBeGenotyped(genomicsDBOptions.getMaxAlternateAlleles());
+            exportConfigurationBuilder.setProduceGTField(genomicsDBOptions.doCallGenotypes())
+                    .setMaxDiploidAltAllelesThatCanBeGenotyped(genomicsDBOptions.getMaxAlternateAlleles())
+                    .setMaxGenotypeCount(genomicsDBOptions.getMaxGenotypeCount());
         }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.engine.ReadsContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.VariantLocusWalker;
 import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBImport;
+import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBOptions;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.StandardAnnotation;
 import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine;
@@ -95,6 +96,7 @@ public final class GenotypeGVCFs extends VariantLocusWalker {
     public static final String KEEP_COMBINED_LONG_NAME = "keep-combined-raw-annotations";
     public static final String KEEP_COMBINED_SHORT_NAME = "keep-combined";
     public static final String FORCE_OUTPUT_INTERVALS_NAME = "force-output-intervals";
+    public static final boolean CALL_GENOTYPES = false;
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             doc="File to which variants should be written", optional=false)
@@ -194,6 +196,15 @@ public final class GenotypeGVCFs extends VariantLocusWalker {
         } else {
             return getIntervals;
         }
+    }
+
+    @Override
+    protected GenomicsDBOptions getGenomicsDBOptions() {
+        if (genomicsDBOptions == null) {
+            genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), CALL_GENOTYPES,
+                    genotypeArgs.MAX_ALTERNATE_ALLELES, genotypeArgs.MAX_GENOTYPE_COUNT);
+        }
+        return genomicsDBOptions;
     }
 
     @Override


### PR DESCRIPTION
Not sure if this will resolve what is reported here: https://github.com/broadinstitute/gatk/issues/6275#issuecomment-574329688

My guess is that the user's issue is being caused by an extremely large String that Java can't handle...this PR passes along some parameters from GenotypeGVCFs (`max-alternate-alleles` and `max-genotype-count`) to GenomicsDB...which will hopefully result in us not having to deal with the large String.