### PR TITLE
Added functionality to better handle indels/spanning deletions in the cigar base quality adjustment code.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -47,10 +47,13 @@ public final class FragmentUtils {
         final Pair<Integer, CigarOperator> offsetAndOperator = ReadUtils.getReadIndexForReferenceCoordinate(firstRead, secondRead.getStart());
         final CigarOperator operator = offsetAndOperator.getRight();
         final int offset = offsetAndOperator.getLeft();
-        if (offset == ReadUtils.READ_INDEX_NOT_FOUND) { // no overlap
+        if (offset == ReadUtils.READ_INDEX_NOT_FOUND || operator.isClipping()) { // no overlap or only overlap in clipped region
             return;
         }
 
+        // Compute the final aligned base indexes for both since there might be right base softclips
+        final int firstReadEndBase = ReadUtils.getReadIndexForReferenceCoordinate(firstRead, firstRead.getEnd()).getLeft();
+        final int secondReadEndBase = ReadUtils.getReadIndexForReferenceCoordinate(secondRead, secondRead.getEnd()).getLeft();
 
         // TODO: we should be careful about the case where {@code operator} is a deletion; that is, when the second read start falls in a deletion of the first read
         // TODO: however, the issue is bigger than simply getting the start correctly, because the code below assumes that all bases of both reads are aligned in their overlap.
@@ -58,31 +61,34 @@ public final class FragmentUtils {
         // TODO: in their overlap and correct the double-counting for all aligned bases.
         // TODO: a cheaper solution would be to cap all quals in the overlap region by half of the PCR qual.
         final int firstReadStop = offset;
-        final int numOverlappingBases = Math.min(firstRead.getLength() - firstReadStop, secondRead.getLength());
+        final int secondOffset = ReadUtils.getReadIndexForReferenceCoordinate(secondRead, secondRead.getStart()).getLeft(); //This operation handles softclipped bases in the qual/base array
+        final int numOverlappingBases = Math.min(firstReadEndBase + 1 - firstReadStop, secondReadEndBase + 1 - secondOffset); // Add 1 here because if R1 ends on the same base that R2 starts then there is 1 base of overlap not 0
 
         final byte[] firstReadBases = firstRead.getBases();
         final byte[] firstReadQuals = firstRead.getBaseQualities();
         final byte[] secondReadBases = secondRead.getBases();
         final byte[] secondReadQuals = secondRead.getBaseQualities();
+        // adjustments to make to handle softclipping bases
 
         final int halfOfPcrErrorQual = halfOfPcrSnvQual.orElse(HALF_OF_DEFAULT_PCR_SNV_ERROR_QUAL);
 
         for (int i = 0; i < numOverlappingBases; i++) {
 
             final int firstReadIndex = firstReadStop + i;
+            final int secondReadIndex = secondOffset + i;
             final byte firstReadBase = firstReadBases[firstReadIndex];
-            final byte secondReadBase = secondReadBases[i];
+            final byte secondReadBase = secondReadBases[secondReadIndex];
 
             if (firstReadBase == secondReadBase) {
                 firstReadQuals[firstReadIndex] = (byte) Math.min(firstReadQuals[firstReadIndex], halfOfPcrErrorQual);
-                secondReadQuals[i] = (byte) Math.min(secondReadQuals[i], halfOfPcrErrorQual);
+                secondReadQuals[secondReadIndex] = (byte) Math.min(secondReadQuals[secondReadIndex], halfOfPcrErrorQual);
             } else if (setConflictingToZero) {
                 // If downstream processing forces read pairs to support the same haplotype, setConflictingToZero should be false
                 // because the original base qualities of conflicting bases, when pegged to the same haplotype, will
                 // automatically weaken the strength of one another's evidence.  Furthermore, if one base if low quality
                 // and one is high it will essentially ignore the low quality base without compromising the high-quality base
                 firstReadQuals[firstReadIndex] = 0;
-                secondReadQuals[i] = 0;
+                secondReadQuals[secondReadIndex] = 0;
             }
         }
         firstRead.setBaseQualities(firstReadQuals);
@@ -97,10 +103,11 @@ public final class FragmentUtils {
 
             for (int i = 0; i < numOverlappingBases; i++) {
                 final int firstReadIndex = firstReadStop + i;
+                final int secondReadIndex = secondOffset + i;
                 firstReadDeletionQuals[firstReadIndex] = (byte) Math.min(firstReadDeletionQuals[firstReadIndex], maxIndelQual);
                 firstReadInsertionQuals[firstReadIndex] = (byte) Math.min(firstReadInsertionQuals[firstReadIndex], maxIndelQual);
-                secondReadDeletionQuals[i] = (byte) Math.min(secondReadDeletionQuals[i], maxIndelQual);
-                secondReadInsertionQuals[i] = (byte) Math.min(secondReadInsertionQuals[i], maxIndelQual);
+                secondReadDeletionQuals[secondReadIndex] = (byte) Math.min(secondReadDeletionQuals[secondReadIndex], maxIndelQual);
+                secondReadInsertionQuals[secondReadIndex] = (byte) Math.min(secondReadInsertionQuals[secondReadIndex], maxIndelQual);
             }
 
             ReadUtils.setDeletionBaseQualities(firstRead, firstReadDeletionQuals);

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -62,13 +62,12 @@ public final class FragmentUtils {
         // TODO: a cheaper solution would be to cap all quals in the overlap region by half of the PCR qual.
         final int firstReadStop = offset;
         final int secondOffset = ReadUtils.getReadIndexForReferenceCoordinate(secondRead, secondRead.getStart()).getLeft(); //This operation handles softclipped bases in the qual/base array
-        final int numOverlappingBases = Math.min(firstReadEndBase + 1 - firstReadStop, secondReadEndBase + 1 - secondOffset); // Add 1 here because if R1 ends on the same base that R2 starts then there is 1 base of overlap not 0
+        final int numOverlappingBases = Math.min(firstReadEndBase - firstReadStop, secondReadEndBase - secondOffset) + 1; // Add 1 here because if R1 ends on the same base that R2 starts then there is 1 base of overlap not 0
 
         final byte[] firstReadBases = firstRead.getBases();
         final byte[] firstReadQuals = firstRead.getBaseQualities();
         final byte[] secondReadBases = secondRead.getBases();
         final byte[] secondReadQuals = secondRead.getBaseQualities();
-        // adjustments to make to handle softclipping bases
 
         final int halfOfPcrErrorQual = halfOfPcrSnvQual.orElse(HALF_OF_DEFAULT_PCR_SNV_ERROR_QUAL);
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
@@ -20,16 +20,16 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
 
     private GATKRead makeOverlappingRead(final String leftFlank, final int leftQual, final String overlapBases,
                                               final byte[] overlapQuals, final String rightFlank, final int rightQual,
-                                              final int alignmentStart) {
+                                              final int alignmentStart, final int leftSoftclip, final int rightSoftclip) {
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
         header.addReadGroup(new SAMReadGroupRecord("RG1"));
         final String bases = leftFlank + overlapBases + rightFlank;
         final int readLength = bases.length();
-        final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "myRead", 0, alignmentStart, readLength);
+        final GATKRead read = ArtificialReadUtils.createArtificialRead(header, "myRead", 0, alignmentStart + leftSoftclip, readLength);
         final byte[] leftQuals = Utils.dupBytes((byte) leftQual, leftFlank.length());
         final byte[] rightQuals = Utils.dupBytes((byte) rightQual, rightFlank.length());
         final byte[] quals = Utils.concat(leftQuals, overlapQuals, rightQuals);
-        read.setCigar(readLength + "M");
+        read.setCigar((leftSoftclip != 0 ? leftSoftclip + "S" : "") + (readLength - rightSoftclip - leftSoftclip) + "M" + (rightSoftclip != 0 ? rightSoftclip + "S" : "") );
         read.setBases(bases.getBytes());
         read.setBaseQualities(quals);
         read.setReadGroup("RG1");
@@ -50,8 +50,8 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
             for ( int i = 0; i < overlapSize; i++ ) {
                 overlappingBaseQuals[i] = HIGH_QUALITY;
             }
-            final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1);
-            final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1);
+            final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, 0 );
+            final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, 0);
             tests.add(new Object[]{read1, read2, overlapSize});
         }
 
