### PR TITLE
Update POPAF retrieval

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -151,12 +151,11 @@ public class SomaticGenotypingEngine {
 
             final List<Allele> allAllelesToEmit = ListUtils.union(Arrays.asList(mergedVC.getReference()), tumorAltAlleles);
 
-
-            final Map<String, Object> negativeLogPopulationAFAnnotation = getNegativeLogPopulationAFAnnotation(featureContext.getValues(MTAC.germlineResource, loc), tumorAltAlleles, MTAC.getDefaultAlleleFrequency());
+            final Map<Allele, Double> populationAFAnnotation = getPopulationAFAnnotation(featureContext.getValues(MTAC.germlineResource, loc), mergedVC, MTAC.getDefaultAlleleFrequency());
 
             final VariantContextBuilder callVcb = new VariantContextBuilder(mergedVC)
                     .alleles(allAllelesToEmit)
-                    .attributes(negativeLogPopulationAFAnnotation)
+                    .attribute(GATKVCFConstants.POPULATION_AF_KEY, tumorAltAlleles.stream().mapToDouble(a -> - Math.log10(populationAFAnnotation.get(a))).toArray())
                     .attribute(GATKVCFConstants.TUMOR_LOG_10_ODDS_KEY, tumorAltAlleles.stream().mapToDouble(a -> MathUtils.logToLog10(tumorLogOdds.getAlt(a))).toArray());
 
             if (hasNormal) {
@@ -328,31 +327,22 @@ public class SomaticGenotypingEngine {
         return hasNormal ? Optional.of(supplier.get()) : Optional.empty();
     }
 
-    private static Map<String, Object> getNegativeLogPopulationAFAnnotation(List<VariantContext> germlineResourceVariants,
-                                                                            final List<Allele> altAlleles,
-                                                                            final double afOfAllelesNotInGermlineResource) {
-        final Optional<VariantContext> germlineVC = germlineResourceVariants.isEmpty() ? Optional.empty()
-                : Optional.of(germlineResourceVariants.get(0));  // assume only one VC per site
-        final double[] populationAlleleFrequencies = getGermlineAltAlleleFrequencies(altAlleles, germlineVC, afOfAllelesNotInGermlineResource);
-
-        return ImmutableMap.of(GATKVCFConstants.POPULATION_AF_KEY, MathUtils.applyToArray(populationAlleleFrequencies, x -> - Math.log10(x)));
-    }
-
     @VisibleForTesting
-    static double[] getGermlineAltAlleleFrequencies(final List<Allele> altAlleles, final Optional<VariantContext> germlineVC, final double afOfAllelesNotInGermlineResource) {
-        if (germlineVC.isPresent())  {
+    static Map<Allele, Double> getPopulationAFAnnotation(List<VariantContext> germlineResourceVariants,
+                                                         final VariantContext mergedVC,
+                                                         final double afOfAllelesNotInGermlineResource) {
+        final Optional<VariantContext> germlineVC = germlineResourceVariants.isEmpty() ? Optional.empty()
+            : Optional.of(germlineResourceVariants.get(0));  // assume only one VC per site
+        if (germlineVC.isPresent()) {
             final List<Double> germlineAltAFs = Mutect2Engine.getAttributeAsDoubleList(germlineVC.get(), VCFConstants.ALLELE_FREQUENCY_KEY, afOfAllelesNotInGermlineResource);
-            return altAlleles.stream()
-                    .mapToDouble(allele -> {
-                        final VariantContext vc = germlineVC.get();
-                        final OptionalInt germlineAltIndex = IntStream.range(0, vc.getNAlleles() - 1)
-                                .filter(n -> vc.getAlternateAllele(n).basesMatch(allele))
-                                .findAny();
-                        return germlineAltIndex.isPresent() ? germlineAltAFs.get(germlineAltIndex.getAsInt())
-                                : afOfAllelesNotInGermlineResource;
-                    }).toArray();
-        }
+            final int[] matchedAlleleIndex = GATKVariantContextUtils.matchAllelesOnly(mergedVC, germlineVC.get());
+            return IntStream.range(0, matchedAlleleIndex.length).boxed()
+                .collect(Collectors.toMap(n -> mergedVC.getAlternateAllele(n),
+                                          n -> matchedAlleleIndex[n] >= 0 ?
+                                          germlineAltAFs.get(matchedAlleleIndex[n]) : afOfAllelesNotInGermlineResource));
+         }
 
-        return Doubles.toArray(Collections.nCopies(altAlleles.size(), afOfAllelesNotInGermlineResource));
+         return mergedVC.getAlternateAlleles().stream()
+             .collect(Collectors.toMap(a -> a, a -> afOfAllelesNotInGermlineResource));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -455,7 +455,11 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         final List<VariantContext> missedObviousVariantsAtTenPercent = filteredVariants.get(10).stream()
                 .filter(vc -> !vc.getFilters().contains(GATKVCFConstants.CONTAMINATION_FILTER_NAME))
                 .filter(VariantContext::isBiallelic)
-                .filter(vc -> {
+	        .filter(vc -> {
+                    final double[] population_af = VariantContextGetters.getAttributeAsDoubleArray(vc,
+                    GATKVCFConstants.POPULATION_AF_KEY, () -> new double[]{Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, Double.POSITIVE_INFINITY);
+                    return population_af[0] < 6.0;
+                }).filter(vc -> {
                     final int[] AD = vc.getGenotype(0).getAD();
                     return AD[1] < 0.15 * AD[0];
                 }).collect(Collectors.toList());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.testng.Assert.*;
@@ -20,57 +21,89 @@ public class SomaticGenotypingEngineUnitTest {
         final double defaultAF = 0.001;
         final double nonDefaultAF1 = 0.1;
         final double nonDefaultAF2 = 0.01;
+
         final Allele Aref = Allele.create("A", true);
+        final Allele CTref = Allele.create("CT", true);
+        final Allele Cref = Allele.create("C", true);
+
         final Allele C = Allele.create("C");
         final Allele G = Allele.create("G");
         final Allele T = Allele.create("T");
+        final Allele CT = Allele.create("CT");
+        final Allele CTT = Allele.create("CTT");
+        final Allele CTTT = Allele.create("CTTT");
 
         final String source = "SOURCE";
         final int start = 1;
         final int stop = 1;
 
         //biallelic, vc has the same alt allele
-        final List<Allele> altAlleles1 = Arrays.asList(C);
         final VariantContext vc1 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C))
                 .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1}).make();
-        final double[] af1 = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(altAlleles1, Optional.of(vc1), defaultAF);
-        Assert.assertEquals(af1.length, altAlleles1.size());
-        Assert.assertEquals(af1[0], nonDefaultAF1, 0.00001);
+        final List<VariantContext> germlineVC1 = Arrays.asList(vc1);
+        final VariantContext emitVC1 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C)).make();
+        final Map<Allele, Double> af1 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC1, emitVC1, defaultAF);
+        Assert.assertEquals(af1.size(), 1);
+        Assert.assertEquals(af1.get(C), nonDefaultAF1, 0.00001);
 
         //biallelic, vc has different alt allele
-        final List<Allele> altAlleles2 = Arrays.asList(C);
         final VariantContext vc2 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, G))
                 .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1}).make();
