### PR TITLE
Fix tab completion tests.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/help/DocumentationGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/help/DocumentationGenerationIntegrationTest.java
@@ -5,7 +5,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,8 +33,10 @@ public class DocumentationGenerationIntegrationTest extends CommandLineProgramTe
             "picard.analysis"
     };
 
+    // suppress deprecation warning on Java 11 since we're using deprecated javadoc APIs
+    @SuppressWarnings({"deprecation","removal"})
     @Test
-    public static void documentationSmokeTest() throws IOException {
+    public static void documentationSmokeTest() {
         final File docTestTarget = createTempDir("docgentest");
         final String[] argArray = new String[]{
                 "javadoc",

--- a/src/test/java/org/broadinstitute/hellbender/utils/help/DocumentationGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/help/DocumentationGenerationIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.utils.help;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
-import org.broadinstitute.hellbender.utils.runtime.ProcessController;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -36,8 +36,8 @@ public class DocumentationGenerationIntegrationTest extends CommandLineProgramTe
 
     @Test
     public static void documentationSmokeTest() throws IOException {
-        File docTestTarget = createTempDir("docgentest");
-        String[] argArray = new String[]{
+        final File docTestTarget = createTempDir("docgentest");
+        final String[] argArray = new String[]{
                 "javadoc",
                 "-doclet", GATKHelpDoclet.class.getName(),
                 "-docletpath", System.getProperty("java.class.path"),
@@ -47,18 +47,17 @@ public class DocumentationGenerationIntegrationTest extends CommandLineProgramTe
                 "-output-file-extension", "html",
                 "-build-timestamp", "2016/11/11 11:11:11",
                 "-absolute-version", "1.1-111",
-                "-cp", System.getProperty("java.class.path"),
                 "-verbose"
         };
 
         final List<String> docArgList = new ArrayList<>();
         docArgList.addAll(Arrays.asList(argArray));
+        docArgList.add("-cp");
+        docArgList.add(System.getProperty("java.class.path"));
         docArgList.addAll(Arrays.asList(docTestPackages));
 
-        // This is  smoke test; we just want to make sure it doesn't blow up
-
-        // Run this as a process, not through Java itself:
-        final ProcessController processController = new ProcessController();
-        runProcess(processController, docArgList.toArray(new String[] {}), "Failure processing gatkDoc via javadoc" );
+        // Run javadoc in the current JVM with the custom doclet, and make sure it succeeds (this is a smoke test;
+        // we just want to make sure it doesn't blow up).
+        Assert.assertEquals(com.sun.tools.javadoc.Main.execute(docArgList.toArray(new String[] {})), 0);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/help/TabCompletionIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/help/TabCompletionIntegrationTest.java
@@ -36,8 +36,10 @@ public class TabCompletionIntegrationTest extends CommandLineProgramTest {
         );
     }
 
+    // suppress deprecation warning on Java 11 since we're using deprecated javadoc APIs
+    @SuppressWarnings({"deprecation","removal"})
     @Test
-    public static void tabCompleteSmokeTest() throws IOException, InterruptedException {
+    public static void tabCompleteSmokeTest() {
         final File tabCompletionTestTarget = createTempDir("tabCompletionTest");
 
         // Setup rote input arguments:

--- a/src/test/java/org/broadinstitute/hellbender/utils/help/TabCompletionIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/help/TabCompletionIntegrationTest.java
@@ -4,7 +4,7 @@ import org.broadinstitute.barclay.argparser.ClassFinder;
 import org.broadinstitute.barclay.help.BashTabCompletionDoclet;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
-import org.broadinstitute.hellbender.utils.runtime.ProcessController;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.*;
@@ -27,7 +27,12 @@ public class TabCompletionIntegrationTest extends CommandLineProgramTest {
         final ClassFinder classFinder = new ClassFinder();
         classFinder.find("org.broadinstitute.hellbender", CommandLineProgram.class);
         tabCompletionTestPackages = Collections.unmodifiableList(
-                classFinder.getClasses().stream().map(Class::getName).collect(Collectors.toList())
+                classFinder.getClasses()
+                        .stream()
+                        .map(cl -> cl.getPackage().getName())
+                        .collect(Collectors.toSet()) // uniquify
+                        .stream()
+                        .collect(Collectors.toList())
         );
     }
 
@@ -45,7 +50,6 @@ public class TabCompletionIntegrationTest extends CommandLineProgramTest {
                 "-docletpath", System.getProperty("java.class.path"),
                 "-sourcepath", "src/main/java",
                 "-d", tabCompletionTestTarget.getAbsolutePath(), // directory must exist
-                "-cp", System.getProperty("java.class.path"),
 
                 "-use-default-templates",
 
@@ -76,13 +80,13 @@ public class TabCompletionIntegrationTest extends CommandLineProgramTest {
         // Point the javadoc at our packages:
         final List<String> docArgList = new ArrayList<>();
         docArgList.addAll(argList);
+        docArgList.add("-cp");
+        docArgList.add(System.getProperty("java.class.path"));
         docArgList.addAll(tabCompletionTestPackages);
 
-        // This is  smoke test; we just want to make sure it doesn't blow up
-
-        // Run this as a process, not through Java itself:
-        final ProcessController processController = new ProcessController();
-        runProcess(processController, docArgList.toArray(new String[] {}) );
+        // Run javadoc in the current JVM with the custom doclet, and make sure it succeeds (this is a smoke test;
+        // we just want to make sure it doesn't blow up).
+        Assert.assertEquals(com.sun.tools.javadoc.Main.execute(docArgList.toArray(new String[] {})), 0);
     }
 
 }


### PR DESCRIPTION
The tab completion integration test wasn't actually emitting any output because the classpath contained a list of class names (basenames only, without the ".class" extension), so no work units were ever created. This PR:

- changes the classpath to use package names that contain CLPs instead of class names
- runs the javadoc in the current JVM (which makes debugging the test so much easier...)
- adds an Assert to ensure the javadoc process succeeds

 I made the latter change to the doc gen smoke test as well, to make debugging easier.