### PR TITLE
Pin h5py version to 2.10.0.

### DIFF
--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -32,6 +32,7 @@ dependencies:
                                     #   verify that this is using numpy compiled against MKL (e.g., by checking tensorflow.pywrap_tensorflow.IsMklEnabled())
 - conda-forge::scipy=1.0.0          # do not update, this will break a scipy.misc.logsumexp import (deprecated in scipy=1.0.0) in pymc3=3.1
 - conda-forge::pymc3=3.1            # do not update, this will break gcnvkernel
+- conda-forge::h5py=2.10.0          # required by keras 2.2.4
 - conda-forge::keras=2.2.4          # updated from pip-installed 2.2.0, which caused various conflicts/clobbers of conda-installed packages
                                     #   conda-installed 2.2.4 appears to be the most recent version with a consistent API and without conflicts/clobbers
                                     #   if you wish to update, note that versions of conda-forge::keras after 2.2.5

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -51,6 +51,7 @@ dependencies:
 - r-gplots=3.0.3
 - r-gsalib=2.1
 - r-optparse=1.6.4
+- r-backports=1.1.10
 
 # other python dependencies; these should be removed after functionality is moved into Java code
 - biopython=1.76

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
@@ -24,11 +24,15 @@ public class PythonEnvironmentIntegrationTest {
                 { "scipy",          "1.0.0" },
                 { "pymc3",          "3.1" },
                 { "keras",          "2.2.4" },
+                { "h5py",           "2.10.0" },
                 { "sklearn",        "0.22.2.post1" },
                 { "matplotlib",     "3.2.1" },
                 { "pandas",         "1.0.3" },
                 { "argparse",       null },
-                { "gcnvkernel",     null }
+                { "gcnvkernel",     null },
+                // R packages
+                { "r-backports",    "1.1.10" },
+
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
@@ -30,9 +30,10 @@ public class PythonEnvironmentIntegrationTest {
                 { "pandas",         "1.0.3" },
                 { "argparse",       null },
                 { "gcnvkernel",     null },
-                // R packages
-                { "r-backports",    "1.1.10" },
 
+                // R packages
+                // Commented out since we can't check versions of R packages in this test
+                // { "r-backports",    "1.1.10" },
         };
     }
 


### PR DESCRIPTION
It looks like the conda env recently started resolving h5py to v3.1.0, which in turn appears to be incompatible with the keras version we're using, causing the CNNScoreVariants integration tests to fail when keras tries to load the model file (see https://github.com/tensorflow/tensorflow/issues/44467). This PR pins the version to the version used by the last build I could find that succeeded, which is 2.10.0.