### PR TITLE
fixed bug in tandem repeat annotation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
@@ -50,9 +50,8 @@ public final class TandemRepeat extends InfoFieldAnnotation implements StandardM
 
     public static Pair<List<Integer>, byte[]> getNumTandemRepeatUnits(final ReferenceContext ref, final VariantContext vc) {
         final byte[] refBases = ref.getBases();
-        final int startIndex = vc.getStart() - ref.getWindow().getStart();
-        final byte[] refBasesStartingAtVariantLocus = new String(refBases).substring(startIndex).getBytes();
-        return GATKVariantContextUtils.getNumTandemRepeatUnits(vc, refBasesStartingAtVariantLocus);
+        final int startIndex = vc.getStart() + 1 - ref.getWindow().getStart();  // +1 to exclude leading match base common to VC's ref and alt alleles
+        return GATKVariantContextUtils.getNumTandemRepeatUnits(vc, Arrays.copyOfRange(refBases, startIndex, refBases.length));
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -673,18 +673,19 @@ public final class GATKVariantContextUtils {
     /**
      *
      * @param vc
-     * @param refBasesStartingAtVCWithPad
+     * @param refBasesStartingAtVCWithoutPad    Ref bases excluding the initial base of the variant context where the alt matches the ref.
+     *                                          For example, if the reference sequence is GATCCACCACCAGTCGA and we have a deletion
+     *                                          of one STR unit CCA, it is represented as a variant context TCCA -> T, where the 'T' is
+     *                                          the padding base.  In this case, {@code refBasesStartingAtVCWithoutPad} is CCACCACCAGTCGA.
      * @return
      */
-    public static Pair<List<Integer>, byte[]> getNumTandemRepeatUnits(final VariantContext vc, final byte[] refBasesStartingAtVCWithPad) {
+    public static Pair<List<Integer>, byte[]> getNumTandemRepeatUnits(final VariantContext vc, final byte[] refBasesStartingAtVCWithoutPad) {
         Utils.nonNull(vc);
-        Utils.nonNull(refBasesStartingAtVCWithPad);
+        Utils.nonNull(refBasesStartingAtVCWithoutPad);
 
         if ( ! vc.isIndel() ){ // only indels are tandem repeats
             return null;
         }
-        final boolean VERBOSE = false;
-        final String refBasesStartingAtVCWithoutPad = new String(refBasesStartingAtVCWithPad).substring(1);
 
         final Allele refAllele = vc.getReference();
         final byte[] refAlleleBases = Arrays.copyOfRange(refAllele.getBases(), 1, refAllele.length());
@@ -693,7 +694,7 @@ public final class GATKVariantContextUtils {
         final List<Integer> lengths = new ArrayList<>();
 
         for ( final Allele allele : vc.getAlternateAlleles() ) {
-            Pair<int[],byte[]> result = getNumTandemRepeatUnits(refAlleleBases, Arrays.copyOfRange(allele.getBases(), 1, allele.length()), refBasesStartingAtVCWithoutPad.getBytes());
+            Pair<int[],byte[]> result = getNumTandemRepeatUnits(refAlleleBases, Arrays.copyOfRange(allele.getBases(), 1, allele.length()), refBasesStartingAtVCWithoutPad);
 
             final int[] repetitionCount = result.getLeft();
             // repetition count = 0 means allele is not a tandem expansion of context
@@ -706,12 +707,6 @@ public final class GATKVariantContextUtils {
             lengths.add(repetitionCount[1]);  // add this alt allele's length
 
             repeatUnit = result.getRight();
-            if (VERBOSE) {
-                System.out.println("RefContext:"+refBasesStartingAtVCWithoutPad);
-                System.out.println("Ref:"+refAllele.toString()+" Count:" + String.valueOf(repetitionCount[0]));
-                System.out.println("Allele:"+allele.toString()+" Count:" + String.valueOf(repetitionCount[1]));
-                System.out.println("RU:"+new String(repeatUnit));
-            }
         }
 
         return new MutablePair<>(lengths,repeatUnit);

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -882,7 +882,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         int insLocStop = 20;
 
         Pair<List<Integer>,byte[]> result;
-        byte[] refBytes = "TATCATCATCGGA".getBytes();
+        byte[] refBytes = "ATCATCATCGGA".getBytes();    // excludes leading match base common to VC's ref and alt alleles
 
         Assert.assertEquals(GATKVariantContextUtils.findRepeatedSubstring("ATG".getBytes()),3);
         Assert.assertEquals(GATKVariantContextUtils.findRepeatedSubstring("AAA".getBytes()),1);
@@ -908,7 +908,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(result.getRight().length,3);
 
         // simple non-tandem deletion: CCCC*, -
-        refBytes = "TCCCCCCCCATG".getBytes();
+        refBytes = "CCCCCCCCATG".getBytes();    // excludes leading match base common to VC's ref and alt alleles
         vc = new VariantContextBuilder("foo", delLoc, 10, 14, Arrays.asList(ccccR,nullA)).make();
         result = GATKVariantContextUtils.getNumTandemRepeatUnits(vc, refBytes);
         Assert.assertEquals(result.getLeft().toArray()[0],8);
@@ -916,7 +916,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(result.getRight().length,1);
 
         // CCCC*,CC,-,CCCCCC, context = CCC: (C)7 -> (C)5,(C)3,(C)9
-        refBytes = "TCCCCCCCAGAGAGAG".getBytes();
+        refBytes = "CCCCCCCAGAGAGAG".getBytes();    // excludes leading match base common to VC's ref and alt alleles
         vc = new VariantContextBuilder("foo", insLoc, insLocStart, insLocStart+4, Arrays.asList(ccccR,cc, nullA,cccccc)).make();
         result = GATKVariantContextUtils.getNumTandemRepeatUnits(vc, refBytes);
         Assert.assertEquals(result.getLeft().toArray()[0],7);
@@ -926,7 +926,7 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(result.getRight().length,1);
 
         // GAGA*,-,GAGAGAGA
-        refBytes = "TGAGAGAGAGATTT".getBytes();
+        refBytes = "GAGAGAGAGATTT".getBytes();  // excludes leading match base common to VC's ref and alt alleles
         vc = new VariantContextBuilder("foo", insLoc, insLocStart, insLocStart+4, Arrays.asList(gagaR, nullA,gagagaga)).make();
         result = GATKVariantContextUtils.getNumTandemRepeatUnits(vc, refBytes);
         Assert.assertEquals(result.getLeft().toArray()[0],5);


### PR DESCRIPTION
@fleharty Here is a quick M2 and HC edge case bug for you.

In the edge case where an alt haplotype starts with an indel, and hence the variant context start is one base before the assembly region due to padding a leading matching base, there was a problem.  The variant start was before the reference context window (since in this part of the code the reference context window is pegged to the assembly region, which caused problems in the lines
```
final int startIndex = vc.getStart() - ref.getWindow().getStart();
        final byte[] refBasesStartingAtVariantLocus = new String(refBases).substring(startIndex).getBytes();
```

The fix is for `refBasesStartingAtVariantLocus` to exclude the padding base, which as you can see was done previously in the line
```
final String refBasesStartingAtVCWithoutPad = new String(refBasesStartingAtVCWithPad).substring(1);
```
That is, instead of taking a subarray of the reference bytes twice, once from the variant context start with padding and once more to remove the padding, we take a single subarray without the padding.

While I was at it, I replaced some slow conversions from `byte[]` to `String` to `String` back to `byte[]` with subarray operations.