### PR TITLE
Yf make BaseUtils methods more robust to handle all possible byte values

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/BaseUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/BaseUtils.java
@@ -120,7 +120,9 @@ public final class BaseUtils {
         final int start = ignoreConversionOfFirstByte ? 1 : 0;
 
         for ( int i = start; i < length; i++ ) {
-            final int baseIndex = baseIndexWithIupacMap[bases[i]];
+            // we want to make sure we treat the base as an unsigned byte....so that we can access this array with it.
+            final int unsignedBase = ((int)bases[i]) & 0xff;
+            final int baseIndex = baseIndexWithIupacMap[unsignedBase];
             if ( baseIndex == Base.N.ordinal() ) {
                 bases[i] = 'N';
             } else if ( errorOnBadReferenceBase && baseIndex == -1 ) {
@@ -137,9 +139,9 @@ public final class BaseUtils {
      * @return 0, 1, 2, 3, or -1 if the base can't be understood
      */
     public static int simpleBaseToBaseIndex(final byte base) {
-        Utils.validateArg( base >= 0 && base < 256,
-                "Non-standard bases were encountered in either the input reference or BAM file(s)");
-        return baseIndexMap[base];
+        // we want to make sure we treat the base as an unsigned byte....so that we can access this array with it.
+        final int unsignedBase = ((int)base) & 0xff;
+        return baseIndexMap[unsignedBase];
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
@@ -51,27 +51,27 @@ public final class BaseUtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testTransitionTransversion() {
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'T' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'C' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'G' ) == BaseUtils.BaseSubstitutionType.TRANSITION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'C', (byte)'A' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'C', (byte)'T' ) == BaseUtils.BaseSubstitutionType.TRANSITION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'C', (byte)'G' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'T', (byte)'A' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'T', (byte)'C' ) == BaseUtils.BaseSubstitutionType.TRANSITION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'T', (byte)'G' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'G', (byte)'A' ) == BaseUtils.BaseSubstitutionType.TRANSITION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'G', (byte)'T' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'G', (byte)'C' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'T'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'C'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'G'), BaseUtils.BaseSubstitutionType.TRANSITION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'C', (byte) 'A'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'C', (byte) 'T'), BaseUtils.BaseSubstitutionType.TRANSITION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'C', (byte) 'G'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'T', (byte) 'A'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'T', (byte) 'C'), BaseUtils.BaseSubstitutionType.TRANSITION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'T', (byte) 'G'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'G', (byte) 'A'), BaseUtils.BaseSubstitutionType.TRANSITION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'G', (byte) 'T'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'G', (byte) 'C'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
 
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'a', (byte)'T' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'a', (byte)'C' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'T' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'C' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'t' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'A', (byte)'c' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'a', (byte)'t' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
-        Assert.assertTrue( BaseUtils.SNPSubstitutionType( (byte)'a', (byte)'c' ) == BaseUtils.BaseSubstitutionType.TRANSVERSION );
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'a', (byte) 'T'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'a', (byte) 'C'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'T'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'C'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 't'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'A', (byte) 'c'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'a', (byte) 't'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
+        Assert.assertSame(BaseUtils.SNPSubstitutionType((byte) 'a', (byte) 'c'), BaseUtils.BaseSubstitutionType.TRANSVERSION);
     }
 
     @Test
@@ -84,7 +84,7 @@ public final class BaseUtilsUnitTest extends GATKBaseTest {
     private void compareRCStringToExpected(String fw, String rcExp) {
         String rcObs = new String(BaseUtils.simpleReverseComplement(fw.getBytes()));
 
-        Assert.assertTrue(rcObs.equals(rcExp));
+        Assert.assertEquals(rcExp, rcObs);
     }
 
 
@@ -140,7 +140,7 @@ public final class BaseUtilsUnitTest extends GATKBaseTest {
     @Test(dataProvider="baseComparatorData")
     public void testBaseComparator(final Collection<byte[]> basesToSort) {
         final ArrayList<byte[]> sorted = new ArrayList<>(basesToSort);
-        Collections.sort(sorted, BaseUtils.BASES_COMPARATOR);
+        sorted.sort(BaseUtils.BASES_COMPARATOR);
         for (int i = 0; i < sorted.size(); i++)   {
             Assert.assertEquals(BaseUtils.BASES_COMPARATOR.compare(sorted.get(i),sorted.get(i)),0);
             final String iString = new String(sorted.get(i));

--- a/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
@@ -7,7 +7,12 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.PrintStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
 
 
 public final class BaseUtilsUnitTest extends GATKBaseTest {

--- a/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
@@ -8,11 +8,13 @@ import org.testng.annotations.Test;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 
 public final class BaseUtilsUnitTest extends GATKBaseTest {
@@ -44,6 +46,16 @@ public final class BaseUtilsUnitTest extends GATKBaseTest {
         BaseUtils.convertIUPACtoN(new byte[]{b, b, b}, false, false);
     }
 
+    /** from the javaDoc of {@link BaseUtils#simpleBaseToBaseIndex} */
+    private final static Integer[] possibleResults = {0, 1, 2, 3, -1};
+    private final static Set<Integer> possibleResultsSet = new HashSet<>(Arrays.asList(possibleResults));
+
+    @Test(dataProvider = "allByteValues")
+    public void testCanConvertToBaseIndex(final byte b) {
+        Assert.assertTrue(possibleResultsSet.contains(BaseUtils.simpleBaseToBaseIndex(b)));
+    }
+
+    // TODO: where should this be?
     private void checkBytesAreEqual(final byte[] b1, final byte[] b2) {
         for ( int i = 0; i < b1.length; i++ )
             Assert.assertEquals(b1[i], b2[i]);

--- a/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/BaseUtilsUnitTest.java
@@ -7,10 +7,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Random;
+import java.util.*;
 
 
 public final class BaseUtilsUnitTest extends GATKBaseTest {
@@ -25,6 +22,21 @@ public final class BaseUtilsUnitTest extends GATKBaseTest {
         checkBytesAreEqual(BaseUtils.convertIUPACtoN(new byte[]{'A', 'M', 'A'}, false, false), new byte[]{'A', 'N', 'A'});
         checkBytesAreEqual(BaseUtils.convertIUPACtoN(new byte[]{'A', 'A', 'K'}, false, false), new byte[]{'A', 'A', 'N'});
         checkBytesAreEqual(BaseUtils.convertIUPACtoN(new byte[]{'M', 'M', 'M'}, false, false), new byte[]{'N', 'N', 'N'});
+    }
+
+    @DataProvider
+    Iterator<Object[]> allByteValues() {
+        final List<Object[]> bytes = new ArrayList<>(256);
+        for (int i = 0; i < 256; i++) {
+            final byte oneByte = (byte) i;
+            bytes.add(new Object[]{oneByte});
+        }
+        return bytes.iterator();
+    }
+
+    @Test(dataProvider = "allByteValues")
+    public void testCanConvertAllBytes(final byte b) {
+        BaseUtils.convertIUPACtoN(new byte[]{b, b, b}, false, false);
     }
 
     private void checkBytesAreEqual(final byte[] b1, final byte[] b2) {


### PR DESCRIPTION
Fixes a bug that was exposed in https://gatk.broadinstitute.org/hc/en-us/community/posts/360075631171-BQSR-no-output-table-found

The issue is that bytes are signed in java, and yet we were treating them as unsigned and directly indexing an array with them.....this works as long as you don't have weird characters in your bam/reference...but if you do you get an access error that is non-informative.