### PR TITLE
Fixed typo in conda environment YML documentation.

### DIFF
--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -23,7 +23,7 @@ dependencies:
 - pip=20.0.2                        # specifying channel may cause a warning to be emitted by conda
 - conda-forge::mkl=2019.5           # MKL typically provides dramatic performance increases for theano, tensorflow, and other key dependencies
 - conda-forge::mkl-service=2.3.0
-- conda-forge::numpy=1.17.5         # do not update, this will break scipy=0.19.1
+- conda-forge::numpy=1.17.5         # do not update, this will break scipy=1.0.0
                                     #   verify that numpy is compiled against MKL (e.g., by checking *_mkl_info using numpy.show_config())
                                     #   and that it is used in tensorflow, theano, and other key dependencies
 - conda-forge::theano=1.0.4         # it is unlikely that new versions of theano will be released


### PR DESCRIPTION
Let me double check this and expand if necessary.