### PR TITLE
optionally provide sample-map-file instead of sample-map-table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ script:
   elif [[ $RUN_CNN_WDL == true ]]; then
     echo "Running CNN WDL";
     travis_wait 60 sudo bash scripts/cnn_variant_cromwell_tests/run_cnn_variant_wdl.sh;
-  elif [[ $RUN_VARIANTSTORE_WDL == true ]]; then
+  elif [[ $RUN_VARIANTSTORE_WDL == true && $TRAVIS_SECURE_ENV_VARS == true ]]; then
     echo "Running variantstore WDL";
     travis_wait 60 sudo bash scripts/variantstore_cromwell_tests/run_variantstore_wdl.sh;
   elif [[ $TEST_DOCKER == true ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,9 +148,13 @@ script:
   elif [[ $RUN_CNN_WDL == true ]]; then
     echo "Running CNN WDL";
     travis_wait 60 sudo bash scripts/cnn_variant_cromwell_tests/run_cnn_variant_wdl.sh;
-  elif [[ $RUN_VARIANTSTORE_WDL == true && $TRAVIS_SECURE_ENV_VARS == true ]]; then
-    echo "Running variantstore WDL";
-    travis_wait 60 sudo bash scripts/variantstore_cromwell_tests/run_variantstore_wdl.sh;
+  elif [[ $RUN_VARIANTSTORE_WDL == true ]]; then
+    if [[ $TRAVIS_SECURE_ENV_VARS == true ]]; then
+      echo "Running variantstore WDL";
+      travis_wait 60 sudo bash scripts/variantstore_cromwell_tests/run_variantstore_wdl.sh;
+    else
+      echo "Skipping variantstore tests since google cloud authentication is required.";
+    fi;
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Building docker image and running appropriate tests..." ;
     if [ ${TRAVIS_PULL_REQUEST} != false ]; then

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohort.java
@@ -52,11 +52,11 @@ public class ArrayExtractCohort extends GATKTool {
     private String outputVcfPathString = null;
 
     @Argument(
-            fullName = "project-id",
-            doc = "ID of the Google Cloud project to use when executing queries",
+            fullName = "read-project-id",
+            doc = "ID of the Google Cloud project to use (bill) when reading the microarray data tables",
             optional = false
     )
-    private String projectID = null;
+    private String readProjectID = null;
 
     @Argument(
             fullName = "cohort-sample-table",
@@ -212,7 +212,7 @@ public class ArrayExtractCohort extends GATKTool {
 
         Map<Long, ProbeInfo> probeIdMap;
         if (probeCsvExportFile == null) {
-            probeIdMap = ProbeInfo.getProbeIdMapWithStorageAPI(probeTableName, printDebugInformation);
+            probeIdMap = ProbeInfo.getProbeIdMapWithStorageAPI(probeTableName, printDebugInformation, readProjectID);
         } else {
             probeIdMap = ProbeInfo.getProbeIdMapFromExport(probeCsvExportFile);
         }
@@ -220,13 +220,13 @@ public class ArrayExtractCohort extends GATKTool {
         // if we have a qcMetrics table, augment the probeInfo map with that information
         Map<Long, ProbeQcMetrics> probeQcMetricsMap = null;
         if (qcMetricsTableName != null) {
-            probeQcMetricsMap = ProbeQcMetrics.getProbeQcMetricsWithStorageAPI(qcMetricsTableName);
+            probeQcMetricsMap = ProbeQcMetrics.getProbeQcMetricsWithStorageAPI(qcMetricsTableName, readProjectID);
         }
 
         //ChromosomeEnum.setRefVersion(refVersion);
 
         engine = new ArrayExtractCohortEngine(
-                projectID,
+            readProjectID,
                 vcfWriter,
                 header,
                 annotationEngine,

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohort.java
@@ -54,7 +54,7 @@ public class ArrayExtractCohort extends GATKTool {
     @Argument(
             fullName = "read-project-id",
             doc = "ID of the Google Cloud project to use (bill) when reading the microarray data tables",
-            optional = false
+            optional = true
     )
     private String readProjectID = null;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ArrayExtractCohortEngine.java
@@ -18,7 +18,6 @@ import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEng
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.bigquery.*;
 import org.broadinstitute.hellbender.utils.localsort.SortingCollection;
-import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -44,7 +43,7 @@ public class ArrayExtractCohortEngine {
     private final ReferenceDataSource refSource;
 
     private final ProgressMeter progressMeter;
-    private final String projectID;
+    private final String readProjectId;
 
     /** List of sample names seen in the variant data from BigQuery. */
     private final Map<Integer, String> sampleIdMap;
@@ -65,7 +64,7 @@ public class ArrayExtractCohortEngine {
     final float callRateThreshold;
     final boolean filterInvariants;
 
-    public ArrayExtractCohortEngine(final String projectID,
+    public ArrayExtractCohortEngine(final String readProjectId,
                                     final VariantContextWriter vcfWriter,
                                     final VCFHeader vcfHeader,
                                     final VariantAnnotatorEngine annotationEngine,
@@ -92,7 +91,7 @@ public class ArrayExtractCohortEngine {
                                 
         this.localSortMaxRecordsInRam = localSortMaxRecordsInRam;
 
-        this.projectID = projectID;
+        this.readProjectId = readProjectId;
         this.vcfWriter = vcfWriter;
         this.refSource = refSource;
         this.sampleIdMap = sampleIdMap;
@@ -133,7 +132,7 @@ public class ArrayExtractCohortEngine {
             rowRestriction = "probe_id >= " + minProbeId + " AND probe_id <= " + maxProbeId;
         }
 
-        final StorageAPIAvroReader storageAPIAvroReader = new StorageAPIAvroReader(cohortTableRef, rowRestriction);
+        final StorageAPIAvroReader storageAPIAvroReader = new StorageAPIAvroReader(cohortTableRef, rowRestriction, readProjectId);
         createVariantsFromUngroupedTableResult(storageAPIAvroReader);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ExtractCohortBQ.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/ExtractCohortBQ.java
@@ -28,7 +28,7 @@ public class ExtractCohortBQ {
 
     public static Map<String, ProbeInfo> getProbeNameMap(String fqProbeTableName, boolean printDebugInformation) {
         Map<String, ProbeInfo> results = new HashMap<>();
-        for (final ProbeInfo pi : ProbeInfo.getProbeIdMapWithStorageAPI(fqProbeTableName, printDebugInformation).values()) {
+        for (final ProbeInfo pi : ProbeInfo.getProbeIdMapWithStorageAPI(fqProbeTableName, printDebugInformation, null).values()) {
             results.put(pi.name, pi);
         }
         return results;

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeInfo.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeInfo.java
@@ -101,10 +101,11 @@ public class ProbeInfo {
 
                 probeIdMap.put(p.probeId, p);
             }
+
             return probeIdMap;
         } catch (final Exception e) {
             throw new GATKException("Error processing probe CSV file", e);
-        }        
+        }
     }
 
     public static Map<Long, ProbeInfo> getProbeIdMapWithStorageAPI(String fqProbeTableName, boolean printDebugInformation) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeInfo.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeInfo.java
@@ -108,7 +108,7 @@ public class ProbeInfo {
         }
     }
 
-    public static Map<Long, ProbeInfo> getProbeIdMapWithStorageAPI(String fqProbeTableName, boolean printDebugInformation) {
+    public static Map<Long, ProbeInfo> getProbeIdMapWithStorageAPI(String fqProbeTableName, boolean printDebugInformation, String readProjectId) {
         Map<Long, ProbeInfo> results = new HashMap<>();
 
         TableReference tableRef = new TableReference(fqProbeTableName, ProbeInfoSchema.PROBE_INFO_FIELDS);
@@ -116,7 +116,7 @@ public class ProbeInfo {
         System.out.println("Beginning probe retrieval...");
         long start = System.currentTimeMillis();
 
-        try (final StorageAPIAvroReader reader = new StorageAPIAvroReader(tableRef)) {
+        try (final StorageAPIAvroReader reader = new StorageAPIAvroReader(tableRef, readProjectId)) {
             for ( final GenericRecord row : reader ) {                
                 ProbeInfo p = new ProbeInfo(
                     (Long) row.get(ProbeInfoSchema.PROBE_ID),

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeQcMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/ProbeQcMetrics.java
@@ -20,7 +20,7 @@ public class ProbeQcMetrics {
         this.invariant = invariant;
     }
 
-    public static Map<Long, ProbeQcMetrics> getProbeQcMetricsWithStorageAPI(String fqProbeTableName) {
+    public static Map<Long, ProbeQcMetrics> getProbeQcMetricsWithStorageAPI(String fqProbeTableName, String readProjectId) {
         Map<Long, ProbeQcMetrics> results = new HashMap<>();
 
         TableReference tableRef = new TableReference(fqProbeTableName, ProbeQcMetricsSchema.PROBE_QC_METRIC_FIELDS);
@@ -28,7 +28,7 @@ public class ProbeQcMetrics {
         System.out.println("Beginning probe QC metrics retrieval...");
         long start = System.currentTimeMillis();
 
-        try (final StorageAPIAvroReader reader = new StorageAPIAvroReader(tableRef)) {
+        try (final StorageAPIAvroReader reader = new StorageAPIAvroReader(tableRef, readProjectId)) {
             for ( final GenericRecord row : reader ) {                
                 ProbeQcMetrics p = new ProbeQcMetrics(
                     (Long) row.get(ProbeQcMetricsSchema.PROBE_ID),

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/arrays/tables/SampleList.java
@@ -2,6 +2,11 @@ package org.broadinstitute.hellbender.tools.variantdb.arrays.tables;
 
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.TableResult;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,6 +52,16 @@ public class SampleList {
             results.put((int) row.get(0).getLongValue(), row.get(1).getStringValue());
         }
         return results;
+    }
+
+    public static Map<Integer, String> getSampleIdMap(File cohortSampleFile) {
+        try {
+            return Files.readAllLines(cohortSampleFile.toPath(), StandardCharsets.US_ASCII).stream()
+                .map(s -> s.split(","))
+                .collect(Collectors.toMap(tokens -> Integer.parseInt(tokens[0]), tokens -> tokens[1]));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not parse --cohort-sample-file", e);
+        }
     }
 
     private static TableResult querySampleTable(String fqSampleTableName, String whereClause, boolean printDebugInformation) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.bigquery;
 
 import com.google.api.gax.rpc.ServerStream;
+import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.storage.v1beta1.*;
 import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions.Builder;
 import com.google.common.base.Preconditions;
@@ -50,7 +51,7 @@ public class StorageAPIAvroReader implements GATKAvroReader {
         try {
             this.client = BigQueryStorageClient.create();
 
-            final String parent = String.format("projects/%s", tableRef.tableProject);
+            final String parent = String.format("projects/%s", BigQueryOptions.getDefaultInstance().getProjectId());
 
             final TableReferenceProto.TableReference tableReference = TableReferenceProto.TableReference.newBuilder()
                     .setProjectId(tableRef.tableProject)

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
@@ -42,7 +42,7 @@ public class StorageAPIAvroReader implements GATKAvroReader {
     private GenericRecord nextRow = null;
 
     public StorageAPIAvroReader(final TableReference tableRef) {
-        this(tableRef, null, "");
+        this(tableRef, null, null);
     }
 
     public StorageAPIAvroReader(final TableReference tableRef, String parentProjectId) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
@@ -16,7 +16,6 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 public class StorageAPIAvroReader implements GATKAvroReader {
@@ -43,15 +42,19 @@ public class StorageAPIAvroReader implements GATKAvroReader {
     private GenericRecord nextRow = null;
 
     public StorageAPIAvroReader(final TableReference tableRef) {
-        this(tableRef, null);
+        this(tableRef, null, "");
     }
 
-    public StorageAPIAvroReader(final TableReference tableRef, final String rowRestriction) {
+    public StorageAPIAvroReader(final TableReference tableRef, String parentProjectId) {
+        this(tableRef, null, parentProjectId);
+    }
+
+    public StorageAPIAvroReader(final TableReference tableRef, final String rowRestriction, String parentProjectId) {
 
         try {
             this.client = BigQueryStorageClient.create();
 
-            final String parent = String.format("projects/%s", BigQueryOptions.getDefaultInstance().getProjectId());
+            final String parent = String.format("projects/%s", parentProjectId == null || parentProjectId.isEmpty() ? tableRef.tableProject : parentProjectId);
 
             final TableReferenceProto.TableReference tableReference = TableReferenceProto.TableReference.newBuilder()
                     .setProjectId(tableRef.tableProject)


### PR DESCRIPTION
Changes
- `--cohort-sample-file` can be used instead of `--cohort-sample-table` to provide the (sample_id,sample_name) map
- The Avro reader was changed to set the BQ client's parent to be the current project instead of the destination table's project. This was needed for AoU since our notebook users do not have BQ jobs permissions on the microarray dataset.