### PR TITLE
Updating extract wdls to apply filtering

### DIFF
--- a/scripts/variantstore/wdl/ngs_cohort_extract.inputs.json
+++ b/scripts/variantstore/wdl/ngs_cohort_extract.inputs.json
@@ -2,11 +2,15 @@
   "NgsCohortExtract.reference": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "NgsCohortExtract.reference_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "NgsCohortExtract.reference_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "NgsCohortExtract.wgs_intervals": "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list",
+  "NgsCohortExtract.scatter_count": 50,
 
-  "NgsCohortExtract.gatk_override": "gs://broad-dsp-spec-ops/kcibul/gatk-package-4.1.8.1-140-g8aa14d3-SNAPSHOT-local.jar",
+  "NgsCohortExtract.gatk_override": "gs://broad-dsp-spec-ops/scratch/mshand/JointGenotyping/jars/gatk_filtering_for_export.jar",
 
   "NgsCohortExtract.fq_sample_table": "spec-ops-aou.kc_high_cov_ccdg.cohort_100_of_194",
   "NgsCohortExtract.fq_cohort_extract_table": "spec-ops-aou.kc_high_cov_ccdg.exported_cohort_100_test",
+  "NgsCohortExtract.fq_filter_set_table": "spec-ops-aou.kc_high_cov_ccdg.filter_set_info",
+  "NgsCohortExtract.filter_set_name": "wgs_v1",
   "NgsCohortExtract.query_project": "spec-ops-aou",
 
   "NgsCohortExtract.output_file_base_name": "ccdg_high_cov_export_100"

--- a/scripts/variantstore/wdl/ngs_cohort_extract.wdl
+++ b/scripts/variantstore/wdl/ngs_cohort_extract.wdl
@@ -2,11 +2,9 @@ version 1.0
 
 workflow NgsCohortExtract {
    input {
-        Int max_chrom_id = 24
-        
-        # bug in cromwell, can't support large integers...
-        # https://github.com/broadinstitute/cromwell/issues/2685
-        String chrom_offset = "1000000000000"
+
+        File wgs_intervals
+        Int scatter_count
        
         File reference
         File reference_index
@@ -15,12 +13,23 @@ workflow NgsCohortExtract {
         String fq_sample_table
         String fq_cohort_extract_table
         String query_project
+        String fq_filter_set_table
+        String filter_set_name
     
         String output_file_base_name
         File? gatk_override
     }
+
+    call SplitIntervals {
+      input:
+          intervals = wgs_intervals,
+          ref_fasta = reference,
+          ref_fai = reference_index,
+          ref_dict = reference_dict,
+          scatter_count = scatter_count
+    }
     
-    scatter(i in range(max_chrom_id)) {
+    scatter(i in range(scatter_count) ) {
         call ExtractTask {
             input:
                 gatk_override            = gatk_override,
@@ -28,10 +37,11 @@ workflow NgsCohortExtract {
                 reference_index          = reference_index,
                 reference_dict           = reference_dict,
                 fq_sample_table          = fq_sample_table,
-                chrom_offset             = chrom_offset,
-                chrom_id                 = i+1,
+                intervals                = SplitIntervals.interval_files[i],
                 fq_cohort_extract_table  = fq_cohort_extract_table,
                 read_project_id          = query_project,
+                fq_filter_set_table      = fq_filter_set_table,
+                filter_set_name          = filter_set_name,
                 output_file              = "${output_file_base_name}_${i}.vcf.gz"
         }
     }
@@ -53,14 +63,13 @@ task ExtractTask {
     
         String fq_sample_table
 
-        # bug in cromwell, can't support large integers...
-        # https://github.com/broadinstitute/cromwell/issues/2685
-        String chrom_offset
-        Int chrom_id
+        File intervals
 
         String fq_cohort_extract_table
         String read_project_id
         String output_file
+        String fq_filter_set_table
+        String filter_set_name
         
         # Runtime Options:
         File? gatk_override
@@ -76,10 +85,8 @@ task ExtractTask {
         export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
         df -h
-        min_location=$(echo "~{chrom_id} * ~{chrom_offset}" | bc)
-        max_location=$(echo "( ~{chrom_id} + 1 ) * ~{chrom_offset}" | bc)
 
-        gatk --java-options "-Xmx4g" \
+        gatk --java-options "-Xmx9g" \
             ExtractCohort \
                 --mode GENOMES --ref-version 38 --query-mode LOCAL_SORT \
                 -R "~{reference}" \
@@ -87,16 +94,18 @@ task ExtractTask {
                 --local-sort-max-records-in-ram ~{local_sort_max_records_in_ram} \
                 --sample-table ~{fq_sample_table} \
                 --cohort-extract-table ~{fq_cohort_extract_table} \
-                --min-location ${min_location} --max-location ${max_location} \
-                --project-id ~{read_project_id}
+                -L ~{intervals} \
+                --project-id ~{read_project_id} \
+                --variant-filter-table ~{fq_filter_set_table} \
+                --filter-set-name ~{filter_set_name}
     >>>
 
     # ------------------------------------------------
     # Runtime settings:
     runtime {
         docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_d8a72b825eab2d979c8877448c0ca948fd9b34c7_change_to_hwe"
-        memory: "7 GB"
-        disks: "local-disk 10 HDD"
+        memory: "10 GB"
+        disks: "local-disk 100 HDD"
         bootDiskSizeGb: 15
         preemptible: 3
         cpu: 2
@@ -109,7 +118,46 @@ task ExtractTask {
         File output_vcf_index = "~{output_file}.tbi"
     }
  }
- 
+
+ task SplitIntervals {
+     input {
+       File? intervals
+       File ref_fasta
+       File ref_fai
+       File ref_dict
+       Int scatter_count
+       String? split_intervals_extra_args
+
+       File? gatk_override
+     }
+
+     command {
+         set -e
+         export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
+
+         mkdir interval-files
+         gatk --java-options "-Xmx5g" SplitIntervals \
+             -R ~{ref_fasta} \
+             ~{"-L " + intervals} \
+             -scatter ~{scatter_count} \
+             -O interval-files \
+             ~{split_intervals_extra_args}
+         cp interval-files/*.interval_list .
+     }
+
+     runtime {
+         docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_d8a72b825eab2d979c8877448c0ca948fd9b34c7_change_to_hwe"
+         bootDiskSizeGb: 15
+         memory: "6 GB"
+         disks: "local-disk 10 HDD"
+         preemptible: 3
+         cpu: 1
+     }
+
+     output {
+         Array[File] interval_files = glob("*.interval_list")
+     }
+ }
 
 
 


### PR DESCRIPTION
I added the scatter so we could easily scatter by more than 24 ways, but we still need to change how we are partitioning the filtering/PET/VET tables to line up with our scattered intervals.

Scattering 50 ways, each shard took about 10-15 min extracting 100 WGS samples.