### PR TITLE
Added dockstore yml file with workflow description

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,59 @@
+workflows:
+   - name: cnv_germline_case_workflow
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+     testParameterFiles:
+     -  /scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
+   - name: cnv_germline_cohort_workflow
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
+     testParameterFiles:
+     -  /scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
+   - name: cnv_somatic_pair_workflow
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+     testParameterFiles: 
+     -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_do-gc_workflow.json
+   - name: cnv_somatic_panel_workflow
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
+     testParameterFiles:
+     -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_panel_wes_do-gc_workflow.json
+   - name: cram2filtered
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2filtered.wdl
+     testParameterFiles:
+     - /scripts/cnn_variant_wdl/jsons/cram2filtered.json
+   - name: cram2model
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
+     testParameterFiles:
+     - /scripts/cnn_variant_wdl/jsons/cram2model.json
+   - name: funcotator
+     subclass: WDL
+     primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl
+     testParameterFiles:
+     - /scripts/funcotator_wdl/funcotator.json
+   - name: MitochondriaPipeline
+     subclass: WDL
+     primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+     testParameterFiles:
+     -  /scripts/mitochondria_m2_wdl/test_mitochondria_m2_wdl.json
+   - name: mutect2
+     subclass: WDL
+     primaryDescriptorPath: /scripts/mutect2_wdl/mutect2.wdl
+     testParameterFiles:
+     - /scripts/m2_cromwell_tests/mutect2.inputs.json
+   - name: mutect2_pon
+     subclass: WDL
+     primaryDescriptorPath: /scripts/mutect2_wdl/mutect2_pon.wd
+   - name: run_happy
+     subclass: WDL
+     primaryDescriptorPath: /scripts/cnn_variant_wdl/run_happy.wdl
+     testParameterFiles:
+     - /scripts/cnn_variant_wdl/jsons/run_happy.json
+   - name: pathseq_pipeline
+     subclass: WDL
+     primaryDescriptorPath: /scripts/pathseq/wdl/pathseq_pipeline.wdl
+     testParameterFiles:
+     - /scripts/pathseq/wdl/pathseq_pipeline_template.json


### PR DESCRIPTION
Added .dockstore.yml file to the root directory of the gatk repo to allow automatic syncing to occur with workflows in [Dockstore](https://dockstore.org/organizations/BroadInstitute/collections/GATKWorkflows). 
**Problem:** 
The GATK workflows are currently organized in [Dockstore](https://dockstore.org/organizations/BroadInstitute/collections/GATKWorkflows), maintenance of the workflows requires manually refreshing the workflow profile in Dockstore in order to view the latest releases of the workflows. Also some workflows like germline_cnv fails to sync because Dockstore has trouble handling the number of branches/tags in the gatk repo.
**Solution:** 
Adding the dockstore yml file allows this syncing to happen automatically whenever there is a push to the gatk repo. This may also help focus which branches to sync and prevent Dockstore from failing during sync. 

See [doc](https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html) for description. 