### PR TITLE
Fix treatment of star alleles in use genotype posteriors for qual mode

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -208,7 +208,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
             // here we need to get indices of genotypes composed of REF and * alleles
             final int ploidy = gt.getPloidy();
             final GenotypeLikelihoodCalculator glCalc = GL_CALCS.getInstance(ploidy, alleles.size());
-git st            final int spanDelIndex = alleles.indexOf(Allele.SPAN_DEL);
+            final int spanDelIndex = alleles.indexOf(Allele.SPAN_DEL);
             // allele counts are in the GenotypeLikelihoodCalculator format of {ref index, ref count, span del index, span del count}
             final double[] nonVariantLog10Posteriors = IntStream.rangeClosed(0, ploidy)
                     .map(n -> glCalc.alleleCountsToIndex(0, ploidy - n, spanDelIndex, n))


### PR DESCRIPTION
This PR updates the `--use-posteriors-to-calculate-qual` mode to properly treat the star allele as a non-variant (for that site) allele. With this change, if a spanning deletion is present, it is treated as a non-variant allele for that site, and the posterior of no variant allele being present becomes the sum of the posteriors of all genotypes composed of combinations of the reference allele and the star allele.