### PR TITLE
Ignore specified contigs for pre-aligned BAMs in PathSeq

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilter.java
@@ -4,22 +4,34 @@ import htsjdk.samtools.Cigar;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
- * Filters out reads above a threshold identity (number of matches less deletions), given in bases.
+ * Filters out reads above a threshold identity (number of matches less deletions), given in bases. Reads mapped to
+ * any of the excluded contigs, if provided, will automatically pass the filter regardless of mapping identity.
  */
 public final class HostAlignmentReadFilter extends ReadFilter {
 
     private static final long serialVersionUID = 1L;
 
     private final int minIdentity;
+    private final Set<String> excludedContigs;
+
+    public HostAlignmentReadFilter(final int minIdent, final Set<String> excludedContigs) {
+        this.minIdentity = minIdent;
+        this.excludedContigs = excludedContigs;
+    }
 
     public HostAlignmentReadFilter(final int minIdent) {
         this.minIdentity = minIdent;
+        this.excludedContigs = Collections.emptySet();
     }
 
     @Override
     public boolean test(final GATKRead read) {
         if ( read.isUnmapped() ) return true;
+        if ( excludedContigs.contains(read.getContig()) ) return true;
         final Integer nmVal = read.getAttributeAsInteger("NM");
         if ( nmVal == null ) return true;
         return test(read.getCigar(), nmVal.intValue());

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.spark.pathseq;
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.SequenceUtil;
@@ -11,6 +12,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.filters.AmbiguousBaseReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadLengthReadFilter;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.pathseq.loggers.PSFilterLogger;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
 import org.broadinstitute.hellbender.tools.spark.utils.ReadFilterSparkifier;
@@ -57,6 +59,7 @@ public final class PSFilter implements AutoCloseable {
         this.ctx = ctx;
         this.filterArgs = filterArgs;
         this.header = header;
+        validateFilterArguments();
     }
 
     @VisibleForTesting
@@ -171,6 +174,21 @@ public final class PSFilter implements AutoCloseable {
     }
 
     /**
+     * Validate arguments
+     */
+    private void validateFilterArguments() {
+        final SAMSequenceDictionary dictionary = header.getSequenceDictionary();
+        if (filterArgs.alignedInput) {
+            final Set<String> contigsToIgnoreSet = new HashSet<>(filterArgs.alignmentContigsToIgnore);
+            for (final String contig : contigsToIgnoreSet) {
+                if (dictionary.getSequence(contig) == null) {
+                    throw new UserException.MissingContigInSequenceDictionary(contig, dictionary);
+                }
+            }
+        }
+    }
+
+    /**
      * Pairs reads with canonical Long ID using the lesser 64-bit hash of the sequence and its reverse complement
      */
     @VisibleForTesting
@@ -198,6 +216,15 @@ public final class PSFilter implements AutoCloseable {
         return reads.mapPartitions(itr -> (new PSBwaFilter(indexFileName, minIdentity, minSeedLength, numThreads, false)).apply(itr));
     }
 
+    private static void validateIgnoredContigs(final List<String> contigs, final SAMSequenceDictionary dictionary) {
+        final Set<String> contigsToIgnoreSet = new HashSet<>();
+        for (final String contig : contigsToIgnoreSet) {
+            if (dictionary.getSequence(contig) == null) {
+                throw new UserException.MissingContigInSequenceDictionary(contig, dictionary);
+            }
+        }
+    }
+
     /**
      * Main PathSeq filtering method. See PathSeqFilterSpark for an overview.
      * Returns a tuple containing the paired reads and unpaired reads as separate RDDs.
@@ -210,7 +237,8 @@ public final class PSFilter implements AutoCloseable {
         filterLogger.logPrimaryReads(reads);
 
         if (filterArgs.alignedInput) {
-            reads = reads.filter(new ReadFilterSparkifier(new HostAlignmentReadFilter(filterArgs.minIdentity)));
+            final Set<String> contigsToIgnoreSet = Collections.unmodifiableSet(new HashSet<>(filterArgs.alignmentContigsToIgnore));
+            reads = reads.filter(new ReadFilterSparkifier(new HostAlignmentReadFilter(filterArgs.minIdentity, contigsToIgnoreSet)));
         }
         filterLogger.logReadsAfterPrealignedHostFilter(reads);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
@@ -182,7 +182,7 @@ public final class PSFilter implements AutoCloseable {
             final Set<String> contigsToIgnoreSet = new HashSet<>(filterArgs.alignmentContigsToIgnore);
             for (final String contig : contigsToIgnoreSet) {
                 if (dictionary.getSequence(contig) == null) {
-                    throw new UserException.MissingContigInSequenceDictionary(contig, dictionary);
+                    throw new UserException.BadInput("Ignored sequence " + contig + " not found in input header.");
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilter.java
@@ -216,15 +216,6 @@ public final class PSFilter implements AutoCloseable {
         return reads.mapPartitions(itr -> (new PSBwaFilter(indexFileName, minIdentity, minSeedLength, numThreads, false)).apply(itr));
     }
 
-    private static void validateIgnoredContigs(final List<String> contigs, final SAMSequenceDictionary dictionary) {
-        final Set<String> contigsToIgnoreSet = new HashSet<>();
-        for (final String contig : contigsToIgnoreSet) {
-            if (dictionary.getSequence(contig) == null) {
-                throw new UserException.MissingContigInSequenceDictionary(contig, dictionary);
-            }
-        }
-    }
-
     /**
      * Main PathSeq filtering method. See PathSeqFilterSpark for an overview.
      * Returns a tuple containing the paired reads and unpaired reads as separate RDDs.

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/PSFilterArgumentCollection.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadLengthReadFilter;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class PSFilterArgumentCollection implements Serializable {
@@ -45,6 +46,8 @@ public final class PSFilterArgumentCollection implements Serializable {
     public static final String DUST_T_SCORE_SHORT_NAME = DUST_T_SCORE_LONG_NAME;
     public static final String HOST_MIN_IDENTITY_LONG_NAME = "host-min-identity";
     public static final String HOST_MIN_IDENTITY_SHORT_NAME = HOST_MIN_IDENTITY_LONG_NAME;
+    public static final String IGNORE_ALIGNMENT_CONTIGS_LONG_NAME = "ignore-alignment-contigs";
+    public static final String IGNORE_ALIGNMENT_CONTIGS_SHORT_NAME = IGNORE_ALIGNMENT_CONTIGS_LONG_NAME;
     public static final String HOST_KMER_COUNT_THRESHOLD_LONG_NAME = "host-kmer-thresh";
     public static final String HOST_KMER_COUNT_THRESHOLD_SHORT_NAME = HOST_KMER_COUNT_THRESHOLD_LONG_NAME;
     public static final String FILTER_BWA_SEED_LENGTH_LONG_NAME = "filter-bwa-seed-length";
@@ -189,6 +192,16 @@ public final class PSFilterArgumentCollection implements Serializable {
             minValue = 1,
             optional = true)
     public int minIdentity = 30;
+
+    /**
+     * If using --is-host-aligned, ignores alignments to these contigs (can be specified multiple times). This
+     * can be useful if the alignment is to a reference containing a microbe, such as chrEBV in hg38.
+     */
+    @Argument(doc = "Host-aligned BAM contigs to ignore",
+            fullName = IGNORE_ALIGNMENT_CONTIGS_LONG_NAME,
+            shortName = IGNORE_ALIGNMENT_CONTIGS_SHORT_NAME,
+            optional = true)
+    public List<String> alignmentContigsToIgnore = new ArrayList<>();
 
     /**
      * Controls the stringency of read filtering based on host k-mer matching. Reads with at least this many matching

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilterTest.java
@@ -72,7 +72,7 @@ public final class HostAlignmentReadFilterTest {
         final GATKRead read_in = ArtificialReadUtils.createArtificialRead(bases, qual, "*");
         read_in.setIsUnmapped();
         final boolean test_i = filter.test(read_in);
-        Assert.assertEquals(true, test_i);
+        Assert.assertTrue(test_i);
     }
 
     @Test
@@ -89,28 +89,28 @@ public final class HostAlignmentReadFilterTest {
         readA.setAttribute("NM", 0);
         readA.setPosition(IGNORED_CONTIG, 1);
         final boolean testA = filter.test(readA);
-        Assert.assertEquals(true, testA);
+        Assert.assertTrue(testA);
 
         // Mapped fully to non-ignored contig
         final GATKRead readB = ArtificialReadUtils.createArtificialRead(bases, qual, "100M");
         readB.setAttribute("NM", 0);
         readB.setPosition("chrNotIgnore", 1);
         final boolean testB = filter.test(readB);
-        Assert.assertEquals(false, testB);
+        Assert.assertFalse(testB);
 
         // Mapped poorly to ignored contig
         final GATKRead readC = ArtificialReadUtils.createArtificialRead(bases, qual, "10M90S");
         readC.setAttribute("NM", 90);
         readC.setPosition(IGNORED_CONTIG, 1);
         final boolean testC = filter.test(readC);
-        Assert.assertEquals(true, testC);
+        Assert.assertTrue(testC);
 
         // Mapped poorly to non-ignored contig
         final GATKRead readD = ArtificialReadUtils.createArtificialRead(bases, qual, "10M90S");
         readD.setAttribute("NM", 90);
         readD.setPosition("chrNotIgnore", 1);
         final boolean testD = filter.test(readD);
-        Assert.assertEquals(true, testD);
+        Assert.assertTrue(testD);
     }
 
     @Test
@@ -121,6 +121,6 @@ public final class HostAlignmentReadFilterTest {
         final GATKRead read_in = ArtificialReadUtils.createArtificialRead(cigar);
         read_in.setPosition("pos", 1);
         final boolean test_i = filter.test(read_in);
-        Assert.assertEquals(true, test_i); //Don't filter out reads if there is no NM tag
+        Assert.assertTrue(test_i); //Don't filter out reads if there is no NM tag
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pathseq/HostAlignmentReadFilterTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq;
 
+import com.google.common.collect.Sets;
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
@@ -9,10 +10,12 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Set;
 
 public final class HostAlignmentReadFilterTest {
 
     private static final int MIN_IDENTITY = 70;
+    private final String IGNORED_CONTIG = "chrIgnore";
 
     @DataProvider(name = "alignmentData")
     public Object[][] getAlignmentData() {
@@ -54,7 +57,6 @@ public final class HostAlignmentReadFilterTest {
         final Cigar cigar = TextCigarCodec.decode(cigarString);
         final GATKRead read_in = ArtificialReadUtils.createArtificialRead(cigar);
         read_in.setAttribute("NM", NM);
-        read_in.setPosition("test_contig", 1);
         read_in.setPosition("pos", 1);
         final boolean test_i = filter.test(read_in);
         Assert.assertEquals(test_out, test_i);
@@ -74,12 +76,49 @@ public final class HostAlignmentReadFilterTest {
     }
 
     @Test
+    public void testIgnoredContig() {
+        final Set<String> ignoredContigSet = Sets.newHashSet(IGNORED_CONTIG);
+        final HostAlignmentReadFilter filter = new HostAlignmentReadFilter(MIN_IDENTITY, ignoredContigSet);
+        final byte[] bases = new byte[100];
+        final byte[] qual = new byte[100];
+        Arrays.fill(bases, (byte) 'A');
+        Arrays.fill(qual, (byte) 30);
+
+        // Mapped fully to ignored contig
+        final GATKRead readA = ArtificialReadUtils.createArtificialRead(bases, qual, "100M");
+        readA.setAttribute("NM", 0);
+        readA.setPosition(IGNORED_CONTIG, 1);
+        final boolean testA = filter.test(readA);
+        Assert.assertEquals(true, testA);
+
+        // Mapped fully to non-ignored contig
+        final GATKRead readB = ArtificialReadUtils.createArtificialRead(bases, qual, "100M");
+        readB.setAttribute("NM", 0);
+        readB.setPosition("chrNotIgnore", 1);
+        final boolean testB = filter.test(readB);
+        Assert.assertEquals(false, testB);
+
+        // Mapped poorly to ignored contig
+        final GATKRead readC = ArtificialReadUtils.createArtificialRead(bases, qual, "10M90S");
+        readC.setAttribute("NM", 90);
+        readC.setPosition(IGNORED_CONTIG, 1);
+        final boolean testC = filter.test(readC);
+        Assert.assertEquals(true, testC);
+
+        // Mapped poorly to non-ignored contig
+        final GATKRead readD = ArtificialReadUtils.createArtificialRead(bases, qual, "10M90S");
+        readD.setAttribute("NM", 90);
+        readD.setPosition("chrNotIgnore", 1);
+        final boolean testD = filter.test(readD);
+        Assert.assertEquals(true, testD);
+    }
+
+    @Test
     public void testMappedReadWithoutNMTag() {
         final String cigarString = "100M";
         final HostAlignmentReadFilter filter = new HostAlignmentReadFilter(MIN_IDENTITY);
         final Cigar cigar = TextCigarCodec.decode(cigarString);
         final GATKRead read_in = ArtificialReadUtils.createArtificialRead(cigar);
-        read_in.setPosition("test_contig", 1);
         read_in.setPosition("pos", 1);
         final boolean test_i = filter.test(read_in);
         Assert.assertEquals(true, test_i); //Don't filter out reads if there is no NM tag


### PR DESCRIPTION
Adds an argument to PathSeq filtering that lets users specify any contigs that should be ignored. This is useful for BAMs aligned to hg38, which contains the Epstein-Barr virus (chrEBV).