### PR TITLE
Make adaptive pruner smarter in complex graphs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
@@ -18,9 +18,9 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.utils.HopscotchMap;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Tail;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
-import org.broadinstitute.hellbender.utils.read.ClippingTail;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 
@@ -1623,8 +1623,8 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
             final List<CigarElement> elements = cigar.getCigarElements();
             final int nElements = elements.size();
             if ( nElements < 2 ) return cigar;
-            final int initialClipLength = CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL);
-            final int finalClipLength = CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+            final int initialClipLength = CigarUtils.countClippedBases(cigar, Tail.LEFT);
+            final int finalClipLength = CigarUtils.countClippedBases(cigar, Tail.RIGHT);
             if ( initialClipLength >= minAltLength || finalClipLength >= minAltLength ) {
                 final String saTag = read.getAttributeAsString("SA");
                 if ( saTag == null ) return cigar;
@@ -1653,8 +1653,8 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
                     final List<CigarElement> altElements = altCigar.getCigarElements();
                     final int nAltElements = altElements.size();
                     if ( nAltElements < 2 ) continue;
-                    final int initialAltClipLength = CigarUtils.countClippedBases(altCigar, ClippingTail.LEFT_TAIL);
-                    final int finalAltClipLength = CigarUtils.countClippedBases(altCigar, ClippingTail.RIGHT_TAIL);
+                    final int initialAltClipLength = CigarUtils.countClippedBases(altCigar, Tail.LEFT);
+                    final int finalAltClipLength = CigarUtils.countClippedBases(altCigar, Tail.RIGHT);
                     final Interval altReadInterval =
                             new Interval(initialAltClipLength, readLength - finalAltClipLength);
                     final int overlapLength = primaryReadInterval.overlapLength(altReadInterval);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/AlignmentInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/AlignmentInterval.java
@@ -10,11 +10,11 @@ import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVInterval;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.Strand;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Tail;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
-import org.broadinstitute.hellbender.utils.read.ClippingTail;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import scala.Tuple2;
@@ -152,9 +152,9 @@ public final class AlignmentInterval {
 
         this.referenceSpan = new SimpleInterval(referenceContig, start,
                 Math.max(start, cigar.getReferenceLength() + start - 1));
-        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL);
+        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, Tail.LEFT);
         this.endInAssembledContig =
-                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, Tail.RIGHT);
         this.cigarAlong5to3DirectionOfContig = cigar;
         this.mapQual = mappingQuality;
         this.mismatches = mismatches;
@@ -239,9 +239,9 @@ public final class AlignmentInterval {
         final boolean isMappedReverse = samRecord.getReadNegativeStrandFlag();
         this.referenceSpan = new SimpleInterval(samRecord);
         final Cigar cigar = isMappedReverse ? CigarUtils.invertCigar(samRecord.getCigar()) : samRecord.getCigar();
-        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL);
+        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, Tail.LEFT);
         this.endInAssembledContig =
-                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, Tail.RIGHT);
         this.cigarAlong5to3DirectionOfContig = cigar;
         this.forwardStrand = !isMappedReverse;
         this.mapQual = samRecord.getMappingQuality();
@@ -265,9 +265,9 @@ public final class AlignmentInterval {
         this.referenceSpan = new SimpleInterval(read);
         final Cigar cigar = isMappedReverse ? CigarUtils.invertCigar(read.getCigar()) : read.getCigar();
         this.cigarAlong5to3DirectionOfContig = cigar;
-        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL);
+        this.startInAssembledContig = 1 + CigarUtils.countClippedBases(cigar, Tail.LEFT);
         this.endInAssembledContig =
-                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+                CigarUtils.countUnclippedReadBases(cigar) - CigarUtils.countClippedBases(cigar, Tail.RIGHT);
         this.forwardStrand = !isMappedReverse;
         this.mapQual = read.getMappingQuality();
         this.mismatches = ReadUtils.getOptionalIntAttribute(read, SAMTag.NM.name()).orElse(NO_NM);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/ContigAlignmentsModifier.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/alignment/ContigAlignmentsModifier.java
@@ -7,10 +7,10 @@ import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Tail;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.CigarBuilder;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
-import org.broadinstitute.hellbender.utils.read.ClippingTail;
 import scala.Tuple2;
 import scala.Tuple3;
 
@@ -64,10 +64,10 @@ public final class ContigAlignmentsModifier {
             newTigStart = originalContigStart;
             newTigEnd   = Math.min(originalContigEnd - clipLengthOnRead,
                                    CigarUtils.countUnclippedReadBases(newCigarAlong5to3DirectionOfContig) -
-                                           CigarUtils.countClippedBases(newCigarAlong5to3DirectionOfContig, ClippingTail.RIGHT_TAIL));
+                                           CigarUtils.countClippedBases(newCigarAlong5to3DirectionOfContig, Tail.RIGHT));
         } else {
             newTigStart = Math.max(originalContigStart + clipLengthOnRead,
-                                   CigarUtils.countClippedBases(newCigarAlong5to3DirectionOfContig, ClippingTail.LEFT_TAIL) + 1);
+                                   CigarUtils.countClippedBases(newCigarAlong5to3DirectionOfContig, Tail.LEFT) + 1);
             newTigEnd   = originalContigEnd;
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityRankSumTest.java
@@ -4,7 +4,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
-import org.broadinstitute.hellbender.utils.read.ClippingTail;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -37,7 +37,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
-                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
+                useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(!doNotRecoverDanglingBranches);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -23,7 +23,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
     public ReadThreadingAssembler makeReadThreadingAssembler() {
         final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
-                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
+                !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);
         assemblyEngine.setRecoverDanglingBranches(true);
         assemblyEngine.setRecoverAllDanglingBranches(recoverAllDanglingBranches);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -18,6 +18,7 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     private static final long serialVersionUID = 1L;
 
     public static final double DEFAULT_PRUNING_LOG_ODDS_THRESHOLD = MathUtils.log10ToLog(1.0);
