### PR TITLE
Added requster pays option to germline and somatic CNV WDLs

### DIFF
--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -271,7 +271,7 @@ task CollectCounts {
             --format ~{default="HDF5" hdf5_or_tsv_or_null_format} \
             --interval-merging-rule OVERLAPPING_ONLY \
             --output ~{counts_filename_for_collect_read_counts} \
-            ~{"--gcs-project-for-requester-pays" + gcs_project_for_requester_pays} \
+            ~{"--gcs-project-for-requester-pays " + gcs_project_for_requester_pays} \
             ~{sep=' ' disabled_read_filters_arr}
 
         if [ ~{do_block_compression} = "true" ]; then
@@ -346,7 +346,7 @@ task CollectAllelicCounts {
             --reference ~{ref_fasta} \
             --minimum-base-quality ~{default="20" minimum_base_quality} \
             --output ~{allelic_counts_filename} \
-            ~{"--gcs-project-for-requester-pays" + gcs_project_for_requester_pays}
+            ~{"--gcs-project-for-requester-pays " + gcs_project_for_requester_pays}
     >>>
 
     runtime {

--- a/scripts/cnv_wdl/cnv_common_tasks.wdl
+++ b/scripts/cnv_wdl/cnv_common_tasks.wdl
@@ -192,6 +192,7 @@ task CollectCounts {
       Boolean? enable_indexing
       String? format
       File? gatk4_jar_override
+      String? gcs_project_for_requester_pays
 
       # Runtime parameters
       String gatk_docker
@@ -270,6 +271,7 @@ task CollectCounts {
             --format ~{default="HDF5" hdf5_or_tsv_or_null_format} \
             --interval-merging-rule OVERLAPPING_ONLY \
             --output ~{counts_filename_for_collect_read_counts} \
+            ~{"--gcs-project-for-requester-pays" + gcs_project_for_requester_pays} \
             ~{sep=' ' disabled_read_filters_arr}
 
         if [ ~{do_block_compression} = "true" ]; then
@@ -306,6 +308,7 @@ task CollectAllelicCounts {
       File ref_fasta_dict
       Int? minimum_base_quality
       File? gatk4_jar_override
+      String? gcs_project_for_requester_pays
 
       # Runtime parameters
       String gatk_docker
@@ -342,7 +345,8 @@ task CollectAllelicCounts {
             --input ~{bam} \
             --reference ~{ref_fasta} \
             --minimum-base-quality ~{default="20" minimum_base_quality} \
-            --output ~{allelic_counts_filename}
+            --output ~{allelic_counts_filename} \
+            ~{"--gcs-project-for-requester-pays" + gcs_project_for_requester_pays}
     >>>
 
     runtime {

--- a/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_scattered_workflow.wdl
@@ -40,6 +40,9 @@ workflow CNVGermlineCaseScatteredWorkflow {
       File? gatk4_jar_override
       Int? preemptible_attempts
 
+      # Required if BAM/CRAM is in a requester pays bucket
+      String? gcs_project_for_requester_pays
+
       ####################################################
       #### optional arguments for PreprocessIntervals ####
       ####################################################
@@ -148,6 +151,7 @@ workflow CNVGermlineCaseScatteredWorkflow {
                 gatk_docker = gatk_docker,
                 gatk4_jar_override = gatk4_jar_override,
                 preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays,
                 padding = padding,
                 bin_length = bin_length,
                 disabled_read_filters_for_collect_counts = disabled_read_filters_for_collect_counts,

--- a/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
@@ -50,6 +50,9 @@ workflow CNVGermlineCaseWorkflow {
       File? gatk4_jar_override
       Int? preemptible_attempts
 
+      # Required if BAM/CRAM is in a requester pays bucket
+      String? gcs_project_for_requester_pays
+
       ####################################################
       #### optional arguments for PreprocessIntervals ####
       ####################################################
@@ -157,7 +160,8 @@ workflow CNVGermlineCaseWorkflow {
                 gatk4_jar_override = gatk4_jar_override,
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_counts,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays
         }
     }
 

--- a/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
+++ b/scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
@@ -51,6 +51,9 @@ workflow CNVGermlineCohortWorkflow {
       File? gatk4_jar_override
       Int? preemptible_attempts
 
+      # Required if BAM/CRAM is in a requester pays bucket
+      String? gcs_project_for_requester_pays
+
       ####################################################
       #### optional arguments for PreprocessIntervals ####
       ####################################################
@@ -213,7 +216,8 @@ workflow CNVGermlineCohortWorkflow {
                 gatk4_jar_override = gatk4_jar_override,
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_counts,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays
         }
     }
 

--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -73,6 +73,9 @@ workflow CNVSomaticPairWorkflow {
       # Use as a last resort to increase the disk given to every task in case of ill behaving data
       Int? emergency_extra_disk
 
+      # Required if BAM/CRAM is in a requester pays bucket
+      String? gcs_project_for_requester_pays
+
       ####################################################
       #### optional arguments for PreprocessIntervals ####
       ####################################################
@@ -212,7 +215,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_collect_counts,
             disk_space_gb = collect_counts_tumor_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            gcs_project_for_requester_pays = gcs_project_for_requester_pays
     }
 
     Int collect_allelic_counts_tumor_disk = tumor_bam_size + ref_size + disk_pad
@@ -229,7 +233,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_collect_allelic_counts,
             disk_space_gb = collect_allelic_counts_tumor_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            gcs_project_for_requester_pays = gcs_project_for_requester_pays
     }
 
     Int denoise_read_counts_tumor_disk = read_count_pon_size + ceil(size(CollectCountsTumor.counts, "GB")) + disk_pad

--- a/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
@@ -354,7 +354,8 @@ workflow CNVSomaticPairWorkflow {
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_counts,
                 disk_space_gb = collect_counts_normal_disk,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays
         }
 
         Int collect_allelic_counts_normal_disk = normal_bam_size + ref_size + disk_pad
@@ -371,7 +372,8 @@ workflow CNVSomaticPairWorkflow {
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_allelic_counts,
                 disk_space_gb = collect_allelic_counts_normal_disk,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays
         }
 
         Int denoise_read_counts_normal_disk = read_count_pon_size + ceil(size(CollectCountsNormal.counts, "GB")) + disk_pad

--- a/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
@@ -55,6 +55,9 @@ workflow CNVSomaticPanelWorkflow {
       File? gatk4_jar_override
       Int? preemptible_attempts
 
+      # Required if BAM/CRAM is in a requester pays bucket
+      String? gcs_project_for_requester_pays
+
       ####################################################
       #### optional arguments for PreprocessIntervals ####
       ####################################################

--- a/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
+++ b/scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
@@ -145,7 +145,8 @@ workflow CNVSomaticPanelWorkflow {
                 gatk4_jar_override = gatk4_jar_override,
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_counts,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays
         }
     }
 


### PR DESCRIPTION
Closes #6829
@mwalker174 Could you please review? 

I only added `gcs_project_for_requester_pays` input to tasks that need access to BAMs. Do we also need it for the ones that require reference such as `PreprocessIntervals`? 