### PR TITLE
Improve error message in GATKRead.setMatePosition

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -99,10 +99,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public void setPosition( final String contig, final int start ) {
-        if ( contig == null || contig.equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME) || start < 1 ) {
-            throw new IllegalArgumentException("contig must be non-null and not equal to " + SAMRecord.NO_ALIGNMENT_REFERENCE_NAME
-                    + ", and start must be >= 1 \ncontig = " + contig + "\nstart = " + start);
-        }
+        assertPositionIsValid(contig, start);
 
         clearCachedValues();
         samRecord.setReferenceName(contig);
@@ -193,9 +190,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
 
     @Override
     public void setMatePosition( final String contig, final int start ) {
-        if ( contig == null || contig.equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME) || start < 1 ) {
-            throw new IllegalArgumentException("contig must be non-null and not equal to " + SAMRecord.NO_ALIGNMENT_REFERENCE_NAME + ", and start must be >= 1");
-        }
+        assertPositionIsValid(contig, start);
 
         clearCachedValues();
 
@@ -205,6 +200,13 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
         samRecord.setMateReferenceName(contig);
         samRecord.setMateAlignmentStart(start);
         samRecord.setMateUnmappedFlag(false);
+    }
+
+    private static void assertPositionIsValid(final String contig, final int start) {
+        if ( contig == null || contig.equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME) || start < 1 ) {
+            throw new IllegalArgumentException("contig must be non-null and not equal to " + SAMRecord.NO_ALIGNMENT_REFERENCE_NAME + ", and start must be >= 1"
+            + "\nContig: " + contig + "\nStart: " + start);
+        }
     }
 
     @Override
@@ -235,7 +237,7 @@ public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     @Override
     public void setMappingQuality( final int mappingQuality ) {
         if ( mappingQuality < 0 || mappingQuality > 255 ) {
-            throw new IllegalArgumentException("mapping quality must be >= 0 and <= 255");
+            throw new IllegalArgumentException("mapping quality must be >= 0 and <= 255 \nMappingQuality: " + mappingQuality);
         }
 
         clearCachedValues();


### PR DESCRIPTION
* Add contig and start position to error message in setMatePosition
* Extract the check to a shared method with setPosition so it's not inconsistent
* Improves the unhelpful error reported in https://github.com/broadinstitute/gatk/issues/6776