### PR TITLE
Fix typo in KernelSegmenter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/segmentation/KernelSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/utils/segmentation/KernelSegmenter.java
@@ -259,7 +259,7 @@ public final class KernelSegmenter<DATA> {
         //do not all appear at only a single window size)
         for (final int windowSize : windowSizes) {
             logger.debug(String.format("Calculating local changepoints costs for window size %d...", windowSize));
-            if (windowSize > data.size()) {
+            if (2 * windowSize > data.size()) {
                 logger.warn(String.format("Number of points needed to calculate local changepoint costs (2 * window size = %d) " +
                         "exceeds number of data points (%d).  Local changepoint costs will not be calculated for this window size.",
                         2 * windowSize, data.size()));


### PR DESCRIPTION
This seems to be a simple typo. The minimal data to calculate the segmentation cost should be `2 * windowSize`, rather than `windowSize`, as the error message indicates.

In the current logic, the segmentation cost at a particular point is calculated as the difference between the sum of costs of two windows to the left and right of that point and the cost of a big window of size `2 * windowSize`. If the # of the data points is less than the `2 * windowSize`, the cost for the full window will be wrong in the circular buffer representation; it will get the wrong cost of a window of size `2 * windowSize - data_size`, instead.