-        final double[] af2 = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(altAlleles2, Optional.of(vc2), defaultAF);
-        Assert.assertEquals(af2.length, altAlleles2.size());
-        Assert.assertEquals(af2[0], defaultAF, 0.00001);
+        final List<VariantContext> germlineVC2 = Arrays.asList(vc2);
+        final VariantContext emitVC2 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C)).make();
+        final Map<Allele, Double> af2 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC2, emitVC2, defaultAF);
+        Assert.assertEquals(af2.size(), 1);
+        Assert.assertEquals(af2.get(C), defaultAF, 0.00001);
 
         //triallelic, same alt alleles
-        final List<Allele> altAlleles3 = Arrays.asList(C, G);
         final VariantContext vc3 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C, G))
-                .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
-        final double[] af3 = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(altAlleles3, Optional.of(vc3), defaultAF);
-        Assert.assertEquals(af3.length, altAlleles3.size());
-        Assert.assertEquals(af3[0], nonDefaultAF1, 0.00001);
-        Assert.assertEquals(af3[1], nonDefaultAF2, 0.00001);
+            .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
+        final List<VariantContext> germlineVC3 = Arrays.asList(vc3);
+        final VariantContext emitVC3 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C, G)).make();
+        final Map<Allele, Double> af3 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC3, emitVC3, defaultAF);
+        Assert.assertEquals(af3.size(), 2);
+        Assert.assertEquals(af3.get(C), nonDefaultAF1, 0.00001);
+        Assert.assertEquals(af3.get(G), nonDefaultAF2, 0.00001);
 
         //triallelic, same alt alleles in different order
