### PR TITLE
Adjusted logic for filtering zero-coverage samples and intervals in CreateReadCountPanelOfNormals.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormals.java
@@ -177,7 +177,7 @@ public final class CreateReadCountPanelOfNormals extends SparkCommandLineProgram
     private double minimumIntervalMedianPercentile = DEFAULT_MINIMUM_INTERVAL_MEDIAN_PERCENTILE;
 
     @Argument(
-            doc = "Samples with a fraction of zero-coverage genomic intervals above this percentage are filtered out.  " +
+            doc = "Samples with a fraction of zero-coverage genomic intervals greater than or equal to this percentage are filtered out.  " +
                     "(This is the second filter applied.)",
             fullName = MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE_LONG_NAME,
             minValue = 0.,
@@ -187,7 +187,7 @@ public final class CreateReadCountPanelOfNormals extends SparkCommandLineProgram
     private double maximumZerosInSamplePercentage = DEFAULT_MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE;
 
     @Argument(
-            doc = "Genomic intervals with a fraction of zero-coverage samples above this percentage are filtered out.  " +
+            doc = "Genomic intervals with a fraction of zero-coverage samples greater than or equal to this percentage are filtered out.  " +
                     "(This is the third filter applied.)",
             fullName = MAXIMUM_ZEROS_IN_INTERVAL_PERCENTAGE_LONG_NAME,
             minValue = 0.,
@@ -198,7 +198,7 @@ public final class CreateReadCountPanelOfNormals extends SparkCommandLineProgram
 
     @Argument(
             doc = "Samples with a median (across genomic intervals) of fractional coverage normalized by genomic-interval medians  " +
-                    "below this percentile or above the complementary percentile are filtered out.  " +
+                    "strictly below this percentile or strictly above the complementary percentile are filtered out.  " +
                     "(This is the fourth filter applied.)",
             fullName = EXTREME_SAMPLE_MEDIAN_PERCENTILE_LONG_NAME,
             minValue = 0.,
@@ -217,7 +217,7 @@ public final class CreateReadCountPanelOfNormals extends SparkCommandLineProgram
 
     @Argument(
             doc = "Fractional coverages normalized by genomic-interval medians that are " +
-                    "below this percentile or above the complementary percentile are set to the corresponding percentile value.  " +
+                    "strictly below this percentile or strictly above the complementary percentile are set to the corresponding percentile value.  " +
                     "(This is applied after all filters and imputation.)",
             fullName = EXTREME_OUTLIER_TRUNCATION_PERCENTILE_LONG_NAME,
             minValue = 0.,

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormalsIntegrationTest.java
@@ -62,8 +62,12 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
 
     //we test only for filtering of samples and intervals with too many zeros
     private static final double MINIMUM_INTERVAL_MEDIAN_PERCENTILE = 0.;
-    private static final double MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE = 5.;
-    private static final double MAXIMUM_ZEROS_IN_INTERVAL_PERCENTAGE = 5.;
+    //test filtering of 5 bad samples
+    private static final int NUM_ZEROS_IN_BAD_SAMPLE_FOR_SIMULATION = 20;
+    private static final double MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE = 19.5;              //chosen to guard against regression of an equality check fixed in https://github.com/broadinstitute/gatk/pull/6624
+    //test filtering of 5 bad intervals (applied after sample filter)
+    private static final int NUM_ADDITIONAL_ZEROS_IN_BAD_INTERVAL_FOR_SIMULATION = 15;  //these zeros are added only in remaining good, unfiltered samples
+    private static final double MAXIMUM_ZEROS_IN_INTERVAL_PERCENTAGE = 14.5;            //chosen to guard against regression of an equality check fixed in https://github.com/broadinstitute/gatk/pull/6624
     private static final double EXTREME_SAMPLE_MEDIAN_PERCENTILE = 0.;
 
     //test that number of eigenvalues is recovered for a few different values using fraction of variance as a heuristic
@@ -163,24 +167,24 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
                 }
             });
 
-            //corrupt first NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS samples by randomly adding zeros
-            //to 5 * MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE / 100. of intervals
+            //corrupt first NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS samples by adding zeros
+            //to NUM_ZEROS_IN_BAD_SAMPLE_FOR_SIMULATION randomly chosen good intervals
             for (int sampleIndex = 0; sampleIndex < NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS; sampleIndex++) {
-                for (int intervalIndex = 0; intervalIndex < NUM_INTERVALS; intervalIndex++) {
-                    if (rng.nextUniform(0., 1.) < 5 * MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE / 100.) {
-                        counts.setEntry(sampleIndex, intervalIndex, 0.);
-                    }
-                }
+                final List<Integer> intervalIndicesToZero = IntStream.range(NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS, NUM_INTERVALS).boxed().collect(Collectors.toList());
+                Collections.shuffle(intervalIndicesToZero);
+                final int si = sampleIndex;
+                intervalIndicesToZero.subList(0, NUM_ZEROS_IN_BAD_SAMPLE_FOR_SIMULATION)
+                        .forEach(intervalIndex -> counts.setEntry(si, intervalIndex, 0.));
             }
 
-            //corrupt first NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS intervals by randomly adding zeros
-            //to 5 * MAXIMUM_ZEROS_IN_INTERVAL_PERCENTAGE / 100. of samples
+            //corrupt first NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS intervals by adding zeros
+            //to NUM_ADDITIONAL_ZEROS_IN_BAD_INTERVAL_FOR_SIMULATION randomly chosen from remaining good samples
             for (int intervalIndex = 0; intervalIndex < NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS; intervalIndex++) {
-                for (int sampleIndex = 0; sampleIndex < NUM_SAMPLES; sampleIndex++) {
-                    if (rng.nextUniform(0., 1.) < 5 * MAXIMUM_ZEROS_IN_INTERVAL_PERCENTAGE / 100.) {
-                        counts.setEntry(sampleIndex, intervalIndex, 0.);
-                    }
-                }
+                final List<Integer> sampleIndicesToZero = IntStream.range(NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS, NUM_SAMPLES).boxed().collect(Collectors.toList()); //choose only from good samples
+                Collections.shuffle(sampleIndicesToZero);
+                final int ii = intervalIndex;
+                sampleIndicesToZero.subList(0, NUM_ADDITIONAL_ZEROS_IN_BAD_INTERVAL_FOR_SIMULATION)
+                        .forEach(sampleIndex -> counts.setEntry(sampleIndex, ii, 0.));
             }
 
             //make input files from counts matrix
@@ -232,7 +236,7 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
     public void test(final List<File> inputFiles,
                      final File annotatedIntervalsFile,
                      final int expectedNumberOfEigenvalues) {
-        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".tsv");
+        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".hdf5");
         final ArgumentsBuilder argsBuilder = new ArgumentsBuilder()
                 .add(CreateReadCountPanelOfNormals.MINIMUM_INTERVAL_MEDIAN_PERCENTILE_LONG_NAME, Double.toString(MINIMUM_INTERVAL_MEDIAN_PERCENTILE))
                 .add(CreateReadCountPanelOfNormals.MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE_LONG_NAME, Double.toString(MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE))
