### PR TITLE
Enable direct s3a:// file accesses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,7 @@ dependencies {
     compile('org.disq-bio:disq:' + disqVersion)
     compile('org.apache.hadoop:hadoop-client:' + hadoopVersion) // should be a 'provided' dependency
     compile('com.github.jsr203hadoop:jsr203hadoop:1.0.3')
+    compile('net.fnothaft:jsr203-s3a:0.0.1')
 
     compile('de.javakaffee:kryo-serializers:0.41') {
         exclude module: 'kryo' // use Spark's version

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKPath.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKPath.java
@@ -26,6 +26,7 @@ public class GATKPath extends PathSpecifier implements TaggedArgument, Serializa
     private static final long serialVersionUID = 1L;
 
     public static final String HDFS_SCHEME = "hdfs";
+    public static final String S3A_SCHEME = "s3a";
 
     private String tagName;
     private Map<String, String> tagAttributes;
@@ -70,7 +71,7 @@ public class GATKPath extends PathSpecifier implements TaggedArgument, Serializa
 
         try {
             InputStream inputStream;
-            if (getURI().getScheme().equals(HDFS_SCHEME)) {
+            if (isHadoopURL()) {
                 org.apache.hadoop.fs.Path file = new org.apache.hadoop.fs.Path(getURIString());
                 org.apache.hadoop.fs.FileSystem fs = file.getFileSystem(new org.apache.hadoop.conf.Configuration());
                 inputStream = fs.open(file);
@@ -98,7 +99,7 @@ public class GATKPath extends PathSpecifier implements TaggedArgument, Serializa
 
         try {
             OutputStream outputStream;
-            if (getURI().getScheme().equals(HDFS_SCHEME)) {
+            if (isHadoopURL()) {
                 org.apache.hadoop.fs.Path fsPath = new org.apache.hadoop.fs.Path(getURIString());
                 org.apache.hadoop.fs.FileSystem fs = fsPath.getFileSystem(new org.apache.hadoop.conf.Configuration());
                 return fs.create(fsPath);
@@ -116,7 +117,7 @@ public class GATKPath extends PathSpecifier implements TaggedArgument, Serializa
      * Returns true if this is a HDFS (Hadoop filesystem) URL.
      */
     public boolean isHadoopURL() {
-        return getScheme().equals(HDFS_SCHEME);
+        return getScheme().equals(HDFS_SCHEME) || getScheme().equals(S3A_SCHEME);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -171,7 +171,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         final SAMFileHeader header;
         final BwaSparkEngine bwaEngine;
         if (align) {
-            bwaEngine = new BwaSparkEngine(ctx, referenceArguments.getReferenceFileName(), bwaArgs.indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary());
+            bwaEngine = new BwaSparkEngine(ctx, referenceArguments.getReferenceSpecifier().getRawInputString(), bwaArgs.indexImageFile, getHeaderForReads(), getReferenceSequenceDictionary());
             if (bwaArgs.singleEndAlignment) {
                 alignedReads = bwaEngine.alignUnpaired(getReads());
             } else {
@@ -221,7 +221,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
                 .flatMap(interval -> Shard.divideIntervalIntoShards(interval, shardingArgs.readShardSize, shardingArgs.readShardPadding, sequenceDictionary).stream())
                 .collect(Collectors.toList());
 
-        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, readsHeader, sequenceDictionary, referenceArguments.getReferenceFileName(), intervalShards, hcArgs, shardingArgs, assemblyRegionArgs, output, makeVariantAnnotations(), logger, strict, createOutputVariantIndex);
+        HaplotypeCallerSpark.callVariantsWithHaplotypeCallerAndWriteOutput(ctx, filteredReadsForHC, readsHeader, sequenceDictionary, referenceArguments.getReferenceSpecifier().getRawInputString(), intervalShards, hcArgs, shardingArgs, assemblyRegionArgs, output, makeVariantAnnotations(), logger, strict, createOutputVariantIndex);
 
         if (bwaEngine != null) {
             bwaEngine.close();

--- a/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gcs/BucketUtils.java
@@ -49,6 +49,8 @@ public final class BucketUtils {
     public static final String HTTPS_PREFIX = HttpsFileSystemProvider.SCHEME +"://";
     public static final String HDFS_SCHEME = "hdfs";
     public static final String HDFS_PREFIX = HDFS_SCHEME + "://";
+    public static final String S3A_SCHEME = "s3a";
+    public static final String S3A_PREFIX = S3A_SCHEME + "://";
 
     // slashes omitted since hdfs paths seem to only have 1 slash which would be weirder to include than no slashes
     public static final String FILE_PREFIX = "file:";
@@ -110,7 +112,7 @@ public final class BucketUtils {
      * Returns true if the given path is a HDFS (Hadoop filesystem) URL.
      */
     public static boolean isHadoopUrl(String path) {
-        return path.startsWith(HDFS_PREFIX);
+        return path.startsWith(HDFS_PREFIX) || path.startsWith(S3A_PREFIX);
     }
 
     /**


### PR DESCRIPTION
Currently, we need to copy files on S3 to local storage before using
them. This patch enables gatk local and spark modes to access s3a://
files directly to reduce copy overhead and local disk usages.

s3a file accesses require additional configuration of core-site.xml
located in CLASSPATH as well as other hadoop applications. Spark
already has hadoop dependencies but local modes need to add hadoop
jars in the classpath.

Example core-site.xml:

```
<configuration>
<property>
<name>fs.s3a.access.key</name>
<value>{Your AWS_ACCESS_KEY_ID}</value>
</property>
<property>
<name>fs.s3a.secret.key</name>
<value>{Your AWS_SECRET_ACCESS_KEY}</value>
</property>
</configuration>
```