@@ -72,6 +72,112 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         for ( int i = 0; i < overlapSize; i++ ) {
             Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
+        for ( int i = overlapSize; i < read2.getLength(); i++ ) {
+            Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
+        }
+    }
+
+
+    // Generate a bunch of reads with softclips that do not overlap with the other read.
+    @DataProvider(name = "AdjustFragmentsTestSoftClipsNotOverlapping")
+    public Object[][] createAdjustFragmentsTestSoftClips() throws Exception {
+        List<Object[]> tests = new ArrayList<>();
+
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
+        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+            for (int leftSoftclip = 0; leftSoftclip <= leftFlank.length(); leftSoftclip++) {
+                for (int rightSoftclip = 0; rightSoftclip <= rightFlank.length(); rightSoftclip++) {
+                    final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
+                    final byte[] overlappingBaseQuals = new byte[overlapSize];
+                    for ( int i = 0; i < overlapSize; i++ ) {
+                        overlappingBaseQuals[i] = HIGH_QUALITY;
+                    }
+                    final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, leftSoftclip, 0);
+                    final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, rightSoftclip);
+                    tests.add(new Object[]{read1, read2, overlapSize});
+                }
+            }
+        }
+        return tests.toArray(new Object[][]{});
+    }
+
+    // Assert that despite the softclips that the reads are being properly
+    @Test(dataProvider = "AdjustFragmentsTestSoftClipsNotOverlapping")
+    public void testAdjustingTwoReadsWithSoftClipping(final GATKRead read1, final GATKRead read2, final int overlapSize) {
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
+
+        for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
+            Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
+        }
+        for ( int i = read1.getLength() - overlapSize; i < read1.getLength(); i++ ) {
+            Assert.assertEquals(read1.getBaseQualities()[i], OVERLAPPING_QUALITY);
+        }
+
+        for ( int i = 0; i < overlapSize; i++ ) {
+            Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
+        }
+        for ( int i = overlapSize; i < read2.getLength(); i++ ) {
+            Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
+        }
+    }
+
+
+    // Generate a bunch of reads with softclips that are overlapping with the other read (and allow for reads with no overlap at all except for softclips)
+    @DataProvider(name = "AdjustFragmentsTestSoftClipsInOverlapRegion")
+    public Object[][] createAdjustFragmentsTestSoftClipsInOverlapRegion() throws Exception {
+        List<Object[]> tests = new ArrayList<>();
+
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
+        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+            for (int leftSoftclip = 0; leftSoftclip <= overlapSize; leftSoftclip++) {
+                for (int rightSoftclip = 0; rightSoftclip <= overlapSize; rightSoftclip++) {
+                    final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
+                    final byte[] overlappingBaseQuals = new byte[overlapSize];
+                    for ( int i = 0; i < overlapSize; i++ ) {
+                        overlappingBaseQuals[i] = HIGH_QUALITY;
+                    }
+                    // Flipped so that the softclips occur in the overlapping region instead
+                    final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, rightSoftclip);
+                    final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, leftSoftclip, 0);
+                    tests.add(new Object[]{read1, rightSoftclip, read2, leftSoftclip, overlapSize});
+                }
+            }
+        }
+        return tests.toArray(new Object[][]{});
+    }
+
+    // Assert that despite the softclips that the reads are being properly
+    @Test(dataProvider = "AdjustFragmentsTestSoftClipsInOverlapRegion")
+    public void testAdjustingTwoReadsWithSoftClippingOverlapingEachother(final GATKRead read1, final int read1Softclips, final GATKRead read2, final int read2Softclips, final int overlapSize) {
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
+
+        // Untouched bases in R1 that don't overlap
+        for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
+            Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
+        }
+        // Bases in R1 that overlap with R2 (before R1 softclips and sans R2 softclips)
+        for ( int i = read1.getLength() - overlapSize + read2Softclips; i < read1.getLength() - read1Softclips; i++ ) {
+            Assert.assertEquals(read1.getBaseQualities()[i], OVERLAPPING_QUALITY);
+        }
+        // Softclipped bases from R1 that did not get adjusted
+        for ( int i = read1.getLength() - read1Softclips ; i < read1.getLength(); i++ ) {
+            Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
+        }
+
+
+        // Softclipped bases from R2 that did not get adjusted
+        for ( int i = 0; i < read2Softclips; i++ ) {
+            Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
+        }
+        // Bases in R2 that overlap with R1 (after R2 softclips adjusted for R1 softclips)
+        for ( int i = read2Softclips; i < overlapSize - read1Softclips; i++ ) {
+            Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
+        }
+        // Bases in R2 that did not overlap at all with R1
         for ( int i = overlapSize; i < read2.getLength(); i++ ) {
             Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
         }

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
@@ -1,10 +1,13 @@
 package org.broadinstitute.hellbender.utils.fragments;
 
