### PR TITLE
- ContextCovariate assumes that all non-ACGT bases in the read are N'…

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
@@ -188,7 +188,7 @@ public final class ContextCovariate implements Covariate {
             currentKey = 0;
             currentNPenalty = contextSize - 1;
             int offset = newBaseOffset;
-            while (bases[currentNPenalty] != 'N') {
+            while (BaseUtils.simpleBaseToBaseIndex(bases[currentNPenalty]) != -1) {
                 final int baseIndex = BaseUtils.simpleBaseToBaseIndex(bases[currentNPenalty]);
                 currentKey |= (baseIndex << offset);
                 offset -= 2;

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariate.java
@@ -182,14 +182,14 @@ public final class ContextCovariate implements Covariate {
         int currentKey = keyFromContext(bases, 0, contextSize);
         keys.add(currentKey);
 
-        // if the first key was -1 then there was an N in the context; figure out how many more consecutive contexts it affects
+        // if the first key was -1 then there was an non-ACGT in the context; figure out how many more consecutive contexts it affects
         int currentNPenalty = 0;
         if (currentKey == -1) {
             currentKey = 0;
             currentNPenalty = contextSize - 1;
             int offset = newBaseOffset;
-            while (BaseUtils.simpleBaseToBaseIndex(bases[currentNPenalty]) != -1) {
-                final int baseIndex = BaseUtils.simpleBaseToBaseIndex(bases[currentNPenalty]);
+            int baseIndex;
+            while ((baseIndex = BaseUtils.simpleBaseToBaseIndex(bases[currentNPenalty])) != -1) {
                 currentKey |= (baseIndex << offset);
                 offset -= 2;
                 currentNPenalty--;

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
@@ -63,7 +63,7 @@ public final class ContextCovariateUnitTest extends GATKBaseTest {
 
         final String[] bases = new String[] {
 //           A string of all IUPAC bases
-                "NBTRMLNACMGRSVTWYHKDBNABTRMLNBTRML",
+                "NBRMLNMRSVWYHKDBNBRMLNBRML",
 //           A string that starts with an ACGT base, then has a mix of ACGT and IUPAC bases
                 "ACTNBTRMLACMGRSVTWYHKDBNANBTRMLNBTRML",
 //           A string that starts with an IUPAC base, then has a mix of ACGT and IUPAC bases

--- a/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/recalibration/covariates/ContextCovariateUnitTest.java
@@ -80,7 +80,6 @@ public final class ContextCovariateUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "AnnoyingReads")
     public void testContextsAnnoyingReads(final List<Byte> bases, final List<Integer> positions, final boolean strand, final int readLength){
-        final Random rnd = Utils.getRandomGenerator();
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
         final GATKRead read = ArtificialReadUtils.createRandomRead(header, readLength,false);
 


### PR DESCRIPTION
…s and this might actually be wrong.

- fixes this assumption
- add tests
- modify tests so that they use actually random bases and not just AAAAAA bases....