### PR TITLE
Added version number to dockstore yml file

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,3 +1,4 @@
+version: 1.2
 workflows:
    - name: cnv_germline_case_workflow
      subclass: WDL


### PR DESCRIPTION
The dockstore yml file requires the version number at the top of file which was missing in the initial PR. 
Stated by dockstore team in the following thread [here](https://discuss.dockstore.org/t/setting-up-dockstore-app-with-existing-workflows/3932/2) and dockstore docs [here](https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html).