### PR TITLE
Fix crash in BQSR R script

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/utils/recalibration/BQSR.R
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/recalibration/BQSR.R
@@ -12,7 +12,7 @@ if ( interactive() ) {
   args <- commandArgs(TRUE)
 } 
 
-data <- read.csv(args[1])
+data <- read.csv(args[1], stringsAsFactors = TRUE)
 
 data$Recalibration = as.factor(sapply(as.character(data$Recalibration),function(x) { 
   xu = toupper(x); 


### PR DESCRIPTION
* Fix a crash in the BQSR.R script by specifying stringsAsFactors = TRUE
* fixes https://github.com/broadinstitute/gatk/issues/6650