### PR TITLE
fixed an error where the read mate key in SplitNCigarReads was not sufficiently strict about readnames causing cigar errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,12 +182,12 @@ script:
   docker login --username=$DOCKER_SERVICE_LOGIN --password=$DOCKER_SERVICE_PASS;
   $GCLOUD_HOME/gcloud components -q update gsutil;
   gsutil ls -l gs://gatk-nightly-builds | grep gatk | sort -r -k 2 | grep -o '\S\+$' | tail -n +11 | xargs -I {} gsutil rm {};
-  sudo ./gradlew bundle;
+  ./gradlew bundle;
   ZIP_FILE="$(ls build/ | grep '^gatk.*.zip$' | grep -iv python)";
   echo "Uploading zip to gs://gatk-nightly-builds/";
   $GCLOUD_HOME/gsutil -m cp build/$ZIP_FILE gs://gatk-nightly-builds/"$(date +%Y-%m-%d)"-$ZIP_FILE;
 
-  sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u;
+  bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u;
   DOCKER_TAG=$(docker images -q | head -n 1);
   DATE=$(date +%Y-%m-%d);
   DOCKER_NIGHTLY_TAG=broadinstitute/gatk-nightly:$DATE-$(git describe)-NIGHTLY-SNAPSHOT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,12 +182,12 @@ script:
   docker login --username=$DOCKER_SERVICE_LOGIN --password=$DOCKER_SERVICE_PASS;
   $GCLOUD_HOME/gcloud components -q update gsutil;
   gsutil ls -l gs://gatk-nightly-builds | grep gatk | sort -r -k 2 | grep -o '\S\+$' | tail -n +11 | xargs -I {} gsutil rm {};
-  ./gradlew bundle;
+  sudo ./gradlew bundle;
   ZIP_FILE="$(ls build/ | grep '^gatk.*.zip$' | grep -iv python)";
   echo "Uploading zip to gs://gatk-nightly-builds/";
   $GCLOUD_HOME/gsutil -m cp build/$ZIP_FILE gs://gatk-nightly-builds/"$(date +%Y-%m-%d)"-$ZIP_FILE;
 
-  bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u;
+  sudo bash build_docker.sh  -e ${TRAVIS_COMMIT} -s -u;
   DOCKER_TAG=$(docker images -q | head -n 1);
   DATE=$(date +%Y-%m-%d);
   DOCKER_NIGHTLY_TAG=broadinstitute/gatk-nightly:$DATE-$(git describe)-NIGHTLY-SNAPSHOT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,14 +110,14 @@ install:
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Skip the install because we're doing a docker build";
   else
-    ./gradlew assemble;
-    ./gradlew installDist;
+    sudo ./gradlew assemble;
+    sudo ./gradlew installDist;
     if [[ $RUN_CNV_GERMLINE_COHORT_WDL == true || $RUN_CNV_GERMLINE_CASE_WDL == true || $RUN_CNV_SOMATIC_WDL == true || $RUN_M2_WDL == true || $RUN_CNN_WDL == true ]]; then
       echo "building a shadow jar for the wdl";
-      ./gradlew shadowJar;
+      sudo ./gradlew shadowJar;
     elif [[ $TEST_TYPE == cloud ]]; then
       echo "building a spark jar for the dataproc tests";
-      ./gradlew sparkjar;
+      sudo ./gradlew sparkjar;
     fi;
   fi;
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,14 +110,14 @@ install:
   elif [[ $TEST_DOCKER == true ]]; then
     echo "Skip the install because we're doing a docker build";
   else
-    sudo ./gradlew assemble;
-    sudo ./gradlew installDist;
+    ./gradlew assemble;
+    ./gradlew installDist;
     if [[ $RUN_CNV_GERMLINE_COHORT_WDL == true || $RUN_CNV_GERMLINE_CASE_WDL == true || $RUN_CNV_SOMATIC_WDL == true || $RUN_M2_WDL == true || $RUN_CNN_WDL == true ]]; then
       echo "building a shadow jar for the wdl";
-      sudo ./gradlew shadowJar;
+      ./gradlew shadowJar;
     elif [[ $TEST_TYPE == cloud ]]; then
       echo "building a spark jar for the dataproc tests";
-      sudo ./gradlew sparkjar;
+      ./gradlew sparkjar;
     fi;
   fi;
 script:

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManager.java
@@ -422,9 +422,11 @@ public class OverhangFixingManager {
         }
     }
 
-    // Generates the string key to be used for
-    private static String makeKey(String name, boolean firstOfPair, int mateStart) {
-        return name + (firstOfPair ? 1 : 0) + mateStart;
+    // Generates the string key to be used for storing mates that had their cigar strings changed between iterations over the input reads
+    @VisibleForTesting
+    static String makeKey(String name, boolean firstOfPair, int mateStart) {
+        // NOTE: We use the '@' character here because it is explicitly forbidden for use in read names by the SAM Spec and we don't want to risk accidental matches across read pairs
+        return name + "@" +  (firstOfPair ? 1 : 0) + "@" + mateStart;
     }
     /**
      * Will edit the mate MC tag and mate start position field for given read if that read has been recorded being edited

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/OverhangFixingManagerUnitTest.java
@@ -202,6 +202,20 @@ public final class OverhangFixingManagerUnitTest extends GATKBaseTest {
     }
 
     @Test
+    // Test asserting that the failure found in https://github.com/broadinstitute/gatk/issues/6776 has been fixed
+    public void testIncidentalMatchFromReportedFailure() {
+        GATKRead read1 = ArtificialReadUtils.createArtificialRead(hg19Header, "RR.6123", 1, 3500, 100);
+        read1.setIsFirstOfPair();
+        GATKRead read2 = ArtificialReadUtils.createArtificialUnmappedRead(hg19Header, new byte[]{(byte)'A'}, new byte[]{(byte)'A'});
+        read2.setName("RR.6123135");
+        read2.setIsSecondOfPair();
+
+        // Asserting that in the case of reads that end with widely ranged numbers it is no longer possible to incidentally overlap in key generation
+        Assert.assertNotEquals( OverhangFixingManager.makeKey(read1.getName(), read1.isFirstOfPair(), read1.getStart()),
+                                OverhangFixingManager.makeKey(read2.getName(), read2.isFirstOfPair(), read2.getStart()));
+    }
+
+    @Test
     public void testMappingReadMateRepairNoMCTag() {
         final OverhangFixingManager manager = new OverhangFixingManagerAlwaysSplit10000Reads(getHG19Header(), null, hg19GenomeLocParser, hg19ReferenceReader, 10000, 1, 40, false, false);
         GATKRead read1a = ArtificialReadUtils.createArtificialRead(hg19Header, "read1", 1, 10000, "AAAAAA".getBytes(), "AAAAAA".getBytes(), "6M");


### PR DESCRIPTION
Fixes #6776 
