### PR TITLE
Added a new FuncotateSegments parameter for minimum segment length.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
@@ -105,4 +105,11 @@ abstract class BaseFuncotatorArgumentCollection implements Serializable {
     )
     public int lookaheadFeatureCachingInBp = FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE;
 
+    @Advanced
+    @Argument(
+            fullName = FuncotatorArgumentDefinitions.MIN_NUM_BASES_FOR_SEGMENT_FUNCOTATION,
+            optional = true,
+            doc = "The minimum number of bases for a variant to be annotated as a segment.  Recommended to be changed only for use with FuncotateSegments.  Defaults to " + FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT
+    )
+    public int minNumBasesForValidSegment = FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/DataSourceFuncotationFactory.java
@@ -62,6 +62,11 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
      */
     protected final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput;
 
+    /**
+     * Minimum number of bases for a segment to be considered valid.
+     */
+    protected int minBasesForValidSegment;
+
     @VisibleForTesting
     public FeatureInput<? extends Feature> getMainSourceFileAsFeatureInput() {
         return mainSourceFileAsFeatureInput;
@@ -69,17 +74,22 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
 
     /**
      * Constructor to initialize final fields in this class with defaults.
+     * @param minBasesForValidSegment The minimum number of bases for a segment to be considered valid.
      */
-    protected DataSourceFuncotationFactory() {
+    protected DataSourceFuncotationFactory(final int minBasesForValidSegment) {
         this.mainSourceFileAsFeatureInput = null;
+        this.minBasesForValidSegment = minBasesForValidSegment;
     }
 
     /**
      * Constructor to initialize final fields in this class.
      * @param mainSourceFileAsFeatureInput The backing data store as a FeatureInput to leverage tribble querying.  Can be {@code null} for non-locatable funcotation factories.
+     * @param minBasesForValidSegment The minimum number of bases for a segment to be considered valid.
      */
-    protected DataSourceFuncotationFactory(final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput) {
+    protected DataSourceFuncotationFactory(final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput,
+                                           final int minBasesForValidSegment) {
         this.mainSourceFileAsFeatureInput = mainSourceFileAsFeatureInput;
+        this.minBasesForValidSegment = minBasesForValidSegment;
     }
 
 
@@ -225,7 +235,7 @@ public abstract class DataSourceFuncotationFactory implements Closeable {
         // Create our funcotations:
         final List<Funcotation> outputFuncotations;
 
-        if (FuncotatorUtils.isSegmentVariantContext(variant) && isSupportingSegmentFuncotation()) {
+        if (FuncotatorUtils.isSegmentVariantContext(variant, minBasesForValidSegment) && isSupportingSegmentFuncotation()) {
             outputFuncotations = createFuncotationsOnSegment(variant, referenceContext, featureList);
         } else {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotateSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotateSegments.java
@@ -142,10 +142,13 @@ public class FuncotateSegments extends FeatureWalker<AnnotatedInterval> {
                 funcotatorArgs.transcriptSelectionMode,
                 finalUserTranscriptIdSet,
                 this,
-                funcotatorArgs.lookaheadFeatureCachingInBp, new FlankSettings(0,0), true)
-                .stream()
-                .filter(DataSourceFuncotationFactory::isSupportingSegmentFuncotation)
-                .collect(Collectors.toList());
+                funcotatorArgs.lookaheadFeatureCachingInBp,
+                new FlankSettings(0,0),
+                true,
+                funcotatorArgs.minNumBasesForValidSegment
+        ).stream()
+         .filter(DataSourceFuncotationFactory::isSupportingSegmentFuncotation)
+         .collect(Collectors.toList());
 
         // Log the datasources
         logger.info("The following datasources support funcotation on segments: ");

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -784,7 +784,8 @@ public class Funcotator extends VariantWalker {
                 this,
                 funcotatorArgs.lookaheadFeatureCachingInBp,
                 new FlankSettings(funcotatorArgs.fivePrimeFlankSize, funcotatorArgs.threePrimeFlankSize),
-                false
+                false,
+                funcotatorArgs.minNumBasesForValidSegment
         );
 
         logger.info("Initializing Funcotator Engine...");

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -64,6 +64,7 @@ public class FuncotatorArgumentDefinitions {
     public static final int LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE = VariantWalkerBase.DEFAULT_DRIVING_VARIANTS_LOOKAHEAD_BASES;
 
     public static final String FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION = "force-b37-to-hg19-reference-contig-conversion";
+    public static final String MIN_NUM_BASES_FOR_SEGMENT_FUNCOTATION = "min-num-bases-for-segment-funcotation";
 
     // ------------------------------------------------------------
     // Helper Types:

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -234,10 +234,10 @@ public final class FuncotatorEngine implements AutoCloseable {
      * @return The requested {@link OutputRenderer} based on the given {@code funcotatorArgs}.
      */
     OutputRenderer createOutputRenderer(final LinkedHashMap<String, String> annotationDefaultsMap,
-                                               final LinkedHashMap<String, String> annotationOverridesMap,
-                                               final VCFHeader headerForVariants,
-                                               final Set<VCFHeaderLine> defaultToolVcfHeaderLines,
-                                               final GATKTool gatkToolInstance) {
+                                        final LinkedHashMap<String, String> annotationOverridesMap,
+                                        final VCFHeader headerForVariants,
+                                        final Set<VCFHeaderLine> defaultToolVcfHeaderLines,
+                                        final GATKTool gatkToolInstance) {
 
         final OutputRenderer outputRenderer;
 
@@ -286,7 +286,7 @@ public final class FuncotatorEngine implements AutoCloseable {
 
                                     new GeneListOutputRenderer(new File(funcotatorArgs.outputFile.getAbsolutePath() + GENE_LIST_FILE_SUFFIX).toPath(),
                                         unaccountedForDefaultAnnotations, unaccountedForOverrideAnnotations,
-                                        funcotatorArgs.excludedFields, gatkToolInstance.getVersion())
+                                        funcotatorArgs.excludedFields, gatkToolInstance.getVersion(), funcotatorArgs.minNumBasesForValidSegment)
                         ), gatkToolInstance.getVersion());
                 break;
             default:

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -53,6 +53,8 @@ public final class FuncotatorUtils {
      */
     private FuncotatorUtils() {}
 
+    public static final int DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT = 150;
+
     private static final Map<String, AminoAcid> tableByCodon;
     private static final Map<String, AminoAcid> tableByCode;
     private static final Map<String, AminoAcid> tableByLetter;
@@ -2070,11 +2072,11 @@ public final class FuncotatorUtils {
      * Dev note: this is done by examining the length and the alt allele of the segment.
      *
      * @param vc Never {@code null}
+     * @param minSizeForSegment Minimum size for a segment to be valid.
      * @return Boolean whether the given variant context could represent a copy number segment.
      */
-    public static boolean isSegmentVariantContext(final VariantContext vc) {
+    public static boolean isSegmentVariantContext(final VariantContext vc, final int minSizeForSegment) {
         Utils.nonNull(vc);
-        final int MIN_SIZE_FOR_SEGMENT = 150;
         final List<String> ACCEPTABLE_ALT_ALLELES = Stream.concat(
                 Stream.of(SimpleSVType.SupportedType.values())
                         .map(s -> SimpleSVType.createBracketedSymbAlleleString(s.toString())),
@@ -2089,7 +2091,7 @@ public final class FuncotatorUtils {
             }
         }
 
-        return acceptableAlternateAllele && (VariantContextUtils.getSize(vc) > MIN_SIZE_FOR_SEGMENT);
+        return acceptableAlternateAllele && (VariantContextUtils.getSize(vc) > minSizeForSegment);
     }
 
     // ========================================================================================

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/cosmic/CosmicFuncotationFactory.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
 import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -143,6 +144,16 @@ public class CosmicFuncotationFactory extends DataSourceFuncotationFactory {
                                     final LinkedHashMap<String, String> annotationOverridesMap,
                                     final String version,
                                     final boolean isDataSourceB37) {
+        this(pathToCosmicDb, annotationOverridesMap, version, isDataSourceB37, FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT);
+    }
+
+    public CosmicFuncotationFactory(final Path pathToCosmicDb,
+                                    final LinkedHashMap<String, String> annotationOverridesMap,
+                                    final String version,
+                                    final boolean isDataSourceB37,
+                                    final int minBasesForValidSegment) {
+
+        super(minBasesForValidSegment);
 
         this.pathToCosmicDb = localizeCosmicDbFileIfRemote(pathToCosmicDb);
         this.version = version;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -318,9 +318,43 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
                                      final FeatureInput<? extends Feature> mainFeatureInput,
                                      final FlankSettings flankSettings,
                                      final boolean isDataSourceB37,
-                                     final String ncbiBuildVersion, final boolean isSegmentFuncotationEnabled) {
+                                     final String ncbiBuildVersion,
+                                     final boolean isSegmentFuncotationEnabled) {
+        this(gencodeTranscriptFastaFilePath, version, name,
+                transcriptSelectionMode, userRequestedTranscripts, annotationOverrides, mainFeatureInput,
+                flankSettings, isDataSourceB37, ncbiBuildVersion, isSegmentFuncotationEnabled,
+                FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT);
+    }
 
-        super(mainFeatureInput);
+        /**
+         * Create a {@link GencodeFuncotationFactory}.
+         *
+         * @param gencodeTranscriptFastaFilePath {@link Path} to the FASTA file containing the sequences of all transcripts in the Gencode data source.
+         * @param version The version {@link String} of Gencode from which {@link Funcotation}s will be made.
+         * @param name A {@link String} containing the name of this {@link GencodeFuncotationFactory}.
+         * @param transcriptSelectionMode The {@link TranscriptSelectionMode} by which representative/verbose transcripts will be chosen for overlapping variants.
+         * @param userRequestedTranscripts A {@link Set<String>} containing Gencode TranscriptIDs that the user requests to be annotated with priority over all other transcripts for overlapping variants.
+         * @param annotationOverrides A {@link LinkedHashMap<String,String>} containing user-specified overrides for specific {@link Funcotation}s.
+         * @param mainFeatureInput The backing {@link FeatureInput} for this {@link GencodeFuncotationFactory}, from which all {@link Funcotation}s will be created.
+         * @param flankSettings Settings object containing our 5'/3' flank sizes
+         * @param isDataSourceB37 If {@code true}, indicates that the data source behind this {@link GencodeFuncotationFactory} contains B37 data.
+         * @param ncbiBuildVersion The NCBI build version for this {@link GencodeFuncotationFactory} (can be found in the datasource config file)
+         * @param minBasesForValidSegment The minimum number of bases for a segment to be considered valid.
+         */
+    public GencodeFuncotationFactory(final Path gencodeTranscriptFastaFilePath,
+                                     final String version,
+                                     final String name,
+                                     final TranscriptSelectionMode transcriptSelectionMode,
+                                     final Set<String> userRequestedTranscripts,
+                                     final LinkedHashMap<String, String> annotationOverrides,
+                                     final FeatureInput<? extends Feature> mainFeatureInput,
+                                     final FlankSettings flankSettings,
+                                     final boolean isDataSourceB37,
+                                     final String ncbiBuildVersion,
+                                     final boolean isSegmentFuncotationEnabled,
+                                     final int minBasesForValidSegment) {
+
+        super(mainFeatureInput, minBasesForValidSegment);
 
         // Set up our local transcript fasta file.
         // We must localize it (if not on disk) to make read times fast enough to be manageable:
@@ -456,7 +490,8 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
 
     @Override
     protected List<Funcotation> createDefaultFuncotationsOnVariant( final VariantContext variant, final ReferenceContext referenceContext ) {
-        if (FuncotatorUtils.isSegmentVariantContext(variant)) {
+
+        if (FuncotatorUtils.isSegmentVariantContext(variant, minBasesForValidSegment)) {
             return createSegmentFuncotations(variant, Collections.emptyList(), null, null, null, null);
         } else {
             // Simply create IGR

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/vcf/VcfFuncotationFactory.java
@@ -11,10 +11,10 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
 import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationFactory;
@@ -25,8 +25,6 @@ import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -134,8 +132,28 @@ public class VcfFuncotationFactory extends DataSourceFuncotationFactory {
                                  final LinkedHashMap<String, String> annotationOverridesMap,
                                  final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput,
                                  final boolean isDataSourceB37) {
+        this(name, version, sourceFilePath, annotationOverridesMap, mainSourceFileAsFeatureInput, isDataSourceB37, FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT);
+    }
 
-        super(mainSourceFileAsFeatureInput);
+    /**
+     * Create a {@link VcfFuncotationFactory}.
+     * @param name A {@link String} containing the name of this {@link VcfFuncotationFactory}.
+     * @param version  The version {@link String} of the backing data source from which {@link Funcotation}s will be made.
+     * @param sourceFilePath {@link Path} to the VCF file from which {@link VariantContext}s will be read in and used as Features from which to create {@link Funcotation}s.
+     * @param annotationOverridesMap A {@link LinkedHashMap<String,String>} containing user-specified overrides for specific {@link Funcotation}s.
+     * @param mainSourceFileAsFeatureInput The backing {@link FeatureInput} for this {@link VcfFuncotationFactory}, from which all {@link Funcotation}s will be created.
+     * @param isDataSourceB37 If {@code true}, indicates that the data source behind this {@link GencodeFuncotationFactory} contains B37 data.
+     * @param minBasesForValidSegment The minimum number of bases for a segment to be considered valid.
+     */
+    public VcfFuncotationFactory(final String name,
+                                 final String version,
+                                 final Path sourceFilePath,
+                                 final LinkedHashMap<String, String> annotationOverridesMap,
+                                 final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput,
+                                 final boolean isDataSourceB37,
+                                 final int minBasesForValidSegment) {
+
+        super(mainSourceFileAsFeatureInput, minBasesForValidSegment);
 
         this.name = name;
         this.version = version;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
@@ -10,9 +10,7 @@ import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
-import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
-import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.*;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -96,8 +94,23 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
     public LocatableXsvFuncotationFactory(final String name, final String version, final LinkedHashMap<String, String> annotationOverridesMap,
                                           final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput,
                                           final boolean isDataSourceB37){
+        this(name, version, annotationOverridesMap, mainSourceFileAsFeatureInput, isDataSourceB37, FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT);
+    }
 
-        super(mainSourceFileAsFeatureInput);
+    /**
+     * Create a {@link LocatableXsvFuncotationFactory}.
+     * @param name A {@link String} containing the name of this {@link LocatableXsvFuncotationFactory}.
+     * @param version  The version {@link String} of the backing data source from which {@link Funcotation}s will be made.
+     * @param annotationOverridesMap A {@link LinkedHashMap<String,String>} containing user-specified overrides for specific {@link Funcotation}s.
+     * @param mainSourceFileAsFeatureInput The backing {@link FeatureInput} for this {@link LocatableXsvFuncotationFactory}, from which all {@link Funcotation}s will be created.
+     * @param isDataSourceB37 If {@code true}, indicates that the data source behind this {@link LocatableXsvFuncotationFactory} contains B37 data.
+     * @param minBasesForValidSegment The minimum number of bases for a segment to be considered valid.
+     */
+    public LocatableXsvFuncotationFactory(final String name, final String version, final LinkedHashMap<String, String> annotationOverridesMap,
+                                          final FeatureInput<? extends Feature> mainSourceFileAsFeatureInput,
+                                          final boolean isDataSourceB37, final int minBasesForValidSegment){
+
+        super(mainSourceFileAsFeatureInput, minBasesForValidSegment);
 
         this.name = name;
         this.version = version;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/LocatableXsvFuncotationFactory.java
@@ -10,7 +10,10 @@ import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.funcotator.*;
+import org.broadinstitute.hellbender.tools.funcotator.DataSourceFuncotationFactory;
+import org.broadinstitute.hellbender.tools.funcotator.Funcotation;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -21,7 +24,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Factory for creating {@link TableFuncotation}s by handling `Separated Value` files with arbitrary delimiters
@@ -144,7 +153,7 @@ public class LocatableXsvFuncotationFactory extends DataSourceFuncotationFactory
     }
 
     @Override
-    protected List<Funcotation> createDefaultFuncotationsOnVariant( final VariantContext variant, final ReferenceContext referenceContext ) {
+    protected List<Funcotation> createDefaultFuncotationsOnVariant(final VariantContext variant, final ReferenceContext referenceContext ) {
         return createDefaultFuncotationsOnVariantHelper(variant, referenceContext, Collections.emptySet());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/xsv/SimpleKeyXsvFuncotationFactory.java
@@ -122,6 +122,22 @@ public class SimpleKeyXsvFuncotationFactory extends DataSourceFuncotationFactory
                                           final int numHeaderLinesToIgnore,
                                           final boolean permissiveColumns,
                                           final boolean isDataSourceB37) {
+        this(name, filePath, version, delim, keyColumn, keyType, annotationOverrides, numHeaderLinesToIgnore, permissiveColumns, isDataSourceB37, FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT);
+    }
+
+    public SimpleKeyXsvFuncotationFactory(final String name,
+                                          final Path filePath,
+                                          final String version,
+                                          final String delim,
+                                          final int keyColumn,
+                                          final XsvDataKeyType keyType,
+                                          final LinkedHashMap<String, String> annotationOverrides,
+                                          final int numHeaderLinesToIgnore,
+                                          final boolean permissiveColumns,
+                                          final boolean isDataSourceB37,
+                                          final int minBasesForValidSegment) {
+
+        super(minBasesForValidSegment);
 
         this.name = name;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngineUnitTest.java
@@ -62,7 +62,9 @@ public class FuncotatorEngineUnitTest extends GATKBaseTest {
                                 new HashSet<>(),
                                 new DummyPlaceholderGatkTool(),
                                 FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE,
-                                new FlankSettings(0, 0), false)
+                                new FlankSettings(0, 0),
+                                false,
+                                FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT)
                 );
 
         for (int i = 0; i < entireVcf.getRight().size(); i++) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/genelistoutput/GeneListOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/genelistoutput/GeneListOutputRendererUnitTest.java
@@ -9,7 +9,11 @@ import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.FuncotatorReferenceTestUtils;
-import org.broadinstitute.hellbender.tools.funcotator.*;
+import org.broadinstitute.hellbender.tools.funcotator.AnnotatedIntervalToSegmentVariantContextConverter;
+import org.broadinstitute.hellbender.tools.funcotator.FlankSettings;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotationMap;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.FuncotatorUtils;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.TableFuncotation;
 import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotationFactory;
 import org.broadinstitute.hellbender.tools.funcotator.metadata.FuncotationMetadataUtils;
@@ -24,7 +28,15 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -42,8 +54,8 @@ public class GeneListOutputRendererUnitTest extends GATKBaseTest {
         final LinkedHashSet<String> funcotationFields = createDummyGencodeFuncotationFactory()
                 .getSupportedFuncotationFieldsForSegments();
 
-        final List<String> testFieldValues1 = Arrays.asList("GENE1,GENE2,GENE1-AS1", "GENE1", "", "1-", "", "", "");
-        final List<Pair<String,String>> gtKeys1 = Arrays.asList(Pair.of("GENE1", "1-"), Pair.of("GENE1-AS1", ""), Pair.of("GENE2", ""));
+        final List<String>  testFieldValues1 = Arrays.asList("GENE1,GENE2,GENE1-AS1", "GENE1", "", "1-", "", "", "");
+        final List<Pair<String,String>> gtKeys1  = Arrays.asList(Pair.of("GENE1", "1-"), Pair.of("GENE1-AS1", ""), Pair.of("GENE2", ""));
         final FuncotationMap funcotationMap1 = createTestFuncotationMap(funcotationFields, testFieldValues1);
         final Pair<VariantContext, FuncotationMap> pairValue1 = Pair.of(segmentVariantContext, funcotationMap1);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/mafOutput/MafOutputRendererUnitTest.java
@@ -119,7 +119,9 @@ public class MafOutputRendererUnitTest extends GATKBaseTest {
                 new HashSet<>(),
                 new DummyPlaceholderGatkTool(),
                 FuncotatorArgumentDefinitions.LOOKAHEAD_CACHE_IN_BP_DEFAULT_VALUE,
-                new FlankSettings(0, 0), false
+                new FlankSettings(0, 0),
+                false,
+                FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT
         );
 
         // Sort the datasources to ensure the same order every time:

--- a/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/test/FuncotatorTestUtils.java
@@ -335,6 +335,21 @@ public class FuncotatorTestUtils {
     }
 
     /**
+     * Create a very simple dummy variant context that may or may not adhere to the conventions in
+     * {@link AnnotatedIntervalToSegmentVariantContextConverter#convert(AnnotatedInterval, ReferenceContext)}
+     *
+     * Resulting variant will be based on hg19 and will be placed on Chromosome 3.
+     * Resulting variant will always have {@link AnnotatedIntervalToSegmentVariantContextConverter#COPY_NEUTRAL_ALLELE} as its ALT allele.
+     *
+     * @return Never {@code null}
+     */
+    public static VariantContext createDummySegmentVariantContext(final int start, final int end, final String refAllele) {
+        return createSimpleVariantContext(FuncotatorReferenceTestUtils.retrieveHg19Chr3Ref(),
+                "3", start, end, refAllele,
+                AnnotatedIntervalToSegmentVariantContextConverter.COPY_NEUTRAL_ALLELE.getDisplayString());
+    }
+
+    /**
      * See {@link FuncotatorTestUtils#createDummySegmentVariantContext()}, but this allows caller to specify attributes
      *   to add.
      *


### PR DESCRIPTION
- Added `--min-num-bases-for-segment-funcotation` parameter to Funcotator.
This will allow for segments of length less than 150 bases to be
annotated if given at run time (defaults to 150 bases to preserve
    previous behavior).
- Added miles of piping to support new parameter.
- Added test to ensure that the logic for this is adhered to in the
output renderer where the UserError was being thrown before
(GeneListOutputRenderer).

Fixes #6575