### PR TITLE
more control over scattering genomics DB in M2 pon wdl

### DIFF
--- a/scripts/mutect2_wdl/mutect2_pon.wdl
+++ b/scripts/mutect2_wdl/mutect2_pon.wdl
@@ -29,7 +29,7 @@ workflow Mutect2_Panel {
     String pon_name
 
     Int? min_contig_size
-    Int? num_contigs
+    Int? create_panel_scatter_count
 
     # runtime
     String gatk_docker
@@ -79,8 +79,8 @@ workflow Mutect2_Panel {
             ref_fasta = ref_fasta,
             ref_fai = ref_fai,
             ref_dict = ref_dict,
-            scatter_count = select_first([num_contigs, 24]),
-            split_intervals_extra_args = "--subdivision-mode BALANCING_WITHOUT_INTERVAL_SUBDIVISION --min-contig-size " + contig_size,
+            scatter_count = select_first([create_panel_scatter_count, 24]),
+            split_intervals_extra_args = "--dont-mix-contigs --min-contig-size " + contig_size,
             runtime_params = standard_runtime
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
@@ -19,6 +19,7 @@ import picard.util.IntervalList.IntervalListScatterer;
 
 import java.io.File;
 import java.text.DecimalFormat;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,6 +82,8 @@ public class SplitIntervals extends GATKTool {
     public static final String SUBDIVISION_MODE_SHORT_NAME = "mode";
     public static final String SUBDIVISION_MODE_lONG_NAME = "subdivision-mode";
 
+    public static final String DONT_MIX_CONTIGS_LONG_NAME = "dont-mix-contigs";
+
     public static final String MIN_CONTIG_SIZE_LONG_NAME = "min-contig-size";
 
     public static final String INTERVAL_FILE_EXTENSION_FULL_NAME = "extension";
@@ -106,6 +109,9 @@ public class SplitIntervals extends GATKTool {
     @Argument(doc = "Extension to use when writing interval files", fullName = INTERVAL_FILE_EXTENSION_FULL_NAME, optional = true)
     public String extension = DEFAULT_EXTENSION;
 
+    @Argument(doc = "Scattered interval files do not contain intervals from multiple contigs.  This is applied after the initial scatter, so that the requested scatter count is a lower bound on the number of actual scattered files.", fullName = DONT_MIX_CONTIGS_LONG_NAME, optional = true)
+    public boolean dontMixContigs = false;
+
     @Override
     public void onTraversalStart() {
         ParamUtils.isPositive(scatterCount, "scatter-count must be > 0.");
@@ -128,8 +134,21 @@ public class SplitIntervals extends GATKTool {
         final IntervalListScatterer scatterer = subdivisionMode.make();
         final List<IntervalList> scattered = scatterer.scatter(intervalList, scatterCount);
 
+        // optionally split interval lists that contain intervals from multiple contigs
+        final List<IntervalList> scatteredFinal = !dontMixContigs ? scattered :
+                scattered.stream().flatMap(il -> il.getIntervals().stream()
+                        .collect(Collectors.groupingBy(Interval::getContig)).entrySet().stream()    // group each interval list into sublists
+                .sorted(Comparator.comparingInt(entry -> sequenceDictionary.getSequenceIndex(entry.getKey())))  // sort entries by contig
+                 .map(entry -> entry.getValue()) // discard the keys and just keep the lists of intervals
+                .map(list -> {
+                    final IntervalList singleContigList = new IntervalList(sequenceDictionary);
+                    singleContigList.addall(list);
+                    return singleContigList;
+                })  // turn the intervals back into an IntervalList
+                ).collect(Collectors.toList());
+
         final DecimalFormat formatter = new DecimalFormat("0000");
-        IntStream.range(0, scattered.size()).forEach(n -> scattered.get(n).write(new File(outputDir, formatter.format(n) + extension)));
+        IntStream.range(0, scatteredFinal.size()).forEach(n -> scatteredFinal.get(n).write(new File(outputDir, formatter.format(n) + extension)));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
@@ -138,13 +138,13 @@ public class SplitIntervals extends GATKTool {
         final List<IntervalList> scatteredFinal = !dontMixContigs ? scattered :
                 scattered.stream().flatMap(il -> il.getIntervals().stream()
                         .collect(Collectors.groupingBy(Interval::getContig)).entrySet().stream()    // group each interval list into sublists
-                .sorted(Comparator.comparingInt(entry -> sequenceDictionary.getSequenceIndex(entry.getKey())))  // sort entries by contig
-                 .map(entry -> entry.getValue()) // discard the keys and just keep the lists of intervals
-                .map(list -> {
-                    final IntervalList singleContigList = new IntervalList(sequenceDictionary);
-                    singleContigList.addall(list);
-                    return singleContigList;
-                })  // turn the intervals back into an IntervalList
+                        .sorted(Comparator.comparingInt(entry -> sequenceDictionary.getSequenceIndex(entry.getKey())))  // sort entries by contig
+                        .map(entry -> entry.getValue()) // discard the keys and just keep the lists of intervals
+                        .map(list -> {
+                            final IntervalList singleContigList = new IntervalList(sequenceDictionary);
+                            singleContigList.addall(list);
+                            return singleContigList;
+                        })  // turn the intervals back into an IntervalList
                 ).collect(Collectors.toList());
 
         final DecimalFormat formatter = new DecimalFormat("0000");

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
@@ -16,8 +16,6 @@ import org.testng.annotations.Test;
 import picard.util.IntervalList.IntervalListScatterMode;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
@@ -3,13 +3,14 @@ package org.broadinstitute.hellbender.tools.walkers;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.IntervalList;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.IntervalMergingRule;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import picard.util.IntervalList.IntervalListScatterMode;
@@ -29,20 +30,20 @@ import java.util.stream.Stream;
  */
 public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
 
-    private static final Path REFERENCE = Paths.get(b37_reference_20_21);
-    private static final GenomeLocParser GLP = new GenomeLocParser(ReferenceDataSource.of(REFERENCE).getSequenceDictionary());
+    private static final GenomeLocParser GLP = new GenomeLocParser(ReferenceDataSource.of(IOUtils.getPath(b37Reference)).getSequenceDictionary());
     private static final DecimalFormat formatter = new DecimalFormat("0000");
 
     @Test
     public void testOneInterval() {
         final int scatterCount = 5;
         final File outputDir = createTempDir("output");
-        final String[] args = {
-                "-L", "20:1000000-2000000",
-                "-R", REFERENCE.toAbsolutePath().toString(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "-O", outputDir.getAbsolutePath()
-        };
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInterval("20:1000000-2000000")
+                .addReference(b37Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, SplitIntervals.DEFAULT_EXTENSION);
         checkIntervalSizes(scatterCount, outputDir, 1000000, SplitIntervals.DEFAULT_EXTENSION);
@@ -52,14 +53,14 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
     public void testOneIntervalAlternateExtension() {
         final int scatterCount = 5;
         final File outputDir = createTempDir("output");
-        final String extension = "-scattered.with.a.wierd.extension";
-        final String[] args = {
-                "-L", "20:1000000-2000000",
-                "-R", REFERENCE.toAbsolutePath().toString(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "-O", outputDir.getAbsolutePath(),
-                "--extension", extension
-        };
+        final String extension = "-scattered.with.a.weird.extension";
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInterval("20:1000000-2000000")
+                .addReference(b37Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .add(SplitIntervals.INTERVAL_FILE_EXTENSION_FULL_NAME, extension)
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, extension);
         checkIntervalSizes(scatterCount, outputDir, 1000000, extension);
@@ -69,12 +70,12 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
     public void testSingleScatter() {
         final int scatterCount = 1;
         final File outputDir = createTempDir("output");
-        final String[] args = {
-                "-L", "20:1000000-2000000",
-                "-R", REFERENCE.toAbsolutePath().toString(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "-O", outputDir.getAbsolutePath()
-        };
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInterval("20:1000000-2000000")
+                .addReference(b37Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, SplitIntervals.DEFAULT_EXTENSION);
         checkIntervalSizes(scatterCount, outputDir, 1000000, SplitIntervals.DEFAULT_EXTENSION);
@@ -85,13 +86,13 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
     public void testTwoIntervals() {
         final int scatterCount = 5;
         final File outputDir = createTempDir("output");
-        final String[] args = {
-                "-L", "20:1000000-2000000",
-                "-L", "20:3000000-4000000",
-                "-R", REFERENCE.toAbsolutePath().toString(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "-O", outputDir.getAbsolutePath()
-        };
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInterval("20:1000000-2000000")
+                .addInterval("20:3000000-4000000")
+                .addReference(b37Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, SplitIntervals.DEFAULT_EXTENSION);
         checkIntervalSizes(scatterCount, outputDir, 2000000, SplitIntervals.DEFAULT_EXTENSION);
@@ -119,16 +120,15 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
     public void testNoIntervals() {
         final int scatterCount = 5;
         final File outputDir = createTempDir("output");
-        final String[] args = {
-                "-R", REFERENCE.toAbsolutePath().toString(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "-O", outputDir.getAbsolutePath()
-        };
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addReference(b37Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, SplitIntervals.DEFAULT_EXTENSION);
-        final int totalLengthInRef = GLP.getSequenceDictionary().getSequences().stream().mapToInt(SAMSequenceRecord::getSequenceLength).sum();
+        final long totalLengthInRef = GLP.getSequenceDictionary().getSequences().stream().mapToLong(SAMSequenceRecord::getSequenceLength).sum();
         checkIntervalSizes(scatterCount, outputDir, totalLengthInRef, SplitIntervals.DEFAULT_EXTENSION);
-
     }
 
     @Test
@@ -137,25 +137,27 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         final File wgsCallingIntervals = new File(publicTestDir + "hg38.handcurated.noCentromeres.noTelomeres.interval_list");
         final int scatterCount = 100;
         final File outputDir = createTempDir("output");
-        final String[] args = {
-                "-R", hg38Reference,
-                "-L", wgsCallingIntervals.getAbsolutePath(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "--" + SplitIntervals.SUBDIVISION_MODE_lONG_NAME, IntervalListScatterMode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW.toString(),
-                "-imr", IntervalMergingRule.OVERLAPPING_ONLY.toString(),
-                "-O", outputDir.getAbsolutePath()
-        };
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addIntervals(wgsCallingIntervals)
+                .addReference(hg38Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .add(SplitIntervals.SUBDIVISION_MODE_lONG_NAME, IntervalListScatterMode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW.toString())
+                .add(IntervalArgumentCollection.INTERVAL_MERGING_RULE_LONG_NAME, IntervalMergingRule.OVERLAPPING_ONLY.toString())
+                .addOutput(outputDir);
+
         runCommandLine(args);
         verifyScatteredFilesExist(scatterCount, outputDir, SplitIntervals.DEFAULT_EXTENSION);
 
         final File outputDir2 = createTempDir("output2");
-        final String[] args2 = {
-                "-R", hg38Reference,
-                "-L", wgsCallingIntervals.getAbsolutePath(),
-                "-" + SplitIntervals.SCATTER_COUNT_SHORT_NAME, Integer.toString(scatterCount),
-                "--" + SplitIntervals.SUBDIVISION_MODE_lONG_NAME, IntervalListScatterMode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW.toString(),
-                "-O", outputDir2.getAbsolutePath()
-        };
+
+        final ArgumentsBuilder args2 = new ArgumentsBuilder()
+                .addIntervals(wgsCallingIntervals)
+                .addReference(hg38Reference)
+                .add(SplitIntervals.SCATTER_COUNT_SHORT_NAME, scatterCount)
+                .add(SplitIntervals.SUBDIVISION_MODE_lONG_NAME, IntervalListScatterMode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW.toString())
+                .addOutput(outputDir2);
+
         runCommandLine(args2);
         Assert.assertTrue(outputDir2.listFiles().length < scatterCount);
     }
@@ -174,14 +176,14 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
         return Utils.stream(IntervalList.fromFile(intervalsFile)).map(SimpleInterval::new).collect(Collectors.toList());
     }
 
-    private static void checkIntervalSizes(final int scatterCount, final File outputDir, final int expectedTotalLength, String extension) {
-        final int splitLength = expectedTotalLength / scatterCount;
-        getExpectedScatteredFiles(scatterCount, outputDir, extension).forEach(f -> Assert.assertEquals(readIntervals(f).stream().mapToInt(SimpleInterval::size).sum(), splitLength, 100));
+    private static void checkIntervalSizes(final int scatterCount, final File outputDir, final long expectedTotalLength, String extension) {
+        final long splitLength = expectedTotalLength / scatterCount;
+        getExpectedScatteredFiles(scatterCount, outputDir, extension).forEach(f -> Assert.assertEquals(readIntervals(f).stream().mapToLong(SimpleInterval::size).sum(), splitLength, 100));
     }
 
-    private static void checkTotalSize(final int scatterCount, final File outputDir, final int expectedTotalLength, String extension) {
-        final int totalLength = getExpectedScatteredFiles(scatterCount, outputDir, extension)
-                .mapToInt(f -> readIntervals(f).stream().mapToInt(SimpleInterval::size).sum())
+    private static void checkTotalSize(final int scatterCount, final File outputDir, final long expectedTotalLength, String extension) {
+        final long totalLength = getExpectedScatteredFiles(scatterCount, outputDir, extension)
+                .mapToLong(f -> readIntervals(f).stream().mapToLong(SimpleInterval::size).sum())
                 .sum();
         Assert.assertEquals(totalLength, expectedTotalLength);
     }


### PR DESCRIPTION
@fleharty This should resolve Sachet's issue by allowing arbitrarily much scattering, reducing the memory required by `GenomicsDBImport`.