### PR TITLE
Fix a performance regression in SelectVariants

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -709,16 +709,16 @@ public final class SelectVariants extends VariantWalker {
      * @param vc    Variant Context
      */
     private void initalizeAlleleAnyploidIndicesCache(final VariantContext vc) {
-        if (vc.getType() != VariantContext.Type.NO_VARIATION) { // Bypass if not a variant
+        if (vc.getType() != VariantContext.Type.NO_VARIATION &&
+                vc.getGenotypes().stream().anyMatch(Genotype::hasLikelihoods)) { // Bypass if not a variant or no genotype has Pls
             for (final Genotype g : vc.getGenotypes()) {
                 // Make a new entry if the we have not yet cached a PL to allele indices map for this ploidy and allele count
                 // skip if there are no PLs -- this avoids hanging on high-allelic somatic samples, for example, where
                 // there's no need for the PL indices since they don't exist
-                if (g.getPloidy() != 0 && (!ploidyToNumberOfAlleles.containsKey(g.getPloidy()) || ploidyToNumberOfAlleles.get(g.getPloidy()) < vc.getNAlleles())) {
-                    if (vc.getGenotypes().stream().anyMatch(Genotype::hasLikelihoods)) {
-                        GenotypeLikelihoods.initializeAnyploidPLIndexToAlleleIndices(vc.getNAlleles() - 1, g.getPloidy());
-                        ploidyToNumberOfAlleles.put(g.getPloidy(), vc.getNAlleles());
-                    }
+                final int genotypePloidy = g.getPloidy();
+                if (genotypePloidy != 0 && (!ploidyToNumberOfAlleles.containsKey(genotypePloidy) || ploidyToNumberOfAlleles.get(genotypePloidy) < vc.getNAlleles())) {
+                    GenotypeLikelihoods.initializeAnyploidPLIndexToAlleleIndices(vc.getNAlleles() - 1, genotypePloidy);
+                    ploidyToNumberOfAlleles.put(genotypePloidy, vc.getNAlleles());
                 }
             }
         }


### PR DESCRIPTION
* There was an "optimization" put in place in SelectVariants which accidentally added a quadraticly scaling check on the genotypes.
* This keeps the optimization but makes it linear instead of quadratic on the number of samples.
* On one example with several thousand samples there was a speed up from ~5 minutes to .1 minutes.