### PR TITLE
Fixed typo in --tmp-dir argument in the GenotypeGVCFs docs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -67,7 +67,7 @@ import java.util.*;
  *   -R Homo_sapiens_assembly38.fasta \
  *   -V gendb://my_database \
  *   -O output.vcf.gz \
- *   --tmp-dir=/path/to/large/tmp
+ *   --tmp-dir /path/to/large/tmp
  * </pre>
  *
  * <h3>Caveats</h3>


### PR DESCRIPTION
Documentation change  for tmp dir in example command - GenotypeGVCFs