### PR TITLE
Fix ReadsSparkSource CRAM code paths.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -171,12 +171,11 @@ public final class ReadsSparkSource implements Serializable {
 
         // GCS case
         if (BucketUtils.isGcsUrl(filePath)) {
-            final SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(validationStringency);
-            try (ReadsDataSource readsDataSource = new ReadsDataSource(
-                    Collections.singletonList(IOUtils.getPath(filePath)),
-                    cramReferencePathSpec == null ?
-                            factory :
-                            factory.referenceSequence(referencePathSpecifier.toPath()))) {
+            final SamReaderFactory factory = SamReaderFactory.makeDefault()
+                    .validationStringency(validationStringency)
+                    .referenceSequence(cramReferencePathSpec == null ? null : referencePathSpecifier.toPath());
+            try (final ReadsDataSource readsDataSource =
+                         new ReadsDataSource(Collections.singletonList(IOUtils.getPath(filePath)), factory)) {
                  return readsDataSource.getHeader();
             }
         }


### PR DESCRIPTION
This fixes two issues discovered while testing my URI migration branch:

- ReadsSourceSpark.getHeader doesn't propagate the reference at all when a CRAM file input resides on GCS, so it always results in a "no reference was provided" error, even when a reference was provided.
- ReadsSourceSpark.checkCramReference always tried to create a Hadoop Path object for the reference no matter what file system it lives on, which fails when using a reference on GCS.