+    public static final double DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD = MathUtils.log10ToLog(2.0);
 
     public static final String ERROR_CORRECT_READS_LONG_NAME = "error-correct-reads";
     public static final String PILEUP_ERROR_CORRECTION_LOG_ODDS_NAME = "error-correction-log-odds";
@@ -117,6 +118,13 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     @Advanced
     @Argument(fullName="pruning-lod-threshold", doc = "Ln likelihood ratio threshold for adaptive pruning algorithm", optional = true)
     public double pruningLogOddsThreshold = DEFAULT_PRUNING_LOG_ODDS_THRESHOLD;
+
+    /**
+     * Log-10 likelihood ratio threshold for adaptive pruning algorithm.
+     */
+    @Advanced
+    @Argument(fullName="pruning-seeding-lod-threshold", doc = "Ln likelihood ratio threshold for seeding subgraph of good variation in adaptive pruning algorithm", optional = true)
+    public double pruningSeedingLogOddsThreshold = DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD;
 
     /**
      * The maximum number of variants in graph the adaptive pruner will allow

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReadThreadingAssemblerArgumentCollection.java
@@ -18,7 +18,7 @@ public abstract class ReadThreadingAssemblerArgumentCollection implements Serial
     private static final long serialVersionUID = 1L;
 
     public static final double DEFAULT_PRUNING_LOG_ODDS_THRESHOLD = MathUtils.log10ToLog(1.0);
-    public static final double DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD = MathUtils.log10ToLog(2.0);
+    public static final double DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD = MathUtils.log10ToLog(4.0);
 
     public static final String ERROR_CORRECT_READS_LONG_NAME = "error-correct-reads";
     public static final String PILEUP_ERROR_CORRECTION_LOG_ODDS_NAME = "error-correction-log-odds";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
@@ -1,23 +1,27 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
-import org.apache.commons.math3.util.FastMath;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2Engine;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.util.*;
-import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
 public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> extends ChainPruner<V,E> {
     private final double initialErrorProbability;
     private final double logOddsThreshold;
+    private final double seedingLogOddsThreshold;   // threshold for seeding subgraph of good vertices
     private final int maxUnprunedVariants;
 
-    public AdaptiveChainPruner(final double initialErrorProbability, final double logOddsThreshold, final int maxUnprunedVariants) {
+    public AdaptiveChainPruner(final double initialErrorProbability, final double logOddsThreshold, final double seedingLogOddsThreshold, final int maxUnprunedVariants) {
         ParamUtils.isPositive(initialErrorProbability, "Must have positive error probability");
         this.initialErrorProbability = initialErrorProbability;
         this.logOddsThreshold = logOddsThreshold;
+        this.seedingLogOddsThreshold = seedingLogOddsThreshold;
         this.maxUnprunedVariants = maxUnprunedVariants;
     }
 
@@ -29,41 +33,105 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
 
         final BaseGraph<V,E> graph = chains.get(0).getGraph();
 
+
+
         Collection<Path<V,E>> probableErrorChains = likelyErrorChains(chains, graph, initialErrorProbability);
         final int errorCount = probableErrorChains.stream().mapToInt(c -> c.getLastEdge().getMultiplicity()).sum();
         final int totalBases = chains.stream().mapToInt(c -> c.getEdges().stream().mapToInt(E::getMultiplicity).sum()).sum();
         final double errorRate = (double) errorCount / totalBases;
 
-        return likelyErrorChains(chains, graph, errorRate);
+        return likelyErrorChains(chains, graph, errorRate).stream().filter(c -> !c.getEdges().stream().anyMatch(BaseEdge::isRef)).collect(Collectors.toList());
     }
 
     private Collection<Path<V,E>> likelyErrorChains(final List<Path<V, E>> chains, final BaseGraph<V,E> graph, final double errorRate) {
-        final Map<Path<V,E>, Double> chainLogOdds = chains.stream()
+        /////// NEW
+
+        // pre-compute the left and right log odds of each chain
+        final Map<Path<V,E>, Pair<Double, Double>> chainLogOdds = chains.stream()
                 .collect(Collectors.toMap(c -> c, c-> chainLogOdds(c, graph, errorRate)));
 
-        final Set<Path<V,E>> result = new HashSet<>(chains.size());
+        // compute correspondence of vertices to incident chains with log odds above the seeding and extending thresholds
+        final Multimap<V, Path<V,E>> vertexToSeedableChains = ArrayListMultimap.create();
+        final Multimap<V, Path<V,E>> vertexToGoodIncomingChains = ArrayListMultimap.create();
+        final Multimap<V, Path<V,E>> vertexToGoodOutgoingChains = ArrayListMultimap.create();
 
-        chainLogOdds.forEach((chain, lod) -> {
-            if (lod < logOddsThreshold) {
-                result.add(chain);
+        for (final Path<V,E> chain : chains) {
+            if (chainLogOdds.get(chain).getRight() >= logOddsThreshold) {
+                vertexToGoodIncomingChains.put(chain.getLastVertex(), chain);
             }
-        });
 
-        chains.stream().filter(c -> isChainPossibleVariant(c, graph))
-                .sorted(Comparator.comparingDouble((ToDoubleFunction<Path<V, E>>) chainLogOdds::get)
-                        .reversed().thenComparingInt(Path::length))
+            if (chainLogOdds.get(chain).getLeft() >= logOddsThreshold) {
+                vertexToGoodOutgoingChains.put(chain.getFirstVertex(), chain);
+            }
+
+            // seed-worthy chains must pass the more stringent seeding log odds threshold on both sides
+            // in addition to that, we only seed from vertices with multiple such chains incoming or outgoing (see below)
+            if (chainLogOdds.get(chain).getRight() >= seedingLogOddsThreshold && chainLogOdds.get(chain).getLeft() >= seedingLogOddsThreshold) {
+                vertexToSeedableChains.put(chain.getFirstVertex(), chain);
+                vertexToSeedableChains.put(chain.getLastVertex(), chain);
+            }
+        }
+
+        // find a subset of good vertices from which to grow the subgraph of good chains.
+        final Queue<V> verticesToProcess = new ArrayDeque<>();
+        final Path<V,E> maxWeightChain = getMaxWeightChain(chains);
+        verticesToProcess.add(maxWeightChain.getFirstVertex());
+        verticesToProcess.add(maxWeightChain.getLastVertex());
+
+        // look for vertices with two incoming or two outgoing chains (plus one outgoing or incoming for a total of 3 or more) with good log odds to seed the subgraph of good vertices
+        // the logic here is that a high-multiplicity error chain A that branches into a second error chain B and a continuation-of-the-original-error chain A'
+        // may have a high log odds for A'.  However, only in the case of true variation will  multiple branches leaving the same vertex have good log odds.
+        vertexToSeedableChains.keySet().stream()
+                .filter(v -> vertexToSeedableChains.get(v).size() > 2)
+                .forEach(verticesToProcess::add);
+
+        final Set<V> processedVertices = new HashSet<>();
+        final Set<Path<V,E>> goodChains = new HashSet<>();
+
+        // starting from the high-confidence seed vertices, grow the "good" subgraph along chains with above-threshold log odds,
+        // discovering good chains as we go.
+        while (!verticesToProcess.isEmpty()) {
+            final V vertex = verticesToProcess.poll();
+            processedVertices.add(vertex);
+            for (final Path<V,E> outgoingChain : vertexToGoodOutgoingChains.get(vertex)) {
+                goodChains.add(outgoingChain);
+                if(!processedVertices.contains(outgoingChain.getLastVertex())) {
+                    verticesToProcess.add(outgoingChain.getLastVertex());
+                }
+            }
+
+            for (final Path<V,E> incomingChain : vertexToGoodIncomingChains.get(vertex)) {
+                goodChains.add(incomingChain);
+                if(!processedVertices.contains(incomingChain.getFirstVertex())) {
+                    verticesToProcess.add(incomingChain.getFirstVertex());
+                }
+            }
+        }
+
+        final Set<Path<V,E>> errorChains = chains.stream().filter(c -> !goodChains.contains(c)).collect(Collectors.toSet());
+
+        // add non-error chains to error chains if maximum number of variants has been exceeded
+        chains.stream()
+                .filter(c -> !errorChains.contains(c))
+                .filter(c -> isChainPossibleVariant(c, graph))
+                .sorted(Comparator.comparingDouble(c -> Math.min(chainLogOdds.get(c).getLeft(), chainLogOdds.get(c).getLeft())).reversed())
                 .skip(maxUnprunedVariants)
-                .forEach(result::add);
+                .forEach(errorChains::add);
 
-        return result;
+        return errorChains;
 
     }
 
-    private double chainLogOdds(final Path<V,E> chain, final BaseGraph<V,E> graph, final double errorRate) {
-        if (chain.getEdges().stream().anyMatch(E::isRef)) {
-            return Double.POSITIVE_INFINITY;
-        }
+    // find the chain containing the edge of greatest weight, taking care to break ties deterministically
+    private Path<V, E> getMaxWeightChain(final Collection<Path<V, E>> chains) {
+        return chains.stream()
+                .max(Comparator.comparingInt((Path<V, E> chain) -> chain.getEdges().stream().mapToInt(BaseEdge::getMultiplicity).max().orElse(0))
+                        .thenComparingInt(Path::length)
+                        .thenComparingInt(Path::hashCode)).get();
+    }
 
+    // left and right chain log odds
+    private Pair<Double, Double> chainLogOdds(final Path<V,E> chain, final BaseGraph<V,E> graph, final double errorRate) {
         final int leftTotalMultiplicity = MathUtils.sumIntFunction(graph.outgoingEdgesOf(chain.getFirstVertex()), E::getMultiplicity);
         final int rightTotalMultiplicity = MathUtils.sumIntFunction(graph.incomingEdgesOf(chain.getLastVertex()), E::getMultiplicity);
 
@@ -75,7 +143,7 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
         final double rightLogOdds = graph.isSink(chain.getLastVertex()) ? 0.0 :
                 Mutect2Engine.logLikelihoodRatio(rightTotalMultiplicity - rightMultiplicity, rightMultiplicity, errorRate);
 
-        return FastMath.max(leftLogOdds, rightLogOdds);
+        return ImmutablePair.of(leftLogOdds, rightLogOdds);
     }
     
     private boolean isChainPossibleVariant(final Path<V,E> chain, final BaseGraph<V,E> graph) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
@@ -160,7 +160,8 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
 
         // done up to here
 
-        int numberOfVariantsInGraph = outgoing.keySet().stream().mapToInt(v -> Math.max(outgoing.get(v).size() - 1, 0)).sum();
+        int numberOfVariantsInGraph = subgraphChains
+                outgoing.keySet().stream().mapToInt(v -> Math.max(outgoing.get(v).size() - 1, 0)).sum();
 
         // start with the worst good variants
         final PriorityQueue<Path<V,E>> pruningQueue = new PriorityQueue<>(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
@@ -104,14 +104,18 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
         while (!chainsToAdd.isEmpty() && variantCount.intValue() <= maxUnprunedVariants) {
             final Path<V,E> chain = chainsToAdd.poll().getLeft();
 
+            if (!goodChains.add(chain)) {
+                continue;
+            }
+
             // When we add an outgoing chain starting from a vertex with other good outgoing chains, we add a variant
-            final boolean newVariant = verticesThatAlreadyHaveOutgoingGoodChains.add(chain.getFirstVertex());
+            final boolean newVariant = !verticesThatAlreadyHaveOutgoingGoodChains.add(chain.getFirstVertex());
             if (newVariant) {
                 variantCount.increment();
             }
 
             // check whether we've already added this chain from the other side or we've exceeded the variant count limit
-            if (!goodChains.add(chain) || (newVariant && variantCount.intValue() > maxUnprunedVariants)) {
+            if (newVariant && variantCount.intValue() > maxUnprunedVariants) {
                 continue;
             }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -12,7 +12,6 @@ import org.broadinstitute.hellbender.engine.AssemblyRegion;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResult;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AssemblyResultSet;
-import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.NearbyKmerErrorCorrector;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadErrorCorrector;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs.*;
 import org.broadinstitute.hellbender.utils.Histogram;
@@ -76,7 +75,7 @@ public final class ReadThreadingAssembler {
                                   final boolean dontIncreaseKmerSizesForCycles, final boolean allowNonUniqueKmersInRef,
                                   final int numPruningSamples, final int pruneFactor, final boolean useAdaptivePruning,
                                   final double initialErrorRateForPruning, final double pruningLogOddsThreshold,
-                                  final int maxUnprunedVariants, final boolean useLinkedDebruijnGraphs) {
+                                  final double pruningSeedingLogOddsThreshold, final int maxUnprunedVariants, final boolean useLinkedDebruijnGraphs) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
         this.kmerSizes = kmerSizes.stream().sorted(Integer::compareTo).collect(Collectors.toList());
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
@@ -88,14 +87,14 @@ public final class ReadThreadingAssembler {
             logger.error("JunctionTreeLinkedDeBruijnGraph is enabled.\n This is an experimental assembly graph mode that has not been fully validated\n\n");
         }
 
-        chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants) :
+        chainPruner = useAdaptivePruning ? new AdaptiveChainPruner<>(initialErrorRateForPruning, pruningLogOddsThreshold, pruningSeedingLogOddsThreshold, maxUnprunedVariants) :
                 new LowWeightChainPruner<>(pruneFactor);
         numBestHaplotypesPerGraph = maxAllowedPathsForReadThreadingAssembler;
     }
 
     @VisibleForTesting
     ReadThreadingAssembler(final int maxAllowedPathsForReadThreadingAssembler, final List<Integer> kmerSizes, final int pruneFactor) {
-        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, Integer.MAX_VALUE, false);
+        this(maxAllowedPathsForReadThreadingAssembler, kmerSizes, true, true, 1, pruneFactor, false, 0.001, 2, 2, Integer.MAX_VALUE, false);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/broadinstitute/hellbender/utils/Tail.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Tail.java
@@ -1,0 +1,9 @@
+package org.broadinstitute.hellbender.utils;
+
+/**
+ * Enum for two-sided things, for example which end of a read has been clipped, which end of a chain within an assembly graph etc.
+ */
+public enum Tail {
+    LEFT,
+    RIGHT
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/CigarUtils.java
@@ -1,16 +1,12 @@
 package org.broadinstitute.hellbender.utils.read;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
-import htsjdk.samtools.TextCigarCodec;
-import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
-import org.apache.commons.lang3.tuple.Triple;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWParameters;
-import org.broadinstitute.hellbender.utils.IndexRange;
+import org.broadinstitute.hellbender.utils.Tail;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAligner;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAlignment;
@@ -18,7 +14,6 @@ import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanAlignment;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 
 public final class CigarUtils {
 
@@ -286,7 +281,7 @@ public final class CigarUtils {
     /**
      * Count the number of soft- or hard- clipped bases from either the left or right end of a cigar
      */
-    public static int countClippedBases(final Cigar cigar, final ClippingTail tail, final CigarOperator typeOfClip) {
+    public static int countClippedBases(final Cigar cigar, final Tail tail, final CigarOperator typeOfClip) {
         Utils.validateArg(typeOfClip.isClipping(), "typeOfClip must be a clipping operator");
 
         final int size = cigar.numCigarElements();
@@ -298,7 +293,7 @@ public final class CigarUtils {
         int result = 0;
 
         for (int n = 0; n < size; n++) {
-            final int index = (tail == ClippingTail.LEFT_TAIL ? n : size - n - 1);
+            final int index = (tail == Tail.LEFT ? n : size - n - 1);
             final CigarElement element = cigar.getCigarElement(index);
             if (!element.getOperator().isClipping()) {
                 return result;
@@ -313,7 +308,7 @@ public final class CigarUtils {
     /**
      * Count the number clipped bases (both soft and hard) from either the left or right end of a cigar
      */
-    public static int countClippedBases(final Cigar cigar, final ClippingTail tail) {
+    public static int countClippedBases(final Cigar cigar, final Tail tail) {
         return countClippedBases(cigar, tail, CigarOperator.SOFT_CLIP) + countClippedBases(cigar, tail, CigarOperator.HARD_CLIP);
     }
 
@@ -321,14 +316,14 @@ public final class CigarUtils {
      * Count the number of soft- and hard-clipped bases over both ends of a cigar
      */
     public static int countClippedBases(final Cigar cigar, final CigarOperator clippingType) {
-        return countClippedBases(cigar, ClippingTail.LEFT_TAIL, clippingType) + countClippedBases(cigar, ClippingTail.RIGHT_TAIL, clippingType);
+        return countClippedBases(cigar, Tail.LEFT, clippingType) + countClippedBases(cigar, Tail.RIGHT, clippingType);
     }
 
     /**
      * Count the number of clipped bases (both soft and hard) over both ends of a cigar
      */
     public static int countClippedBases(final Cigar cigar) {
-        return countClippedBases(cigar, ClippingTail.LEFT_TAIL) + countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+        return countClippedBases(cigar, Tail.LEFT) + countClippedBases(cigar, Tail.RIGHT);
     }
 
     public static int countAlignedBases(final Cigar cigar ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ClippingTail.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ClippingTail.java
@@ -1,9 +1,0 @@
-package org.broadinstitute.hellbender.utils.read;
-
-/**
- * A marker to tell which end of the read has been clipped
- */
-public enum ClippingTail {
-    LEFT_TAIL,
-    RIGHT_TAIL
-}

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/TestUtilsForAssemblyBasedSVDiscovery.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/TestUtilsForAssemblyBasedSVDiscovery.java
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.tools.spark.sv.discovery.alignment.*;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
-import org.broadinstitute.hellbender.utils.read.ClippingTail;
+import org.broadinstitute.hellbender.utils.Tail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -90,8 +90,8 @@ public final class TestUtilsForAssemblyBasedSVDiscovery {
 
         final SimpleInterval refSpan = new SimpleInterval(chr, start, start - 1 + cigar.getReferenceLength());
         return new AlignmentInterval(refSpan,
-                CigarUtils.countClippedBases(readCigar, ClippingTail.LEFT_TAIL) + 1,
-                CigarUtils.countUnclippedReadBases(readCigar) - CigarUtils.countClippedBases(readCigar, ClippingTail.RIGHT_TAIL),
+                CigarUtils.countClippedBases(readCigar, Tail.LEFT) + 1,
+                CigarUtils.countUnclippedReadBases(readCigar) - CigarUtils.countClippedBases(readCigar, Tail.RIGHT),
                 readCigar,
                 forwardStrand,
                 mapQual, numMismatch, alignerScore,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
@@ -148,7 +148,7 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         // note: these are the steps in ReadThreadingAssembler::createGraph
         graph.buildGraphIfNecessary();
 
-        final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> pruner = new AdaptiveChainPruner<>(0.001, logOddsThreshold, 50);
+        final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> pruner = new AdaptiveChainPruner<>(0.001, logOddsThreshold, 2.0, 50);
         pruner.pruneLowWeightChains(graph);
 
         final SmithWatermanAligner aligner = SmithWatermanJavaAligner.getInstance();
@@ -173,6 +173,47 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         // around the log-10 of the allele fraction up to some fudge factor, assumign we didn't do any dumb pruning
         Assert.assertEquals(bestPaths.get(altIndex.getAsInt()).score(), Math.log10(altFraction), 0.5);
         Assert.assertTrue(bestPaths.size() < 15);
+    }
+
+    // test that in graph with good path A -> B -> C and bad edges A -> D -> C and D -> B that the adjacency of bad edges --
+    // such that when bad edges meet the multiplicities do not indicate an error - does not harm pruning.
+    // we test with and without a true variant path A -> E -> C
+    @Test
+    public void testAdaptivePruningWithAdjacentBadEdges() {
+        final int goodMultiplicity = 1000;
+        final int variantMultiplicity = 50;
+        final int badMultiplicity = 5;
+
+        final SeqVertex source = new SeqVertex("source");
+        final SeqVertex sink = new SeqVertex("sink");
+        final SeqVertex A = new SeqVertex("A");
+        final SeqVertex B = new SeqVertex("B");
+        final SeqVertex C = new SeqVertex("C");
+        final SeqVertex D = new SeqVertex("D");
+        final SeqVertex E = new SeqVertex("E");
+
+
+        for (boolean variantPresent : new boolean[] {false, true}) {
+            final SeqGraph graph = new SeqGraph(20);
+
+            graph.addVertices(source, A, B, C, D, sink);
+            graph.addEdges(() -> new BaseEdge(true, goodMultiplicity), source, A, B, C, sink);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), A, D, C);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), D, B);
+
+            if (variantPresent) {
+                graph.addVertices(E);
+                graph.addEdges(() -> new BaseEdge(false, variantMultiplicity), A, E, C);
+            }
+
+            final ChainPruner<SeqVertex, BaseEdge> pruner = new AdaptiveChainPruner<>(0.01, 2.0, 2.0, 50);
+            pruner.pruneLowWeightChains(graph);
+
+            Assert.assertFalse(graph.containsVertex(D));
+            if (variantPresent) {
+                Assert.assertTrue(graph.containsVertex(E));
+            }
+        }
     }
 
     @DataProvider(name = "chainPrunerData")

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
@@ -2,7 +2,9 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller.graphs;
 
 import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.random.RandomGeneratorFactory;
+import org.apache.commons.math3.util.FastMath;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReadThreadingAssemblerArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.MultiDeBruijnVertex;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingGraph;
 import org.broadinstitute.hellbender.utils.BaseUtils;
@@ -135,7 +137,7 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
      */
     @Test(dataProvider = "chainPrunerData")
     public void testAdaptivePruning(final int kmerSize, final byte[] ref, final byte[] alt, final double altFraction, final double errorRate, final int depthPerAlignmentStart, final double logOddsThreshold) {
-        final RandomGenerator rng = RandomGeneratorFactory.createRandomGenerator(new Random(kmerSize + ref.hashCode() + alt.hashCode()));
+        final RandomGenerator rng = RandomGeneratorFactory.createRandomGenerator(new Random(kmerSize + FastMath.round(10000*(errorRate + altFraction))));
         final ReadThreadingGraph graph = new ReadThreadingGraph(kmerSize);
         graph.addSequence(ref, true);
         final List<byte[]> reads = IntStream.range(0, ref.length)
@@ -148,7 +150,8 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         // note: these are the steps in ReadThreadingAssembler::createGraph
         graph.buildGraphIfNecessary();
 
-        final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> pruner = new AdaptiveChainPruner<>(0.001, logOddsThreshold, 2.0, 50);
+        final ChainPruner<MultiDeBruijnVertex, MultiSampleEdge> pruner = new AdaptiveChainPruner<>(0.001,
+                logOddsThreshold, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD, 50);
         pruner.pruneLowWeightChains(graph);
 
         final SmithWatermanAligner aligner = SmithWatermanJavaAligner.getInstance();
@@ -167,12 +170,19 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new GraphBasedKBestHaplotypeFinder<>(seqGraph).findBestHaplotypes(10);
 
         final OptionalInt altIndex = IntStream.range(0, bestPaths.size()).filter(n -> bestPaths.get(n).haplotype().basesMatch(alt)).findFirst();
-        Assert.assertTrue(altIndex.isPresent());
+        //Assert.assertTrue(altIndex.isPresent());
+        if (!altIndex.isPresent()) {
+            int g = 90;
+        }
+
+        // ref path should not be pruned even if all reads are alt
+        final OptionalInt refIndex = IntStream.range(0, bestPaths.size()).filter(n -> bestPaths.get(n).haplotype().basesMatch(ref)).findFirst();
+        Assert.assertTrue(refIndex.isPresent());
 
         // the haplotype score is the sum of the log-10 of all branching fractions, so the alt haplotype score should come out to
-        // around the log-10 of the allele fraction up to some fudge factor, assumign we didn't do any dumb pruning
-        Assert.assertEquals(bestPaths.get(altIndex.getAsInt()).score(), Math.log10(altFraction), 0.5);
-        Assert.assertTrue(bestPaths.size() < 15);
+        // around the log-10 of the allele fraction up to some fudge factor, assuming we didn't do any dumb pruning
+        //Assert.assertEquals(bestPaths.get(altIndex.getAsInt()).score(), Math.log10(altFraction), 0.5);
+        //Assert.assertTrue(bestPaths.size() < 15);
     }
 
     // test that in graph with good path A -> B -> C and bad edges A -> D -> C and D -> B that the adjacency of bad edges --
@@ -206,12 +216,60 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
                 graph.addEdges(() -> new BaseEdge(false, variantMultiplicity), A, E, C);
             }
 
-            final ChainPruner<SeqVertex, BaseEdge> pruner = new AdaptiveChainPruner<>(0.01, 2.0, 2.0, 50);
+            final ChainPruner<SeqVertex, BaseEdge> pruner = new AdaptiveChainPruner<>(0.01, 2.0,
+                    ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD, 50);
             pruner.pruneLowWeightChains(graph);
 
             Assert.assertFalse(graph.containsVertex(D));
             if (variantPresent) {
                 Assert.assertTrue(graph.containsVertex(E));
+            }
+        }
+    }
+
+    // test that in graph with good path A -> B -> C and bad edges A -> D and E -> C with a bubble with edges F, G between D and E
+    // that the bad bubble does not harm pruning.
+    // we test with and without a true variant path A -> H -> C
+    @Test
+    public void testAdaptivePruningWithBadBubble() {
+        final int goodMultiplicity = 1000;
+        final int variantMultiplicity = 50;
+        final int badMultiplicity = 5;
+
+        final SeqVertex source = new SeqVertex("source");
+        final SeqVertex sink = new SeqVertex("sink");
+        final SeqVertex A = new SeqVertex("A");
+        final SeqVertex B = new SeqVertex("B");
+        final SeqVertex C = new SeqVertex("C");
+        final SeqVertex D = new SeqVertex("D");
+        final SeqVertex E = new SeqVertex("E");
+        final SeqVertex F = new SeqVertex("F");
+        final SeqVertex G = new SeqVertex("G");
+        final SeqVertex H = new SeqVertex("H");
+
+
+        for (boolean variantPresent : new boolean[] {false, true}) {
+            final SeqGraph graph = new SeqGraph(20);
+
+            graph.addVertices(source, A, B, C, D, E, F, G, sink);
+            graph.addEdges(() -> new BaseEdge(true, goodMultiplicity), source, A, B, C, sink);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), A, D);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), D, F, E);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), D, G, E);
+            graph.addEdges(() -> new BaseEdge(false, badMultiplicity), E, C);
+
+            if (variantPresent) {
+                graph.addVertices(H);
+                graph.addEdges(() -> new BaseEdge(false, variantMultiplicity), A, H, C);
+            }
+
+            final ChainPruner<SeqVertex, BaseEdge> pruner = new AdaptiveChainPruner<>(0.01, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD,
+                    ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_SEEDING_LOG_ODDS_THRESHOLD, 50);
+            pruner.pruneLowWeightChains(graph);
+
+            Assert.assertFalse(graph.containsVertex(D));
+            if (variantPresent) {
+                Assert.assertTrue(graph.containsVertex(H));
             }
         }
     }
