### PR TITLE
improved checking for upstream deletions in GenotypingEngine

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -159,6 +159,8 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
 
         // start constructing the resulting VC
         final List<Allele> outputAlleles = outputAlternativeAlleles.outputAlleles(vc.getReference());
+        outputAlleles.forEach(a -> recordDeletion(vc.getReference().length() - a.length(), vc));
+        
         final VariantContextBuilder builder = new VariantContextBuilder(callSourceString(), vc.getContig(), vc.getStart(), vc.getEnd(), outputAlleles);
 
         builder.log10PError(log10Confidence);
@@ -256,7 +258,6 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
                 if (toOutput) {
                     outputAlleles.add(allele);
                     mleCounts.add(afCalculationResult.getAlleleCountAtMLE(allele));
-                    recordDeletion(referenceAlleleSize - allele.length(), vc);
                 }
             }
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngineUnitTest.java
@@ -38,7 +38,7 @@ public class GenotypingEngineUnitTest extends GATKBaseTest {
         final int deletionSize = refAllele.length() - altT.length();
         final int start = 1;
         final VariantContext deletionVC = new VariantContextBuilder("testDeletion", "1", start, start + deletionSize, allelesDel).make();
-        genotypingEngine.recordDeletion(deletionSize, deletionVC);
+        genotypingEngine.recordDeletions(deletionVC, Collections.singletonList(altT));
     }
 
     private static GenotypingEngine<?> getGenotypingEngine() {


### PR DESCRIPTION
* It no longer modifies state.  Closes #2537
* Upstream deletions are only recorded once they definitely will be emitted.  Closes #6031 

@ldgauthier Here's a `GenotypeGVCFs` bug fix for you.

@tfenne Your suspicion was correct.