### PR TITLE
PathSeq WDL overhaul

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -3,7 +3,7 @@
 # Have script stop if there is an error
 set -e
 
-REPO=broadinstitute
+REPO=mwalker174
 PROJECT=gatk
 REPO_PRJ=${REPO}/${PROJECT}
 GCR_REPO="us.gcr.io/broad-gatk/gatk"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -3,7 +3,7 @@
 # Have script stop if there is an error
 set -e
 
-REPO=mwalker174
+REPO=broadinstitute
 PROJECT=gatk
 REPO_PRJ=${REPO}/${PROJECT}
 GCR_REPO="us.gcr.io/broad-gatk/gatk"

--- a/scripts/pathseq/wdl/README.md
+++ b/scripts/pathseq/wdl/README.md
@@ -3,45 +3,44 @@
 ### Setting up parameter json file for a run
 
 To get started, *copy* the ``pathseq_pipeline_template.json`` for the workflow and modify the parameters accordingly.
-DO NOT commit your json file to this repo. This file has reasonable default parameters.
+DO NOT commit your json file to this repo.
 
-PathSeq reference files are available in the [GATK Resource Bundle](https://software.broadinstitute.org/gatk/download/bundle).
+PathSeq reference files are available in the [GATK Resource Bundle](https://software.broadinstitute.org/gatk/download/bundle) at `gs://gatk-best-practices/pathseq`.
 
 *Please note that there are optional parameters that do not appear in the template files, since we do not want to specify them by default*
 
-### Docker image
-- "broadinstitute/gatk:4.1.1.0"
-
 ### Parameter descriptions
 
-Recommended default values (where possible) are found in ``pathseq_pipeline_template.json``
+Example values (where possible) are found in ``pathseq_pipeline_template.json``
 
-- ``PathSeqPipelineWorkflow.sample_name`` -- sample ID
-- ``PathSeqPipelineWorkflow.input_bam_or_cram`` -- sample BAM or CRAM file
-- ``PathSeqPipelineWorkflow.is_host_aligned`` -- Set to true if the input has already been aligned to a host reference. *NOTE: common human references (e.g. GrCh38) contain decoy sequences such as the Epstein-Barr Virus genome. If this flag is set to true, reads aligning to these decoys will be misidentified as "host" and filtered out.*
-- ``PathSeqPipelineWorkflow.filter_bwa_image`` -- Path to host BWA index image. This corresponds to `pathseq_host.fa.img` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.kmer_file`` -- Path to host k-mer file. This corresponds to `pathseq_host.bfi` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.microbe_bwa_image`` -- Path to microbe BWA index image. This corresponds to `pathseq_microbe.fa.img` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.microbe_fasta_dict`` -- Path to microbe reference dictionary file. This corresponds to `pathseq_microbe.dict` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.taxonomy_file`` -- Path to PathSeq taxonomy file. This corresponds to `pathseq_taxonomy.db` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.gatk_docker`` -- GATK docker image ( >= v4.0.0.0)
+- ``PathSeqPipeline.sample_name`` -- Sample ID
+- ``PathSeqPipeline.input_bam_or_cram`` -- Sample BAM or CRAM file
+- ``PathSeqPipeline.input_bam_or_cram_index`` -- Sample BAM or CRAM index
+- ``PathSeqPipeline.downsample`` -- Set true to downsample input. It is strongly recommended that there are <10M total microbial reads.
+- ``PathSeqPipeline.Downsample.reads_after_downsampling`` - Target number of reads if downsampling is enabled
+- ``PathSeqPipeline.PathSeqFilter.is_host_aligned`` -- Set to true if the input has already been aligned to a host reference. *NOTE: some human references (e.g. hg38) contain decoy sequences such as Epstein-Barr virus. If this flag is set to true, use `ignored_alignment_contigs` as necessary to prevent reads aligning to these decoys from being misidentified as "host".*
+- ``PathSeqPipeline.PathSeqFilter.filter_bwa_image`` -- Path to host BWA index image (may be omitted to skip). This corresponds to `pathseq_host.fa.img` in the Resource Bundle.
+- ``PathSeqPipeline.PathSeqFilter.kmer_file`` -- Path to host k-mer file (may be omitted to skip). This corresponds to `pathseq_host.bfi` in the Resource Bundle.
+- ``PathSeqPipeline.PathSeqAlign.microbe_bwa_image`` -- Path to microbe BWA index image. This corresponds to `pathseq_microbe.fa.img` in the Resource Bundle.
+- ``PathSeqPipeline.PathSeqAlign.microbe_dict`` -- Path to microbe reference dictionary file. This corresponds to `pathseq_microbe.dict` in the Resource Bundle.
+- ``PathSeqPipeline.PathSeqScore.taxonomy_file`` -- Path to PathSeq taxonomy file. This corresponds to `pathseq_taxonomy.db` in the Resource Bundle.
+- ``PathSeqPipeline.gatk_docker`` -- GATK docker image ( > v4.1.7.0)
 
 Optional parameters:
 
-- ``PathSeqPipelineWorkflow.estimate_filter_metrics_with_downsampling`` -- read filter metrics will be estimated using a downsampled bam (highly recommended) (default true)
-- ``PathSeqPipelineWorkflow.estimate_filter_metrics_reads`` -- number of reads to downsample to for filter metrics estimation, recommended 1M for samples with ~0.1% non-host reads (default 1M)
-- ``PathSeqPipelineWorkflow.min_clipped_read_length`` -- Minimum read length after quality trimming. Increasing may increase microbial classification specificity but may reduce sensitivity (default 31)
-- ``PathSeqPipelineWorkflow.min_score_identity`` -- Fraction of bases aligned to count a microbe alignment in abundance scoring (default 0.9)
-- ``PathSeqPipelineWorkflow.identity_margin`` -- If a read maps to more than one microbe, the best alignment is counted. Any additional alignments are also counted if they are within this margin of the best alignment (default 0.02)
-- ``PathSeqPipelineWorkflow.divide_by_genome_length`` -- If true, abundance scores are normalized by genome length (default false)
-- ``PathSeqPipelineWorkflow.filter_duplicates`` -- If true, reads with identical sequences will be filtered (default true)
-- ``PathSeqPipelineWorkflow.skip_quality_filters`` -- If true, skips quality filtering steps (default false)
-- ``PathSeqPipelineWorkflow.skip_pre_bwa_repartition`` -- Advanced tuning parameter; recommended if the sample contains a large number (e.g. >10M) microbial reads (default false)
-- ``PathSeqPipelineWorkflow.filter_bwa_seed_length`` -- Sets host alignment MEM length. Reducing this valueincreases host read detection sensitivity but is slower (default 19) 
-- ``PathSeqPipelineWorkflow.host_min_identity`` -- Minimum identity score for reads to be classified as host (default 30)
-- ``PathSeqPipelineWorkflow.filter_bam_partition_size`` -- Advanced tuning parameter; set size of Spark partitions read from disk (default 4000000)
-- ``PathSeqPipelineWorkflow.*_mem_gb`` -- Virtual machine (VM) memory in GB (default 208 GB)
-- ``PathSeqPipelineWorkflow.*_preemptible_attempts`` -- Minimum number of attempts on preemtible VMs before the job will fail (default 3)
-- ``PathSeqPipelineWorkflow.*_additional_disk_gb`` -- VM disk space padding in GB
-- ``PathSeqPipelineWorkflow.*_cpu`` -- Number of VM virtual processor cores (default 32)
-- ``PathSeqPipelineWorkflow.*_ssd`` -- Use solid-state disks (default false)
+- ``PathSeqPipeline.ignored_alignment_contigs`` -- Array of contig names that will be ignored when filtering pre-aligned reads (see `is_host_aligned` above), e.g. "chrEBV".
+- ``PathSeqPipeline.PathSeqFilter.min_clipped_read_length`` -- Minimum read length after quality trimming. Increasing may increase microbial classification specificity but may reduce sensitivity (default 31)
+- ``PathSeqPipeline.PathSeqFilter.filter_duplicates`` -- If true, reads with identical sequences will be filtered (default true)
+- ``PathSeqPipeline.PathSeqFilter.skip_quality_filters`` -- If true, skips quality filtering steps (default false)
+- ``PathSeqPipeline.PathSeqFilter.skip_pre_bwa_repartition`` -- Advanced tuning parameter; recommended if the sample contains a large number (e.g. >10M) microbial reads (default false)
+- ``PathSeqPipeline.PathSeqFilter.filter_bwa_seed_length`` -- Sets host alignment MEM length. Reducing this value increases host read detection sensitivity but is slower (default 19) 
+- ``PathSeqPipeline.PathSeqFilter.host_min_identity`` -- Minimum identity score for reads to be classified as host (default 30)
+- ``PathSeqPipeline.PathSeqScore.min_score_identity`` -- Fraction of bases aligned to count a microbe alignment in abundance scoring (default 0.9)
+- ``PathSeqPipeline.PathSeqScore.identity_margin`` -- If a read maps to more than one microbe, the best alignment is counted. Any additional alignments are also counted if they are within this margin of the best alignment (default 0.02)
+- ``PathSeqPipeline.PathSeqScore.divide_by_genome_length`` -- If true, abundance scores are normalized by genome length (default false)
+- ``PathSeqPipeline.PathSeqScore.not_normalized_by_kingdom`` -- If true, normalized scores are tallied by superkingdom (default false)
+- ``PathSeqPipeline.*_mem_gb`` -- Virtual machine (VM) memory in GB (default 208 GB)
+- ``PathSeqPipeline.*_preemptible_attempts`` -- Minimum number of attempts on preemtible VMs before the job will fail (default 3)
+- ``PathSeqPipeline.*_additional_disk_gb`` -- VM disk space padding in GB
+- ``PathSeqPipeline.*_cpu`` -- Number of VM virtual processor cores (default 32)
+- ``PathSeqPipeline.*_ssd`` -- Use solid-state disks (default false)

--- a/scripts/pathseq/wdl/README.md
+++ b/scripts/pathseq/wdl/README.md
@@ -5,31 +5,32 @@
 To get started, *copy* the ``pathseq_pipeline_template.json`` for the workflow and modify the parameters accordingly.
 DO NOT commit your json file to this repo. This file has reasonable default parameters.
 
-PathSeq reference files are available in the [GATK Resource Bundle](https://software.broadinstitute.org/gatk/download/bundle) (located [here](ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/beta/PathSeq)).
+PathSeq reference files are available in the [GATK Resource Bundle](https://software.broadinstitute.org/gatk/download/bundle).
 
 *Please note that there are optional parameters that do not appear in the template files, since we do not want to specify them by default*
 
 ### Docker image
-- "broadinstitute/gatk:4.0.0.0"
+- "broadinstitute/gatk:4.1.1.0"
 
 ### Parameter descriptions
 
 Recommended default values (where possible) are found in ``pathseq_pipeline_template.json``
 
 - ``PathSeqPipelineWorkflow.sample_name`` -- sample ID
-- ``PathSeqPipelineWorkflow.input_bam`` -- sample BAM file
+- ``PathSeqPipelineWorkflow.input_bam_or_cram`` -- sample BAM or CRAM file
 - ``PathSeqPipelineWorkflow.is_host_aligned`` -- Set to true if the input has already been aligned to a host reference. *NOTE: common human references (e.g. GrCh38) contain decoy sequences such as the Epstein-Barr Virus genome. If this flag is set to true, reads aligning to these decoys will be misidentified as "host" and filtered out.*
 - ``PathSeqPipelineWorkflow.filter_bwa_image`` -- Path to host BWA index image. This corresponds to `pathseq_host.fa.img` in the Resource Bundle.
 - ``PathSeqPipelineWorkflow.kmer_file`` -- Path to host k-mer file. This corresponds to `pathseq_host.bfi` in the Resource Bundle.
 - ``PathSeqPipelineWorkflow.microbe_bwa_image`` -- Path to microbe BWA index image. This corresponds to `pathseq_microbe.fa.img` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.microbe_fasta`` -- Path to microbe reference FASTA file. This corresponds to `pathseq_microbe.fa` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.microbe_fasta_dict`` -- Path to microbe reference dictionary file.This corresponds to `pathseq_microbe.dict` in the Resource Bundle.
+- ``PathSeqPipelineWorkflow.microbe_fasta_dict`` -- Path to microbe reference dictionary file. This corresponds to `pathseq_microbe.dict` in the Resource Bundle.
 - ``PathSeqPipelineWorkflow.taxonomy_file`` -- Path to PathSeq taxonomy file. This corresponds to `pathseq_taxonomy.db` in the Resource Bundle.
-- ``PathSeqPipelineWorkflow.gatk_docker`` -- GATK docker image
+- ``PathSeqPipelineWorkflow.gatk_docker`` -- GATK docker image ( >= v4.0.0.0)
 
 Optional parameters:
 
-- ``PathSeqPipelineWorkflow.min_clipped_read_length`` -- Minimum read length after quality trimming. You may need to reduce this if your input reads are shorter than the default value (default 60)
+- ``PathSeqPipelineWorkflow.estimate_filter_metrics_with_downsampling`` -- read filter metrics will be estimated using a downsampled bam (highly recommended) (default true)
+- ``PathSeqPipelineWorkflow.estimate_filter_metrics_reads`` -- number of reads to downsample to for filter metrics estimation, recommended 1M for samples with ~0.1% non-host reads (default 1M)
+- ``PathSeqPipelineWorkflow.min_clipped_read_length`` -- Minimum read length after quality trimming. Increasing may increase microbial classification specificity but may reduce sensitivity (default 31)
 - ``PathSeqPipelineWorkflow.min_score_identity`` -- Fraction of bases aligned to count a microbe alignment in abundance scoring (default 0.9)
 - ``PathSeqPipelineWorkflow.identity_margin`` -- If a read maps to more than one microbe, the best alignment is counted. Any additional alignments are also counted if they are within this margin of the best alignment (default 0.02)
 - ``PathSeqPipelineWorkflow.divide_by_genome_length`` -- If true, abundance scores are normalized by genome length (default false)
@@ -38,8 +39,9 @@ Optional parameters:
 - ``PathSeqPipelineWorkflow.skip_pre_bwa_repartition`` -- Advanced tuning parameter; recommended if the sample contains a large number (e.g. >10M) microbial reads (default false)
 - ``PathSeqPipelineWorkflow.filter_bwa_seed_length`` -- Sets host alignment MEM length. Reducing this valueincreases host read detection sensitivity but is slower (default 19) 
 - ``PathSeqPipelineWorkflow.host_min_identity`` -- Minimum identity score for reads to be classified as host (default 30)
-- ``PathSeqPipelineWorkflow.bam_partition_size`` -- Advanced tuning parameter; set size of Spark read partitions. Reducing this value increases parallelism but may also increase overhead and affect host BWA alignment (default 4000000)
-- ``PathSeqPipelineWorkflow.mem_gb`` -- Virtual machine (VM) memory in GB (default 208 GB)
-- ``PathSeqPipelineWorkflow.preemptible_attempts`` -- Minimum number of attempts on preemtible VMs before the job will fail (default 3)
-- ``PathSeqPipelineWorkflow.disk_space_gb`` -- VM disk space in GB (automatically sized by default)
-- ``PathSeqPipelineWorkflow.cpu`` -- Number of VM virtual processor cores (default 32)
+- ``PathSeqPipelineWorkflow.filter_bam_partition_size`` -- Advanced tuning parameter; set size of Spark partitions read from disk (default 4000000)
+- ``PathSeqPipelineWorkflow.*_mem_gb`` -- Virtual machine (VM) memory in GB (default 208 GB)
+- ``PathSeqPipelineWorkflow.*_preemptible_attempts`` -- Minimum number of attempts on preemtible VMs before the job will fail (default 3)
+- ``PathSeqPipelineWorkflow.*_additional_disk_gb`` -- VM disk space padding in GB
+- ``PathSeqPipelineWorkflow.*_cpu`` -- Number of VM virtual processor cores (default 32)
+- ``PathSeqPipelineWorkflow.*_ssd`` -- Use solid-state disks (default false)

--- a/scripts/pathseq/wdl/README.md
+++ b/scripts/pathseq/wdl/README.md
@@ -5,7 +5,7 @@
 To get started, *copy* the ``pathseq_pipeline_template.json`` for the workflow and modify the parameters accordingly.
 DO NOT commit your json file to this repo.
 
-PathSeq reference files are available in the [GATK Resource Bundle](https://software.broadinstitute.org/gatk/download/bundle) at `gs://gatk-best-practices/pathseq`.
+PathSeq reference files are available in the [GATK Resource Bundle](https://gatk.broadinstitute.org/hc/en-us/articles/360035890811-Resource-bundle) at `gs://gatk-best-practices/pathseq`.
 
 *Please note that there are optional parameters that do not appear in the template files, since we do not want to specify them by default*
 

--- a/scripts/pathseq/wdl/pathseq_pipeline.wdl
+++ b/scripts/pathseq/wdl/pathseq_pipeline.wdl
@@ -2,7 +2,13 @@
 ## PathSeq Pipeline WDL
 ########################################################################################################################
 ##
-## Runs the PathSeq pipeline
+## Runs the PathSeq pipeline for detecting microbes in deep sequencing data.
+##
+## Important: Filtering metrics should only be generated (gather_filter_metrics=true) on a downsampled BAM.
+##
+## Important: For microbe-rich samples users should set downsampling=true and adjust downsample_reads so that the total
+##   number of microbe reads is <10M. The total number of microbe reads can be estimated from a preliminary run of this
+#    workflow with downsampling=true, filtering_only=false, and gather_filter_metrics=true.
 ##
 ## For further info see the GATK Documentation for the PathSeqPipelineSpark tool:
 ##   https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_spark_pathseq_PathSeqPipelineSpark.php
@@ -10,7 +16,7 @@
 ########################################################################################################################
 ##
 ## Input requirements :
-## - Sequencing data in BAM format
+## - Sequencing data in CRAM or BAM format
 ## - Host and microbe references files available in the GATK Resource Bundle (available on FTP):
 ##     https://software.broadinstitute.org/gatk/download/bundle
 ##
@@ -20,179 +26,712 @@
 ## - - one or more read groups all belong to a single sample (SM)
 ##
 ## Output:
-## - BAM file containing microbe-mapped reads and reads of unknown sequence
-## - Tab-separated value (.tsv) file of taxonomic abundance scores
-## - Picard-style metrics files for the filter and scoring phases of the pipeline
+## - non_host_paired_bam, non_host_unpaired_bam: BAM files containing quality-filtered non-host paired and unpaired reads
+## - If filtering_only = false:
+##   - final_bam : BAM file containing microbe-mapped reads and reads of unknown sequence
+##   - taxonomy_scores : tab-separated value (.tsv) file of taxonomic abundance scores
+##   - score_metrics_file : Picard-style metrics file for scoring stage
+##   - non_host_mapped_reads : number of non-host reads mapped to microbe reference
+##   - non_host_unmapped_reads : number of non-host reads that did not map to the microbe reference
+## - If gather_filter_metrics = true:
+##   - filter_metrics_file : Picard-style metrics file for filtering stage
+##   - frac_after_prealigned_filter : estimated fraction of reads remaining after filtering prealigned host reads
+##   - frac_after_qual_cpx_filter : estimated fraction of reads remaining after low-quality and low-complexity filtering
+##   - frac_after_host_filter : estimated fraction of reads remaining after host read filtering
+##   - frac_after_dedup : estimated fraction of reads remaining after deduplication
+##   - frac_final_paired : estimated fraction of reads that were paired in the final output
+##   - frac_final_unpaired : estimated fraction of reads that were unpaired in the final output
+##   - frac_final_total : estimated fraction of reads in the final output
+##   - frac_qual_cpx_filtered : estimated fraction of reads removed by low-quality/low-complexity filtering
+##   - frac_host_filtered : estimated fraction of reads removed by host filtering
+##   - frac_dup_filtered : estimated fraction of reads removed by deduplication
+## - If downsample = true:
+##   - total_reads_if_avail : total number of reads in the original input BAM
 ##
 ########################################################################################################################
 
-task PathseqPipeline {
+workflow PathSeqPipeline {
 
-  # Inputs for this task
   String sample_name
-  File input_bam
+  File input_bam_or_cram
+  # Required if a cram
+  File? input_bam_or_cram_index
 
-  File kmer_file
-  File filter_bwa_image
-  File microbe_bwa_image
-  File microbe_fasta
-  File microbe_fasta_dict
-  File taxonomy_file
+  # Required if the input is a cram
+  File? cram_reference_fasta
+  File? cram_reference_fasta_index
+  File? cram_reference_dict
 
+  # Set to true if host aligned. WARNING: Results in loss of EBV reads if in the aligned reference.
   Boolean is_host_aligned
-  Boolean? skip_quality_filters
+
+  File? kmer_file
+  File? filter_bwa_image
+  # Required if filtering_only=true
+  File? microbe_bwa_image
+  File? microbe_dict
+  File? taxonomy_file
+
+  # If enabled, filter metrics will be estimated using a downsampled bam with this many reads (recommended)
+  # If disabled, no filter metrics will be generated
+  Boolean downsample = false
+  Int downsample_reads = 1000000
+
+  # Enable to only perform host filtering
+  Boolean filtering_only = false
+
+  # Only recommended if downsample = true
+  Boolean gather_filter_metrics = false
+
+  # This can be calculated from a downsampled run to help optimize disk allocation during filtering
+  Float frac_non_host_reads = 1.0
+
+  # Filtering options
   Boolean? filter_duplicates
-  Boolean? skip_pre_bwa_repartition
-  Boolean? divide_by_genome_length
-  Int? filter_bwa_seed_length
+  Boolean? skip_quality_filters
   Int? host_min_identity
+  Int? host_kmer_threshold
+  Int? filter_bwa_seed_length
   Int? min_clipped_read_length
-  Int? bam_partition_size
+  Int? max_masked_bases
+  Int? min_base_quality
+  Int? quality_threshold
+  Int? dust_mask_quality
+  Int? dust_window
+  Float? dust_t
+  Int? max_adapter_mistmatches
+  Int? min_adapter_length
+  Int? filter_reads_per_partition
+  Int? filter_bam_partition_size
+  Boolean? skip_pre_bwa_repartition
+
+  # Alignment options
+  Int? microbe_min_seed_length
+  Int? max_alternate_hits
+  Int? bwa_score_threshold
+
+  # Taxonomy scoring options
+  Boolean? divide_by_genome_length
   Float? min_score_identity
   Float? identity_margin
+  Boolean? not_normalized_by_kingdom
+  Int? score_reads_per_partition_estimate
 
-  String bam_output_path = "${sample_name}.pathseq.bam"
-  String scores_output_path = "${sample_name}.pathseq.tsv"
-  String filter_metrics_output_path = "${sample_name}.pathseq.filter_metrics"
-  String score_metrics_output_path = "${sample_name}.pathseq.score_metrics"
+  # Runtime parameters
+  String gatk_docker
+  String samtools_docker = "biocontainers/samtools:v1.9-4-deb_cv1"
+  String genomes_in_the_cloud_docker = "broadinstitute/genomes-in-the-cloud:2.3.1-1512499786"
+  String linux_docker = "ubuntu:18.10"
 
   File? gatk4_jar_override
 
-  # Runtime parameters
-  Int? mem_gb
-  String gatk_docker
-  Int? preemptible_attempts
-  Int? disk_space_gb
-  Int? cpu
-  Boolean use_ssd = true
+  Int? cram_to_bam_preemptible_attempts
+  Int? downsample_preemptible_attempts
+  Int? filter_preemptible_attempts
+  Int? align_preemptible_attempts
+  Int? score_preemptible_attempts
+  Int? process_filter_metrics_preemptible_attempts
+  Int? process_score_metrics_preemptible_attempts
 
-  # You may have to change the following two parameter values depending on the task requirements
-  Int default_ram_mb = 208000
-  # WARNING: In the workflow, you should calculate the disk space as an input to this task (disk_space_gb).
-  Int default_disk_space_gb = 400
-  # Mem is in units of GB but our command and memory runtime values are in MB
-  Int machine_mem = if defined(mem_gb) then mem_gb *1000 else default_ram_mb
-  Int command_mem = machine_mem - 4000
+  Int? cram_to_bam_cpu
+  Int? filter_cpu
+  Int? align_cpu
+  Int? score_cpu
 
-  Float default_min_score_identity = 0.9
-  Float default_identity_margin = 0.02
+  Float? cram_to_bam_mem_gb
+  Int? filter_mem_gb
+  Int? align_mem_gb
+  Int? score_mem_gb
+
+  Boolean? filter_ssd
+  Boolean? align_ssd
+  Boolean? score_ssd
+
+  Int? cram_to_bam_max_retries
+
+  # Optional input to increase all disk sizes in case of outlier sample with strange size behavior
+  Int? cram_to_bam_additional_disk_gb
+  Int? downsample_additional_disk_gb
+  Int? filter_additional_disk_gb
+  Int? align_additional_disk_gb
+  Int? score_additional_disk_gb
+
+  Boolean is_bam = basename(input_bam_or_cram, ".bam") + ".bam" == basename(input_bam_or_cram)
+
+  # Convert to BAM if we have a CRAM
+  if (!is_bam) {
+    call CramToBam {
+      input:
+        cram_file = input_bam_or_cram,
+        cram_index = select_first([input_bam_or_cram_index]),
+        reference_fasta = select_first([cram_reference_fasta]),
+        reference_index = select_first([cram_reference_fasta_index]),
+        docker = samtools_docker,
+        cpu = cram_to_bam_cpu,
+        mem_gb = cram_to_bam_mem_gb,
+        extra_disk_gb = cram_to_bam_additional_disk_gb,
+        preemptible = cram_to_bam_preemptible_attempts,
+        max_retries = cram_to_bam_max_retries,
+    }
+  }
+
+  File bam_file = select_first([CramToBam.bam_file, input_bam_or_cram])
+  File? bam_index = if defined(CramToBam.bam_index) then CramToBam.bam_index else input_bam_or_cram_index
+
+  # Downsample bam for filter metrics estimation
+  if (downsample) {
+    call Downsample {
+      input:
+        input_bam_file=bam_file,
+        input_bam_index_file=bam_index,
+        downsampled_bam_filename="${sample_name}.downsampled.bam",
+        reads_after_downsampling=downsample_reads,
+        additional_disk_gb=downsample_additional_disk_gb,
+        preemptible_tries=downsample_preemptible_attempts,
+        docker=genomes_in_the_cloud_docker
+    }
+  }
+
+  call PathSeqFilter {
+    input:
+      sample_name=sample_name,
+      input_bam_or_cram=select_first([Downsample.output_bam_file, bam_file]),
+      kmer_file=kmer_file,
+      filter_bwa_image=filter_bwa_image,
+      frac_non_host_reads=frac_non_host_reads,
+      gather_metrics=gather_filter_metrics,
+      is_host_aligned=is_host_aligned,
+      filter_duplicates=filter_duplicates,
+      skip_quality_filters=skip_quality_filters,
+      min_clipped_read_length=min_clipped_read_length,
+      bam_partition_size=filter_bam_partition_size,
+      host_min_identity=host_min_identity,
+      filter_bwa_seed_length=filter_bwa_seed_length,
+      max_masked_bases=max_masked_bases,
+      min_base_quality=min_base_quality,
+      quality_threshold=quality_threshold,
+      dust_mask_quality=dust_mask_quality,
+      dust_window=dust_window,
+      dust_t=dust_t,
+      host_kmer_threshold=host_kmer_threshold,
+      max_adapter_mistmatches=max_adapter_mistmatches,
+      min_adapter_length=min_adapter_length,
+      filter_reads_per_partition=filter_reads_per_partition,
+      skip_pre_bwa_repartition=skip_pre_bwa_repartition,
+      gatk4_jar_override=gatk4_jar_override,
+      mem_gb=filter_mem_gb,
+      gatk_docker=gatk_docker,
+      preemptible_attempts=filter_preemptible_attempts,
+      additional_disk_gb=filter_additional_disk_gb,
+      cpu=filter_cpu,
+      use_ssd=filter_ssd
+  }
+
+  if (gather_filter_metrics) {
+    call ProcessFilterMetrics {
+      input:
+        metrics_file=PathSeqFilter.filter_metrics,
+        preemptible_tries=process_filter_metrics_preemptible_attempts,
+        docker=linux_docker
+    }
+  }
+
+  if (!filtering_only) {
+    call PathSeqAlign {
+      input:
+        sample_name=sample_name,
+        input_paired_bam=PathSeqFilter.paired_bam_out,
+        input_unpaired_bam=PathSeqFilter.unpaired_bam_out,
+        microbe_bwa_image=select_first([microbe_bwa_image]),
+        microbe_dict=select_first([microbe_dict]),
+        microbe_min_seed_length=microbe_min_seed_length,
+        max_alternate_hits=max_alternate_hits,
+        bwa_score_threshold=bwa_score_threshold,
+        gatk4_jar_override=gatk4_jar_override,
+        mem_gb=align_mem_gb,
+        gatk_docker=gatk_docker,
+        preemptible_attempts=align_preemptible_attempts,
+        additional_disk_gb=align_additional_disk_gb,
+        cpu=align_cpu,
+        use_ssd=align_ssd
+    }
+
+    call PathSeqScore {
+      input:
+        sample_name=sample_name,
+        input_paired_bam=PathSeqAlign.paired_bam_out,
+        input_unpaired_bam=PathSeqAlign.unpaired_bam_out,
+        taxonomy_file=select_first([taxonomy_file]),
+        divide_by_genome_length=divide_by_genome_length,
+        min_score_identity=min_score_identity,
+        identity_margin=identity_margin,
+        not_normalized_by_kingdom=not_normalized_by_kingdom,
+        score_reads_per_partition_estimate=score_reads_per_partition_estimate,
+        gatk4_jar_override=gatk4_jar_override,
+        mem_gb=score_mem_gb,
+        gatk_docker=gatk_docker,
+        preemptible_attempts=score_preemptible_attempts,
+        additional_disk_gb=score_additional_disk_gb,
+        cpu=score_cpu,
+        use_ssd=score_ssd
+    }
+
+    call ProcessScoreMetrics {
+      input:
+        metrics_file=PathSeqScore.score_metrics,
+        preemptible_tries=process_score_metrics_preemptible_attempts,
+        docker=linux_docker
+    }
+  }
+
+  output {
+    # Filtered non-host reads
+    File non_host_paired_bam = PathSeqFilter.paired_bam_out
+    File non_host_unpaired_bam = PathSeqFilter.unpaired_bam_out
+
+    # Only generated if filtering_only=false
+    File? final_bam = PathSeqScore.bam_out
+    File? taxonomy_scores = PathSeqScore.scores
+    File? score_metrics_file = PathSeqScore.score_metrics
+    Int? non_host_mapped_reads = ProcessScoreMetrics.non_host_mapped_reads
+    Int? non_host_unmapped_reads = ProcessScoreMetrics.non_host_unmapped_reads
+
+    # Only generated if gather_filter_metrics=true
+    File? filter_metrics_file = ProcessFilterMetrics.metrics_file_out
+    Float? frac_after_prealigned_filter = ProcessFilterMetrics.frac_after_prealigned_filter
+    Float? frac_after_qual_cpx_filter = ProcessFilterMetrics.frac_after_qual_cpx_filter
+    Float? frac_after_host_filter = ProcessFilterMetrics.frac_after_host_filter
+    Float? frac_after_dedup = ProcessFilterMetrics.frac_after_dedup
+    Float? frac_non_host_paired = ProcessFilterMetrics.frac_final_paired
+    Float? frac_non_host_unpaired = ProcessFilterMetrics.frac_final_unpaired
+    Float? frac_non_host_total =ProcessFilterMetrics.frac_final_total
+    Float? frac_qual_cpx_filtered = ProcessFilterMetrics.frac_qual_cpx_filtered
+    Float? frac_host_filtered = ProcessFilterMetrics.frac_host_filtered
+    Float? frac_dup_filtered = ProcessFilterMetrics.frac_dup_filtered
+
+    # Only generated if downsample=true
+    Int? total_reads = Downsample.total_reads
+  }
+}
+
+task CramToBam {
+  File cram_file
+  File? cram_index
+  File reference_fasta
+  File? reference_index
+
+  String docker
+
+  Int? cpu = 4
+  Float? mem_gb = 15
+  Int? extra_disk_gb = 10
+  Int? preemptible = 3
+  Int? max_retries = 1
+
+  String bam_file_name = basename(cram_file, ".cram") + ".bam"
+
+  File cram_index_file = select_first([cram_index, cram_file + ".crai"])
+  File reference_index_file = select_first([reference_index, reference_fasta + ".fai"])
+
+  Float cram_inflate_ratio = 3.0
+  Float cram_size = size(cram_file, "GiB")
+  Float cram_index_size = size(cram_index_file, "GiB")
+  Float bam_size = cram_inflate_ratio * cram_size
+  Float bam_index_size = cram_index_size
+  Float ref_size = size(reference_fasta, "GiB")
+  Float ref_index_size = size(reference_index_file, "GiB")
+  Int vm_disk_size = ceil(cram_size + cram_index_size + bam_size + bam_index_size + ref_size + ref_index_size + extra_disk_gb)
+
+  output {
+    File bam_file = bam_file_name
+    File bam_index = bam_file_name + ".bai"
+  }
+  command <<<
+
+        set -Eeuo pipefail
+
+        # covert cram to bam
+        samtools view  -@ ${cpu} -h -b -T "${reference_fasta}" -o "${bam_file_name}" "${cram_file}"
+
+        # index bam file
+        samtools index -@ ${cpu} "${bam_file_name}"
+
+  >>>
+  runtime {
+    cpu: 1
+    memory: mem_gb + " GiB"
+    disks: "local-disk " + vm_disk_size + " HDD"
+    bootDiskSizeGb: 10
+    docker: docker
+    preemptible: preemptible
+    maxRetries: max_retries
+  }
+}
+
+# Downsamples BAM to a specified number of reads
+task Downsample {
+  File input_bam_file
+  File? input_bam_index_file
+  String downsampled_bam_filename
+
+  Int reads_after_downsampling
+
+  String docker
+  Int additional_disk_gb = 20
+  Int preemptible_tries = 3
+
+  Int disk_size = ceil(size(input_bam_file, "GB")*2 + additional_disk_gb)
 
   command <<<
-    set -e
+    set -euo pipefail
+    if ${defined(input_bam_index_file)}; then
+      NUM_READS=`samtools idxstats ${input_bam_file} | awk '{s+=$3+$4} END {print s}'`
+    else
+      NUM_READS=`samtools view -c ${input_bam_file}`
+    fi
+    P_DOWNSAMPLE=`python -c "print ${reads_after_downsampling}/float($NUM_READS)"`
+    RESULT=`python -c "print $P_DOWNSAMPLE > 1"`
+    if [ "$RESULT" == "True" ]
+    then
+        P_DOWNSAMPLE="1"
+    fi
+    echo $NUM_READS > num_reads.txt
+    java -Xmx2000m -jar /usr/gitc/picard.jar \
+      DownsampleSam \
+      INPUT=${input_bam_file} \
+      OUTPUT=${downsampled_bam_filename} \
+      P=$P_DOWNSAMPLE \
+      VALIDATION_STRINGENCY=SILENT
+  >>>
+  output {
+    File output_bam_file = "${downsampled_bam_filename}"
+    Int total_reads = read_int("num_reads.txt")
+  }
+  runtime {
+    preemptible: "${preemptible_tries}"
+    docker: docker
+    memory: "3.75 GiB"
+    cpu: "1"
+    disks: "local-disk ${disk_size} HDD"
+  }
+}
+
+task PathSeqFilter {
+
+  # Inputs for this task
+  String sample_name
+  File input_bam_or_cram
+
+  File? kmer_file
+  File? filter_bwa_image
+
+  Boolean is_host_aligned
+  Boolean gather_metrics
+  # Optimizes disk space if provided
+  Float frac_non_host_reads = 1.0
+
+  Boolean? skip_quality_filters
+  Boolean? skip_pre_bwa_repartition
+  Boolean? filter_duplicates
+  Int? host_min_identity
+  Int? filter_bwa_seed_length
+  Int? min_clipped_read_length
+  Int? bam_partition_size
+  Int? max_masked_bases
+  Int? min_base_quality
+  Int? quality_threshold
+  Int? dust_mask_quality
+  Int? dust_window
+  Float? dust_t
+  Int? host_kmer_threshold
+  Int? max_adapter_mistmatches
+  Int? min_adapter_length
+  Int? filter_reads_per_partition
+
+  String paired_bam_output_path = "${sample_name}.non_host.paired.bam"
+  String unpaired_bam_output_path = "${sample_name}.non_host.unpaired.bam"
+  String filter_metrics_output_path = "${sample_name}.pathseq.filter_metrics"
+
+  File? gatk4_jar_override
+
+  # Default to WARNING which will avoid excessive Spark logging
+  String verbosity = "WARNING"
+
+  # Runtime parameters
+  String gatk_docker
+  Int mem_gb = 32
+  Int preemptible_attempts = 3
+  Float additional_disk_gb = 50
+  Int cpu = 8
+  Boolean use_ssd = false
+
+  Int disk_size = ceil(((1.0 + frac_non_host_reads)*size(input_bam_or_cram, "GB")) + size(kmer_file, "GB") + size(filter_bwa_image, "GB") + additional_disk_gb)
+
+  # Mem is in units of GB but our command and memory runtime values are in MB
+  Int machine_mem = mem_gb * 1000
+  Int command_mem = ceil((machine_mem - size(filter_bwa_image, "MB")) * 0.8)
+
+  command <<<
+    set -euo pipefail
     export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
-      gatk --java-options "-Xmx${command_mem}m" \
-      PathSeqPipelineSpark \
-      --input ${input_bam} \
-      --output ${bam_output_path} \
-      --scores-output ${scores_output_path} \
-      --filter-metrics ${filter_metrics_output_path} \
-      --score-metrics ${score_metrics_output_path} \
-      --kmer-file ${kmer_file} \
-      --filter-bwa-image ${filter_bwa_image} \
-      --microbe-bwa-image ${microbe_bwa_image} \
-      --microbe-fasta ${microbe_fasta} \
-      --taxonomy-file ${taxonomy_file} \
-      --bam-partition-size ${select_first([bam_partition_size, 4000000])} \
-      --is-host-aligned ${is_host_aligned} \
-      --skip-quality-filters ${select_first([skip_quality_filters, false])} \
-      --min-clipped-read-length ${select_first([min_clipped_read_length, 60])} \
-      --filter-bwa-seed-length ${select_first([filter_bwa_seed_length, 19])} \
-      --host-min-identity ${select_first([host_min_identity, 30])} \
-      --filter-duplicates ${select_first([filter_duplicates, true])} \
-      --skip-pre-bwa-repartition ${select_first([skip_pre_bwa_repartition, false])} \
-      --min-score-identity ${select_first([min_score_identity, default_min_score_identity])} \
-      --identity-margin ${select_first([identity_margin, default_identity_margin])} \
-      --divide-by-genome-length ${select_first([divide_by_genome_length, true])}
+    touch ${filter_metrics_output_path}
+    gatk --java-options "-Xmx${command_mem}m" \
+      PathSeqFilterSpark \
+      --input ${input_bam_or_cram} \
+      --paired-output ${paired_bam_output_path} \
+      --unpaired-output ${unpaired_bam_output_path} \
+      --is-host-aligned ${is_host_aligned}  \
+      --verbosity ${verbosity} \
+      ${if gather_metrics then "--filter-metrics ${filter_metrics_output_path}" else ""} \
+      ${if defined(kmer_file) then "--kmer-file ${kmer_file}" else ""} \
+      ${if defined(filter_bwa_image) then "--filter-bwa-image ${filter_bwa_image}" else ""} \
+      ${if defined(bam_partition_size) then "--bam-partition-size ${bam_partition_size}" else ""} \
+      ${if defined(skip_quality_filters) then "--skip-quality-filters ${skip_quality_filters}" else ""}\
+      ${if defined(min_clipped_read_length) then "--min-clipped-read-length ${min_clipped_read_length}" else ""} \
+      ${if defined(max_masked_bases) then "--max-masked-bases ${max_masked_bases}" else ""} \
+      ${if defined(min_base_quality) then "--min-base-quality ${min_base_quality}" else ""} \
+      ${if defined(quality_threshold) then "--quality-threshold ${quality_threshold}" else ""} \
+      ${if defined(dust_mask_quality) then "--dust-mask-quality ${dust_mask_quality}" else ""} \
+      ${if defined(dust_window) then "--dust-window ${dust_window}" else ""} \
+      ${if defined(dust_t) then "--dust-t ${dust_t}" else ""} \
+      ${if defined(host_kmer_threshold) then "--host-kmer-thresh ${host_kmer_threshold}" else ""} \
+      ${if defined(max_adapter_mistmatches) then "--max-adapter-mismatches ${max_adapter_mistmatches}" else ""} \
+      ${if defined(min_adapter_length) then "--min-adapter-length ${min_adapter_length}" else ""} \
+      ${if defined(filter_bwa_seed_length) then "--filter-bwa-seed-length ${filter_bwa_seed_length}" else ""} \
+      ${if defined(host_min_identity) then "--host-min-identity ${host_min_identity}" else ""} \
+      ${if defined(filter_duplicates) then "--filter-duplicates ${filter_duplicates}" else ""} \
+      ${if defined(skip_pre_bwa_repartition) then "--skip-pre-bwa-repartition ${skip_pre_bwa_repartition}" else ""} \
+      ${if defined(filter_reads_per_partition) then "--filter-reads-per-partition ${filter_reads_per_partition}" else ""}
+
+    if [ ! -f "${paired_bam_output_path}" ]; then
+    	echo "File ${paired_bam_output_path} not found, creating empty BAM"
+    	printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:${sample_name}\n" | samtools view -hb - > ${paired_bam_output_path}
+    fi
+
+    if [ ! -f "${unpaired_bam_output_path}" ]; then
+    	echo "File ${unpaired_bam_output_path} not found, creating empty BAM"
+    	printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:${sample_name}\n" | samtools view -hb - > ${unpaired_bam_output_path}
+    fi
   >>>
   runtime {
     docker: gatk_docker
     memory: machine_mem + " MB"
     # Note that the space before SSD and HDD should be included.
-    disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + if use_ssd then " SSD" else " HDD"
-    preemptible: select_first([preemptible_attempts, 3])
-    cpu: select_first([cpu, 32])
+    disks: "local-disk " + disk_size + if use_ssd then " SSD" else " HDD"
+    preemptible: preemptible_attempts
+    cpu: cpu
   }
   output {
-    File bam_output_pathFile = "${sample_name}.pathseq.bam"
-    File outputScoresFile = "${sample_name}.pathseq.tsv"
-    File outputFilterMetricsFile = "${sample_name}.pathseq.filter_metrics"
-    File outputScoreMetricsFile = "${sample_name}.pathseq.score_metrics"
+    File paired_bam_out = "${paired_bam_output_path}"
+    File unpaired_bam_out = "${unpaired_bam_output_path}"
+    File filter_metrics = "${sample_name}.pathseq.filter_metrics"
   }
 }
 
-workflow PathSeqPipelineWorkflow {
+task PathSeqAlign {
 
+  # Inputs for this task
   String sample_name
-  File input_bam
+  File input_paired_bam
+  File input_unpaired_bam
 
-  File kmer_file
-  File filter_bwa_image
   File microbe_bwa_image
-  File microbe_fasta
-  File microbe_fasta_dict
+  File microbe_dict
+
+  Int? microbe_min_seed_length
+  Int? max_alternate_hits
+  Int? bwa_score_threshold
+
+  String paired_bam_output_path = "${sample_name}.microbe_aligned.paired.bam"
+  String unpaired_bam_output_path = "${sample_name}.microbe_aligned.unpaired.bam"
+
+  File? gatk4_jar_override
+
+  # Default to WARNING which will avoid excessive Spark logging
+  String verbosity = "WARNING"
+
+  # Runtime parameters
+  String gatk_docker
+  Int mem_gb = 140
+  Int preemptible_attempts = 3
+  Float additional_disk_gb = 50
+  Int cpu = 8
+  Boolean use_ssd = false
+
+  Int disk_size = ceil((2.5*size(input_paired_bam, "GB")) + (2.5*size(input_unpaired_bam, "GB")) + size(microbe_bwa_image, "GB") + additional_disk_gb)
+
+  # Mem is in units of GB but our command and memory runtime values are in MB
+  Int machine_mem = mem_gb * 1000
+  Int command_mem = ceil((machine_mem - size(microbe_bwa_image, "MB")) * 0.8)
+
+  command <<<
+    set -e
+    export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
+    gatk --java-options "-Xmx${command_mem}m" \
+      PathSeqBwaSpark \
+      --paired-input ${input_paired_bam} \
+      --unpaired-input ${input_unpaired_bam} \
+      --paired-output ${paired_bam_output_path} \
+      --unpaired-output ${unpaired_bam_output_path} \
+      --microbe-bwa-image ${microbe_bwa_image} \
+      --microbe-dict ${microbe_dict} \
+      --verbosity ${verbosity} \
+      ${if defined(microbe_min_seed_length) then "--microbe-min-seed-length ${microbe_min_seed_length}" else ""} \
+      ${if defined(max_alternate_hits) then "--max-alternate-hits ${max_alternate_hits}" else ""} \
+      ${if defined(bwa_score_threshold) then "--bwa-score-threshold ${bwa_score_threshold}" else ""}
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: machine_mem + " MB"
+    # Note that the space before SSD and HDD should be included.
+    disks: "local-disk " + disk_size + if use_ssd then " SSD" else " HDD"
+    preemptible: preemptible_attempts
+    cpu: cpu
+  }
+  output {
+    File paired_bam_out = "${paired_bam_output_path}"
+    File unpaired_bam_out = "${unpaired_bam_output_path}"
+  }
+}
+
+task PathSeqScore {
+
+  # Inputs for this task
+  String sample_name
+  File input_paired_bam
+  File input_unpaired_bam
+
   File taxonomy_file
 
-  Boolean is_host_aligned
-  Boolean? filter_duplicates
-  Boolean? skip_pre_bwa_repartition
   Boolean? divide_by_genome_length
-  Int? filter_bwa_seed_length
-  Int? host_min_identity
-  Int? min_clipped_read_length
-  Int? bam_partition_size
   Float? min_score_identity
   Float? identity_margin
+  Boolean? not_normalized_by_kingdom
+  Int? score_reads_per_partition_estimate
+
+  String bam_output_path = "${sample_name}.pathseq.bam"
+  String scores_output_path = "${sample_name}.pathseq.tsv"
+  String score_metrics_output_path = "${sample_name}.pathseq.score_metrics"
 
   File? gatk4_jar_override
 
   # Runtime parameters
-  Int? mem_gb
   String gatk_docker
-  Int? preemptible_attempts
-  Int? cpu
+  Int mem_gb = 8
+  Int preemptible_attempts = 3
+  Float additional_disk_gb = 10
+  Int cpu = 2
+  Boolean use_ssd = false
 
-  # Optional input to increase all disk sizes in case of outlier sample with strange size behavior
-  Int? increase_disk_size
+  Int disk_size = ceil(size(input_paired_bam, "GB") + size(input_unpaired_bam, "GB") + additional_disk_gb)
 
-  # Some tasks need wiggle room, and we also need to add a small amount of disk to prevent getting a
-  # Cromwell error from asking for 0 disk when the input is less than 1GB.
-  # Also Spark requires some temporary storage.
-  Int additional_disk = select_first([increase_disk_size, 20])
+  # Mem is in units of GB but our command and memory runtime values are in MB
+  Int machine_mem = mem_gb * 1000
+  Int command_mem = ceil(machine_mem * 0.8)
 
-  # Disk sizes for Downsample and PathSeq tasks
-  Float disk_space_gb = size(input_bam, "GB") + size(kmer_file, "GB") + size(filter_bwa_image, "GB") + size(microbe_bwa_image, "GB") + size(microbe_fasta, "GB") + additional_disk
-
-  call PathseqPipeline {
-    input:
-      sample_name=sample_name,
-      input_bam=input_bam,
-      kmer_file=kmer_file,
-      filter_bwa_image=filter_bwa_image,
-      microbe_bwa_image=microbe_bwa_image,
-      microbe_fasta=microbe_fasta,
-      microbe_fasta_dict=microbe_fasta_dict,
-      taxonomy_file=taxonomy_file,
-      is_host_aligned=is_host_aligned,
-      filter_duplicates=filter_duplicates,
-      skip_pre_bwa_repartition=skip_pre_bwa_repartition,
-      divide_by_genome_length=divide_by_genome_length,
-      min_clipped_read_length=min_clipped_read_length,
-      bam_partition_size=bam_partition_size,
-      min_score_identity=min_score_identity,
-      identity_margin=identity_margin,
-      host_min_identity=host_min_identity,
-      filter_bwa_seed_length=filter_bwa_seed_length,
-      gatk4_jar_override=gatk4_jar_override,
-      mem_gb=mem_gb,
-      gatk_docker=gatk_docker,
-      preemptible_attempts=preemptible_attempts,
-      disk_space_gb=disk_space_gb,
-      cpu=cpu
+  command <<<
+    set -e
+    export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
+    gatk --java-options "-Xmx${command_mem}m" \
+      PathSeqScoreSpark \
+      --paired-input ${input_paired_bam} \
+      --unpaired-input ${input_unpaired_bam} \
+      --output ${bam_output_path} \
+      --scores-output ${scores_output_path} \
+      --score-metrics ${score_metrics_output_path} \
+      --taxonomy-file ${taxonomy_file} \
+      ${if defined(min_score_identity) then "--min-score-identity ${min_score_identity}" else ""} \
+      ${if defined(identity_margin) then "--identity-margin ${identity_margin}" else ""} \
+      ${if defined(divide_by_genome_length) then "--divide-by-genome-length ${divide_by_genome_length}" else ""} \
+      ${if defined(not_normalized_by_kingdom) then "--not-normalized-by-kingdom ${not_normalized_by_kingdom}" else ""} \
+      ${if defined(score_reads_per_partition_estimate) then "--score-reads-per-partition-estimate ${score_reads_per_partition_estimate}" else ""}
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: machine_mem + " MB"
+    # Note that the space before SSD and HDD should be included.
+    disks: "local-disk " + disk_size + if use_ssd then " SSD" else " HDD"
+    preemptible: preemptible_attempts
+    cpu: cpu
   }
   output {
-    File pathseqBam = PathseqPipeline.bam_output_pathFile
-    File pathseqScores = PathseqPipeline.outputScoresFile
-    File pathseqFilterMetrics = PathseqPipeline.outputFilterMetricsFile
-    File pathseqScoreMetrics = PathseqPipeline.outputScoreMetricsFile
+    File bam_out = "${sample_name}.pathseq.bam"
+    File scores = "${sample_name}.pathseq.tsv"
+    File score_metrics = "${sample_name}.pathseq.score_metrics"
+  }
+}
+
+# Extracts filter metrics as fraction of total reads
+task ProcessFilterMetrics {
+  File metrics_file
+  String docker
+  Int preemptible_tries = 3
+
+  String dollar = "$"
+
+  command <<<
+    set -euo pipefail
+    if [ ! -s ${metrics_file} ]; then
+      echo "" | awk -v OFS="\t" '{print 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}'
+    else
+      sed -n '8p' ${metrics_file} \
+        | awk -F"\t" -v OFS="\t" '{if (${dollar}1 > 0) {print ${dollar}2/${dollar}1, ${dollar}3/${dollar}1, ${dollar}4/${dollar}1, ${dollar}5/${dollar}1, ${dollar}6/${dollar}1, ${dollar}7/${dollar}1, ${dollar}8/${dollar}1, ${dollar}9/${dollar}1, ${dollar}0/${dollar}1, ${dollar}11/${dollar}1} else {print 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}'
+    fi > metrics.txt
+
+    cut -f1 metrics.txt > frac_after_prealigned_filter.txt
+    cut -f2 metrics.txt> frac_after_qual_cpx_filter.txt
+    cut -f3 metrics.txt > frac_after_host_filter.txt
+    cut -f4 metrics.txt > frac_after_dedup.txt
+    cut -f5 metrics.txt > frac_final_paired.txt
+    cut -f6 metrics.txt > frac_final_unpaired.txt
+    cut -f7 metrics.txt > frac_final_total.txt
+    cut -f8 metrics.txt > frac_qual_cpx_filtered.txt
+    cut -f9 metrics.txt > frac_host_filtered.txt
+    cut -f10 metrics.txt > frac_dup_filtered.txt
+  >>>
+  output {
+    File metrics_file_out = metrics_file
+    Float frac_after_prealigned_filter = read_float("frac_after_prealigned_filter.txt")
+    Float frac_after_qual_cpx_filter = read_float("frac_after_qual_cpx_filter.txt")
+    Float frac_after_host_filter = read_float("frac_after_host_filter.txt")
+    Float frac_after_dedup = read_float("frac_after_dedup.txt")
+    Float frac_final_paired = read_float("frac_final_paired.txt")
+    Float frac_final_unpaired = read_float("frac_final_unpaired.txt")
+    Float frac_final_total = read_float("frac_final_total.txt")
+    Float frac_qual_cpx_filtered = read_float("frac_qual_cpx_filtered.txt")
+    Float frac_host_filtered = read_float("frac_host_filtered.txt")
+    Float frac_dup_filtered = read_float("frac_dup_filtered.txt")
+  }
+  runtime {
+    preemptible: preemptible_tries
+    docker: docker
+    memory: "2 GiB"
+    cpu: "1"
+    disks: "local-disk 10 HDD"
+  }
+}
+
+# Extracts score metrics
+task ProcessScoreMetrics {
+  File metrics_file
+  String docker
+  Int preemptible_tries = 3
+
+  command <<<
+    set -euo pipefail
+    sed -n '8p' ${metrics_file} > metrics.txt
+    cut -f1 metrics.txt > non_host_mapped_reads.txt
+    cut -f2 metrics.txt > non_host_unmapped_reads.txt
+  >>>
+  output {
+    Int non_host_mapped_reads = read_int("non_host_mapped_reads.txt")
+    Int non_host_unmapped_reads = read_int("non_host_unmapped_reads.txt")
+  }
+  runtime {
+    preemptible: preemptible_tries
+    docker: docker
+    memory: "2 GiB"
+    cpu: "1"
+    disks: "local-disk 10 HDD"
   }
 }

--- a/scripts/pathseq/wdl/pathseq_pipeline.wdl
+++ b/scripts/pathseq/wdl/pathseq_pipeline.wdl
@@ -87,6 +87,7 @@ workflow PathSeqPipeline {
   Float frac_non_host_reads = 1.0
 
   # Filtering options
+  Array[String]? host_contigs_to_ignore
   Boolean? filter_duplicates
   Boolean? skip_quality_filters
   Int? host_min_identity
@@ -201,6 +202,7 @@ workflow PathSeqPipeline {
       frac_non_host_reads=frac_non_host_reads,
       gather_metrics=gather_filter_metrics,
       is_host_aligned=is_host_aligned,
+      host_contigs_to_ignore=host_contigs_to_ignore,
       filter_duplicates=filter_duplicates,
       skip_quality_filters=skip_quality_filters,
       min_clipped_read_length=min_clipped_read_length,
@@ -426,6 +428,7 @@ task PathSeqFilter {
   File? filter_bwa_image
 
   Boolean is_host_aligned
+  Array[String]? host_contigs_to_ignore
   Boolean gather_metrics
   # Optimizes disk space if provided
   Float frac_non_host_reads = 1.0
@@ -482,6 +485,7 @@ task PathSeqFilter {
       --unpaired-output ${unpaired_bam_output_path} \
       --is-host-aligned ${is_host_aligned}  \
       --verbosity ${verbosity} \
+      ${if defined(host_contigs_to_ignore) then "--ignore-alignment-contigs " else ""} ${sep=" --ignore-alignment-contigs " host_contigs_to_ignore} \
       ${if gather_metrics then "--filter-metrics ${filter_metrics_output_path}" else ""} \
       ${if defined(kmer_file) then "--kmer-file ${kmer_file}" else ""} \
       ${if defined(filter_bwa_image) then "--filter-bwa-image ${filter_bwa_image}" else ""} \

--- a/scripts/pathseq/wdl/pathseq_pipeline.wdl
+++ b/scripts/pathseq/wdl/pathseq_pipeline.wdl
@@ -4,23 +4,23 @@
 ##
 ## Runs the PathSeq pipeline for detecting microbes in deep sequencing data.
 ##
-## Important: Filtering metrics should only be generated (gather_filter_metrics=true) on a downsampled BAM.
+## Important: Filtering metrics should only be generated (gather_filter_metrics=true) on downsampled BAMs.
 ##
 ## Important: For microbe-rich samples users should set downsampling=true and adjust downsample_reads so that the total
 ##   number of microbe reads is <10M. The total number of microbe reads can be estimated from a preliminary run of this
 #    workflow with downsampling=true, filtering_only=false, and gather_filter_metrics=true.
 ##
-## For further info see the GATK Documentation for the PathSeqPipelineSpark tool:
-##   https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_spark_pathseq_PathSeqPipelineSpark.php
+## For further info see the GATK Documentation for the PathSeq tools.
 ##
 ########################################################################################################################
 ##
 ## Input requirements :
 ## - Sequencing data in CRAM or BAM format
-## - Host and microbe references files available in the GATK Resource Bundle (available on FTP):
-##     https://software.broadinstitute.org/gatk/download/bundle
+## - Host and microbe references files available in the GATK Resource Bundle (available on Google Cloud Storage):
+##     gs://gatk-best-practices/pathseq
 ##
 ## - Input BAM files must comply with the following requirements:
+## - - indexed
 ## - - file must pass validation by ValidateSamFile
 ## - - all reads must have an RG tag
 ## - - one or more read groups all belong to a single sample (SM)
@@ -49,191 +49,75 @@
 ##   - total_reads_if_avail : total number of reads in the original input BAM
 ##
 ########################################################################################################################
+version 1.0
 
 workflow PathSeqPipeline {
+  input {
+    String sample_name
+    File input_bam_or_cram
+    File input_bam_or_cram_index
 
-  String sample_name
-  File input_bam_or_cram
-  # Required if a cram
-  File? input_bam_or_cram_index
+    # Required for crams
+    File? cram_reference_fasta
+    File? cram_reference_fasta_index
+    File? cram_reference_dict
 
-  # Required if the input is a cram
-  File? cram_reference_fasta
-  File? cram_reference_fasta_index
-  File? cram_reference_dict
+    # If enabled, filter metrics will be estimated using a downsampled bam with this many reads (recommended)
+    Boolean downsample = false
 
-  # Set to true if host aligned. WARNING: Results in loss of EBV reads if in the aligned reference.
-  Boolean is_host_aligned
+    # If BAM is aligned, ignore these contigs when filtering (e.g. chrEBV)
+    Array[String] ignored_alignment_contigs = []
 
-  File? kmer_file
-  File? filter_bwa_image
-  # Required if filtering_only=true
-  File? microbe_bwa_image
-  File? microbe_dict
-  File? taxonomy_file
+    # Enable to only perform host filtering
+    Boolean filtering_only = false
 
-  # If enabled, filter metrics will be estimated using a downsampled bam with this many reads (recommended)
-  # If disabled, no filter metrics will be generated
-  Boolean downsample = false
-  Int downsample_reads = 1000000
+    # Only recommended if downsample = true
+    Boolean gather_filter_metrics = false
 
-  # Enable to only perform host filtering
-  Boolean filtering_only = false
+    # Runtime parameters
+    String gatk_docker
+    String samtools_docker = "biocontainers/samtools:v1.9-4-deb_cv1"
+    String linux_docker = "ubuntu:18.10"
 
-  # Only recommended if downsample = true
-  Boolean gather_filter_metrics = false
+    # Required if BAM/CRAM is in a requester pays bucket
+    String? gcs_project_for_requester_pays
 
-  # This can be calculated from a downsampled run to help optimize disk allocation during filtering
-  Float frac_non_host_reads = 1.0
-
-  # Filtering options
-  Array[String]? host_contigs_to_ignore
-  Boolean? filter_duplicates
-  Boolean? skip_quality_filters
-  Int? host_min_identity
-  Int? host_kmer_threshold
-  Int? filter_bwa_seed_length
-  Int? min_clipped_read_length
-  Int? max_masked_bases
-  Int? min_base_quality
-  Int? quality_threshold
-  Int? dust_mask_quality
-  Int? dust_window
-  Float? dust_t
-  Int? max_adapter_mistmatches
-  Int? min_adapter_length
-  Int? filter_reads_per_partition
-  Int? filter_bam_partition_size
-  Boolean? skip_pre_bwa_repartition
-
-  # Alignment options
-  Int? microbe_min_seed_length
-  Int? max_alternate_hits
-  Int? bwa_score_threshold
-
-  # Taxonomy scoring options
-  Boolean? divide_by_genome_length
-  Float? min_score_identity
-  Float? identity_margin
-  Boolean? not_normalized_by_kingdom
-  Int? score_reads_per_partition_estimate
-
-  # Runtime parameters
-  String gatk_docker
-  String samtools_docker = "biocontainers/samtools:v1.9-4-deb_cv1"
-  String genomes_in_the_cloud_docker = "broadinstitute/genomes-in-the-cloud:2.3.1-1512499786"
-  String linux_docker = "ubuntu:18.10"
-
-  File? gatk4_jar_override
-
-  Int? cram_to_bam_preemptible_attempts
-  Int? downsample_preemptible_attempts
-  Int? filter_preemptible_attempts
-  Int? align_preemptible_attempts
-  Int? score_preemptible_attempts
-  Int? process_filter_metrics_preemptible_attempts
-  Int? process_score_metrics_preemptible_attempts
-
-  Int? cram_to_bam_cpu
-  Int? filter_cpu
-  Int? align_cpu
-  Int? score_cpu
-
-  Float? cram_to_bam_mem_gb
-  Int? filter_mem_gb
-  Int? align_mem_gb
-  Int? score_mem_gb
-
-  Boolean? filter_ssd
-  Boolean? align_ssd
-  Boolean? score_ssd
-
-  Int? cram_to_bam_max_retries
-
-  # Optional input to increase all disk sizes in case of outlier sample with strange size behavior
-  Int? cram_to_bam_additional_disk_gb
-  Int? downsample_additional_disk_gb
-  Int? filter_additional_disk_gb
-  Int? align_additional_disk_gb
-  Int? score_additional_disk_gb
-
-  Boolean is_bam = basename(input_bam_or_cram, ".bam") + ".bam" == basename(input_bam_or_cram)
-
-  # Convert to BAM if we have a CRAM
-  if (!is_bam) {
-    call CramToBam {
-      input:
-        cram_file = input_bam_or_cram,
-        cram_index = select_first([input_bam_or_cram_index]),
-        reference_fasta = select_first([cram_reference_fasta]),
-        reference_index = select_first([cram_reference_fasta_index]),
-        docker = samtools_docker,
-        cpu = cram_to_bam_cpu,
-        mem_gb = cram_to_bam_mem_gb,
-        extra_disk_gb = cram_to_bam_additional_disk_gb,
-        preemptible = cram_to_bam_preemptible_attempts,
-        max_retries = cram_to_bam_max_retries,
-    }
+    File? gatk4_jar_override
   }
-
-  File bam_file = select_first([CramToBam.bam_file, input_bam_or_cram])
-  File? bam_index = if defined(CramToBam.bam_index) then CramToBam.bam_index else input_bam_or_cram_index
 
   # Downsample bam for filter metrics estimation
   if (downsample) {
     call Downsample {
       input:
-        input_bam_file=bam_file,
-        input_bam_index_file=bam_index,
-        downsampled_bam_filename="${sample_name}.downsampled.bam",
-        reads_after_downsampling=downsample_reads,
-        additional_disk_gb=downsample_additional_disk_gb,
-        preemptible_tries=downsample_preemptible_attempts,
-        docker=genomes_in_the_cloud_docker
+        cram_or_bam_file=input_bam_or_cram,
+        cram_or_bam_index=input_bam_or_cram_index,
+        cram_reference_fasta=cram_reference_fasta,
+        cram_reference_fasta_index=cram_reference_fasta_index,
+        cram_reference_dict=cram_reference_dict,
+        output_bam_name="~{sample_name}.downsampled.bam",
+        docker=gatk_docker
     }
   }
 
   call PathSeqFilter {
     input:
       sample_name=sample_name,
-      input_bam_or_cram=select_first([Downsample.output_bam_file, bam_file]),
-      kmer_file=kmer_file,
-      filter_bwa_image=filter_bwa_image,
-      frac_non_host_reads=frac_non_host_reads,
+      input_bam_or_cram=select_first([Downsample.out, input_bam_or_cram]),
+      input_bam_or_cram_index=select_first([Downsample.out_index, input_bam_or_cram_index]),
+      cram_reference_fasta=cram_reference_fasta,
+      cram_reference_fasta_index=cram_reference_fasta_index,
+      cram_reference_dict=cram_reference_dict,
+      ignored_alignment_contigs=ignored_alignment_contigs,
       gather_metrics=gather_filter_metrics,
-      is_host_aligned=is_host_aligned,
-      host_contigs_to_ignore=host_contigs_to_ignore,
-      filter_duplicates=filter_duplicates,
-      skip_quality_filters=skip_quality_filters,
-      min_clipped_read_length=min_clipped_read_length,
-      bam_partition_size=filter_bam_partition_size,
-      host_min_identity=host_min_identity,
-      filter_bwa_seed_length=filter_bwa_seed_length,
-      max_masked_bases=max_masked_bases,
-      min_base_quality=min_base_quality,
-      quality_threshold=quality_threshold,
-      dust_mask_quality=dust_mask_quality,
-      dust_window=dust_window,
-      dust_t=dust_t,
-      host_kmer_threshold=host_kmer_threshold,
-      max_adapter_mistmatches=max_adapter_mistmatches,
-      min_adapter_length=min_adapter_length,
-      filter_reads_per_partition=filter_reads_per_partition,
-      skip_pre_bwa_repartition=skip_pre_bwa_repartition,
       gatk4_jar_override=gatk4_jar_override,
-      mem_gb=filter_mem_gb,
-      gatk_docker=gatk_docker,
-      preemptible_attempts=filter_preemptible_attempts,
-      additional_disk_gb=filter_additional_disk_gb,
-      cpu=filter_cpu,
-      use_ssd=filter_ssd
+      gcs_project_for_requester_pays=gcs_project_for_requester_pays,
+      gatk_docker=gatk_docker
   }
 
   if (gather_filter_metrics) {
     call ProcessFilterMetrics {
       input:
         metrics_file=PathSeqFilter.filter_metrics,
-        preemptible_tries=process_filter_metrics_preemptible_attempts,
         docker=linux_docker
     }
   }
@@ -244,18 +128,8 @@ workflow PathSeqPipeline {
         sample_name=sample_name,
         input_paired_bam=PathSeqFilter.paired_bam_out,
         input_unpaired_bam=PathSeqFilter.unpaired_bam_out,
-        microbe_bwa_image=select_first([microbe_bwa_image]),
-        microbe_dict=select_first([microbe_dict]),
-        microbe_min_seed_length=microbe_min_seed_length,
-        max_alternate_hits=max_alternate_hits,
-        bwa_score_threshold=bwa_score_threshold,
         gatk4_jar_override=gatk4_jar_override,
-        mem_gb=align_mem_gb,
-        gatk_docker=gatk_docker,
-        preemptible_attempts=align_preemptible_attempts,
-        additional_disk_gb=align_additional_disk_gb,
-        cpu=align_cpu,
-        use_ssd=align_ssd
+        gatk_docker=gatk_docker
     }
 
     call PathSeqScore {
@@ -263,25 +137,13 @@ workflow PathSeqPipeline {
         sample_name=sample_name,
         input_paired_bam=PathSeqAlign.paired_bam_out,
         input_unpaired_bam=PathSeqAlign.unpaired_bam_out,
-        taxonomy_file=select_first([taxonomy_file]),
-        divide_by_genome_length=divide_by_genome_length,
-        min_score_identity=min_score_identity,
-        identity_margin=identity_margin,
-        not_normalized_by_kingdom=not_normalized_by_kingdom,
-        score_reads_per_partition_estimate=score_reads_per_partition_estimate,
         gatk4_jar_override=gatk4_jar_override,
-        mem_gb=score_mem_gb,
-        gatk_docker=gatk_docker,
-        preemptible_attempts=score_preemptible_attempts,
-        additional_disk_gb=score_additional_disk_gb,
-        cpu=score_cpu,
-        use_ssd=score_ssd
+        gatk_docker=gatk_docker
     }
 
     call ProcessScoreMetrics {
       input:
         metrics_file=PathSeqScore.score_metrics,
-        preemptible_tries=process_score_metrics_preemptible_attempts,
         docker=linux_docker
     }
   }
@@ -316,159 +178,111 @@ workflow PathSeqPipeline {
   }
 }
 
-task CramToBam {
-  File cram_file
-  File? cram_index
-  File reference_fasta
-  File? reference_index
-
-  String docker
-
-  Int? cpu = 4
-  Float? mem_gb = 15
-  Int? extra_disk_gb = 10
-  Int? preemptible = 3
-  Int? max_retries = 1
-
-  String bam_file_name = basename(cram_file, ".cram") + ".bam"
-
-  File cram_index_file = select_first([cram_index, cram_file + ".crai"])
-  File reference_index_file = select_first([reference_index, reference_fasta + ".fai"])
-
-  Float cram_inflate_ratio = 3.0
-  Float cram_size = size(cram_file, "GiB")
-  Float cram_index_size = size(cram_index_file, "GiB")
-  Float bam_size = cram_inflate_ratio * cram_size
-  Float bam_index_size = cram_index_size
-  Float ref_size = size(reference_fasta, "GiB")
-  Float ref_index_size = size(reference_index_file, "GiB")
-  Int vm_disk_size = ceil(cram_size + cram_index_size + bam_size + bam_index_size + ref_size + ref_index_size + extra_disk_gb)
-
-  output {
-    File bam_file = bam_file_name
-    File bam_index = bam_file_name + ".bai"
-  }
-  command <<<
-
-        set -Eeuo pipefail
-
-        # covert cram to bam
-        samtools view  -@ ${cpu} -h -b -T "${reference_fasta}" -o "${bam_file_name}" "${cram_file}"
-
-        # index bam file
-        samtools index -@ ${cpu} "${bam_file_name}"
-
-  >>>
-  runtime {
-    cpu: 1
-    memory: mem_gb + " GiB"
-    disks: "local-disk " + vm_disk_size + " HDD"
-    bootDiskSizeGb: 10
-    docker: docker
-    preemptible: preemptible
-    maxRetries: max_retries
-  }
-}
-
 # Downsamples BAM to a specified number of reads
 task Downsample {
-  File input_bam_file
-  File? input_bam_index_file
-  String downsampled_bam_filename
+  input {
+    File cram_or_bam_file
+    File cram_or_bam_index
+    String output_bam_name
+    Int reads_after_downsampling = 10000000
 
-  Int reads_after_downsampling
+    File? cram_reference_fasta
+    File? cram_reference_fasta_index
+    File? cram_reference_dict
 
-  String docker
-  Int additional_disk_gb = 20
-  Int preemptible_tries = 3
+    File? gatk4_jar_override
+    String docker
+    Int additional_disk_gb = 20
+    Int preemptible_tries = 3
+  }
 
-  Int disk_size = ceil(size(input_bam_file, "GB")*2 + additional_disk_gb)
+  Int disk_size = ceil(size(cram_or_bam_file, "GB")*2 + additional_disk_gb)
 
   command <<<
     set -euo pipefail
-    if ${defined(input_bam_index_file)}; then
-      NUM_READS=`samtools idxstats ${input_bam_file} | awk '{s+=$3+$4} END {print s}'`
-    else
-      NUM_READS=`samtools view -c ${input_bam_file}`
-    fi
-    P_DOWNSAMPLE=`python -c "print ${reads_after_downsampling}/float($NUM_READS)"`
-    RESULT=`python -c "print $P_DOWNSAMPLE > 1"`
-    if [ "$RESULT" == "True" ]
-    then
-        P_DOWNSAMPLE="1"
-    fi
+    NUM_READS=`samtools view -c ~{cram_or_bam_file}`
+    P_DOWNSAMPLE=`python -c "print(min(~{reads_after_downsampling}/float($NUM_READS), 1))"`
     echo $NUM_READS > num_reads.txt
-    java -Xmx2000m -jar /usr/gitc/picard.jar \
+
+    export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk4_jar_override}
+    gatk --java-options "-Xmx3000m" \
       DownsampleSam \
-      INPUT=${input_bam_file} \
-      OUTPUT=${downsampled_bam_filename} \
-      P=$P_DOWNSAMPLE \
-      VALIDATION_STRINGENCY=SILENT
+      -I "~{cram_or_bam_file}" \
+      -O "~{output_bam_name}" \
+      -P "$P_DOWNSAMPLE" \
+      --VALIDATION_STRINGENCY "SILENT"
+    samtools index "~{output_bam_name}"
   >>>
   output {
-    File output_bam_file = "${downsampled_bam_filename}"
+    File out = output_bam_name
+    File out_index = "~{output_bam_name}.bai"
     Int total_reads = read_int("num_reads.txt")
   }
   runtime {
-    preemptible: "${preemptible_tries}"
+    preemptible: "~{preemptible_tries}"
     docker: docker
     memory: "3.75 GiB"
     cpu: "1"
-    disks: "local-disk ${disk_size} HDD"
+    disks: "local-disk ~{disk_size} HDD"
   }
 }
 
 task PathSeqFilter {
+  input {
+    String sample_name
+    File input_bam_or_cram
+    File input_bam_or_cram_index
 
-  # Inputs for this task
-  String sample_name
-  File input_bam_or_cram
+    # Required if the input is a cram
+    File? cram_reference_fasta
+    File? cram_reference_fasta_index
+    File? cram_reference_dict
 
-  File? kmer_file
-  File? filter_bwa_image
+    File? kmer_file
+    File? filter_bwa_image
 
-  Boolean is_host_aligned
-  Array[String]? host_contigs_to_ignore
-  Boolean gather_metrics
-  # Optimizes disk space if provided
-  Float frac_non_host_reads = 1.0
+    Boolean is_host_aligned
+    Array[String] ignored_alignment_contigs
+    Boolean gather_metrics
 
-  Boolean? skip_quality_filters
-  Boolean? skip_pre_bwa_repartition
-  Boolean? filter_duplicates
-  Int? host_min_identity
-  Int? filter_bwa_seed_length
-  Int? min_clipped_read_length
-  Int? bam_partition_size
-  Int? max_masked_bases
-  Int? min_base_quality
-  Int? quality_threshold
-  Int? dust_mask_quality
-  Int? dust_window
-  Float? dust_t
-  Int? host_kmer_threshold
-  Int? max_adapter_mistmatches
-  Int? min_adapter_length
-  Int? filter_reads_per_partition
+    Boolean? skip_quality_filters
+    Boolean? skip_pre_bwa_repartition
+    Boolean? filter_duplicates
+    Int? host_min_identity
+    Int? filter_bwa_seed_length
+    Int? min_clipped_read_length
+    Int? bam_partition_size
+    Int? max_masked_bases
+    Int? min_base_quality
+    Int? quality_threshold
+    Int? dust_mask_quality
+    Int? dust_window
+    Float? dust_t
+    Int? host_kmer_threshold
+    Int? max_adapter_mistmatches
+    Int? min_adapter_length
+    Int? filter_reads_per_partition
 
-  String paired_bam_output_path = "${sample_name}.non_host.paired.bam"
-  String unpaired_bam_output_path = "${sample_name}.non_host.unpaired.bam"
-  String filter_metrics_output_path = "${sample_name}.pathseq.filter_metrics"
+    File? gatk4_jar_override
+    String? gcs_project_for_requester_pays
 
-  File? gatk4_jar_override
+    # Default to WARNING which will avoid excessive Spark logging
+    String verbosity = "WARNING"
 
-  # Default to WARNING which will avoid excessive Spark logging
-  String verbosity = "WARNING"
+    # Runtime parameters
+    String gatk_docker
+    Int mem_gb = 32
+    Int preemptible_attempts = 3
+    Float additional_disk_gb = 50
+    Int cpu = 8
+    Boolean use_ssd = false
+  }
 
-  # Runtime parameters
-  String gatk_docker
-  Int mem_gb = 32
-  Int preemptible_attempts = 3
-  Float additional_disk_gb = 50
-  Int cpu = 8
-  Boolean use_ssd = false
+  String paired_bam_output_path = "~{sample_name}.non_host.paired.bam"
+  String unpaired_bam_output_path = "~{sample_name}.non_host.unpaired.bam"
+  String filter_metrics_output_path = "~{sample_name}.pathseq.filter_metrics"
 
-  Int disk_size = ceil(((1.0 + frac_non_host_reads)*size(input_bam_or_cram, "GB")) + size(kmer_file, "GB") + size(filter_bwa_image, "GB") + additional_disk_gb)
+  Int disk_size = ceil(size(input_bam_or_cram, "GB") + size(kmer_file, "GB") + size(filter_bwa_image, "GB") + additional_disk_gb)
 
   # Mem is in units of GB but our command and memory runtime values are in MB
   Int machine_mem = mem_gb * 1000
@@ -476,45 +290,47 @@ task PathSeqFilter {
 
   command <<<
     set -euo pipefail
-    export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
-    touch ${filter_metrics_output_path}
-    gatk --java-options "-Xmx${command_mem}m" \
+    export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk4_jar_override}
+    touch ~{filter_metrics_output_path}
+    gatk --java-options "-Xmx~{command_mem}m" \
       PathSeqFilterSpark \
-      --input ${input_bam_or_cram} \
-      --paired-output ${paired_bam_output_path} \
-      --unpaired-output ${unpaired_bam_output_path} \
-      --is-host-aligned ${is_host_aligned}  \
-      --verbosity ${verbosity} \
-      ${if defined(host_contigs_to_ignore) then "--ignore-alignment-contigs " else ""} ${sep=" --ignore-alignment-contigs " host_contigs_to_ignore} \
-      ${if gather_metrics then "--filter-metrics ${filter_metrics_output_path}" else ""} \
-      ${if defined(kmer_file) then "--kmer-file ${kmer_file}" else ""} \
-      ${if defined(filter_bwa_image) then "--filter-bwa-image ${filter_bwa_image}" else ""} \
-      ${if defined(bam_partition_size) then "--bam-partition-size ${bam_partition_size}" else ""} \
-      ${if defined(skip_quality_filters) then "--skip-quality-filters ${skip_quality_filters}" else ""}\
-      ${if defined(min_clipped_read_length) then "--min-clipped-read-length ${min_clipped_read_length}" else ""} \
-      ${if defined(max_masked_bases) then "--max-masked-bases ${max_masked_bases}" else ""} \
-      ${if defined(min_base_quality) then "--min-base-quality ${min_base_quality}" else ""} \
-      ${if defined(quality_threshold) then "--quality-threshold ${quality_threshold}" else ""} \
-      ${if defined(dust_mask_quality) then "--dust-mask-quality ${dust_mask_quality}" else ""} \
-      ${if defined(dust_window) then "--dust-window ${dust_window}" else ""} \
-      ${if defined(dust_t) then "--dust-t ${dust_t}" else ""} \
-      ${if defined(host_kmer_threshold) then "--host-kmer-thresh ${host_kmer_threshold}" else ""} \
-      ${if defined(max_adapter_mistmatches) then "--max-adapter-mismatches ${max_adapter_mistmatches}" else ""} \
-      ${if defined(min_adapter_length) then "--min-adapter-length ${min_adapter_length}" else ""} \
-      ${if defined(filter_bwa_seed_length) then "--filter-bwa-seed-length ${filter_bwa_seed_length}" else ""} \
-      ${if defined(host_min_identity) then "--host-min-identity ${host_min_identity}" else ""} \
-      ${if defined(filter_duplicates) then "--filter-duplicates ${filter_duplicates}" else ""} \
-      ${if defined(skip_pre_bwa_repartition) then "--skip-pre-bwa-repartition ${skip_pre_bwa_repartition}" else ""} \
-      ${if defined(filter_reads_per_partition) then "--filter-reads-per-partition ${filter_reads_per_partition}" else ""}
+      --input ~{input_bam_or_cram} \
+      --paired-output ~{paired_bam_output_path} \
+      --unpaired-output ~{unpaired_bam_output_path} \
+      --is-host-aligned ~{is_host_aligned} \
+      --verbosity ~{verbosity} \
+      ~{if length(ignored_alignment_contigs) > 0 then "--ignore-alignment-contigs " else ""} ~{sep=" --ignore-alignment-contigs " ignored_alignment_contigs} \
+      ~{if defined(cram_reference_fasta) then "--reference ~{cram_reference_fasta}" else ""} \
+      ~{if gather_metrics then "--filter-metrics ~{filter_metrics_output_path}" else ""} \
+      ~{if defined(kmer_file) then "--kmer-file ~{kmer_file}" else ""} \
+      ~{if defined(filter_bwa_image) then "--filter-bwa-image ~{filter_bwa_image}" else ""} \
+      ~{if defined(bam_partition_size) then "--bam-partition-size ~{bam_partition_size}" else ""} \
+      ~{if defined(skip_quality_filters) then "--skip-quality-filters ~{skip_quality_filters}" else ""}\
+      ~{if defined(min_clipped_read_length) then "--min-clipped-read-length ~{min_clipped_read_length}" else ""} \
+      ~{if defined(max_masked_bases) then "--max-masked-bases ~{max_masked_bases}" else ""} \
+      ~{if defined(min_base_quality) then "--min-base-quality ~{min_base_quality}" else ""} \
+      ~{if defined(quality_threshold) then "--quality-threshold ~{quality_threshold}" else ""} \
+      ~{if defined(dust_mask_quality) then "--dust-mask-quality ~{dust_mask_quality}" else ""} \
+      ~{if defined(dust_window) then "--dust-window ~{dust_window}" else ""} \
+      ~{if defined(dust_t) then "--dust-t ~{dust_t}" else ""} \
+      ~{if defined(host_kmer_threshold) then "--host-kmer-thresh ~{host_kmer_threshold}" else ""} \
+      ~{if defined(max_adapter_mistmatches) then "--max-adapter-mismatches ~{max_adapter_mistmatches}" else ""} \
+      ~{if defined(min_adapter_length) then "--min-adapter-length ~{min_adapter_length}" else ""} \
+      ~{if defined(filter_bwa_seed_length) then "--filter-bwa-seed-length ~{filter_bwa_seed_length}" else ""} \
+      ~{if defined(host_min_identity) then "--host-min-identity ~{host_min_identity}" else ""} \
+      ~{if defined(filter_duplicates) then "--filter-duplicates ~{filter_duplicates}" else ""} \
+      ~{if defined(skip_pre_bwa_repartition) then "--skip-pre-bwa-repartition ~{skip_pre_bwa_repartition}" else ""} \
+      ~{if defined(filter_reads_per_partition) then "--filter-reads-per-partition ~{filter_reads_per_partition}" else ""} \
+      ~{if defined(gcs_project_for_requester_pays) then "--gcs-project-for-requester-pays ~{gcs_project_for_requester_pays}" else ""}
 
-    if [ ! -f "${paired_bam_output_path}" ]; then
-    	echo "File ${paired_bam_output_path} not found, creating empty BAM"
-    	printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:${sample_name}\n" | samtools view -hb - > ${paired_bam_output_path}
+    if [ ! -f "~{paired_bam_output_path}" ]; then
+      echo "File ~{paired_bam_output_path} not found, creating empty BAM"
+      printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:~{sample_name}\n" | samtools view -hb - > ~{paired_bam_output_path}
     fi
 
-    if [ ! -f "${unpaired_bam_output_path}" ]; then
-    	echo "File ${unpaired_bam_output_path} not found, creating empty BAM"
-    	printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:${sample_name}\n" | samtools view -hb - > ${unpaired_bam_output_path}
+    if [ ! -f "~{unpaired_bam_output_path}" ]; then
+      echo "File ~{unpaired_bam_output_path} not found, creating empty BAM"
+      printf "@HD     VN:1.5  SO:queryname\n@RG     ID:A    SM:~{sample_name}\n" | samtools view -hb - > ~{unpaired_bam_output_path}
     fi
   >>>
   runtime {
@@ -526,41 +342,41 @@ task PathSeqFilter {
     cpu: cpu
   }
   output {
-    File paired_bam_out = "${paired_bam_output_path}"
-    File unpaired_bam_out = "${unpaired_bam_output_path}"
-    File filter_metrics = "${sample_name}.pathseq.filter_metrics"
+    File paired_bam_out = "~{paired_bam_output_path}"
+    File unpaired_bam_out = "~{unpaired_bam_output_path}"
+    File filter_metrics = "~{sample_name}.pathseq.filter_metrics"
   }
 }
 
 task PathSeqAlign {
+  input {
+    String sample_name
+    File input_paired_bam
+    File input_unpaired_bam
 
-  # Inputs for this task
-  String sample_name
-  File input_paired_bam
-  File input_unpaired_bam
+    File microbe_bwa_image
+    File microbe_dict
 
-  File microbe_bwa_image
-  File microbe_dict
+    Int? microbe_min_seed_length
+    Int? max_alternate_hits
+    Int? bwa_score_threshold
 
-  Int? microbe_min_seed_length
-  Int? max_alternate_hits
-  Int? bwa_score_threshold
+    File? gatk4_jar_override
 
-  String paired_bam_output_path = "${sample_name}.microbe_aligned.paired.bam"
-  String unpaired_bam_output_path = "${sample_name}.microbe_aligned.unpaired.bam"
+    # Default to WARNING which will avoid excessive Spark logging
+    String verbosity = "WARNING"
 
-  File? gatk4_jar_override
+    # Runtime parameters
+    String gatk_docker
+    Int mem_gb = 140
+    Int preemptible_attempts = 3
+    Float additional_disk_gb = 50
+    Int cpu = 8
+    Boolean use_ssd = false
+  }
 
-  # Default to WARNING which will avoid excessive Spark logging
-  String verbosity = "WARNING"
-
-  # Runtime parameters
-  String gatk_docker
-  Int mem_gb = 140
-  Int preemptible_attempts = 3
-  Float additional_disk_gb = 50
-  Int cpu = 8
-  Boolean use_ssd = false
+  String paired_bam_output_path = "~{sample_name}.microbe_aligned.paired.bam"
+  String unpaired_bam_output_path = "~{sample_name}.microbe_aligned.unpaired.bam"
 
   Int disk_size = ceil((2.5*size(input_paired_bam, "GB")) + (2.5*size(input_unpaired_bam, "GB")) + size(microbe_bwa_image, "GB") + additional_disk_gb)
 
@@ -570,19 +386,19 @@ task PathSeqAlign {
 
   command <<<
     set -e
-    export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
-    gatk --java-options "-Xmx${command_mem}m" \
+    export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk4_jar_override}
+    gatk --java-options "-Xmx~{command_mem}m" \
       PathSeqBwaSpark \
-      --paired-input ${input_paired_bam} \
-      --unpaired-input ${input_unpaired_bam} \
-      --paired-output ${paired_bam_output_path} \
-      --unpaired-output ${unpaired_bam_output_path} \
-      --microbe-bwa-image ${microbe_bwa_image} \
-      --microbe-dict ${microbe_dict} \
-      --verbosity ${verbosity} \
-      ${if defined(microbe_min_seed_length) then "--microbe-min-seed-length ${microbe_min_seed_length}" else ""} \
-      ${if defined(max_alternate_hits) then "--max-alternate-hits ${max_alternate_hits}" else ""} \
-      ${if defined(bwa_score_threshold) then "--bwa-score-threshold ${bwa_score_threshold}" else ""}
+      --paired-input ~{input_paired_bam} \
+      --unpaired-input ~{input_unpaired_bam} \
+      --paired-output ~{paired_bam_output_path} \
+      --unpaired-output ~{unpaired_bam_output_path} \
+      --microbe-bwa-image ~{microbe_bwa_image} \
+      --microbe-dict ~{microbe_dict} \
+      --verbosity ~{verbosity} \
+      ~{if defined(microbe_min_seed_length) then "--microbe-min-seed-length ~{microbe_min_seed_length}" else ""} \
+      ~{if defined(max_alternate_hits) then "--max-alternate-hits ~{max_alternate_hits}" else ""} \
+      ~{if defined(bwa_score_threshold) then "--bwa-score-threshold ~{bwa_score_threshold}" else ""}
   >>>
   runtime {
     docker: gatk_docker
@@ -593,39 +409,39 @@ task PathSeqAlign {
     cpu: cpu
   }
   output {
-    File paired_bam_out = "${paired_bam_output_path}"
-    File unpaired_bam_out = "${unpaired_bam_output_path}"
+    File paired_bam_out = "~{paired_bam_output_path}"
+    File unpaired_bam_out = "~{unpaired_bam_output_path}"
   }
 }
 
 task PathSeqScore {
+  input {
+    String sample_name
+    File input_paired_bam
+    File input_unpaired_bam
 
-  # Inputs for this task
-  String sample_name
-  File input_paired_bam
-  File input_unpaired_bam
+    File taxonomy_file
 
-  File taxonomy_file
+    Boolean? divide_by_genome_length
+    Float? min_score_identity
+    Float? identity_margin
+    Boolean? not_normalized_by_kingdom
+    Int? score_reads_per_partition_estimate
 
-  Boolean? divide_by_genome_length
-  Float? min_score_identity
-  Float? identity_margin
-  Boolean? not_normalized_by_kingdom
-  Int? score_reads_per_partition_estimate
+    File? gatk4_jar_override
 
-  String bam_output_path = "${sample_name}.pathseq.bam"
-  String scores_output_path = "${sample_name}.pathseq.tsv"
-  String score_metrics_output_path = "${sample_name}.pathseq.score_metrics"
+    # Runtime parameters
+    String gatk_docker
+    Int mem_gb = 8
+    Int preemptible_attempts = 3
+    Float additional_disk_gb = 10
+    Int cpu = 2
+    Boolean use_ssd = false
+  }
 
-  File? gatk4_jar_override
-
-  # Runtime parameters
-  String gatk_docker
-  Int mem_gb = 8
-  Int preemptible_attempts = 3
-  Float additional_disk_gb = 10
-  Int cpu = 2
-  Boolean use_ssd = false
+  String bam_output_path = "~{sample_name}.pathseq.bam"
+  String scores_output_path = "~{sample_name}.pathseq.tsv"
+  String score_metrics_output_path = "~{sample_name}.pathseq.score_metrics"
 
   Int disk_size = ceil(size(input_paired_bam, "GB") + size(input_unpaired_bam, "GB") + additional_disk_gb)
 
@@ -635,20 +451,20 @@ task PathSeqScore {
 
   command <<<
     set -e
-    export GATK_LOCAL_JAR=${default="/root/gatk.jar" gatk4_jar_override}
-    gatk --java-options "-Xmx${command_mem}m" \
+    export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk4_jar_override}
+    gatk --java-options "-Xmx~{command_mem}m" \
       PathSeqScoreSpark \
-      --paired-input ${input_paired_bam} \
-      --unpaired-input ${input_unpaired_bam} \
-      --output ${bam_output_path} \
-      --scores-output ${scores_output_path} \
-      --score-metrics ${score_metrics_output_path} \
-      --taxonomy-file ${taxonomy_file} \
-      ${if defined(min_score_identity) then "--min-score-identity ${min_score_identity}" else ""} \
-      ${if defined(identity_margin) then "--identity-margin ${identity_margin}" else ""} \
-      ${if defined(divide_by_genome_length) then "--divide-by-genome-length ${divide_by_genome_length}" else ""} \
-      ${if defined(not_normalized_by_kingdom) then "--not-normalized-by-kingdom ${not_normalized_by_kingdom}" else ""} \
-      ${if defined(score_reads_per_partition_estimate) then "--score-reads-per-partition-estimate ${score_reads_per_partition_estimate}" else ""}
+      --paired-input ~{input_paired_bam} \
+      --unpaired-input ~{input_unpaired_bam} \
+      --output ~{bam_output_path} \
+      --scores-output ~{scores_output_path} \
+      --score-metrics ~{score_metrics_output_path} \
+      --taxonomy-file ~{taxonomy_file} \
+      ~{if defined(min_score_identity) then "--min-score-identity ~{min_score_identity}" else ""} \
+      ~{if defined(identity_margin) then "--identity-margin ~{identity_margin}" else ""} \
+      ~{if defined(divide_by_genome_length) then "--divide-by-genome-length ~{divide_by_genome_length}" else ""} \
+      ~{if defined(not_normalized_by_kingdom) then "--not-normalized-by-kingdom ~{not_normalized_by_kingdom}" else ""} \
+      ~{if defined(score_reads_per_partition_estimate) then "--score-reads-per-partition-estimate ~{score_reads_per_partition_estimate}" else ""}
   >>>
   runtime {
     docker: gatk_docker
@@ -659,27 +475,27 @@ task PathSeqScore {
     cpu: cpu
   }
   output {
-    File bam_out = "${sample_name}.pathseq.bam"
-    File scores = "${sample_name}.pathseq.tsv"
-    File score_metrics = "${sample_name}.pathseq.score_metrics"
+    File bam_out = "~{sample_name}.pathseq.bam"
+    File scores = "~{sample_name}.pathseq.tsv"
+    File score_metrics = "~{sample_name}.pathseq.score_metrics"
   }
 }
 
 # Extracts filter metrics as fraction of total reads
 task ProcessFilterMetrics {
-  File metrics_file
-  String docker
-  Int preemptible_tries = 3
-
-  String dollar = "$"
+  input {
+    File metrics_file
+    String docker
+    Int preemptible_tries = 3
+  }
 
   command <<<
     set -euo pipefail
-    if [ ! -s ${metrics_file} ]; then
+    if [ ! -s ~{metrics_file} ]; then
       echo "" | awk -v OFS="\t" '{print 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}'
     else
-      sed -n '8p' ${metrics_file} \
-        | awk -F"\t" -v OFS="\t" '{if (${dollar}1 > 0) {print ${dollar}2/${dollar}1, ${dollar}3/${dollar}1, ${dollar}4/${dollar}1, ${dollar}5/${dollar}1, ${dollar}6/${dollar}1, ${dollar}7/${dollar}1, ${dollar}8/${dollar}1, ${dollar}9/${dollar}1, ${dollar}0/${dollar}1, ${dollar}11/${dollar}1} else {print 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}'
+      sed -n '8p' ~{metrics_file} \
+        | awk -F"\t" -v OFS="\t" '{if ($1 > 0) {print $2/$1, $3/$1, $4/$1, $5/$1, $6/$1, $7/$1, $8/$1, $9/$1, $0/$1, $11/$1} else {print 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}'
     fi > metrics.txt
 
     cut -f1 metrics.txt > frac_after_prealigned_filter.txt
@@ -717,13 +533,15 @@ task ProcessFilterMetrics {
 
 # Extracts score metrics
 task ProcessScoreMetrics {
-  File metrics_file
-  String docker
-  Int preemptible_tries = 3
+  input {
+    File metrics_file
+    String docker
+    Int preemptible_tries = 3
+  }
 
   command <<<
     set -euo pipefail
-    sed -n '8p' ${metrics_file} > metrics.txt
+    sed -n '8p' ~{metrics_file} > metrics.txt
     cut -f1 metrics.txt > non_host_mapped_reads.txt
     cut -f2 metrics.txt > non_host_unmapped_reads.txt
   >>>

--- a/scripts/pathseq/wdl/pathseq_pipeline_template.json
+++ b/scripts/pathseq/wdl/pathseq_pipeline_template.json
@@ -1,19 +1,18 @@
 {
-  "PathSeqPipelineWorkflow.sample_name": "sample",
-  "PathSeqPipelineWorkflow.input_bam": "gs://my-bucket/sample.bam",
+  "PathSeqThreeStageWorkflow.sample_name": "sample",
+  "PathSeqThreeStageWorkflow.input_bam_or_cram": "gs://my-bucket/sample.bam",
 
-  "PathSeqPipelineWorkflow.is_host_aligned": false,
-  "PathSeqPipelineWorkflow.min_clipped_read_length": 60,
-  "PathSeqPipelineWorkflow.filter_duplicates": true,
-  "PathSeqPipelineWorkflow.min_score_identity": 0.90,
-  "PathSeqPipelineWorkflow.identity_margin": 0.02,
-  "PathSeqPipelineWorkflow.divide_by_genome_length": true,
+  "PathSeqThreeStageWorkflow.is_host_aligned": false,
+  "PathSeqThreeStageWorkflow.min_clipped_read_length": 60,
+  "PathSeqThreeStageWorkflow.filter_duplicates": true,
+  "PathSeqThreeStageWorkflow.min_score_identity": 0.90,
+  "PathSeqThreeStageWorkflow.identity_margin": 0.02,
+  "PathSeqThreeStageWorkflow.divide_by_genome_length": true,
 
-  "PathSeqPipelineWorkflow.filter_bwa_image": "gs://my-bucket/references/pathseq_host.fa.img",
-  "PathSeqPipelineWorkflow.kmer_file": "gs://my-bucket/references/pathseq_host.bfi",
-  "PathSeqPipelineWorkflow.microbe_bwa_image": "gs://my-bucket/references/pathseq_microbe.fa.img",
-  "PathSeqPipelineWorkflow.microbe_fasta": "gs://my-bucket/references/pathseq_microbe.fa",
-  "PathSeqPipelineWorkflow.microbe_fasta_dict": "gs://my-bucket/references/pathseq_microbe.dict",
-  "PathSeqPipelineWorkflow.taxonomy_file": "gs://my-bucket/references/pathseq_taxonomy.db",
-  "PathSeqPipelineWorkflow.gatk_docker": "broadinstitute/gatk:4.0.0.0"
+  "PathSeqThreeStageWorkflow.filter_bwa_image": "gs://my-bucket/references/pathseq_host.fa.img",
+  "PathSeqThreeStageWorkflow.kmer_file": "gs://my-bucket/references/pathseq_host.bfi",
+  "PathSeqThreeStageWorkflow.microbe_bwa_image": "gs://my-bucket/references/pathseq_microbe.fa.img",
+  "PathSeqThreeStageWorkflow.microbe_dict": "gs://my-bucket/references/pathseq_microbe.dict",
+  "PathSeqThreeStageWorkflow.taxonomy_file": "gs://my-bucket/references/pathseq_taxonomy.db",
+  "PathSeqThreeStageWorkflow.gatk_docker": "broadinstitute/gatk:4.1.0.0"
 }

--- a/scripts/pathseq/wdl/pathseq_pipeline_template.json
+++ b/scripts/pathseq/wdl/pathseq_pipeline_template.json
@@ -18,5 +18,5 @@
   "PathSeqPipeline.PathSeqFilter.filter_bwa_image": "gs://gatk-best-practices/pathseq/resources/pathseq_host.fa.img",
   "PathSeqPipeline.PathSeqScore.taxonomy_file": "gs://gatk-best-practices/pathseq/resources/meats.min2k.db",
 
-  "PathSeqPipeline.gatk_docker": "broadinstitute/gatk:latest"
+  "PathSeqPipeline.gatk_docker": "broadinstitute/gatk:4.1.7.0"
 }

--- a/scripts/pathseq/wdl/pathseq_pipeline_template.json
+++ b/scripts/pathseq/wdl/pathseq_pipeline_template.json
@@ -1,18 +1,22 @@
 {
-  "PathSeqThreeStageWorkflow.sample_name": "sample",
-  "PathSeqThreeStageWorkflow.input_bam_or_cram": "gs://my-bucket/sample.bam",
+  "PathSeqPipeline.sample_name": "NA12878_24RG_med.hg380.7chicken0.3",
+  "PathSeqPipeline.input_bam_or_cram": "gs://gatk-best-practices/pathseq/contaminated-bam/NA12878_24RG_med.hg380.7chicken0.3.bam",
+  "PathSeqPipeline.input_bam_or_cram_index": "gs://gatk-best-practices/pathseq/contaminated-bam/NA12878_24RG_med.hg380.7chicken0.3.bam.bai",
+  "PathSeqPipeline.downsample": false,
+  "PathSeqPipeline.gather_filter_metrics": true,
+  "PathSeqPipeline.PathSeqFilter.is_host_aligned": false,
 
-  "PathSeqThreeStageWorkflow.is_host_aligned": false,
-  "PathSeqThreeStageWorkflow.min_clipped_read_length": 60,
-  "PathSeqThreeStageWorkflow.filter_duplicates": true,
-  "PathSeqThreeStageWorkflow.min_score_identity": 0.90,
-  "PathSeqThreeStageWorkflow.identity_margin": 0.02,
-  "PathSeqThreeStageWorkflow.divide_by_genome_length": true,
+  "PathSeqPipeline.PathSeqFilter.min_clipped_read_length": 60,
+  "PathSeqPipeline.PathSeqFilter.filter_duplicates": true,
+  "PathSeqPipeline.PathSeqScore.min_score_identity": 0.90,
+  "PathSeqPipeline.PathSeqScore.identity_margin": 0.02,
+  "PathSeqPipeline.PathSeqScore.divide_by_genome_length": true,
 
-  "PathSeqThreeStageWorkflow.filter_bwa_image": "gs://my-bucket/references/pathseq_host.fa.img",
-  "PathSeqThreeStageWorkflow.kmer_file": "gs://my-bucket/references/pathseq_host.bfi",
-  "PathSeqThreeStageWorkflow.microbe_bwa_image": "gs://my-bucket/references/pathseq_microbe.fa.img",
-  "PathSeqThreeStageWorkflow.microbe_dict": "gs://my-bucket/references/pathseq_microbe.dict",
-  "PathSeqThreeStageWorkflow.taxonomy_file": "gs://my-bucket/references/pathseq_taxonomy.db",
-  "PathSeqThreeStageWorkflow.gatk_docker": "broadinstitute/gatk:4.1.0.0"
+  "PathSeqPipeline.PathSeqFilter.kmer_file": "gs://gatk-best-practices/pathseq/resources/pathseq_host.bfi",
+  "PathSeqPipeline.PathSeqAlign.microbe_bwa_image": "gs://gatk-best-practices/pathseq/resources/meats.fa.img",
+  "PathSeqPipeline.PathSeqAlign.microbe_dict": "gs://gatk-best-practices/pathseq/resources/meats.dict",
+  "PathSeqPipeline.PathSeqFilter.filter_bwa_image": "gs://gatk-best-practices/pathseq/resources/pathseq_host.fa.img",
+  "PathSeqPipeline.PathSeqScore.taxonomy_file": "gs://gatk-best-practices/pathseq/resources/meats.min2k.db",
+
+  "PathSeqPipeline.gatk_docker": "broadinstitute/gatk:latest"
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaArgumentCollection.java
@@ -9,25 +9,18 @@ public final class PSBwaArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public static final String MICROBE_BWA_IMAGE_LONG_NAME = "microbe-bwa-image";
-    public static final String MICROBE_BWA_IMAGE_SHORT_NAME = "MI";
-    public static final String MICROBE_FASTA_LONG_NAME = "microbe-fasta";
-    public static final String MICROBE_FASTA_SHORT_NAME = "MF";
+    public static final String MICROBE_REF_DICT_LONG_NAME = "microbe-dict";
     public static final String MICROBE_MIN_SEED_LENGTH_LONG_NAME = "microbe-min-seed-length";
-    public static final String MICROBE_MIN_SEED_LENGTH_SHORT_NAME = MICROBE_MIN_SEED_LENGTH_LONG_NAME;
     public static final String MAX_ALT_HITS_LONG_NAME = "max-alternate-hits";
-    public static final String MAX_ALT_HITS_SHORT_NAME = MAX_ALT_HITS_LONG_NAME;
     public static final String SCORE_THRESHOLD_LONG_NAME = "bwa-score-threshold";
-    public static final String SCORE_THRESHOLD_SHORT_NAME = SCORE_THRESHOLD_LONG_NAME;
 
     @Argument(doc = "Microbe reference BWA index image file generated using BwaMemIndexImageCreator. If running on a Spark cluster, this must be distributed to local disk on each node.",
-            fullName = MICROBE_BWA_IMAGE_LONG_NAME,
-            shortName = MICROBE_BWA_IMAGE_SHORT_NAME)
+            fullName = MICROBE_BWA_IMAGE_LONG_NAME)
     public String bwaImage;
 
-    @Argument(doc = "Reference corresponding to the microbe reference image file",
-            fullName = MICROBE_FASTA_LONG_NAME,
-            shortName = MICROBE_FASTA_SHORT_NAME)
-    public GATKPathSpecifier referencePath;
+    @Argument(fullName = MICROBE_REF_DICT_LONG_NAME,
+            doc = "Use the given sequence dictionary as the microbe sequence dictionary.  Must be a .dict file.")
+    public String microbeDictionary = null;
 
     /**
      * This parameter controls the sensitivity of the BWA-MEM aligner. Smaller values result in more alignments at the
@@ -35,7 +28,6 @@ public final class PSBwaArgumentCollection implements Serializable {
      */
     @Argument(doc = "Minimum BWA-MEM seed length for the microbe alignment",
             fullName = MICROBE_MIN_SEED_LENGTH_LONG_NAME,
-            shortName = MICROBE_MIN_SEED_LENGTH_SHORT_NAME,
             minValue = 1,
             minRecommendedValue = 11,
             optional = true)
@@ -46,7 +38,6 @@ public final class PSBwaArgumentCollection implements Serializable {
      */
     @Argument(doc = "Maximum number of alternate microbe alignments",
             fullName = MAX_ALT_HITS_LONG_NAME,
-            shortName = MAX_ALT_HITS_SHORT_NAME,
             minValue = 0,
             optional = true)
     public int maxAlternateHits = 5000;
@@ -56,7 +47,6 @@ public final class PSBwaArgumentCollection implements Serializable {
      */
     @Argument(doc = "Minimum score threshold for microbe alignments",
             fullName = SCORE_THRESHOLD_LONG_NAME,
-            shortName = SCORE_THRESHOLD_SHORT_NAME,
             minValue = 0,
             optional = true)
     public int scoreThreshold = 30;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtils.java
@@ -3,16 +3,13 @@ package org.broadinstitute.hellbender.tools.spark.pathseq;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import org.apache.spark.api.java.JavaRDD;
-import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
-import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 
+import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -22,9 +19,8 @@ import java.util.stream.Collectors;
 public final class PSBwaUtils {
 
     static void addReferenceSequencesToHeader(final SAMFileHeader header,
-                                              final GATKPathSpecifier referencePath,
-                                              final SerializableFunction<GATKRead, SimpleInterval> windowFunction) {
-        final List<SAMSequenceRecord> refSeqs = getReferenceSequences(referencePath, windowFunction);
+                                              final String referenceDictionaryPath) {
+        final List<SAMSequenceRecord> refSeqs = getReferenceSequences(referenceDictionaryPath);
         for (final SAMSequenceRecord rec : refSeqs) {
             if (header.getSequence(rec.getSequenceName()) == null) {
                 header.addSequence(rec);
@@ -32,13 +28,8 @@ public final class PSBwaUtils {
         }
     }
 
-    private static List<SAMSequenceRecord> getReferenceSequences(final GATKPathSpecifier referencePath,
-                                                                 final SerializableFunction<GATKRead, SimpleInterval> windowFunction) {
-        final ReferenceMultiSparkSource referenceSource = new ReferenceMultiSparkSource(referencePath, windowFunction);
-        final SAMSequenceDictionary referenceDictionary = referenceSource.getReferenceSequenceDictionary(null);
-        if (referenceDictionary == null) {
-            throw new UserException.MissingReferenceDictFile(referencePath.getRawInputString());
-        }
+    private static List<SAMSequenceRecord> getReferenceSequences(final String referenceDictionaryPath) {
+        final SAMSequenceDictionary referenceDictionary = ReferenceUtils.loadFastaDictionary(new File(referenceDictionaryPath));
         return referenceDictionary.getSequences();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilterArgumentCollection.java
@@ -18,67 +18,45 @@ public final class PSFilterArgumentCollection implements Serializable {
     public final int bwaThreads = 1;
 
     public static final String KMER_FILE_PATH_LONG_NAME = "kmer-file";
-    public static final String KMER_FILE_PATH_SHORT_NAME = "K";
     public static final String FILTER_METRICS_FILE_LONG_NAME = "filter-metrics";
-    public static final String FILTER_METRICS_FILE_SHORT_NAME = "FM";
     public static final String FILTER_BWA_IMAGE_LONG_NAME = "filter-bwa-image";
-    public static final String FILTER_BWA_IMAGE_SHORT_NAME = "FI";
 
     public static final String IS_HOST_ALIGNED_LONG_NAME = "is-host-aligned";
-    public static final String IS_HOST_ALIGNED_SHORT_NAME = IS_HOST_ALIGNED_LONG_NAME;
     public static final String SKIP_FILTERS_LONG_NAME = "skip-quality-filters";
-    public static final String SKIP_FILTERS_SHORT_NAME = SKIP_FILTERS_LONG_NAME;
     public static final String SKIP_PRE_BWA_REPARTITION_LONG_NAME = "skip-pre-bwa-repartition";
-    public static final String SKIP_PRE_BWA_REPARTITION_SHORT_NAME = SKIP_PRE_BWA_REPARTITION_LONG_NAME;
     public static final String MIN_CLIPPED_READ_LENGTH_LONG_NAME = "min-clipped-read-length";
-    public static final String MIN_CLIPPED_READ_LENGTH_SHORT_NAME = MIN_CLIPPED_READ_LENGTH_LONG_NAME;
     public static final String MAX_MASKED_BASES_LONG_NAME = "max-masked-bases";
-    public static final String MAX_MASKED_BASES_SHORT_NAME = MAX_MASKED_BASES_LONG_NAME;
     public static final String MIN_BASE_QUALITY_LONG_NAME = "min-base-quality";
-    public static final String MIN_BASE_QUALITY_SHORT_NAME = MIN_BASE_QUALITY_LONG_NAME;
     public static final String QUALITY_SCORE_THRESHOLD_LONG_NAME = "quality-threshold";
-    public static final String QUALITY_SCORE_THRESHOLD_SHORT_NAME = QUALITY_SCORE_THRESHOLD_LONG_NAME;
     public static final String DUST_MASK_QUALITY_LONG_NAME = "dust-mask-quality";
-    public static final String DUST_MASK_QUALITY_SHORT_NAME = DUST_MASK_QUALITY_LONG_NAME;
     public static final String DUST_WINDOW_SIZE_LONG_NAME = "dust-window";
-    public static final String DUST_WINDOW_SIZE_SHORT_NAME = DUST_WINDOW_SIZE_LONG_NAME;
     public static final String DUST_T_SCORE_LONG_NAME = "dust-t";
-    public static final String DUST_T_SCORE_SHORT_NAME = DUST_T_SCORE_LONG_NAME;
     public static final String HOST_MIN_IDENTITY_LONG_NAME = "host-min-identity";
     public static final String HOST_MIN_IDENTITY_SHORT_NAME = HOST_MIN_IDENTITY_LONG_NAME;
     public static final String IGNORE_ALIGNMENT_CONTIGS_LONG_NAME = "ignore-alignment-contigs";
     public static final String IGNORE_ALIGNMENT_CONTIGS_SHORT_NAME = IGNORE_ALIGNMENT_CONTIGS_LONG_NAME;
     public static final String HOST_KMER_COUNT_THRESHOLD_LONG_NAME = "host-kmer-thresh";
-    public static final String HOST_KMER_COUNT_THRESHOLD_SHORT_NAME = HOST_KMER_COUNT_THRESHOLD_LONG_NAME;
     public static final String FILTER_BWA_SEED_LENGTH_LONG_NAME = "filter-bwa-seed-length";
-    public static final String FILTER_BWA_SEED_LENGTH_SHORT_NAME = FILTER_BWA_SEED_LENGTH_LONG_NAME;
     public static final String FILTER_READS_PER_PARTITION_LONG_NAME = "filter-reads-per-partition";
-    public static final String FILTER_READS_PER_PARTITION_SHORT_NAME = FILTER_READS_PER_PARTITION_LONG_NAME;
     public static final String FILTER_DUPLICATES_LONG_NAME = "filter-duplicates";
-    public static final String FILTER_DUPLICATES_SHORT_NAME = FILTER_DUPLICATES_LONG_NAME;
     public static final String MAX_ADAPTER_MISMATCHES_LONG_NAME = "max-adapter-mismatches";
-    public static final String MAX_ADAPTER_MISMATCHES_SHORT_NAME = MAX_ADAPTER_MISMATCHES_LONG_NAME;
     public static final String MIN_ADAPTER_LENGTH_LONG_NAME = "min-adapter-length";
-    public static final String MIN_ADAPTER_LENGTH_SHORT_NAME = MIN_ADAPTER_LENGTH_LONG_NAME;
 
     /**
      * PathSeq will rapidly filter the reads if they are aligned to a host reference, thus reducing run time.
      */
     @Argument(doc = "Set if the input BAM is aligned to the host",
             fullName = IS_HOST_ALIGNED_LONG_NAME,
-            shortName = IS_HOST_ALIGNED_SHORT_NAME,
             optional = true)
     public boolean alignedInput = false;
 
     @Argument(doc = "Path to host k-mer file generated with PathSeqBuildKmers. K-mer filtering is skipped if this is not specified.",
             fullName = KMER_FILE_PATH_LONG_NAME,
-            shortName = KMER_FILE_PATH_SHORT_NAME,
             optional = true)
     public String kmerFilePath = null;
 
     @Argument(doc = "Skip low-quality and low-complexity read filtering",
             fullName = SKIP_FILTERS_LONG_NAME,
-            shortName = SKIP_FILTERS_SHORT_NAME,
             optional = true)
     public boolean skipFilters = false;
 
@@ -110,7 +88,6 @@ public final class PSFilterArgumentCollection implements Serializable {
     @Argument(doc = "Skip pre-BWA repartition. Set to true for inputs with a high proportion of microbial reads that " +
             "are not host coordinate-sorted.",
             fullName = SKIP_PRE_BWA_REPARTITION_LONG_NAME,
-            shortName = SKIP_PRE_BWA_REPARTITION_SHORT_NAME,
             optional = true)
     public boolean skipPreBwaRepartition = false;
 
@@ -121,7 +98,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Minimum length of reads after quality trimming",
             fullName = MIN_CLIPPED_READ_LENGTH_LONG_NAME,
-            shortName = MIN_CLIPPED_READ_LENGTH_SHORT_NAME,
             minValue = 1,
             minRecommendedValue = 31,
             optional = true)
@@ -139,14 +115,12 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Max allowable number of masked bases per read",
             fullName = MAX_MASKED_BASES_LONG_NAME,
-            shortName = MAX_MASKED_BASES_SHORT_NAME,
             minValue = 0,
             optional = true)
     public int maxAmbiguousBases = 2;
 
     @Argument(doc = "Bases below this call quality will be masked with 'N'",
             fullName = MIN_BASE_QUALITY_LONG_NAME,
-            shortName = MIN_BASE_QUALITY_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int qualPhredThresh = 15;
@@ -156,20 +130,17 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Quality score trimmer threshold",
             fullName = QUALITY_SCORE_THRESHOLD_LONG_NAME,
-            shortName = QUALITY_SCORE_THRESHOLD_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int readTrimThresh = 15;
 
     @Argument(doc = "Base quality to assign low-complexity bases",
             fullName = DUST_MASK_QUALITY_LONG_NAME,
-            shortName = DUST_MASK_QUALITY_SHORT_NAME,
             optional = true)
     public int dustMask = 2;
 
     @Argument(doc = "DUST algorithm window size",
             fullName = DUST_WINDOW_SIZE_LONG_NAME,
-            shortName = DUST_WINDOW_SIZE_SHORT_NAME,
             optional = true)
     public int dustW = 64;
 
@@ -178,7 +149,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "DUST algorithm score threshold",
             fullName = DUST_T_SCORE_LONG_NAME,
-            shortName = DUST_T_SCORE_SHORT_NAME,
             optional = true)
     public double dustT = 20.0;
 
@@ -188,7 +158,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Host alignment identity score threshold, in bp",
             fullName = HOST_MIN_IDENTITY_LONG_NAME,
-            shortName = HOST_MIN_IDENTITY_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int minIdentity = 30;
@@ -209,7 +178,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Host kmer count threshold.",
             fullName = HOST_KMER_COUNT_THRESHOLD_LONG_NAME,
-            shortName = HOST_KMER_COUNT_THRESHOLD_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int hostKmerThresh = 1;
@@ -219,7 +187,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "The BWA image file of the host reference. This must be distributed to local disk on each node.",
             fullName = FILTER_BWA_IMAGE_LONG_NAME,
-            shortName = FILTER_BWA_IMAGE_SHORT_NAME,
             optional = true)
     public String indexImageFile = null;
 
@@ -229,7 +196,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Minimum seed length for the host BWA alignment.",
             fullName = FILTER_BWA_SEED_LENGTH_LONG_NAME,
-            shortName = FILTER_BWA_SEED_LENGTH_SHORT_NAME,
             minValue = 1,
             minRecommendedValue = 11,
             optional = true)
@@ -242,7 +208,6 @@ public final class PSFilterArgumentCollection implements Serializable {
     @Advanced
     @Argument(doc = "Estimated reads per partition after quality, kmer, and BWA filtering",
             fullName = FILTER_READS_PER_PARTITION_LONG_NAME,
-            shortName = FILTER_READS_PER_PARTITION_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int filterReadsPerPartition = 200000;
@@ -253,7 +218,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Filter duplicate reads",
             fullName = FILTER_DUPLICATES_LONG_NAME,
-            shortName = FILTER_DUPLICATES_SHORT_NAME,
             optional = true)
     public boolean filterDuplicates = true;
 
@@ -262,14 +226,12 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Minimum length of adapter sequence to trim",
             fullName = MIN_ADAPTER_LENGTH_LONG_NAME,
-            shortName = MIN_ADAPTER_LENGTH_SHORT_NAME,
             minValue = 1,
             optional = true)
     public int minAdapterLength = 12;
 
     @Argument(doc = "Maximum number of mismatches for adapter trimming",
             fullName = MAX_ADAPTER_MISMATCHES_LONG_NAME,
-            shortName = MAX_ADAPTER_MISMATCHES_SHORT_NAME,
             minValue = 0,
             optional = true)
     public int maxAdapterMismatches = 1;
@@ -295,7 +257,6 @@ public final class PSFilterArgumentCollection implements Serializable {
      */
     @Argument(doc = "Log counts of filtered reads to this file",
             fullName = FILTER_METRICS_FILE_LONG_NAME,
-            shortName = FILTER_METRICS_FILE_SHORT_NAME,
             optional = true)
     public String filterMetricsFileUri = null;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
@@ -207,7 +207,7 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
         if (!readArguments.getReadFiles().isEmpty()) {
             throw new UserException.BadInput("Please use --paired-input or --unpaired-input instead of --input");
         }
-        Utils.validateArg(outputPaired == null || (IOUtils.isBamFileName(outputPaired)) && (outputUnpaired == null || IOUtils.isBamFileName(outputUnpaired)), "Only BAM output is supported");
+        Utils.validateArg((outputPaired == null || IOUtils.isBamFileName(outputPaired)) && (outputUnpaired == null || IOUtils.isBamFileName(outputUnpaired)), "Only BAM output is supported");
         final ReadsSparkSource readsSource = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
 
         final PSBwaAlignerSpark aligner = new PSBwaAlignerSpark(ctx, bwaArgs);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSpark.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gcs.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import scala.Tuple2;
@@ -35,7 +36,7 @@ import java.io.IOException;
  *     <li>Unaligned queryname-sorted BAM file containing only paired reads (paired-end reads with mates)</li>
  *     <li>Unaligned BAM file containing only unpaired reads (paired-end reads without mates and/or single-end reads)</li>
  *     <li>*Microbe reference BWA-MEM index image generated using BwaMemIndexImageCreator</li>
- *     <li>*Indexed microbe reference FASTA file</li>
+ *     <li>*Indexed microbe reference dictionary (fasta file NOT required)</li>
  * </ul>
  *
  * <p>*A standard microbe reference is available in the <a href="https://software.broadinstitute.org/gatk/download/bundle">GATK Resource Bundle</a>.</p>
@@ -63,7 +64,7 @@ import java.io.IOException;
  *   --paired-output output_reads_paired.bam \
  *   --unpaired-output output_reads_unpaired.bam \
  *   --microbe-bwa-image reference.img \
- *   --microbe-fasta reference.fa
+ *   --microbe-dict reference.dict
  * </pre>
  *
  * <h4>Spark cluster on Google Cloud DataProc with 6 32-core / 208GB memory worker nodes:</h4>
@@ -75,7 +76,7 @@ import java.io.IOException;
  *   --paired-output gs://my-gcs-bucket/output_reads_paired.bam \
  *   --unpaired-output gs://my-gcs-bucket/output_reads_unpaired.bam \
  *   --microbe-bwa-image /references/reference.img \
- *   --microbe-fasta hdfs://my-cluster-m:8020//references/reference.fa \
+ *   --microbe-dict hdfs://my-cluster-m:8020//references/reference.dict \
  *   --bam-partition-size 4000000 \
  *   -- \
  *   --sparkRunner GCS \
@@ -110,35 +111,27 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 
     public static final String PAIRED_INPUT_LONG_NAME = "paired-input";
-    public static final String PAIRED_INPUT_SHORT_NAME = "PI";
     public static final String UNPAIRED_INPUT_LONG_NAME = "unpaired-input";
-    public static final String UNPAIRED_INPUT_SHORT_NAME = "UI";
     public static final String PAIRED_OUTPUT_LONG_NAME = "paired-output";
-    public static final String PAIRED_OUTPUT_SHORT_NAME = "PO";
     public static final String UNPAIRED_OUTPUT_LONG_NAME = "unpaired-output";
-    public static final String UNPAIRED_OUTPUT_SHORT_NAME = "UO";
 
     @Argument(doc = "Input queryname-sorted BAM containing only paired reads",
             fullName = PAIRED_INPUT_LONG_NAME,
-            shortName = PAIRED_INPUT_SHORT_NAME,
             optional = true)
     public String inputPaired = null;
 
     @Argument(doc = "Input BAM containing only unpaired reads",
             fullName = UNPAIRED_INPUT_LONG_NAME,
-            shortName = UNPAIRED_INPUT_SHORT_NAME,
             optional = true)
     public String inputUnpaired = null;
 
     @Argument(doc = "Output BAM containing only paired reads",
             fullName = PAIRED_OUTPUT_LONG_NAME,
-            shortName = PAIRED_OUTPUT_SHORT_NAME,
             optional = true)
     public String outputPaired = null;
 
     @Argument(doc = "Output BAM containing only unpaired reads",
             fullName = UNPAIRED_OUTPUT_LONG_NAME,
-            shortName = UNPAIRED_OUTPUT_SHORT_NAME,
             optional = true)
     public String outputUnpaired = null;
 
@@ -156,8 +149,8 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
             if (header.getSequenceDictionary() != null && !header.getSequenceDictionary().isEmpty()) {
                 throw new UserException.BadInput("Input BAM should be unaligned, but found one or more sequences in the header.");
             }
-            PSBwaUtils.addReferenceSequencesToHeader(header, bwaArgs.referencePath, getReferenceWindowFunction());
-            final JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize, useNio);
+            PSBwaUtils.addReferenceSequencesToHeader(header, bwaArgs.microbeDictionary);
+            final JavaRDD<GATKRead> reads = readsSource.getParallelReads(path, null, null, bamPartitionSplitSize);
             return new Tuple2<>(header, reads);
         }
         logger.warn("Could not find file " + path + ". Skipping...");
@@ -178,7 +171,7 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
 
         final String outputPath = isPaired ? outputPaired : outputUnpaired;
         try {
-            ReadsSparkSink.writeReads(ctx, outputPath, bwaArgs.referencePath, reads, header,
+            ReadsSparkSink.writeReads(ctx, outputPath, null, reads, header,
                     shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE,
                     PSUtils.pathseqGetRecommendedNumReducers(inputBamPath, numReducers, getTargetPartitionSize()), shardedPartsDir, true, splittingIndexGranularity);
         } catch (final IOException e) {
@@ -214,6 +207,7 @@ public final class PathSeqBwaSpark extends GATKSparkTool {
         if (!readArguments.getReadFiles().isEmpty()) {
             throw new UserException.BadInput("Please use --paired-input or --unpaired-input instead of --input");
         }
+        Utils.validateArg(outputPaired == null || (IOUtils.isBamFileName(outputPaired)) && (outputUnpaired == null || IOUtils.isBamFileName(outputUnpaired)), "Only BAM output is supported");
         final ReadsSparkSource readsSource = new ReadsSparkSource(ctx, readArguments.getReadValidationStringency());
 
         final PSBwaAlignerSpark aligner = new PSBwaAlignerSpark(ctx, bwaArgs);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqFilterSpark.java
@@ -126,19 +126,15 @@ public final class PathSeqFilterSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 
     public static final String PAIRED_OUTPUT_LONG_NAME = "paired-output";
-    public static final String PAIRED_OUTPUT_SHORT_NAME = "PO";
     public static final String UNPAIRED_OUTPUT_LONG_NAME = "unpaired-output";
-    public static final String UNPAIRED_OUTPUT_SHORT_NAME = "UO";
 
     @Argument(doc = "Output BAM containing only paired reads",
             fullName = PAIRED_OUTPUT_LONG_NAME,
-            shortName = PAIRED_OUTPUT_SHORT_NAME,
             optional = true)
     public String outputPaired = null;
 
     @Argument(doc = "Output BAM containing only unpaired reads",
             fullName = UNPAIRED_OUTPUT_LONG_NAME,
-            shortName = UNPAIRED_OUTPUT_SHORT_NAME,
             optional = true)
     public String outputUnpaired = null;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqScoreSpark.java
@@ -105,19 +105,15 @@ public class PathSeqScoreSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 
     public static final String PAIRED_INPUT_LONG_NAME = "paired-input";
-    public static final String PAIRED_INPUT_SHORT_NAME = "PI";
     public static final String UNPAIRED_INPUT_LONG_NAME = "unpaired-input";
-    public static final String UNPAIRED_INPUT_SHORT_NAME = "UI";
 
     @Argument(doc = "Input queryname-sorted BAM containing only paired reads",
             fullName = PAIRED_INPUT_LONG_NAME,
-            shortName = PAIRED_INPUT_SHORT_NAME,
             optional = true)
     public String pairedInput = null;
 
     @Argument(doc = "Input BAM containing only unpaired reads",
             fullName = UNPAIRED_INPUT_LONG_NAME,
-            shortName = UNPAIRED_INPUT_SHORT_NAME,
             optional = true)
     public String unpairedInput = null;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtilTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSBwaUtilTest.java
@@ -1,28 +1,25 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import org.broadinstitute.hellbender.engine.GATKPathSpecifier;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceMultiSparkSource;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReferenceWindowFunctions;
-import org.broadinstitute.hellbender.utils.SerializableFunction;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.io.File;
 
 public class PSBwaUtilTest extends GATKBaseTest {
 
     @Test
     public void testAddReferenceSequencesToHeader() {
         final SAMFileHeader header = new SAMFileHeader();
-        final SerializableFunction<GATKRead, SimpleInterval> windowFunction = ReferenceWindowFunctions.IDENTITY_FUNCTION;
-        final GATKPathSpecifier referencePath = new GATKPathSpecifier(hg19MiniReference);
-        PSBwaUtils.addReferenceSequencesToHeader(header, referencePath, windowFunction);
-        final ReferenceMultiSparkSource ref = new ReferenceMultiSparkSource(referencePath, windowFunction);
-        Assert.assertEquals(ref.getReferenceSequenceDictionary(null).size(), header.getSequenceDictionary().size());
-        for (final SAMSequenceRecord rec : ref.getReferenceSequenceDictionary(null).getSequences()) {
+        final String dictionaryPath = hg19_chr1_1M_dict;
+        PSBwaUtils.addReferenceSequencesToHeader(header, dictionaryPath);
+        final SAMSequenceDictionary refDict = ReferenceUtils.loadFastaDictionary(new File(dictionaryPath));
+        Assert.assertEquals(refDict.size(), header.getSequenceDictionary().size());
+        for (final SAMSequenceRecord rec : refDict.getSequences()) {
             final SAMSequenceRecord recTest = header.getSequenceDictionary().getSequence(rec.getSequenceName());
             Assert.assertNotNull(recTest);
             Assert.assertEquals(rec, recTest);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqBwaSparkIntegrationTest.java
@@ -12,7 +12,7 @@ import java.io.File;
 public class PathSeqBwaSparkIntegrationTest extends CommandLineProgramTest {
 
     private final String IMAGE_PATH = publicTestDir + "hg19mini.fasta.img";
-    private final String REF_PATH = publicTestDir + "hg19mini.fasta";
+    private final String REF_DICT_PATH = publicTestDir + "hg19mini.dict";
 
     @DataProvider(name = "pathseqBwaTestData")
     public Object[][] getTestData() {
@@ -35,7 +35,7 @@ public class PathSeqBwaSparkIntegrationTest extends CommandLineProgramTest {
         args.add(PathSeqBwaSpark.PAIRED_INPUT_LONG_NAME, inputBamFile);
         args.add(PathSeqBwaSpark.PAIRED_OUTPUT_LONG_NAME, pairedOutputBamFile);
         args.add(PSBwaArgumentCollection.MICROBE_BWA_IMAGE_LONG_NAME, IMAGE_PATH);
-        args.add(PSBwaArgumentCollection.MICROBE_FASTA_LONG_NAME, REF_PATH);
+        args.add(PSBwaArgumentCollection.MICROBE_REF_DICT_LONG_NAME, REF_DICT_PATH);
         this.runCommandLine(args.getArgsArray());
         SamAssertionUtils.assertSamsEqual(pairedOutputBamFile, getTestFile(expectedBamFilename), ValidationStringency.LENIENT);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/PathSeqPipelineSparkIntegrationTest.java
@@ -58,7 +58,7 @@ public class PathSeqPipelineSparkIntegrationTest extends CommandLineProgramTest 
         final File outputFilterMetricsFile = createTempFile("filter", ".metrics");
         final File outputScoreMetricsFile = createTempFile("score", ".metrics");
         final File pathogenBwaImage = getTestFile("e_coli_k12_mini.fa.img");
-        final File pathogenFasta = getTestFile("e_coli_k12_mini.fa");
+        final File pathogenDict = getTestFile("e_coli_k12_mini.dict");
         final File taxonomyDatabase = getTestFile("e_coli_k12_mini.db");
 
         final ArgumentsBuilder args = new ArgumentsBuilder();
@@ -69,7 +69,7 @@ public class PathSeqPipelineSparkIntegrationTest extends CommandLineProgramTest 
         args.add(PSFilterArgumentCollection.FILTER_BWA_IMAGE_LONG_NAME, filterImagePath);
         args.add(PSFilterArgumentCollection.IS_HOST_ALIGNED_LONG_NAME, isHostAligned);
         args.add(PSBwaArgumentCollection.MICROBE_BWA_IMAGE_LONG_NAME, pathogenBwaImage);
-        args.add(PSBwaArgumentCollection.MICROBE_FASTA_LONG_NAME, pathogenFasta);
+        args.add(PSBwaArgumentCollection.MICROBE_REF_DICT_LONG_NAME, pathogenDict);
         args.add(PSScoreArgumentCollection.TAXONOMIC_DATABASE_LONG_NAME, taxonomyDatabase);
         args.add(PSFilterArgumentCollection.FILTER_METRICS_FILE_LONG_NAME, outputFilterMetricsFile);
         args.add(PSScoreArgumentCollection.SCORE_METRICS_FILE_LONG_NAME, outputScoreMetricsFile);


### PR DESCRIPTION
This new PathSeq WDL redesigns the workflow for improved performance in the cloud. Downsampling can be applied to BAMs with high microbial content (ie >10M reads) that normally cause performance issues. 

Other improvements include:

* Removed microbial fasta input, as only the sequence dictionary is needed.
* Broke pipeline down to into smaller tasks. This helps reduce costs by a) provisioning fewer resources at the filter and score phases of the pipeline and b) reducing job wall time to minimize the likelihood of VM preemption.
* Filter-only option, which can be used to cheaply estimate the number of microbial reads in the sample.
* Metrics are now parsed so they can be fed as output to the Terra data model.
* CRAM-to-BAM capability
* Updated WDL readme
* Deleted unneeded WDL json configuration, as the configuration can be provided in Terra