### PR TITLE
Updated to a newer release of the carrot-publish-github-action

### DIFF
--- a/.github/workflows/carrot_run_test_from_pr_comment.yml
+++ b/.github/workflows/carrot_run_test_from_pr_comment.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Parse comment
-        uses: broadinstitute/carrot-publish-github-action@v0.3.0-beta
+        uses: broadinstitute/carrot-publish-github-action@v0.3.1-beta
         with:
           software-name: gatk
           github-token: ${{ secrets.GITHUB_TOKEN }}
           topic-name: ${{ secrets.CARROT_TOPIC_NAME }}
           sa-key: ${{ secrets.CARROT_SA_KEY }}
+          minimum-permissions: write


### PR DESCRIPTION
New version allows restricting which users can trigger carrot jobs based on their access to the repository.  In this case, I've set it to restrict to only users who have at least write access.