### PR TITLE
Update Mutect2's filtering

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/Mutect2FilteringEngine.java
@@ -232,7 +232,7 @@ public class Mutect2FilteringEngine {
         // this will not change the status of whether a variant is actually filtered or not
         final double maxErrorProb = siteFiltersWithErrorProb.values().stream().mapToDouble(p->p).max().orElse(1);
         siteFiltersWithErrorProb.entrySet().stream().forEach(entry -> {
-            if (entry.getValue() >= Math.min(maxErrorProb, MIN_REPORTABLE_ERROR_PROBABILITY)) {
+            if (entry.getValue() >= Math.max(maxErrorProb, MIN_REPORTABLE_ERROR_PROBABILITY)) {
                 vcb.filter(entry.getKey());
             }
         });

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/StrictStrandBiasFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/StrictStrandBiasFilter.java
@@ -31,7 +31,7 @@ public class StrictStrandBiasFilter extends HardAlleleFilter {
             sbs = GATKVariantContextUtils.removeDataForSymbolicAlleles(vc, sbs);
         }
         // skip the reference
-        return sbs.subList(1, sbs.size()).stream().map(altList -> altList.stream().anyMatch(x -> x == 0)).collect(Collectors.toList());
+        return sbs.subList(1, sbs.size()).stream().map(altList -> altList.stream().anyMatch(x -> x <= minReadsOnEachStrand)).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
This PR makes two changes to Mutect2's filtering.

1. The first change updates `Math.min` to `Math.max` in `applyFiltersAndAccumulateOutputStats()`, which is probably the intended behavior. Unfortunately, this update breaks some of the integration tests at `org.broadinstitute.hellbender.tools.walkers.readorientation.LearnReadOrientationModelIntegrationTest.testOnRealBam`. I'm not quite sure how the dev team would prefer to handle the failed tests, so I thought I'd raise the issue here.

2. In `StrictStrandBiasFilter`, the argument `minReadsOnEachStrand` is not used in the `areAllelesArtifacts()` function. The second update turns on the `minReadsOnEachStrand` argument rather than using the default of 0.