-        final List<Allele> altAlleles4 = Arrays.asList(C, G);
-        final VariantContext vc4 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, G, C))
-                .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
-        final double[] af4 = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(altAlleles4, Optional.of(vc4), defaultAF);
-        Assert.assertEquals(af4.length, altAlleles4.size());
-        Assert.assertEquals(af4[0], nonDefaultAF2, 0.00001);
-        Assert.assertEquals(af4[1], nonDefaultAF1, 0.00001);
+        final VariantContext vc4 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C, G))
+            .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
+        final List<VariantContext> germlineVC4 = Arrays.asList(vc4);
+        final VariantContext emitVC4 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, G, C)).make();
+        final Map<Allele, Double> af4 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC4, emitVC4, defaultAF);
+        Assert.assertEquals(af4.size(), 2);
+        Assert.assertEquals(af4.get(C), nonDefaultAF1, 0.00001);
+        Assert.assertEquals(af4.get(G), nonDefaultAF2, 0.00001);
 
         //triallelic, only one allele in common
-        final List<Allele> altAlleles5 = Arrays.asList(C, G);
         final VariantContext vc5 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C, T))
-                .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
-        final double[] af5 = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(altAlleles5, Optional.of(vc5), defaultAF);
-        Assert.assertEquals(af5.length, altAlleles5.size());
-        Assert.assertEquals(af5[0], nonDefaultAF1, 0.00001);
-        Assert.assertEquals(af5[1], defaultAF, 0.00001);
+            .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
+        final List<VariantContext> germlineVC5 = Arrays.asList(vc5);
+        final VariantContext emitVC5 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Aref, C, G)).make();
+        final Map<Allele, Double> af5 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC5, emitVC5, defaultAF);
+        Assert.assertEquals(af5.size(), 2);
+        Assert.assertEquals(af5.get(C), nonDefaultAF1, 0.00001);
+        Assert.assertEquals(af5.get(G), defaultAF, 0.00001);
+
+        //triallelic reference with mixed DEL/INS/SNP, e.g. CT - C/CTT
+        final VariantContext vc6 = new VariantContextBuilder(source, "1", start, stop+1, Arrays.asList(CTref, C, CTT))
+            .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
+        final List<VariantContext> germlineVC6 = Arrays.asList(vc6);
+        final VariantContext emitVC6 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Cref, CT, CTT)).make();
+        final Map<Allele, Double> af6 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC6, emitVC6, defaultAF);
+        Assert.assertEquals(af6.size(), 2);
+        Assert.assertEquals(af6.get(CT), nonDefaultAF2, 0.00001); //Cref/CT matches CTref/CTT
+        Assert.assertEquals(af6.get(CTT), defaultAF, 0.00001);    //No match
+
+        //triallelic to-be-emitted call with mixed DEL/INS/SNP, e.g. CT - C/CTT
+        final VariantContext vc7 = new VariantContextBuilder(source, "1", start, stop, Arrays.asList(Cref, CT, CTT))
+            .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {nonDefaultAF1, nonDefaultAF2}).make();
+        final List<VariantContext> germlineVC7 = Arrays.asList(vc7);
+        final VariantContext emitVC7 = new VariantContextBuilder(source, "1", start, stop+1, Arrays.asList(CTref, C, CTT)).make();
+        final Map<Allele, Double> af7 = SomaticGenotypingEngine.getPopulationAFAnnotation(germlineVC7, emitVC7, defaultAF);
+        Assert.assertEquals(af7.size(), 2);
+        Assert.assertEquals(af7.get(C), defaultAF, 0.00001);          // no match
+        Assert.assertEquals(af7.get(CTT), nonDefaultAF1, 0.00001);    // CTref/CTT matches Cref/CT
     }
 
 }


### PR DESCRIPTION
Mutect2 matches called variants against known variants retrieved from the germline resource VCF (if available) for the POPAF annotation. While comparing the called allele to the germline resource variants, Mutect2 only takes into account the sequence of the alternate allele(s) while ignoring the reference allele sequence. This can cause incorrect annotations at sites with multiple alternate alleles (e.g. CT -> C/CTT in the germline resource while M2 calls C -> CT).

This PR is a proposed fix along with some unit tests that demonstrate the issue.