### PR TITLE
Echo log file after failed travis run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -206,6 +206,7 @@ after_success:
     ./gradlew uploadArchives; 
   fi;
 after_failure:
+- test -f hs_err_*.log && cat hs_err_*.log
 - dmesg | tail -100
 - export FAILED=true
 after_script:


### PR DESCRIPTION
If a core dump is produced while running tests on travis, this will echo the log file to the travis log (ie., it was triggered [here](https://api.travis-ci.com/v3/job/468677651/log.txt) by the pair hmm seg fault) so the java and native thread stacks can be inspected.