### PR TITLE
Update `isInformative` to use the natural log

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
@@ -1092,7 +1092,7 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
         }
 
         public boolean isInformative() {
-            return confidence > LOG_10_INFORMATIVE_THRESHOLD;
+            return confidence > getInformativeThreshold();
         }
     }
 


### PR DESCRIPTION
Mutect adopted natural logarithms in #5858. In the update, it looks like one base 10 log was missed. This PR updates the missed log.