### PR TITLE
Fix two phasing bugs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -637,10 +637,12 @@ public final class AssemblyBasedCallerUtils {
 
         // construct a mapping from alternate allele to the set of haplotypes that contain that allele
         final Map<VariantContext, Set<Haplotype>> haplotypeMap = constructHaplotypeMapping(calls, calledHaplotypes);
+        final Set<Haplotype> haplotypesWithCalledVariants = new HashSet<>(calledHaplotypes.size());
+        haplotypeMap.values().forEach(haplotypesWithCalledVariants::addAll);
 
         // construct a mapping from call to phase set ID
         final Map<VariantContext, Pair<Integer, PhaseGroup>> phaseSetMapping = new HashMap<>();
-        final int uniqueCounterEndValue = constructPhaseSetMapping(calls, haplotypeMap, calledHaplotypes.size() - 1, phaseSetMapping);
+        final int uniqueCounterEndValue = constructPhaseSetMapping(calls, haplotypeMap, haplotypesWithCalledVariants.size(), phaseSetMapping);
 
         // we want to establish (potential) *groups* of phased variants, so we need to be smart when looking at pairwise phasing partners
         return constructPhaseGroups(calls, phaseSetMapping, uniqueCounterEndValue);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -860,48 +860,51 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         pos234.getEventMap().put(2, vc2);
         pos234.getEventMap().put(3, vc3);
         pos234.getEventMap().put(4, vc4);
+        final Haplotype pos23 = new Haplotype("ACCAA".getBytes());
+        pos24.setEventMap(new EventMap(Arrays.asList(vc2, vc3)));
+        pos24.getEventMap().put(2, vc2);
+        pos24.getEventMap().put(3, vc3);
+
 
         final Map<VariantContext, Set<Haplotype>> haplotypeMap = new HashMap<>();
 
-        // test no phased variants #1
+        // test 1: no phased variants #1
         final Set<Haplotype> haplotypes2 = new HashSet<>();
         haplotypes2.add(pos2);
         haplotypeMap.put(vc2, haplotypes2);
-        tests.add(new Object[]{Arrays.asList(vc2), new HashMap<>(haplotypeMap), 2, 0, 0, 0, 0});
+        tests.add(new Object[]{Arrays.asList(vc2), new HashMap<>(haplotypeMap), 1, 0, 0, 0, 0});
 
-        // test no phased variants #2
+        // test 2: opposite phase
         final Set<Haplotype> haplotypes3 = new HashSet<>();
         haplotypes3.add(pos3);
         haplotypeMap.put(vc3, haplotypes3);
-        tests.add(new Object[]{Arrays.asList(vc2, vc3), new HashMap<>(haplotypeMap), 3, 0, 0, 0, 0});
-
-        // test opposite phase
         tests.add(new Object[]{Arrays.asList(vc2, vc3), new HashMap<>(haplotypeMap), 2, 2, 1, 1, 1});
 
-        // test no phased variants #3
+        // test 3: no phased variants (a third call is out of phase)
         final Set<Haplotype> haplotypes4 = new HashSet<>();
         haplotypes4.add(pos4);
         haplotypeMap.put(vc4, haplotypes4);
         tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 3, 0, 0, 0, 0});
 
-        // test mixture
+        // test 4: mixture
         final Set<Haplotype> haplotypes24 = new HashSet<>();
         haplotypes24.add(pos24);
         haplotypeMap.put(vc2, haplotypes24);
         haplotypeMap.put(vc4, haplotypes24);
         tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 2, 3, 1, 2, 1});
 
-        // test 2 hets
+        // test 5: 2 hets
         haplotypeMap.remove(vc3);
         tests.add(new Object[]{Arrays.asList(vc2, vc4), new HashMap<>(haplotypeMap), 1, 2, 1, 2, 0});
 
-        // test 2 with opposite phase
+        // test 6: two snps with opposite phase
         final Set<Haplotype> haplotypes1 = new HashSet<>();
         haplotypes1.add(pos1);
         haplotypeMap.put(vc1, haplotypes1);
         tests.add(new Object[]{Arrays.asList(vc1, vc2, vc4), new HashMap<>(haplotypeMap), 2, 3, 1, 1, 2});
 
-        // test homs around a het
+        // test 7: homs around a het
+        haplotypeMap.clear();
         final Set<Haplotype> haplotypes2hom = new HashSet<>();
         haplotypes2hom.add(pos24);
         haplotypes2hom.add(pos234);
@@ -915,7 +918,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         haplotypeMap.put(vc4, haplotypes4hom);
         tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 2, 3, 1, 3, 0});
 
-        // test hets around a hom
+        // test 8: hets around a hom
         final Set<Haplotype> haplotypes2het = new HashSet<>();
         haplotypes2het.add(pos234);
         final Set<Haplotype> haplotypes4het = new HashSet<>();
