### PR TITLE
Spark-based sharder for PB CCS uBAM

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/programgroups/LongReadAnalysisProgramGroup.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/programgroups/LongReadAnalysisProgramGroup.java
@@ -1,0 +1,13 @@
+package org.broadinstitute.hellbender.cmdline.programgroups;
+
+import org.broadinstitute.barclay.argparser.CommandLineProgramGroup;
+import org.broadinstitute.hellbender.utils.help.HelpConstants;
+
+public class LongReadAnalysisProgramGroup implements CommandLineProgramGroup {
+
+    @Override
+    public String getName() { return HelpConstants.DOC_CAT_LR_ANALYSIS; }
+
+    @Override
+    public String getDescription() { return HelpConstants.DOC_CAT_LR_ANALYSIS_SUMMARY; }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/longread/ShardPacBioSubReadsUBamByZMWClusterSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/longread/ShardPacBioSubReadsUBamByZMWClusterSpark.java
@@ -1,0 +1,98 @@
+package org.broadinstitute.hellbender.tools.spark.longread;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.barclay.argparser.Advanced;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.programgroups.LongReadAnalysisProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+
+import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+
+/**
+ * Shard PacBio sub-reads uBAM by ZMW (e.g. for running CCS algo.).
+ *
+ * Now that the output BAMs will NOT be the same as the number of ZMWs, as that will be too many files.
+ * We cluster several ZMWs together in each output BAM.
+ *
+ * Note that currently the tool <b>requires</b> an SBI (Hadoop BAM splitting index) for the BAM to be split.
+ *
+ * <h3>Usage example</h3>
+ * <pre>
+ *   gatk ShardPacBioSubReadsUBamByZMWClusterSpark \
+ *     -I input_reads.bam \
+ *     --read-index input_reads.bam.sbi \
+ *     -O output_prefix_
+ * </pre>
+ */
+@DocumentedFeature
+@BetaFeature
+@CommandLineProgramProperties(
+        oneLineSummary = "Shard PacBio sub-reads uBAM by ZMW clusters",
+        summary =
+                "Shard PacBio sub-reads uBAM by ZMW clusters.",
+        programGroup = LongReadAnalysisProgramGroup.class)
+public class ShardPacBioSubReadsUBamByZMWClusterSpark extends GATKSparkTool {
+    private static final long serialVersionUID = 1L;
+
+    private static final String ZMW_ATTRIBUTE_KEY = "zm";
+
+    @Argument(doc = "the output prefix", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME)
+    protected String output;
+
+    @Advanced
+    @Argument(doc = "(approximate) number of shards to produce", fullName = "num-shards", optional = true)
+    protected Integer numOfShards = 400;
+
+    @Override
+    public boolean requiresReads() {
+        return true;
+    }
+
+    @Override
+    protected void runTool( final JavaSparkContext ctx ) {
+
+        final Integer maxZMWnum = getUnfilteredReads()
+                .map(read -> read.getAttributeAsInteger(ZMW_ATTRIBUTE_KEY))
+                .max(Comparator.naturalOrder());
+        final int local_shard_size = maxZMWnum/numOfShards;
+
+        // these redundant local variables are here just to avoid the whole tool having to be serialized...
+        final String output_prefix = output;
+
+        final SAMFileHeader headerForReads = getHeaderForReads();
+        headerForReads.setSortOrder(SAMFileHeader.SortOrder.queryname); // each output will be sorted by read name
+
+        getUnfilteredReads()
+                .groupBy(read -> read.getAttributeAsInteger(ZMW_ATTRIBUTE_KEY) / local_shard_size) // shard index
+                .foreach( shard -> {
+                    final Iterator<SAMRecord> readsInThisCluster =
+                            StreamSupport.stream(shard._2.spliterator(), false)
+                                    .map(read -> read.convertToSAMRecord(headerForReads))
+                                    .sorted(Comparator.comparing(SAMRecord::getReadName))
+                                    .iterator();
+
+                    final Integer shardIdx = shard._1;
+                    try ( SAMFileWriter writer = new SAMFileWriterFactory().setCreateIndex(false)
+                            .makeBAMWriter(headerForReads, true,
+                                    IOUtils.getPath(output_prefix + shardIdx + ".bam"))) {
+                        readsInThisCluster.forEachRemaining(writer::addAlignment);
+                    } catch ( final UncheckedIOException ie ) {
+                        throw new GATKException("Can't write BAM file for shard: " + shardIdx, ie);
+                    }
+                });
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/HelpConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/HelpConstants.java
@@ -47,6 +47,9 @@ public final class HelpConstants {
     public final static String DOC_CAT_SV_DISCOVERY = "Structural Variant Discovery";
     public final static String DOC_CAT_SV_DISCOVERY_SUMMARY = "Tools that detect structural variants";
 
+    public final static String DOC_CAT_LR_ANALYSIS = "Long read analysis";
+    public final static String DOC_CAT_LR_ANALYSIS_SUMMARY = "Tools that perform analysis on long reads";
+
     public final static String DOC_CAT_TEST = "Test Tools";
     public final static String DOC_CAT_TEST_SUMMARY = "Tools for internal test purposes";
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/longread/ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/longread/ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest.java
@@ -1,0 +1,151 @@
+package org.broadinstitute.hellbender.tools.spark.longread;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
+import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
+import org.broadinstitute.hellbender.testutils.MiniClusterUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest extends CommandLineProgramTest {
+
+    private static final String THIS_TEST_FOLDER = largeFileTestDir + "longreads/";
+
+    private static final String pbCCSUnalignedReads = THIS_TEST_FOLDER +
+            "NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam";
+
+    private static final String pbCCSUnalignedReadsBAI = THIS_TEST_FOLDER +
+            "NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.bai";
+
+    private static final String pbCCSUnalignedReadsSBI = THIS_TEST_FOLDER +
+            "NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.sbi";
+
+    private static final String OUTPUT_SPILT_PREFIX = "PBCCSUBAMSparkSplit";
+
+    private static final class ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs {
+        final String workDir;
+
+        ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs(final String workDir) {
+            this.workDir = workDir;
+        }
+
+        String getCommandLine() {
+            return  " -I " + pbCCSUnalignedReads +
+                    " --read-index " + pbCCSUnalignedReadsSBI +
+                    " -O " + workDir + "/" + OUTPUT_SPILT_PREFIX;
+        }
+    }
+
+    @DataProvider(name = "forShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest")
+    private Object[][] createData() {
+        List<Object[]> data = new ArrayList<>();
+
+        final File testWorkDir = createTempDir("ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest");
+        final ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs testArgs =
+                new ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs(testWorkDir.getAbsolutePath());
+        data.add(new Object[]{testArgs});
+
+        return data.toArray(new Object[data.size()][]);
+    }
+
+    @Test(groups = "longreads", dataProvider = "forShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest")
+    public void testRunLocal(final ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs params) throws Exception {
+        final List<String> args = Arrays.asList( new ArgumentsBuilder().addRaw(params.getCommandLine()).getArgsArray() );
+        runCommandLine(args);
+
+        final List<java.nio.file.Path> splits = Files.list(Paths.get(params.workDir)).collect(Collectors.toList());
+        testReadsOfSameZMWAreNotSeparated(Paths.get(pbCCSUnalignedReads), splits);
+    }
+
+    @Test(groups = "longreads", dataProvider = "forShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTest")
+    public void testRunHDFS(final ShardPacBioSubReadsUBamByZMWClusterSparkIntegrationTestArgs params) throws Exception {
+        MiniClusterUtils.runOnIsolatedMiniCluster(cluster -> {
+            final DistributedFileSystem fileSystem = cluster.getFileSystem();
+
+            final List<String> argsToBeModified = Arrays.asList( new ArgumentsBuilder().addRaw(params.getCommandLine()).getArgsArray() );
+            final Path workingDirectory = MiniClusterUtils.getWorkingDir(cluster);
+
+            int idx = 0;
+
+            // copy inputs to HDFS
+            idx = argsToBeModified.indexOf("-I");
+            Path path = new Path(workingDirectory, "hdfs.bam");
+            File bamFile = new File(argsToBeModified.get(idx+1));
+            fileSystem.copyFromLocalFile(new Path(bamFile.toURI()), path);
+            argsToBeModified.set(idx+1, path.toUri().toString());
+
+            idx = argsToBeModified.indexOf("--read-index");
+            path = new Path(workingDirectory, "hdfs.bam.sbi");
+            File sbiFile = new File(argsToBeModified.get(idx+1));
+            fileSystem.copyFromLocalFile(new Path(sbiFile.toURI()), path);
+            argsToBeModified.set(idx+1, path.toUri().toString());
+
+            // outputs, prefix with hdfs address
+            idx = argsToBeModified.indexOf("-O");
+            Path outputDir = new Path(workingDirectory, "split");
+            String outputPrefix = outputDir.toUri().toString() + "/test";
+            argsToBeModified.set(idx+1, outputPrefix);
+
+            runCommandLine(argsToBeModified);
+
+            // copy back the split bams from HDFS and test
+            final File hdfsToLocal = GATKBaseTest.createTempDir("hdfsToLocal");
+            hdfsToLocal.deleteOnExit();
+            for(final FileStatus status : fileSystem.listStatus(outputDir)){
+                fileSystem.copyToLocalFile(status.getPath(), new Path(hdfsToLocal.toURI()));
+            }
+            final List<java.nio.file.Path> splits = Files.list(Paths.get(hdfsToLocal.toString())).collect(Collectors.toList());
+            testReadsOfSameZMWAreNotSeparated(Paths.get(pbCCSUnalignedReads), splits);
+        });
+    }
+
+    /**
+     * To test that
+     * <ul>
+     *     <li>no reads are lost, and</li>
+     *     <li>no ZMWs have their associated reads dumped into separate BAMs</li>
+     * </ul>
+     */
+    private static void testReadsOfSameZMWAreNotSeparated(final java.nio.file.Path originalReads,
+                                                          final List<java.nio.file.Path> splitBAMs) throws Exception {
+
+        // collect a map from ZMW number to the number of associated reads
+        final Map<String, Integer> zmwReadCounter = new HashMap<>();
+        try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(Paths.get(pbCCSUnalignedReads))) {
+            for (final GATKRead read : readsSource ) {
+                final String zmw = read.getAttributeAsString("zm");
+                zmwReadCounter.merge(zmw, 1, Integer::sum);
+            }
+        }
+
+        // iterate through split uBAMs and check on integrity
+        for (final java.nio.file.Path path: splitBAMs) {
+            if (!path.endsWith("bam")) continue;
+            final Map<String, Integer> counterForThisSplit = new HashMap<>();
+            try ( final ReadsPathDataSource readsSource = new ReadsPathDataSource(path)) {
+                for (final GATKRead read : readsSource ) {
+                    final String zmw = read.getAttributeAsString("zm");
+                    counterForThisSplit.merge(zmw, 1, Integer::sum);
+                }
+            }
+            for (String zmw : counterForThisSplit.keySet()) {
+                Integer expected = zmwReadCounter.get(zmw);
+                Integer actual = counterForThisSplit.get(zmw);
+                Assert.assertEquals(actual, expected,
+                                    String.format("Read count for ZMW %s doesn't match!", zmw));
+            }
+        }
+    }
+}

--- a/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam
+++ b/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba880b8b9005dc775a05e06de7642eae12cb256ebbda35411c22e46b3fe32cca
+size 18292228

--- a/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.bai
+++ b/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1847985d89428c68ff3e221d2ab28c0300687ce2914db2bdc8d980e834c6a218
+size 16

--- a/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.pbi
+++ b/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.pbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95def72017bfffa521ab5feea27a0e434e13d6f17ff2bb7f6f53f9f9448ca2f7
+size 12911

--- a/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.sbi
+++ b/src/test/resources/large/longreads/NA12878rep1.chrM_and_chr20.tiny_subset.unaligned.subreads.bam.sbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb8da3b3c2553d87aa3bb86ebcf490db66b85f68807d82d414c88007fdc8d030
+size 9804


### PR DESCRIPTION
A trivial Spark tool that shards PacBio reads into smaller bams such that reads from the same ZMW are guaranteed to be in the same split bam.