### PR TITLE
Update versions of htsjdk/picard/disq

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,13 +61,13 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.21.2')
-final picardVersion = System.getProperty('picard.version','2.21.9')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.22.0')
+final picardVersion = System.getProperty('picard.version','2.22.8')
 final barclayVersion = System.getProperty('barclay.version','2.1.0')
-final sparkVersion = System.getProperty('spark.version', '2.4.3')
+final sparkVersion = System.getProperty('spark.version', '2.4.5')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
-final disqVersion = System.getProperty('disq.version','0.3.5')
+final disqVersion = System.getProperty('disq.version','0.3.6')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','1.2.1')
 final testNGVersion = '7.0.0'
 // Using the shaded version to avoid conflicts between its protobuf dependency


### PR DESCRIPTION
* This includes major improvements to the cram code.
* htsjdk 2.21.2 -> 2.22.0
* picard 2.21.9 -> 2.22.8
* disq 0.3.5 -> 0.3.6
* spark 2.4.3 -> 2.4.5