### PR TITLE
fix an NPE in FastaReferenceMaker

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/FastaReferenceMaker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/FastaReferenceMaker.java
@@ -138,7 +138,9 @@ public class FastaReferenceMaker extends ReferenceWalker {
     public void closeTool() {
         super.closeTool();
         try{
-            writer.close();
+           if( writer != null ) {
+               writer.close();
+           }
         } catch (IllegalStateException e){
             //sink this
         } catch (IOException e) {


### PR DESCRIPTION
* We now check if the writer is null before trying to close it.
* Fix for https://github.com/broadinstitute/gatk/issues/6434