+import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
@@ -19,8 +22,8 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
     private static final byte OVERLAPPING_QUALITY = 20;
 
     private GATKRead makeOverlappingRead(final String leftFlank, final int leftQual, final String overlapBases,
-                                              final byte[] overlapQuals, final String rightFlank, final int rightQual,
-                                              final int alignmentStart, final int leftSoftclip, final int rightSoftclip) {
+                                         final byte[] overlapQuals, final String rightFlank, final int rightQual,
+                                         final int alignmentStart, final int leftSoftclip, final int rightSoftclip) {
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
         header.addReadGroup(new SAMReadGroupRecord("RG1"));
         final String bases = leftFlank + overlapBases + rightFlank;
@@ -29,7 +32,7 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         final byte[] leftQuals = Utils.dupBytes((byte) leftQual, leftFlank.length());
         final byte[] rightQuals = Utils.dupBytes((byte) rightQual, rightFlank.length());
         final byte[] quals = Utils.concat(leftQuals, overlapQuals, rightQuals);
-        read.setCigar((leftSoftclip != 0 ? leftSoftclip + "S" : "") + (readLength - rightSoftclip - leftSoftclip) + "M" + (rightSoftclip != 0 ? rightSoftclip + "S" : "") );
+        read.setCigar((leftSoftclip != 0 ? leftSoftclip + "S" : "") + (readLength - rightSoftclip - leftSoftclip) + "M" + (rightSoftclip != 0 ? rightSoftclip + "S" : ""));
         read.setBases(bases.getBytes());
         read.setBaseQualities(quals);
         read.setReadGroup("RG1");
@@ -44,14 +47,14 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         final String leftFlank = "CCC";
         final String rightFlank = "AAA";
         final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
-        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+        for (int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++) {
             final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
             final byte[] overlappingBaseQuals = new byte[overlapSize];
-            for ( int i = 0; i < overlapSize; i++ ) {
+            for (int i = 0; i < overlapSize; i++) {
                 overlappingBaseQuals[i] = HIGH_QUALITY;
             }
-            final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, 0 );
-            final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, 0);
+            final GATKRead read1 = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, 0);
+            final GATKRead read2 = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, 0);
             tests.add(new Object[]{read1, read2, overlapSize});
         }
 
