### PR TITLE
Example code to mark fields that do not have a combination operation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
 import com.googlecode.protobuf.format.JsonFormat;
+import htsjdk.variant.vcf.VCFConstants;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.AnnotationUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -36,9 +37,31 @@ public class GenomicsDBUtils {
     private static final String HISTOGRAM_SUM = "histogram_sum";
     private static final String MOVE_TO_FORMAT = "move_to_FORMAT";
 
+    private static final String NO_COMBINE_OP = "none";
+    private static final String[] NO_COMBINE_FIELDS = {
+            GATKVCFConstants.ALLELE_FRACTION_KEY,           // AF
+            GATKVCFConstants.AS_BASE_QUAL_RANK_SUM_KEY,     // AS_BaseQRankSum
+            GATKVCFConstants.AS_INBREEDING_COEFFICIENT_KEY, // AS_InbreedingCoeff
+            GATKVCFConstants.AS_FISHER_STRAND_KEY,          // AS_FS
+            GATKVCFConstants.AS_RMS_MAPPING_QUALITY_KEY,    // AS_MQ
+            GATKVCFConstants.AS_MAP_QUAL_RANK_SUM_KEY,      // AS_MQRankSum
+            GATKVCFConstants.AS_QUAL_BY_DEPTH_KEY,          // AS_QD
+            GATKVCFConstants.AS_READ_POS_RANK_SUM_KEY,      // AS_ReadPosRankSum
+            GATKVCFConstants.AS_STRAND_ODDS_RATIO_KEY,      // AS_SOR
+            GATKVCFConstants.DOWNSAMPLED_KEY,               // DS
+            GATKVCFConstants.FISHER_STRAND_KEY,             // FS
+            GATKVCFConstants.STRAND_ODDS_RATIO_KEY,         // SOR
+            GATKVCFConstants.HAPLOTYPE_SCORE_KEY,           // HaplotypeScore
+            GATKVCFConstants.INBREEDING_COEFFICIENT_KEY,    // InbreedingCoeff
+            GATKVCFConstants.MLE_ALLELE_COUNT_KEY,          // MLEAC
+            GATKVCFConstants.MLE_ALLELE_FREQUENCY_KEY,      // MLEAF
+            GATKVCFConstants.QUAL_BY_DEPTH_KEY,             // QD
+            VCFConstants.ALLELE_COUNT_KEY,                  // AC
+            VCFConstants.ALLELE_NUMBER_KEY                  // AN
+    };
+
     private static final String GDB_TYPE_FLOAT = "float";
     private static final String GDB_TYPE_INT = "int";
-
 
     /**
      * Info and Allele-specific fields that need to be treated differently
@@ -66,6 +89,11 @@ public class GenomicsDBUtils {
 
         vidMapPB = updateAlleleSpecificINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList,
                 GATKVCFConstants.AS_RAW_RMS_MAPPING_QUALITY_KEY, ELEMENT_WISE_FLOAT_SUM);
+
+        for (String field : NO_COMBINE_FIELDS) {
+            vidMapPB = updateINFOFieldCombineOperation(vidMapPB, fieldNameToIndexInVidFieldsList, field, NO_COMBINE_OP);
+            assert(vidMapPB != null);
+        }
 
         //Update combine operations for GnarlyGenotyper
         //Note that this MQ format is deprecated, but was used by the prototype version of ReblockGVCF


### PR DESCRIPTION
#2689 - Example code to mark fields that do not have a combination operation to avoid warnings such as 'No valid combination operation found for INFO field AN - the field will NOT be part of INFO fields in the generated VCF record'

We also have [GenomicsDB PR#85](https://github.com/GenomicsDB/GenomicsDB/pull/85) in the works that will log these types of messages only once per field.