### PR TITLE
Reducing duplicate code in ReadInputArgumentCollection

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -24,24 +24,6 @@ public final class OptionalReadInputArgumentCollection extends ReadInputArgument
     private List<String> readFilesNames = new ArrayList<>();
 
     @Override
-    public List<File> getReadFiles() {
-        ArrayList<File> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(new File(fn));
-        }
-        return ret;
-    }
-
-    @Override
-    public List<Path> getReadPaths() {
-        ArrayList<Path> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(IOUtils.getPath(fn));
-        }
-        return ret;
-    }
-
-    @Override
     public List<String> getReadFilesNames() {
         return new ArrayList<>(readFilesNames);
     }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.utils.read.ReadConstants;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,12 +39,6 @@ public abstract class ReadInputArgumentCollection implements Serializable {
     protected List<String> readIndices;
 
     /**
-     * Get the list of BAM/SAM/CRAM files specified at the command line.
-     * Paths are the preferred format, as this can handle both local disk and NIO direct access to cloud storage.
-     */
-    public abstract List<Path> getReadPaths();
-
-    /**
      * @return The list of indices to be used with the read inputs, or {@code null} if none were specified and the indices should be
      *         inferred automatically.
      *
@@ -55,13 +50,27 @@ public abstract class ReadInputArgumentCollection implements Serializable {
             return null;
         }
 
-        return readIndices.stream().map(index -> IOUtils.getPath(index)).collect(Collectors.toList());
+        return readIndices.stream().map(IOUtils::getPath).collect(Collectors.toList());
     }
 
     /**
      * Get the list of BAM/SAM/CRAM files specified at the command line
      */
-    public abstract List<File> getReadFiles();
+    public List<File> getReadFiles(){
+        return getReadFilesNames().stream()
+                .map(File::new)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Get the list of BAM/SAM/CRAM files specified at the command line.
+     * Paths are the preferred format, as this can handle both local disk and NIO direct access to cloud storage.
+     */
+    public List<Path> getReadPaths(){
+        return getReadFilesNames().stream()
+                .map(IOUtils::getPath)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
 
     /**
      * Get the list of BAM/SAM/CRAM filenames specified at the command line

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * An argument collection for use with tools that accept one or more input files containing reads
@@ -17,24 +18,6 @@ public final class RequiredReadInputArgumentCollection extends ReadInputArgument
     private static final long serialVersionUID = 1L;
     @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = false, common = true)
     public List<String> readFilesNames;
-
-    @Override
-    public List<File> getReadFiles() {
-        ArrayList<File> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(new File(fn));
-        }
-        return ret;
-    }
-
-    @Override
-    public List<Path> getReadPaths() {
-        ArrayList<Path> ret = new ArrayList<>();
-        for (String fn : readFilesNames) {
-            ret.add(IOUtils.getPath(fn));
-        }
-        return ret;
-    }
 
     @Override
     public List<String> getReadFilesNames() {


### PR DESCRIPTION
* Removing 2 redundant abstract methods by pulling them up to the base class