@@ -252,7 +256,7 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
     public void testSingleSample(final List<File> inputFiles,
                                  final File annotatedIntervalsFile,
                                  final int expectedNumberOfEigenvalues) {   //ignored in this test
-        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".tsv");
+        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".hdf5");
         final ArgumentsBuilder argsBuilder = new ArgumentsBuilder()
                 .add(CreateReadCountPanelOfNormals.MINIMUM_INTERVAL_MEDIAN_PERCENTILE_LONG_NAME, Double.toString(MINIMUM_INTERVAL_MEDIAN_PERCENTILE))
                 .add(CreateReadCountPanelOfNormals.MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE_LONG_NAME, Double.toString(MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE))
@@ -271,7 +275,7 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
     public void testZeroEigensamples(final List<File> inputFiles,
                                      final File annotatedIntervalsFile,
                                      final int expectedNumberOfEigenvalues) {   //ignored in this test
-        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".tsv");
+        final File resultOutputFile = createTempFile("create-read-count-panel-of-normals-test", ".hdf5");
         final ArgumentsBuilder argsBuilder = new ArgumentsBuilder()
                 .add(CreateReadCountPanelOfNormals.MINIMUM_INTERVAL_MEDIAN_PERCENTILE_LONG_NAME, Double.toString(MINIMUM_INTERVAL_MEDIAN_PERCENTILE))
                 .add(CreateReadCountPanelOfNormals.MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE_LONG_NAME, Double.toString(MAXIMUM_ZEROS_IN_SAMPLE_PERCENTAGE))

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CreateReadCountPanelOfNormalsIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
@@ -171,7 +172,7 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
             //to NUM_ZEROS_IN_BAD_SAMPLE_FOR_SIMULATION randomly chosen good intervals
             for (int sampleIndex = 0; sampleIndex < NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS; sampleIndex++) {
                 final List<Integer> intervalIndicesToZero = IntStream.range(NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS, NUM_INTERVALS).boxed().collect(Collectors.toList());
-                Collections.shuffle(intervalIndicesToZero);
+                Collections.shuffle(intervalIndicesToZero, new Random(sampleIndex));
                 final int si = sampleIndex;
                 intervalIndicesToZero.subList(0, NUM_ZEROS_IN_BAD_SAMPLE_FOR_SIMULATION)
                         .forEach(intervalIndex -> counts.setEntry(si, intervalIndex, 0.));
@@ -181,7 +182,7 @@ public final class CreateReadCountPanelOfNormalsIntegrationTest extends CommandL
             //to NUM_ADDITIONAL_ZEROS_IN_BAD_INTERVAL_FOR_SIMULATION randomly chosen from remaining good samples
             for (int intervalIndex = 0; intervalIndex < NUM_BAD_INTERVALS_WITH_TOO_MANY_ZEROS; intervalIndex++) {
                 final List<Integer> sampleIndicesToZero = IntStream.range(NUM_BAD_SAMPLES_WITH_TOO_MANY_ZEROS, NUM_SAMPLES).boxed().collect(Collectors.toList()); //choose only from good samples
-                Collections.shuffle(sampleIndicesToZero);
+                Collections.shuffle(sampleIndicesToZero, new Random(intervalIndex));
                 final int ii = intervalIndex;
                 sampleIndicesToZero.subList(0, NUM_ADDITIONAL_ZEROS_IN_BAD_INTERVAL_FOR_SIMULATION)
                         .forEach(sampleIndex -> counts.setEntry(sampleIndex, ii, 0.));


### PR DESCRIPTION
Just a minor fix, but could conceivably change results by keeping/dropping samples/intervals on the edge of the filter. See discussion in https://gatk.broadinstitute.org/hc/en-us/community/posts/360057785591-Error-while-running-CreateReadCountPanelOfNormals