### PR TITLE
Exposed maximum copy ratio and point size for CNV plotting tools.

### DIFF
--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -136,6 +136,10 @@ workflow CNVSomaticPairWorkflow {
       #### optional arguments for plotting ####
       #########################################
       Int? minimum_contig_length
+      # If maximum_copy_ratio = Infinity, the maximum copy ratio will be automatically determined
+      String? maximum_copy_ratio
+      Float? point_size_copy_ratio
+      Float? point_size_allele_fraction
       Int? mem_gb_for_plotting
 
       ##########################################
@@ -302,6 +306,8 @@ workflow CNVSomaticPairWorkflow {
             denoised_copy_ratios = DenoiseReadCountsTumor.denoised_copy_ratios,
             ref_fasta_dict = ref_fasta_dict,
             minimum_contig_length = minimum_contig_length,
+            maximum_copy_ratio = maximum_copy_ratio,
+            point_size_copy_ratio = point_size_copy_ratio,
             gatk4_jar_override = gatk4_jar_override,
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_plotting,
@@ -317,6 +323,9 @@ workflow CNVSomaticPairWorkflow {
             modeled_segments = ModelSegmentsTumor.modeled_segments,
             ref_fasta_dict = ref_fasta_dict,
             minimum_contig_length = minimum_contig_length,
+            maximum_copy_ratio = maximum_copy_ratio,
+            point_size_copy_ratio = point_size_copy_ratio,
+            point_size_allele_fraction = point_size_allele_fraction,
             gatk4_jar_override = gatk4_jar_override,
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_plotting,
@@ -431,6 +440,8 @@ workflow CNVSomaticPairWorkflow {
                 denoised_copy_ratios = DenoiseReadCountsNormal.denoised_copy_ratios,
                 ref_fasta_dict = ref_fasta_dict,
                 minimum_contig_length = minimum_contig_length,
+                maximum_copy_ratio = maximum_copy_ratio,
+                point_size_copy_ratio = point_size_copy_ratio,
                 gatk4_jar_override = gatk4_jar_override,
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_plotting,
@@ -446,6 +457,9 @@ workflow CNVSomaticPairWorkflow {
                 modeled_segments = ModelSegmentsNormal.modeled_segments,
                 ref_fasta_dict = ref_fasta_dict,
                 minimum_contig_length = minimum_contig_length,
+                maximum_copy_ratio = maximum_copy_ratio,
+                point_size_copy_ratio = point_size_copy_ratio,
+                point_size_allele_fraction = point_size_allele_fraction,
                 gatk4_jar_override = gatk4_jar_override,
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_plotting,
@@ -514,7 +528,6 @@ workflow CNVSomaticPairWorkflow {
         File called_copy_ratio_segments_tumor = CallCopyRatioSegmentsTumor.called_copy_ratio_segments
         File called_copy_ratio_legacy_segments_tumor = CallCopyRatioSegmentsTumor.called_copy_ratio_legacy_segments
         File denoised_copy_ratios_plot_tumor = PlotDenoisedCopyRatiosTumor.denoised_copy_ratios_plot
-        File denoised_copy_ratios_lim_4_plot_tumor = PlotDenoisedCopyRatiosTumor.denoised_copy_ratios_lim_4_plot
         File standardized_MAD_tumor = PlotDenoisedCopyRatiosTumor.standardized_MAD
         Float standardized_MAD_value_tumor = PlotDenoisedCopyRatiosTumor.standardized_MAD_value
         File denoised_MAD_tumor = PlotDenoisedCopyRatiosTumor.denoised_MAD
@@ -545,7 +558,6 @@ workflow CNVSomaticPairWorkflow {
         File? called_copy_ratio_segments_normal = CallCopyRatioSegmentsNormal.called_copy_ratio_segments
         File? called_copy_ratio_legacy_segments_normal = CallCopyRatioSegmentsNormal.called_copy_ratio_legacy_segments
         File? denoised_copy_ratios_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_plot
-        File? denoised_copy_ratios_lim_4_plot_normal = PlotDenoisedCopyRatiosNormal.denoised_copy_ratios_lim_4_plot
         File? standardized_MAD_normal = PlotDenoisedCopyRatiosNormal.standardized_MAD
         Float? standardized_MAD_value_normal = PlotDenoisedCopyRatiosNormal.standardized_MAD_value
         File? denoised_MAD_normal = PlotDenoisedCopyRatiosNormal.denoised_MAD
@@ -774,6 +786,8 @@ task PlotDenoisedCopyRatios {
       File denoised_copy_ratios
       File ref_fasta_dict
       Int? minimum_contig_length
+      String? maximum_copy_ratio
+      Float? point_size_copy_ratio
       String? output_dir
       File? gatk4_jar_override
 
@@ -801,6 +815,8 @@ task PlotDenoisedCopyRatios {
             --denoised-copy-ratios ~{denoised_copy_ratios} \
             --sequence-dictionary ~{ref_fasta_dict} \
             --minimum-contig-length ~{default="1000000" minimum_contig_length} \
+            --maximum-copy-ratio ~{default="4.0" maximum_copy_ratio} \
+            --point-size-copy-ratio ~{default="0.2" point_size_copy_ratio} \
             --output ~{output_dir_} \
             --output-prefix ~{entity_id}
     >>>
@@ -815,7 +831,6 @@ task PlotDenoisedCopyRatios {
 
     output {
         File denoised_copy_ratios_plot = "~{output_dir_}/~{entity_id}.denoised.png"
-        File denoised_copy_ratios_lim_4_plot = "~{output_dir_}/~{entity_id}.denoisedLimit4.png"
         File standardized_MAD = "~{output_dir_}/~{entity_id}.standardizedMAD.txt"
         Float standardized_MAD_value = read_float(standardized_MAD)
         File denoised_MAD = "~{output_dir_}/~{entity_id}.denoisedMAD.txt"
@@ -835,6 +850,9 @@ task PlotModeledSegments {
       File modeled_segments
       File ref_fasta_dict
       Int? minimum_contig_length
+      String? maximum_copy_ratio
+      Float? point_size_copy_ratio
+      Float? point_size_allele_fraction
       String? output_dir
       File? gatk4_jar_override
 
@@ -863,6 +881,9 @@ task PlotModeledSegments {
             --segments ~{modeled_segments} \
             --sequence-dictionary ~{ref_fasta_dict} \
             --minimum-contig-length ~{default="1000000" minimum_contig_length} \
+            --maximum-copy-ratio ~{default="4.0" maximum_copy_ratio} \
+            --point-size-copy-ratio ~{default="0.2" point_size_copy_ratio} \
+            --point-size-allele-fraction ~{default="0.4" point_size_allele_fraction} \
             --output ~{output_dir_} \
             --output-prefix ~{entity_id}
     >>>

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatios.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Creates plots of denoised copy ratios.  The tool also generates various denoising metrics.
+ * Creates plots of standardized and denoised copy ratios.  The tool also generates various denoising metrics.
  *
  * <h3>Inputs</h3>
  *
@@ -52,9 +52,10 @@ import java.util.stream.Collectors;
  *
  * <ul>
  *     <li>
- *         Denoised-plot files.
- *         Two versions of a plot showing both the standardized and denoised copy ratios are output;
- *         the first covers the entire range of the copy ratios, while the second is limited to copy ratios within [0, 4].
+ *         Denoised-plot file.
+ *         A plot showing both the standardized and denoised copy ratios is output.
+ *         Copy ratios are only plotted up to the maximum value specified by the argument {@code maximum-copy-ratio}.
+ *         Point size can be specified by the argument {@code point-size-copy-ratio}.
  *     </li>
  *      <li>
  *         Median-absolute-deviation files.
@@ -112,6 +113,22 @@ public final class PlotDenoisedCopyRatios extends CommandLineProgram {
             optional = true
     )
     private int minContigLength = PlottingUtils.DEFAULT_MINIMUM_CONTIG_LENGTH;
+
+    @Argument(
+            doc = PlottingUtils.MAXIMUM_COPY_RATIO_DOC_STRING,
+            fullName =  PlottingUtils.MAXIMUM_COPY_RATIO_LONG_NAME,
+            minValue = 0,
+            optional = true
+    )
+    private double maxCopyRatio = PlottingUtils.DEFAULT_MAXIMUM_COPY_RATIO;
+
+    @Argument(
+            doc = PlottingUtils.POINT_SIZE_COPY_RATIO_DOC_STRING,
+            fullName =  PlottingUtils.POINT_SIZE_COPY_RATIO_LONG_NAME,
+            minValue = 0,
+            optional = true
+    )
+    private double pointSizeCopyRatio = PlottingUtils.DEFAULT_POINT_SIZE_COPY_RATIO;
 
     @Argument(
             doc = "Prefix for output filenames.",
@@ -183,7 +200,7 @@ public final class PlotDenoisedCopyRatios extends CommandLineProgram {
     private void writeDenoisingPlots(final String sampleName,
                                      final List<String> contigNames,
                                      final List<Integer> contigLengths) {
-        final String contigNamesArg = contigNames.stream().collect(Collectors.joining(PlottingUtils.CONTIG_DELIMITER));                            //names separated by delimiter
+        final String contigNamesArg = String.join(PlottingUtils.CONTIG_DELIMITER, contigNames); //names separated by delimiter
         final String contigLengthsArg = contigLengths.stream().map(Object::toString).collect(Collectors.joining(PlottingUtils.CONTIG_DELIMITER));  //names separated by delimiter
         final String outputDirArg = CopyNumberArgumentValidationUtils.addTrailingSlashIfNecessary(CopyNumberArgumentValidationUtils.getCanonicalPath(outputDir));
 
@@ -199,6 +216,8 @@ public final class PlotDenoisedCopyRatios extends CommandLineProgram {
                 "--denoised_copy_ratios_file=" + CopyNumberArgumentValidationUtils.getCanonicalPath(inputDenoisedCopyRatiosFile),
                 "--contig_names=" + contigNamesArg,
                 "--contig_lengths=" + contigLengthsArg,
+                "--maximum_copy_ratio=" + maxCopyRatio,
+                "--point_size_copy_ratio=" + pointSizeCopyRatio,
                 "--output_dir=" + outputDirArg,
                 "--output_prefix=" + outputPrefix);
         executor.exec();

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegments.java
@@ -67,6 +67,8 @@ import java.util.stream.Collectors;
  *         Modeled-segments-plot file.
  *         This shows the input denoised copy ratios and/or alternate-allele fractions as points, as well as box plots
  *         for the available posteriors in each segment.  The colors of the points alternate with the segmentation.
+ *         Copy ratios are only plotted up to the maximum value specified by the argument {@code maximum-copy-ratio}.
+ *         Point sizes can be specified by the arguments {@code point-size-copy-ratio} and {@code point-size-allele-fraction}.
  *     </li>
  * </ul>
  *
@@ -146,6 +148,30 @@ public final class PlotModeledSegments extends CommandLineProgram {
             optional = true
     )
     private int minContigLength = PlottingUtils.DEFAULT_MINIMUM_CONTIG_LENGTH;
+
+    @Argument(
+            doc = PlottingUtils.MAXIMUM_COPY_RATIO_DOC_STRING,
+            fullName =  PlottingUtils.MAXIMUM_COPY_RATIO_LONG_NAME,
+            minValue = 0,
+            optional = true
+    )
+    private double maxCopyRatio = PlottingUtils.DEFAULT_MAXIMUM_COPY_RATIO;
+
+    @Argument(
+            doc = PlottingUtils.POINT_SIZE_COPY_RATIO_DOC_STRING,
+            fullName =  PlottingUtils.POINT_SIZE_COPY_RATIO_LONG_NAME,
+            minValue = 0,
+            optional = true
+    )
+    private double pointSizeCopyRatio = PlottingUtils.DEFAULT_POINT_SIZE_COPY_RATIO;
+
+    @Argument(
+            doc = PlottingUtils.POINT_SIZE_ALLELE_FRACTION_DOC_STRING,
+            fullName =  PlottingUtils.POINT_SIZE_ALLELE_FRACTION_LONG_NAME,
+            minValue = 0,
+            optional = true
+    )
+    private double pointSizeAlleleFraction = PlottingUtils.DEFAULT_POINT_SIZE_ALLELE_FRACTION;
 
     @Argument(
             doc = "Prefix for output filenames.",
@@ -270,7 +296,7 @@ public final class PlotModeledSegments extends CommandLineProgram {
                                           final List<String> contigNames,
                                           final List<Integer> contigLengths,
                                           final File outputFile) {
-        final String contigNamesArg = contigNames.stream().collect(Collectors.joining(PlottingUtils.CONTIG_DELIMITER));                            //names separated by delimiter
+        final String contigNamesArg = String.join(PlottingUtils.CONTIG_DELIMITER, contigNames); //names separated by delimiter
         final String contigLengthsArg = contigLengths.stream().map(Object::toString).collect(Collectors.joining(PlottingUtils.CONTIG_DELIMITER));  //lengths separated by delimiter
         final RScriptExecutor executor = new RScriptExecutor();
 
@@ -285,6 +311,9 @@ public final class PlotModeledSegments extends CommandLineProgram {
                 "--modeled_segments_file=" + CopyNumberArgumentValidationUtils.getCanonicalPath(inputModeledSegmentsFile),
                 "--contig_names=" + contigNamesArg,
                 "--contig_lengths=" + contigLengthsArg,
+                "--maximum_copy_ratio=" + maxCopyRatio,
+                "--point_size_copy_ratio=" + pointSizeCopyRatio,
+                "--point_size_allele_fraction=" + pointSizeAlleleFraction,
                 "--output_file=" + CopyNumberArgumentValidationUtils.getCanonicalPath(outputFile));
         executor.exec();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlottingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlottingUtils.java
@@ -22,10 +22,17 @@ import java.util.stream.Collectors;
 final class PlottingUtils {
     static final String CNV_PLOTTING_R_LIBRARY = "CNVPlottingLibrary.R";
 
-    static final String MINIMUM_CONTIG_LENGTH_LONG_NAME = "minimum-contig-length";
-
     static final String CONTIG_DELIMITER = "CONTIG_DELIMITER";  //used to delimit contig names and lengths passed to the R script
+
+    static final String MINIMUM_CONTIG_LENGTH_LONG_NAME = "minimum-contig-length";
+    static final String MAXIMUM_COPY_RATIO_LONG_NAME = "maximum-copy-ratio";
+    static final String POINT_SIZE_COPY_RATIO_LONG_NAME = "point-size-copy-ratio";
+    static final String POINT_SIZE_ALLELE_FRACTION_LONG_NAME = "point-size-allele-fraction";
+
     static final int DEFAULT_MINIMUM_CONTIG_LENGTH = 1000000;   //can be used to filter out mitochondrial contigs, unlocalized contigs, etc.
+    static final double DEFAULT_MAXIMUM_COPY_RATIO = 4.;
+    static final double DEFAULT_POINT_SIZE_COPY_RATIO = 0.2;
+    static final double DEFAULT_POINT_SIZE_ALLELE_FRACTION = 0.4;
 
     static final String SEQUENCE_DICTIONARY_DOC_STRING = "File containing a sequence dictionary, which specifies the contigs to be plotted and their relative lengths. " +
             "The sequence dictionary must be a subset of those contained in other input files. " +
@@ -39,6 +46,13 @@ final class PlottingUtils {
     static final String MINIMUM_CONTIG_LENGTH_DOC_STRING = "Threshold length (in bp) for contigs to be plotted. " +
             "Contigs with lengths less than this threshold will not be plotted. " +
             "This can be used to filter out mitochondrial contigs, unlocalized contigs, etc.";
+
+    static final String MAXIMUM_COPY_RATIO_DOC_STRING = "Maximum copy ratio to be plotted. " +
+            "If Infinity, the maximum copy ratio will be automatically determined.";
+
+    static final String POINT_SIZE_COPY_RATIO_DOC_STRING = "Point size to use for plotting copy-ratio points.";
+
+    static final String POINT_SIZE_ALLELE_FRACTION_DOC_STRING = "Point size to use for plotting allele-fraction points.";
 
     private PlottingUtils() {}
 
@@ -81,7 +95,7 @@ final class PlottingUtils {
         }
         final Map<String, Integer> fileContigMaxPositionMap = locatableCollection.getIntervals().stream().filter(i -> contigNames.contains(i.getContig()))
                 .collect(Collectors.toMap(SimpleInterval::getContig, SimpleInterval::getEnd, Integer::max));
-        fileContigMaxPositionMap.keySet().forEach(c -> Utils.validateArg(fileContigMaxPositionMap.get(c) <= contigLengthMap.get(c),
+        fileContigMaxPositionMap.forEach((c, integer) -> Utils.validateArg(integer <= contigLengthMap.get(c),
                 String.format("Position present in the file %s exceeds contig length in the sequence dictionary.", file)));
     }
 

--- a/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/CNVPlottingLibrary.R
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/copynumber/plotting/CNVPlottingLibrary.R
@@ -28,9 +28,9 @@ SetUpPlot = function(sample_name, y.lab, y.min, y.max, x.lab, contig_names, cont
     }
 }
 
-PlotCopyRatios = function(copy_ratios_df, color, contig_names, contig_starts) {
+PlotCopyRatios = function(copy_ratios_df, color, contig_names, contig_starts, point_size) {
     genomic_coordinates = contig_starts[match(copy_ratios_df[["CONTIG"]], contig_names)] + copy_ratios_df[["MIDDLE"]]
-    points(x=genomic_coordinates, y=copy_ratios_df[["COPY_RATIO"]], col=color, pch=".", cex=0.2)
+    points(x=genomic_coordinates, y=copy_ratios_df[["COPY_RATIO"]], col=color, pch=".", cex=point_size)
 }
 
 PlotCopyRatiosWithModeledSegments = function(denoised_copy_ratios_df, modeled_segments_df, contig_names, contig_starts, point_size=0.2) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatiosIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotDenoisedCopyRatiosIntegrationTest.java
@@ -30,20 +30,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
     private static final String OUTPUT_PREFIX = "test";
     private static final int THRESHOLD_PLOT_FILE_SIZE_IN_BYTES = 50000;  //test that data points are plotted (not just background/axes)
 
-    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
-    @Test(groups = "R")
-    public void testPlotting() {
-        final File outputDir = createTempDir("testDir");
-        final String[] arguments = {
-                "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
-                "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
-                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
-                "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
-        };
-        runCommandLine(arguments);
-        Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".denoisedLimit4.png").exists());
-        Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".denoisedLimit4.png").length() > THRESHOLD_PLOT_FILE_SIZE_IN_BYTES);
+    private void assertFilesCreated(final File outputDir) {
         Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".denoised.png").exists());
         Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".denoised.png").length() > THRESHOLD_PLOT_FILE_SIZE_IN_BYTES);
         Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".standardizedMAD.txt").exists());
@@ -62,13 +49,44 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         Assert.assertEquals(scaledDeltaMAD, (standardizedMAD - denoisedMAD) / standardizedMAD);
     }
 
+    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
+    @Test(groups = "R")
+    public void testPlotting() {
+        final File outputDir = createTempDir("testDir");
+        final String[] arguments = {
+                "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
+        };
+        runCommandLine(arguments);
+        assertFilesCreated(outputDir);
+    }
+
+    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
+    @Test(groups = "R")
+    public void testPlottingInfiniteMaximumCopyRatio() {
+        final File outputDir = createTempDir("testDir");
+        final String[] arguments = {
+                "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + PlottingUtils.MAXIMUM_COPY_RATIO_LONG_NAME, "Infinity",
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
+        };
+        runCommandLine(arguments);
+        assertFilesCreated(outputDir);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMinimumContigLength() {
         final File outputDir = createTempDir("testDir");
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_WITH_NO_CONTIGS_ABOVE_MINIMUM_LENGTH_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_WITH_NO_CONTIGS_ABOVE_MINIMUM_LENGTH_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -81,7 +99,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, "Non-existent-file",
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -94,7 +112,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, "Non-existent-file",
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -107,7 +125,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, "Non-existent-file",
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, "Non-existent-file",
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -120,7 +138,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, COPY_RATIOS_OUT_OF_DICTIONARY_BOUNDS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, COPY_RATIOS_OUT_OF_DICTIONARY_BOUNDS_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -133,7 +151,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, COPY_RATIOS_WITH_SAMPLE_NAME_MISMATCH_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };
@@ -146,7 +164,7 @@ public final class PlotDenoisedCopyRatiosIntegrationTest extends CommandLineProg
         final String[] arguments = {
                 "--" + CopyNumberStandardArgument.STANDARDIZED_COPY_RATIOS_FILE_LONG_NAME, STANDARDIZED_COPY_RATIOS_FILE.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, COPY_RATIOS_WITH_MISSING_INTERVALS_FILE.getAbsolutePath(),
-                "-" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
                 "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
                 "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegmentsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/plotting/PlotModeledSegmentsIntegrationTest.java
@@ -52,6 +52,25 @@ public final class PlotModeledSegmentsIntegrationTest extends CommandLineProgram
         Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".modeled.png").length() > THRESHOLD_PLOT_FILE_SIZE_IN_BYTES);
     }
 
+    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
+    @Test(groups = "R")
+    public void testPlottingInfiniteMaximumCopyRatio() {
+        final File outputDir = createTempDir("testDir");
+        final String[] arguments = {
+                "--" + CopyNumberStandardArgument.DENOISED_COPY_RATIOS_FILE_LONG_NAME, DENOISED_COPY_RATIOS_FILE.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.ALLELIC_COUNTS_FILE_LONG_NAME, ALLELIC_COUNTS_FILE.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.SEGMENTS_FILE_LONG_NAME, MODELED_SEGMENTS_FILE.getAbsolutePath(),
+                "--" + StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, SEQUENCE_DICTIONARY_FILE.getAbsolutePath(),
+                "--" + PlottingUtils.MAXIMUM_COPY_RATIO_LONG_NAME, "Infinity",
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputDir.getAbsolutePath(),
+                "--" + CopyNumberStandardArgument.OUTPUT_PREFIX_LONG_NAME, OUTPUT_PREFIX
+        };
+        runCommandLine(arguments);
+        Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".modeled.png").exists());
+        Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".modeled.png").length() > THRESHOLD_PLOT_FILE_SIZE_IN_BYTES);
+    }
+
+    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
     @Test(groups = "R")
     public void testPlottingDenoisedCopyRatiosOnly() {
         final File outputDir = createTempDir("testDir");
@@ -67,6 +86,7 @@ public final class PlotModeledSegmentsIntegrationTest extends CommandLineProgram
         Assert.assertTrue(new File(outputDir, OUTPUT_PREFIX + ".modeled.png").length() > THRESHOLD_PLOT_FILE_SIZE_IN_BYTES / 2);    //copy-ratio-only plot is half the size
     }
 
+    //checks that output files with reasonable file sizes are generated, but correctness of output is not checked
     @Test(groups = "R")
     public void testPlottingAllelicCountsOnly() {
         final File outputDir = createTempDir("testDir");


### PR DESCRIPTION
Closes #6391.
Closes #5748.

Note that the *.denoisedLimit4.png output has been removed from the PlotDenoisedCopyRatios tool and the corresponding WDL task.  The default behavior has changed slightly, in that the remaining *.denoised.png output is now delimited to maximum copy ratio = 4.0 (instead of covering the entire range in the data).  @fleharty @droazen we may want to mention this in the release notes.