### PR TITLE
make progress meter async

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -158,10 +158,6 @@ public abstract class AssemblyRegionWalker extends WalkerBase {
 
         CountingReadFilter countedFilter = makeReadFilter();
 
-        // Since we're processing regions rather than individual reads, tell the progress
-        // meter to check the time more frequently (every 10 regions instead of every 1000 regions).
-        progressMeter.setRecordsBetweenTimeChecks(10L);
-
         for ( final MultiIntervalLocalReadShard readShard : readShards ) {
             // Since reads in each shard are lazily fetched, we need to pass the filter and transformers to the window
             // instead of filtering the reads directly here

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -26,6 +26,8 @@ import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
+import org.broadinstitute.hellbender.engine.progressmeter.LocatableProgressMeter;
+import org.broadinstitute.hellbender.engine.progressmeter.ProgressMeter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.genomicsdb.GenomicsDBOptions;
@@ -217,10 +219,10 @@ public abstract class GATKTool extends CommandLineProgram {
 
     /**
      * Progress meter to print out traversal statistics. Subclasses must invoke
-     * {@link ProgressMeter#update(Locatable)} after each record processed from
+     * {@link LocatableProgressMeter#update(Locatable)} after each record processed from
      * the primary input in their {@link #traverse} method.
      */
-    protected ProgressMeter progressMeter;
+    protected LocatableProgressMeter progressMeter;
 
     /**
      * Return the list of GATKCommandLinePluginDescriptors to be used for this tool.
@@ -713,7 +715,7 @@ public abstract class GATKTool extends CommandLineProgram {
 
         checkToolRequirements();
 
-        progressMeter = new ProgressMeter(secondsBetweenProgressUpdates);
+        progressMeter = new LocatableProgressMeter(secondsBetweenProgressUpdates);
         progressMeter.setRecordLabel(getProgressMeterRecordLabel());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/progressmeter/LocatableProgressMeter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/progressmeter/LocatableProgressMeter.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.hellbender.engine.progressmeter;
+
+import htsjdk.samtools.util.Locatable;
+
+/**
+ * A ProgressMeter which accepts Locatables
+ */
+public class LocatableProgressMeter extends ProgressMeter<Locatable> {
+
+    public LocatableProgressMeter(){
+        super();
+    }
+
+    public LocatableProgressMeter(final double secondsBetweenUpdates ){
+        super( secondsBetweenUpdates );
+    }
+
+    /**
+     * @return genomic location of the most recent record formatted for output to the logger
+     */
+    @Override
+    protected String formatRecord(Locatable locatable) {
+        return locatable != null ? locatable.getContig() + ":" + locatable.getStart() : "unmapped";
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/progressmeter/ProgressMeter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/progressmeter/ProgressMeter.java
@@ -1,8 +1,7 @@
-package org.broadinstitute.hellbender.engine;
+package org.broadinstitute.hellbender.engine.progressmeter;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import htsjdk.samtools.util.Locatable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,23 +10,24 @@ import org.broadinstitute.hellbender.utils.Utils;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * A basic progress meter to print out the number of records processed (and other metrics) during a traversal
  * at a configurable time interval.
  *
  * Clients set the update interval at construction, which controls how many seconds must elapse
- * before printing an update. Then call {@link #start} at traversal start, {@link #update(Locatable)}
+ * before printing an update. Then call {@link #start} at traversal start, {@link #update(T)}
  * after processing each record from the primary input, and {@link #stop} at traversal end to print
  * summary statistics.
  *
- * Note that {@link #start} must only be called once, before any {@link #update(Locatable)}.
- * Note no {@link #update(Locatable)} must be called after {@link #stop}.
+ * Note that {@link #start} must only be called once, before any {@link #update(T)}.
+ * Note no {@link #update(T)} must be called after {@link #stop}.
  *
  * All output is made at INFO level via log4j.
  */
-public final class ProgressMeter {
-    protected static final Logger logger = LogManager.getLogger(ProgressMeter.class);
+public abstract class ProgressMeter<T> {
+    private static final Logger logger = LogManager.getLogger(ProgressMeter.class);
 
     /**
      * By default, we output a line to the logger after this many seconds have elapsed
@@ -76,10 +76,9 @@ public final class ProgressMeter {
     private long lastPrintTimeMs = 0L;
 
     /**
-     * The genomic location of the most recently processed record, or null if the most recent record had no location.
-     * Updated only when we actually output a line to the logger.
+     * The most recently processed record, or null if the most recent update was a null.
      */
-    private Locatable currentLocus = null;
+    private T currentRecord = null;
 
     /**
      * The number of times we've outputted a status line to the logger via {@link #printProgress}.
@@ -127,7 +126,7 @@ public final class ProgressMeter {
         Utils.validate(millisecondsBetweenUpdates > 0, "millisecondsBetweenUpdates must be > 0");
 
         this.scheduler = Executors.newScheduledThreadPool(1,
-                                                          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Progress Meter").build());
+                new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Progress Meter").build());
     }
 
     /**
@@ -156,7 +155,7 @@ public final class ProgressMeter {
         lastPrintTimeMs = startTimeMs;
         numRecordsProcessed = 0L;
         numLoggerUpdates = 0L;
-        currentLocus = null;
+        currentRecord = null;
 
         scheduler.scheduleAtFixedRate(this::printProgress, millisecondsBetweenUpdates, millisecondsBetweenUpdates, TimeUnit.MILLISECONDS);
     }
@@ -172,11 +171,11 @@ public final class ProgressMeter {
      * @param currentLocus the genomic location of the record just processed or null if the most recent record had no location.
      * @throws IllegalStateException if the meter has not been started yet or has been stopped already
      */
-    public synchronized void update( final Locatable currentLocus ) {
+    public synchronized void update( final T currentLocus ) {
         Utils.validate(started, "the progress meter has not been started yet");
         Utils.validate( !stopped, "the progress meter has been stopped already");
         ++numRecordsProcessed;
-        this.currentLocus = currentLocus;
+        this.currentRecord = currentLocus;
     }
 
     /**
@@ -212,8 +211,17 @@ public final class ProgressMeter {
         lastPrintTimeMs = currentTimeMs;
         ++numLoggerUpdates;
         logger.info(String.format("%20s  %15.1f  %20d  %15.1f",
-                                  currentLocusString(), elapsedTimeInMinutes(), numRecordsProcessed, processingRate()));
+                                  formatRecord(currentRecord), elapsedTimeInMinutes(), numRecordsProcessed, processingRate()));
     }
+
+    /**
+     * Format the current record into a string for printing.  This should ideally give the user some information about
+     * the state of progress.
+     *
+     * @param currentRecord the most recent update the ProgressMeter has recieved.
+     * @return a String summarizing the state of progress from this given record.
+     */
+    protected abstract String formatRecord(final T currentRecord);
 
     /**
      * @return the total minutes elapsed since we called {@link #start}
@@ -258,14 +266,6 @@ public final class ProgressMeter {
     @VisibleForTesting
     long getNumRecordsProcessed(){
         return numRecordsProcessed;
-    }
-
-    /**
-     * @return genomic location of the most recent record formatted for output to the logger
-     */
-    private String currentLocusString() {
-        return currentLocus != null ? currentLocus.getContig() + ":" + currentLocus.getStart() :
-                                      "unmapped";
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/IndexFeatureFile.java
@@ -15,9 +15,9 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
+import org.broadinstitute.hellbender.engine.progressmeter.ProgressMeter;
 import picard.cmdline.programgroups.OtherProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureManager;
-import org.broadinstitute.hellbender.engine.ProgressMeter;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.codecs.ProgressReportingDelegatingCodec;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -144,7 +144,7 @@ import java.util.stream.Collectors;
  *      --genomicsdb-update-workspace-path my_database \
  *      --tmp-dir=/path/to/large/tmp \
  *  </pre>
- *  In the incremental import case, no intervals are specified in the command because the tool will use the same 
+ *  In the incremental import case, no intervals are specified in the command because the tool will use the same
  *  intervals used in the initial import. Sample map is also supported for incremental import
  *
  *  Get Picard-style interval_list from existing workspace
@@ -428,7 +428,7 @@ public final class GenomicsDBImport extends GATKTool {
                 getIntervalsFromExistingWorkspace = true;
             }
         }
-        
+
     }
 
     private void assertOverwriteWorkspaceAndIncrementalImportMutuallyExclusive() {
@@ -731,8 +731,6 @@ public final class GenomicsDBImport extends GATKTool {
         if (getIntervalsFromExistingWorkspace) {
            return;
         }
-        // Force the progress meter to update after every batch
-        progressMeter.setRecordsBetweenTimeChecks(1L);
 
         final int sampleCount = sampleNameToVcfPath.size();
         final int updatedBatchSize = (batchSize == DEFAULT_ZERO_BATCH_SIZE) ? sampleCount : batchSize;

--- a/src/main/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualities.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/validation/CompareBaseQualities.java
@@ -6,18 +6,19 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.SecondaryOrSupplementarySkippingIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.PositionalArguments;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.*;
-import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
-import org.broadinstitute.hellbender.engine.ProgressMeter;
+import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.progressmeter.LocatableProgressMeter;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 
-import java.io.*;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -138,7 +139,7 @@ public final class CompareBaseQualities extends PicardCommandLineProgram {
 
         final CompareMatrix finalMatrix = new CompareMatrix(staticQuantizedMapping);
 
-        final ProgressMeter progressMeter = new ProgressMeter(1.0);
+        final LocatableProgressMeter progressMeter = new LocatableProgressMeter(1.0);
         progressMeter.start();
 
         while (it1.hasCurrent() && it2.hasCurrent()) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -100,11 +100,11 @@ public final class Utils {
 
     public static List<String> warnUserLines(final String msg) {
         final List<String> results = new ArrayList<>();
-        results.add(String.format(TEXT_WARNING_BORDER));
-        results.add(String.format(TEXT_WARNING_PREFIX + "WARNING:"));
-        results.add(String.format(TEXT_WARNING_PREFIX));
+        results.add(TEXT_WARNING_BORDER);
+        results.add(TEXT_WARNING_PREFIX + "WARNING:");
+        results.add(TEXT_WARNING_PREFIX);
         prettyPrintWarningMessage(results, msg);
-        results.add(String.format(TEXT_WARNING_BORDER));
+        results.add(TEXT_WARNING_BORDER);
         return results;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/ProgressReportingDelegatingCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/ProgressReportingDelegatingCodec.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.hellbender.utils.codecs;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.FeatureCodecHeader;
 import htsjdk.tribble.index.tabix.TabixFormat;
-import org.broadinstitute.hellbender.engine.ProgressMeter;
+import org.broadinstitute.hellbender.engine.progressmeter.LocatableProgressMeter;
+import org.broadinstitute.hellbender.engine.progressmeter.ProgressMeter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,7 +20,7 @@ import java.io.InputStream;
 public final class ProgressReportingDelegatingCodec<A extends Feature, B> implements FeatureCodec<A, B> {
     private final FeatureCodec<A, B> delegatee;
 
-    private final ProgressMeter pm;
+    private final ProgressMeter<Locatable> pm;
 
     //Note: this default constructor is needed for the FeatureManager when it loads codecs.
     @SuppressWarnings("unused")
@@ -32,7 +34,7 @@ public final class ProgressReportingDelegatingCodec<A extends Feature, B> implem
             throw new IllegalArgumentException("secondsBetweenUpdates must be > 0.0");
         }
         this.delegatee = delegatee;
-        this.pm = new ProgressMeter(secondsBetweenUpdates);
+        this.pm = new LocatableProgressMeter(secondsBetweenUpdates);
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
+import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
@@ -13,142 +14,54 @@ import java.util.function.LongSupplier;
 
 public class ProgressMeterUnitTest extends GATKBaseTest {
 
-    private static class ListBasedTimeFunction implements LongSupplier {
-        private final List<Long> values;
-        private int currentIndex = 0;
-
-        public ListBasedTimeFunction( final List<Long> values ) {
-            this.values = values;
-        }
-
-        @Override
-        public long getAsLong() {
-            if ( currentIndex >= values.size() ) {
-                throw new NoSuchElementException();
-            }
-
-            return values.get(currentIndex++);
-        }
-
-        public int size() {
-            return values.size();
-        }
-    }
-
     @DataProvider(name = "UpdateIntervalTestData")
     public Object[][] getUpdateIntervalTestData() {
         return new Object[][] {
-                // Seconds between logger updates, time function, total number of records to process, and expected number of progress updates
-                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS, 1 },
-                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS * 2, 2 },
-                { 1.5, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS, 0 },
-                { 2.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l, 4000l, 5000l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS * 4, 2 },
-                { 2.0, new ListBasedTimeFunction(Arrays.asList(1000l, 2000l, 3000l, 4000l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS * 3, 1 },
-                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2500l, 3500l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS * 3, 2 },
-                { 1.0, new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2500l, 3400l)), ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS * 3, 1 },
+                // Seconds between logger updates, time waited, total number of records to process, and expected number of progress updates
+                { 0.001, 5, 100},
+                { 0.2, 5, 10000},
         };
     }
 
     @Test(dataProvider = "UpdateIntervalTestData")
-    public void testUpdateInterval( final double secondsBetweenUpdates, final ListBasedTimeFunction timeFunction, final long numRecords, final int expectedUpdates ) {
-        final ProgressMeter meter = new ProgressMeter(secondsBetweenUpdates, timeFunction);
-        meter.start();
-        for ( int i = 1; i <= numRecords; ++i ) {
-            meter.update(new SimpleInterval("1", 1, 1));
+    public void testUpdateInterval( final double secondsBetweenUpdates, final int waitTime, final long numRecords) throws InterruptedException {
+        final ProgressMeter meter = new ProgressMeter(secondsBetweenUpdates);
+        //should take ~0 seconds...
+        try {
+            meter.start();
+            Thread.sleep(10000);
+            for (int i = 1; i <= numRecords; ++i) {
+                meter.update(new SimpleInterval("1", 1, 1));
+            }
+            //now run the clock
+            Thread.sleep(waitTime * 1000);
+        } finally {
+            meter.stop();
         }
+        final double expectedUpdates = waitTime / secondsBetweenUpdates;
+        final long updates = meter.numLoggerUpdates();
+        final double allowableRatio = 1.0;
+        BaseTest.assertEqualsDoubleSmart((updates - expectedUpdates) / expectedUpdates, expectedUpdates allowableRatio,
+                          "Wrong number of logger updates given secondsBetweenUpdates = " + secondsBetweenUpdates + " saw " + updates + " but expected between ");
 
-        Assert.assertEquals(meter.numLoggerUpdates(), expectedUpdates, "Wrong number of logger updates given secondsBetweenUpdates = " + secondsBetweenUpdates);
+        Assert.assertEquals(meter.getNumRecordsProcessed(), numRecords);
     }
+
+    public void assertCloseish(long actual, long expected, )
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInvalidUpdateInterval() {
         final ProgressMeter meter = new ProgressMeter(0.0);
     }
 
-    @DataProvider(name = "ElapsedTimeInMinutesTestData")
-    public Object[][] getElapsedTimeInMinutesTestData() {
-        return new Object[][] {
-                // 600,000ms = 10 minutes
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l * 10l + 1000l)), 10.0 },
-                // 60,000ms = 1 minute
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l + 1000l)), 1.0 },
-                // 30,000ms = 0.5 minutes
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 30000l + 1000l)), 0.5 },
-                // 0ms = 0 minutes
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 1000l)), 0.0 },
-                // 10,000ms = 1.0/6.0 minutes
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 3000l, 6000l, 10000l, 11000l)), 1.0 / 6.0 }
-        };
-    }
-
-    @Test(dataProvider = "ElapsedTimeInMinutesTestData")
-    public void testElapsedTimeInMinutes( final ListBasedTimeFunction timeFunction, final double expectedElapsedMinutes ) {
-        final ProgressMeter meter = new ProgressMeter(1l, timeFunction);
-
-        meter.start();
-        // The start() call consumes one value from the time function, so we need to process
-        // (timeFunction.size() - 1) * ProgressMeter.RECORDS_BETWEEN_TIME_CHECKS in order
-        // to consume the rest of the values in the time function
-        for ( int i = 1; i <= (timeFunction.size() - 1) * ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS; ++i ) {
-            meter.update(new SimpleInterval("1", 1, 1));
-        }
-
-        Assert.assertEquals(meter.elapsedTimeInMinutes(), expectedElapsedMinutes, "elapsed minutes differs from expected value");
-    }
-
-    @DataProvider(name = "ProcessingRateTestData")
-    public Object[][] getProcessingRateTestData() {
-        // We need to base the number of records we process on the time check interval (to ensure that
-        // the progress meter pulls all values from the time function and gets updated properly).
-        final long timeCheckRecords = ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS;
-        return new Object[][] {
-                // If we process timeCheckRecords records in 1 minute, rate should be timeCheckRecords
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l + 1000l)), timeCheckRecords, timeCheckRecords },
-                // If we process timeCheckRecords records in 2 minutes, rate should be timeCheckRecords / 2
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 60000l * 2l + 1000l)), timeCheckRecords, timeCheckRecords / 2},
-                // timeCheckRecords records in 15 seconds should give timeCheckRecords * 4 records/minute
-                { new ListBasedTimeFunction(Arrays.asList(1000l, 15000l + 1000l)), timeCheckRecords, timeCheckRecords * 4 }
-        };
-    }
-
-    @Test(dataProvider = "ProcessingRateTestData")
-    public void testProcessingRate( final ListBasedTimeFunction timeFunction, final long recordsToProcess, final double expectedProcessingRate ) {
-        final ProgressMeter meter = new ProgressMeter(1.0, timeFunction);
-
-        meter.start();
-        for ( int i = 1; i <= recordsToProcess; ++i ) {
-            meter.update(new SimpleInterval("1", 1, 1));
-        }
-
-        Assert.assertEquals(meter.processingRate(), expectedProcessingRate, "actual processing rate differs from expected value");
-    }
-
-    @Test
-    public void testSecondsSinceLastPrint() {
-        final ListBasedTimeFunction timeFunction = new ListBasedTimeFunction(Arrays.asList(1000l, 1500l, 2000l, 2500l, 3000l));
-        final ProgressMeter meter = new ProgressMeter(1.0, timeFunction);
-        final List<Double> expectedSecondsSinceLastPrint = Arrays.asList(0.5, 0.0, 0.5, 0.0);
-
-        meter.start();
-        // start() consumes one timestamp from our function, so we need to process size() - 1 more timestamps
-        for ( int i = 1; i <= timeFunction.size() - 1; ++i ) {
-            for ( int j = 1; j <= ProgressMeter.DEFAULT_RECORDS_BETWEEN_TIME_CHECKS; ++j ) {
-                meter.update(new SimpleInterval("1", 1, 1));
-            }
-
-            Assert.assertEquals(meter.secondsSinceLastPrint(), (double) expectedSecondsSinceLastPrint.get(i - 1), "Wrong number of seconds reported since last print");
-        }
-
-    }
-
     @Test(expectedExceptions = IllegalStateException.class)
