### PR TITLE
Parse combined AS_QUALapprox values from older reblocked GVCFs properly

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
@@ -230,12 +230,16 @@ public class AS_QualByDepth extends InfoFieldAnnotation implements ReducibleAnno
         }
         else if (vc.hasAttribute(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY)) {
             String asQuals = vc.getAttributeAsString(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, "").replaceAll("\\[\\]\\s","");
-            String[] values = asQuals.split(AnnotationUtils.ALLELE_SPECIFIC_SPLIT_REGEX);
+            String[] values = asQuals.split(AnnotationUtils.ALLELE_SPECIFIC_SPLIT_REGEX, -1); //allow for empty tokens at the end
             if (values.length != vc.getNAlleles()) {
                 throw new IllegalStateException("Number of AS_QUALapprox values doesn't match the number of alleles in the variant context.");
             }
             for (int i = 1; i < vc.getNAlleles(); i++) {
-                alleleQualList.add(Integer.parseInt(values[i]));
+                if (!values[i].equals("")) {
+                    alleleQualList.add(Integer.parseInt(values[i]));
+                } else {
+                    alleleQualList.add(0);
+                }
             }
         }
         return alleleQualList;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
@@ -1,8 +1,15 @@
 package org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific;
 
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,6 +32,18 @@ public class AS_QualByDepthUnitTest extends ReducibleAnnotationBaseTest {
     @Override
     protected String getKey() {
         return GATKVCFConstants.AS_QUAL_KEY;
+    }
+
+    @Test
+    public void testParseQualList() {
+        final String goodQualList = "|234|0"; //combined VCs from GenomicsDB have zero value for NON-REF
+        final String trickyQualList = "|234|"; //older single-sample GVCFs don't have a value for NON-REF -- GenomicsDB assigns an empty value, which is fair
+        final VariantContext withNonRefValue = new VariantContextBuilder(GATKVariantContextUtils.makeFromAlleles("good", "chr1", 10001, Arrays.asList("A","T", Allele.NON_REF_STRING))).
+                attribute(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, goodQualList).make();
+        final VariantContext withNoNonRefValue = new VariantContextBuilder(GATKVariantContextUtils.makeFromAlleles("good", "chr1", 10001, Arrays.asList("A","T", Allele.NON_REF_STRING))).
+                attribute(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, trickyQualList).make();
+        Assert.assertTrue(AS_QualByDepth.parseQualList(withNonRefValue).size() == withNonRefValue.getAlternateAlleles().size());
+        Assert.assertTrue(AS_QualByDepth.parseQualList(withNoNonRefValue).size() == withNonRefValue.getAlternateAlleles().size());
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
@@ -13,8 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.testng.Assert.*;
-
 /**
  * Created by emeryj on 8/11/17.
  */
@@ -36,14 +34,17 @@ public class AS_QualByDepthUnitTest extends ReducibleAnnotationBaseTest {
 
     @Test
     public void testParseQualList() {
+        final int NON_REF_INDEX = 2;
         final String goodQualList = "|234|0"; //combined VCs from GenomicsDB have zero value for NON-REF
         final String trickyQualList = "|234|"; //older single-sample GVCFs don't have a value for NON-REF -- GenomicsDB assigns an empty value, which is fair
         final VariantContext withNonRefValue = new VariantContextBuilder(GATKVariantContextUtils.makeFromAlleles("good", "chr1", 10001, Arrays.asList("A","T", Allele.NON_REF_STRING))).
                 attribute(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, goodQualList).make();
         final VariantContext withNoNonRefValue = new VariantContextBuilder(GATKVariantContextUtils.makeFromAlleles("good", "chr1", 10001, Arrays.asList("A","T", Allele.NON_REF_STRING))).
                 attribute(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY, trickyQualList).make();
-        Assert.assertTrue(AS_QualByDepth.parseQualList(withNonRefValue).size() == withNonRefValue.getAlternateAlleles().size());
-        Assert.assertTrue(AS_QualByDepth.parseQualList(withNoNonRefValue).size() == withNonRefValue.getAlternateAlleles().size());
+        Assert.assertEquals(AS_QualByDepth.parseQualList(withNonRefValue).size(), withNonRefValue.getAlternateAlleles().size());
+        final List<Integer> qualsFromNoNonRefList = AS_QualByDepth.parseQualList(withNoNonRefValue);
+        Assert.assertEquals(qualsFromNoNonRefList.size(), withNonRefValue.getAlternateAlleles().size());
+        Assert.assertEquals((int)qualsFromNoNonRefList.get(NON_REF_INDEX), 0);  //int cast because Integer results in ambiguous method call for assert
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepthUnitTest.java
@@ -34,7 +34,7 @@ public class AS_QualByDepthUnitTest extends ReducibleAnnotationBaseTest {
 
     @Test
     public void testParseQualList() {
-        final int NON_REF_INDEX = 2;
+        final int NON_REF_INDEX = 1; //finalized QD values won't have an entry for ref
         final String goodQualList = "|234|0"; //combined VCs from GenomicsDB have zero value for NON-REF
         final String trickyQualList = "|234|"; //older single-sample GVCFs don't have a value for NON-REF -- GenomicsDB assigns an empty value, which is fair
         final VariantContext withNonRefValue = new VariantContextBuilder(GATKVariantContextUtils.makeFromAlleles("good", "chr1", 10001, Arrays.asList("A","T", Allele.NON_REF_STRING))).


### PR DESCRIPTION
Sometimes NON_REF gets a zero and sometimes it's empty.  This seems isolated to a much older version of ReblockGVCF, but that was what we were running for production pipeline tests.

@droazen I'd like this to go into this week's release