@@ -241,11 +299,12 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
 
         // kmer size, ref bases, alt bases, alt fraction, base error rate, depth per start, log odds threshold, max unpruned variants
         return new Object[][] {
-                { 10, ref, leftSNV, 0.5, 0.001, 20, 1.0},
-                { 10, ref, middleSNV, 0.1, 0.001, 5, 1.0},
-                { 25, ref, middleSNV, 0.1, 0.001, 5, 1.0},
-                { 25, ref, middleSNV, 0.01, 0.001, 1000, 1.0},   // note the extreme depth -- this would confuse non-adaptive pruning
-                { 10, ref, rightSNV, 0.1, 0.001, 2, 1.0}
+                { 10, ref, leftSNV, 0.5, 0.001, 20, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD},
+                { 10, ref, leftSNV, 1.0, 0.001, 20, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD},
+                { 10, ref, middleSNV, 0.1, 0.001, 5, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD},
+                { 25, ref, middleSNV, 0.1, 0.001, 5, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD},
+                { 25, ref, middleSNV, 0.01, 0.001, 1000, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD},   // note the extreme depth -- this would confuse non-adaptive pruning
+                { 10, ref, rightSNV, 0.1, 0.001, 2, ReadThreadingAssemblerArgumentCollection.DEFAULT_PRUNING_LOG_ODDS_THRESHOLD}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/ChainPrunerUnitTest.java
@@ -170,10 +170,7 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
         final List<KBestHaplotype<SeqVertex, BaseEdge>> bestPaths = new GraphBasedKBestHaplotypeFinder<>(seqGraph).findBestHaplotypes(10);
 
         final OptionalInt altIndex = IntStream.range(0, bestPaths.size()).filter(n -> bestPaths.get(n).haplotype().basesMatch(alt)).findFirst();
-        //Assert.assertTrue(altIndex.isPresent());
-        if (!altIndex.isPresent()) {
-            int g = 90;
-        }
+        Assert.assertTrue(altIndex.isPresent());
 
         // ref path should not be pruned even if all reads are alt
         final OptionalInt refIndex = IntStream.range(0, bestPaths.size()).filter(n -> bestPaths.get(n).haplotype().basesMatch(ref)).findFirst();
@@ -181,8 +178,8 @@ public final class ChainPrunerUnitTest extends GATKBaseTest {
 
         // the haplotype score is the sum of the log-10 of all branching fractions, so the alt haplotype score should come out to
         // around the log-10 of the allele fraction up to some fudge factor, assuming we didn't do any dumb pruning
-        //Assert.assertEquals(bestPaths.get(altIndex.getAsInt()).score(), Math.log10(altFraction), 0.5);
-        //Assert.assertTrue(bestPaths.size() < 15);
+        Assert.assertEquals(bestPaths.get(altIndex.getAsInt()).score(), Math.log10(altFraction), 0.5);
+        Assert.assertTrue(bestPaths.size() < 15);
     }
 
     // test that in graph with good path A -> B -> C and bad edges A -> D -> C and D -> B that the adjacency of bad edges --

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -507,7 +507,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "chrM:750-750 A*, [G]");
         Assert.assertTrue(variantKeys.containsAll(expectedKeys));
 
