### PR TITLE
Exposes an argument in the mitochondria WDL

### DIFF
--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -452,7 +452,7 @@ task M2 {
     File ref_dict
     File input_bam
     File input_bai
-    Int max_reads_per_alignment_start = 75
+    Int? max_reads_per_alignment_start
     String? m2_extra_args
     Boolean? make_bamout
     Boolean compress
@@ -463,6 +463,7 @@ task M2 {
     Int? preemptible_tries
   }
 
+  Int max_reads_per_alignment_start_arg = select_first([max_reads_per_alignment_start, 75])
   String output_vcf = "raw" + if compress then ".vcf.gz" else ".vcf"
   String output_vcf_index = output_vcf + if compress then ".tbi" else ".idx"
   Float ref_size = size(ref_fasta, "GB") + size(ref_fai, "GB")
@@ -496,7 +497,7 @@ task M2 {
         ~{m2_extra_args} \
         --annotation StrandBiasBySample \
         --mitochondria-mode \
-        --max-reads-per-alignment-start ~{max_reads_per_alignment_start} \
+        --max-reads-per-alignment-start ~{max_reads_per_alignment_start_arg} \
         --max-mnp-distance 0
   >>>
   runtime {

--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -452,7 +452,7 @@ task M2 {
     File ref_dict
     File input_bam
     File input_bai
-    Int? max_reads_per_alignment_start
+    Int max_reads_per_alignment_start = 75
     String? m2_extra_args
     Boolean? make_bamout
     Boolean compress
@@ -463,7 +463,6 @@ task M2 {
     Int? preemptible_tries
   }
 
-  Int max_reads_per_alignment_start_arg = select_first([max_reads_per_alignment_start, 75])
   String output_vcf = "raw" + if compress then ".vcf.gz" else ".vcf"
   String output_vcf_index = output_vcf + if compress then ".tbi" else ".idx"
   Float ref_size = size(ref_fasta, "GB") + size(ref_fai, "GB")
@@ -497,7 +496,7 @@ task M2 {
         ~{m2_extra_args} \
         --annotation StrandBiasBySample \
         --mitochondria-mode \
-        --max-reads-per-alignment-start ~{max_reads_per_alignment_start_arg} \
+        --max-reads-per-alignment-start ~{max_reads_per_alignment_start} \
         --max-mnp-distance 0
   >>>
   runtime {

--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -47,7 +47,6 @@ workflow AlignAndCall {
     Boolean compress_output_vcf
     Float? verifyBamID
     Int? max_low_het_sites
-    Int? max_reads_per_alignment_start
 
     # Read length used for optimization only. If this is too small CollectWgsMetrics might fail, but the results are not
     # affected by this number. Default is 151.
@@ -114,7 +113,6 @@ workflow AlignAndCall {
       gatk_docker_override = gatk_docker_override,
       # Everything is called except the control region.
       m2_extra_args = select_first([m2_extra_args, ""]) + " -L chrM:576-16024 ",
-      max_reads_per_alignment_start = max_reads_per_alignment_start,
       mem = M2_mem,
       preemptible_tries = preemptible_tries
   }
@@ -131,7 +129,6 @@ workflow AlignAndCall {
       gatk_docker_override = gatk_docker_override,
       # Everything is called except the control region.
       m2_extra_args = select_first([m2_extra_args, ""]) + " -L chrM:8025-9144 ",
-      max_reads_per_alignment_start = max_reads_per_alignment_start,
       mem = M2_mem,
       preemptible_tries = preemptible_tries
   }

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -8,6 +8,7 @@ workflow MitochondriaPipeline {
 
   meta {
     description: "Takes in an hg38 bam or cram and outputs VCF of SNP/Indel calls on the mitochondria."
+    allowNestedInputs: true
   }
 
   input {
@@ -62,7 +63,6 @@ workflow MitochondriaPipeline {
     Float? verifyBamID
     Boolean compress_output_vcf = false
     Int? max_low_het_sites
-    Int? max_reads_per_alignment_start
 
     #Optional runtime arguments
     Int? preemptible_tries
@@ -75,7 +75,6 @@ workflow MitochondriaPipeline {
     vaf_filter_threshold: "Hard threshold for filtering low VAF sites"
     f_score_beta: "F-Score beta balances the filtering strategy between recall and precision. The relative weight of recall to precision."
     contig_name: "Name of mitochondria contig in reference that wgs_aligned_input_bam_or_cram is aligned to"
-    max_reads_per_alignment_start: "Argument for Mutect2"
   }
 
   call SubsetBamToChrM {
@@ -128,7 +127,6 @@ workflow MitochondriaPipeline {
       gatk_override = gatk_override,
       gatk_docker_override = gatk_docker_override,
       m2_extra_args = m2_extra_args,
-      max_reads_per_alignment_start = max_reads_per_alignment_start,
       m2_filter_extra_args = m2_filter_extra_args,
       vaf_filter_threshold = vaf_filter_threshold,
       f_score_beta = f_score_beta,

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -62,6 +62,7 @@ workflow MitochondriaPipeline {
     Float? verifyBamID
     Boolean compress_output_vcf = false
     Int? max_low_het_sites
+    Int? max_reads_per_alignment_start
 
     #Optional runtime arguments
     Int? preemptible_tries
@@ -74,6 +75,7 @@ workflow MitochondriaPipeline {
     vaf_filter_threshold: "Hard threshold for filtering low VAF sites"
     f_score_beta: "F-Score beta balances the filtering strategy between recall and precision. The relative weight of recall to precision."
     contig_name: "Name of mitochondria contig in reference that wgs_aligned_input_bam_or_cram is aligned to"
+    max_reads_per_alignment_start: "Argument for Mutect2"
   }
 
   call SubsetBamToChrM {
@@ -126,6 +128,7 @@ workflow MitochondriaPipeline {
       gatk_override = gatk_override,
       gatk_docker_override = gatk_docker_override,
       m2_extra_args = m2_extra_args,
+      max_reads_per_alignment_start = max_reads_per_alignment_start,
       m2_filter_extra_args = m2_filter_extra_args,
       vaf_filter_threshold = vaf_filter_threshold,
       f_score_beta = f_score_beta,


### PR DESCRIPTION
@ahaessly Could you please take a look at this? We had a request to change this argument which wasn't previously possible since it was hardcoded into the WDL task. Ideally I'd like to expose all of the arguments but even wiring this one through the imported WDL was annoying. I tried making it an input to the task with a value like this:

```
task M2 {
  input {
    Int max_reads_arg = 75
  }
...
```
which looks a lot cleaner (don't have to make sure you wire it through from the main inputs), but when I looked in Terra it didn't actually expose the argument (I'm assuming because the M2 task is in a sub-workflow). Any thoughts on how to make this better so I can expose everything? Or is this the best way to do that at the moment?