### PR TITLE
Migrate reference arguments and downstream code to GATKPathSpecifier.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
@@ -2,8 +2,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-
-import java.io.File;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 
 /**
  * An argument collection for use with tools that optionally accept a reference file as input.
@@ -12,10 +11,10 @@ public final class OptionalReferenceInputArgumentCollection extends ReferenceInp
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence", optional = true)
-    private String referenceFileName;
+    private GATKPathSpecifier referenceInputPathSpecifier;
 
     @Override
-    public String getReferenceFileName() {
-        return referenceFileName;
+    public GATKPathSpecifier getReferenceSpecifier() {
+        return referenceInputPathSpecifier;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
@@ -1,8 +1,7 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
-import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 
-import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
 
@@ -13,14 +12,27 @@ public abstract class ReferenceInputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
+     * Get the name of the reference input specified at the command line.
+     */
+    public abstract GATKPathSpecifier getReferenceSpecifier();
+
+    /**
      * Get the name of the reference file specified at the command line.
      */
-    public abstract String getReferenceFileName();
+    public String getReferenceFileName() {
+        // We should remove this method completely once all the call sites that use it are updated
+        // and the migration to GATKPathSpecifier is complete, since its not not clear what format
+        // the return value can have (i.e., can it have a URI scheme ? query params ?). Instead, all
+        // consumers shoule either rely directly on GATKPathSpecifier, or use a Path or URI, which
+        // can both be obtained from a GATKPathSpecifier.
+        final GATKPathSpecifier inputPathSpec = getReferenceSpecifier();
+        return inputPathSpec == null ? null : inputPathSpec.getURI().getPath();
+    }
 
     /**
      * Get the Path to the reference, may be null
      */
     public Path getReferencePath() {
-        return getReferenceFileName() != null ? IOUtils.getPath(getReferenceFileName()) : null;
+        return getReferenceSpecifier() != null ? getReferenceSpecifier().toPath() : null;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
@@ -2,8 +2,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-
-import java.io.File;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 
 /**
  * An argument collection for use with tools that require a reference file as input.
@@ -12,10 +11,10 @@ public final class RequiredReferenceInputArgumentCollection extends ReferenceInp
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file", optional = false)
-    private String referenceFileName;
+    private GATKPathSpecifier referenceInputPathSpecifier;
 
     @Override
-    public String getReferenceFileName() {
-        return referenceFileName;
+    public GATKPathSpecifier getReferenceSpecifier() {
+        return referenceInputPathSpecifier;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AssemblyRegionWalkerSpark.java
@@ -113,7 +113,7 @@ public abstract class AssemblyRegionWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
-        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         processAssemblyRegions(getAssemblyRegions(ctx), ctx);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -28,6 +28,7 @@ import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.Annotation;
 import org.broadinstitute.hellbender.utils.*;
@@ -346,8 +347,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             if (hasCramInput() && !hasReference()){
                 throw UserException.MISSING_REFERENCE_FOR_CRAM;
             }
-            final String refPath = hasReference() ?  referenceArguments.getReferenceFileName() : null;
-            output = source.getParallelReads(input, refPath, traversalParameters, bamPartitionSplitSize, useNio);
+            output = source.getParallelReads(input, referenceArguments.getReferenceSpecifier(), traversalParameters, bamPartitionSplitSize, useNio);
         }
         return output;
     }
@@ -372,7 +372,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
     public void writeReads(final JavaSparkContext ctx, final String outputFile, JavaRDD<GATKRead> reads, SAMFileHeader header, final boolean sortReadsToHeader) {
         try {
             ReadsSparkSink.writeReads(ctx, outputFile,
-                    hasReference() ? referenceArguments.getReferencePath().toAbsolutePath().toUri().toString() : null,
+                    hasReference() ? referenceArguments.getReferenceSpecifier() : null,
                     reads, header, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                     getRecommendedNumReducers(), shardedPartsDir, createOutputBamIndex, createOutputBamSplittingIndex, sortReadsToHeader, splittingIndexGranularity);
         } catch (IOException e) {
@@ -567,8 +567,7 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
         readInputs = new LinkedHashMap<>();
         readsSource = new ReadsSparkSource(sparkContext, readArguments.getReadValidationStringency());
         for (String input : readArguments.getReadFilesNames()) {
-            readInputs.put(input, readsSource.getHeader(
-                    input, hasReference() ?  referenceArguments.getReferenceFileName() : null));
+            readInputs.put(input, readsSource.getHeader(input, referenceArguments.getReferenceSpecifier()));
         }
         readsHeader = createHeaderMerger().getMergedHeader();
     }
@@ -594,12 +593,12 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * Initializes our reference source. Does nothing if no reference was specified.
      */
     private void initializeReference() {
-        final String referenceURL = referenceArguments.getReferenceFileName();
-        if ( referenceURL != null ) {
-            referenceSource = new ReferenceMultiSparkSource(referenceURL, getReferenceWindowFunction());
+        final GATKPathSpecifier referencePathSpecifier = referenceArguments.getReferenceSpecifier();
+        if ( referencePathSpecifier != null ) {
+            referenceSource = new ReferenceMultiSparkSource(referencePathSpecifier, getReferenceWindowFunction());
             referenceDictionary = referenceSource.getReferenceSequenceDictionary(readsHeader != null ? readsHeader.getSequenceDictionary() : null);
             if (referenceDictionary == null) {
-                throw new UserException.MissingReferenceDictFile(referenceURL);
+                throw new UserException.MissingReferenceDictFile(referencePathSpecifier.getRawInputString());
             }
         }
     }
@@ -673,19 +672,18 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * Register the reference file (and associated dictionary and index) to be downloaded to every node using Spark's
      * copying mechanism ({@code SparkContext#addFile()}).
      * @param ctx the Spark context
-     * @param referenceFile the reference file, can be a local file or a remote path
+     * @param referencePath the reference file, can be a local file or a remote path
      * @return the reference file name; the absolute path of the file can be found by a Spark task using {@code SparkFiles#get()}
      */
-    protected static String addReferenceFilesForSpark(JavaSparkContext ctx, String referenceFile) {
-        if (referenceFile == null) {
+    protected static String addReferenceFilesForSpark(JavaSparkContext ctx, Path referencePath) {
+        if (referencePath == null) {
             return null;
         }
-        Path referencePath = IOUtils.getPath(referenceFile);
         Path indexPath = ReferenceSequenceFileFactory.getFastaIndexFileName(referencePath);
         Path dictPath = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(referencePath);
         Path gziPath = GZIIndex.resolveIndexNameForBgzipFile(referencePath);
 
-        ctx.addFile(referenceFile);
+        ctx.addFile(referencePath.toUri().toString());
         if (Files.exists(indexPath)) {
             ctx.addFile(indexPath.toUri().toString());
         }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/IntervalWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/IntervalWalkerSpark.java
@@ -89,7 +89,7 @@ public abstract class IntervalWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
-        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         processIntervals(getIntervals(ctx), ctx);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/LocusWalkerSpark.java
@@ -131,7 +131,7 @@ public abstract class LocusWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
-        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         processAlignments(getAlignments(ctx), ctx);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/ReadWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/ReadWalkerSpark.java
@@ -83,7 +83,7 @@ public abstract class ReadWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
-        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         processReads(getReads(ctx), ctx);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/VariantWalkerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/VariantWalkerSpark.java
@@ -150,7 +150,7 @@ public abstract class VariantWalkerSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(JavaSparkContext ctx) {
-        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         processVariants(getVariants(ctx), ctx);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
@@ -17,6 +17,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.bdgenomics.adam.models.ReadGroupDictionary;
 import org.bdgenomics.adam.models.SequenceDictionary;
 import org.bdgenomics.formats.avro.AlignmentRecord;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
@@ -43,22 +44,22 @@ public final class ReadsSparkSink {
      * writeReads writes rddReads to outputFile with header as the file header.
      * @param ctx the JavaSparkContext to write.
      * @param outputFile path to the output bam.
-     * @param referenceFile path to the reference. required for cram output, otherwise may be null.
+     * @param referencePathSpecifier GATKPathSpecifier to the reference. required for cram output, otherwise may be null.
      * @param reads reads to write.
      * @param header the header to put at the top of the files
      * @param format should the output be a single file, sharded, ADAM, etc.
      */
     public static void writeReads(
-            final JavaSparkContext ctx, final String outputFile, final String referenceFile, final JavaRDD<GATKRead> reads,
+            final JavaSparkContext ctx, final String outputFile, final GATKPathSpecifier referencePathSpecifier, final JavaRDD<GATKRead> reads,
             final SAMFileHeader header, ReadsWriteFormat format) throws IOException {
-        writeReads(ctx, outputFile, referenceFile, reads, header, format, 0, null, true, SBIIndexWriter.DEFAULT_GRANULARITY);
+        writeReads(ctx, outputFile, referencePathSpecifier, reads, header, format, 0, null, true, SBIIndexWriter.DEFAULT_GRANULARITY);
     }
 
     /**
      * writeReads writes rddReads to outputFile with header as the file header.
      * @param ctx the JavaSparkContext to write.
      * @param outputFile path to the output bam.
-     * @param referenceFile path to the reference. required for cram output, otherwise may be null.
+     * @param referencePathSpecifier GATKPathSpecifier to the reference. required for cram output, otherwise may be null.
      * @param reads reads to write.
      * @param header the header to put at the top of the files
      * @param format should the output be a single file, sharded, ADAM, etc.
@@ -69,16 +70,16 @@ public final class ReadsSparkSink {
      * @param splittingIndexGranularity the granularity of the splitting index
      */
     public static void writeReads(
-            final JavaSparkContext ctx, final String outputFile, final String referenceFile, final JavaRDD<GATKRead> reads,
+            final JavaSparkContext ctx, final String outputFile, final GATKPathSpecifier referencePathSpecifier, final JavaRDD<GATKRead> reads,
             final SAMFileHeader header, ReadsWriteFormat format, final int numReducers, final String outputPartsDir, final boolean sortReadsToHeader, final long splittingIndexGranularity) throws IOException {
-        writeReads(ctx, outputFile, referenceFile, reads, header, format, numReducers, outputPartsDir, true, true, sortReadsToHeader, splittingIndexGranularity);
+        writeReads(ctx, outputFile, referencePathSpecifier, reads, header, format, numReducers, outputPartsDir, true, true, sortReadsToHeader, splittingIndexGranularity);
     }
 
     /**
      * writeReads writes rddReads to outputFile with header as the file header.
      * @param ctx the JavaSparkContext to write.
      * @param outputFile path to the output bam.
-     * @param referenceFile path to the reference. required for cram output, otherwise may be null.
+     * @param referencePathSpecifier GATKPathSpecifier to the reference. required for cram output, otherwise may be null.
      * @param reads reads to write.
      * @param header the header to put at the top of the files
      * @param format should the output be a single file, sharded, ADAM, etc.
@@ -91,15 +92,12 @@ public final class ReadsSparkSink {
      * @param splittingIndexGranularity  the granularity of the splitting index if one is created
      */
     public static void writeReads(
-            final JavaSparkContext ctx, final String outputFile, final String referenceFile, final JavaRDD<GATKRead> reads,
+            final JavaSparkContext ctx, final String outputFile, final GATKPathSpecifier referencePathSpecifier, final JavaRDD<GATKRead> reads,
             final SAMFileHeader header, ReadsWriteFormat format, final int numReducers, final String outputPartsDir,
             final boolean writeBai, final boolean writeSbi, final boolean sortReadsToHeader, final long splittingIndexGranularity) throws IOException {
 
         String absoluteOutputFile = BucketUtils.makeFilePathAbsolute(outputFile);
-        String absoluteReferenceFile = referenceFile != null ?
-                                        BucketUtils.makeFilePathAbsolute(referenceFile) :
-                                        referenceFile;
-      ReadsSparkSource.checkCramReference(ctx, absoluteOutputFile, absoluteReferenceFile);
+        ReadsSparkSource.checkCramReference(ctx, absoluteOutputFile, referencePathSpecifier);
 
         // The underlying reads are required to be in SAMRecord format in order to be
         // written out, so we convert them to SAMRecord explicitly here. If they're already
@@ -118,12 +116,12 @@ public final class ReadsSparkSink {
                     absoluteOutputFile.endsWith(FileExtensions.CRAM) ||
                     absoluteOutputFile.endsWith(FileExtensions.SAM)) {
                 // don't specify a write option for format since it is inferred from the extension in the path
-                writeReads(ctx, absoluteOutputFile, absoluteReferenceFile, readsToOutput, header,
+                writeReads(ctx, absoluteOutputFile, referencePathSpecifier, readsToOutput, header,
                         splittingIndexGranularity, fileCardinalityWriteOption, tempPartsDirectoryWriteOption, baiWriteOption, sbiWriteOption);
             } else {
                 // default to BAM
                 ReadsFormatWriteOption formatWriteOption = ReadsFormatWriteOption.BAM;
-                writeReads(ctx, absoluteOutputFile, absoluteReferenceFile, readsToOutput, header, splittingIndexGranularity, formatWriteOption,
+                writeReads(ctx, absoluteOutputFile, referencePathSpecifier, readsToOutput, header, splittingIndexGranularity, formatWriteOption,
                         fileCardinalityWriteOption, tempPartsDirectoryWriteOption, baiWriteOption, sbiWriteOption);
             }
         } else if (format == ReadsWriteFormat.SHARDED) {
@@ -132,7 +130,7 @@ public final class ReadsSparkSink {
             }
             ReadsFormatWriteOption formatWriteOption = ReadsFormatWriteOption.BAM; // use BAM if output file is a directory
             FileCardinalityWriteOption fileCardinalityWriteOption = FileCardinalityWriteOption.MULTIPLE;
-            writeReads(ctx, absoluteOutputFile, absoluteReferenceFile, readsToOutput, header, splittingIndexGranularity, formatWriteOption, fileCardinalityWriteOption);
+            writeReads(ctx, absoluteOutputFile, referencePathSpecifier, readsToOutput, header, splittingIndexGranularity, formatWriteOption, fileCardinalityWriteOption);
         } else if (format == ReadsWriteFormat.ADAM) {
             if (outputPartsDir!=null) {
                 throw new  GATKException(String.format("You specified the bam output parts directory %s, but requested an ADAM output format which does not use this option",outputPartsDir));
@@ -142,7 +140,7 @@ public final class ReadsSparkSink {
     }
 
     private static void writeReads(
-            final JavaSparkContext ctx, final String outputFile, final String referenceFile, final JavaRDD<SAMRecord> reads,
+            final JavaSparkContext ctx, final String outputFile, final GATKPathSpecifier referencePathSpecifier, final JavaRDD<SAMRecord> reads,
             final SAMFileHeader header, final long sbiIndexGranularity, final WriteOption... writeOptions) throws IOException {
 
         Broadcast<SAMFileHeader> headerBroadcast = ctx.broadcast(header);
@@ -152,7 +150,7 @@ public final class ReadsSparkSink {
         });
         HtsjdkReadsRdd htsjdkReadsRdd = new HtsjdkReadsRdd(header, sortedReadsWithHeader);
         HtsjdkReadsRddStorage.makeDefault(ctx)
-                .referenceSourcePath(referenceFile)
+                .referenceSourcePath(referencePathSpecifier == null ? null : referencePathSpecifier.getRawInputString())
                 .sbiIndexGranularity(sbiIndexGranularity)
                 .write(htsjdkReadsRdd, outputFile, writeOptions);
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSource.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 
 import java.io.IOException;
@@ -46,7 +45,7 @@ public class ReferenceFileSparkSource implements ReferenceSparkSource, Serializa
 
     private synchronized Path getReferencePath() {
         if (null == referencePath) {
-            this.referencePath = IOUtils.getPath(referenceUri.toString());
+            this.referencePath = (new GATKPathSpecifier(referenceUri.toString()).toPath());
         }
         return referencePath;
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceHadoopSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceHadoopSparkSource.java
@@ -6,10 +6,10 @@ import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 
 import java.io.Serializable;
+import java.net.URI;
 
 /**
  * Class to load a reference sequence from a fasta file on HDFS.
@@ -17,7 +17,7 @@ import java.io.Serializable;
 public class ReferenceHadoopSparkSource implements ReferenceSparkSource, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final String referencePath;
+    private final URI referenceURI;
 
     /**
      * @param referencePathSpecifier the path to the reference file on HDFS
@@ -26,19 +26,19 @@ public class ReferenceHadoopSparkSource implements ReferenceSparkSource, Seriali
         // It would simplify this class if we could cache the GATKPathSpecifier, but ReferenceFileSparkSource
         // objects are used as Spark broadcast variables, and caching GATKPathSpecifier here triggers a known
         // issue during broadcast with the Java 11 GATK build. See https://issues.apache.org/jira/browse/SPARK-26963.
-        this.referencePath = referencePathSpecifier.getRawInputString();
+        this.referenceURI = referencePathSpecifier.getURI();
     }
 
     @Override
     public ReferenceBases getReferenceBases(final SimpleInterval interval) {
-        ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(IOUtils.getPath(referencePath));
+        ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(new GATKPathSpecifier(referenceURI.toString()).toPath());
         ReferenceSequence sequence = referenceSequenceFile.getSubsequenceAt(interval.getContig(), interval.getStart(), interval.getEnd());
         return new ReferenceBases(sequence.getBases(), interval);
     }
 
     @Override
     public SAMSequenceDictionary getReferenceSequenceDictionary(final SAMSequenceDictionary optReadSequenceDictionaryToMatch) {
-        ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(IOUtils.getPath(referencePath));
+        ReferenceSequenceFile referenceSequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(new GATKPathSpecifier(referenceURI.toString()).toPath());
         return referenceSequenceFile.getSequenceDictionary();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceHadoopSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceHadoopSparkSource.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -19,10 +20,13 @@ public class ReferenceHadoopSparkSource implements ReferenceSparkSource, Seriali
     private final String referencePath;
 
     /**
-     * @param referencePath the path to the reference file on HDFS
+     * @param referencePathSpecifier the path to the reference file on HDFS
      */
-    public ReferenceHadoopSparkSource( final String referencePath) {
-        this.referencePath = referencePath;
+    public ReferenceHadoopSparkSource( final GATKPathSpecifier referencePathSpecifier) {
+        // It would simplify this class if we could cache the GATKPathSpecifier, but ReferenceFileSparkSource
+        // objects are used as Spark broadcast variables, and caching GATKPathSpecifier here triggers a known
+        // issue during broadcast with the Java 11 GATK build. See https://issues.apache.org/jira/browse/SPARK-26963.
+        this.referencePath = referencePathSpecifier.getRawInputString();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSource.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * Wrapper to load a reference sequence from the Google Genomics API, or a file stored on HDFS or locally.
+ * Wrapper to load a reference sequence from a file stored on HDFS, GCS, or locally.
  *
  * This class needs to subclassed by test code, so it cannot be declared final.
  */
@@ -31,7 +31,7 @@ public class ReferenceMultiSparkSource implements ReferenceSparkSource, Serializ
     protected ReferenceMultiSparkSource() {};
 
     /**
-     * @param referencePathSpecifier the name of the reference (if using the Google Genomics API), or a path to the reference file
+     * @param referencePathSpecifier local path or URL to the reference file
      * @param referenceWindowFunction the custom reference window function used to map reads to desired reference bases
      */
     public ReferenceMultiSparkSource( final GATKPathSpecifier referencePathSpecifier,

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSource.java
@@ -8,13 +8,13 @@ import org.bdgenomics.adam.util.TwoBitFile;
 import org.bdgenomics.adam.util.TwoBitRecord;
 import org.bdgenomics.formats.avro.Strand;
 import org.bdgenomics.utils.io.ByteAccess;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
-import scala.collection.immutable.IndexedSeq;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -37,9 +37,12 @@ public class ReferenceTwoBitSparkSource implements ReferenceSparkSource, Seriali
     private final TwoBitFile twoBitFile;
     private final Map<String, TwoBitRecord> twoBitSeqEntries;
 
-    public ReferenceTwoBitSparkSource( String referenceURL) throws IOException {
-        this.referenceURL = referenceURL;
-        Utils.validateArg(isTwoBit(this.referenceURL), "ReferenceTwoBitSource can only take .2bit files");
+    public ReferenceTwoBitSparkSource( GATKPathSpecifier referencePathSpecifier) throws IOException {
+        // It would simplify this class if we could cache the GATKPathSpecifier, but ReferenceFileSparkSource
+        // objects are used as Spark broadcast variables, and caching GATKPathSpecifier here triggers a known
+        // issue during broadcast with the Java 11 GATK build. See https://issues.apache.org/jira/browse/SPARK-26963.
+        this.referenceURL = referencePathSpecifier.getRawInputString();
+        Utils.validateArg(isTwoBit(referencePathSpecifier), "ReferenceTwoBitSource can only take .2bit files");
         byte[] bytes = ByteStreams.toByteArray(BucketUtils.openFile(this.referenceURL));
         ByteAccess byteAccess = new DirectFullByteArrayByteAccess(bytes);
         this.twoBitFile = new TwoBitFile(byteAccess);
@@ -72,8 +75,8 @@ public class ReferenceTwoBitSparkSource implements ReferenceSparkSource, Seriali
         return new SAMSequenceDictionary(records);
     }
 
-    public static boolean isTwoBit(String file) {
-        return file.endsWith(TWO_BIT_EXTENSION);
+    public static boolean isTwoBit(final GATKPathSpecifier referenceSpecifier) {
+        return referenceSpecifier.getURI().getPath().endsWith(TWO_BIT_EXTENSION);
     }
 
     private static ReferenceRegion simpleIntervalToReferenceRegion(SimpleInterval interval) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSpark.java
@@ -124,7 +124,7 @@ public class BaseRecalibratorSpark extends GATKSparkTool {
 
     @Override
     protected void runTool( JavaSparkContext ctx ) {
-        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         JavaPairRDD<GATKRead, Iterable<GATKVariant>> readsWithVariants = JoinReadsWithVariants.join(getReads(), localKnownSitesFilePaths);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaArgumentCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 
 import java.io.Serializable;
 
@@ -26,7 +27,7 @@ public final class PSBwaArgumentCollection implements Serializable {
     @Argument(doc = "Reference corresponding to the microbe reference image file",
             fullName = MICROBE_FASTA_LONG_NAME,
             shortName = MICROBE_FASTA_SHORT_NAME)
-    public String referencePath;
+    public GATKPathSpecifier referencePath;
 
     /**
      * This parameter controls the sensitivity of the BWA-MEM aligner. Smaller values result in more alignments at the

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtils.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 public final class PSBwaUtils {
 
     static void addReferenceSequencesToHeader(final SAMFileHeader header,
-                                              final String referencePath,
+                                              final GATKPathSpecifier referencePath,
                                               final SerializableFunction<GATKRead, SimpleInterval> windowFunction) {
         final List<SAMSequenceRecord> refSeqs = getReferenceSequences(referencePath, windowFunction);
         for (final SAMSequenceRecord rec : refSeqs) {
@@ -31,12 +32,12 @@ public final class PSBwaUtils {
         }
     }
 
-    private static List<SAMSequenceRecord> getReferenceSequences(final String referencePath,
+    private static List<SAMSequenceRecord> getReferenceSequences(final GATKPathSpecifier referencePath,
                                                                  final SerializableFunction<GATKRead, SimpleInterval> windowFunction) {
         final ReferenceMultiSparkSource referenceSource = new ReferenceMultiSparkSource(referencePath, windowFunction);
         final SAMSequenceDictionary referenceDictionary = referenceSource.getReferenceSequenceDictionary(null);
         if (referenceDictionary == null) {
-            throw new UserException.MissingReferenceDictFile(referencePath);
+            throw new UserException.MissingReferenceDictFile(referencePath.getRawInputString());
         }
         return referenceDictionary.getSequences();
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildKmers.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBuildKmers.java
@@ -6,6 +6,7 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.MetagenomicsProgramGroup;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceFileSparkSource;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVKmerShort;
 import org.broadinstitute.hellbender.tools.spark.utils.LargeLongHopscotchSet;
@@ -97,7 +98,7 @@ public final class PathSeqBuildKmers extends CommandLineProgram {
     @Argument(doc = "Reference FASTA file path on local disk",
             fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME,
             shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME)
-    public String reference;
+    public GATKPathSpecifier reference;
 
     /**
      * <p>Note that the provided argument is used as an upper limit on the probability, and the actual false positive

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSpark.java
@@ -96,7 +96,7 @@ public final class BQSRPipelineSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         //Should this get the getUnfilteredReads? getReads will merge default and command line filters.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/BwaAndMarkDuplicatesPipelineSpark.java
@@ -69,7 +69,7 @@ public final class BwaAndMarkDuplicatesPipelineSpark extends GATKSparkTool {
             final JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.mark(alignedReads, bwaEngine.getHeader(), new OpticalDuplicateFinder(), markDuplicatesSparkArgumentCollection, getRecommendedNumReducers());
             try {
                 ReadsSparkSink.writeReads(ctx, output,
-                        referenceArguments.getReferencePath().toAbsolutePath().toUri().toString(),
+                        referenceArguments.getReferenceSpecifier(),
                         markedReads, bwaEngine.getHeader(),
                         shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                         getRecommendedNumReducers(), shardedPartsDir, true, splittingIndexGranularity);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -164,7 +164,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
 
     @Override
     protected void runTool(final JavaSparkContext ctx) {
-        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferenceFileName());
+        String referenceFileName = addReferenceFilesForSpark(ctx, referenceArguments.getReferencePath());
         List<String> localKnownSitesFilePaths = addVCFsForSpark(ctx, knownVariants);
 
         final JavaRDD<GATKRead> alignedReads;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotator.java
@@ -200,14 +200,12 @@ public class VariantAnnotator extends VariantWalker {
         Set<VCFHeaderLine> hInfo = new HashSet<>();
         hInfo.addAll(annotatorEngine.getVCFAnnotationDescriptions(false));
         hInfo.addAll(getHeaderForVariants().getMetaDataInInputOrder());
+        hInfo = VcfUtils.updateHeaderContigLines(
+                hInfo,
+                hasReference() ? referenceArguments.getReferencePath() : null,
+                hasReference() ? getReferenceDictionary() : getBestAvailableSequenceDictionary(),
+                false);
 
-        if (hasReference()) {
-            hInfo = VcfUtils.updateHeaderContigLines(
-                    hInfo,
-                    referenceArguments.getReferencePath(),
-                    getReferenceDictionary(),
-                    false);
-        }
         vcfWriter = createVCFWriter(outputFile);
         vcfWriter.writeHeader(new VCFHeader(hInfo, samples));
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
 import org.broadinstitute.hellbender.engine.AssemblyRegion;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.tools.walkers.ReferenceConfidenceVariantContextMerger;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 import org.broadinstitute.hellbender.utils.QualityUtils;
@@ -180,9 +181,9 @@ public final class AssemblyBasedCallerUtils {
         return new SimpleInterval(region.getPaddedSpan().getContig(), padLeft, padRight);
     }
 
-    public static CachingIndexedFastaSequenceFile createReferenceReader(final String reference) {
+    public static CachingIndexedFastaSequenceFile createReferenceReader(final GATKPathSpecifier referenceInput) {
         // fasta reference reader to supplement the edges of the reference sequence
-        return new CachingIndexedFastaSequenceFile(IOUtils.getPath(reference));
+        return new CachingIndexedFastaSequenceFile(referenceInput.toPath());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -202,9 +202,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
     }
 
     private static CachingIndexedFastaSequenceFile getReferenceReader(ReferenceInputArgumentCollection referenceArguments) {
-        // TODO: this code is duplicated in AssemblyBasedCallerUtils
-        final Path reference = IOUtils.getPath(referenceArguments.getReferenceFileName());
-        return new CachingIndexedFastaSequenceFile(reference);
+        return new CachingIndexedFastaSequenceFile(referenceArguments.getReferencePath());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -202,7 +202,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
     }
 
     private static CachingIndexedFastaSequenceFile getReferenceReader(ReferenceInputArgumentCollection referenceArguments) {
-        return new CachingIndexedFastaSequenceFile(referenceArguments.getReferencePath());
+        return new CachingIndexedFastaSequenceFile(referenceArguments.getReferenceSpecifier());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -258,7 +258,7 @@ public final class Mutect2 extends AssemblyRegionWalker {
     @Override
     public void onTraversalStart() {
         VariantAnnotatorEngine annotatorEngine = new VariantAnnotatorEngine(makeVariantAnnotations(), null, Collections.emptyList(), false, false);
-        m2Engine = new Mutect2Engine(MTAC, assemblyRegionArgs, createOutputBamIndex, createOutputBamMD5, getHeaderForReads(), referenceArguments.getReferenceFileName(), annotatorEngine);
+        m2Engine = new Mutect2Engine(MTAC, assemblyRegionArgs, createOutputBamIndex, createOutputBamMD5, getHeaderForReads(), referenceArguments.getReferenceSpecifier(), annotatorEngine);
         vcfWriter = createVCFWriter(outputVCF);
         if (m2Engine.emitReferenceConfidence()) {
             logger.warn("Note that the Mutect2 reference confidence mode is in BETA -- the likelihoods model and output format are subject to change in subsequent versions.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -113,14 +113,14 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator {
      * @param createBamOutIndex true to create an index file for the bamout
      * @param createBamOutMD5 true to create an md5 file for the bamout
      * @param header header for the reads
-     * @param reference path to the reference
+     * @param referenceSpec reference specifier for the reference
      * @param annotatorEngine annotator engine built with desired annotations
      */
-    public Mutect2Engine(final M2ArgumentCollection MTAC, AssemblyRegionArgumentCollection assemblyRegionArgs, final boolean createBamOutIndex, final boolean createBamOutMD5, final SAMFileHeader header, final String reference, final VariantAnnotatorEngine annotatorEngine) {
+    public Mutect2Engine(final M2ArgumentCollection MTAC, AssemblyRegionArgumentCollection assemblyRegionArgs, final boolean createBamOutIndex, final boolean createBamOutMD5, final SAMFileHeader header, final GATKPathSpecifier referenceSpec, final VariantAnnotatorEngine annotatorEngine) {
         this.MTAC = Utils.nonNull(MTAC);
         this.header = Utils.nonNull(header);
         minCallableDepth = MTAC.callableDepth;
-        referenceReader = AssemblyBasedCallerUtils.createReferenceReader(Utils.nonNull(reference));
+        referenceReader = AssemblyBasedCallerUtils.createReferenceReader(Utils.nonNull(referenceSpec));
         aligner = SmithWatermanAligner.getAligner(MTAC.smithWatermanImplementation);
         samplesList = new IndexedSampleList(new ArrayList<>(ReadUtils.getSamplesFromHeader(header)));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
@@ -187,7 +187,7 @@ public class FilterAlignmentArtifacts extends MultiVariantWalkerGroupedOnStart {
         vcfWriter.writeHeader(vcfHeader);
         bamHeader = getHeaderForReads();
         samplesList = new IndexedSampleList(new ArrayList<>(ReadUtils.getSamplesFromHeader(bamHeader)));
-        referenceReader = AssemblyBasedCallerUtils.createReferenceReader(Utils.nonNull(referenceArguments.getReferenceFileName()));
+        referenceReader = AssemblyBasedCallerUtils.createReferenceReader(Utils.nonNull(referenceArguments.getReferenceSpecifier()));
         assemblyEngine = MTAC.createReadThreadingAssembler();
         likelihoodCalculationEngine = AssemblyBasedCallerUtils.createLikelihoodCalculationEngine(MTAC.likelihoodArgs);
         haplotypeBAMWriter = bamOutputPath == null ? Optional.empty() :

--- a/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fasta/CachingIndexedFastaSequenceFile.java
@@ -12,6 +12,7 @@ import htsjdk.samtools.util.StringUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
@@ -81,6 +82,19 @@ public final class CachingIndexedFastaSequenceFile implements ReferenceSequenceF
             throw new GATKException("Could not load " + fasta.toUri().toString() + " as an indexed fasta despite passing checks before loading.");
         }
         return referenceSequenceFile;
+    }
+
+    /**
+     * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
+     *
+     * Looks for index files for the fasta on disk.
+     * This CachingIndexedFastaReader will convert all FASTA bases to upper cases under the hood and
+     * all IUPAC bases to `N`.
+     *
+     * @param fasta The file to open.
+     */
+    public CachingIndexedFastaSequenceFile(final GATKPathSpecifier fasta) {
+        this(fasta.toPath(), false);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -47,7 +47,8 @@ public final class BucketUtils {
     public static final String GCS_PREFIX = GoogleCloudStorageFileSystem.SCHEME + "://";
     public static final String HTTP_PREFIX = HttpFileSystemProvider.SCHEME + "://";
     public static final String HTTPS_PREFIX = HttpsFileSystemProvider.SCHEME +"://";
-    public static final String HDFS_PREFIX = "hdfs://";
+    public static final String HDFS_SCHEME = "hdfs";
+    public static final String HDFS_PREFIX = HDFS_SCHEME + "://";
 
     // slashes omitted since hdfs paths seem to only have 1 slash which would be weirder to include than no slashes
     public static final String FILE_PREFIX = "file:";
@@ -98,6 +99,13 @@ public final class BucketUtils {
     /**
      * Returns true if the given path is a HDFS (Hadoop filesystem) URL.
      */
+    public static boolean isHadoopUrl(GATKPathSpecifier pathSpecifier) {
+        return pathSpecifier == null ? false : pathSpecifier.getURI().getScheme().equals(HDFS_SCHEME);
+    }
+
+    /**
+     * Returns true if the given path is a HDFS (Hadoop filesystem) URL.
+     */
     public static boolean isHadoopUrl(String path) {
         return path.startsWith(HDFS_PREFIX);
     }
@@ -142,7 +150,7 @@ public final class BucketUtils {
                 FileSystem fs = file.getFileSystem(new Configuration());
                 inputStream = fs.open(file);
             } else {
-                 inputStream = new FileInputStream(path);
+                inputStream = new FileInputStream(path);
             }
 
             if(IOUtil.hasBlockCompressedExtension(path)){

--- a/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkUtils.java
@@ -26,6 +26,7 @@ import org.broadinstitute.hellbender.utils.read.*;
 import scala.Tuple2;
 
 import java.io.*;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -110,17 +111,18 @@ public final class SparkUtils {
     /**
      * Determine if the <code>targetPath</code> exists.
      * @param ctx JavaSparkContext
-     * @param targetPath the <code>org.apache.hadoop.fs.Path</code> object to check
+     * @param targetURI the <code>org.apache.hadoop.fs.Path</code> URI to check
      * @return true if the targetPath exists, otherwise false
      */
-    public static boolean pathExists(final JavaSparkContext ctx, final Path targetPath) {
+    public static boolean hadoopPathExists(final JavaSparkContext ctx, final URI targetURI) {
         Utils.nonNull(ctx);
-        Utils.nonNull(targetPath);
+        Utils.nonNull(targetURI);
         try {
-            final FileSystem fs = targetPath.getFileSystem(ctx.hadoopConfiguration());
-            return fs.exists(targetPath);
+            final Path targetHadoopPath = new Path(targetURI);
+            final FileSystem fs = targetHadoopPath.getFileSystem(ctx.hadoopConfiguration());
+            return fs.exists(targetHadoopPath);
         } catch (IOException e) {
-            throw new UserException("Error validating existence of path " + targetPath + ": " + e.getMessage());
+            throw new UserException("Error validating existence of path " + targetURI + ": " + e.getMessage());
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
@@ -5,11 +5,9 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineParser;
-import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.io.File;
 
 public final class ReferenceInputArgumentCollectionTest {
     private static class WithOptionalReferenceCollection {
@@ -43,7 +41,7 @@ public final class ReferenceInputArgumentCollectionTest {
     public void testGetNullPath(){
         final ReferenceInputArgumentCollection nullPath = new ReferenceInputArgumentCollection(){
             private static final long serialVersionUID = 0L;
-            @Override public String getReferenceFileName() { return null;}
+            @Override public GATKPathSpecifier getReferenceSpecifier() { return null;}
         };
 
         Assert.assertNull(nullPath.getReferencePath());

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -172,11 +173,13 @@ public class ReadsSparkSinkUnitTest extends GATKBaseTest {
     private void assertSingleShardedWritingWorks(String inputBam, String referenceFile, String outputPath, String outputPartsPath, boolean writeBai, boolean writeSbi, long sbiGranularity) throws IOException {
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
 
-        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, referenceFile);
-        SAMFileHeader header = readSource.getHeader(inputBam, referenceFile);
+        final GATKPathSpecifier referencePath = referenceFile == null ? null : new GATKPathSpecifier(referenceFile);
 
-        ReadsSparkSink.writeReads(ctx, outputPath, referenceFile, rddParallelReads, header, ReadsWriteFormat.SINGLE, 0, outputPartsPath, writeBai, writeSbi, true, sbiGranularity);
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, referencePath);
+        SAMFileHeader header = readSource.getHeader(inputBam, referencePath);
+
+        ReadsSparkSink.writeReads(ctx, outputPath, referencePath, rddParallelReads, header, ReadsWriteFormat.SINGLE, 0, outputPartsPath, writeBai, writeSbi, true, sbiGranularity);
 
         // check that a bai file is created
         if (IOUtils.isBamFileName(outputPath) && writeBai) {
@@ -190,7 +193,7 @@ public class ReadsSparkSinkUnitTest extends GATKBaseTest {
             Assert.assertEquals(sbi.getGranularity(), sbiGranularity);
         }
 
-        JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputPath, referenceFile);
+        JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputPath, referencePath);
         final List<GATKRead> writtenReads = rddParallelReads2.collect();
 
         assertReadsAreSorted(header, writtenReads);
@@ -214,19 +217,21 @@ public class ReadsSparkSinkUnitTest extends GATKBaseTest {
         final File outputFile = createTempFile(outputFileName, outputFileExtension);
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
 
-        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, referenceFile);
-        rddParallelReads = rddParallelReads.repartition(2); // ensure that the output is in two shards
-        SAMFileHeader header = readSource.getHeader(inputBam, referenceFile);
+        final GATKPathSpecifier referencePath = referenceFile == null ? null : new GATKPathSpecifier(referenceFile);
 
-        ReadsSparkSink.writeReads(ctx, outputFile.getAbsolutePath(), referenceFile, rddParallelReads, header, ReadsWriteFormat.SHARDED, 0, null, false, sbiGranularity);
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam, referencePath);
+        rddParallelReads = rddParallelReads.repartition(2); // ensure that the output is in two shards
+        SAMFileHeader header = readSource.getHeader(inputBam, referencePath);
+
+        ReadsSparkSink.writeReads(ctx, outputFile.getAbsolutePath(), referencePath, rddParallelReads, header, ReadsWriteFormat.SHARDED, 0, null, false, sbiGranularity);
         int shards = outputFile.listFiles((dir, name) -> !name.startsWith(".") && !name.startsWith("_")).length;
         Assert.assertEquals(shards, 2);
         // check that no local .crc files are created
         int crcs = outputFile.listFiles((dir, name) -> name.startsWith(".") && name.endsWith(".crc")).length;
         Assert.assertEquals(crcs, 0);
 
-        JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputFile.getAbsolutePath(), referenceFile);
+        JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputFile.getAbsolutePath(), referencePath);
         // reads are not globally sorted, so don't test that
         Assert.assertEquals(rddParallelReads.count(), rddParallelReads2.count());
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSourceUnitTest.java
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 public class ReferenceFileSparkSourceUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = UserException.MissingReference.class)
-    public void testMissingReferenceFile() throws IOException {
+    public void testMissingReferenceFile() {
         new ReferenceFileSparkSource(
                 new GATKPathSpecifier(GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta").toString()));
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceFileSparkSourceUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.engine.spark.datasources;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.SparkTestUtils;
 import org.testng.annotations.Test;
@@ -17,8 +18,7 @@ public class ReferenceFileSparkSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = UserException.MissingReference.class)
     public void testMissingReferenceFile() throws IOException {
         new ReferenceFileSparkSource(
-                GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta")
-                        .getAbsolutePath());
+                new GATKPathSpecifier(GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta").toString()));
     }
 
     @Test
@@ -31,7 +31,7 @@ public class ReferenceFileSparkSourceUnitTest extends GATKBaseTest {
             final Path dictPath = jimfs.getPath("reference.dict");
             Files.createFile(dictPath);
 
-            new ReferenceFileSparkSource(refPath);
+            new ReferenceFileSparkSource(new GATKPathSpecifier(refPath.toUri().toString()));
         }
     }
 
@@ -41,7 +41,7 @@ public class ReferenceFileSparkSourceUnitTest extends GATKBaseTest {
         GATKBaseTest.createTempFile("reference", ".fasta.fai");
         GATKBaseTest.createTempFile("reference", ".dict");
 
-        final ReferenceFileSparkSource referenceFileSource = new ReferenceFileSparkSource(refPath);
+        final ReferenceFileSparkSource referenceFileSource = new ReferenceFileSparkSource(new GATKPathSpecifier(refPath.toUri().toString()));
 
         //can we serialize it?
         ReferenceFileSparkSource otherSide = SparkTestUtils.roundTripThroughJavaSerialization(referenceFileSource);

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSourceUnitTest.java
@@ -1,19 +1,39 @@
 package org.broadinstitute.hellbender.engine.spark.datasources;
 
 import org.apache.spark.SparkConf;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.SparkTestUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ReferenceMultiSparkSourceUnitTest extends GATKBaseTest {
+    private String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
 
-    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+    @DataProvider(name="referenceTestCases")
+    public Object[][] getReferenceTestCases() {
+        return new Object[][] {
+                { twoBitRefURL, false },
+                { "file:///" + twoBitRefURL, false },
+                { hg38Reference, true }, // gzipped
+                { "file:///" + hg38Reference, true }, // gzipped
+                { GCS_b37_CHR20_21_REFERENCE_2BIT, false },
+                { GCS_b37_CHR20_21_REFERENCE, true },
+                // dummy query params at the end to make sure URI.getPath does the right thing
+                { GCS_b37_CHR20_21_REFERENCE + "?query=param", true}
+        };
+    }
+
+    @Test(dataProvider = "referenceTestCases")
+    public void testIsFasta(final String referenceSpec, final boolean expectedIsFasta) {
+        Assert.assertEquals(ReferenceMultiSparkSource.isFasta(new GATKPathSpecifier(referenceSpec)), expectedIsFasta);
+    }
 
     @Test
     public void testSerializeRoundTrip2Bit() {
-        ReferenceMultiSparkSource referenceMultiSource = new ReferenceMultiSparkSource(twoBitRefURL, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        ReferenceMultiSparkSource referenceMultiSource = new ReferenceMultiSparkSource(new GATKPathSpecifier(twoBitRefURL), ReferenceWindowFunctions.IDENTITY_FUNCTION);
 
         final ReferenceMultiSparkSource roundTrippedReference = SparkTestUtils.roundTripInKryo(referenceMultiSource, ReferenceMultiSparkSource.class, new SparkConf());
 
@@ -25,7 +45,7 @@ public class ReferenceMultiSparkSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = UserException.MissingReference.class)
     public void testBadReferenceFile() {
         new ReferenceMultiSparkSource(
-                GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta").getAbsolutePath(),
+                new GATKPathSpecifier(GATKBaseTest.getSafeNonExistentFile("NonExistentReference.fasta").getAbsolutePath()),
                 ReferenceWindowFunctions.IDENTITY_FUNCTION);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceMultiSparkSourceUnitTest.java
@@ -16,9 +16,9 @@ public class ReferenceMultiSparkSourceUnitTest extends GATKBaseTest {
     public Object[][] getReferenceTestCases() {
         return new Object[][] {
                 { twoBitRefURL, false },
-                { "file:///" + twoBitRefURL, false },
+                { "file://" + twoBitRefURL, false },
                 { hg38Reference, true }, // gzipped
-                { "file:///" + hg38Reference, true }, // gzipped
+                { "file://" + hg38Reference, true }, // gzipped
                 { GCS_b37_CHR20_21_REFERENCE_2BIT, false },
                 { GCS_b37_CHR20_21_REFERENCE, true },
                 // dummy query params at the end to make sure URI.getPath does the right thing

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.engine.spark.datasources;
 
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -15,8 +16,8 @@ public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
 
     @DataProvider(name = "goodIntervals")
     public Object[][] goodIntervals() throws IOException {
-        ReferenceSparkSource fastaRef = new ReferenceFileSparkSource(fastaRefURL);
-        ReferenceSparkSource twoBitRef = new ReferenceTwoBitSparkSource(twoBitRefURL);
+        ReferenceSparkSource fastaRef = new ReferenceFileSparkSource(new GATKPathSpecifier(fastaRefURL));
+        ReferenceSparkSource twoBitRef = new ReferenceTwoBitSparkSource(new GATKPathSpecifier(twoBitRefURL));
         return new Object[][]{
                 {fastaRef, twoBitRef, "20:2-10"},
                 {fastaRef, twoBitRef, "20:4-5"},
@@ -35,7 +36,7 @@ public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
 
     @DataProvider(name = "outOfBoundsIntervals")
     public Object[][] getOutOfBoundsIntervals() throws IOException {
-        final ReferenceTwoBitSparkSource twoBitRef = new ReferenceTwoBitSparkSource(publicTestDir + "large/human_g1k_v37.20.21.2bit");
+        final ReferenceTwoBitSparkSource twoBitRef = new ReferenceTwoBitSparkSource(new GATKPathSpecifier(publicTestDir + "large/human_g1k_v37.20.21.2bit"));
         final int chr20End = 63025520;
 
         return new Object[][] {
@@ -56,4 +57,25 @@ public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
         Assert.assertEquals(bases.getBases().length, expectedNumBases, "Wrong number of bases returned from query");
         Assert.assertEquals(bases.getInterval().size(), expectedNumBases, "Wrong interval in ReferenceBases object returned from query");
     }
+
+    @DataProvider(name="referenceTestCases")
+    public Object[][] getReferenceTestCases() {
+        return new Object[][] {
+                { twoBitRefURL, true },
+                { "file:///" + twoBitRefURL, true },
+                { hg38Reference, false }, // gzipped
+                { "file:///" + hg38Reference, false }, // gzipped
+                { GCS_b37_CHR20_21_REFERENCE_2BIT, true },
+                { GCS_b37_CHR20_21_REFERENCE, false },
+                // dummy query params at the end to make sure URI.getPath does the right thing
+                { GCS_b37_CHR20_21_REFERENCE_2BIT + "?query=param", true },
+                { GCS_b37_CHR20_21_REFERENCE + "?query=param", false},
+        };
+    }
+
+    @Test(dataProvider = "referenceTestCases")
+    public void testIsTwoBit(final String referenceSpec, final boolean expectedIsTwoBit) {
+        Assert.assertEquals(ReferenceTwoBitSparkSource.isTwoBit(new GATKPathSpecifier(referenceSpec)), expectedIsTwoBit);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
@@ -62,9 +62,9 @@ public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
     public Object[][] getReferenceTestCases() {
         return new Object[][] {
                 { twoBitRefURL, true },
-                { "file:///" + twoBitRefURL, true },
+                { "file://" + twoBitRefURL, true },
                 { hg38Reference, false }, // gzipped
-                { "file:///" + hg38Reference, false }, // gzipped
+                { "file://" + hg38Reference, false }, // gzipped
                 { GCS_b37_CHR20_21_REFERENCE_2BIT, true },
                 { GCS_b37_CHR20_21_REFERENCE, false },
                 // dummy query params at the end to make sure URI.getPath does the right thing

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -6,6 +6,7 @@ import htsjdk.variant.variantcontext.GenotypeBuilder;
 import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -294,7 +295,7 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
 
     @Test
     public void testReferenceMultiSourceIsSerializable() {
-        final ReferenceMultiSparkSource args = new ReferenceMultiSparkSource(GATKBaseTest.b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+        final ReferenceMultiSparkSource args = new ReferenceMultiSparkSource(new GATKPathSpecifier(GATKBaseTest.b37_reference_20_21), ReferenceWindowFunctions.IDENTITY_FUNCTION);
         SparkTestUtils.roundTripInKryo(args, ReferenceMultiSparkSource.class, SparkContextFactory.getTestSparkContext().getConf());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtilTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtilTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.utils.SerializableFunction;
@@ -17,7 +18,7 @@ public class PSBwaUtilTest extends GATKBaseTest {
     public void testAddReferenceSequencesToHeader() {
         final SAMFileHeader header = new SAMFileHeader();
         final SerializableFunction<GATKRead, SimpleInterval> windowFunction = ReferenceWindowFunctions.IDENTITY_FUNCTION;
-        final String referencePath = hg19MiniReference;
+        final GATKPathSpecifier referencePath = new GATKPathSpecifier(hg19MiniReference);
         PSBwaUtils.addReferenceSequencesToHeader(header, referencePath, windowFunction);
         final ReferenceMultiSparkSource ref = new ReferenceMultiSparkSource(referencePath, windowFunction);
         Assert.assertEquals(ref.getReferenceSequenceDictionary(null).size(), header.getSequenceDictionary().size());

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSKmerUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSKmerUtilsTest.java
@@ -4,6 +4,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceFileSparkSource;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVKmerShort;
 import org.broadinstitute.hellbender.tools.spark.utils.LargeLongHopscotchSet;
@@ -23,7 +24,7 @@ public class PSKmerUtilsTest extends CommandLineProgramTest {
 
     @Test
     public void testGetKmersFromReference() throws IOException {
-        final ReferenceFileSparkSource ref = new ReferenceFileSparkSource( hg19MiniReference);
+        final ReferenceFileSparkSource ref = new ReferenceFileSparkSource( new GATKPathSpecifier(hg19MiniReference));
         final Collection<long[]> longCollection = PSKmerUtils.getMaskedKmersFromLocalReference(ref, 31, 1, SVKmerShort.getMask(new byte[0], 31));
 
         Assert.assertNotNull(longCollection);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
@@ -8,6 +8,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -111,10 +112,10 @@ public final class SortSamSparkIntegrationTest extends CommandLineProgramTest {
         this.runCommandLine(args);
 
         final ReadsSparkSource source = new ReadsSparkSource(SparkContextFactory.getTestSparkContext());
-        final JavaRDD<GATKRead> reads = source.getParallelReads(actualOutputFile.getAbsolutePath(), referenceFile == null ? null : referenceFile.getAbsolutePath());
+        final JavaRDD<GATKRead> reads = source.getParallelReads(actualOutputFile.getAbsolutePath(), referenceFile == null ? null : new GATKPathSpecifier(referenceFile.getAbsolutePath()));
 
         final SAMFileHeader header = source.getHeader(actualOutputFile.getAbsolutePath(),
-                                                      referenceFile == null ? null : referenceFile.getAbsolutePath());
+                referenceFileName == null ? null : new GATKPathSpecifier(referenceFile.getAbsolutePath()));
 
         final List<SAMRecord> reloadedReads = reads.collect().stream().map(read -> read.convertToSAMRecord(header)).collect(Collectors.toList());
         BaseTest.assertSorted(reloadedReads.iterator(), sortOrder.getComparatorInstance(),   reloadedReads.stream().map(SAMRecord::getSAMString).collect(Collectors.joining("\n")));

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/metrics/InsertSizeMetricsCollectorSparkUnitTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.ValidationStringency;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -57,7 +58,9 @@ public class InsertSizeMetricsCollectorSparkUnitTest extends CommandLineProgramT
             final String expectedResultsFile) throws IOException {
 
         final String inputPath = new File(TEST_DATA_DIR, fileName).getAbsolutePath();
-        final String referencePath = referenceName != null ? new File(referenceName).getAbsolutePath() : null;
+        final GATKPathSpecifier referencePath = referenceName != null ?
+                new GATKPathSpecifier(referenceName) :
+                null;
 
         final File outfile = GATKBaseTest.createTempFile("test", ".insert_size_metrics");
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/TestUtilsForAssemblyBasedSVDiscovery.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/TestUtilsForAssemblyBasedSVDiscovery.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.util.SequenceUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -25,11 +26,11 @@ import static org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils.getCano
 public final class TestUtilsForAssemblyBasedSVDiscovery {
 
     public static final ReferenceMultiSparkSource b37_reference = new ReferenceMultiSparkSource(
-            GATKBaseTest.b37_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+            new GATKPathSpecifier(GATKBaseTest.b37_reference_20_21), ReferenceWindowFunctions.IDENTITY_FUNCTION);
     public static final SAMSequenceDictionary b37_seqDict = b37_reference.getReferenceSequenceDictionary(null);
     public static final Set<String> b37_canonicalChromosomes = getCanonicalChromosomes(null, b37_seqDict);
     public static final ReferenceMultiSparkSource b38_reference_chr20_chr21 = new ReferenceMultiSparkSource(
-            GATKBaseTest.b38_reference_20_21, ReferenceWindowFunctions.IDENTITY_FUNCTION);
+            new GATKPathSpecifier(GATKBaseTest.b38_reference_20_21), ReferenceWindowFunctions.IDENTITY_FUNCTION);
     public static final SAMSequenceDictionary b38_seqDict_chr20_chr21 = b38_reference_chr20_chr21.getReferenceSequenceDictionary(null);
     public static final Set<String> b38_canonicalChromosomes = getCanonicalChromosomes(null, b38_seqDict_chr20_chr21);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ImpreciseVariantDetectorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/inference/ImpreciseVariantDetectorUnitTest.java
@@ -6,6 +6,7 @@ import htsjdk.variant.vcf.VCFConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.tools.spark.sv.StructuralVariationDiscoveryArgumentCollection;
@@ -32,7 +33,7 @@ public class ImpreciseVariantDetectorUnitTest extends GATKBaseTest {
 
 
     private final Logger localLogger = LogManager.getLogger(ImpreciseVariantDetectorUnitTest.class);
-    private static String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
+    private static GATKPathSpecifier twoBitRefURL = new GATKPathSpecifier(publicTestDir + "large/human_g1k_v37.20.21.2bit");
 
     @DataProvider(name = "evidenceTargetLinksAndVariants")
     public Object[][] getEvidenceTargetLinksAndVariants() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBadGenomicKmersSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/evidence/FindBadGenomicKmersSparkUnitTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -23,7 +24,7 @@ import java.util.*;
 public class FindBadGenomicKmersSparkUnitTest extends GATKBaseTest {
 
     private static final int KMER_SIZE = StructuralVariationDiscoveryArgumentCollection.FindBreakpointEvidenceSparkArgumentCollection.KMER_SIZE;
-    private static final String REFERENCE_FILE_NAME = hg19MiniReference;
+    private static final GATKPathSpecifier REFERENCE_FILE_NAME = new GATKPathSpecifier(hg19MiniReference);
 
     @Test(groups = "sv")
     public void badKmersTest() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVContextUnitTest.java
@@ -10,6 +10,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.tools.spark.sv.integration.SVIntegrationTestDataProvider;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -36,7 +37,7 @@ public class SVContextUnitTest extends GATKBaseTest {
 
     private static final File VALID_VARIANTS_FILE = new File(TEST_SUB_DIR, "SVContext.vcf.gz");
 
-    private static final File REFERENCE_FILE = new File(b38_reference_20_21);
+    private static final GATKPathSpecifier REFERENCE_FILE = new GATKPathSpecifier(b38_reference_20_21);
 
     /**
      * Tests {@link SVContext#of}.
@@ -212,7 +213,7 @@ public class SVContextUnitTest extends GATKBaseTest {
 
     @DataProvider(name="validVariantContexts")
     public Object[][] validVariantContexts(){
-        final ReferenceMultiSparkSource reference = referenceMultiSource(REFERENCE_FILE.getAbsolutePath());
+        final ReferenceMultiSparkSource reference = referenceMultiSource(REFERENCE_FILE);
         try (final VCFFileReader reader = new VCFFileReader(VALID_VARIANTS_FILE, false)) {
             return Utils.stream(reader)
                     .map(vc -> new Object[]{vc, reference})
@@ -224,7 +225,7 @@ public class SVContextUnitTest extends GATKBaseTest {
 
     @DataProvider(name="validInsertionsAndDeletions")
     public Object[][] validInsertionsAndDeletions(){
-        final ReferenceMultiSparkSource reference = referenceMultiSource(REFERENCE_FILE.getAbsolutePath());
+        final ReferenceMultiSparkSource reference = referenceMultiSource(REFERENCE_FILE);
         try (final VCFFileReader reader = new VCFFileReader(VALID_VARIANTS_FILE, false)) {
             return Utils.stream(reader)
                     .filter(vc -> {
@@ -251,7 +252,7 @@ public class SVContextUnitTest extends GATKBaseTest {
         for (final Tuple2<String, String> outputAndReference : outputFilesAndReference) {
             final String file = outputAndReference._1();
             final String referenceName = outputAndReference._2();
-            final ReferenceMultiSparkSource reference = referenceMultiSource(referenceName);
+            final ReferenceMultiSparkSource reference = referenceMultiSource(new GATKPathSpecifier(referenceName));
             try (final VCFFileReader reader = new VCFFileReader(new File(file), false)) {
                 reader.forEach(vc -> result.add(new Object[] {vc, reference, file}));
             } catch (final Throwable ex) {
@@ -261,8 +262,8 @@ public class SVContextUnitTest extends GATKBaseTest {
         return result.toArray(new Object[result.size()][]);
     }
 
-    private static ReferenceMultiSparkSource referenceMultiSource( final String fastaFileName) {
-        return new ReferenceMultiSparkSource(fastaFileName,
+    private static ReferenceMultiSparkSource referenceMultiSource( final GATKPathSpecifier fastaFileSpec) {
+        return new ReferenceMultiSparkSource(fastaFileSpec,
                                         (r) -> new SimpleInterval(r.getContig(), r.getAssignedStart(), r.getEnd()));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/utils/SVVCFWriterUnitTest.java
@@ -8,6 +8,7 @@ import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFIDHeaderLine;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
 import org.broadinstitute.hellbender.tools.spark.sv.discovery.TestUtilsForAssemblyBasedSVDiscovery;
@@ -71,7 +72,7 @@ public class SVVCFWriterUnitTest extends GATKBaseTest {
     @Test(groups = "sv")
     public void testSetHeader() {
         SAMSequenceDictionary referenceSequenceDictionary = new ReferenceMultiSparkSource(
-                b37_2bit_reference_20_21 , ReferenceWindowFunctions.IDENTITY_FUNCTION).getReferenceSequenceDictionary(null);
+                new GATKPathSpecifier(b37_2bit_reference_20_21), ReferenceWindowFunctions.IDENTITY_FUNCTION).getReferenceSequenceDictionary(null);
         final VCFHeader vcfHeader = SVVCFWriter.getVcfHeader(referenceSequenceDictionary);
         Assert.assertNotNull(vcfHeader.getSequenceDictionary());
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -76,12 +76,12 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
             final Path tempPath = new Path(workingDirectory, "testFileExists.txt");
             final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
 
-            Assert.assertFalse(SparkUtils.pathExists(ctx, tempPath));
+            Assert.assertFalse(SparkUtils.hadoopPathExists(ctx, tempPath.toUri()));
             final FileSystem fs = tempPath.getFileSystem(ctx.hadoopConfiguration());
             final FSDataOutputStream fsOutStream = fs.create(tempPath);
             fsOutStream.close();
             fs.deleteOnExit(tempPath);
-            Assert.assertTrue(SparkUtils.pathExists(ctx, tempPath));
+            Assert.assertTrue(SparkUtils.hadoopPathExists(ctx, tempPath.toUri()));
         });
     }
 


### PR DESCRIPTION
Use `GATKPathSpecifier` for reference input and outputs, using only `GATKPathSpecifier` and `Path` internally, and eliminate as many internal interconversions between `String` and `File` in reference code paths as possible. 

