### PR TITLE
Annotate some tools for WDL autogen.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
@@ -11,8 +11,8 @@ import org.broadinstitute.hellbender.engine.GATKPath;
 public final class OptionalReferenceInputArgumentCollection extends ReferenceInputArgumentCollection {
     private static final long serialVersionUID = 1L;
 
-    @WorkflowResource(input=true, output=false, companionResources = {"referenceDictionary", "referenceIndex"})
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence", optional = true)
+    @WorkflowResource(input=true, output=false, companionResources = {"referenceDictionary", "referenceIndex"})
     private GATKPath referenceInputPathSpecifier;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
@@ -11,8 +11,8 @@ import org.broadinstitute.hellbender.engine.GATKPath;
 public final class RequiredReferenceInputArgumentCollection extends ReferenceInputArgumentCollection {
     private static final long serialVersionUID = 1L;
 
-    @WorkflowResource(input=true, output=false, companionResources = {"referenceDictionary", "referenceIndex"})
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file", optional = false)
+    @WorkflowResource(input=true, output=false, companionResources = {"referenceDictionary", "referenceIndex"})
     private GATKPath referenceInputPathSpecifier;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/AddOriginalAlignmentTags.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/AddOriginalAlignmentTags.java
@@ -4,6 +4,8 @@ import htsjdk.samtools.SAMTag;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -19,10 +21,12 @@ import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
         programGroup = ReadDataManipulationProgramGroup.class
 )
 @ExperimentalFeature
+@RuntimeProperties
 public class AddOriginalAlignmentTags extends ReadWalker {
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             doc="Write output to this file")
+    @WorkflowResource(output=true, input=false, companionResources = {StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath output;
     private SAMFileGATKReadWriter outputWriter;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -29,6 +30,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 	oneLineSummary = "Count bases in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )
+@RuntimeProperties
 public final class CountBases extends ReadWalker {
 
     private long count = 0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -29,6 +30,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 	oneLineSummary = "Count reads in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )
+@RuntimeProperties
 public final class CountReads extends ReadWalker {
 
     private long count = 0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -39,6 +40,7 @@ import java.text.NumberFormat;
 	oneLineSummary = "Accumulate flag statistics given a BAM file",
     programGroup = DiagnosticsAndQCProgramGroup.class
 )
+@RuntimeProperties
 public final class FlagStat extends ReadWalker {
 
     private final FlagStatus sum = new FlagStatus();

--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -49,9 +51,11 @@ import org.broadinstitute.hellbender.utils.read.*;
         oneLineSummary = "Left-aligns indels from reads in a SAM/BAM/CRAM file",
         programGroup = ReadDataManipulationProgramGroup.class
 )
+@RuntimeProperties
 public final class LeftAlignIndels extends ReadWalker {
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,doc="Output BAM")
+    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     private GATKPath output;
 
     private SAMFileGATKReadWriter outputWriter = null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -88,10 +88,10 @@ import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 @RuntimeProperties(memory = "1GB")
 public final class PrintReads extends ReadWalker {
 
-    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             doc="Write output to this file")
+    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath output;
     private SAMFileGATKReadWriter outputWriter;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -4,6 +4,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -61,6 +63,7 @@ import java.util.stream.Collectors;
         oneLineSummary = "Outputs reads from a SAM/BAM/CRAM by read group, sample and library name",
         programGroup = ReadDataManipulationProgramGroup.class
 )
+@RuntimeProperties
 public final class SplitReads extends ReadWalker {
 
     public static final String SAMPLE_SHORT_NAME = "SM";
@@ -77,6 +80,7 @@ public final class SplitReads extends ReadWalker {
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             doc = "The directory to output SAM/BAM/CRAM files."
     )
+    @WorkflowResource(input=false, output=true)
     public GATKPath OUTPUT_DIRECTORY;
 
     @Argument(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReadAnonymizer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReadAnonymizer.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang.ArrayUtils;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -51,12 +53,14 @@ import java.util.List;
         oneLineSummary = "Replace bases in reads with reference bases.",
         programGroup = OtherProgramGroup.class
 )
+@RuntimeProperties
 public final class ReadAnonymizer extends ReadWalker {
 
     @Argument(
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             doc="Output bam file.")
+    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath output;
 
     @Argument(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/RevertBaseQualityScores.java
@@ -2,6 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -26,10 +28,11 @@ import java.util.List;
         usageExample = "hellbender RevertQualityScores -I input.bam -O output.bam",
         programGroup = ReadDataManipulationProgramGroup.class
 )
-
+@RuntimeProperties
 public class RevertBaseQualityScores extends ReadWalker {
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/UnmarkDuplicates.java
@@ -2,6 +2,8 @@ package org.broadinstitute.hellbender.tools.walkers;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -59,6 +61,7 @@ import java.util.List;
         usageExample = "gatk UnmarkDuplicates -I marked_duplicates.bam -O unmarked_duplicates.bam",
         programGroup = ReadDataManipulationProgramGroup.class)
 @DocumentedFeature
+@RuntimeProperties
 public class UnmarkDuplicates extends ReadWalker {
 
     static final String USAGE_SUMMARY = "Clears the 0x400 duplicate SAM flag";
@@ -66,6 +69,7 @@ public class UnmarkDuplicates extends ReadWalker {
             "Clears the 0x400 SAM flag bit on all reads.";
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @WorkflowResource(input=false, output=true, companionResources={StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath OUTPUT;
 
     private SAMFileGATKReadWriter outputWriter;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSR.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -69,6 +71,7 @@ import java.io.File;
         programGroup = ReadDataManipulationProgramGroup.class
 )
 @DocumentedFeature
+@RuntimeProperties
 public final class ApplyBQSR extends ReadWalker{
     static final String USAGE_ONE_LINE_SUMMARY = "Apply base quality score recalibration";
     static final String USAGE_SUMMARY = "Apply a linear base quality recalibration model trained with the BaseRecalibrator tool.";
@@ -76,6 +79,7 @@ public final class ApplyBQSR extends ReadWalker{
     private static final Logger logger = LogManager.getLogger(ApplyBQSR.class);
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc="Write output to this file")
+    @WorkflowResource(output=true, input=false, companionResources = {StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath OUTPUT;
 
     /**
@@ -84,6 +88,7 @@ public final class ApplyBQSR extends ReadWalker{
      * created on the same input data.
      */
     @Argument(fullName=StandardArgumentDefinitions.BQSR_TABLE_LONG_NAME, shortName=StandardArgumentDefinitions.BQSR_TABLE_SHORT_NAME, doc="Input recalibration table for BQSR")
+    @WorkflowResource(output=false, input=true)
     public File BQSR_RECAL_FILE;
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -6,6 +6,8 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.*;
@@ -80,6 +82,7 @@ import java.util.List;
         programGroup = ReadDataManipulationProgramGroup.class
 )
 @DocumentedFeature
+@RuntimeProperties
 public final class BaseRecalibrator extends ReadWalker {
     public static final String USAGE_ONE_LINE_SUMMARY = "Generates recalibration table for Base Quality Score Recalibration (BQSR)";
     public static final String USAGE_SUMMARY = "First pass of the Base Quality Score Recalibration (BQSR)" +
@@ -104,6 +107,7 @@ public final class BaseRecalibrator extends ReadWalker {
      * reflected those sites skipped by the -XL argument.
      */
     @Argument(fullName = KNOWN_SITES_ARG_FULL_NAME, doc = "One or more databases of known polymorphic sites used to exclude regions around known polymorphisms from analysis.", optional = false)
+    @WorkflowResource(output=false, input=true)
     private List<FeatureInput<Feature>> knownSites;
 
     /**
@@ -113,6 +117,7 @@ public final class BaseRecalibrator extends ReadWalker {
      * and the raw empirical quality score calculated by phred-scaling the mismatch rate.   Use '/dev/stdout' to print to standard out.
      */
     @Argument(shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, doc = "The output recalibration table file to create", optional = false)
+    @WorkflowResource(output=true, input=false)
     private File recalTableFile = null;
 
     private BaseRecalibrationEngine recalibrationEngine;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/consensus/DownsampleByDuplicateSet.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.tools.walkers.consensus;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.RuntimeProperties;
+import org.broadinstitute.barclay.argparser.WorkflowResource;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.DuplicateSetWalker;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -56,8 +58,10 @@ import java.util.Random;
  * -O umiGrouped_0.95.bam
  **/
 @BetaFeature
+@RuntimeProperties
 public class DownsampleByDuplicateSet extends DuplicateSetWalker {
-    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "")
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output file")
+    @WorkflowResource(output=true, input=false, companionResources = {StandardArgumentDefinitions.OUTPUT_LONG_NAME + "Index"})
     public GATKPath outputBam;
 
     public static final String FRACTION_TO_KEEP_NAME = "fraction-to-keep";

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKWDLWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKWDLWorkUnitHandler.java
@@ -256,6 +256,9 @@ public class GATKWDLWorkUnitHandler extends WDLWorkUnitHandler {
             final CommandLineProgramProperties clpProperties = currentWorkUnit.getCommandLineProperties();
             currentWorkUnit.setProperty("picardsummary", clpProperties.summary());
         }
+
+        // add the buildDir as a property so it can be accessed by the test inputs JSON file
+        currentWorkUnit.setProperty("buildDir", ((GATKWDLDoclet)getDoclet()).getBuildDir());
     }
 
 }

--- a/src/main/resources/org/broadinstitute/hellbender/utils/wdlTemplates/wdlJSONTemplateAllArgsTest.json.ftl
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/wdlTemplates/wdlJSONTemplateAllArgsTest.json.ftl
@@ -4,7 +4,7 @@
 <#--- Store positional args in a WDL arg called "positionalArgs"--->
 <#assign positionalArgs="positionalArgs"/>
     "${name}.dockerImage": "broadinstitute/gatk:${version}",
-    "${name}.gatk": "java -cp /home/travis/build/broadinstitute/gatk/build/libs/gatk.jar org.broadinstitute.hellbender.CommandLineArgumentValidatorMain",
+    "${name}.gatk": "java -cp ${buildDir}/build/libs/gatk.jar org.broadinstitute.hellbender.CommandLineArgumentValidatorMain",
 <#if runtimeProperties?? && runtimeProperties?size != 0 && runtimeProperties.memoryRequirements != "">
     "${name}.memoryRequirements": "${runtimeProperties.memoryRequirements}",
 <#else>

--- a/src/test/java/org/broadinstitute/hellbender/utils/help/WDLGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/help/WDLGenerationIntegrationTest.java
@@ -47,6 +47,7 @@ public class WDLGenerationIntegrationTest extends CommandLineProgramTest {
                 "-d", wdlTestTarget.getAbsolutePath(), // directory must exist
                 "-output-file-extension", "wdl",
                 "-build-timestamp", "2016/11/11 11:11:11",
+                "-build-dir", ".",
                 "-absolute-version", "1.1-111",
                 "-verbose"
         };


### PR DESCRIPTION
These will be done in tranches; this first PR is mostly a random subset of ReadWalkers, since those are prepped with GATKPath, etc. I've relied on default values for `RuntimeProperties` for all the tools in this PR, but as we review them, we should look for tools that shouldn't use the defaults (i.e., need override values for additional memory, etc.). The defaults are:

```
  "memoryRequirements": "1GB",
  "diskRequirements": "local-disk 40 HDD",
  "cpuRequirements": "1",
  "preemptibleRequirements": "3",
  "bootdisksizegbRequirements": "15",
```
