### PR TITLE
Use an inital value for FuncotateSegments MAPPING_FULL_NAME that the CLP can mutate.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotateSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotateSegments.java
@@ -96,7 +96,7 @@ public class FuncotateSegments extends FeatureWalker<AnnotatedInterval> {
         renderer might further transform the name.*/
     @Argument(doc="(Advanced) Mapping between an alias and key values that are recognized by the backend.  Users should not typically have to specify this.",
             fullName = MAPPING_FULL_NAME)
-    private List<String> aliasToKeyMappingAsString = MAPPING_DEFAULT;
+    private List<String> aliasToKeyMappingAsString = new ArrayList<>(MAPPING_DEFAULT);
 
     private LinkedHashMap<String, String> aliasToKeyMapping;
 


### PR DESCRIPTION
Discovered by running the autogenerated tests for autogenerated WDL.