### PR TITLE
Move to GenomicsDB 1.3.0 and add support for shared posixfs optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ final sparkVersion = System.getProperty('spark.version', '2.4.5')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.3.6')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.2.3.1')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.3.0')
 final testNGVersion = '7.0.0'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ final sparkVersion = System.getProperty('spark.version', '2.4.5')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.3.6')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.2.1')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.2.3.1')
 final testNGVersion = '7.0.0'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one
@@ -255,7 +255,8 @@ dependencies {
     compile 'com.github.broadinstitute:picard:' + picardVersion
     externalSourceConfiguration 'com.github.broadinstitute:picard:' + picardVersion + ':sources'
     compile ('org.genomicsdb:genomicsdb:' + genomicsdbVersion)  {
-        exclude module: 'log4j'
+        exclude module: 'log4j-api'
+        exclude module: 'log4j-core'
         exclude module: 'spark-core_2.11'
         exclude module: 'spark-sql_2.11'
         exclude module: 'htsjdk'

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBArgumentCollection.java
@@ -9,9 +9,11 @@ import java.io.Serializable;
 public class GenomicsDBArgumentCollection implements Serializable {
   private static final long serialVersionUID = 1L;
   public static final String USE_VCF_CODEC_LONG_NAME = "genomicsdb-use-vcf-codec";
+  public static final String SHARED_POSIXFS_OPTIMIZATIONS = "genomicsdb-shared-posixfs-optimizations";
 
   private static final boolean DEFAULT_CALL_GENOTYPES = false;
   private static final boolean DEFAULT_USE_VCF_CODEC = false;
+  private static final boolean DEFAULT_SHARED_POSIXFS_OPTIMIZATIONS = false;
 
   /**
    * Not full-fledged arguments for now.
@@ -31,4 +33,10 @@ public class GenomicsDBArgumentCollection implements Serializable {
       doc = "Use VCF Codec Streaming for data from GenomicsDB instead of the default BCF",
       optional = true)
   public boolean useVCFCodec = DEFAULT_USE_VCF_CODEC;
+
+  @Argument(fullName = SHARED_POSIXFS_OPTIMIZATIONS,
+          doc = "Allow for optimizations to improve the usability and performance for shared Posix Filesystems(e.g. NFS, Lustre). " +
+                  "If set, file level locking is disabled and file system writes are minimized.",
+          optional = true)
+  public boolean sharedPosixFSOptimizations = DEFAULT_SHARED_POSIXFS_OPTIMIZATIONS;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -200,6 +200,8 @@ public final class GenomicsDBImport extends GATKTool {
     public static final String MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL = "max-num-intervals-to-import-in-parallel";
     public static final int INTERVAL_LIST_SIZE_WARNING_THRESHOLD = 100;
 
+    public static final String SHARED_POSIXFS_OPTIMIZATIONS = "genomicsdb-shared-posixfs-optimizations";
+
     @Argument(fullName = WORKSPACE_ARG_LONG_NAME,
               doc = "Workspace for GenomicsDB. Must be a POSIX file system path, but can be a relative path. " +
                     "Use this argument when creating a new GenomicsDB workspace. " +
@@ -219,22 +221,20 @@ public final class GenomicsDBImport extends GATKTool {
 
     @Argument(fullName = SEGMENT_SIZE_ARG_LONG_NAME,
               doc = "Buffer size in bytes allocated for GenomicsDB attributes during " +
-                    "import. Should be large enough to hold data from one site. " +
-                    " Defaults to " + DEFAULT_SEGMENT_SIZE,
+                    "import. Should be large enough to hold data from one site. ",
               optional = true)
     private long segmentSize = DEFAULT_SEGMENT_SIZE;
 
     @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME,
               shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME,
               doc = "GVCF files to be imported to GenomicsDB. Each file must contain" +
-                    "data for only a single sample. Either this or " + SAMPLE_NAME_MAP_LONG_NAME +
+                    " data for only a single sample. Either this or " + SAMPLE_NAME_MAP_LONG_NAME +
                     " must be specified.",
               optional = true,
               mutex = {SAMPLE_NAME_MAP_LONG_NAME})
     private List<String> variantPaths;
 
     @Argument(fullName = VCF_BUFFER_SIZE_ARG_NAME,
-              shortName = VCF_BUFFER_SIZE_ARG_NAME,
               doc = "Buffer size in bytes to store variant contexts." +
                     " Larger values are better as smaller values cause frequent disk writes." +
                     " Defaults to " + DEFAULT_VCF_BUFFER_SIZE_PER_SAMPLE + " which was empirically determined to work" +
@@ -262,7 +262,6 @@ public final class GenomicsDBImport extends GATKTool {
     private int batchSize = DEFAULT_ZERO_BATCH_SIZE;
 
     @Argument(fullName = CONSOLIDATE_ARG_NAME,
-              shortName = CONSOLIDATE_ARG_NAME,
               doc = "Boolean flag to enable consolidation. If importing data in batches, a new fragment is created for " +
                     "each batch. In case thousands of fragments are created, GenomicsDB feature readers will try " +
                     "to open ~20x as many files. Also, internally GenomicsDB would consume more memory to maintain " +
@@ -285,7 +284,6 @@ public final class GenomicsDBImport extends GATKTool {
     private String sampleNameMapFile;
 
     @Argument(fullName = VALIDATE_SAMPLE_MAP_LONG_NAME,
-            shortName = VALIDATE_SAMPLE_MAP_LONG_NAME,
             doc = "Boolean flag to enable checks on the sampleNameMap file. If true, tool checks whether" +
                 "feature readers are valid and shows a warning if sample names do not match with the headers. " +
                 "Defaults to false",
@@ -293,13 +291,11 @@ public final class GenomicsDBImport extends GATKTool {
     private Boolean validateSampleToReaderMap = false;
 
     @Argument(fullName = MERGE_INPUT_INTERVALS_LONG_NAME,
-            shortName = MERGE_INPUT_INTERVALS_LONG_NAME,
             doc = "Boolean flag to import all data in between intervals.  Improves performance using large lists of " +
                 "intervals, as in exome sequencing, especially if GVCF data only exists for specified intervals.")
     private boolean mergeInputIntervals = false;
 
     @Argument(fullName = INTERVAL_LIST_LONG_NAME,
-            shortName = INTERVAL_LIST_LONG_NAME,
             doc = "Path to output file where intervals from existing workspace should be written." +
                   "If this option is specified, the tools outputs the interval_list of the workspace pointed to " +
                   "by "+INCREMENTAL_WORKSPACE_ARG_LONG_NAME+" at the path specified here in a Picard-style interval_list " +
@@ -310,7 +306,6 @@ public final class GenomicsDBImport extends GATKTool {
 
     @Advanced
     @Argument(fullName = VCF_INITIALIZER_THREADS_LONG_NAME,
-            shortName = VCF_INITIALIZER_THREADS_LONG_NAME,
             doc = "How many simultaneous threads to use when opening VCFs in batches; higher values may improve performance " +
                     "when network latency is an issue. Multiple reader threads are not supported when running with multiple intervals.",
             optional = true,
@@ -319,12 +314,19 @@ public final class GenomicsDBImport extends GATKTool {
 
     @Advanced
     @Argument(fullName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
-            shortName = MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL,
             doc = "Max number of intervals to import in parallel; higher values may improve performance, but require more" +
                   " memory and a higher number of file descriptors open at the same time",
             optional = true,
             minValue = 1)
     private int maxNumIntervalsToImportInParallel = 1;
+
+    @Argument(fullName = SHARED_POSIXFS_OPTIMIZATIONS,
+            doc = "Allow for optimizations to improve the usability and performance for shared Posix Filesystems(e.g. NFS, Lustre). " +
+                  "If set, file level locking is disabled and file system writes are minimized by keeping a higher number of " +
+                  "file descriptors open for longer periods of time. Use with " + BATCHSIZE_ARG_LONG_NAME + " option if keeping a " +
+                  "large number of file descriptors open is an issue",
+            optional = true)
+    private boolean sharedPosixFSOptimizations = false;
 
     //executor service used when vcfInitializerThreads > 1
     private ExecutorService inputPreloadExecutorService;
@@ -432,12 +434,11 @@ public final class GenomicsDBImport extends GATKTool {
     }
 
     private void assertOverwriteWorkspaceAndIncrementalImportMutuallyExclusive() {
-        if ( overwriteExistingWorkspace && doIncrementalImport) {
+        if (overwriteExistingWorkspace && doIncrementalImport) {
             throw new CommandLineException(OVERWRITE_WORKSPACE_LONG_NAME + " cannot be set to true when " +
                     INCREMENTAL_WORKSPACE_ARG_LONG_NAME + " is set");
         }
     }
-
 
     private void assertVariantPathsOrSampleNameFileWasSpecified(){
         if ( (variantPaths == null || variantPaths.isEmpty()) && sampleNameMapFile == null && !getIntervalsFromExistingWorkspace) {
@@ -621,12 +622,12 @@ public final class GenomicsDBImport extends GATKTool {
 
         if (doIncrementalImport) {
             logger.info("Callset Map JSON file will be re-written to " + callsetMapJSONFile);
-            logger.info("Incrementally importing to array - " + workspaceDir + "/" + GenomicsDBConstants.DEFAULT_ARRAY_NAME);
+            logger.info("Incrementally importing to workspace - " + workspaceDir);
         } else {
             logger.info("Vid Map JSON file will be written to " + vidMapJSONFile);
             logger.info("Callset Map JSON file will be written to " + callsetMapJSONFile);
             logger.info("Complete VCF Header will be written to " + vcfHeaderFile);
-            logger.info("Importing to array - " + workspaceDir + "/" + GenomicsDBConstants.DEFAULT_ARRAY_NAME);
+            logger.info("Importing to workspace - " + workspaceDir);
         }
         initializeInputPreloadExecutorService();
     }
@@ -711,6 +712,7 @@ public final class GenomicsDBImport extends GATKTool {
         importConfigurationBuilder.setFailIfUpdating(true && !doIncrementalImport);
         importConfigurationBuilder.setSegmentSize(segmentSize);
         importConfigurationBuilder.setConsolidateTiledbArrayAfterLoad(doConsolidation);
+        importConfigurationBuilder.setEnableSharedPosixfsOptimizations(sharedPosixFSOptimizations);
         ImportConfig importConfig = new ImportConfig(importConfigurationBuilder.build(), validateSampleToReaderMap, true,
                 batchSize, mergedHeaderLines, sampleNameToVcfPath, this::createSampleToReaderMap, doIncrementalImport);
         importConfig.setOutputCallsetmapJsonFile(callsetMapJSONFile);

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -200,7 +200,7 @@ public final class GenomicsDBImport extends GATKTool {
     public static final String MAX_NUM_INTERVALS_TO_IMPORT_IN_PARALLEL = "max-num-intervals-to-import-in-parallel";
     public static final int INTERVAL_LIST_SIZE_WARNING_THRESHOLD = 100;
 
-    public static final String SHARED_POSIXFS_OPTIMIZATIONS = "genomicsdb-shared-posixfs-optimizations";
+    public static final String SHARED_POSIXFS_OPTIMIZATIONS = GenomicsDBArgumentCollection.SHARED_POSIXFS_OPTIMIZATIONS;
 
     @Argument(fullName = WORKSPACE_ARG_LONG_NAME,
               doc = "Workspace for GenomicsDB. Must be a POSIX file system path, but can be a relative path. " +

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
@@ -13,6 +13,7 @@ public final class GenomicsDBOptions {
     final private int maxDiploidAltAllelesThatCanBeGenotyped;
     final private int maxGenotypeCount;
     final private boolean useVCFCodec;
+    final private boolean sharedPosixFSOptimizations;
 
     public GenomicsDBOptions() {
         this(null);
@@ -32,6 +33,7 @@ public final class GenomicsDBOptions {
         this.maxDiploidAltAllelesThatCanBeGenotyped = genomicsdbArgs.maxDiploidAltAllelesThatCanBeGenotyped;
         this.maxGenotypeCount = genotypeCalcArgs.MAX_GENOTYPE_COUNT;
         this.useVCFCodec = genomicsdbArgs.useVCFCodec;
+        this.sharedPosixFSOptimizations = genomicsdbArgs.sharedPosixFSOptimizations;
     }
 
     public Path getReference() {
@@ -52,5 +54,9 @@ public final class GenomicsDBOptions {
 
     public boolean useVCFCodec() {
         return useVCFCodec;
+    }
+
+    public boolean sharedPosixFSOptimizations() {
+        return sharedPosixFSOptimizations;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBUtils.java
@@ -106,7 +106,8 @@ public class GenomicsDBUtils {
                         .setProduceGTWithMinPLValueForSpanningDeletions(false)
                         .setSitesOnlyQuery(false)
                         .setMaxDiploidAltAllelesThatCanBeGenotyped(genomicsDBOptions.getMaxDiploidAltAllelesThatCanBeGenotyped())
-                        .setMaxGenotypeCount(genomicsDBOptions.getMaxGenotypeCount());
+                        .setMaxGenotypeCount(genomicsDBOptions.getMaxGenotypeCount())
+                        .setEnableSharedPosixfsOptimizations(genomicsDBOptions.sharedPosixFSOptimizations());
 
         final Path arrayFolder = Paths.get(workspace, GenomicsDBConstants.DEFAULT_ARRAY_NAME).toAbsolutePath();
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -1026,7 +1026,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         Assert.assertTrue(generatedInterval.sorted().equals(expectedInterval.sorted()));
     }
 
-    void basicWriteAndQueryWithOptions(String workspace, Map<String, Object> options) throws IOException {
+    /*void basicWriteAndQueryWithOptions(String workspace, Map<String, Object> options) throws IOException {
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
         INTERVAL.forEach(args::addInterval);
@@ -1068,7 +1068,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         } catch (GenomicsDBImport.UnableToCreateGenomicsDBWorkspace e) {
             // pass
         }
-    }
+    }*/
 
   @Test(groups = {"bucket"})
     public void testWriteToAndQueryFromGCS() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -1026,7 +1026,7 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         Assert.assertTrue(generatedInterval.sorted().equals(expectedInterval.sorted()));
     }
 
-    /*void basicWriteAndQueryWithOptions(String workspace, Map<String, Object> options) throws IOException {
+    void basicWriteAndQueryWithOptions(String workspace, Map<String, Object> options) throws IOException {
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.add(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
         INTERVAL.forEach(args::addInterval);
@@ -1068,9 +1068,9 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         } catch (GenomicsDBImport.UnableToCreateGenomicsDBWorkspace e) {
             // pass
         }
-    }*/
+    }
 
-  @Test(groups = {"bucket"})
+    @Test(groups = {"bucket"})
     public void testWriteToAndQueryFromGCS() throws IOException {
         final String workspace = BucketUtils.randomRemotePath(getGCPTestStaging(), "", "") + "/";
         IOUtils.deleteOnExit(IOUtils.getPath(workspace));

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -1059,15 +1059,18 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         // Test with shared posixfs optimizations and overwrite workspace set
         options.put(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME, true);
         basicWriteAndQueryWithOptions(workspace, options);
+    }
 
-        // Test with overwrite workspace set to false - should throw an exception
+    @Test(expectedExceptions = GenomicsDBImport.UnableToCreateGenomicsDBWorkspace.class)
+    public void testWithMiscOptionsNoOverwrite() throws IOException {
+        final String workspace = createTempDir("genomicsdb-misc-options-nooverwrite").getAbsolutePath() + "/workspace";
+        IOUtils.deleteOnExit(IOUtils.getPath(workspace));
+        Map<String, Object> options = new HashMap<String, Object>();
+        basicWriteAndQueryWithOptions(workspace, options);
+
+        // Test with overwrite workspace set to false - should throw an exception - GenomicsDBImport.UnableToCreateGenomicsDBWorkspace
         options.replace(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME, false);
-        try {
-            basicWriteAndQueryWithOptions(workspace, options);
-            Assert.fail();
-        } catch (GenomicsDBImport.UnableToCreateGenomicsDBWorkspace e) {
-            // pass
-        }
+        basicWriteAndQueryWithOptions(workspace, options);
     }
 
     @Test(groups = {"bucket"})

--- a/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImportIntegrationTest.java
@@ -1026,7 +1026,51 @@ public final class GenomicsDBImportIntegrationTest extends CommandLineProgramTes
         Assert.assertTrue(generatedInterval.sorted().equals(expectedInterval.sorted()));
     }
 
