### PR TITLE
Fixed concurrent modification exception for local runs of HapltoypeCallerSpark 

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -6,6 +6,7 @@ import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 
 import java.io.File;
+import java.util.Collections;
 
 public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends ReadThreadingAssemblerArgumentCollection {
     private static final long serialVersionUID = 6520834L;
@@ -34,7 +35,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
 
     @Override
     public ReadThreadingAssembler makeReadThreadingAssembler() {
-        final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
+        final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, useAdaptivePruning ? 0 : minPruneFactor,
                 useAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/MutectReadThreadingAssemblerArgumentCollection.java
@@ -5,6 +5,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 
 import java.io.File;
+import java.util.Collections;
 
 public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadingAssemblerArgumentCollection {
     private static final long serialVersionUID = 5304L;
@@ -20,7 +21,7 @@ public class MutectReadThreadingAssemblerArgumentCollection extends ReadThreadin
 
     @Override
     public ReadThreadingAssembler makeReadThreadingAssembler() {
-        final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, kmerSizes,
+        final ReadThreadingAssembler assemblyEngine = new ReadThreadingAssembler(maxNumHaplotypesInPopulation, Collections.unmodifiableList(kmerSizes),
                 dontIncreaseKmerSizesForCycles, allowNonUniqueKmersInRef, numPruningSamples, disableAdaptivePruning ? minPruneFactor : 0,
                 !disableAdaptivePruning, initialErrorRateForPruning, pruningLogOddsThreshold, maxUnprunedVariants, useLinkedDeBruijnGraph);
         assemblyEngine.setDebugGraphTransformations(debugGraphTransformations);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -78,7 +78,7 @@ public final class ReadThreadingAssembler {
                                   final int maxUnprunedVariants, final boolean useLinkedDebruijnGraphs) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
         this.kmerSizes = new ArrayList<>(kmerSizes);
-        kmerSizes.sort(Integer::compareTo);
+        this.kmerSizes.sort(Integer::compareTo);
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -32,7 +32,7 @@ import java.util.*;
 public final class ReadThreadingAssembler {
     private static final Logger logger = LogManager.getLogger(ReadThreadingAssembler.class);
 
-    private static final int DEFAULT_NUM_PATHS_PER_GRAPH = 128;
+    static final int DEFAULT_NUM_PATHS_PER_GRAPH = 128;
     private static final int KMER_SIZE_ITERATION_INCREASE = 10;
     private static final int MAX_KMER_ITERATIONS_TO_ATTEMPT = 6;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public final class ReadThreadingAssembler {
     private static final Logger logger = LogManager.getLogger(ReadThreadingAssembler.class);
@@ -77,8 +78,7 @@ public final class ReadThreadingAssembler {
                                   final double initialErrorRateForPruning, final double pruningLogOddsThreshold,
                                   final int maxUnprunedVariants, final boolean useLinkedDebruijnGraphs) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
-        this.kmerSizes = new ArrayList<>(kmerSizes);
-        this.kmerSizes.sort(Integer::compareTo);
+        this.kmerSizes = kmerSizes.stream().sorted(Integer::compareTo).collect(Collectors.toList());
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -49,6 +49,7 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
     }
 
     @Test
+    // Test of fix for https://github.com/broadinstitute/gatk/issues/6513
     public void testReadThreadingAssemblerDoesntModifyInputKmerList() {
         List<Integer> kmersOutOfOrder = Arrays.asList(65, 25, 45, 35, 85);
         List<Integer> kmersOutOfOrderCopy = new ArrayList<>(kmersOutOfOrder);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssemblerUnitTest.java
@@ -48,6 +48,17 @@ public final class ReadThreadingAssemblerUnitTest extends GATKBaseTest {
         seq.close();
     }
 
+    @Test
+    public void testReadThreadingAssemblerDoesntModifyInputKmerList() {
+        List<Integer> kmersOutOfOrder = Arrays.asList(65, 25, 45, 35, 85);
+        List<Integer> kmersOutOfOrderCopy = new ArrayList<>(kmersOutOfOrder);
+        ReadThreadingAssembler assembler = new ReadThreadingAssembler(ReadThreadingAssembler.DEFAULT_NUM_PATHS_PER_GRAPH, kmersOutOfOrderCopy, 2);
+
+        Assert.assertEquals(kmersOutOfOrder, kmersOutOfOrderCopy);
+        Assert.assertEquals(assembler.getExpandedKmerList(), Arrays.asList(25, 35, 45, 65, 85)); // checking that the sort was preformed on the internal kmer list
+
+    }
+
     @DataProvider(name = "AssembleIntervalsData")
     public Object[][] makeAssembleIntervalsData() {
         List<Object[]> tests = new ArrayList<>();


### PR DESCRIPTION
This seems to resolve the issue (which I had no problem reproducing) locally. Interestingly when I run the test suite locally I get test failures here but apparently we never caught this on travis. There must be something different about the tests on travis... I am happy for advice as to how to write a test for this fix though because the error seems to be occurring under a dizzying array of spark/hadoop internal serialization code and I'm not sure how to test that properly. 

Fixes #6513 #6738