### PR TITLE
Change doc template to no print null missing values.

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -65,7 +65,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
+			<#if arg.synonyms?? && arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -51,7 +51,11 @@
 						</#if>
 					</td>
 					<!--<td>${arg.type}</td> -->
-					<td>${arg.defaultValue!"NA"}</td>
+					<#if arg.defaultValue != "null" && arg.defaultValue != "[]" && arg.defaultValue != "\"\"">
+						<td>${arg.defaultValue}</td>
+					<#else>
+						<td></td>
+					</#if>
 					<td>${arg.summary}</td>
 				</tr>
 			</#list>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -65,7 +65,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms??> / <small>${arg.synonyms}</small></#if>
+			<#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />


### PR DESCRIPTION
* Now docs won't include null, "", or [] in the default value list.

This is one of the changes I mentioned on the call.  