-        Assert.assertEquals(variants.get(0).getAttributeAsInt(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY, 0), 1672);
+        Assert.assertEquals(variants.get(0).getAttributeAsInt(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY, 0), 1664);
     }
 
     @DataProvider(name = "vcfsForFiltering")
@@ -703,7 +703,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 //ref blocks will be dependent on TLOD band values
                 "chrM:218-218 A*, [<NON_REF>]",
                 "chrM:264-266 C*, [<NON_REF>]",
-                "chrM:479-483 A*, [<NON_REF>]",
+                "chrM:475-483 A*, [<NON_REF>]",
                 "chrM:488-492 T*, [<NON_REF>]");
 
         //ref block boundaries aren't particularly stable, so try a few and make sure we check at least one

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -507,7 +507,7 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
                 "chrM:750-750 A*, [G]");
         Assert.assertTrue(variantKeys.containsAll(expectedKeys));
 
-        Assert.assertEquals(variants.get(0).getAttributeAsInt(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY, 0), 1664);
+        Assert.assertEquals(variants.get(0).getAttributeAsInt(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY, 0), 1709);
     }
 
     @DataProvider(name = "vcfsForFiltering")
@@ -664,10 +664,10 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final List<String> expectedKeys = Arrays.asList(
                 "chrM:152-152 T*, [<NON_REF>, C]",
                 "chrM:263-263 A*, [<NON_REF>, G]",
-                "chrM:297-297 A*, [<NON_REF>, AC, C]",  //alt alleles get sorted when converted to keys
-                //"chrM:301-301 A*, [<NON_REF>, AC, ACC]",
-                //"chrM:302-302 A*, [<NON_REF>, AC, ACC, C]",  //one of these commented out variants has an allele that only appears in debug mode
-                "chrM:310-310 T*, [<NON_REF>, C, TC]",
+                //"chrM:297-297 A*, [<NON_REF>, AC, C]",
+                //"chrM:301-301 A*, [<NON_REF>, AC, ACC, ACCC]",
+                "chrM:302-302 A*, [<NON_REF>, AC, ACC, ACCC, C]",  //one of these commented out variants has an allele that only appears in debug mode
+                "chrM:310-310 T*, [<NON_REF>, TC]",
                 "chrM:750-750 A*, [<NON_REF>, G]");
         Assert.assertTrue(variantKeys.containsAll(expectedKeys));
         //First entry should be a homRef block

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/CigarUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/CigarUtilsUnitTest.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.TextCigarCodec;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
+import org.broadinstitute.hellbender.utils.Tail;
 import org.broadinstitute.hellbender.utils.smithwaterman.SmithWatermanJavaAligner;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -253,12 +254,12 @@ public final class CigarUtilsUnitTest {
 
     @Test(dataProvider = "allClipFunkyCigars", expectedExceptions = IllegalArgumentException.class)
     public void testLeftClipFunkly(final Cigar cigar) {
-        CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL);
+        CigarUtils.countClippedBases(cigar, Tail.LEFT);
     }
 
     @Test(dataProvider = "allClipFunkyCigars", expectedExceptions = IllegalArgumentException.class)
     public void testRightClipFunkly(final Cigar cigar) {
-        CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL);
+        CigarUtils.countClippedBases(cigar, Tail.RIGHT);
     }
 
     @Test
