### PR TITLE
Remove unused isCompatibleWithSparkBroadcast method.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSource.java
@@ -65,14 +65,6 @@ public class ReferenceMultiSparkSource implements ReferenceSparkSource, Serializ
     }
 
     /**
-     * Returns whether this reference source can be used with Spark broadcast.
-     */
-    @Override
-    public boolean isCompatibleWithSparkBroadcast(){
-        return referenceSource.isCompatibleWithSparkBroadcast();
-    }
-
-    /**
      * @return the custom reference window function used to map reads to desired reference bases
      */
     public SerializableFunction<GATKRead, SimpleInterval> getReferenceWindowFunction() {

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceSparkSource.java
@@ -12,12 +12,4 @@ import java.io.IOException;
 public interface ReferenceSparkSource {
     ReferenceBases getReferenceBases(SimpleInterval interval) throws IOException;
     SAMSequenceDictionary getReferenceSequenceDictionary(SAMSequenceDictionary optReadSequenceDictionaryToMatch) throws IOException;
-
-    /**
-     * Returns whether this reference source can be used with Spark broadcast.
-     * Currently, only {@link ReferenceTwoBitSparkSource} is compatible with the Spark broadcast implementation.
-     */
-    default public boolean isCompatibleWithSparkBroadcast(){
-        return this instanceof ReferenceTwoBitSparkSource;
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
+++ b/src/main/java/org/broadinstitute/hellbender/exceptions/UserException.java
@@ -390,13 +390,6 @@ public class UserException extends RuntimeException {
         }
     }
 
-    public static final class Require2BitReferenceForBroadcast extends BadInput {
-        private static final long serialVersionUID = 0L;
-        public Require2BitReferenceForBroadcast() {
-            super("Running this tool with BROADCAST strategy requires a 2bit reference. To create a 2bit reference from an existing fasta file, download faToTwoBit from the link on https://genome.ucsc.edu/goldenPath/help/twoBit.html, then run faToTwoBit in.fasta out.2bit");
-	}
-    }
-
     public static final class NoSuitableCodecs extends  UserException {
         private static final long serialVersionUID = 0L;
 


### PR DESCRIPTION
Another issue that came up on the URI migration branch. The implementation of this method declares that only the `ReferenceTwoBitSparkSource` implementation of `ReferenceSparkSource` is broadcastable, but the method is unused, and there are tools with tests (`CpxVariantReInterpreterSparkIntegrationTest`) that broadcast both the File and Hadoop implementations. So we should either take this, or fix the callers to be more discriminating.
