### PR TITLE
Switch travis gcloud installation to use noninteractive mode

### DIFF
--- a/scripts/travis/install_and_authenticate_to_gcloud.sh
+++ b/scripts/travis/install_and_authenticate_to_gcloud.sh
@@ -5,9 +5,9 @@
 export BOTO_CONFIG=/dev/null; # see for more information https://github.com/broadinstitute/gatk/pull/3350
 openssl aes-256-cbc -K $encrypted_703d76169d63_key -iv $encrypted_703d76169d63_iv -in resources_for_CI/servicekey.json.enc -out servicekey.json -d;
 scripts/travis/install_gcloud.sh;
-printf 'y\n' | $GCLOUD_HOME/gcloud components update;
+$GCLOUD_HOME/gcloud components update --quiet;
 if [[ $TEST_TYPE == cloud ]]; then
-   printf 'y\n' | $GCLOUD_HOME/gcloud components install beta;
+   $GCLOUD_HOME/gcloud components install beta --quiet;
 fi;
 $GCLOUD_HOME/gcloud config set project broad-dsde-dev;
 $GCLOUD_HOME/gcloud auth activate-service-account --key-file servicekey.json;

--- a/scripts/travis/install_gcloud.sh
+++ b/scripts/travis/install_gcloud.sh
@@ -5,6 +5,6 @@ if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
     wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud &&
     cd $HOME/gcloud &&
     tar xzf google-cloud-sdk.tar.gz &&
-    printf '\ny\n\ny\ny\n' | ./google-cloud-sdk/install.sh &&
+    ./google-cloud-sdk/install.sh --quiet --path-update true &&
     cd $TRAVIS_BUILD_DIR;
 fi


### PR DESCRIPTION
Our travis gcloud installation scripts relied on piping interactive responses
into the stdin of the installer, which is brittle.

This patch changes our script to instead run the installer in non-interactive mode.