### PR TITLE
Fix crash when building with a JDK instead of a JRE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, sk
     if (JavaVersion.current().isJava8() && ToolProvider.getSystemToolClassLoader() == null) {
         throw new GradleException(
                 "The ClassLoader obtained from the Java ToolProvider is null. "
-                + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
+                + "A full Java 8 or 11 JDK must be installed, check that you are not using a JRE. $buildPrerequisitesMessage")
     }
     if (!JavaVersion.current().isJava8() && !JavaVersion.current().isJava11()) {
         println("Warning: using Java ${JavaVersion.current()} but only Java 8 and Java 11 have been tested.")


### PR DESCRIPTION
* A previouus change left a reference to an uninitialized property in build.gradle.
  This caused a crash when trying to produce an error message warning that the JDK was not found.

  Ex: Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'requiredJavaVersion' for root project 'gatk' of type org.gradle.api.Project
*  Fix the crash by removing the reference to the missing property.