### PR TITLE
Disable SortSamSparkIntegrationTest.testSortBAMsSharded()

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSparkIntegrationTest.java
@@ -89,7 +89,8 @@ public final class SortSamSparkIntegrationTest extends CommandLineProgramTest {
         }
     }
 
-    @Test(dataProvider="sortbams", groups="spark")
+    // This test is disabled until https://github.com/broadinstitute/gatk/issues/5881 is fixed
+    @Test(enabled = false, dataProvider="sortbams", groups="spark")
     public void testSortBAMsSharded(
             final String inputFileName,
             final String unused,


### PR DESCRIPTION
* Disabling SortSamSparkIntegrationTest.testSortBAMsSharded()
* This test is failing in master because of a disq bug.
* This should be re-enabled when https://github.com/broadinstitute/gatk/issues/5881 is fixed.