@@ -928,7 +931,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         haplotypeMap.put(vc4, haplotypes4het);
         tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 2, 3, 1, 3, 0});
 
-        // test no phased variants around a hom
+        // test 9: no phased variants around a hom
         final Set<Haplotype> haplotypes2incomplete = new HashSet<>();
         haplotypes2incomplete.add(pos24);
         final Set<Haplotype> haplotypes3incomplete = new HashSet<>();
@@ -940,8 +943,9 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         haplotypeMap.put(vc2, haplotypes2incomplete);
         haplotypeMap.put(vc3, haplotypes3incomplete);
         haplotypeMap.put(vc4, haplotypes4complete);
-        tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 0, 0, 0, 0, 0});
+        tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 3, 0, 0, 0, 0});
 
+        // test 10: snp spanned by overlapping deletion
         final Allele refForDel = Allele.create("AG", true);
         final Allele altDel = Allele.create("A", false);
 
@@ -970,7 +974,29 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         spandelCalls.add(spannedSnpVC);
 
         tests.add(new Object[]{spandelCalls, new HashMap<>(spanDelHapMap), 2, 2, 1, 1, 1});
+
+        // test 11: a hom followed by two opposite-phase hets
+        haplotypeMap.clear();
+        final Set<Haplotype> haplotypes2hom2 = new HashSet<>();
+        haplotypes2hom2.add(pos24);
+        haplotypes2hom2.add(pos23);
+        final Set<Haplotype> haplotypes3het2 = new HashSet<>();
+        haplotypes3het2.add(pos23);
+        final Set<Haplotype> haplotypes4het2 = new HashSet<>();
+        haplotypes4het2.add(pos24);
+        haplotypeMap.put(vc2, haplotypes2hom2);
+        haplotypeMap.put(vc3, haplotypes3het2);
+        haplotypeMap.put(vc4, haplotypes4het2);
+        tests.add(new Object[]{calls, new HashMap<>(haplotypeMap), 2, 3, 1, 2, 1});
+
+
         return tests.toArray(new Object[][]{});
+    }
+
+    private int getTotalHaplotypes(final Map<VariantContext, Set<Haplotype>> haplotypeMap) {
+        final Set<Haplotype> haplotypesWithCalledVariants = new HashSet<>();
+        haplotypeMap.values().forEach(haplotypesWithCalledVariants::addAll);
+        return haplotypesWithCalledVariants.size();
     }
 
     @Test(dataProvider="ConstructPhaseSetMappingProvider")
@@ -982,6 +1008,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
                                              final int expectedNum01,
                                              final int expectedNum10) {
         final Map<VariantContext, Pair<Integer, PhaseGroup>> actualPhaseSetMapping = new HashMap<>();
+        Assert.assertEquals(totalHaplotypes, getTotalHaplotypes(haplotypeMap));
         final int actualNumGroups = constructPhaseSetMapping(calls, haplotypeMap, totalHaplotypes, actualPhaseSetMapping);
         Assert.assertEquals(actualNumGroups, expectedNumGroups);
         Assert.assertEquals(actualPhaseSetMapping.size(), expectedMapSize);


### PR DESCRIPTION
This PR addresses two phasing bugs, https://github.com/broadinstitute/gatk/issues/6463 and https://github.com/broadinstitute/gatk/issues/6845.

https://github.com/broadinstitute/gatk/issues/6463 identified a bug in the phasing algorithm which caused the wrong phase information to be output for scenarios where the first variant in a phase set is homozygous variant and it is followed by het variants in opposite phase. Without this change the het variants were incorrectly placed on the same phase strand because the phase set was tied to the hom var variant, and the algorithm assumed that each het variant could be put in the same phase strand as it because it was on all haplotypes. I've modified the algorithm to keep track, for variants that occur on all haplotypes, of which of the haplotypes have already been used for phasing an upstream "comp" variant so that further downstream variants can be checked against the remaining set.

https://github.com/broadinstitute/gatk/issues/6845 showed an example of phase sets being disrupted by the presence of an alternate haplotype that supported an additional, uncalled, variant in the region. In this case there was an alternate haplotype supported by two reads that supported a SNP downstream of two pairs of SNPs in alternate phase. The presence of an additional haplotype causes the phasing algorithm to break the phase sets in the region. I've modified the algorithm to only use haplotypes that support the alternate alleles present in called variants in phasing by modifying the number that we pass as `AssemblyBasedCallerUtils.constructPhaseSetMapping()`'s `totalAvailableHaplotypes` parameter. In my opinion this 
 fix produces output that is still correct and is much easier to understand (since it only depends on sites that are visible in the output VCF), but if anyone objects to this change please let me know. 

Non-test code changes for this PR are in two different commits to try to make it easier to understand the scope of the two changes.
