### PR TITLE
Fix typo in log message.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortSamSpark.java
@@ -106,7 +106,7 @@ public final class SortSamSpark extends GATKSparkTool {
     protected void runTool(final JavaSparkContext ctx) {
         final JavaRDD<GATKRead> reads = getReads();
         final int numReducers = getRecommendedNumReducers();
-        logger.info("Using %d reducers", numReducers);
+        logger.info("Using {} reducers", numReducers);
 
         final SAMFileHeader header = getHeaderForReads();
         header.setSortOrder(sortOrder.getSamOrder());


### PR DESCRIPTION
* A log message in SortSamSpark was using the wrong placeholder for inserting text so the message was printing
  the literal characters %d instead inserting the correct value.  Now it puts in a number.