### PR TITLE
Update phasingString so it is unique across contigs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilteredHaplotypeFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilteredHaplotypeFilter.java
@@ -34,7 +34,7 @@ public class FilteredHaplotypeFilter extends Mutect2VariantFilter {
                 .max(Comparator.comparingDouble(g -> MathUtils.arrayMax(VariantContextGetters.getAttributeAsDoubleArray(g, VCFConstants.ALLELE_FREQUENCY_KEY,
                         () -> new double[] {0.0}, 0.0)))).get();
 
-        final Optional<String> phasingString = makePhasingString(tumorGenotype);
+        final Optional<String> phasingString = makePhasingString(vc.getContig(), tumorGenotype);
         if (!phasingString.isPresent()) {
             return 0.0;
         }
@@ -66,7 +66,7 @@ public class FilteredHaplotypeFilter extends Mutect2VariantFilter {
                 continue;
             }
 
-            final Optional<String> phasingString = makePhasingString(tumorGenotype);
+            final Optional<String> phasingString = makePhasingString(vc.getContig(), tumorGenotype);
 
             if (!phasingString.isPresent()) {
                 continue;
@@ -104,9 +104,9 @@ public class FilteredHaplotypeFilter extends Mutect2VariantFilter {
     public Optional<String> phredScaledPosteriorAnnotationName() { return Optional.empty(); }
 
     // concatenate the PGT and PID strings, if present
-    private static Optional<String> makePhasingString(final Genotype genotype) {
+    private static Optional<String> makePhasingString(final String contig, final Genotype genotype) {
         final String pgt = (String) genotype.getExtendedAttribute(GATKVCFConstants.HAPLOTYPE_CALLER_PHASING_GT_KEY, null);
         final String pid = (String) genotype.getExtendedAttribute(GATKVCFConstants.HAPLOTYPE_CALLER_PHASING_ID_KEY, null);
-        return (pgt == null || pid == null) ? Optional.empty() : Optional.of(pgt + pid);
+        return (pgt == null || pid == null) ? Optional.empty() : Optional.of(pgt + pid + contig);
     }
 }


### PR DESCRIPTION
In `makePhasingString` of `FilteredHaplotypeFilter.java`, the phase string is built through the concatenation of PGT and PID. However, PGT and PID are not always sufficient to uniquely identify a haplotype. This PR adds the contig to ensure that the returned `phasingString` is unique.