### PR TITLE
Pip install and pin numpy version.

### DIFF
--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -8,7 +8,6 @@ dependencies:
 - intel-openmp=2018.0.0
 - mkl=2018.0.1
 - mkl-service=1.1.2
-- defaults::numpy==1.13.3
 - openssl=1.0.2l=0
 - pip=9.0.1=py36_1
 - python=3.6.2=0
@@ -21,6 +20,7 @@ dependencies:
 - xz=5.2.3=0
 - zlib=1.2.11=0
 - pip:
+  - numpy==1.13.3
   - biopython==1.70
   - bleach==1.5.0
   - cycler==0.10.0


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/6396.