### PR TITLE
Added GitHub Actions workflow file for CARROT integration

### DIFF
--- a/.github/workflows/carrot_run_test_from_pr_comment.yml
+++ b/.github/workflows/carrot_run_test_from_pr_comment.yml
@@ -1,0 +1,15 @@
+name: carrot-test-run-from-pr-comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  publish-test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Parse comment
+        uses: broadinstitute/carrot-publish-github-action@v0.3.0-beta
+        with:
+          software-name: gatk
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          topic-name: ${{ secrets.CARROT_TOPIC_NAME }}
+          sa-key: ${{ secrets.CARROT_SA_KEY }}


### PR DESCRIPTION
Added a workflow file for enabling the GitHub Action which processes PR comments to determine if they are meant to trigger and CARROT test, and then processes them if they are formatted in that way.

BIG IMPORTANT NOTE: Before this is merged, we need to set two secrets for this repo:
- `CARROT_TOPIC_NAME`, which is the name of the Google Cloud PubSub topic that messages will be sent to if a comment should trigger a run, and
- `CARROT_SA_KEY`, which is the service account key JSON for the service account that has write access to the PubSub topic.
If this is merged before those are set, I'm fairly confident we're just gonna get an email saying the action failed each time someone posts a PR comment (CARROT or otherwise), which would be less than ideal.

Closes #6916 