@@ -276,10 +277,10 @@ public final class CigarUtilsUnitTest {
                 .stream().map(pair -> Pair.of(TextCigarCodec.decode(pair.getLeft()), pair.getRight())).collect(Collectors.toList());
 
         for (final Pair<Cigar, int[]> test : tests) {
-            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), ClippingTail.LEFT_TAIL, CigarOperator.HARD_CLIP), test.getRight()[0]);
-            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), ClippingTail.LEFT_TAIL, CigarOperator.SOFT_CLIP), test.getRight()[1]);
-            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), ClippingTail.RIGHT_TAIL, CigarOperator.HARD_CLIP), test.getRight()[2]);
-            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), ClippingTail.RIGHT_TAIL, CigarOperator.SOFT_CLIP), test.getRight()[3]);
+            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), Tail.LEFT, CigarOperator.HARD_CLIP), test.getRight()[0]);
+            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), Tail.LEFT, CigarOperator.SOFT_CLIP), test.getRight()[1]);
+            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), Tail.RIGHT, CigarOperator.HARD_CLIP), test.getRight()[2]);
+            Assert.assertEquals(CigarUtils.countClippedBases(test.getLeft(), Tail.RIGHT, CigarOperator.SOFT_CLIP), test.getRight()[3]);
         }
     }
 
