### PR TITLE
Updated --mapping-quality-threshold and its documentation to be less confusing

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -184,7 +184,7 @@ public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
 
     @Override
     public List<ReadFilter> getDefaultReadFilters() {
-        return HaplotypeCallerEngine.makeStandardHCReadFilters(hcArgs.mappingQualityThreshold);
+        return HaplotypeCallerEngine.makeStandardHCReadFilters();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -212,7 +212,7 @@ public class ReadsPipelineSpark extends GATKSparkTool {
         }
 
         // Run Haplotype Caller
-        final ReadFilter hcReadFilter = ReadFilter.fromList(HaplotypeCallerEngine.makeStandardHCReadFilters(hcArgs.mappingQualityThreshold), header);
+        final ReadFilter hcReadFilter = ReadFilter.fromList(HaplotypeCallerEngine.makeStandardHCReadFilters(), header);
         final JavaRDD<GATKRead> filteredReadsForHC = finalReads.filter(hcReadFilter::test);
         SAMSequenceDictionary sequenceDictionary = getBestAvailableSequenceDictionary();
         final List<SimpleInterval> intervals = hasUserSuppliedIntervals() ? getIntervals() : IntervalUtils.getAllIntervalsForReference(sequenceDictionary);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -156,7 +156,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
 
     @Override
     public List<ReadFilter> getDefaultReadFilters() {
-        return HaplotypeCallerEngine.makeStandardHCReadFilters(hcArgs.mappingQualityThreshold);
+        return HaplotypeCallerEngine.makeStandardHCReadFilters();
     }
 
     /**
@@ -224,7 +224,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
             logger.warn("* --apply-bqd                                                           *");
             logger.warn("* --transform-dragen-mapping-quality                                    *");
             logger.warn("* --soft-clip-low-quality-ends                                          *");
-            logger.warn("* --mapping-quality-threshold  1                                        *");
+            logger.warn("* --mapping-quality-threshold-for-genotyping  1                                        *");
             logger.warn("* --minimum-mapping-quality  1                                          *");
             logger.warn("* --allele-informative-reads-overlap-margin  1                          *");
             logger.warn("* --disable-cap-base-qualities-to-map-quality                           *");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -224,7 +224,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
             logger.warn("* --apply-bqd                                                           *");
             logger.warn("* --transform-dragen-mapping-quality                                    *");
             logger.warn("* --soft-clip-low-quality-ends                                          *");
-            logger.warn("* --mapping-quality-threshold-for-genotyping  1                                        *");
+            logger.warn("* --mapping-quality-threshold-for-genotyping  1                         *");
             logger.warn("* --minimum-mapping-quality  1                                          *");
             logger.warn("* --allele-informative-reads-overlap-margin  1                          *");
             logger.warn("* --disable-cap-base-qualities-to-map-quality                           *");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -5,6 +5,7 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.Hidden;
+import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.DbsnpArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureInput;
@@ -150,7 +151,7 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
     //TODO pull the threshold from that filter since it might or might not exist by the time we go to filter for threading, really
     //TODO we should unify on the readFilter version of this check i think but perhaps they are seperate for athropological historical reasons and it is thus culturally protected?
     @Advanced
-    @Argument(fullName = "mapping-quality-threshold", doc = "Control the threshold for discounting reads from genotyping/calling due to mapping quality")
+    @Argument(fullName = "mapping-quality-threshold-for-genotyping", doc = "Control the threshold for discounting reads from the genotyper due to mapping quality after the active region detection and assembly steps but before genotyping. NOTE: this is in contrast to the --"+ ReadFilterArgumentDefinitions.MINIMUM_MAPPING_QUALITY_NAME+" argument which filters reads from all parts of the HaplotypeCaller. If you would like to call genotypes with a different threshold both arguments must be set.", optional = true)
     public int mappingQualityThreshold = HaplotypeCallerEngine.DEFAULT_READ_QUALITY_FILTER_THRESHOLD;
     @Advanced
     @Argument(fullName = "max-effective-depth-adjustment-for-frd", doc = "Set the maximum depth to modify FRD adjustment to in the event of high depth sites (0 to disable)", optional = false)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -333,9 +333,9 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     /**
      * @return the default set of read filters for use with the HaplotypeCaller
      */
-    public static List<ReadFilter> makeStandardHCReadFilters(final int mappingQualityThreshold) {
+    public static List<ReadFilter> makeStandardHCReadFilters() {
         List<ReadFilter> filters = new ArrayList<>();
-        filters.add(new MappingQualityReadFilter(mappingQualityThreshold));
+        filters.add(new MappingQualityReadFilter(DEFAULT_READ_QUALITY_FILTER_THRESHOLD));
         filters.add(ReadFilterLibrary.MAPPING_QUALITY_AVAILABLE);
         filters.add(ReadFilterLibrary.MAPPED);
         filters.add(ReadFilterLibrary.NOT_SECONDARY_ALIGNMENT);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngineUnitTest.java
@@ -54,7 +54,7 @@ public class HaplotypeCallerEngineUnitTest extends GATKBaseTest {
 
             final HaplotypeCallerEngine hcEngine = new HaplotypeCallerEngine(hcArgs, new AssemblyRegionArgumentCollection(), false, false, reads.getHeader(), referenceReader, new VariantAnnotatorEngine(new ArrayList<>(), hcArgs.dbsnp.dbsnp, hcArgs.comps, false, false));
 
-            List<ReadFilter> hcFilters = HaplotypeCallerEngine.makeStandardHCReadFilters(hcArgs.mappingQualityThreshold);
+            List<ReadFilter> hcFilters = HaplotypeCallerEngine.makeStandardHCReadFilters();
             hcFilters.forEach(filter -> filter.setHeader(reads.getHeader()));
             ReadFilter hcCombinedFilter = hcFilters.get(0);
             for ( int i = 1; i < hcFilters.size(); ++i ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -245,7 +245,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-O", outputPath,
                 "-pairHMM", "AVX_LOGLESS_CACHING",
                 // FRD arguments
-                "--apply-frd", "--transform-dragen-mapping-quality", "--mapping-quality-threshold", "1", "--disable-cap-base-qualities-to-map-quality", "--minimum-mapping-quality", "1",
+                "--apply-frd", "--transform-dragen-mapping-quality", "--mapping-quality-threshold-for-genotyping", "1", "--disable-cap-base-qualities-to-map-quality", "--minimum-mapping-quality", "1",
                 // BQD arguments
                 "--apply-bqd",  "--soft-clip-low-quality-ends",
                 // Dynamic read disqualification arguments"
@@ -460,7 +460,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-O", outputPath,
                 "-pairHMM", "AVX_LOGLESS_CACHING",
                 // FRD arguments
-                "--apply-frd", "--transform-dragen-mapping-quality", "--mapping-quality-threshold", "1", "--disable-cap-base-qualities-to-map-quality", "--minimum-mapping-quality", "1",
+                "--apply-frd", "--transform-dragen-mapping-quality", "--mapping-quality-threshold-for-genotyping", "1", "--disable-cap-base-qualities-to-map-quality", "--minimum-mapping-quality", "1",
                 // BQD arguments
                 "--apply-bqd",  "--soft-clip-low-quality-ends",
                 // Dynamic read disqualification arguments"


### PR DESCRIPTION
Also removed some confusing (and not working!) code that made it seem the argument affected the read filters when in fact it did not because Barclay generates default read filters at the begining of time before that argument gets populated and thus it wouldn't affect the default read filter construction.

Fixes #7034 