-    @Test(groups = {"bucket"})
+    void basicWriteAndQueryWithOptions(String workspace, Map<String, Object> options) throws IOException {
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add(GenomicsDBImport.WORKSPACE_ARG_LONG_NAME, workspace);
+        INTERVAL.forEach(args::addInterval);
+        LOCAL_GVCFS.forEach(vcf -> args.add("V", vcf));
+        for ( String key : options.keySet()) {
+            if (key.equals(GenomicsDBImport.SHARED_POSIXFS_OPTIMIZATIONS)) {
+                Assert.assertTrue(options.get(key) instanceof Boolean);
+                args.add(GenomicsDBImport.SHARED_POSIXFS_OPTIMIZATIONS, (Boolean)options.get(key));
+            }
+            if (key.equals(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME)) {
+                Assert.assertTrue(options.get(key) instanceof Boolean);
+                args.add(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME, (Boolean)options.get(key));
+            }
+        }
+        runCommandLine(args);
+        checkJSONFilesAreWritten(workspace);
+        checkGenomicsDBAgainstExpected(workspace, INTERVAL, COMBINED, b38_reference_20_21, true, ATTRIBUTES_TO_IGNORE);
+    }
+
+    @Test
+    public void testWithMiscOptions() throws IOException {
+        final String workspace = createTempDir("genomicsdb-misc-options").getAbsolutePath() + "/workspace";
+        IOUtils.deleteOnExit(IOUtils.getPath(workspace));
+        Map<String, Object> options = new HashMap<String, Object>();
+
+        // Test with shared posixfs optimizations set
+        options.put(GenomicsDBImport.SHARED_POSIXFS_OPTIMIZATIONS, true);
+        basicWriteAndQueryWithOptions(workspace, options);
+
+        // Test with shared posixfs optimizations and overwrite workspace set
+        options.put(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME, true);
+        basicWriteAndQueryWithOptions(workspace, options);
+
+        // Test with overwrite workspace set to false - should throw an exception
+        options.replace(GenomicsDBImport.OVERWRITE_WORKSPACE_LONG_NAME, false);
+        try {
+            basicWriteAndQueryWithOptions(workspace, options);
+            Assert.fail();
+        } catch (GenomicsDBImport.UnableToCreateGenomicsDBWorkspace e) {
+            // pass
+        }
+    }
+
+  @Test(groups = {"bucket"})
     public void testWriteToAndQueryFromGCS() throws IOException {
         final String workspace = BucketUtils.randomRemotePath(getGCPTestStaging(), "", "") + "/";
         IOUtils.deleteOnExit(IOUtils.getPath(workspace));


### PR DESCRIPTION
1. Add new arg `genomicsdb-shared-posixfs-optimizations` to help with shared posix filesystems like NFS and Lustre. This turns on `disable file locking` and for GenomicsDB import it minimizes writes to disks. The performance on some of the gatk datasets for the import of about 10 samples went from 23.72m to 6.34m on NFS which was comparable to importing to a local filesystem. Hopefully this helps with Issue #6487 and #6627. Also, fixes Issue #6519.
2. This version of GenomicsDB also uses pre-compression filters for offset and compression files for new workspaces and genomicsdb arrays. The total sizes for a GenomicsDB workspace using the same dataset as above and the 10 samples went from 313MB to 170MB with no change in import and query times. Smaller GenomicsDB arrays also help with performance on distributed and cloud file systems.
3. This version has added support to handle MNVs similar to deletions as described in Issue #6500.  See [GenomicsDB PR 88](https://github.com/GenomicsDB/GenomicsDB/pull/88). Thanks @kgururaj.
4. There is added support in the GenomicsDBImporter to have multiple contigs in the same GenomicsDB partition/array. This will hopefully help import times in cases where users have many thousands of contigs. See [GenomicsDB PR 91](https://github.com/GenomicsDB/GenomicsDB/pull/91). Changes will be needed from the gatk side to avail this support. Thanks @mlathara.
5. Logging has been improved somewhat with the native C/C++ code using [spdlog](https://github.com/gabime/spdlog) and [fmt](https://github.com/fmtlib/fmt) and the Java layer using apache log4j and log4j.properties provided by the application. Also, info messages like `No valid combination operation found for INFO field AA  - the field will NOT be part of INFO fields in the generated VCF records` will only be output once for the operation. Also see open PR #6514 for code to actually suppress these warnings for known fields.