@@ -308,16 +309,16 @@ public final class CigarUtilsUnitTest {
             }
         }
 
-        Assert.assertEquals(leftSoft, CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL, CigarOperator.SOFT_CLIP));
-        Assert.assertEquals(leftHard, CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL, CigarOperator.HARD_CLIP));
-        Assert.assertEquals(rightSoft, CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL, CigarOperator.SOFT_CLIP));
-        Assert.assertEquals(rightHard, CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL, CigarOperator.HARD_CLIP));
+        Assert.assertEquals(leftSoft, CigarUtils.countClippedBases(cigar, Tail.LEFT, CigarOperator.SOFT_CLIP));
+        Assert.assertEquals(leftHard, CigarUtils.countClippedBases(cigar, Tail.LEFT, CigarOperator.HARD_CLIP));
+        Assert.assertEquals(rightSoft, CigarUtils.countClippedBases(cigar, Tail.RIGHT, CigarOperator.SOFT_CLIP));
+        Assert.assertEquals(rightHard, CigarUtils.countClippedBases(cigar, Tail.RIGHT, CigarOperator.HARD_CLIP));
 
         Assert.assertEquals(leftSoft + rightSoft, CigarUtils.countClippedBases(cigar, CigarOperator.SOFT_CLIP));
         Assert.assertEquals(leftHard + rightHard, CigarUtils.countClippedBases(cigar, CigarOperator.HARD_CLIP));
 
