### PR TITLE
Extracting a new ReadsDataSource interface

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -146,7 +146,7 @@ public abstract class GATKTool extends CommandLineProgram {
     /**
      * Our source of reads data (null if no source of reads was provided)
      */
-    ReadsDataSource reads;
+    ReadsDataSourceInterface reads;
 
     /**
      * Our source of Feature data (null if no source of Features was provided)
@@ -181,7 +181,7 @@ public abstract class GATKTool extends CommandLineProgram {
     }
 
     /**
-     * Get the {@link ReadsDataSource} for this {@link GATKTool}.
+     * Get the {@link ReadsDataSourceInterface} for this {@link GATKTool}.
      * Will throw a {@link GATKException} if the reads are null.
      * Clients are expected to call the {@link #hasReads()} method prior to calling this.
      *
@@ -190,9 +190,9 @@ public abstract class GATKTool extends CommandLineProgram {
      * Tools that extend a walker type should get their data via {@code apply()} rather than directly accessing
      * the engine datasources.
      *
-     * @return the {@link ReadsDataSource} for this {@link GATKTool}.  Never {@code null}.
+     * @return the {@link ReadsDataSourceInterface} for this {@link GATKTool}.  Never {@code null}.
      */
-    protected ReadsDataSource directlyAccessEngineReadsDataSource() {
+    protected ReadsDataSourceInterface directlyAccessEngineReadsDataSource() {
         if ( reads == null ) {
             throw new GATKException("Attempted to retrieve null reads!");
         }
@@ -455,7 +455,7 @@ public abstract class GATKTool extends CommandLineProgram {
                 factory = factory.enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES);
             }
 
-            reads = new ReadsDataSource(readArguments.getReadPaths(), readArguments.getReadIndexPaths(), factory, cloudPrefetchBuffer,
+            reads = new ReadsPathDataSource(readArguments.getReadPaths(), readArguments.getReadIndexPaths(), factory, cloudPrefetchBuffer,
                 (cloudIndexPrefetchBuffer < 0 ? cloudPrefetchBuffer : cloudIndexPrefetchBuffer));
         }
         else {

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -146,7 +146,7 @@ public abstract class GATKTool extends CommandLineProgram {
     /**
      * Our source of reads data (null if no source of reads was provided)
      */
-    ReadsDataSourceInterface reads;
+    ReadsDataSource reads;
 
     /**
      * Our source of Feature data (null if no source of Features was provided)
@@ -181,7 +181,7 @@ public abstract class GATKTool extends CommandLineProgram {
     }
 
     /**
-     * Get the {@link ReadsDataSourceInterface} for this {@link GATKTool}.
+     * Get the {@link ReadsDataSource} for this {@link GATKTool}.
      * Will throw a {@link GATKException} if the reads are null.
      * Clients are expected to call the {@link #hasReads()} method prior to calling this.
      *
@@ -190,9 +190,9 @@ public abstract class GATKTool extends CommandLineProgram {
      * Tools that extend a walker type should get their data via {@code apply()} rather than directly accessing
      * the engine datasources.
      *
-     * @return the {@link ReadsDataSourceInterface} for this {@link GATKTool}.  Never {@code null}.
+     * @return the {@link ReadsDataSource} for this {@link GATKTool}.  Never {@code null}.
      */
-    protected ReadsDataSourceInterface directlyAccessEngineReadsDataSource() {
+    protected ReadsDataSource directlyAccessEngineReadsDataSource() {
         if ( reads == null ) {
             throw new GATKException("Attempted to retrieve null reads!");
         }

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
@@ -30,7 +30,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
 
     private final List<SimpleInterval> intervals;
     private final List<SimpleInterval> paddedIntervals;
-    private final ReadsDataSource readsSource;
+    private final ReadsDataSourceInterface readsSource;
 
     private ReadTransformer preReadFilterTransformer;
     private ReadFilter readFilter;
@@ -45,7 +45,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
      * @param intervalPadding Number of bases to pad each of the shard's intervals (on both sides)
      * @param readsSource Source of reads
      */
-    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final int intervalPadding, final ReadsDataSource readsSource) {
+    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final int intervalPadding, final ReadsDataSourceInterface readsSource) {
         Utils.nonNull(intervals);
         Utils.nonNull(readsSource);
         Utils.validateArg(intervalPadding >= 0, "intervalPadding must be >= 0");
@@ -68,7 +68,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
      * @param intervals The intervals that this shard spans
      * @param readsSource Source of reads
      */
-    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final ReadsDataSource readsSource) {
+    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final ReadsDataSourceInterface readsSource) {
         this(intervals, 0, readsSource);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
@@ -30,7 +30,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
 
     private final List<SimpleInterval> intervals;
     private final List<SimpleInterval> paddedIntervals;
-    private final ReadsDataSourceInterface readsSource;
+    private final ReadsDataSource readsSource;
 
     private ReadTransformer preReadFilterTransformer;
     private ReadFilter readFilter;
@@ -45,7 +45,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
      * @param intervalPadding Number of bases to pad each of the shard's intervals (on both sides)
      * @param readsSource Source of reads
      */
-    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final int intervalPadding, final ReadsDataSourceInterface readsSource) {
+    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final int intervalPadding, final ReadsDataSource readsSource) {
         Utils.nonNull(intervals);
         Utils.nonNull(readsSource);
         Utils.validateArg(intervalPadding >= 0, "intervalPadding must be >= 0");
@@ -68,7 +68,7 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
      * @param intervals The intervals that this shard spans
      * @param readsSource Source of reads
      */
-    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final ReadsDataSourceInterface readsSource) {
+    public MultiIntervalLocalReadShard(final List<SimpleInterval> intervals, final ReadsDataSource readsSource) {
         this(intervals, 0, readsSource);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
@@ -9,8 +9,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import java.util.*;
 
 /**
- * Wrapper around ReadsDataSource that presents reads overlapping a specific interval to a client,
- * without improperly exposing the entire ReadsDataSource interface.
+ * Wrapper around ReadsDataSourceInterface that presents reads overlapping a specific interval to a client,
+ * without improperly exposing the entire ReadsDataSourceInterface interface.
  *
  * Reads data in the interval is lazily queried, so there's no overhead if the client chooses
  * not to examine contextual information from the reads.
@@ -75,7 +75,7 @@ public final class ReadsContext implements Iterable<GATKRead> {
     /**
      * Does this context have a backing source of reads data?
      *
-     * @return true if there is a backing ReadsDataSource, otherwise false
+     * @return true if there is a backing ReadsDataSourceInterface, otherwise false
      */
     public boolean hasBackingDataSource() {
         return dataSource != null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsContext.java
@@ -9,8 +9,8 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import java.util.*;
 
 /**
- * Wrapper around ReadsDataSourceInterface that presents reads overlapping a specific interval to a client,
- * without improperly exposing the entire ReadsDataSourceInterface interface.
+ * Wrapper around ReadsDataSource that presents reads overlapping a specific interval to a client,
+ * without improperly exposing the entire ReadsDataSource interface.
  *
  * Reads data in the interval is lazily queried, so there's no overhead if the client chooses
  * not to examine contextual information from the reads.
@@ -75,7 +75,7 @@ public final class ReadsContext implements Iterable<GATKRead> {
     /**
      * Does this context have a backing source of reads data?
      *
-     * @return true if there is a backing ReadsDataSourceInterface, otherwise false
+     * @return true if there is a backing ReadsDataSource, otherwise false
      */
     public boolean hasBackingDataSource() {
         return dataSource != null;

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSource.java
@@ -17,7 +17,7 @@ import java.util.List;
  * -Iteration over all reads, optionally restricted to reads that overlap a set of intervals
  * -Targeted queries by one interval at a time
  */
-public interface ReadsDataSourceInterface extends GATKDataSource<GATKRead>, AutoCloseable {
+public interface ReadsDataSource extends GATKDataSource<GATKRead>, AutoCloseable {
 
     /**
      * Restricts a traversal of this data source via {@link #iterator} to only return reads that overlap the given intervals,
@@ -80,7 +80,7 @@ public interface ReadsDataSourceInterface extends GATKDataSource<GATKRead>, Auto
     SAMFileHeader getHeader();
 
     /**
-     * Get the sequence dictionary for this ReadsDataSourceInterface
+     * Get the sequence dictionary for this ReadsDataSource
      *
      * @return SAMSequenceDictionary for the reads backing this datasource.
      */
@@ -89,7 +89,7 @@ public interface ReadsDataSourceInterface extends GATKDataSource<GATKRead>, Auto
     }
 
     /**
-     * @return true if this {@code ReadsDataSourceInterface} supports multiple iterations over the data
+     * @return true if this {@code ReadsDataSource} supports multiple iterations over the data
      */
     boolean supportsSerialIteration();
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSourceInterface.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsDataSourceInterface.java
@@ -1,0 +1,101 @@
+package org.broadinstitute.hellbender.engine;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *
+ * An interface for managing traversals over sources of reads.
+ *
+ * Two basic operations are available:
+ *
+ * -Iteration over all reads, optionally restricted to reads that overlap a set of intervals
+ * -Targeted queries by one interval at a time
+ */
+public interface ReadsDataSourceInterface extends GATKDataSource<GATKRead>, AutoCloseable {
+
+    /**
+     * Restricts a traversal of this data source via {@link #iterator} to only return reads that overlap the given intervals,
+     * and to unmapped reads if specified.
+     *
+     * Calls to {@link #query} are not affected by this method.
+     *
+     * @param intervals Our next full traversal will return reads overlapping these intervals
+     * @param traverseUnmapped Our next full traversal will return unmapped reads (this affects only unmapped reads that
+     *                         have no position -- unmapped reads that have the position of their mapped mates will be
+     *                         included if the interval overlapping that position is included).
+     */
+    void setTraversalBounds(List<SimpleInterval> intervals, boolean traverseUnmapped);
+
+    /**
+     * Restricts a traversal of this data source via {@link #iterator} to only return reads which overlap the given intervals.
+     * Calls to {@link #query} are not affected by setting these intervals.
+     *
+     * @param intervals Our next full traversal will return only reads overlapping these intervals
+     */
+    default void setTraversalBounds(List<SimpleInterval> intervals) {
+        setTraversalBounds(intervals, false);
+    }
+
+    /**
+     * Restricts a traversal of this data source via {@link #iterator} to only return reads that overlap the given intervals,
+     * and to unmapped reads if specified.
+     *
+     * Calls to {@link #query} are not affected by this method.
+     *
+     * @param traversalParameters set of traversal parameters to control which reads get returned by the next call
+     *                            to {@link #iterator}
+     */
+    default void setTraversalBounds(TraversalParameters traversalParameters){
+        setTraversalBounds(traversalParameters.getIntervalsForTraversal(), traversalParameters.traverseUnmappedReads());
+    }
+
+    /**
+     * @return true if traversals initiated via {@link #iterator} will be restricted to reads that overlap intervals
+     *         as configured via {@link #setTraversalBounds}, otherwise false
+     */
+    boolean traversalIsBounded();
+
+    /**
+     * @return true if this datasource supports the query() operation otherwise false.
+     */
+    boolean isQueryableByInterval();
+
+    /**
+     * @return An iterator over just the unmapped reads with no assigned position. This operation is not affected
+     *         by prior calls to {@link #setTraversalBounds}. The underlying file must be indexed.
+     */
+    Iterator<GATKRead> queryUnmapped();
+
+    /**
+     * Returns the SAM header for this data source.
+     *
+     * @return SAM header for this data source
+     */
+    SAMFileHeader getHeader();
+
+    /**
+     * Get the sequence dictionary for this ReadsDataSourceInterface
+     *
+     * @return SAMSequenceDictionary for the reads backing this datasource.
+     */
+    default SAMSequenceDictionary getSequenceDictionary(){
+        return getHeader().getSequenceDictionary();
+    }
+
+    /**
+     * @return true if this {@code ReadsDataSourceInterface} supports multiple iterations over the data
+     */
+    boolean supportsSerialIteration();
+
+    /**
+     * Shut down this data source permanently, closing all iterations and readers.
+     */
+    @Override  //Overriden here to disallow throwing checked exceptions.
+    void close();
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadsPathDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadsPathDataSource.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  * -Iteration over all reads, optionally restricted to reads that overlap a set of intervals
  * -Targeted queries by one interval at a time
  */
-public final class ReadsPathDataSource implements ReadsDataSourceInterface {
+public final class ReadsPathDataSource implements ReadsDataSource {
     private static final Logger logger = LogManager.getLogger(ReadsPathDataSource.class);
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/WalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/WalkerBase.java
@@ -44,8 +44,8 @@ public abstract class WalkerBase extends GATKTool {
      * directly accessing the engine datasources, since walker tools should get their data via {@code apply()} instead.
      */
     @Override
-    final protected ReadsDataSourceInterface directlyAccessEngineReadsDataSource() {
-        throw new GATKException("Should never directly access the engine ReadsDataSourceInterface in walker tool classes " +
+    final protected ReadsDataSource directlyAccessEngineReadsDataSource() {
+        throw new GATKException("Should never directly access the engine ReadsDataSource in walker tool classes " +
                 "outside of the engine package. Walker tools should get their data via apply() instead.");
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/WalkerBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/WalkerBase.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.engine;
 
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
  * Base class for pre-packaged walker traversals in the GATK engine.
@@ -45,8 +44,8 @@ public abstract class WalkerBase extends GATKTool {
      * directly accessing the engine datasources, since walker tools should get their data via {@code apply()} instead.
      */
     @Override
-    final protected ReadsDataSource directlyAccessEngineReadsDataSource() {
-        throw new GATKException("Should never directly access the engine ReadsDataSource in walker tool classes " +
+    final protected ReadsDataSourceInterface directlyAccessEngineReadsDataSource() {
+        throw new GATKException("Should never directly access the engine ReadsDataSourceInterface in walker tool classes " +
                 "outside of the engine package. Walker tools should get their data via apply() instead.");
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -11,7 +11,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
 import org.broadinstitute.hellbender.engine.TraversalParameters;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -173,8 +174,8 @@ public final class ReadsSparkSource implements Serializable {
             final SamReaderFactory factory = SamReaderFactory.makeDefault()
                     .validationStringency(validationStringency)
                     .referenceSequence(cramReferencePathSpec == null ? null : referencePathSpecifier.toPath());
-            try (final ReadsDataSource readsDataSource =
-                         new ReadsDataSource(Collections.singletonList(filePathSpecifier.toPath()), factory)) {
+            try (final ReadsDataSourceInterface readsDataSource =
+                         new ReadsPathDataSource(Collections.singletonList(filePathSpecifier.toPath()), factory)) {
                  return readsDataSource.getHeader();
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -11,8 +11,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
 import org.broadinstitute.hellbender.engine.TraversalParameters;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -174,7 +174,7 @@ public final class ReadsSparkSource implements Serializable {
             final SamReaderFactory factory = SamReaderFactory.makeDefault()
                     .validationStringency(validationStringency)
                     .referenceSequence(cramReferencePathSpec == null ? null : referencePathSpecifier.toPath());
-            try (final ReadsDataSourceInterface readsDataSource =
+            try (final ReadsDataSource readsDataSource =
                          new ReadsPathDataSource(Collections.singletonList(filePathSpecifier.toPath()), factory)) {
                  return readsDataSource.getHeader();
             }

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
@@ -54,7 +54,7 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
      */
     @Test(dataProvider = "testCorrectRegionsHaveCorrectReadsAndSizeData")
     public void testRegionsHaveCorrectReadsAndSize( final String reads, final String reference, final List<SimpleInterval> shardIntervals, final int minRegionSize, final int maxRegionSize, final int assemblyRegionPadding ) throws IOException {
-        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(reads));
+        try (final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(reads));
              final ReferenceDataSource refSource = ReferenceDataSource.of(IOUtils.getPath(reference));
              final ReferenceSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(IOUtils.getPath(b37_reference_20_21));
         ) {
@@ -104,7 +104,7 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
                     previousRead = currentRead;
                 }
 
-                try ( final ReadsDataSourceInterface innerReadsSource = new ReadsPathDataSource(IOUtils.getPath(reads)) ) {
+                try ( final ReadsDataSource innerReadsSource = new ReadsPathDataSource(IOUtils.getPath(reads)) ) {
                     final List<GATKRead> regionExpectedReads = Lists.newArrayList(innerReadsSource.query(regionInterval)).stream().filter(combinedReadFilter).collect(Collectors.toList());
 
                     final List<GATKRead> actualNotInExpected = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/AssemblyRegionIteratorUnitTest.java
@@ -54,7 +54,7 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
      */
     @Test(dataProvider = "testCorrectRegionsHaveCorrectReadsAndSizeData")
     public void testRegionsHaveCorrectReadsAndSize( final String reads, final String reference, final List<SimpleInterval> shardIntervals, final int minRegionSize, final int maxRegionSize, final int assemblyRegionPadding ) throws IOException {
-        try (final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(reads));
+        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(reads));
              final ReferenceDataSource refSource = ReferenceDataSource.of(IOUtils.getPath(reference));
              final ReferenceSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(IOUtils.getPath(b37_reference_20_21));
         ) {
@@ -104,7 +104,7 @@ public class AssemblyRegionIteratorUnitTest extends GATKBaseTest {
                     previousRead = currentRead;
                 }
 
-                try ( final ReadsDataSource innerReadsSource = new ReadsDataSource(IOUtils.getPath(reads)) ) {
+                try ( final ReadsDataSourceInterface innerReadsSource = new ReadsPathDataSource(IOUtils.getPath(reads)) ) {
                     final List<GATKRead> regionExpectedReads = Lists.newArrayList(innerReadsSource.query(regionInterval)).stream().filter(combinedReadFilter).collect(Collectors.toList());
 
                     final List<GATKRead> actualNotInExpected = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShardUnitTest.java
@@ -17,7 +17,7 @@ public class MultiIntervalLocalReadShardUnitTest extends GATKBaseTest {
 
     @DataProvider
     public Object[][] shardBoundsTestData() {
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 // Shard, expected shard intervals, expected padded shard intervals
@@ -116,7 +116,7 @@ public class MultiIntervalLocalReadShardUnitTest extends GATKBaseTest {
 
     @DataProvider
     public Object[][] shardIterationTestData() {
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         final ReadFilter keepReadBOnly = new ReadFilter() {
             private static final long serialVersionUID = 1l;

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShardUnitTest.java
@@ -17,7 +17,7 @@ public class MultiIntervalLocalReadShardUnitTest extends GATKBaseTest {
 
     @DataProvider
     public Object[][] shardBoundsTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         return new Object[][] {
                 // Shard, expected shard intervals, expected padded shard intervals
@@ -116,7 +116,7 @@ public class MultiIntervalLocalReadShardUnitTest extends GATKBaseTest {
 
     @DataProvider
     public Object[][] shardIterationTestData() {
-        final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
 
         final ReadFilter keepReadBOnly = new ReadFilter() {
             private static final long serialVersionUID = 1l;

--- a/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
@@ -18,8 +18,8 @@ public class PipelineSupportIntegrationTest extends GATKBaseTest {
         File output = createTempFile("testOutput",".bam");
         BaseTest.runProcess(ProcessController.getThreadLocal(), new String[]{"/bin/sh","-c"," ./gatk SortSam -I "+INPUT_BAM+" -O /dev/stdout -SO coordinate " +
                 "| ./gatk SetNmMdAndUqTags -I /dev/stdin -O "+ output.getAbsolutePath()+ " --CREATE_INDEX true -R "+b37_reference_20_21});//.split(" "));
-        try (ReadsDataSource inputReads = new ReadsDataSource(new File(INPUT_BAM).toPath());
-             ReadsDataSource outputReads = new ReadsDataSource(output.toPath())) {
+        try (ReadsDataSourceInterface inputReads = new ReadsPathDataSource(new File(INPUT_BAM).toPath());
+             ReadsDataSourceInterface outputReads = new ReadsPathDataSource(output.toPath())) {
             Assert.assertTrue(inputReads.iterator().hasNext());
             Assert.assertTrue(outputReads.iterator().hasNext());
             final int[] count = {0};

--- a/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
@@ -18,8 +18,8 @@ public class PipelineSupportIntegrationTest extends GATKBaseTest {
         File output = createTempFile("testOutput",".bam");
         BaseTest.runProcess(ProcessController.getThreadLocal(), new String[]{"/bin/sh","-c"," ./gatk SortSam -I "+INPUT_BAM+" -O /dev/stdout -SO coordinate " +
                 "| ./gatk SetNmMdAndUqTags -I /dev/stdin -O "+ output.getAbsolutePath()+ " --CREATE_INDEX true -R "+b37_reference_20_21});//.split(" "));
-        try (ReadsDataSourceInterface inputReads = new ReadsPathDataSource(new File(INPUT_BAM).toPath());
-             ReadsDataSourceInterface outputReads = new ReadsPathDataSource(output.toPath())) {
+        try (ReadsDataSource inputReads = new ReadsPathDataSource(new File(INPUT_BAM).toPath());
+             ReadsDataSource outputReads = new ReadsPathDataSource(output.toPath())) {
             Assert.assertTrue(inputReads.iterator().hasNext());
             Assert.assertTrue(outputReads.iterator().hasNext());
             final int[] count = {0};

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.engine;
 
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.ReadNameReadFilter;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -27,7 +26,7 @@ public final class ReadsContextUnitTest extends GATKBaseTest {
                 { new ReadsContext() },
                 { new ReadsContext(null, null, null) },
                 { new ReadsContext(null, new SimpleInterval("1", 1, 1), null ) },
-                { new ReadsContext(new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
+                { new ReadsContext(new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")), null) }
         };
     }
 
@@ -46,12 +45,12 @@ public final class ReadsContextUnitTest extends GATKBaseTest {
         readNameFilter.readName = "d";
         return new Object[][]{
                 {new ReadsContext(
-                        new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
+                        new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
                         new SimpleInterval("1", 200, 210), // query over small interval, with no read filter
                         ReadFilterLibrary.ALLOW_ALL_READS), new String[] { "a", "b", "c" },
                 },
                 {new ReadsContext(
-                        new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
+                        new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam")),
                         new SimpleInterval("1", 200, 1000), // query over larger interval with readNameFilter on "d"
                         readNameFilter), new String[] { "d" }
                 }
@@ -70,7 +69,7 @@ public final class ReadsContextUnitTest extends GATKBaseTest {
 
     @Test
     public void testIteratorOverDifferentInterval() {
-        final ReadsDataSource readsDataSource = new ReadsDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SimpleInterval originalInterval = new SimpleInterval("1", 200, 210);
         final ReadsContext readsContext = new ReadsContext(readsDataSource, originalInterval, ReadFilterLibrary.ALLOW_ALL_READS);
         final SimpleInterval otherInterval = new SimpleInterval("1", 276, 300);

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsContextUnitTest.java
@@ -69,7 +69,7 @@ public final class ReadsContextUnitTest extends GATKBaseTest {
 
     @Test
     public void testIteratorOverDifferentInterval() {
-        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
+        final ReadsDataSource readsDataSource = new ReadsPathDataSource(IOUtils.getPath(publicTestDir + "org/broadinstitute/hellbender/engine/reads_data_source_test1.bam"));
         final SimpleInterval originalInterval = new SimpleInterval("1", 200, 210);
         final ReadsContext readsContext = new ReadsContext(readsDataSource, originalInterval, ReadFilterLibrary.ALLOW_ALL_READS);
         final SimpleInterval otherInterval = new SimpleInterval("1", 276, 300);

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsPathDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsPathDataSourceUnitTest.java
@@ -30,18 +30,18 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleNullFile() {
         Path nullFile = null;
-        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(nullFile);
+        ReadsDataSource readsSource = new ReadsPathDataSource(nullFile);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleNullFileList() {
         List<Path> nullList = null;
-        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(nullList);
+        ReadsDataSource readsSource = new ReadsPathDataSource(nullList);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleEmptyFileList() {
-        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(new ArrayList<>());
+        ReadsDataSource readsSource = new ReadsPathDataSource(new ArrayList<>());
     }
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)
@@ -54,7 +54,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         // Cannot initialize a reads source with intervals unless all files are indexed
         final Path unindexed = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam");
         Assert.assertNull(SamFiles.findIndex(unindexed), "Expected file to have no index, but found an index file. " + unindexed.toAbsolutePath());
-        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(unindexed);
+        ReadsDataSource readsSource = new ReadsPathDataSource(unindexed);
         readsSource.setTraversalBounds(Arrays.asList(new SimpleInterval("1", 1, 5)));
     }
 
@@ -63,14 +63,14 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         // Construction should succeed, since we don't pass in any intervals, but the query should throw.
         final Path unindexed = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam");
         Assert.assertNull(SamFiles.findIndex(unindexed), "Expected file to have no index, but found an index file" + unindexed.toAbsolutePath());
-        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(unindexed);
+        ReadsDataSource readsSource = new ReadsPathDataSource(unindexed);
         readsSource.query(new SimpleInterval("1", 1, 5));
     }
 
     @Test
     public void testDefaultSamReaderValidationStringency() {
         // Default validation stringency = SILENT results in no validation errors on invalid coordinate sort
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(FIRST_TEST_SAM);
+        final ReadsDataSource readsSource = new ReadsPathDataSource(FIRST_TEST_SAM);
         //noinspection StatementWithEmptyBody
         for ( @SuppressWarnings("unused") final GATKRead read : readsSource ) {
         }
@@ -79,7 +79,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = SAMFormatException.class)
     public void testCustomSamReaderFactory() {
         // Custom SamReaderFactory with validation stringency = STRICT fails on invalid coordinate sort
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(
+        final ReadsDataSource readsSource = new ReadsPathDataSource(
                 FIRST_TEST_SAM,
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT));
         //noinspection StatementWithEmptyBody
@@ -100,7 +100,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SupportsSerialIteration")
     public void testSupportsSerialIteration(final List<Path> inputs, final boolean expectedSupportsSerialIteration) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(inputs)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(inputs)) {
             Assert.assertEquals(readsSource.supportsSerialIteration(), expectedSupportsSerialIteration);
         }
     }
@@ -117,14 +117,14 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SingleFileCompleteTraversalData")
     public void testSingleFileCompleteTraversal( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(samFile)) {
             traverseOnce(readsSource, samFile, expectedReadNames);
         }
     }
 
     @Test(dataProvider = "SingleFileCompleteTraversalData")
     public void testSingleFileSerialTraversal( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(samFile)) {
             Assert.assertTrue(readsSource.supportsSerialIteration());
 
             traverseOnce(readsSource, samFile, expectedReadNames);
@@ -133,7 +133,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         }
     }
 
-    private void traverseOnce(final ReadsDataSourceInterface readsSource, final Path samFile, final List<String> expectedReadNames) {
+    private void traverseOnce(final ReadsDataSource readsSource, final Path samFile, final List<String> expectedReadNames) {
         List<GATKRead> reads = new ArrayList<>();
         for ( GATKRead read : readsSource ) {
             reads.add(read);
@@ -252,7 +252,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         }
     }
 
-    private void traverseOnceByInterval(final ReadsDataSourceInterface readsSource, final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames) {
+    private void traverseOnceByInterval(final ReadsDataSource readsSource, final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames) {
         List<GATKRead> reads = new ArrayList<>();
         Iterator<GATKRead> queryIterator = readsSource.query(interval);
         while (queryIterator.hasNext()) {
@@ -281,7 +281,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "MultipleFilesCompleteTraversalData")
     public void testMultipleFilesCompleteTraversal(final List<Path> samFiles, final List<String> expectedReadNames) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFiles)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(samFiles)) {
             List<GATKRead> reads = new ArrayList<>();
 
             for (GATKRead read : readsSource) {
@@ -454,7 +454,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "TraversalWithUnmappedReadsTestData")
     public void testTraversalWithUnmappedReads( final Path samFile, final List<SimpleInterval> queryIntervals, final boolean queryUnmapped, final List<String> expectedReadNames ) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(samFile)) {
             readsSource.setTraversalBounds(queryIntervals, queryUnmapped);
 
             if ( (queryIntervals != null && ! queryIntervals.isEmpty()) || queryUnmapped ) {
@@ -489,7 +489,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "QueryUnmappedTestData")
     public void testQueryUnmapped( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(samFile)) {
             List<GATKRead> reads = new ArrayList<>();
             Iterator<GATKRead> queryIterator = readsSource.queryUnmapped();
             while (queryIterator.hasNext()) {
@@ -536,7 +536,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         final File testFile1 = getFileWithAddedContig(FIRST_TEST_BAM, "EXTRA_CONTIG_1", "test1", ".bam");
         final File testFile2 = getFileWithAddedContig(SECOND_TEST_BAM, "EXTRA_CONTIG_2", "test2", ".bam");
 
-        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(Arrays.asList(testFile1.toPath(), testFile2.toPath()))) {
+        try (final ReadsDataSource readsSource = new ReadsPathDataSource(Arrays.asList(testFile1.toPath(), testFile2.toPath()))) {
             SAMFileHeader samHeader = readsSource.getHeader();
             SAMSequenceDictionary sequenceDictionary = readsSource.getSequenceDictionary();
 
@@ -567,7 +567,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
             final String outputName,
             final String extension) {
         final File outputFile = GATKBaseTest.createTempFile(outputName, extension);
-        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(inputPath)) {
+        try (ReadsDataSource readsSource = new ReadsPathDataSource(inputPath)) {
             SAMFileHeader header = readsSource.getHeader();
             SAMSequenceRecord fakeSequenceRec = new SAMSequenceRecord(extraContig, 100);
             header.addSequence(fakeSequenceRec);
@@ -640,7 +640,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
     @Test(dataProvider = "manuallySpecifiedIndexTestData")
     public void testManuallySpecifiedIndicesWithCustomReaderFactoryAndNullWrappers( final List<Path> bams, final List<Path> indices ) {
         final SamReaderFactory customFactory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
-        // ReadsDataSourceInterface should not be using the wrapper since the files are not on the Google cloud.
+        // ReadsDataSource should not be using the wrapper since the files are not on the Google cloud.
         // So we pass this invalid wrapper: if the code tries to use it, it'll blow up.
         Function<SeekableByteChannel, SeekableByteChannel> nullWrapper = (SeekableByteChannel) -> null;
 
@@ -701,7 +701,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData", expectedExceptions = UserException.class)
     public void testManuallySpecifiedIndicesEmptyIndexList( final List<Path> bams, final List<Path> indices ) {
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bams, Collections.emptyList());
+        final ReadsDataSource readsSource = new ReadsPathDataSource(bams, Collections.emptyList());
     }
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData", expectedExceptions = UserException.class)
@@ -709,7 +709,7 @@ public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
         final List<Path> wrongIndices = new ArrayList<>();
         wrongIndices.add(indices.get(0)); // Add one index, but not the other
 
-        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bams, wrongIndices);
+        final ReadsDataSource readsSource = new ReadsPathDataSource(bams, wrongIndices);
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/ReadsPathDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ReadsPathDataSourceUnitTest.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
 
-public final class ReadsDataSourceUnitTest extends GATKBaseTest {
+public final class ReadsPathDataSourceUnitTest extends GATKBaseTest {
     private static final String READS_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
     private final Path FIRST_TEST_BAM = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "reads_data_source_test1.bam");
     private final Path SECOND_TEST_BAM = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "reads_data_source_test2.bam");
@@ -30,23 +30,23 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleNullFile() {
         Path nullFile = null;
-        ReadsDataSource readsSource = new ReadsDataSource(nullFile);
+        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(nullFile);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleNullFileList() {
         List<Path> nullList = null;
-        ReadsDataSource readsSource = new ReadsDataSource(nullList);
+        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(nullList);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testHandleEmptyFileList() {
-        ReadsDataSource readsSource = new ReadsDataSource(new ArrayList<>());
+        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(new ArrayList<>());
     }
 
     @Test(expectedExceptions = UserException.CouldNotReadInputFile.class)
     public void testHandleNonExistentFile() {
-        new ReadsDataSource(GATKBaseTest.getSafeNonExistentPath("nonexistent.bam"));
+        new ReadsPathDataSource(GATKBaseTest.getSafeNonExistentPath("nonexistent.bam"));
     }
 
     @Test(expectedExceptions = UserException.class)
@@ -54,7 +54,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         // Cannot initialize a reads source with intervals unless all files are indexed
         final Path unindexed = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam");
         Assert.assertNull(SamFiles.findIndex(unindexed), "Expected file to have no index, but found an index file. " + unindexed.toAbsolutePath());
-        ReadsDataSource readsSource = new ReadsDataSource(unindexed);
+        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(unindexed);
         readsSource.setTraversalBounds(Arrays.asList(new SimpleInterval("1", 1, 5)));
     }
 
@@ -63,14 +63,14 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         // Construction should succeed, since we don't pass in any intervals, but the query should throw.
         final Path unindexed = IOUtils.getPath(READS_DATA_SOURCE_TEST_DIRECTORY + "unindexed.bam");
         Assert.assertNull(SamFiles.findIndex(unindexed), "Expected file to have no index, but found an index file" + unindexed.toAbsolutePath());
-        ReadsDataSource readsSource = new ReadsDataSource(unindexed);
+        ReadsDataSourceInterface readsSource = new ReadsPathDataSource(unindexed);
         readsSource.query(new SimpleInterval("1", 1, 5));
     }
 
     @Test
     public void testDefaultSamReaderValidationStringency() {
         // Default validation stringency = SILENT results in no validation errors on invalid coordinate sort
-        final ReadsDataSource readsSource = new ReadsDataSource(FIRST_TEST_SAM);
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(FIRST_TEST_SAM);
         //noinspection StatementWithEmptyBody
         for ( @SuppressWarnings("unused") final GATKRead read : readsSource ) {
         }
@@ -79,7 +79,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
     @Test(expectedExceptions = SAMFormatException.class)
     public void testCustomSamReaderFactory() {
         // Custom SamReaderFactory with validation stringency = STRICT fails on invalid coordinate sort
-        final ReadsDataSource readsSource = new ReadsDataSource(
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(
                 FIRST_TEST_SAM,
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT));
         //noinspection StatementWithEmptyBody
@@ -100,7 +100,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SupportsSerialIteration")
     public void testSupportsSerialIteration(final List<Path> inputs, final boolean expectedSupportsSerialIteration) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(inputs)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(inputs)) {
             Assert.assertEquals(readsSource.supportsSerialIteration(), expectedSupportsSerialIteration);
         }
     }
@@ -117,14 +117,14 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SingleFileCompleteTraversalData")
     public void testSingleFileCompleteTraversal( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
             traverseOnce(readsSource, samFile, expectedReadNames);
         }
     }
 
     @Test(dataProvider = "SingleFileCompleteTraversalData")
     public void testSingleFileSerialTraversal( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
             Assert.assertTrue(readsSource.supportsSerialIteration());
 
             traverseOnce(readsSource, samFile, expectedReadNames);
@@ -133,7 +133,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         }
     }
 
-    private void traverseOnce(final ReadsDataSource readsSource, final Path samFile, final List<String> expectedReadNames) {
+    private void traverseOnce(final ReadsDataSourceInterface readsSource, final Path samFile, final List<String> expectedReadNames) {
         List<GATKRead> reads = new ArrayList<>();
         for ( GATKRead read : readsSource ) {
             reads.add(read);
@@ -181,7 +181,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SingleFileTraversalWithIntervalsData")
     public void testSingleFileTraversalWithIntervals( final Path samFile, final List<SimpleInterval> intervals, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsPathDataSource readsSource = new ReadsPathDataSource(samFile)) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Indices should be reported as available for this reads source");
 
             readsSource.setTraversalBounds(intervals);
@@ -234,7 +234,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SingleFileQueryByIntervalData")
     public void testSingleFileQueryByInterval( final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsPathDataSource readsSource = new ReadsPathDataSource(samFile)) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Indices should be reported as available for this reads source");
             traverseOnceByInterval(readsSource, samFile, interval, expectedReadNames);
         }
@@ -242,7 +242,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "SingleFileQueryByIntervalData")
     public void testSingleFileQueryByIntervalSerialIteration( final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsPathDataSource readsSource = new ReadsPathDataSource(samFile)) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Indices should be reported as available for this reads source");
             Assert.assertTrue(readsSource.supportsSerialIteration());
 
@@ -252,7 +252,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         }
     }
 
-    private void traverseOnceByInterval( final ReadsDataSource readsSource, final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames) {
+    private void traverseOnceByInterval(final ReadsDataSourceInterface readsSource, final Path samFile, final SimpleInterval interval, final List<String> expectedReadNames) {
         List<GATKRead> reads = new ArrayList<>();
         Iterator<GATKRead> queryIterator = readsSource.query(interval);
         while (queryIterator.hasNext()) {
@@ -281,7 +281,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "MultipleFilesCompleteTraversalData")
     public void testMultipleFilesCompleteTraversal(final List<Path> samFiles, final List<String> expectedReadNames) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFiles)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFiles)) {
             List<GATKRead> reads = new ArrayList<>();
 
             for (GATKRead read : readsSource) {
@@ -331,7 +331,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "MultipleFilesTraversalWithIntervalsData")
     public void testMultipleFilesTraversalWithIntervals( final List<Path> samFiles, final List<SimpleInterval> intervals, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFiles)) {
+        try (ReadsPathDataSource readsSource = new ReadsPathDataSource(samFiles)) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Indices should be reported as available for this reads source");
 
             readsSource.setTraversalBounds(intervals);
@@ -380,7 +380,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "MultipleFilesQueryByIntervalData")
     public void testMultipleFilesQueryByInterval( final List<Path> samFiles, final SimpleInterval interval, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFiles)) {
+        try (ReadsPathDataSource readsSource = new ReadsPathDataSource(samFiles)) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Indices should be reported as available for this reads source");
 
             List<GATKRead> reads = new ArrayList<>();
@@ -454,7 +454,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "TraversalWithUnmappedReadsTestData")
     public void testTraversalWithUnmappedReads( final Path samFile, final List<SimpleInterval> queryIntervals, final boolean queryUnmapped, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
             readsSource.setTraversalBounds(queryIntervals, queryUnmapped);
 
             if ( (queryIntervals != null && ! queryIntervals.isEmpty()) || queryUnmapped ) {
@@ -489,7 +489,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "QueryUnmappedTestData")
     public void testQueryUnmapped( final Path samFile, final List<String> expectedReadNames ) {
-        try (ReadsDataSource readsSource = new ReadsDataSource(samFile)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(samFile)) {
             List<GATKRead> reads = new ArrayList<>();
             Iterator<GATKRead> queryIterator = readsSource.queryUnmapped();
             while (queryIterator.hasNext()) {
@@ -536,7 +536,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         final File testFile1 = getFileWithAddedContig(FIRST_TEST_BAM, "EXTRA_CONTIG_1", "test1", ".bam");
         final File testFile2 = getFileWithAddedContig(SECOND_TEST_BAM, "EXTRA_CONTIG_2", "test2", ".bam");
 
-        try (final ReadsDataSource readsSource = new ReadsDataSource(Arrays.asList(testFile1.toPath(), testFile2.toPath()))) {
+        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(Arrays.asList(testFile1.toPath(), testFile2.toPath()))) {
             SAMFileHeader samHeader = readsSource.getHeader();
             SAMSequenceDictionary sequenceDictionary = readsSource.getSequenceDictionary();
 
@@ -567,7 +567,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
             final String outputName,
             final String extension) {
         final File outputFile = GATKBaseTest.createTempFile(outputName, extension);
-        try (ReadsDataSource readsSource = new ReadsDataSource(inputPath)) {
+        try (ReadsDataSourceInterface readsSource = new ReadsPathDataSource(inputPath)) {
             SAMFileHeader header = readsSource.getHeader();
             SAMSequenceRecord fakeSequenceRec = new SAMSequenceRecord(extraContig, 100);
             header.addSequence(fakeSequenceRec);
@@ -607,7 +607,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData")
     public void testManuallySpecifiedIndices( final List<Path> bams, final List<Path> indices ) {
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bams, indices) ) {
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(bams, indices) ) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Explicitly-provided indices not detected for bams: " + bams);
 
             final Iterator<GATKRead> queryReads = readsSource.query(new SimpleInterval("1", 1, 300));
@@ -624,7 +624,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
     public void testManuallySpecifiedIndicesWithCustomReaderFactory( final List<Path> bams, final List<Path> indices ) {
         final SamReaderFactory customFactory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bams, indices, customFactory) ) {
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(bams, indices, customFactory) ) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Explicitly-provided indices not detected for bams: " + bams);
 
             final Iterator<GATKRead> queryReads = readsSource.query(new SimpleInterval("1", 1, 300));
@@ -640,11 +640,11 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
     @Test(dataProvider = "manuallySpecifiedIndexTestData")
     public void testManuallySpecifiedIndicesWithCustomReaderFactoryAndNullWrappers( final List<Path> bams, final List<Path> indices ) {
         final SamReaderFactory customFactory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
-        // ReadsDataSource should not be using the wrapper since the files are not on the Google cloud.
+        // ReadsDataSourceInterface should not be using the wrapper since the files are not on the Google cloud.
         // So we pass this invalid wrapper: if the code tries to use it, it'll blow up.
         Function<SeekableByteChannel, SeekableByteChannel> nullWrapper = (SeekableByteChannel) -> null;
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bams, indices, customFactory, nullWrapper, nullWrapper) ) {
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(bams, indices, customFactory, nullWrapper, nullWrapper) ) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Explicitly-provided indices not detected for bams: " + bams);
 
             final Iterator<GATKRead> queryReads = readsSource.query(new SimpleInterval("1", 1, 300));
@@ -679,7 +679,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         Function<SeekableByteChannel, SeekableByteChannel> xorData = XorWrapper.forKey((byte)74);
         Function<SeekableByteChannel, SeekableByteChannel> xorIndex = XorWrapper.forKey((byte)80);
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bams, indices, customFactory, xorData, xorIndex) ) {
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(bams, indices, customFactory, xorData, xorIndex) ) {
             Assert.assertTrue(readsSource.indicesAvailable(), "Explicitly-provided indices not detected for bams: " + bams);
 
             final Iterator<GATKRead> queryReads = readsSource.query(new SimpleInterval("1", 1, 300));
@@ -694,14 +694,14 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData")
     public void testManuallySpecifiedIndicesNullIndexListOK( final List<Path> bams, final List<Path> indices ) {
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bams, (List<Path>)null) ) {
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(bams, (List<Path>)null) ) {
             Assert.assertFalse(readsSource.indicesAvailable(), "Bams not indexed and explicit indices not provided, but indicesAvailable() returns true");
         }
     }
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData", expectedExceptions = UserException.class)
     public void testManuallySpecifiedIndicesEmptyIndexList( final List<Path> bams, final List<Path> indices ) {
-        final ReadsDataSource readsSource = new ReadsDataSource(bams, Collections.emptyList());
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bams, Collections.emptyList());
     }
 
     @Test(dataProvider = "manuallySpecifiedIndexTestData", expectedExceptions = UserException.class)
@@ -709,7 +709,7 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
         final List<Path> wrongIndices = new ArrayList<>();
         wrongIndices.add(indices.get(0)); // Add one index, but not the other
 
-        final ReadsDataSource readsSource = new ReadsDataSource(bams, wrongIndices);
+        final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bams, wrongIndices);
     }
 
 
@@ -741,6 +741,6 @@ public final class ReadsDataSourceUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "readHeaders")
     public void testIdentifySortOrder(final List<SAMFileHeader> headers, final SAMFileHeader.SortOrder expected) {
-        Assert.assertEquals(ReadsDataSource.identifySortOrder(headers), expected);
+        Assert.assertEquals(ReadsPathDataSource.identifySortOrder(headers), expected);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.engine.spark;
 import com.google.common.collect.Iterators;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintReadsSpark;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintVariantsSpark;
@@ -63,7 +63,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
     }
 
     private static void assertReadsAreInCoordinatishOrder(final File bam) {
-        try(final ReadsDataSourceInterface reads = new ReadsPathDataSource(bam.toPath())){
+        try(final ReadsDataSource reads = new ReadsPathDataSource(bam.toPath())){
             final Iterator<GATKRead> iter = reads.iterator();
             GATKRead previous = null;
             final ReadCoordinateComparator comparator = new ReadCoordinateComparator(reads.getHeader());
@@ -117,7 +117,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
         final File actual = copyLocally(bamOut, "actual");
 
         //assert that the output has the right number of reads and they're ordered correctly
-        try( ReadsDataSourceInterface reader = new ReadsPathDataSource(actual.toPath())){
+        try( ReadsDataSource reader = new ReadsPathDataSource(actual.toPath())){
             Assert.assertEquals(Iterators.size(reader.iterator()), 1838);
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
@@ -3,7 +3,8 @@ package org.broadinstitute.hellbender.engine.spark;
 import com.google.common.collect.Iterators;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintReadsSpark;
 import org.broadinstitute.hellbender.tools.spark.pipelines.PrintVariantsSpark;
 import org.broadinstitute.hellbender.tools.spark.transforms.markduplicates.MarkDuplicatesSpark;
@@ -62,7 +63,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
     }
 
     private static void assertReadsAreInCoordinatishOrder(final File bam) {
-        try(final ReadsDataSource reads = new ReadsDataSource(bam.toPath())){
+        try(final ReadsDataSourceInterface reads = new ReadsPathDataSource(bam.toPath())){
             final Iterator<GATKRead> iter = reads.iterator();
             GATKRead previous = null;
             final ReadCoordinateComparator comparator = new ReadCoordinateComparator(reads.getHeader());
@@ -116,7 +117,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
         final File actual = copyLocally(bamOut, "actual");
 
         //assert that the output has the right number of reads and they're ordered correctly
-        try( ReadsDataSource reader = new ReadsDataSource(actual.toPath())){
+        try( ReadsDataSourceInterface reader = new ReadsPathDataSource(actual.toPath())){
             Assert.assertEquals(Iterators.size(reader.iterator()), 1838);
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -8,7 +8,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.TraversalParameters;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -290,7 +291,7 @@ public class ReadsSparkSourceUnitTest extends GATKBaseTest {
             samReaderFactory = SamReaderFactory.makeDefault().validationStringency(validationStringency);
         }
 
-        ReadsDataSource bam2 = new ReadsDataSource(IOUtils.getPath(bam), samReaderFactory);
+        ReadsDataSourceInterface bam2 = new ReadsPathDataSource(IOUtils.getPath(bam), samReaderFactory);
         List<GATKRead> records = Lists.newArrayList();
         for ( GATKRead read : bam2 ) {
             records.add(read);

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -8,7 +8,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.TraversalParameters;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -291,7 +291,7 @@ public class ReadsSparkSourceUnitTest extends GATKBaseTest {
             samReaderFactory = SamReaderFactory.makeDefault().validationStringency(validationStringency);
         }
 
-        ReadsDataSourceInterface bam2 = new ReadsPathDataSource(IOUtils.getPath(bam), samReaderFactory);
+        ReadsDataSource bam2 = new ReadsPathDataSource(IOUtils.getPath(bam), samReaderFactory);
         List<GATKRead> records = Lists.newArrayList();
         for ( GATKRead read : bam2 ) {
             records.add(read);

--- a/src/test/java/org/broadinstitute/hellbender/testutils/ReadTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/testutils/ReadTestUtils.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.util.SequenceUtil;
 import org.apache.commons.lang3.tuple.Pair;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
@@ -107,7 +107,7 @@ public final class ReadTestUtils {
     public static Pair<SAMFileHeader, List<GATKRead>> readEntireBamIntoMemory(final String bamPath) {
         Utils.nonNull(bamPath);
 
-        try ( final ReadsDataSourceInterface bamReader = new ReadsPathDataSource(Paths.get(bamPath)) ) {
+        try ( final ReadsDataSource bamReader = new ReadsPathDataSource(Paths.get(bamPath)) ) {
             final SAMFileHeader header = bamReader.getHeader();
 
             final List<GATKRead> reads = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/testutils/ReadTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/testutils/ReadTestUtils.java
@@ -3,11 +3,9 @@ package org.broadinstitute.hellbender.testutils;
 import htsjdk.samtools.*;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.util.SequenceUtil;
-import htsjdk.variant.variantcontext.VariantContext;
-import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.lang3.tuple.Pair;
-import org.broadinstitute.hellbender.engine.FeatureDataSource;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -109,7 +107,7 @@ public final class ReadTestUtils {
     public static Pair<SAMFileHeader, List<GATKRead>> readEntireBamIntoMemory(final String bamPath) {
         Utils.nonNull(bamPath);
 
-        try ( final ReadsDataSource bamReader = new ReadsDataSource(Paths.get(bamPath)) ) {
+        try ( final ReadsDataSourceInterface bamReader = new ReadsPathDataSource(Paths.get(bamPath)) ) {
             final SAMFileHeader header = bamReader.getHeader();
 
             final List<GATKRead> reads = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/tools/AbstractPrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/AbstractPrintReadsIntegrationTest.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadLengthReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadNameReadFilter;
@@ -180,7 +180,7 @@ public abstract class AbstractPrintReadsIntegrationTest extends CommandLineProgr
 
         runCommandLine(args);
 
-        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(outFile.toPath()) ) {
+        try ( final ReadsDataSource outputReadsSource = new ReadsPathDataSource(outFile.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 actualReads.add(read);
@@ -377,7 +377,7 @@ public abstract class AbstractPrintReadsIntegrationTest extends CommandLineProgr
     @Test()
     public void testUnSorted() throws Exception {
         final File inBam = new File(getTestDataDir(), "print_reads.unsorted.bam");
-        try (ReadsDataSourceInterface ds = new ReadsPathDataSource(inBam.toPath())){
+        try (ReadsDataSource ds = new ReadsPathDataSource(inBam.toPath())){
             Assert.assertEquals(ds.getHeader().getSortOrder(), SAMFileHeader.SortOrder.unsorted);
         }
         final File outBam = GATKBaseTest.createTempFile("print_reads", ".bam");

--- a/src/test/java/org/broadinstitute/hellbender/tools/AbstractPrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/AbstractPrintReadsIntegrationTest.java
@@ -9,7 +9,8 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadLengthReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadNameReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -179,7 +180,7 @@ public abstract class AbstractPrintReadsIntegrationTest extends CommandLineProgr
 
         runCommandLine(args);
 
-        try ( final ReadsDataSource outputReadsSource = new ReadsDataSource(outFile.toPath()) ) {
+        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(outFile.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 actualReads.add(read);
@@ -376,7 +377,7 @@ public abstract class AbstractPrintReadsIntegrationTest extends CommandLineProgr
     @Test()
     public void testUnSorted() throws Exception {
         final File inBam = new File(getTestDataDir(), "print_reads.unsorted.bam");
-        try (ReadsDataSource ds = new ReadsDataSource(inBam.toPath())){
+        try (ReadsDataSourceInterface ds = new ReadsPathDataSource(inBam.toPath())){
             Assert.assertEquals(ds.getHeader().getSortOrder(), SAMFileHeader.SortOrder.unsorted);
         }
         final File outBam = GATKBaseTest.createTempFile("print_reads", ".bam");

--- a/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
@@ -28,7 +28,7 @@ public class ConvertHeaderlessHadoopBamShardToBamIntegrationTest extends Command
         runCommandLine(args);
 
         int actualCount = 0;
-        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(output.toPath()) ) {
+        try ( final ReadsDataSource readsSource = new ReadsPathDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/ConvertHeaderlessHadoopBamShardToBamIntegrationTest.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -27,7 +28,7 @@ public class ConvertHeaderlessHadoopBamShardToBamIntegrationTest extends Command
         runCommandLine(args);
 
         int actualCount = 0;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(output.toPath()) ) {
+        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.SamAssertionUtils;
@@ -96,7 +96,7 @@ public final class PrintReadsIntegrationTest extends AbstractPrintReadsIntegrati
         intervals.forEach(args2::addInterval);
         runCommandLine(args2);
 
-        try(final ReadsDataSourceInterface reader = new ReadsPathDataSource(out.toPath())){
+        try(final ReadsDataSource reader = new ReadsPathDataSource(out.toPath())){
             final long count = Utils.stream(reader).count();
             Assert.assertEquals( count, expectedNumberOfReads);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -4,7 +4,8 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.SamAssertionUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -95,7 +96,7 @@ public final class PrintReadsIntegrationTest extends AbstractPrintReadsIntegrati
         intervals.forEach(args2::addInterval);
         runCommandLine(args2);
 
-        try(final ReadsDataSource reader = new ReadsDataSource(out.toPath())){
+        try(final ReadsDataSourceInterface reader = new ReadsPathDataSource(out.toPath())){
             final long count = Utils.stream(reader).count();
             Assert.assertEquals( count, expectedNumberOfReads);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
@@ -6,7 +6,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -139,7 +139,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try ( final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
+        try ( final ReadsDataSource outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
             for ( GATKRead read : outputReads ) {
                 ++totalReads;
 
@@ -240,7 +240,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
+        try (final ReadsDataSource outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -306,7 +306,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
+        try (final ReadsDataSource outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -365,7 +365,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try ( final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
+        try ( final ReadsDataSource outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
             for ( GATKRead read : outputReads ) {
                 ++totalReads;
 
@@ -420,7 +420,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
+        try (final ReadsDataSource outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -461,7 +461,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
         args.addInput(getTestFile("hashCollisionedReads.bam"));
         runCommandLine(args);
 
-        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
+        try ( final ReadsDataSource outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 Assert.assertFalse(read.isDuplicate());

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/MarkDuplicatesSparkIntegrationTest.java
@@ -6,7 +6,8 @@ import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.MarkDuplicatesSparkArgumentCollection;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
@@ -138,7 +139,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try ( final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath()) ) {
+        try ( final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
             for ( GATKRead read : outputReads ) {
                 ++totalReads;
 
@@ -239,7 +240,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath())) {
+        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -305,7 +306,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath())) {
+        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -364,7 +365,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try ( final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath()) ) {
+        try ( final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath()) ) {
             for ( GATKRead read : outputReads ) {
                 ++totalReads;
 
@@ -419,7 +420,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
 
         int totalReads = 0;
         int duplicateReads = 0;
-        try (final ReadsDataSource outputReads = new ReadsDataSource(outputFile.toPath())) {
+        try (final ReadsDataSourceInterface outputReads = new ReadsPathDataSource(outputFile.toPath())) {
             for (GATKRead read : outputReads) {
                 ++totalReads;
 
@@ -460,7 +461,7 @@ public class MarkDuplicatesSparkIntegrationTest extends AbstractMarkDuplicatesCo
         args.addInput(getTestFile("hashCollisionedReads.bam"));
         runCommandLine(args);
 
-        try ( final ReadsDataSource outputReadsSource = new ReadsDataSource(output.toPath()) ) {
+        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 Assert.assertFalse(read.isDuplicate());

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -2,14 +2,12 @@ package org.broadinstitute.hellbender.tools.spark.pipelines;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SBIIndex;
-import htsjdk.samtools.SBIIndexMerger;
-import htsjdk.samtools.SBIIndexWriter;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.GATKTool;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
@@ -37,7 +35,7 @@ public final class PrintReadsSparkIntegrationTest extends AbstractPrintReadsInte
         // This is a technically incorrectly sam with a header indicating that it is coordinate sorted when it is actually
         // queryname sorted. If the ordering is the same after PrintReadsSpark then it means we aren't automatically sorting the output.
         final File inBam = new File(getTestDataDir(), "print_reads.mismatchedHeader.sam");
-        try (ReadsDataSource ds = new ReadsDataSource(inBam.toPath())){
+        try (ReadsDataSourceInterface ds = new ReadsPathDataSource(inBam.toPath())){
             Assert.assertEquals(ds.getHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
         }
         final File outBam = GATKBaseTest.createTempFile("print_reads", ".bam");

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -6,7 +6,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -35,7 +35,7 @@ public final class PrintReadsSparkIntegrationTest extends AbstractPrintReadsInte
         // This is a technically incorrectly sam with a header indicating that it is coordinate sorted when it is actually
         // queryname sorted. If the ordering is the same after PrintReadsSpark then it means we aren't automatically sorting the output.
         final File inBam = new File(getTestDataDir(), "print_reads.mismatchedHeader.sam");
-        try (ReadsDataSourceInterface ds = new ReadsPathDataSource(inBam.toPath())){
+        try (ReadsDataSource ds = new ReadsPathDataSource(inBam.toPath())){
             Assert.assertEquals(ds.getHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
         }
         final File outBam = GATKBaseTest.createTempFile("print_reads", ".bam");

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
@@ -9,7 +9,8 @@ import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
@@ -84,7 +85,7 @@ public final class SortSamSparkIntegrationTest extends CommandLineProgramTest {
         SamAssertionUtils.assertSamsEqual(actualOutputFile, expectedOutputFile, ValidationStringency.DEFAULT_STRINGENCY, referenceFile);
 
         //test sorting matches htsjdk
-        try(ReadsDataSource in = new ReadsDataSource(actualOutputFile.toPath(), factory )) {
+        try(ReadsDataSourceInterface in = new ReadsPathDataSource(actualOutputFile.toPath(), factory )) {
             BaseTest.assertSorted(Utils.stream(in).map(read -> read.convertToSAMRecord(in.getHeader())).iterator(), sortOrder.getComparatorInstance());
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
@@ -9,7 +9,7 @@ import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
@@ -85,7 +85,7 @@ public final class SortSamSparkIntegrationTest extends CommandLineProgramTest {
         SamAssertionUtils.assertSamsEqual(actualOutputFile, expectedOutputFile, ValidationStringency.DEFAULT_STRINGENCY, referenceFile);
 
         //test sorting matches htsjdk
-        try(ReadsDataSourceInterface in = new ReadsPathDataSource(actualOutputFile.toPath(), factory )) {
+        try(ReadsDataSource in = new ReadsPathDataSource(actualOutputFile.toPath(), factory )) {
             BaseTest.assertSorted(Utils.stream(in).map(read -> read.convertToSAMRecord(in.getHeader())).iterator(), sortOrder.getComparatorInstance());
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVFileUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVFileUtilsUnitTest.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordCoordinateComparator;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVFileUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -22,7 +22,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
     public void testWriteSAMRecords() {
 
         final String inputBam = exampleTestDir + "/metrics/exampleMetrics.bam";
-        final ReadsDataSourceInterface gatkReads = new ReadsPathDataSource(IOUtils.getPath(inputBam));
+        final ReadsDataSource gatkReads = new ReadsPathDataSource(IOUtils.getPath(inputBam));
         SAMFileHeader expectedHeader = gatkReads.getHeader();
         final List<SAMRecord> expectedSamRecords = new ArrayList<>(100_000);
         gatkReads.forEach(gatkRead -> expectedSamRecords.add(gatkRead.convertToSAMRecord(expectedHeader)));
@@ -37,7 +37,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
         SVFileUtils.writeSAMFile(outputPath, expectedSamRecords.iterator(), expectedHeader, true);
         Assert.assertTrue(Files.exists(IOUtils.getPath(outputPath + ".bai"))
                                 || Files.exists(IOUtils.getPath(outputPath.replace(".bam", ".bai"))));
-        final ReadsDataSourceInterface bamOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
+        final ReadsDataSource bamOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
         final SAMFileHeader bamOutHeader = bamOut.getHeader();
         Assert.assertEquals(bamOutHeader, expectedHeader);
         final List<SAMRecord> bamOutRecords = new ArrayList<>(100_000);
@@ -48,7 +48,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
         // test output SAM, equivalent contents
         outputPath = tempDirNew.getAbsolutePath() + "/out.sam";
         SVFileUtils.writeSAMFile(outputPath, expectedSamRecords.iterator(), expectedHeader, false);
-        final ReadsDataSourceInterface samOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
+        final ReadsDataSource samOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
         SAMFileHeader samOutHeader = samOut.getHeader();
         Assert.assertEquals(samOutHeader, expectedHeader);
         final List<SAMRecord> samOutRecords = new ArrayList<>(100_000);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVFileUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/discovery/SVFileUtilsUnitTest.java
@@ -4,7 +4,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordCoordinateComparator;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.SVFileUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
@@ -21,7 +22,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
     public void testWriteSAMRecords() {
 
         final String inputBam = exampleTestDir + "/metrics/exampleMetrics.bam";
-        final ReadsDataSource gatkReads = new ReadsDataSource(IOUtils.getPath(inputBam));
+        final ReadsDataSourceInterface gatkReads = new ReadsPathDataSource(IOUtils.getPath(inputBam));
         SAMFileHeader expectedHeader = gatkReads.getHeader();
         final List<SAMRecord> expectedSamRecords = new ArrayList<>(100_000);
         gatkReads.forEach(gatkRead -> expectedSamRecords.add(gatkRead.convertToSAMRecord(expectedHeader)));
@@ -36,7 +37,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
         SVFileUtils.writeSAMFile(outputPath, expectedSamRecords.iterator(), expectedHeader, true);
         Assert.assertTrue(Files.exists(IOUtils.getPath(outputPath + ".bai"))
                                 || Files.exists(IOUtils.getPath(outputPath.replace(".bam", ".bai"))));
-        final ReadsDataSource bamOut = new ReadsDataSource(IOUtils.getPath(outputPath));
+        final ReadsDataSourceInterface bamOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
         final SAMFileHeader bamOutHeader = bamOut.getHeader();
         Assert.assertEquals(bamOutHeader, expectedHeader);
         final List<SAMRecord> bamOutRecords = new ArrayList<>(100_000);
@@ -47,7 +48,7 @@ public class SVFileUtilsUnitTest extends GATKBaseTest {
         // test output SAM, equivalent contents
         outputPath = tempDirNew.getAbsolutePath() + "/out.sam";
         SVFileUtils.writeSAMFile(outputPath, expectedSamRecords.iterator(), expectedHeader, false);
-        final ReadsDataSource samOut = new ReadsDataSource(IOUtils.getPath(outputPath));
+        final ReadsDataSourceInterface samOut = new ReadsPathDataSource(IOUtils.getPath(outputPath));
         SAMFileHeader samOutHeader = samOut.getHeader();
         Assert.assertEquals(samOutHeader, expectedHeader);
         final List<SAMRecord> samOutRecords = new ArrayList<>(100_000);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
@@ -5,7 +5,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -41,7 +41,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
 
         final SAMFileHeader expectedHeader;
         final List<SAMRecord> expectedRecordsNormalMatch;
-        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
+        try (final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
             expectedHeader = readsSource.getHeader();
             expectedRecordsNormalMatch = Utils.stream(readsSource.iterator()).filter(r -> cleanReaNames.contains(r.getName()))
                     .sorted(Comparator.comparingInt(GATKRead::getAssignedStart)).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
@@ -52,7 +52,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
         data.add(new Object[]{IOUtils.getPath(tempWorkingDir+"/names.bam"), normalArgs, expectedHeader, expectedRecordsNormalMatch});
 
         final List<SAMRecord> expectedRecordsInvertedMatch;
-        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
+        try (final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
             expectedRecordsInvertedMatch = Utils.stream(readsSource.iterator()).filter(r -> !cleanReaNames.contains(r.getName()))
                     .sorted(Comparator.comparingInt(GATKRead::getAssignedStart)).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
         }
@@ -71,7 +71,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
                                                                final SAMFileHeader expectedHeader, final List<SAMRecord> expectedRecords) {
         runCommandLine(args);
 
-        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bamPath)) {
+        try (final ReadsDataSource readsSource = new ReadsPathDataSource(bamPath)) {
             Assert.assertEquals(readsSource.getHeader(), expectedHeader);
             final List<SAMRecord> samRecords = Utils.stream(readsSource.iterator()).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
             Assert.assertEquals(samRecords.stream().map(SAMRecord::getSAMString).sorted().collect(Collectors.toList()),

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/sv/integration/ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest.java
@@ -5,7 +5,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -40,7 +41,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
 
         final SAMFileHeader expectedHeader;
         final List<SAMRecord> expectedRecordsNormalMatch;
-        try (final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
+        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
             expectedHeader = readsSource.getHeader();
             expectedRecordsNormalMatch = Utils.stream(readsSource.iterator()).filter(r -> cleanReaNames.contains(r.getName()))
                     .sorted(Comparator.comparingInt(GATKRead::getAssignedStart)).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
@@ -51,7 +52,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
         data.add(new Object[]{IOUtils.getPath(tempWorkingDir+"/names.bam"), normalArgs, expectedHeader, expectedRecordsNormalMatch});
 
         final List<SAMRecord> expectedRecordsInvertedMatch;
-        try (final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
+        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(SVIntegrationTestDataProvider.TEST_BAM))) {
             expectedRecordsInvertedMatch = Utils.stream(readsSource.iterator()).filter(r -> !cleanReaNames.contains(r.getName()))
                     .sorted(Comparator.comparingInt(GATKRead::getAssignedStart)).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
         }
@@ -70,7 +71,7 @@ public final class ExtractOriginalAlignmentRecordsByNameSparkIntegrationTest ext
                                                                final SAMFileHeader expectedHeader, final List<SAMRecord> expectedRecords) {
         runCommandLine(args);
 
-        try (final ReadsDataSource readsSource = new ReadsDataSource(bamPath)) {
+        try (final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bamPath)) {
             Assert.assertEquals(readsSource.getHeader(), expectedHeader);
             final List<SAMRecord> samRecords = Utils.stream(readsSource.iterator()).map(r -> r.convertToSAMRecord(expectedHeader)).collect(Collectors.toList());
             Assert.assertEquals(samRecords.stream().map(SAMRecord::getSAMString).sorted().collect(Collectors.toList()),

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSetIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSetIntegrationTest.java
@@ -2,7 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers.consensus;
 
 import htsjdk.samtools.SAMTag;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -26,7 +27,7 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
                 .add(DownsampleByDuplicateSet.FRACTION_TO_KEEP_NAME, "1.0");
         runCommandLine(args, DownsampleByDuplicateSet.class.getSimpleName());
 
-        try (final ReadsDataSource readsDataSource = new ReadsDataSource(Paths.get(out.getAbsolutePath()))) {
+        try (final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))) {
             final Iterator<GATKRead> iterator = readsDataSource.iterator();
             while (iterator.hasNext()) {
                 // Make sure that the read and its mate are next to each other in the file
@@ -53,8 +54,8 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
                     .add("O", out.getAbsolutePath());
             runCommandLine(args, DownsampleByDuplicateSet.class.getSimpleName());
 
-            try(final ReadsDataSource originalBam = new ReadsDataSource(Paths.get(NA12878_GROUPED));
-                final ReadsDataSource downsampledBam = new ReadsDataSource(Paths.get(out.getAbsolutePath()))){
+            try(final ReadsDataSourceInterface originalBam = new ReadsPathDataSource(Paths.get(NA12878_GROUPED));
+                final ReadsDataSourceInterface downsampledBam = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))){
 
                 final int originalMoleculeCount = countDuplicateSets(originalBam);
                 final int downsampledMoleculeCount = countDuplicateSets(downsampledBam);
@@ -81,7 +82,7 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
         }
     }
 
-    private int countDuplicateSets(final ReadsDataSource readsDataSource){
+    private int countDuplicateSets(final ReadsDataSourceInterface readsDataSource){
         int count = 0;
         String currentMoleculeId = ""; // Note we are duplex aware: 12/A different from 12/B
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSetIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSetIntegrationTest.java
@@ -2,8 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers.consensus;
 
 import htsjdk.samtools.SAMTag;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -27,7 +27,7 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
                 .add(DownsampleByDuplicateSet.FRACTION_TO_KEEP_NAME, "1.0");
         runCommandLine(args, DownsampleByDuplicateSet.class.getSimpleName());
 
-        try (final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))) {
+        try (final ReadsDataSource readsDataSource = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))) {
             final Iterator<GATKRead> iterator = readsDataSource.iterator();
             while (iterator.hasNext()) {
                 // Make sure that the read and its mate are next to each other in the file
@@ -54,8 +54,8 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
                     .add("O", out.getAbsolutePath());
             runCommandLine(args, DownsampleByDuplicateSet.class.getSimpleName());
 
-            try(final ReadsDataSourceInterface originalBam = new ReadsPathDataSource(Paths.get(NA12878_GROUPED));
-                final ReadsDataSourceInterface downsampledBam = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))){
+            try(final ReadsDataSource originalBam = new ReadsPathDataSource(Paths.get(NA12878_GROUPED));
+                final ReadsDataSource downsampledBam = new ReadsPathDataSource(Paths.get(out.getAbsolutePath()))){
 
                 final int originalMoleculeCount = countDuplicateSets(originalBam);
                 final int downsampledMoleculeCount = countDuplicateSets(downsampledBam);
@@ -82,7 +82,7 @@ public class DownsampleByDuplicateSetIntegrationTest extends CommandLineProgramT
         }
     }
 
-    private int countDuplicateSets(final ReadsDataSourceInterface readsDataSource){
+    private int countDuplicateSets(final ReadsDataSource readsDataSource){
         int count = 0;
         String currentMoleculeId = ""; // Note we are duplex aware: 12/A different from 12/B
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
@@ -48,9 +48,9 @@ public class HaplotypeCallerEngineUnitTest extends GATKBaseTest {
                 new SimpleInterval("20", 10001019, 10001019)
         );
 
-        try ( final ReadsDataSource reads = new ReadsDataSource(testBam.toPath());
-              final ReferenceDataSource ref = new ReferenceFileSource(reference);
-              final CachingIndexedFastaSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(reference)) {
+        try (final ReadsDataSourceInterface reads = new ReadsPathDataSource(testBam.toPath());
+             final ReferenceDataSource ref = new ReferenceFileSource(reference);
+             final CachingIndexedFastaSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(reference)) {
 
             final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, new AssemblyRegionArgumentCollection(), false, false, reads.getHeader(), referenceReader, new VariantAnnotatorEngine(new ArrayList<>(), hcArgs.dbsnp.dbsnp, hcArgs.comps, false, false));
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
@@ -48,7 +48,7 @@ public class HaplotypeCallerEngineUnitTest extends GATKBaseTest {
                 new SimpleInterval("20", 10001019, 10001019)
         );
 
-        try (final ReadsDataSourceInterface reads = new ReadsPathDataSource(testBam.toPath());
+        try (final ReadsDataSource reads = new ReadsPathDataSource(testBam.toPath());
              final ReferenceDataSource ref = new ReferenceFileSource(reference);
              final CachingIndexedFastaSequenceFile referenceReader = new CachingIndexedFastaSequenceFile(reference)) {
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -15,7 +15,8 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
@@ -581,7 +582,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
 
         runCommandLine(argBuilder.getArgsArray());
 
-        try ( final ReadsDataSource bamOutReadsSource = new ReadsDataSource(bamOutput) ) {
+        try ( final ReadsDataSourceInterface bamOutReadsSource = new ReadsPathDataSource(bamOutput) ) {
             int actualBamoutNumReads = 0;
             for ( final GATKRead read : bamOutReadsSource ) {
                 ++actualBamoutNumReads;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -15,7 +15,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -582,7 +582,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
 
         runCommandLine(argBuilder.getArgsArray());
 
-        try ( final ReadsDataSourceInterface bamOutReadsSource = new ReadsPathDataSource(bamOutput) ) {
+        try ( final ReadsDataSource bamOutReadsSource = new ReadsPathDataSource(bamOutput) ) {
             int actualBamoutNumReads = 0;
             for ( final GATKRead read : bamOutReadsSource ) {
                 ++actualBamoutNumReads;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicatesArgumentCollection;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
@@ -445,7 +445,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
         args.addInput(getTestFile("supplementaryReadUnmappedmate.bam"));
         runCommandLine(args);
 
-        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
+        try ( final ReadsDataSource outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 Assert.assertFalse(read.isDuplicate());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -9,7 +9,8 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicatesArgumentCollection;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.BaseTest;
@@ -444,7 +445,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest extends Comma
         args.addInput(getTestFile("supplementaryReadUnmappedmate.bam"));
         runCommandLine(args);
 
-        try ( final ReadsDataSource outputReadsSource = new ReadsDataSource(output.toPath()) ) {
+        try ( final ReadsDataSourceInterface outputReadsSource = new ReadsPathDataSource(output.toPath()) ) {
             final List<GATKRead> actualReads = new ArrayList<>();
             for ( final GATKRead read : outputReadsSource ) {
                 Assert.assertFalse(read.isDuplicate());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/AllelePileupCounterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/AllelePileupCounterUnitTest.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.validation.basicshortmutpile
 
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -26,7 +26,7 @@ public class AllelePileupCounterUnitTest extends GATKBaseTest {
 
         final List<Path> bamFiles = Collections.singletonList(IOUtils.getPath(TEST_DREAM_TUMOR_BAM));
         final List<Path> baiFiles = Collections.singletonList(IOUtils.getPath(TEST_DREAM_TUMOR_BAI));
-        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(bamFiles, baiFiles);
+        final ReadsDataSource readsDataSource = new ReadsPathDataSource(bamFiles, baiFiles);
         final ReadPileup readPileup = new ReadPileup(interval, () -> readsDataSource.query(interval));
 
         final AllelePileupCounter allelePileupCounter = new AllelePileupCounter(ref,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/AllelePileupCounterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/validation/basicshortmutpileup/AllelePileupCounterUnitTest.java
@@ -2,7 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers.validation.basicshortmutpile
 
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
@@ -25,7 +26,7 @@ public class AllelePileupCounterUnitTest extends GATKBaseTest {
 
         final List<Path> bamFiles = Collections.singletonList(IOUtils.getPath(TEST_DREAM_TUMOR_BAM));
         final List<Path> baiFiles = Collections.singletonList(IOUtils.getPath(TEST_DREAM_TUMOR_BAI));
-        final ReadsDataSource readsDataSource = new ReadsDataSource(bamFiles, baiFiles);
+        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(bamFiles, baiFiles);
         final ReadPileup readPileup = new ReadPileup(interval, () -> readsDataSource.query(interval));
 
         final AllelePileupCounter allelePileupCounter = new AllelePileupCounter(ref,

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
@@ -3,7 +3,8 @@ package org.broadinstitute.hellbender.utils.locusiterator;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
@@ -139,7 +140,7 @@ public class IntervalAlignmentContextIteratorUnitTest extends GATKBaseTest {
     private List<AlignmentContext> getAlignmentContexts(final List<SimpleInterval> locusIntervals, final String bamPath) {
         final List<String> sampleNames = Collections.singletonList("NA12878");
 
-        final ReadsDataSource gatkReads = new ReadsDataSource(IOUtils.getPath(bamPath));
+        final ReadsDataSourceInterface gatkReads = new ReadsPathDataSource(IOUtils.getPath(bamPath));
         final SAMFileHeader header = gatkReads.getHeader();
         final Stream<GATKRead> filteredReads = Utils.stream(gatkReads).filter(new WellformedReadFilter(header).and(new ReadFilterLibrary.MappedReadFilter()));
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/locusiterator/IntervalAlignmentContextIteratorUnitTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.utils.locusiterator;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.engine.AlignmentContext;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
@@ -140,7 +140,7 @@ public class IntervalAlignmentContextIteratorUnitTest extends GATKBaseTest {
     private List<AlignmentContext> getAlignmentContexts(final List<SimpleInterval> locusIntervals, final String bamPath) {
         final List<String> sampleNames = Collections.singletonList("NA12878");
 
-        final ReadsDataSourceInterface gatkReads = new ReadsPathDataSource(IOUtils.getPath(bamPath));
+        final ReadsDataSource gatkReads = new ReadsPathDataSource(IOUtils.getPath(bamPath));
         final SAMFileHeader header = gatkReads.getHeader();
         final Stream<GATKRead> filteredReads = Utils.stream(gatkReads).filter(new WellformedReadFilter(header).and(new ReadFilterLibrary.MappedReadFilter()));
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
@@ -30,7 +31,7 @@ public final class ReadCoordinateComparatorUnitTest extends GATKBaseTest {
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header = null;
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(inputBam)) ) {
+        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
             header = readsSource.getHeader();
 
             for ( GATKRead read : readsSource ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadCoordinateComparatorUnitTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
@@ -31,7 +31,7 @@ public final class ReadCoordinateComparatorUnitTest extends GATKBaseTest {
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header = null;
 
-        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
+        try ( final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
             header = readsSource.getHeader();
 
             for ( GATKRead read : readsSource ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadQueryNameComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadQueryNameComparatorUnitTest.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecordQueryNameComparator;
 import htsjdk.samtools.SAMTag;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
@@ -32,7 +32,7 @@ public class ReadQueryNameComparatorUnitTest extends GATKBaseTest {
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header;
 
-        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
+        try ( final ReadsDataSource readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
             header = readsSource.getHeader();
 
             for ( GATKRead read : readsSource ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadQueryNameComparatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadQueryNameComparatorUnitTest.java
@@ -4,7 +4,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecordQueryNameComparator;
 import htsjdk.samtools.SAMTag;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -31,7 +32,7 @@ public class ReadQueryNameComparatorUnitTest extends GATKBaseTest {
         final List<GATKRead> reads = new ArrayList<>();
         SAMFileHeader header;
 
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(IOUtils.getPath(inputBam)) ) {
+        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(IOUtils.getPath(inputBam)) ) {
             header = readsSource.getHeader();
 
             for ( GATKRead read : readsSource ) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -7,7 +7,7 @@ import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.ReadsContext;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -839,7 +839,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test
     public void testGetReadToMateMap() {
         final String bam = largeFileTestDir + "mutect/dream_synthetic_bams/tumor_1.bam";
-        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(IOUtils.getPath(bam));
+        final ReadsDataSource readsDataSource = new ReadsPathDataSource(IOUtils.getPath(bam));
 
         // to keep this example small, we choose a place that only four reads overlap
         final SimpleInterval interval = new SimpleInterval("20", 576_940, 577_000);

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -7,7 +7,8 @@ import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.engine.ReadsContext;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -838,7 +839,7 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     @Test
     public void testGetReadToMateMap() {
         final String bam = largeFileTestDir + "mutect/dream_synthetic_bams/tumor_1.bam";
-        final ReadsDataSource readsDataSource = new ReadsDataSource(IOUtils.getPath(bam));
+        final ReadsDataSourceInterface readsDataSource = new ReadsPathDataSource(IOUtils.getPath(bam));
 
         // to keep this example small, we choose a place that only four reads overlap
         final SimpleInterval interval = new SimpleInterval("20", 576_940, 577_000);

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -10,7 +10,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -41,7 +42,7 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
         final int expectedReadCount = 11;
 
         boolean shardIsNotValidBam = false;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(bamShard.toPath()) ) {
+        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bamShard.toPath()) ) {
             for ( final GATKRead read : readsSource ) {}
         }
         catch ( SAMFormatException e ) {
@@ -61,7 +62,7 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
         SparkUtils.convertHeaderlessHadoopBamShardToBam(bamShard, header, output);
 
         int actualCount = 0;
-        try ( final ReadsDataSource readsSource = new ReadsDataSource(output.toPath()) ) {
+        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/spark/SparkUtilsUnitTest.java
@@ -10,7 +10,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.broadinstitute.hellbender.GATKBaseTest;
-import org.broadinstitute.hellbender.engine.ReadsDataSourceInterface;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -42,7 +42,7 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
         final int expectedReadCount = 11;
 
         boolean shardIsNotValidBam = false;
-        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(bamShard.toPath()) ) {
+        try ( final ReadsDataSource readsSource = new ReadsPathDataSource(bamShard.toPath()) ) {
             for ( final GATKRead read : readsSource ) {}
         }
         catch ( SAMFormatException e ) {
@@ -62,7 +62,7 @@ public class SparkUtilsUnitTest extends GATKBaseTest {
         SparkUtils.convertHeaderlessHadoopBamShardToBam(bamShard, header, output);
 
         int actualCount = 0;
-        try ( final ReadsDataSourceInterface readsSource = new ReadsPathDataSource(output.toPath()) ) {
+        try ( final ReadsDataSource readsSource = new ReadsPathDataSource(output.toPath()) ) {
             for ( final GATKRead read : readsSource ) { ++actualCount; }
         }
 


### PR DESCRIPTION
* Extracting a new interface from the existing class ReadsDataSource
   * the new interface is called ReadsDataSource
   * ReadsDataSource has been renamed to ReadsPathDataSource
* This is to support the introduction of a new ReadsDataSource implementation using Htsget