### PR TITLE
Sharded VCF output option

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -28,6 +28,7 @@ public final class StandardArgumentDefinitions {
     public static final String CREATE_OUTPUT_BAM_MD5_LONG_NAME = "create-output-bam-md5";
     public static final String CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME = "create-output-variant-index";
     public static final String CREATE_OUTPUT_VARIANT_MD5_LONG_NAME = "create-output-variant-md5";
+    public static final String MAX_VARIANTS_PER_SHARD_LONG_NAME = "max-variants-per-shard";
     public static final String METRIC_ACCUMULATION_LEVEL_LONG_NAME = "metric-accumulation-level";
     public static final String CLOUD_PREFETCH_BUFFER_LONG_NAME = "cloud-prefetch-buffer";
     public static final String CLOUD_INDEX_PREFETCH_BUFFER_LONG_NAME = "cloud-index-prefetch-buffer";

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Stream;
+
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
@@ -43,6 +44,7 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.broadinstitute.hellbender.utils.variant.writers.ShardingVCFWriter;
 
 /**
  * Base class for all GATK tools. Tool authors that wish to write a "GATK" tool but not use one of
@@ -92,6 +94,10 @@ public abstract class GATKTool extends CommandLineProgram {
             shortName=StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_MD5_SHORT_NAME,
             doc = "If true, create a a MD5 digest any VCF file created.", optional=true, common = true)
     public boolean createOutputVariantMD5 = false;
+
+    @Argument(fullName = StandardArgumentDefinitions.MAX_VARIANTS_PER_SHARD_LONG_NAME, optional = true, minValue = 0, common = true,
+            doc = "If non-zero, partitions VCF output into shards, each containing up to the given number of records.")
+    private int maxVariantsPerShard = 0;
 
     @Argument(fullName= StandardArgumentDefinitions.LENIENT_LONG_NAME,
             shortName = StandardArgumentDefinitions.LENIENT_SHORT_NAME,
@@ -889,6 +895,14 @@ public abstract class GATKTool extends CommandLineProgram {
             options.add(Options.DO_NOT_WRITE_GENOTYPES);
         }
 
+        if (maxVariantsPerShard > 0) {
+            return new ShardingVCFWriter(
+                    outPath,
+                    maxVariantsPerShard,
+                    sequenceDictionary,
+                    createOutputVariantMD5,
+                    options.toArray(new Options[options.size()]));
+        }
         return GATKVariantContextUtils.createVCFWriter(
                 outPath,
                 sequenceDictionary,

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -1054,4 +1054,24 @@ public final class IOUtils {
     public static Path fileToPath(File toConvert) {
         return (null == toConvert ? null : toConvert.toPath());
     }
+
+
+    /**
+     * Strips extension from the given path, if it has one. Note it will use the first matching extension in the list.
+     *
+     * @param path Path to modify. May not be null.
+     * @param extensions Possible extensions to remove, in order of priority
+     * @return Resulting path
+     */
+    public static Path removeExtension(final Path path, final List<String> extensions) {
+        Utils.nonNull(path);
+        Utils.nonNull(extensions);
+        final String pathString = path.toString();
+        for (final String testExtension : extensions) {
+            if (pathString.endsWith(testExtension)) {
+                return Paths.get(pathString.substring(0, pathString.length() - testExtension.length()));
+            }
+        }
+        return path;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriter.java
@@ -1,0 +1,161 @@
+package org.broadinstitute.hellbender.utils.variant.writers;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.vcf.VCFHeader;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Variant writer tha splits output to multiple VCFs given the maximum records per file. Before using {@link #add},
+ * the header should be set using either {@link #setHeader} or {@link #writeHeader}, which may only be called once
+ * and will determine whether headers are written to all shards.
+ *
+ * @author Mark Walker &lt;markw@broadinstitute.org&gt;
+ */
+public class ShardingVCFWriter implements VariantContextWriter {
+
+    public static final String SHARD_INDEX_PREFIX = ".shard_";
+    public static final String SHARD_INDEX_SUFFIX = FileExtensions.COMPRESSED_VCF;
+
+    private VariantContextWriter writer;
+    private VCFHeader header;
+    private final int maxVariantsPerShard;
+    private final Path basePath;
+    private final SAMSequenceDictionary dictionary;
+    private final boolean createMD5;
+    private final Options[] options;
+
+    /** Current shard  */
+    private int shardIndex;
+    /** Number of records written to current shard  */
+    private int shardSize;
+     /** Whether to write header, or null if header is undefined */
+    private Boolean enableWriteHeader;
+
+    /**
+     * Create a new sharding VCF writer
+     *
+     * @param basePath              base path of the output VCFs. The shard designation and file extension will be added.
+     * @param maxVariantsPerShard   max number of records per file (last shard may have less)
+     * @param dictionary            sequence dictionary for this writer
+     * @param createMD5             enable MD5 file creation
+     * @param options               vcf writer options
+     */
+    public ShardingVCFWriter(final Path basePath,
+                             final int maxVariantsPerShard,
+                             final SAMSequenceDictionary dictionary,
+                             final boolean createMD5,
+                             final Options... options) {
+        Utils.nonNull(basePath);
+        Utils.validateArg(maxVariantsPerShard > 0, "maxVariantsPerShard must be positive");
+        this.basePath = IOUtils.removeExtension(basePath, FileExtensions.VCF_LIST);
+        this.maxVariantsPerShard = maxVariantsPerShard;
+        this.dictionary = dictionary;
+        this.createMD5 = createMD5;
+        this.options = options;
+
+        // Initialize first shard
+        this.shardIndex = 0;
+        this.shardSize = 0;
+        this.writer = createNewWriter();
+    }
+
+    /**
+     * Initializes a new sharded file.
+     */
+    protected void createNextShard() {
+        writer.close();
+        shardIndex++;
+        shardSize = 0;
+        writer = createNewWriter();
+        Utils.nonNull(header, "Attempted to create new shard before header has been set");
+        initializeShardHeader();
+    }
+
+    /**
+     * Initializes shard header depending on which header function (set or write) was used
+     */
+    protected void initializeShardHeader() {
+        if (enableWriteHeader != null) {
+            if (enableWriteHeader.booleanValue()) {
+                writer.writeHeader(header);
+            } else {
+                writer.setHeader(header);
+            }
+        }
+    }
+
+    /**
+     * Creates a writer for a new shard
+     *
+     * @return the new writer
+     */
+    protected VariantContextWriter createNewWriter() {
+        final Path outPath = Paths.get(basePath + SHARD_INDEX_PREFIX + shardIndex + SHARD_INDEX_SUFFIX);
+        return GATKVariantContextUtils.createVCFWriter(
+                outPath,
+                dictionary,
+                createMD5,
+                options);
+    }
+
+    /**
+     * Defines header for the writer. The header will not be written to any shards. May only be called once and only
+     * if {@link #writeHeader} has not been called.
+     *
+     * @param header header to use
+     */
+    @Override
+    public void setHeader(final VCFHeader header) {
+        Utils.validate(this.header == null, "Cannot redefine header");
+        this.header = header;
+        enableWriteHeader = Boolean.FALSE;
+        writer.setHeader(header);
+    }
+
+    /**
+     * Defines header for the writer that will be written to all shards. May only be called once and only
+     * if {@link #setHeader} has not been called.
+     *
+     * @param header header to use
+     */
+    @Override
+    public void writeHeader(final VCFHeader header) {
+        Utils.validate(this.header == null, "Cannot redefine header");
+        this.header = header;
+        enableWriteHeader = Boolean.TRUE;
+        writer.writeHeader(header);
+    }
+
+    @Override
+    public void close() {
+        writer.close();
+    }
+
+    @Override
+    public boolean checkError() {
+        return writer.checkError();
+    }
+
+    /**
+     * Adds variant to writer. Note that a header must be assigned first.
+     *
+     * @param vc variant to write
+     */
+    @Override
+    public void add(final VariantContext vc) {
+        if (shardSize + 1 > maxVariantsPerShard) {
+            createNextShard();
+        }
+        writer.add(vc);
+        shardSize++;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriter.java
@@ -99,12 +99,23 @@ public class ShardingVCFWriter implements VariantContextWriter {
      * @return the new writer
      */
     protected VariantContextWriter createNewWriter() {
-        final Path outPath = Paths.get(basePath + SHARD_INDEX_PREFIX + shardIndex + SHARD_INDEX_SUFFIX);
+        final Path outPath = Paths.get(getShardFilename(basePath, shardIndex));
         return GATKVariantContextUtils.createVCFWriter(
                 outPath,
                 dictionary,
                 createMD5,
                 options);
+    }
+
+    /**
+     * Gets filepath for the given shard and base path
+     *
+     * @param basePath path without extension
+     * @param shardIndex
+     * @return path as String
+     */
+    public static String getShardFilename(final Path basePath, final int shardIndex) {
+        return String.format("%s%s%05d%s", basePath, SHARD_INDEX_PREFIX, shardIndex, SHARD_INDEX_SUFFIX);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
@@ -81,8 +81,9 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
         runCommandLine(Arrays.asList(args), SelectVariants.class.getSimpleName());
 
         // 11 total records in the test input should create 2 vcf shards with 10 and 1 records
-        final String firstShard = Paths.get(outDir, fileBase + ShardingVCFWriter.SHARD_INDEX_PREFIX + "0" + ShardingVCFWriter.SHARD_INDEX_SUFFIX).toString();
-        final String secondShard = Paths.get(outDir, fileBase + ShardingVCFWriter.SHARD_INDEX_PREFIX + "1" + ShardingVCFWriter.SHARD_INDEX_SUFFIX).toString();
+        final Path basePath = Paths.get(outDir, fileBase).toAbsolutePath();
+        final String firstShard = ShardingVCFWriter.getShardFilename(basePath, 0);
+        final String secondShard = ShardingVCFWriter.getShardFilename(basePath, 1);
         final Pair<VCFHeader, List<VariantContext>> firstResults = VariantContextTestUtils.readEntireVCFIntoMemory(firstShard);
         final Pair<VCFHeader, List<VariantContext>> secondResults = VariantContextTestUtils.readEntireVCFIntoMemory(secondShard);
         Assert.assertEquals(firstResults.getValue().size(), 10, "First shard has wrong number of records");

--- a/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
@@ -1,15 +1,17 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.tools.walkers.mutect.Mutect2;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
-import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.variant.writers.ShardingVCFWriter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
@@ -63,5 +66,26 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
         };
 
         runCommandLine(Arrays.asList(args), Mutect2.class.getSimpleName());
+    }
+
+    @Test
+    public void testSharding() {
+        final String outDir = createTempDir("GTShardedOutput").getAbsolutePath();
+        final String fileBase = "test";
+        final String out = Paths.get(outDir, fileBase + FileExtensions.COMPRESSED_VCF).toString();
+        final String[] args = new String[] {
+                "-V",  TEST_DIRECTORY + "example_variants_withSequenceDict.vcf",
+                "-R", hg19MiniReference,
+                "--" + StandardArgumentDefinitions.MAX_VARIANTS_PER_SHARD_LONG_NAME, "10",
+                "-O", out};
+        runCommandLine(Arrays.asList(args), SelectVariants.class.getSimpleName());
+
+        // 11 total records in the test input should create 2 vcf shards with 10 and 1 records
+        final String firstShard = Paths.get(outDir, fileBase + ShardingVCFWriter.SHARD_INDEX_PREFIX + "0" + ShardingVCFWriter.SHARD_INDEX_SUFFIX).toString();
+        final String secondShard = Paths.get(outDir, fileBase + ShardingVCFWriter.SHARD_INDEX_PREFIX + "1" + ShardingVCFWriter.SHARD_INDEX_SUFFIX).toString();
+        final Pair<VCFHeader, List<VariantContext>> firstResults = VariantContextTestUtils.readEntireVCFIntoMemory(firstShard);
+        final Pair<VCFHeader, List<VariantContext>> secondResults = VariantContextTestUtils.readEntireVCFIntoMemory(secondShard);
+        Assert.assertEquals(firstResults.getValue().size(), 10, "First shard has wrong number of records");
+        Assert.assertEquals(secondResults.getValue().size(), 2, "Second shard has wrong number of records");
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GatkToolIntegrationTest.java
@@ -80,7 +80,7 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
                 "-O", out};
         runCommandLine(Arrays.asList(args), SelectVariants.class.getSimpleName());
 
-        // 11 total records in the test input should create 2 vcf shards with 10 and 1 records
+        // 12 total records in the test input should create 2 vcf shards with 10 and 2 records
         final Path basePath = Paths.get(outDir, fileBase).toAbsolutePath();
         final String firstShard = ShardingVCFWriter.getShardFilename(basePath, 0);
         final String secondShard = ShardingVCFWriter.getShardFilename(basePath, 1);
@@ -88,5 +88,7 @@ public class GatkToolIntegrationTest extends CommandLineProgramTest {
         final Pair<VCFHeader, List<VariantContext>> secondResults = VariantContextTestUtils.readEntireVCFIntoMemory(secondShard);
         Assert.assertEquals(firstResults.getValue().size(), 10, "First shard has wrong number of records");
         Assert.assertEquals(secondResults.getValue().size(), 2, "Second shard has wrong number of records");
+        Assert.assertTrue(Files.exists(Paths.get(firstShard + FileExtensions.COMPRESSED_VCF_INDEX)));
+        Assert.assertTrue(Files.exists(Paths.get(secondShard + FileExtensions.COMPRESSED_VCF_INDEX)));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/writers/ShardingVCFWriterUnitTest.java
@@ -1,0 +1,183 @@
+package org.broadinstitute.hellbender.utils.variant.writers;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.testng.Assert;
+import org.testng.TestException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ShardingVCFWriterUnitTest extends GATKBaseTest {
+
+    private static final String testVcfBaseFilename = "test";
+    private static final String testVariantId = "test_var";
+    private static final String contigName = "00";
+    private final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord(contigName, 1000000)));
+    private final Path vcfBasePath = Paths.get(createTempDir(getTestedClassName()).getAbsolutePath(), testVcfBaseFilename);
+    private final String firstShardPath = vcfBasePath.toAbsolutePath().toString() + ShardingVCFWriter.SHARD_INDEX_PREFIX + "0" + ShardingVCFWriter.SHARD_INDEX_SUFFIX;
+
+    private ShardingVCFWriter createTestWriter(final Path path) {
+        return new ShardingVCFWriter(path, 100, dictionary, false, Options.INDEX_ON_THE_FLY);
+    }
+
+    private VariantContext createTestVariant(final String id) {
+        return new VariantContextBuilder(null, contigName, 1, 1, Collections.singletonList(Allele.REF_N)).id(id).make();
+    }
+
+    private void closeReader(final BufferedReader reader) {
+        try {
+            reader.close();
+        } catch (final IOException e) {
+            throw new TestException(e);
+        }
+    }
+
+    private void asssertHeaderDictionariesEqual(final VCFHeader header, final String path) {
+        final Pair<VCFHeader, List<VariantContext>> vcf = VariantContextTestUtils.readEntireVCFIntoMemory(path);
+        final VCFHeader headerTest = vcf.getKey();
+        Assert.assertEquals(header.getSequenceDictionary(), headerTest.getSequenceDictionary(),
+                "Header sequence dictionaries do not match");
+    }
+
+    private void assertVariantCount(final int expectedCount, final String path, final boolean hasHeader) {
+        final int count;
+        if (hasHeader) {
+            final Pair<VCFHeader, List<VariantContext>> vcf = VariantContextTestUtils.readEntireVCFIntoMemory(path);
+            count = vcf.getValue().size();
+        } else {
+            try (final BufferedReader reader = new BufferedReader(IOUtils.makeReaderMaybeGzipped(Paths.get(path)))) {
+                final List<String> lines = reader.lines().collect(Collectors.toList());
+                lines.stream().forEach(line -> Assert.assertFalse(line.startsWith("#"), "Unexpected header line"));
+                count = lines.size();
+            } catch (final IOException e) {
+                throw new TestException(e);
+            }
+        }
+        Assert.assertEquals(count, expectedCount, "Incorrect variant count");
+    }
+
+    @Test
+    public void testWriteHeader() {
+        final ShardingVCFWriter writer = createTestWriter(vcfBasePath);
+        final VCFHeader header = new VCFHeader();
+        header.setSequenceDictionary(dictionary);
+        writer.writeHeader(header);
+        writer.close();
+        asssertHeaderDictionariesEqual(header, firstShardPath);
+    }
+
+    @Test(expectedExceptions = RuntimeIOException.class)
+    public void testDoubleClose() {
+        final ShardingVCFWriter writer = createTestWriter(vcfBasePath);
+        writer.close();
+        writer.close();
+    }
+
+    @Test
+    public void testCheckNoError() {
+        final VariantContextWriter baseWriter = new VariantContextWriterBuilder()
+                .setOutputPath(Paths.get(firstShardPath))
+                .setReferenceDictionary(dictionary)
+                .setCreateMD5(false)
+                .setOption(Options.INDEX_ON_THE_FLY)
+                .build();
+        final ShardingVCFWriter writer = createTestWriter(vcfBasePath);
+        Assert.assertFalse(writer.checkError());
+        Assert.assertEquals(baseWriter.checkError(), writer.checkError());
+    }
+
+    @Test
+    public void testAdd() {
+        final ShardingVCFWriter writer = createTestWriter(vcfBasePath);
+        final VariantContext variant = createTestVariant(testVariantId);
+        final VCFHeader header = new VCFHeader();
+        header.setSequenceDictionary(dictionary);
+        writer.writeHeader(header);
+        writer.add(variant);
+        writer.close();
+
+        final Pair<VCFHeader, List<VariantContext>> vcf = VariantContextTestUtils.readEntireVCFIntoMemory(firstShardPath);
+        final Iterator<VariantContext> iter = vcf.getValue().iterator();
+        Assert.assertTrue(iter.hasNext(), "No variants could be read");
+        final VariantContext variantTest = iter.next();
+        Assert.assertEquals(variant.getID(), variantTest.getID(), "Test variant does not match");
+    }
+
+    @DataProvider(name = "ShardingDataProvider")
+    public Object[][] getShardingData() {
+        // Files, expected to support serial iteration (false if any input is a .sam)
+        return new Object[][] {
+                { 10, 25, 3, 5, true },
+                { 10, 25, 3, 5, false },
+                { 10, 30, 3, 10, true },
+                { 10, 11, 2, 1, true },
+                { 10, 0, 1, 0, true }
+        };
+    }
+
+    @Test(dataProvider = "ShardingDataProvider")
+    public void testSharding(final int shardSize, final int numVariants, final int numExpectedShards,
+                             int numExpectedVariantsLastShard, final boolean writeHeader) {
+        //Initialize our writer
+        final Path shardBasePath = Paths.get(createTempDir(getTestedClassName() + "_ShardTest").getAbsolutePath(), testVcfBaseFilename);
+        final ShardingVCFWriter writer = new ShardingVCFWriter(shardBasePath, shardSize, dictionary, false, Options.INDEX_ON_THE_FLY);
+        final VCFHeader header = new VCFHeader();
+        header.setSequenceDictionary(dictionary);
+        if (writeHeader) {
+            writer.writeHeader(header);
+        } else {
+            writer.setHeader(header);
+        }
+
+        //Write test variants
+        final List<Allele> alleles = Collections.singletonList(Allele.REF_N);
+        for (int i = 0; i < numVariants; i++) {
+            final VariantContext variant = createTestVariant(testVariantId + "_" + i);
+            writer.add(variant);
+        }
+        writer.close();
+
+        //Check that correct number of shards are written and each is the correct size
+        for (int i = 0; i < numExpectedShards; i++) {
+            final String shardPath = shardBasePath.toAbsolutePath().toString() + ShardingVCFWriter.SHARD_INDEX_PREFIX + i + ShardingVCFWriter.SHARD_INDEX_SUFFIX;
+            final int expectedCount = i < numExpectedShards - 1 ? shardSize : numExpectedVariantsLastShard;
+            if (writeHeader) {
+                asssertHeaderDictionariesEqual(header, shardPath);
+            }
+            assertVariantCount(expectedCount, shardPath, writeHeader);
+        }
+    }
+
+    @Test
+    public void testSetHeader() {
+        final ShardingVCFWriter writer = createTestWriter(vcfBasePath);
+        final VariantContext variant = createTestVariant(testVariantId);
+        final VCFHeader header = new VCFHeader();
+        header.setSequenceDictionary(dictionary);
+        writer.setHeader(header);
+        writer.add(variant);
+        writer.close();
+        assertVariantCount(1, firstShardPath, false);
+    }
+}


### PR DESCRIPTION
Sharded output is extremely useful for pipelining. This adds the option `--max-variants-per-shard` to `GATKTool` to let users easily split out VCFs. The functionality is implemented in the `ShardingVCFWriter` class, which is a simple wrapper around `VariantContextWriter` that basically creates a new writer whenever the max shard size is reached.