### PR TITLE
Ensure that the last quantile is added to SomaticClusteringModel

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/clustering/SomaticClusteringModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/clustering/SomaticClusteringModel.java
@@ -236,7 +236,7 @@ public class SomaticClusteringModel {
         for (int n = 0; n < data.size(); n++) {
             cumulativeProb += alleleFractionsAndSomaticProbs.get(n).getRight();
 
-            if (cumulativeProb > quantileProb) {
+            if (cumulativeProb > quantileProb ||  n == data.size()-1) {
                 alleleFractionQuantilesList.add(alleleFractionsAndSomaticProbs.get(n).getLeft());
                 while (cumulativeProb > quantileProb) {
                     quantileProb += quantileStep;


### PR DESCRIPTION
In `calculateAlleleFractionQuantiles()` of SomaticClusteringModel.java, the last quantile may be lost due to the comparison of two "identical" floating point numbers. This PR ensures that the last quantile is not lost.