### PR TITLE
Fixed an off-by-one segmentation argument in ModelSegments.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/ModelSegments.java
@@ -611,9 +611,8 @@ public final class ModelSegments extends CommandLineProgram {
 
     private CopyRatioSegmentCollection performCopyRatioSegmentation(final CopyRatioCollection denoisedCopyRatios) {
         logger.info("Starting segmentation of denoised copy ratios...");
-        final int maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1;
         return new CopyRatioKernelSegmenter(denoisedCopyRatios)
-                .findSegmentation(maxNumChangepointsPerChromosome, kernelVarianceCopyRatio, kernelApproximationDimension,
+                .findSegmentation(maxNumSegmentsPerChromosome, kernelVarianceCopyRatio, kernelApproximationDimension,
                         ImmutableSet.copyOf(windowSizes).asList(),
                         numChangepointsPenaltyFactor, numChangepointsPenaltyFactor);
     }
@@ -745,9 +744,8 @@ public final class ModelSegments extends CommandLineProgram {
 
     private AlleleFractionSegmentCollection performAlleleFractionSegmentation(final AllelicCountCollection hetAllelicCounts) {
         logger.info("Starting segmentation of heterozygous allelic counts...");
-        final int maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1;
         return new AlleleFractionKernelSegmenter(hetAllelicCounts)
-                .findSegmentation(maxNumChangepointsPerChromosome, kernelVarianceAlleleFraction, kernelApproximationDimension,
+                .findSegmentation(maxNumSegmentsPerChromosome, kernelVarianceAlleleFraction, kernelApproximationDimension,
                         ImmutableSet.copyOf(windowSizes).asList(),
                         numChangepointsPenaltyFactor, numChangepointsPenaltyFactor);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/AlleleFractionKernelSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/AlleleFractionKernelSegmenter.java
@@ -50,13 +50,13 @@ public final class AlleleFractionKernelSegmenter {
      * Segments the internally held {@link AllelicCountCollection} using a separate {@link KernelSegmenter} for each chromosome.
      * @param kernelVariance    variance of the Gaussian kernel; if zero, a linear kernel is used instead
      */
-    public AlleleFractionSegmentCollection findSegmentation(final int maxNumChangepointsPerChromosome,
+    public AlleleFractionSegmentCollection findSegmentation(final int maxNumSegmentsPerChromosome,
                                                             final double kernelVariance,
                                                             final int kernelApproximationDimension,
                                                             final List<Integer> windowSizes,
                                                             final double numChangepointsPenaltyLinearFactor,
                                                             final double numChangepointsPenaltyLogLinearFactor) {
-        ParamUtils.isPositiveOrZero(maxNumChangepointsPerChromosome, "Maximum number of changepoints must be non-negative.");
+        ParamUtils.isPositive(maxNumSegmentsPerChromosome, "Maximum number of segments must be positive.");
         ParamUtils.isPositiveOrZero(kernelVariance, "Variance of Gaussian kernel must be non-negative (if zero, a linear kernel will be used).");
         ParamUtils.isPositive(kernelApproximationDimension, "Dimension of kernel approximation must be positive.");
         Utils.validateArg(windowSizes.stream().allMatch(ws -> ws > 0), "Window sizes must all be positive.");
@@ -65,6 +65,8 @@ public final class AlleleFractionKernelSegmenter {
                 "Linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
         ParamUtils.isPositiveOrZero(numChangepointsPenaltyLogLinearFactor,
                 "Log-linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
+
+        final int maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1;
 
         logger.info(String.format("Finding changepoints in %d data points and %d chromosomes...",
                 allelicCounts.size(), allelicCountsPerChromosome.size()));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/CopyRatioKernelSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/CopyRatioKernelSegmenter.java
@@ -53,13 +53,13 @@ public final class CopyRatioKernelSegmenter {
      * Segments the internally held {@link CopyRatioCollection} using a separate {@link KernelSegmenter} for each chromosome.
      * @param kernelVariance    variance of the Gaussian kernel; if zero, a linear kernel is used instead
      */
-    public CopyRatioSegmentCollection findSegmentation(final int maxNumChangepointsPerChromosome,
+    public CopyRatioSegmentCollection findSegmentation(final int maxNumSegmentsPerChromosome,
                                                        final double kernelVariance,
                                                        final int kernelApproximationDimension,
                                                        final List<Integer> windowSizes,
                                                        final double numChangepointsPenaltyLinearFactor,
                                                        final double numChangepointsPenaltyLogLinearFactor) {
-        ParamUtils.isPositiveOrZero(maxNumChangepointsPerChromosome, "Maximum number of changepoints must be non-negative.");
+        ParamUtils.isPositive(maxNumSegmentsPerChromosome, "Maximum number of segments must be positive.");
         ParamUtils.isPositiveOrZero(kernelVariance, "Variance of Gaussian kernel must be non-negative (if zero, a linear kernel will be used).");
         ParamUtils.isPositive(kernelApproximationDimension, "Dimension of kernel approximation must be positive.");
         Utils.validateArg(windowSizes.stream().allMatch(ws -> ws > 0), "Window sizes must all be positive.");
@@ -68,6 +68,8 @@ public final class CopyRatioKernelSegmenter {
                 "Linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
         ParamUtils.isPositiveOrZero(numChangepointsPenaltyLogLinearFactor,
                 "Log-linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
+
+        final int maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1;
 
         logger.info(String.format("Finding changepoints in %d data points and %d chromosomes...",
                 denoisedCopyRatios.size(), denoisedCopyRatiosPerChromosome.size()));

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/MultidimensionalKernelSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/segmentation/MultidimensionalKernelSegmenter.java
@@ -119,7 +119,7 @@ public final class MultidimensionalKernelSegmenter {
      *                                      to the kernel K_CR for copy-ratio data;
      *                                      the total kernel is K_CR + S * K_AF
      */
-    public MultidimensionalSegmentCollection findSegmentation(final int maxNumChangepointsPerChromosome,
+    public MultidimensionalSegmentCollection findSegmentation(final int maxNumSegmentsPerChromosome,
                                                               final double kernelVarianceCopyRatio,
                                                               final double kernelVarianceAlleleFraction,
                                                               final double kernelScalingAlleleFraction,
@@ -127,7 +127,7 @@ public final class MultidimensionalKernelSegmenter {
                                                               final List<Integer> windowSizes,
                                                               final double numChangepointsPenaltyLinearFactor,
                                                               final double numChangepointsPenaltyLogLinearFactor) {
-        ParamUtils.isPositiveOrZero(maxNumChangepointsPerChromosome, "Maximum number of changepoints must be non-negative.");
+        ParamUtils.isPositive(maxNumSegmentsPerChromosome, "Maximum number of segments must be positive.");
         ParamUtils.isPositiveOrZero(kernelVarianceCopyRatio, "Variance of copy-ratio Gaussian kernel must be non-negative (if zero, a linear kernel will be used).");
         ParamUtils.isPositiveOrZero(kernelVarianceAlleleFraction, "Variance of allele-fraction Gaussian kernel must be non-negative (if zero, a linear kernel will be used).");
         ParamUtils.isPositiveOrZero(kernelScalingAlleleFraction, "Scaling of allele-fraction Gaussian kernel must be non-negative.");
@@ -138,6 +138,8 @@ public final class MultidimensionalKernelSegmenter {
                 "Linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
         ParamUtils.isPositiveOrZero(numChangepointsPenaltyLogLinearFactor,
                 "Log-linear factor for the penalty on the number of changepoints per chromosome must be non-negative.");
+
+        final int maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1;
 
         final BiFunction<MultidimensionalPoint, MultidimensionalPoint, Double> kernel = constructKernel(
                 kernelVarianceCopyRatio, kernelVarianceAlleleFraction, kernelScalingAlleleFraction);


### PR DESCRIPTION
Noticed this minor typo while doing some refactoring for a new feature branch.  The issue is that the MultidimensionalKernelSegmenter incorrectly uses `maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome`, when it should be using `maxNumChangepointsPerChromosome = maxNumSegmentsPerChromosome - 1` like the CopyRatioKernelSegmenter and AlleleFractionKernelSegmenter do. @fleharty mind reviewing?