### PR TITLE
SplitIntervals dynamic zero padding in filenames

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervals.java
@@ -91,6 +91,8 @@ public class SplitIntervals extends GATKTool {
     public static final String PICARD_INTERVAL_FILE_EXTENSION = "interval_list";
     public static final String DEFAULT_EXTENSION = "-scattered." + PICARD_INTERVAL_FILE_EXTENSION;
 
+    public static final int DEFAULT_NUMBER_OF_DIGITS = 4;  //to preserve backward compatibility
+
     @Argument(fullName = SCATTER_COUNT_LONG_NAME, shortName = SCATTER_COUNT_SHORT_NAME,
             doc = "scatter count: number of output interval files to split into", optional = true)
     private int scatterCount = 1;
@@ -147,8 +149,9 @@ public class SplitIntervals extends GATKTool {
                         })  // turn the intervals back into an IntervalList
                 ).collect(Collectors.toList());
 
-        final DecimalFormat formatter = new DecimalFormat("0000");
-        IntStream.range(0, scatteredFinal.size()).forEach(n -> scatteredFinal.get(n).write(new File(outputDir, formatter.format(n) + extension)));
+        final int maxNumberOfPlaces = Math.max((int)Math.floor(Math.log10(scatterCount-1))+1, DEFAULT_NUMBER_OF_DIGITS);
+        final String formatString = "%0" + maxNumberOfPlaces + "d";
+        IntStream.range(0, scatteredFinal.size()).forEach(n -> scatteredFinal.get(n).write(new File(outputDir, String.format(formatString, n) + extension)));
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/SplitIntervalsIntegrationTest.java
@@ -162,7 +162,9 @@ public class SplitIntervalsIntegrationTest extends CommandLineProgramTest {
 
     //generates the files to look for given a scatter count, directory and extension
     private static Stream<File> getExpectedScatteredFiles(final int scatterCount, final File outputDir, String extension) {
-        return IntStream.range(0, scatterCount).mapToObj(n -> new File(outputDir, formatter.format(n) + extension));
+        final int maxNumberOfPlaces = (int)Math.max(Math.floor(Math.log10(scatterCount-1))+1, SplitIntervals.DEFAULT_NUMBER_OF_DIGITS);
+        final String fileIndexFormatString = "%0" + maxNumberOfPlaces + "d";
+        return IntStream.range(0, scatterCount).mapToObj(n -> new File(outputDir, String.format(fileIndexFormatString, n) + extension));
     }
 
     private static void verifyScatteredFilesExist(final int scatterCount, final File outputDir, String extension) {


### PR DESCRIPTION
SplitIntervals originally named files with 4-digit padding, but then we exceeded 10,000 shards in production.  This should work forever.