### PR TITLE
Update overlap calculation in FragmentUtils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -39,12 +39,12 @@ public final class FragmentUtils {
                 "attempting to merge two reads with different names " + firstRead + " and " + secondRead);
 
         // don't adjust fragments that do not overlap
-        if (firstRead.getEnd() < secondRead.getStart() || !firstRead.getContig().equals(secondRead.getContig())) {
+        if (firstRead.getSoftEnd() < secondRead.getSoftStart() || !firstRead.getContig().equals(secondRead.getContig())) {
             return;
         }
 
         // the offset and cigar operator in the first read at the start of the left read
-        final Pair<Integer, CigarOperator> offsetAndOperator = ReadUtils.getReadIndexForReferenceCoordinate(firstRead, secondRead.getStart());
+        final Pair<Integer, CigarOperator> offsetAndOperator = ReadUtils.getReadIndexForReferenceCoordinate(firstRead, secondRead.getSoftStart());
         final CigarOperator operator = offsetAndOperator.getRight();
         final int offset = offsetAndOperator.getLeft();
         if (offset == ReadUtils.READ_INDEX_NOT_FOUND) { // no overlap


### PR DESCRIPTION
When extracting the overlapped bases of two reads, FragmentUtils miscalculates the starting position of the second read if there are softclipped bases at its head. This leads to misalignment of the two reads and incorrect updating of the base qualities. In some other cases, it may fail to detect overlapping bases if the first and second read both contain softclips.

This pull request updates the position calculation and adds a unit test to demonstrate the issue.