### PR TITLE
Get GenomicsDB Version 1.3.2 for better propagation of native exceptions and output a limited stacktrace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ final sparkVersion = System.getProperty('spark.version', '2.4.5')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '2.8.2')
 final disqVersion = System.getProperty('disq.version','0.3.6')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.3.0')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.3.2')
 final testNGVersion = '7.0.0'
 // Using the shaded version to avoid conflicts between its protobuf dependency
 // and that of Hadoop/Spark (either the one we reference explicitly, or the one


### PR DESCRIPTION
This was an issue with propagating polymorphic std::exception code from the native library's logger utility and has been fixed in the [1.3.2 release ](https://mvnrepository.com/artifact/org.genomicsdb/genomicsdb/1.3.2) of the GenomicsDB library. Also note that using java option `GATK_STACKTRACE_ON_USER_EXCEPTION` with gatk will also output a C/C++ limited stacktrace as requested by @lbergelson.