-    public void testMustStartBeforeUpdate() throws Exception {
+    public void testMustStartBeforeUpdate() {
         ProgressMeter pm = new ProgressMeter();
         pm.update(new SimpleInterval("1",1,1));
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
-    public void testCantStartTwice() throws Exception {
+    public void testCantStartTwice() {
         ProgressMeter pm = new ProgressMeter();
         pm.start();
         pm.update(new SimpleInterval("1",1,1));
@@ -156,13 +69,13 @@ public class ProgressMeterUnitTest extends GATKBaseTest {
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
-    public void testCantStopBeforeStart() throws Exception {
+    public void testCantStopBeforeStart() {
         ProgressMeter pm = new ProgressMeter();
         pm.stop();
     }
 
     @Test
-    public void testStartedAndStopped() throws Exception {
+    public void testStartedAndStopped() {
         ProgressMeter pm = new ProgressMeter();
         Assert.assertFalse(pm.started());
         Assert.assertFalse(pm.stopped());

--- a/src/test/java/org/broadinstitute/hellbender/engine/progressmeter/ProgressMeterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/progressmeter/ProgressMeterUnitTest.java
@@ -1,16 +1,12 @@
-package org.broadinstitute.hellbender.engine;
+package org.broadinstitute.hellbender.engine.progressmeter;
 
+import htsjdk.samtools.util.Locatable;
+import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.function.LongSupplier;
 
 public class ProgressMeterUnitTest extends GATKBaseTest {
 
@@ -25,7 +21,7 @@ public class ProgressMeterUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "UpdateIntervalTestData")
     public void testUpdateInterval( final double secondsBetweenUpdates, final int waitTime, final long numRecords) throws InterruptedException {
-        final ProgressMeter meter = new ProgressMeter(secondsBetweenUpdates);
+        final ProgressMeter<Locatable> meter = new LocatableProgressMeter(secondsBetweenUpdates);
         //should take ~0 seconds...
         try {
             meter.start();
@@ -41,28 +37,26 @@ public class ProgressMeterUnitTest extends GATKBaseTest {
         final double expectedUpdates = waitTime / secondsBetweenUpdates;
         final long updates = meter.numLoggerUpdates();
         final double allowableRatio = 1.0;
-        BaseTest.assertEqualsDoubleSmart((updates - expectedUpdates) / expectedUpdates, expectedUpdates allowableRatio,
+        BaseTest.assertEqualsDoubleSmart((updates - expectedUpdates) / expectedUpdates, expectedUpdates, allowableRatio,
                           "Wrong number of logger updates given secondsBetweenUpdates = " + secondsBetweenUpdates + " saw " + updates + " but expected between ");
 
         Assert.assertEquals(meter.getNumRecordsProcessed(), numRecords);
     }
 
-    public void assertCloseish(long actual, long expected, )
-
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInvalidUpdateInterval() {
-        final ProgressMeter meter = new ProgressMeter(0.0);
+        final ProgressMeter<Locatable> meter = new LocatableProgressMeter(0.0);
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMustStartBeforeUpdate() {
-        ProgressMeter pm = new ProgressMeter();
+        ProgressMeter<Locatable> pm = new LocatableProgressMeter();
         pm.update(new SimpleInterval("1",1,1));
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testCantStartTwice() {
-        ProgressMeter pm = new ProgressMeter();
+        ProgressMeter<Locatable> pm = new LocatableProgressMeter();
         pm.start();
         pm.update(new SimpleInterval("1",1,1));
         pm.start();
@@ -70,13 +64,13 @@ public class ProgressMeterUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testCantStopBeforeStart() {
-        ProgressMeter pm = new ProgressMeter();
+        ProgressMeter<Locatable> pm = new LocatableProgressMeter();
         pm.stop();
     }
 
     @Test
     public void testStartedAndStopped() {
-        ProgressMeter pm = new ProgressMeter();
+        ProgressMeter<Locatable> pm = new LocatableProgressMeter();
         Assert.assertFalse(pm.started());
         Assert.assertFalse(pm.stopped());
         pm.start();


### PR DESCRIPTION
This branch does 2 things.  
1.  It makes ProgressMeter async #
2.  It makes ProgressMeter and interface so it could be made more flexible for non-locatables. This could be a first step to making it more flexible for https://github.com/broadinstitute/gatk/issues/6390 and https://github.com/broadinstitute/gatk/issues/5178
