### PR TITLE
Yf fix multiplicity bug in split suffixes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixSplitter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/CommonSuffixSplitter.java
@@ -59,7 +59,7 @@ public final class CommonSuffixSplitter {
                     } else {
                         incomingTarget = prefixV;
                         graph.addVertex(prefixV);
-                        graph.addEdge(prefixV, suffixV, new BaseEdge(out.isRef(), 1));
+                        graph.addEdge(prefixV, suffixV, out.copy());
                         edgesToRemove.add(out);
                     }
 


### PR DESCRIPTION
The function that splits suffixes uses a multiplicity of 1 for the connections between the suffix and prefix of the nodes, this can be confusing when debugging (though since this is after pruning, it probably doesn't actually affect anything...

This PR changes that multiplicity to that of the outgoing edge of the node, which seems reasonable.

It also includes a bunch of whitespace changes...so look at the first commit if/when you review...