### PR TITLE
Making ENSEMBL GTF Codec more permissive

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodec.java
@@ -482,13 +482,7 @@ public abstract class AbstractGtfCodec extends AbstractFeatureCodec<GencodeGtfFe
      * @return {@code true} IFF the header line number {@code lineNum} starts with {@code startingText}; {@code false} otherwise.
      */
     boolean checkHeaderLineStartsWith(final List<String> header, final int lineNum, final String startingText, final boolean throwIfInvalid ) {
-        boolean foundGoodLine = false;
-        for ( final String commentPrefix : getAllLineComments() ) {
-            if ( header.get(lineNum).startsWith(commentPrefix + startingText) ) {
-                foundGoodLine = true;
-                break;
-            }
-        }
+        final boolean foundGoodLine = isLineCommented(header.get(lineNum), startingText);
 
         if (!foundGoodLine) {
             if ( throwIfInvalid ) {
@@ -513,6 +507,25 @@ public abstract class AbstractGtfCodec extends AbstractFeatureCodec<GencodeGtfFe
         boolean isCommented = false;
         for ( final String commentPrefix : getAllLineComments() ) {
             if ( line.startsWith(commentPrefix) ) {
+                isCommented = true;
+                break;
+            }
+        }
+
+        return isCommented;
+    }
+
+    /**
+     * Checks whether the given line is commented out or not and if the content of the line begins with the given
+     * {@code linePrefix}.
+     * @param line A {@link String} representing a line in the GTF file.
+     * @param linePrefix A {@link String} containing content that the line must start with in addition to the comment prefix.
+     * @return {@code true} iff the line starts with a comment delimiter.  {@code false} otherwise.
+     */
+    boolean isLineCommented(final String line, final String linePrefix) {
+        boolean isCommented = false;
+        for ( final String commentPrefix : getAllLineComments() ) {
+            if ( line.startsWith(commentPrefix + linePrefix) ) {
                 isCommented = true;
                 break;
             }

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodec.java
@@ -504,15 +504,7 @@ public abstract class AbstractGtfCodec extends AbstractFeatureCodec<GencodeGtfFe
      * @return {@code true} iff the line starts with a comment delimiter.  {@code false} otherwise.
      */
     boolean isLineCommented(final String line) {
-        boolean isCommented = false;
-        for ( final String commentPrefix : getAllLineComments() ) {
-            if ( line.startsWith(commentPrefix) ) {
-                isCommented = true;
-                break;
-            }
-        }
-
-        return isCommented;
+        return isLineCommented(line, "");
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodec.java
@@ -28,8 +28,9 @@ final public class EnsemblGtfCodec extends AbstractGtfCodec {
     //==================================================================================================================
     // Private Static Members:
 
-    private static String VERSION_FIELD = "genome-version";
-    private static String DEFAULT_VERSION = "ENSEMBL_DEFAULT_VERSION";
+    private static String            VERSION_FIELD    = "genome-version";
+    private static String            DEFAULT_VERSION  = "ENSEMBL_DEFAULT_VERSION";
+    private static final Set<String> COMMENT_PREFIXES = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList("#!", "##")));
 
     //==================================================================================================================
     // Private Members:
@@ -37,7 +38,6 @@ final public class EnsemblGtfCodec extends AbstractGtfCodec {
     private final        List<String> header          = new ArrayList<>();
     private              int          currentLineNum  = 1;
     private              String       version         = null;
-    private static final Set<String>  commentPrefixes = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList("#!", "##")));
 
     //==================================================================================================================
     // Constructors:
@@ -56,12 +56,12 @@ final public class EnsemblGtfCodec extends AbstractGtfCodec {
 
     @Override
     String getDefaultLineComment() {
-        return commentPrefixes.iterator().next();
+        return COMMENT_PREFIXES.iterator().next();
     }
 
     @Override
     Set<String> getAllLineComments() {
-        return commentPrefixes;
+        return COMMENT_PREFIXES;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeature.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeature.java
@@ -49,7 +49,7 @@ public abstract class GencodeGtfFeature implements Feature, Comparable<GencodeGt
 
     public static final String ANNOTATION_SOURCE_ENSEMBL = "ENSEMBL";
     public static final String ANNOTATION_SOURCE_HAVANA = "HAVANA";
-    public static String ANNOTATION_SOURCE_ENA = "ena";
+    public static final String ANNOTATION_SOURCE_ENA = "ena";
 
     // ===========================================================================
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeature.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeature.java
@@ -44,6 +44,15 @@ public abstract class GencodeGtfFeature implements Feature, Comparable<GencodeGt
 
     private static final Logger logger = LogManager.getLogger(GencodeGtfFeature.class);
 
+    // ===========================================================================
+
+
+    public static final String ANNOTATION_SOURCE_ENSEMBL = "ENSEMBL";
+    public static final String ANNOTATION_SOURCE_HAVANA = "HAVANA";
+    public static String ANNOTATION_SOURCE_ENA = "ena";
+
+    // ===========================================================================
+
     // Metadata fields:
 
     private static final String FIELD_DELIMITER                 = "\t";
@@ -100,7 +109,7 @@ public abstract class GencodeGtfFeature implements Feature, Comparable<GencodeGt
 
         baseData.gtfSourceFileType       = gtfFileType;
 
-        baseData.annotationSource        = AnnotationSource.valueOf( gtfFields[ANNOTATION_SOURCE_INDEX] );
+        baseData.annotationSource        = gtfFields[ANNOTATION_SOURCE_INDEX];
         baseData.featureType             = GencodeGtfFeature.FeatureType.getEnum( gtfFields[FEATURE_TYPE_INDEX].toLowerCase() );
         baseData.genomicStrand           = convertStringToStrand( gtfFields[GENOMIC_STRAND_INDEX] );
         baseData.genomicPhase            = GenomicPhase.getEnum( gtfFields[GENOMIC_PHASE_INDEX] );
@@ -479,7 +488,7 @@ public abstract class GencodeGtfFeature implements Feature, Comparable<GencodeGt
         return baseData.genomicPosition.getContig();
     }
 
-    public AnnotationSource getAnnotationSource() {
+    public String getAnnotationSource() {
         return baseData.annotationSource;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeatureBaseData.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfFeatureBaseData.java
@@ -35,8 +35,14 @@ final public class GencodeGtfFeatureBaseData {
 
     /**
      * Keyword identifying the source of this feature.
+     *
+     * There is no restriction on which keywords can be used here, but some
+     * known annotation sources are defined in their GTF parent objects:
+     *      {@link GencodeGtfCodec#GENCODE_ANNOTATION_SOURCE_ENSEMBL}
+     *      {@link GencodeGtfCodec#GENCODE_ANNOTATION_SOURCE_HAVANA}
+     *      {@link EnsemblGtfCodec#ENSEMBL_ANNOTATION_SOURCE_ENA}
      */
-    public GencodeGtfFeature.AnnotationSource      annotationSource;
+    public String annotationSource;
 
     /**
      * Type of this feature.
@@ -86,7 +92,7 @@ final public class GencodeGtfFeatureBaseData {
             final String gtfSourceFileType,
             final int featureOrderNumber,
             final String chromosomeName,
-            final GencodeGtfFeature.AnnotationSource annotationSource,
+            final String annotationSource,
             final GencodeGtfFeature.FeatureType featureType,
             final int genomicStartLocation,
             final int genomicEndLocation,

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/DataProviderForExampleGencodeGtfGene.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/DataProviderForExampleGencodeGtfGene.java
@@ -22,14 +22,14 @@ public class DataProviderForExampleGencodeGtfGene {
         // Create the Features as they exist in the test file:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 1, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 1, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 1, 3000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", null, null, null, -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED, null, null);
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(data);
 
         // ======================
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 2, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 2, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 1, 1000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -37,7 +37,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfTranscriptFeature transcript1 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 3, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 3, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1, 200, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -45,7 +45,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon1 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 4, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 4, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 99, 101, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -53,7 +53,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfStartCodonFeature startCodon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 5, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 5, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 201, 400, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 2, "TEST_EXON2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -61,7 +61,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon2 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 201, 400, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 2, "TEST_EXON2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -69,7 +69,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds1 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 401, 600, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 3, "TEST_EXON3", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -77,7 +77,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon3 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 401, 600, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 3, "TEST_EXON3", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -85,7 +85,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds2 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 601, 800, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 4, "TEST_EXON4", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -93,7 +93,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon4 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 601, 800, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 4, "TEST_EXON4", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -102,7 +102,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final GencodeGtfCDSFeature cds3 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 801, 1000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -110,7 +110,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon5 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 900, 902, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -118,7 +118,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfStopCodonFeature stopCodon1 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 1, 98, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -126,7 +126,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfUTRFeature utr1 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 903, 1000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -136,7 +136,7 @@ public class DataProviderForExampleGencodeGtfGene {
 
         // ======================
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 1001, 2000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -144,7 +144,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfTranscriptFeature transcript2 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1001, 1200, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -152,7 +152,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon6 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 1099, 1101, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -160,7 +160,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfStartCodonFeature startCodon2 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 1099, 1200, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -168,7 +168,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds4 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1201, 1400, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 2, "TEST_EXON2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -176,7 +176,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon7 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 1201, 1400, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 2, "TEST_EXON2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -184,7 +184,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds5 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1401, 1600, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 3, "TEST_EXON3", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -192,7 +192,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon8 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 1401, 1600, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 3, "TEST_EXON3", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -200,7 +200,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds6 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1601, 1800, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 4, "TEST_EXON4", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -208,7 +208,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon9 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 1601, 1800, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 4, "TEST_EXON4", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -217,7 +217,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final GencodeGtfCDSFeature cds7 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 1801, 2000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -225,7 +225,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon10 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 1801, 1899, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -233,7 +233,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfCDSFeature cds8 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 1900, 1902, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -241,7 +241,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfStopCodonFeature stopCodon2 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 1001, 1098, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -249,7 +249,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfUTRFeature utr3 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 1903, 2000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT2", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -259,7 +259,7 @@ public class DataProviderForExampleGencodeGtfGene {
         
         // ======================
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 2001, 3000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -267,7 +267,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfTranscriptFeature transcript3 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 2001, 2200, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -275,7 +275,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon11 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 2201, 2400, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", 2, "TEST_EXON2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -283,7 +283,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon12 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 2401, 2600, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", 3, "TEST_EXON3", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -291,7 +291,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon13 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 2601, 2800, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", 4, "TEST_EXON4", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -299,7 +299,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon14 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 2801, 3000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT3", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT3", 5, "TEST_EXON5", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -452,12 +452,12 @@ public class DataProviderForExampleGencodeGtfGene {
 
         final AtomicInteger featureOrderNum = new AtomicInteger(1);
 
-        final GencodeGtfFeatureBaseData tmpGene = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        final GencodeGtfFeatureBaseData tmpGene = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 start, start + totalLength - 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, null, null, null, -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED, null, null);
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(tmpGene);
 
-        final GencodeGtfFeatureBaseData tmpTranscript = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        final GencodeGtfFeatureBaseData tmpTranscript = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 gene.getGenomicStartLocation(), gene.getGenomicEndLocation(), codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -528,7 +528,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final int CODON_LENGTH = 3;
 
         // Exon is created with room
-        final GencodeGtfFeatureBaseData data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        final GencodeGtfFeatureBaseData data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 exonStart, exonStart + lengthExons + length3pUtr - 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exonNum, "TEST_EXON_" + exonNum, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -539,7 +539,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final int cdsStart = codingDirection == Strand.POSITIVE ?  exon.getGenomicStartLocation() : exon.getGenomicStartLocation() + length3pUtr + CODON_LENGTH - 1;
         final int cdsEnd = codingDirection == Strand.POSITIVE ?  exon.getGenomicEndLocation() - length3pUtr - CODON_LENGTH : exon.getGenomicEndLocation();
 
-        final GencodeGtfFeatureBaseData tmpCdsMinusStop = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        final GencodeGtfFeatureBaseData tmpCdsMinusStop = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 cdsStart, cdsEnd, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -550,7 +550,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final int stopCodonStart = codingDirection == Strand.POSITIVE ? cds1.getGenomicEndLocation() + 1 : cds1.getGenomicStartLocation() - CODON_LENGTH;
         final int stopCodonEnd = codingDirection == Strand.POSITIVE ? cds1.getGenomicEndLocation() + CODON_LENGTH : cds1.getGenomicStartLocation() - 1;
 
-        final GencodeGtfFeatureBaseData tmpStopCodon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        final GencodeGtfFeatureBaseData tmpStopCodon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 stopCodonStart, stopCodonEnd, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -569,7 +569,7 @@ public class DataProviderForExampleGencodeGtfGene {
                                                     final GencodeGtfExonFeature exon, final Strand codingDirection) {
         final int start = codingDirection == Strand.FORWARD ? exon.getGenomicEndLocation() - length3Utr + 1 : exon.getGenomicStartLocation();
         final int end = codingDirection == Strand.FORWARD ? exon.getGenomicEndLocation() : exon.getGenomicStartLocation() + length3Utr - 1;
-        final GencodeGtfFeatureBaseData tmp3pUtr = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        final GencodeGtfFeatureBaseData tmp3pUtr = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 start, end, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -584,7 +584,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final int start = codingDirection == Strand.FORWARD ? exon.getGenomicStartLocation() : exon.getGenomicEndLocation() - length5Utr + 1;
         final int end = codingDirection == Strand.FORWARD ? exon.getGenomicStartLocation() + length5Utr - 1 : exon.getGenomicEndLocation();
 
-        final GencodeGtfFeatureBaseData tmp5pUtr = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        final GencodeGtfFeatureBaseData tmp5pUtr = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 start, end, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -598,7 +598,7 @@ public class DataProviderForExampleGencodeGtfGene {
                                                               final AtomicInteger featureOrderNum, final String geneName,
                                                               final int exonNum, final int length5pUtr,
                                                               final Strand codingDirection) {
-        final GencodeGtfFeatureBaseData tmpExon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        final GencodeGtfFeatureBaseData tmpExon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 exonStart, exonStart + length5pUtr + lengthExons - 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exonNum, "TEST_EXON_" + exonNum, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -607,7 +607,7 @@ public class DataProviderForExampleGencodeGtfGene {
         final GencodeGtfExonFeature exon = (GencodeGtfExonFeature) GencodeGtfFeature.create(tmpExon);
 
         if (codingDirection == Strand.POSITIVE) {
-            final GencodeGtfFeatureBaseData tmpStartCodon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+            final GencodeGtfFeatureBaseData tmpStartCodon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                     exon.getGenomicStartLocation() + length5pUtr - 1, exon.getGenomicStartLocation() + length5pUtr + 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                     null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                     Collections.emptyList(),
@@ -615,7 +615,7 @@ public class DataProviderForExampleGencodeGtfGene {
             );
             final GencodeGtfStartCodonFeature startCodon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(tmpStartCodon);
 
-            final GencodeGtfFeatureBaseData tmpCdsMinusStart = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+            final GencodeGtfFeatureBaseData tmpCdsMinusStart = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                     startCodon1.getGenomicEndLocation() + 1, exon.getGenomicEndLocation(), codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                     null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                     Collections.emptyList(),
@@ -628,7 +628,7 @@ public class DataProviderForExampleGencodeGtfGene {
 
         // negative strand, then have CDS appear before start codon (note that UTR is handled elsewhere.
         if (codingDirection == Strand.NEGATIVE) {
-            final GencodeGtfFeatureBaseData tmpStartCodon2 = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+            final GencodeGtfFeatureBaseData tmpStartCodon2 = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                     exon.getGenomicEndLocation() - length5pUtr - 2, exon.getGenomicStartLocation() + length5pUtr, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                     null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", 1, "TEST_EXON1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                     Collections.emptyList(),
@@ -636,7 +636,7 @@ public class DataProviderForExampleGencodeGtfGene {
             );
             final GencodeGtfStartCodonFeature startCodon2 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(tmpStartCodon2);
 
-            final GencodeGtfFeatureBaseData tmpCdsMinusStart2 = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+            final GencodeGtfFeatureBaseData tmpCdsMinusStart2 = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                     exon.getGenomicStartLocation(), startCodon2.getGenomicStartLocation() - 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                     null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                     Collections.emptyList(),
@@ -655,7 +655,7 @@ public class DataProviderForExampleGencodeGtfGene {
                                                           final int exonNum, final Strand codingDirection) {
 
         // Create exon and a CDS that encompasses the entire exon.
-        final GencodeGtfFeatureBaseData tmpExon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        final GencodeGtfFeatureBaseData tmpExon = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 exonStart, exonStart + lengthExons - 1, codingDirection, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exonNum, "TEST_EXON_" + exonNum, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),
@@ -663,7 +663,7 @@ public class DataProviderForExampleGencodeGtfGene {
         );
         final GencodeGtfExonFeature exon = (GencodeGtfExonFeature) GencodeGtfFeature.create(tmpExon);
 
-        final GencodeGtfFeatureBaseData tmpCds = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        final GencodeGtfFeatureBaseData tmpCds = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum.getAndIncrement(), contig, GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 exon.getGenomicStartLocation(), exon.getGenomicEndLocation(), codingDirection, GencodeGtfFeature.GenomicPhase.DOT, exon.getGeneId(), "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, exon.getGeneName(), GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", exon.getExonNumber(), exon.getExonId(), GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactoryUnitTest.java
@@ -242,7 +242,7 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         return new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 
                 1,
                 interval.getContig(),
-                GencodeGtfFeature.AnnotationSource.ENSEMBL,
+                GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL,
                 GencodeGtfFeature.FeatureType.GENE,
                 interval.getStart(),
                 interval.getEnd(),
@@ -677,14 +677,14 @@ public class GencodeFuncotationFactoryUnitTest extends GATKBaseTest {
         // Create the GencodeGtfFeature:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 1, variantInterval.getContig(), GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 1, variantInterval.getContig(), GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 variantInterval.getStart()-2000, variantInterval.getEnd()+2000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", null, null, null, -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED, null, null);
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(data);
 
         // ======================
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 2, variantInterval.getContig(), GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 2, variantInterval.getContig(), GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 variantInterval.getStart()-1000, variantInterval.getEnd()+1000, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "TEST_GENE1", "TEST_TRANSCRIPT1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "TEST_GENE", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "TEST_TRANSCRIPT1", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 Collections.emptyList(),

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/AbstractGtfCodecUnitTest.java
@@ -28,10 +28,10 @@ public class AbstractGtfCodecUnitTest extends GATKBaseTest {
         final EnsemblGtfCodec ensemblGtfCodec = new EnsemblGtfCodec();
 
         return new Object[][] {
-                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getLineComment()), 0, "LINE_1", true},
-                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getLineComment()), 0, "LINE_2", false},
-                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getLineComment()), 0, "LINE_1", true},
-                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getLineComment()), 0, "LINE_2", false},
+                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getDefaultLineComment()), 0, "LINE_1", true},
+                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getDefaultLineComment()), 0, "LINE_2", false},
+                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getDefaultLineComment()), 0, "LINE_1", true},
+                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getDefaultLineComment()), 0, "LINE_2", false},
         };
     }
 
@@ -47,8 +47,8 @@ public class AbstractGtfCodecUnitTest extends GATKBaseTest {
         final EnsemblGtfCodec ensemblGtfCodec = new EnsemblGtfCodec();
 
         return new Object[][] {
-                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getLineComment()), 0, "LINE_2"},
-                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getLineComment()), 0, "LINE_2"},
+                {gencodeGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, gencodeGtfCodec.getDefaultLineComment()), 0, "LINE_2"},
+                {ensemblGtfCodec, prependCommentToArrayElements(new String[] {"LINE_1", "LINE_2", "LINE_3", "LINE_4", "LINE_5"}, ensemblGtfCodec.getDefaultLineComment()), 0, "LINE_2"},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodecUnitTest.java
@@ -37,7 +37,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
 
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.GENE,
                 geneStart, geneEnd, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, geneId, null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, null, null, null, -1, null, null,
                 null,
@@ -45,7 +45,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(data);
         gene.setUcscGenomeVersion(ECOLI_UCSC_GENOME_VERSION);
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 geneStart, geneEnd, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, geneId, transcriptId, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, transcriptName, -1, null, null,
                 null,
@@ -54,7 +54,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
         final GencodeGtfTranscriptFeature transcript = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
         transcript.setUcscGenomeVersion(ECOLI_UCSC_GENOME_VERSION);
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.EXON,
                 geneStart, geneEnd, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, geneId, transcriptId, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, transcriptName, 1, exonId, null,
                 null,
@@ -63,7 +63,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
         final GencodeGtfExonFeature exon = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
         exon.setUcscGenomeVersion(ECOLI_UCSC_GENOME_VERSION);
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.CDS,
                 cdsStart, cdsEnd, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, geneId, transcriptId, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, transcriptName, 1, null, null,
                 Collections.singletonList(new GencodeGtfFeature.OptionalField<>("protein_id", transcriptId)),
@@ -72,7 +72,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
         final GencodeGtfCDSFeature cds = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
         cds.setUcscGenomeVersion(ECOLI_UCSC_GENOME_VERSION);
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum++, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.START_CODON,
                 cdsStart, cdsStart+2, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, geneId, transcriptId, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, transcriptName, 1, null, null,
                 null,
@@ -81,7 +81,7 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
         final GencodeGtfStartCodonFeature startCodon = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
         startCodon.setUcscGenomeVersion(ECOLI_UCSC_GENOME_VERSION);
 
-        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum, ECOLI_CONTIG_NAME, GencodeGtfFeature.AnnotationSource.ena, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(EnsemblGtfCodec.GTF_FILE_TYPE_STRING, featureOrderNum, ECOLI_CONTIG_NAME, GencodeGtfFeature.ANNOTATION_SOURCE_ENA, GencodeGtfFeature.FeatureType.STOP_CODON,
                 cdsEnd+1, cdsEnd+3, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, geneId, transcriptId, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, geneName, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, transcriptName, 1, null, null,
                 null,
@@ -158,63 +158,13 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
     public Object[][] headerProvider() {
         return new Object[][] {
 
-                { new ArrayList<String>(), false },                             // Wrong length header
+                { new ArrayList<String>(), true },                        // No header is a valid Ensembl option.
                 { Arrays.asList( "",
                         "",
                         "",
                         "",
                         ""  ),
-                        false },                                // Bad content
-                { Arrays.asList( "##descr",
-                        "##provider: GENCODE",
-                        "##contact: gencode-help@sanger.ac.uk",
-                        "##format: gtf",
-                        "##date: 2017-04-08" ),
-                        false },                                // Bad header - description
-                { Arrays.asList( "##description: THIS IS A SAMPLE",
-                        "##provider: GARBAGEDAY",
-                        "##contact: gencode-help@sanger.ac.uk",
-                        "##format: gtf",
-                        "##date: 2017-04-08" ),
-                        false },                                // Bad header - provider
-                { Arrays.asList( "##description: THIS IS A SAMPLE",
-                        "##provider: GENCODE",
-                        "##contact: gencode@NORTHPOLE.pl",
-                        "##format: gtf",
-                        "##date: 2017-04-08" ),
-                        false },                                // Bad header - contact
-                { Arrays.asList( "##description: THIS IS A SAMPLE",
-                        "##provider: GENCODE",
-                        "##contact: SANTACLAUSE@sanger.ac.uk",
-                        "##format: gtf",
-                        "##date: 2017-04-08" ),
-                        false },                                // Bad header - contact
-                { Arrays.asList( "##description: THIS IS A SAMPLE",
-                        "##provider: GENCODE",
-                        "##contact: gencode-help@sanger.ac.uk",
-                        "##format: dumpy",
-                        "##date: 2017-04-08" ),
-                        false },                                // Bad header - format
-                { Arrays.asList( "##description: THIS IS A SAMPLE",
-                        "##provider: GENCODE",
-                        "##contact: gencode-help@sanger.ac.uk",
-                        "##format: gtf",
-                        "##doom: ID Software" ),
-                        false },                                // Bad header - date
-                { Arrays.asList( "##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)",
-                        "##provider: GENCODE",
-                        "##contact: gencode@sanger.ac.uk",
-                        "##format: gtf",
-                        "##date: 2014-07-25" ),
-                        false },                                // Good GENCODE Header, but BAD ENSEMBL header!
-                { Arrays.asList( "##description: evidence-based annotation of the human genome (GRCh38), version 26 (Ensembl 88)",
-                        "##provider: GENCODE",
-                        "##contact: gencode-help@sanger.ac.uk",
-                        "##format: gtf",
-                        "##date: 2014-07-25" ),
-                        false },                                 // Good GENCODE Header, but BAD ENSEMBL header!
-
-                // -------------
+                        false },                                          // Bad Ensembl header - no lines commented out.
 
                 { Arrays.asList( "#!genome-build ASM584v2",
                         "#!genome-version ASM584v2",
@@ -222,44 +172,31 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
                         "#!genome-build-accession GCA_000005845.2",
                         "#!genebuild-last-updated 2014-08" ),
                         true },                                           // Good Ensembl GTF Header!
+                { Arrays.asList( "##genome-build ASM584v2",
+                        "##genome-version ASM584v2",
+                        "##genome-date 2014-08",
+                        "##genome-build-accession GCA_000005845.2",
+                        "##genebuild-last-updated 2014-08" ),
+                        true },                                           // Good Ensembl Header - alternate comments
 
-                { Arrays.asList( "ASM584v2",
-                        "#!genome-version ASM584v2",
+                { Arrays.asList( "##genome-build ASM584v2",
+                        "##genome-version ASM584v2",
                         "#!genome-date 2014-08",
-                        "#!genome-build-accession GCA_000005845.2",
+                        "##genome-build-accession GCA_000005845.2",
                         "#!genebuild-last-updated 2014-08" ),
-                        false },                                           // Bad header - genome-build
-                { Arrays.asList( "#!genome-build ASM584v2",
-                        "ASM584v2",
-                        "#!genome-date 2014-08",
-                        "#!genome-build-accession GCA_000005845.2",
+                        true },                                           // Good Ensembl GTF Header - mixed comments
+                { Arrays.asList( "##genome-build ASM584v2",
+                        "##genome-version ASM584v2",
+                        "genome-date 2014-08",
+                        "##genome-build-accession GCA_000005845.2",
+                        "##genebuild-last-updated 2014-08" ),
+                        false },                                           // Bad Ensembl Header - not all lines commented.
+                { Arrays.asList( "##genome-build ASM584v2",
+                        "#!genome-version ASM584v2",
+                        "genome-date 2014-08",
+                        "##genome-build-accession GCA_000005845.2",
                         "#!genebuild-last-updated 2014-08" ),
-                        false },                                           // Bad header - genome-version
-                { Arrays.asList( "#!genome-build ASM584v2",
-                        "#!genome-version ASM584v2",
-                        "#2014-08",
-                        "#!genome-build-accession GCA_000005845.2",
-                        "#!genebuild-last-updated 2014-08" ),
-                        false },                                           // Bad header - genome-date
-                { Arrays.asList( "#!genome-build ASM584v2",
-                        "#!genome-version ASM584v2",
-                        "#!genome-date 2014-08",
-                        "#GCA_000005845.2",
-                        "#!genebuild-last-updated 2014-08" ),
-                        false },                                           // Bad header - genome-build-accession
-                { Arrays.asList( "#!genome-build ASM584v2",
-                        "#!genome-version ASM584v2",
-                        "#!genome-date 2014-08",
-                        "#!genome-build-accession GCA_000005845.2",
-                        "#2014-08" ),
-                        false },                                           // Bad header - genebuild-last-updated
-
-                { Arrays.asList( "#!genome-build ASM584v2",
-                        "#!genome-version ASM584v2",
-                        "#!genome-date 2014-08",
-                        "#!genome-build-accession GCA_000005845.2"),
-                        false },                                           // Bad Ensembl GTF Header - not enough lines!
-
+                        false },                                           // Bad Ensembl Header - not all lines commented.
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/EnsemblGtfCodecUnitTest.java
@@ -132,17 +132,17 @@ public class EnsemblGtfCodecUnitTest extends GATKBaseTest {
                 { "gencode.v26.primary_assembly.annotation.gtf", testResourceDir, false},    // File does not exist
                 { "gencode.v26.long_noncoding_RNAs.gtf"        , testResourceDir, false},    // File does not exist
 
-                { "gencode.invalid_short_header.gtf"           , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header.gtf"       , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header_desc.gtf"  , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header_prov.gtf"  , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header_cont.gtf"  , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header_form.gtf"  , testResourceDir, false},    // File exists, has invalid header
-                { "gencode.invalid_malformed_header_date.gtf"  , testResourceDir, false},    // File exists, has invalid header
+                { "gencode.invalid_short_header.gtf"           , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header.gtf"       , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header_desc.gtf"  , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header_prov.gtf"  , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header_cont.gtf"  , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header_form.gtf"  , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
+                { "gencode.invalid_malformed_header_date.gtf"  , testResourceDir, true},    // File exists, ENSEMBL doesn't care about headers
 
-                { "gencode.valid1.gtf"                           , testResourceDir, false},   // Not an Ensembl GTF file
-                { "gencode.valid_gencode_file2.gtf"              , testResourceDir, false},   // Not an Ensembl GTF file
-                { "gencode.and.this.is.a.valid.one.too.table.gtf", testResourceDir, false},   // Not an Ensembl GTF file
+                { "gencode.valid1.gtf"                           , testResourceDir, false},   // GENCODE GTF File - ENSEMBL will refuse to parse
+                { "gencode.valid_gencode_file2.gtf"              , testResourceDir, false},   // GENCODE GTF File - ENSEMBL will refuse to parse
+                { "gencode.and.this.is.a.valid.one.too.table.gtf", testResourceDir, false},   // GENCODE GTF File - ENSEMBL will refuse to parse
 
                 { "Escherichia_coli_str_k_12_substr_mg1655.ASM584v2.44.gtf", eColiTestDir, true},   // Name doesn't start with 'gencode'
         };

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/gtf/GencodeGtfCodecUnitTest.java
@@ -90,12 +90,12 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Create the Features as they exist in the test file:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 30366, 30503, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000284332.1", null, GencodeGtfFeature.GeneTranscriptType.MIRNA,
                 null, "MIR1302-2", null, null, null, -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED, null, null);
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 30366, 30503, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000284332.1", "ENST00000607096.1", GencodeGtfFeature.GeneTranscriptType.MIRNA,
                 null, "MIR1302-2", GencodeGtfFeature.GeneTranscriptType.MIRNA, null, "MIR1302-2-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -108,7 +108,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfTranscriptFeature transcript = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 30366, 30503, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000284332.1", "ENST00000607096.1", GencodeGtfFeature.GeneTranscriptType.MIRNA,
                 null, "MIR1302-2", GencodeGtfFeature.GeneTranscriptType.MIRNA, null, "MIR1302-2-201", 1, "ENSE00003695741.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -145,7 +145,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Let's define all our features up front:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.GENE,
                 50200979, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", null, null, null, -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -156,7 +156,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfGeneFeature gene1 = (GencodeGtfGeneFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50200979, 50217615, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -171,7 +171,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript1 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50200979, 50201590, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -186,7 +186,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon1 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50201037, 50201590, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -201,7 +201,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds1 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 50201037, 50201039, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -216,7 +216,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStartCodonFeature start_codon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50206317, 50206520, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -231,7 +231,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon2 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50206317, 50206520, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -246,7 +246,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds2 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50208536, 50208716, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -261,7 +261,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon3 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50208536, 50208716, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -276,7 +276,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds3 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50210181, 50210311, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -291,7 +291,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon4 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50210181, 50210311, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -306,7 +306,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds4 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50210631, 50210911, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -321,7 +321,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon5 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50210631, 50210911, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -336,7 +336,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds5 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50215717, 50215867, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -351,7 +351,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon6 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50215717, 50215867, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -366,7 +366,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds6 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50216691, 50216876, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -381,7 +381,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon7 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50216691, 50216876, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -396,7 +396,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds7 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50216972, 50217128, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -411,7 +411,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon8 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50216972, 50217128, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -426,7 +426,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds8 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50217205, 50217357, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 9, "ENSE00003728455.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -441,7 +441,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon9 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50217205, 50217357, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 9, "ENSE00003728455.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -456,7 +456,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds9 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 50217361, 50217615, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 10, "ENSE00003739808.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -471,7 +471,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon10 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 50217361, 50217366, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 10, "ENSE00003739808.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -486,7 +486,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds10 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 50217367, 50217369, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 10, "ENSE00003739808.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -501,7 +501,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStopCodonFeature stop_codon1 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 50200979, 50201036, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -516,7 +516,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr1 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr22", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 50217367, 50217615, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000611222.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-201", 10, "ENSE00003739808.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -531,7 +531,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr2 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50200979, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -550,7 +550,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript2 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.SELENOCYSTEINE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.SELENOCYSTEINE,
                 50217358, 50217360, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -569,7 +569,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfSelenocysteineFeature selenocysteine1 = (GencodeGtfSelenocysteineFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50200979, 50201590, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -588,7 +588,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon11 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50201037, 50201590, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -607,7 +607,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds11 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.START_CODON,
                 50201037, 50201039, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -626,7 +626,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStartCodonFeature start_codon2 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50206317, 50206520, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -645,7 +645,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon12 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50206317, 50206520, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -664,7 +664,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds12 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50208536, 50208716, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -683,7 +683,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon13 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50208536, 50208716, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -702,7 +702,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds13 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50210181, 50210311, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -721,7 +721,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon14 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50210181, 50210311, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -740,7 +740,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds14 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50210631, 50210911, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -759,7 +759,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon15 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 44, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 44, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50210631, 50210911, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -778,7 +778,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds15 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 45, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 45, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50215717, 50215867, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -797,7 +797,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon16 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 46, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 46, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50215717, 50215867, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -816,7 +816,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds16 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 47, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 47, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50216691, 50216876, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -835,7 +835,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon17 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 48, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 48, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50216691, 50216876, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -854,7 +854,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds17 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 49, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 49, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50216972, 50217128, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -873,7 +873,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon18 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 50, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 50, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50216972, 50217128, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -892,7 +892,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds18 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 51, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 51, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50217205, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -911,7 +911,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon19 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 52, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 52, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50217205, 50217366, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -930,7 +930,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds19 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 53, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 53, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.STOP_CODON,
                 50217367, 50217369, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -949,7 +949,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStopCodonFeature stop_codon2 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 54, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 54, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.UTR,
                 50200979, 50201036, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -968,7 +968,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr3 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 55, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 55, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.UTR,
                 50217367, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000380903.6", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "SELENOO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -987,7 +987,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr4 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 56, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 56, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50206442, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1000,7 +1000,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript3 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 57, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 57, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50206442, 50206520, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 1, "ENSE00001890724.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1013,7 +1013,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon20 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 58, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 58, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50208488, 50208716, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 2, "ENSE00001952603.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1026,7 +1026,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon21 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 59, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 59, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50210181, 50210311, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 3, "ENSE00003583919.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1039,7 +1039,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon22 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 60, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 60, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50210631, 50210911, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 4, "ENSE00003620115.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1052,7 +1052,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon23 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 61, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 61, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50215717, 50215867, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 5, "ENSE00003636069.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1065,7 +1065,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon24 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 62, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 62, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50216691, 50216876, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 6, "ENSE00003579717.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1078,7 +1078,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon25 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 63, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 63, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50216972, 50217128, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 7, "ENSE00003650938.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1091,7 +1091,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon26 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 64, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 64, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50217205, 50217616, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.13", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "SELENOO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, null, "SELENOO-002", 8, "ENSE00003475904.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1263,14 +1263,14 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Let's define all our features up front:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 138082, 161852, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", null, GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", null, null, null, -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(), null
         );
 
         final GencodeGtfGeneFeature gene1 = (GencodeGtfGeneFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 138082, 161750, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1283,7 +1283,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript1 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 161689, 161750, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 1, "ENSE00003735197.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1296,7 +1296,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon1 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 156289, 156497, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 2, "ENSE00003737280.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1309,7 +1309,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon2 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 156289, 156446, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 2, "ENSE00003737280.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1322,7 +1322,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds1 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 156444, 156446, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 2, "ENSE00003737280.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1335,7 +1335,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStartCodonFeature start_codon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 150987, 151021, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 3, "ENSE00003731891.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1348,7 +1348,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon3 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 150987, 151021, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 3, "ENSE00003731891.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1361,7 +1361,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds2 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 150350, 150499, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 4, "ENSE00003724613.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1374,7 +1374,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon4 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 150350, 150499, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 4, "ENSE00003724613.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1387,7 +1387,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds3 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 148414, 148478, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 5, "ENSE00003732418.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1400,7 +1400,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon5 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 148414, 148478, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 5, "ENSE00003732418.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1413,7 +1413,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds4 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 148116, 148232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 6, "ENSE00003733960.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1426,7 +1426,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon6 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 148116, 148232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 6, "ENSE00003733960.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1439,7 +1439,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds5 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 147624, 147703, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 7, "ENSE00003727207.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1452,7 +1452,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon7 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 147624, 147703, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 7, "ENSE00003727207.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1465,7 +1465,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds6 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 146640, 146721, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 8, "ENSE00003728972.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1478,7 +1478,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon8 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 146640, 146721, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 8, "ENSE00003728972.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1491,7 +1491,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds7 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 145004, 145096, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 9, "ENSE00003733844.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1504,7 +1504,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon9 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 145004, 145096, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 9, "ENSE00003733844.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1517,7 +1517,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds8 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 144749, 144895, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 10, "ENSE00003752738.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1530,7 +1530,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon10 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 144749, 144895, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 10, "ENSE00003752738.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1543,7 +1543,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds9 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 143614, 143789, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 11, "ENSE00003720006.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1556,7 +1556,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon11 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 143614, 143789, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 11, "ENSE00003720006.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1569,7 +1569,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds10 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 142194, 142292, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 12, "ENSE00003719283.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1582,7 +1582,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon12 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 142194, 142292, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 12, "ENSE00003719283.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1595,7 +1595,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds11 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 138743, 138831, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 13, "ENSE00003751415.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1608,7 +1608,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon13 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 138743, 138831, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 13, "ENSE00003751415.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1621,7 +1621,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds12 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 138082, 138667, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 14, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1634,7 +1634,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon14 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 138483, 138667, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 14, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1647,7 +1647,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds13 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 138480, 138482, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 14, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1660,7 +1660,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStopCodonFeature stop_codon1 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 161689, 161750, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 1, "ENSE00003735197.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1673,7 +1673,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr1 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 156447, 156497, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 2, "ENSE00003737280.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1686,7 +1686,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr2 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 138082, 138482, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000615165.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-202", 14, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1699,7 +1699,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr3 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 138082, 161852, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1712,7 +1712,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript2 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 161689, 161852, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 1, "ENSE00003746084.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1725,7 +1725,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon15 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 161314, 161626, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 2, "ENSE00003719550.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1738,7 +1738,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon16 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 161314, 161586, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 2, "ENSE00003719550.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1751,7 +1751,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds14 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 44, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 44, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 161584, 161586, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 2, "ENSE00003719550.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1764,7 +1764,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStartCodonFeature start_codon2 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 45, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 45, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 156289, 156497, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 3, "ENSE00003723757.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1777,7 +1777,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon17 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 46, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 46, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 156289, 156497, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 3, "ENSE00003723757.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1790,7 +1790,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds15 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 47, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 47, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 150987, 151021, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 4, "ENSE00003731891.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1803,7 +1803,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon18 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 48, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 48, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 150987, 151021, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 4, "ENSE00003731891.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1816,7 +1816,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds16 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 49, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 49, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 150350, 150499, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 5, "ENSE00003724613.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1829,7 +1829,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon19 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 50, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 50, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 150350, 150499, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 5, "ENSE00003724613.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1842,7 +1842,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds17 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 51, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 51, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 148414, 148478, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 6, "ENSE00003732418.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1855,7 +1855,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon20 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 52, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 52, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 148414, 148478, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 6, "ENSE00003732418.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1868,7 +1868,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds18 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 53, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 53, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 148116, 148232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 7, "ENSE00003733960.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1881,7 +1881,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon21 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 54, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 54, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 148116, 148232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 7, "ENSE00003733960.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1894,7 +1894,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds19 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 55, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 55, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 147624, 147703, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 8, "ENSE00003727207.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1907,7 +1907,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon22 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 56, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 56, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 147624, 147703, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 8, "ENSE00003727207.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1920,7 +1920,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds20 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 57, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 57, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 146640, 146721, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 9, "ENSE00003728972.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1933,7 +1933,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon23 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 58, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 58, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 146640, 146721, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 9, "ENSE00003728972.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1946,7 +1946,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds21 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 59, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 59, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 145004, 145096, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 10, "ENSE00003733844.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1959,7 +1959,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon24 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 60, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 60, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 145004, 145096, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 10, "ENSE00003733844.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1972,7 +1972,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds22 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 61, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 61, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 144749, 144895, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 11, "ENSE00003752738.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1985,7 +1985,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon25 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 62, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 62, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 144749, 144895, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 11, "ENSE00003752738.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -1998,7 +1998,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds23 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 63, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 63, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 143614, 143789, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 12, "ENSE00003720006.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2011,7 +2011,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon26 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 64, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 64, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 143614, 143789, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 12, "ENSE00003720006.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2024,7 +2024,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds24 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 65, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 65, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 142194, 142292, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 13, "ENSE00003719283.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2037,7 +2037,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon27 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 66, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 66, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 142194, 142292, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 13, "ENSE00003719283.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2050,7 +2050,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds25 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 67, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 67, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 138743, 138831, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 14, "ENSE00003751415.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2063,7 +2063,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon28 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 68, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 68, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 138743, 138831, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 14, "ENSE00003751415.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2076,7 +2076,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds26 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 69, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 69, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 138082, 138667, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 15, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2089,7 +2089,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon29 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 70, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 70, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 138483, 138667, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 15, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2102,7 +2102,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds27 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 71, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 71, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.STOP_CODON,
                 138480, 138482, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 15, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2115,7 +2115,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStopCodonFeature stop_codon2 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 72, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 72, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 161689, 161852, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 1, "ENSE00003746084.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2128,7 +2128,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr4 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 73, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 73, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 161587, 161626, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 2, "ENSE00003719550.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2141,7 +2141,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr5 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 74, "KI270734.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 74, "KI270734.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 138082, 138482, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000277196.4", "ENST00000621424.4", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 null, "AC007325.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, null, "AC007325.2-201", 15, "ENSE00003753010.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2324,7 +2324,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Create the Features as they exist in the test file:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.GENE,
                 11869, 14412, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000223972.4", "ENSG00000223972.4",
                 GencodeGtfFeature.GeneTranscriptType.PSEUDOGENE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1", GencodeGtfFeature.GeneTranscriptType.PSEUDOGENE,
                  GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
@@ -2337,7 +2337,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfGeneFeature gene = (GencodeGtfGeneFeature)GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 11869, 14409, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000223972.4", "ENST00000456328.2",
                 GencodeGtfFeature.GeneTranscriptType.PSEUDOGENE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1-002", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
@@ -2352,7 +2352,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfTranscriptFeature transcript = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr1", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 11869, 12227, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000223972.4", "ENST00000456328.2",
                 GencodeGtfFeature.GeneTranscriptType.PSEUDOGENE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "DDX11L1-002", 1, "ENSE00002234944.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
@@ -2387,7 +2387,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Create the Features as they exist in the test file:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.GENE,
                 50637519, 50638976, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000273253.1", "ENSG00000273253.1", GencodeGtfFeature.GeneTranscriptType.ANTISENSE,
                 GencodeGtfFeature.GeneTranscriptStatus.NOVEL, "RP3-402G11.26", GencodeGtfFeature.GeneTranscriptType.ANTISENSE, GencodeGtfFeature.GeneTranscriptStatus.NOVEL, "RP3-402G11.26", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2398,7 +2398,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfGeneFeature gene1 = (GencodeGtfGeneFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50637519, 50638976, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000273253.1", "ENST00000608025.1", GencodeGtfFeature.GeneTranscriptType.ANTISENSE,
                 GencodeGtfFeature.GeneTranscriptStatus.NOVEL, "RP3-402G11.26", GencodeGtfFeature.GeneTranscriptType.ANTISENSE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "RP3-402G11.26-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2411,7 +2411,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript1 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50638505, 50638976, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000273253.1", "ENST00000608025.1", GencodeGtfFeature.GeneTranscriptType.ANTISENSE,
                 GencodeGtfFeature.GeneTranscriptStatus.NOVEL, "RP3-402G11.26", GencodeGtfFeature.GeneTranscriptType.ANTISENSE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "RP3-402G11.26-001", 1, "ENSE00003710600.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2424,7 +2424,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon1 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50637519, 50637757, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000273253.1", "ENST00000608025.1", GencodeGtfFeature.GeneTranscriptType.ANTISENSE,
                 GencodeGtfFeature.GeneTranscriptStatus.NOVEL, "RP3-402G11.26", GencodeGtfFeature.GeneTranscriptType.ANTISENSE, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "RP3-402G11.26-001", 2, "ENSE00003710731.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2437,7 +2437,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon2 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.GENE,
                 50639408, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENSG00000073169.9", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2448,7 +2448,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfGeneFeature gene2 = (GencodeGtfGeneFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50639408, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2465,7 +2465,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript2 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.SELENOCYSTEINE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.SELENOCYSTEINE,
                 50655787, 50655789, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2482,7 +2482,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfSelenocysteineFeature selenocysteine1 = (GencodeGtfSelenocysteineFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50639408, 50640019, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2499,7 +2499,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon3 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50639466, 50640019, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2516,7 +2516,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds1 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.START_CODON,
                 50639466, 50639468, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 1, "ENSE00001541223.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2533,7 +2533,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStartCodonFeature start_codon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50644746, 50644949, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2550,7 +2550,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon4 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50644746, 50644949, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 2, "ENSE00001129529.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2567,7 +2567,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds2 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50646965, 50647145, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2584,7 +2584,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon5 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50646965, 50647145, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 3, "ENSE00001129524.2", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2601,7 +2601,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds3 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50648610, 50648740, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2618,7 +2618,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon6 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 21, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50648610, 50648740, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 4, "ENSE00003473644.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2635,7 +2635,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds4 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 22, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50649060, 50649340, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2652,7 +2652,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon7 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 23, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50649060, 50649340, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 5, "ENSE00003503715.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2669,7 +2669,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds5 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 24, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50654146, 50654296, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2686,7 +2686,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon8 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 25, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50654146, 50654296, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.TWO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 6, "ENSE00003573348.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2703,7 +2703,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds6 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 26, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655120, 50655305, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2720,7 +2720,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon9 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 27, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50655120, 50655305, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 7, "ENSE00003510005.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2737,7 +2737,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds7 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 28, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655401, 50655557, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2754,7 +2754,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon10 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 29, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50655401, 50655557, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 8, "ENSE00003591346.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2771,7 +2771,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds8 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 30, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655634, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2788,7 +2788,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon11 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 31, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.CDS,
                 50655634, 50655795, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2805,7 +2805,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfCDSFeature cds9 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.STOP_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 32, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.STOP_CODON,
                 50655796, 50655798, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", 9, "ENSE00003512975.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2822,7 +2822,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfStopCodonFeature stop_codon1 = (GencodeGtfStopCodonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 33, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.UTR,
                 50639408, 50639465, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2839,7 +2839,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr1 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 34, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.UTR,
                 50655796, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000380903.2", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-001", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2856,7 +2856,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfUTRFeature utr2 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 35, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 50644871, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", -1, null, GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2869,7 +2869,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfTranscriptFeature transcript3 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 36, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50644871, 50644949, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 1, "ENSE00001890724.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2882,7 +2882,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon12 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 37, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50646917, 50647145, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 2, "ENSE00001952603.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2895,7 +2895,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon13 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 38, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50648610, 50648740, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 3, "ENSE00003583919.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2908,7 +2908,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon14 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 39, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50649060, 50649340, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 4, "ENSE00003620115.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2921,7 +2921,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon15 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 40, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50654146, 50654296, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 5, "ENSE00003636069.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2934,7 +2934,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon16 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 41, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655120, 50655305, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 6, "ENSE00003579717.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2947,7 +2947,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon17 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 42, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655401, 50655557, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 7, "ENSE00003650938.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -2960,7 +2960,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
                 null
         );
         final GencodeGtfExonFeature exon18 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "chr22", GencodeGtfFeature.AnnotationSource.HAVANA, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 43, "chr22", GencodeGtfFeature.ANNOTATION_SOURCE_HAVANA, GencodeGtfFeature.FeatureType.EXON,
                 50655634, 50656045, Strand.POSITIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000073169.9", "ENST00000492092.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO", GencodeGtfFeature.GeneTranscriptType.PROCESSED_TRANSCRIPT, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "SELO-002", 8, "ENSE00003475904.1", GencodeGtfFeature.LocusLevel.MANUALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3080,7 +3080,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         // Create the Features as they exist in the test file:
         GencodeGtfFeatureBaseData data;
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 6, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.GENE,
                 38792, 97421, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENSG00000215615.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(), null
@@ -3088,7 +3088,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
 
         final GencodeGtfGeneFeature gene1 = (GencodeGtfGeneFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 7, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.TRANSCRIPT,
                 38792, 97421, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3100,7 +3100,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfTranscriptFeature transcript1 = (GencodeGtfTranscriptFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 8, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 97368, 97421, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 1, "ENSE00001544212.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3112,7 +3112,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfExonFeature exon1 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 9, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 95174, 95232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 2, "ENSE00001849396.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3124,7 +3124,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfExonFeature exon2 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 10, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 95174, 95230, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 2, "ENSE00001849396.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3136,7 +3136,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfCDSFeature cds1 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 11, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.START_CODON,
                 95228, 95230, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 2, "ENSE00001849396.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3148,7 +3148,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfStartCodonFeature start_codon1 = (GencodeGtfStartCodonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 12, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 40642, 40872, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 3, "ENSE00001900862.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3160,7 +3160,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfExonFeature exon3 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 13, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 40642, 40872, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 3, "ENSE00001900862.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3172,7 +3172,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfCDSFeature cds2 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 14, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 39874, 40028, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 4, "ENSE00001544206.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3184,7 +3184,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfExonFeature exon4 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 15, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 39874, 40028, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ZERO, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 4, "ENSE00001544206.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3196,7 +3196,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfCDSFeature cds3 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 16, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.EXON,
                 38792, 39019, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 5, "ENSE00001544203.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3208,7 +3208,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfExonFeature exon5 = (GencodeGtfExonFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 17, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.CDS,
                 38794, 39019, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.ONE, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", 5, "ENSE00001544203.1", GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3220,7 +3220,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfCDSFeature cds4 = (GencodeGtfCDSFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 18, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 97368, 97421, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3232,7 +3232,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfUTRFeature utr1 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 19, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 95231, 95232, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(
@@ -3244,7 +3244,7 @@ public class GencodeGtfCodecUnitTest extends GATKBaseTest {
         );
         final GencodeGtfUTRFeature utr2 = (GencodeGtfUTRFeature) GencodeGtfFeature.create(data);
 
-        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "GL000218.1", GencodeGtfFeature.AnnotationSource.ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
+        data = new GencodeGtfFeatureBaseData(GencodeGtfCodec.GTF_FILE_TYPE_STRING, 20, "GL000218.1", GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL, GencodeGtfFeature.FeatureType.UTR,
                 38792, 38793, Strand.NEGATIVE, GencodeGtfFeature.GenomicPhase.DOT, "ENSG00000215615.1", "ENST00000400681.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING,
                 GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1", GencodeGtfFeature.GeneTranscriptType.PROTEIN_CODING, GencodeGtfFeature.GeneTranscriptStatus.KNOWN, "AL354822.1-201", -1, null, GencodeGtfFeature.LocusLevel.AUTOMATICALLY_ANNOTATED,
                 new ArrayList<>(

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -285,7 +285,7 @@ public class FuncotatorTestUtils {
                         GencodeGtfCodec.GTF_FILE_TYPE_STRING,
                         2,
                         contig,
-                        GencodeGtfFeature.AnnotationSource.ENSEMBL,
+                        GencodeGtfFeature.ANNOTATION_SOURCE_ENSEMBL,
                         GencodeGtfFeature.FeatureType.TRANSCRIPT,
                         start,
                         stop,

--- a/src/test/resources/large/funcotator/e_coli.MG1655.expected_output.vcf
+++ b/src/test/resources/large/funcotator/e_coli.MG1655.expected_output.vcf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd943acba507f60e8b2c9948f835c420cd8595d218ebf4d34e6bf53d019587d7
-size 4007
+oid sha256:c347c6f014894029681958b95e4ae20c26c6fdc1600a73762dca31a4d52c1237
+size 3992

--- a/src/test/resources/large/funcotator/ecoli_ds/gencode/ASM584v2/gencode.config
+++ b/src/test/resources/large/funcotator/ecoli_ds/gencode/ASM584v2/gencode.config
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f5cabb0e1106c2cd8d79f8a64b7ca7ccf58c04da796032cdef3cdaba71517ec
-size 2128
+oid sha256:a2d2af382768e3e59b4a3bee44c17fbcb4d47eaa5cde0f9e3380fd756493b2bb
+size 2149


### PR DESCRIPTION
This will allow the ENSEMBL GTF codec to decode any ENSEMBL GTF file that they host.

Fixes #6488 