### PR TITLE
DetermineGermlineContigPloidy can now process interval lists with a single contig

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/DetermineGermlineContigPloidy.java
@@ -110,6 +110,11 @@ import static org.broadinstitute.hellbender.tools.copynumber.arguments.CopyNumbe
  *     prior table (3 in the above example). A ploidy state can be strictly forbidden by setting its prior probability
  *     to 0. For example, the Y contig in the above example can only assume 0 and 1 ploidy states.</p>
  *
+ *     <p>If the provided count data only contains intervals from a single chromosome, the model degeneracy in this
+ *     case will lead to no meaningful inference and the ploidy states will be resolved to the most likely ploidy
+ *     states given by the ploidy prior table. As an example, autosomal contigs will assume ploidy 2, and
+ *     X could assume either 1 or 2 depending on tie breakers.</p>
+ *
  *     <p>The tool output in the COHORT mode will contain two subdirectories, one ending with "-model" and the other
  *     ending with "-calls". The model subdirectory contains the inferred parameters of the ploidy model, which may
  *     be used later on for karyotyping one or more similarly-sequenced samples (see below).
@@ -293,8 +298,17 @@ public final class DetermineGermlineContigPloidy extends CommandLineProgram {
 
         setModeAndResolveIntervals();
 
+        final boolean intervalListContainsMultipleContigs = specifiedIntervals.getRecords().stream()
+                .map(SimpleInterval::getContig).collect(Collectors.toSet()).size() > 1;
+        if (!intervalListContainsMultipleContigs) {
+            logger.warn("The interval list only contains a single contig! Inference of the ploidy states will be" +
+                    "limited to what is provided in contig-ploidy prior table, i.e. the ploidy state with" +
+                    " highest value of prior will be chosen");
+        }
+
         //read in count files and output intervals and samples x coverage-per-contig table to temporary files
         specifiedIntervalsFile = IOUtils.createTempFile("intervals", ".tsv");
+
         specifiedIntervals.write(specifiedIntervalsFile);
         final File samplesByCoveragePerContigFile = IOUtils.createTempFile("samples-by-coverage-per-contig", ".tsv");
         writeSamplesByCoveragePerContig(samplesByCoveragePerContigFile);

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
@@ -252,7 +252,10 @@ class PloidyModel(GeneralizedContinuousModel):
                       * ploidy_k.dimshuffle('x', 'x', 0))
         mu_den_sjk = gamma_rest_sj.dimshuffle(0, 1, 'x') + mu_num_sjk
         eps_mapping_j = eps_mapping * t_j / tt.sum(t_j)  # average number of reads erroneously mapped to contig j
-        mu_sjk = ((1.0 - eps_mapping) * (mu_num_sjk / mu_den_sjk)
+
+        # the switch is required for a single contig edge case
+        mu_ratio_sjk = tt.switch(tt.eq(mu_den_sjk, 0.0), 0.0, mu_num_sjk / mu_den_sjk)
+        mu_sjk = ((1.0 - eps_mapping) * mu_ratio_sjk
                   + eps_mapping_j.dimshuffle('x', 0, 'x')) * n_s.dimshuffle(0, 'x', 'x')
 
         def _get_logp_sjk(_n_sj):


### PR DESCRIPTION
I ran a couple of tests - in case of single contig case the ploidy calls correspond to most likely apriori ploidies. In the case of multiple contigs there is no numerical changes to inference whatsoever. 