### PR TITLE
Fixed typo with "-genelist" argument to "-gene-list" in DepthOfCoverage documentation.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/coverage/DepthOfCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/coverage/DepthOfCoverage.java
@@ -71,7 +71,7 @@ import java.util.*;
  *   -R reference.fasta \
  *   -O file_name_base \
  *   -I input_bams.list
- *   [-geneList refSeq.sorted.refseq] \
+ *   [-gene-list refSeq.sorted.refseq] \
  *   [-partition-type readgroup] \
  *   [--summary-coverage-threshold 4 --summary-coverage-threshold 6 --summary-coverage-threshold 10] \
  *   [-L my_capture_genes.interval_list]


### PR DESCRIPTION
Fixed typo with "-genelist" argument to "-gene-list" in DepthOfCoverage documentation.