### PR TITLE
Making .git directory optional during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can download and run pre-built versions of GATK4 from the following places:
 * Gradle keeps a cache of dependencies used to build GATK.  By default this goes in `~/.gradle`.  If there is insufficient free space in your home directory, you can change the location of the cache by setting the `GRADLE_USER_HOME` environment variable.
 
 * The version number is automatically derived from the git history using `git describe`, you can override it by setting the `versionOverride` property.
-  ( `./gradlew -DversionOverride=my_wierd_version printVersion` )
+  ( `./gradlew -DversionOverride=my_weird_version printVersion` )
 
 ## <a name="running">Running GATK4</a>
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ You can download and run pre-built versions of GATK4 from the following places:
 
 * Gradle keeps a cache of dependencies used to build GATK.  By default this goes in `~/.gradle`.  If there is insufficient free space in your home directory, you can change the location of the cache by setting the `GRADLE_USER_HOME` environment variable.
 
+* The version number is automatically derived from the git history using `git describe`, you can override it by setting the `versionOverride` property.
+  ( `./gradlew -DversionOverride=my_wierd_version printVersion` )
+
 ## <a name="running">Running GATK4</a>
 
 * The standard way to run GATK4 tools is via the **`gatk`** wrapper script located in the root directory of a clone of this repository.

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ def looksLikeWereInAGitRepository(){
 
 // Ensure that we have a clone of the git repository, and resolve any required git-lfs
 // resource files that are needed to run the build but are still lfs stub files.
-def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage) {
+def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, skipGitCheck) {
     if (!JavaVersion.current().isJava8Compatible()) {
         throw new GradleException(
                 "Java 8 or later is required to build GATK, but ${JavaVersion.current()} was found. "
@@ -152,7 +152,7 @@ def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage) {
     if (!JavaVersion.current().isJava8() && !JavaVersion.current().isJava11()) {
         println("Warning: using Java ${JavaVersion.current()} but only Java 8 and Java 11 have been tested.")
     }
-    if (!looksLikeWereInAGitRepository()) {
+    if (!skipGitCheck && !looksLikeWereInAGitRepository() ) {
         throw new GradleException("This doesn't appear to be a git folder. " +
                 "The GATK Github repository must be cloned using \"git clone\" to run the build. " +
                 "\n$buildPrerequisitesMessage")
@@ -162,7 +162,12 @@ def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage) {
     resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessage)
 }
 
-ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage)
+final isRelease = Boolean.getBoolean("release")
+final versionOverriden = System.getProperty("versionOverride") != null
+
+ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, versionOverriden)
+version = (versionOverriden ? System.getProperty("versionOverride") : gitVersion().replaceAll(".dirty", "")) + (isRelease ?  "" : "-SNAPSHOT")
+
 
 configurations.all {
     resolutionStrategy {
@@ -398,9 +403,6 @@ def createGatkSymlinks(destinationDir, archivePath, suffix, baseJarName, seconda
     createSymlinks(archivePath.getAbsolutePath(), symlinkLocation)
     createSymlinks(archivePath.getAbsolutePath(), symlinkLocation2)
 }
-
-final isRelease = Boolean.getBoolean("release")
-version = (isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT").replaceAll(".dirty", "")
 
 logger.info("build for version:" + version)
 group = 'org.broadinstitute'

--- a/build.gradle
+++ b/build.gradle
@@ -163,11 +163,14 @@ def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, sk
 }
 
 final isRelease = Boolean.getBoolean("release")
-final versionOverriden = System.getProperty("versionOverride") != null
+final versionOverridden = System.getProperty("versionOverride") != null
 
-ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, versionOverriden)
-version = (versionOverriden ? System.getProperty("versionOverride") : gitVersion().replaceAll(".dirty", "")) + (isRelease ?  "" : "-SNAPSHOT")
+ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, versionOverridden)
+version = (versionOverridden ? System.getProperty("versionOverride") : gitVersion().replaceAll(".dirty", "")) + (isRelease ?  "" : "-SNAPSHOT")
 
+if (versionOverridden) {
+    println "Version number overridden as " + version
+}
 
 configurations.all {
     resolutionStrategy {


### PR DESCRIPTION
* You can now avoid the check for a git directory during build by manually specifying a version number
  ex:  ./gradlew -DversionOverride=someVersionNumber
* Fix for #6395