### PR TITLE
SelectVariants speedup on large multisample VCFs 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','2.23.0')
+final htsjdkVersion = System.getProperty('htsjdk.version','2.23.0-8-g06f88fa-SNAPSHOT')
 final picardVersion = System.getProperty('picard.version','2.23.3')
 final barclayVersion = System.getProperty('barclay.version','3.0.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.5')

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -600,9 +600,6 @@ public final class SelectVariants extends VariantWalker {
                 return;
         }
 
-        // Initialize the cache of PL index to a list of alleles for each ploidy.
-        initalizeAlleleAnyploidIndicesCache(vc);
-
         final VariantContext sub = subsetRecord(vc, preserveAlleles, removeUnusedAlternates);
         final VariantContext filteredGenotypeToNocall;
 
@@ -699,30 +696,6 @@ public final class SelectVariants extends VariantWalker {
         }
 
         return filters;
-    }
-
-    /**
-     * Initialize cache of allele anyploid indices
-     *
-     * Initialize the cache of PL index to a list of alleles for each ploidy.
-     *
-     * @param vc    Variant Context
-     */
-    private void initalizeAlleleAnyploidIndicesCache(final VariantContext vc) {
-        if (vc.getType() != VariantContext.Type.NO_VARIATION &&
-                vc.getGenotypes().stream().anyMatch(Genotype::hasLikelihoods)) { // Bypass if not a variant or no genotype has Pls
-            for (final Genotype g : vc.getGenotypes()) {
-                // Make a new entry if the we have not yet cached a PL to allele indices map for this ploidy and allele count
-                // skip if there are no PLs -- this avoids hanging on high-allelic somatic samples, for example, where
-                // there's no need for the PL indices since they don't exist
-                final int genotypePloidy = g.getPloidy();
-                if (genotypePloidy != 0 && (!ploidyToNumberOfAlleles.containsKey(genotypePloidy) || ploidyToNumberOfAlleles.get(genotypePloidy) < vc.getNAlleles())) {
-                    GenotypeLikelihoods.initializeAnyploidPLIndexToAlleleIndices(vc.getNAlleles() - 1, genotypePloidy);
-                    ploidyToNumberOfAlleles.put(genotypePloidy, vc.getNAlleles());
-                }
-            }
-        }
-
     }
 
     /**


### PR DESCRIPTION
Currently, SelectVariants includes a call to `initalizeAlleleAnyploidIndicesCache` for every processed variant.  `initalizeAlleleAnyploidIndicesCache` requires extracting genotype information, which forces the LazyGenotypeContext machinery in htsjdk to fully decode all genotypes, even if the subsetting operation being performed does not require genotype information.  This can cause such subsetting operations to take unnecessarily long amounts of time when run on large mutlisample vcfs.  As an example, it takes ~24 hours to extract all snps from a 1000Genomes vcf.

This PR bumps the version of htsjdk to no longer need the call to `initalizeAlleleAnyploidIndicesCache`, thus saving the performance boost from lazy genotype parsing.  On the example mentioned above, this results in a ~13x speedup, as the time to extract all snps from a 1000Genomes vcf drops to under 2 hours.

requires samtools/htsjdk#1500  