-        Assert.assertEquals(leftSoft + leftHard, CigarUtils.countClippedBases(cigar, ClippingTail.LEFT_TAIL));
-        Assert.assertEquals(rightSoft + rightHard, CigarUtils.countClippedBases(cigar, ClippingTail.RIGHT_TAIL));
+        Assert.assertEquals(leftSoft + leftHard, CigarUtils.countClippedBases(cigar, Tail.LEFT));
+        Assert.assertEquals(rightSoft + rightHard, CigarUtils.countClippedBases(cigar, Tail.RIGHT));
 
         Assert.assertEquals(leftSoft + rightSoft + leftHard + rightHard, CigarUtils.countClippedBases(cigar));
     }

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -12,10 +12,7 @@ import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.BaseUtils;
-import org.broadinstitute.hellbender.utils.RandomDNA;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.*;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
@@ -726,7 +723,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test(dataProvider = "mappedGatkReadsData")
     public void testGetFirstAlignedBaseOffset(final GATKRead read) {
         final int actual = ReadUtils.getFirstAlignedBaseOffset(read);
-        final int expected = CigarUtils.countClippedBases(read.getCigar(), Tail.LEFT) - CigarUtils.countClippedBases(read.getCigar(), ClippingTail.LEFT_TAIL, CigarOperator.HARD_CLIP);
+        final int expected = CigarUtils.countClippedBases(read.getCigar(), Tail.LEFT) - CigarUtils.countClippedBases(read.getCigar(), Tail.LEFT, CigarOperator.HARD_CLIP);
         Assert.assertEquals(actual, expected);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -726,7 +726,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test(dataProvider = "mappedGatkReadsData")
     public void testGetFirstAlignedBaseOffset(final GATKRead read) {
         final int actual = ReadUtils.getFirstAlignedBaseOffset(read);
-        final int expected = CigarUtils.countClippedBases(read.getCigar(), ClippingTail.LEFT_TAIL) - CigarUtils.countClippedBases(read.getCigar(), ClippingTail.LEFT_TAIL, CigarOperator.HARD_CLIP);
+        final int expected = CigarUtils.countClippedBases(read.getCigar(), Tail.LEFT) - CigarUtils.countClippedBases(read.getCigar(), ClippingTail.LEFT_TAIL, CigarOperator.HARD_CLIP);
         Assert.assertEquals(actual, expected);
     }
 


### PR DESCRIPTION
@jamesemery This fixes the case you found, hopefully bringing us closer to turning on linked de Bruijn graphs.  I will start testing M2.  If you test in HC, continue to keep in mind that adaptive pruning is not default.

This change will be most important for rare complex graphs and in combination with junction trees but I did see modest improvements to indel sensitivity even with the old assembly.