@@ -62,17 +65,17 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
     public void testAdjustingTwoReads(final GATKRead read1, final GATKRead read2, final int overlapSize) {
         FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
 
-        for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
+        for (int i = 0; i < read1.getLength() - overlapSize; i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
         }
-        for ( int i = read1.getLength() - overlapSize; i < read1.getLength(); i++ ) {
+        for (int i = read1.getLength() - overlapSize; i < read1.getLength(); i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
 
-        for ( int i = 0; i < overlapSize; i++ ) {
+        for (int i = 0; i < overlapSize; i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
-        for ( int i = overlapSize; i < read2.getLength(); i++ ) {
+        for (int i = overlapSize; i < read2.getLength(); i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
         }
     }
@@ -86,16 +89,16 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         final String leftFlank = "CCC";
         final String rightFlank = "AAA";
         final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
-        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+        for (int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++) {
             for (int leftSoftclip = 0; leftSoftclip <= leftFlank.length(); leftSoftclip++) {
                 for (int rightSoftclip = 0; rightSoftclip <= rightFlank.length(); rightSoftclip++) {
                     final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
                     final byte[] overlappingBaseQuals = new byte[overlapSize];
-                    for ( int i = 0; i < overlapSize; i++ ) {
+                    for (int i = 0; i < overlapSize; i++) {
                         overlappingBaseQuals[i] = HIGH_QUALITY;
                     }
-                    final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, leftSoftclip, 0);
-                    final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, rightSoftclip);
+                    final GATKRead read1 = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, leftSoftclip, 0);
+                    final GATKRead read2 = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, rightSoftclip);
                     tests.add(new Object[]{read1, read2, overlapSize});
                 }
             }
@@ -108,17 +111,17 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
     public void testAdjustingTwoReadsWithSoftClipping(final GATKRead read1, final GATKRead read2, final int overlapSize) {
         FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
 
-        for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
+        for (int i = 0; i < read1.getLength() - overlapSize; i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
         }
-        for ( int i = read1.getLength() - overlapSize; i < read1.getLength(); i++ ) {
+        for (int i = read1.getLength() - overlapSize; i < read1.getLength(); i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
 
-        for ( int i = 0; i < overlapSize; i++ ) {
+        for (int i = 0; i < overlapSize; i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
-        for ( int i = overlapSize; i < read2.getLength(); i++ ) {
+        for (int i = overlapSize; i < read2.getLength(); i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
         }
     }
@@ -132,17 +135,17 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         final String leftFlank = "CCC";
         final String rightFlank = "AAA";
         final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
-        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+        for (int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++) {
             for (int leftSoftclip = 0; leftSoftclip <= overlapSize; leftSoftclip++) {
                 for (int rightSoftclip = 0; rightSoftclip <= overlapSize; rightSoftclip++) {
                     final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
                     final byte[] overlappingBaseQuals = new byte[overlapSize];
-                    for ( int i = 0; i < overlapSize; i++ ) {
+                    for (int i = 0; i < overlapSize; i++) {
                         overlappingBaseQuals[i] = HIGH_QUALITY;
                     }
                     // Flipped so that the softclips occur in the overlapping region instead
-                    final GATKRead read1  = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, rightSoftclip);
-                    final GATKRead read2  = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, leftSoftclip, 0);
+                    final GATKRead read1 = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, rightSoftclip);
+                    final GATKRead read2 = makeOverlappingRead("", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, leftSoftclip, 0);
                     tests.add(new Object[]{read1, rightSoftclip, read2, leftSoftclip, overlapSize});
                 }
             }
@@ -150,36 +153,94 @@ public class FragmentUtilsUnitTest extends GATKBaseTest {
         return tests.toArray(new Object[][]{});
     }
 
-    // Assert that despite the softclips that the reads are being properly
+    // Assert that despite reads only overlaping eachother in softlcipped bases that the overlapping code gracefully does nothing rather than failing
     @Test(dataProvider = "AdjustFragmentsTestSoftClipsInOverlapRegion")
-    public void testAdjustingTwoReadsWithSoftClippingOverlapingEachother(final GATKRead read1, final int read1Softclips, final GATKRead read2, final int read2Softclips, final int overlapSize) {
+    public void testAdjustingTwoReadsWithSoftClippingOverlappingEachother(final GATKRead read1, final int read1Softclips, final GATKRead read2, final int read2Softclips, final int overlapSize) {
         FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
 
         // Untouched bases in R1 that don't overlap
-        for ( int i = 0; i < read1.getLength() - overlapSize; i++ ) {
+        for (int i = 0; i < read1.getLength() - overlapSize; i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
         }
         // Bases in R1 that overlap with R2 (before R1 softclips and sans R2 softclips)
-        for ( int i = read1.getLength() - overlapSize + read2Softclips; i < read1.getLength() - read1Softclips; i++ ) {
+        for (int i = read1.getLength() - overlapSize + read2Softclips; i < read1.getLength() - read1Softclips; i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
         // Softclipped bases from R1 that did not get adjusted
-        for ( int i = read1.getLength() - read1Softclips ; i < read1.getLength(); i++ ) {
+        for (int i = read1.getLength() - read1Softclips; i < read1.getLength(); i++) {
             Assert.assertEquals(read1.getBaseQualities()[i], HIGH_QUALITY);
         }
 
 
         // Softclipped bases from R2 that did not get adjusted
-        for ( int i = 0; i < read2Softclips; i++ ) {
+        for (int i = 0; i < read2Softclips; i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
         }
         // Bases in R2 that overlap with R1 (after R2 softclips adjusted for R1 softclips)
-        for ( int i = read2Softclips; i < overlapSize - read1Softclips; i++ ) {
+        for (int i = read2Softclips; i < overlapSize - read1Softclips; i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], OVERLAPPING_QUALITY);
         }
         // Bases in R2 that did not overlap at all with R1
-        for ( int i = overlapSize; i < read2.getLength(); i++ ) {
+        for (int i = overlapSize; i < read2.getLength(); i++) {
             Assert.assertEquals(read2.getBaseQualities()[i], HIGH_QUALITY);
         }
     }
+
+    @Test
+    // This test asserts that that a read with an indel at its end will will have the correct bases examined for qualities
+    public void testLeadingIndelBehaviorForOverlappingReads() {
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String allOverlappingBases = "ACGT";
+
+        final String overlappingBases = allOverlappingBases.substring(0, 4);
+        final byte[] overlappingBaseQuals = new byte[]{HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY};
+
+        // Flipped so that the softclips occur in the overlapping region instead
+        final GATKRead read1 = makeOverlappingRead(leftFlank, HIGH_QUALITY, overlappingBases, overlappingBaseQuals, "", HIGH_QUALITY, 1, 0, 0);
+        final GATKRead read2 = makeOverlappingRead("T", HIGH_QUALITY, overlappingBases, overlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, 0);
+
+        // Add a leading indel to the second cigar (which could happen in HaplotypeCaller due to the clipping operations that happen in the asssembly region)
+        read2.setCigar("1I7M");
+
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
+
+        //Expected Qualities for reads:
+        final byte[] read1Expected = new byte[]{HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY};
+        final byte[] read2Expected = new byte[]{HIGH_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY};
+
+        Assert.assertEquals(read1.getBaseQualities(), read1Expected);
+        Assert.assertEquals(read2.getBaseQualities(), read2Expected);
+    }
+
+    @Test
+    // This test exists to document the current indel behavior, this should be changed to reflect whatever approach is chosen when https://github.com/broadinstitute/gatk/issues/6890 is addressed
+    public void testIndelBehaviorForOverlappingReads() {
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String read1OverlappingRegion = "ACGTTG";
+        final String read2OverlappingRegion = "ACGAATTG"; // 2 A bases inserted in the matched region on read 2
+
+        final byte[] read1OverlappingBaseQuals = new byte[]{HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY};
+        final byte[] read2OverlappingBaseQuals = new byte[]{HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY};
+
+        // Flipped so that the softclips occur in the overlapping region instead
+        final GATKRead read1 = makeOverlappingRead(leftFlank, HIGH_QUALITY, read1OverlappingRegion, read1OverlappingBaseQuals, "", HIGH_QUALITY, 1, 0, 0);
+        final GATKRead read2 = makeOverlappingRead("", HIGH_QUALITY, read2OverlappingRegion, read2OverlappingBaseQuals, rightFlank, HIGH_QUALITY, leftFlank.length() + 1, 0, 0);
+
+        // add a cigar to read 2 reflecting the 2 inserted bases
+        read2.setCigar("3M2I6M");
+
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(ImmutablePair.of(read1, read2), true, OptionalInt.empty(), OptionalInt.empty());
+
+        //Expected Qualities for reads:
+        // NOTE: these merely reflect the current flawed behavior where the cigar is not taken into account when evaluating matched bases.
+        final byte[] read1Expected = new byte[]{HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, 0, 0, 0};
+        final byte[] read2Expected = new byte[]{OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, OVERLAPPING_QUALITY, 0, 0, 0, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY, HIGH_QUALITY};
+        // NOTE: how the TTG bases at positions 7-9 on the reference are zeroed out on read 1 but on read 2 only position 7 (and not 8 or 9) are zeroed out due to the 2 base insertion in read 2.
+
+        Assert.assertEquals(read1.getBaseQualities(), read1Expected);
+        Assert.assertEquals(read2.getBaseQualities(), read2Expected);
+    }
+
 }


### PR DESCRIPTION
I have observed the method adjustQualsOfOverlappingPairedFragments() has a tendency to penalize reads that might have indels relative to each-other. This branch aims to better handle the edge cases that come up when mates have mismatching numbers of bases at the start or end of the reads relative to each-other. As part of #6634 I fixed this behavior somewhat and I am pulling this out into a separate branch in order to ease the comparison for that PR. 