### PR TITLE
Make InfoFieldAnnotation/GenotypeAnnotation into interfaces

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AS_StrandBiasMutectAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AS_StrandBiasMutectAnnotation.java
@@ -6,9 +6,7 @@ import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
-import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.AS_StrandBiasTest;
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.AlleleSpecificAnnotation;
-import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.AlleleSpecificAnnotationData;
 import org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific.StrandBiasUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
@@ -22,7 +20,7 @@ import java.util.Map;
 /**
  * Adds the strand bias table annotation for use in mutect filters
  */
-public class AS_StrandBiasMutectAnnotation extends InfoFieldAnnotation implements StandardMutectAnnotation, AlleleSpecificAnnotation {
+public class AS_StrandBiasMutectAnnotation implements InfoFieldAnnotation, StandardMutectAnnotation, AlleleSpecificAnnotation {
     private final static Logger logger = LogManager.getLogger(StrandBiasBySample.class);
 
     @Override
@@ -35,11 +33,6 @@ public class AS_StrandBiasMutectAnnotation extends InfoFieldAnnotation implement
         }
 
         return StrandBiasUtils.computeSBAnnotation(vc, likelihoods, GATKVCFConstants.AS_SB_TABLE_KEY);
-    }
-
-    @Override
-    public List<VCFInfoHeaderLine> getDescriptions() {
-        return super.getDescriptions();
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
@@ -35,7 +35,7 @@ import java.util.*;
  */
 @DocumentedFeature(groupName= HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Variant allele fraction for a genotype")
 
-public final class AlleleFraction extends GenotypeAnnotation {
+public final class AlleleFraction implements GenotypeAnnotation {
     @Override
     public void annotate(final ReferenceContext ref,
                          final VariantContext vc,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityHistogram.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/BaseQualityHistogram.java
@@ -16,7 +16,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class BaseQualityHistogram extends InfoFieldAnnotation {
+public class BaseQualityHistogram implements InfoFieldAnnotation {
 
     public static final String KEY = "BQHIST";
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ChromosomeCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ChromosomeCounts.java
@@ -33,7 +33,7 @@ import java.util.*;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Counts and frequency of alleles in called genotypes (AC, AF, AN)")
-public final class ChromosomeCounts extends InfoFieldAnnotation implements StandardAnnotation {
+public final class ChromosomeCounts implements InfoFieldAnnotation, StandardAnnotation {
 
     public static final String[] keyNames = {
             VCFConstants.ALLELE_NUMBER_KEY,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/CountNs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/CountNs.java
@@ -5,13 +5,11 @@ import com.google.common.collect.ImmutableMap;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
-import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
-import org.broadinstitute.hellbender.utils.read.AlignmentUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
@@ -25,7 +23,7 @@ import java.util.stream.IntStream;
  * Apply a read-based annotation that reports the number of Ns seen at a given site. This is intended for use on consensus called data.
  */
 @DocumentedFeature(groupName= HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Number of Ns at the pileup")
-public class CountNs extends InfoFieldAnnotation {
+public class CountNs implements InfoFieldAnnotation {
     /**
      * Calculate annotations for each allele based on given VariantContext and likelihoods for a given genotype's sample
      * and add the annotations to the GenotypeBuilder.  By default annotations are only calculated for alt alleles but

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/Coverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/Coverage.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Total depth of coverage per sample and over all samples (DP)")
-public final class Coverage extends InfoFieldAnnotation implements StandardAnnotation, StandardMutectAnnotation {
+public final class Coverage implements InfoFieldAnnotation, StandardAnnotation, StandardMutectAnnotation {
 
     @Override
     public Map<String, Object> annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
@@ -12,7 +12,6 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
-import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.*;
@@ -37,7 +36,7 @@ import java.util.stream.Collectors;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of coverage of each allele per sample (AD)")
-public final class DepthPerAlleleBySample extends GenotypeAnnotation implements StandardAnnotation, StandardMutectAnnotation {
+public final class DepthPerAlleleBySample implements GenotypeAnnotation, StandardAnnotation, StandardMutectAnnotation {
 
     @Override
     public void annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -14,7 +14,6 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
-import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 import java.util.*;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of informative coverage for each sample (DP)")
-public final class DepthPerSampleHC extends GenotypeAnnotation implements StandardHCAnnotation, StandardMutectAnnotation {
+public final class DepthPerSampleHC implements GenotypeAnnotation, StandardHCAnnotation, StandardMutectAnnotation {
     private final static Logger logger = LogManager.getLogger(DepthPerSampleHC.class);
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ExcessHet.java
@@ -40,7 +40,7 @@ import java.util.*;
  * <p><b>InbreedingCoeff</b> also describes the heterozygosity of the called samples, though without explicitly taking into account the number of samples</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Phred-scaled p-value for exact test of excess heterozygosity (ExcessHet)")
-public final class ExcessHet extends PedigreeAnnotation implements StandardAnnotation {
+public final class ExcessHet extends PedigreeAnnotation implements InfoFieldAnnotation, StandardAnnotation {
 
     private static final double MIN_NEEDED_VALUE = 1.0E-16;
     private static final boolean ROUND_GENOTYPE_COUNTS = true;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/GenotypeAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/GenotypeAnnotation.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Represents an annotation that is computed for a single genotype.
  */
-public abstract class GenotypeAnnotation extends VariantAnnotation{
+public interface GenotypeAnnotation extends VariantAnnotation {
 
     /**
      * Computes the annotation for the given genotype and the likelihoods per read.
@@ -26,7 +26,7 @@ public abstract class GenotypeAnnotation extends VariantAnnotation{
      * @param g the genotype to annotate. May be null.
      * @param gb the builder to modify and annotations to. Not null.
      */
-    public abstract void annotate(final ReferenceContext ref,
+    public void annotate(final ReferenceContext ref,
                                   final VariantContext vc,
                                   final Genotype g,
                                   final GenotypeBuilder gb,
@@ -36,5 +36,5 @@ public abstract class GenotypeAnnotation extends VariantAnnotation{
      * Return the descriptions used for the VCF FORMAT meta field.
      * Subclasses must ensure that this list is not null and does not contain null.
      */
-    public abstract List<VCFFormatHeaderLine> getDescriptions();
+    public List<VCFFormatHeaderLine> getDescriptions();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/GenotypeSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/GenotypeSummaries.java
@@ -29,7 +29,7 @@ import java.util.*;
  * <p>These summaries can all be recomputed from the genotypes on the fly but it is a lot faster to add them here as INFO field annotations.</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Summary of genotype statistics from all samples (NCC, GQ_MEAN, GQ_STDDEV)")
-public final class GenotypeSummaries extends InfoFieldAnnotation {
+public final class GenotypeSummaries implements InfoFieldAnnotation {
 
     @Override
     public Map<String, Object> annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InbreedingCoeff.java
@@ -47,7 +47,7 @@ import java.util.Set;
  * <p><b>ExcessHet</b> also describes the heterozygosity of the called samples, giving a probability of excess heterozygosity being observed</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Likelihood-based test for the consanguinity among samples (InbreedingCoeff)")
-public final class InbreedingCoeff extends PedigreeAnnotation implements StandardAnnotation {
+public final class InbreedingCoeff extends PedigreeAnnotation implements InfoFieldAnnotation, StandardAnnotation {
 
     private static final OneShotLogger oneShotLogger = new OneShotLogger(InbreedingCoeff.class);
     private static final int MIN_SAMPLES = 10;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InfoFieldAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/InfoFieldAnnotation.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * Annotations relevant to the INFO field of the variant file (ie annotations for sites).
  */
-public abstract class InfoFieldAnnotation extends VariantAnnotation{
+public interface InfoFieldAnnotation extends VariantAnnotation {
 
     /**
      * Computes the annotation for the given variant and the likelihoods per read.
@@ -25,7 +25,7 @@ public abstract class InfoFieldAnnotation extends VariantAnnotation{
      * @param vc Variant to be annotated. Not null.
      * @param likelihoods likelihoods indexed by sample, allele, and read within sample
      */
-    public abstract Map<String, Object> annotate(final ReferenceContext ref,
+    public Map<String, Object> annotate(final ReferenceContext ref,
                                                  final VariantContext vc,
                                                  final AlleleLikelihoods<GATKRead, Allele> likelihoods);
 
@@ -33,7 +33,7 @@ public abstract class InfoFieldAnnotation extends VariantAnnotation{
      * Returns the descriptions used for the VCF INFO meta field.
      * Subclasses must ensure that this list is not null and does not contain null.
      */
-    public List<VCFInfoHeaderLine> getDescriptions() {
+    default List<VCFInfoHeaderLine> getDescriptions() {
         final List<VCFInfoHeaderLine> lines = new ArrayList<>(getKeyNames().size());
         for (final String key : getKeyNames()) {
             lines.add(GATKVCFHeaderLines.getInfoLine(key));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZero.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZero.java
@@ -35,7 +35,7 @@ import java.util.stream.IntStream;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Count of all reads with MAPQ = 0 across all samples (MQ0)")
-public final class MappingQualityZero extends InfoFieldAnnotation {
+public final class MappingQualityZero implements InfoFieldAnnotation {
 
     @Override
     public Map<String, Object> annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OrientationBiasReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OrientationBiasReadCounts.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  *  by Costello et al, doi: 10.1093/nar/gks1443</a></p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Count of read pairs in the F1R2 and F2R1 configurations supporting REF and ALT alleles (F1R2, F2R1)")
-public final class OrientationBiasReadCounts extends GenotypeAnnotation implements StandardMutectAnnotation {
+public final class OrientationBiasReadCounts implements GenotypeAnnotation, StandardMutectAnnotation {
 
     private static final Logger logger = LogManager.getLogger(OrientationBiasReadCounts.class);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OriginalAlignment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/OriginalAlignment.java
@@ -8,7 +8,8 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.tools.AddOriginalAlignmentTags;
 import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
-import org.broadinstitute.hellbender.utils.*;
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
@@ -35,7 +36,7 @@ import java.util.Map;
  *
  */
 @DocumentedFeature(groupName= HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Number of alt reads with an OA tag that doesn't match the current alignment contig.")
-public class OriginalAlignment extends InfoFieldAnnotation {
+public class OriginalAlignment implements InfoFieldAnnotation {
     protected final OneShotLogger warning = new OneShotLogger(this.getClass());
     public static final String KEY = GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PedigreeAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PedigreeAnnotation.java
@@ -22,7 +22,7 @@ import java.util.*;
  * Alternatively, if a pedigree file has been supplied (not founderIDs) then extending classes can call getTrios() to
  * return a set of Trio objects corresponding to a parsing of pedigree file.
  */
-public abstract class PedigreeAnnotation extends InfoFieldAnnotation {
+public abstract class PedigreeAnnotation implements VariantAnnotation {
     private Collection<String> founderIds;
     private GATKPath pedigreeFile = null;
     private boolean hasAddedPedigreeFounders = false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PerAlleleAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PerAlleleAnnotation.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 /**
  * Apply an annotation based on aggregation data from all reads supporting each allele.
  */
-public abstract class PerAlleleAnnotation extends InfoFieldAnnotation{
+public abstract class PerAlleleAnnotation implements InfoFieldAnnotation {
 
     /**
      * Calculate annotations for each allele based on given VariantContext and likelihoods for a given genotype's sample

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
@@ -34,7 +34,7 @@ import java.util.*;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Existence of a de novo mutation in at least one of the given families (hiConfDeNovo, loConfDeNovo)")
-public final class PossibleDeNovo extends PedigreeAnnotation {
+public final class PossibleDeNovo extends PedigreeAnnotation implements InfoFieldAnnotation {
     protected final Logger warning = LogManager.getLogger(this.getClass());
     private final MendelianViolation mendelianViolation;
     private Set<Trio> trios;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepth.java
@@ -43,7 +43,7 @@ import java.util.Map;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Variant confidence normalized by unfiltered depth of variant samples (QD)")
-public final class QualByDepth extends InfoFieldAnnotation implements StandardAnnotation {
+public final class QualByDepth implements InfoFieldAnnotation, StandardAnnotation {
 
     @VisibleForTesting
     static final double MAX_QD_BEFORE_FIXING = 35;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -44,7 +44,7 @@ import java.util.*;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Root mean square of the mapping quality of reads across all samples (MQ)")
-public final class RMSMappingQuality extends InfoFieldAnnotation implements StandardAnnotation, ReducibleAnnotation {
+public final class RMSMappingQuality implements InfoFieldAnnotation, StandardAnnotation, ReducibleAnnotation {
     private static final OneShotLogger logger = new OneShotLogger(RMSMappingQuality.class);
     private static final RMSMappingQuality instance = new RMSMappingQuality();
     private static final int NUM_LIST_ENTRIES = 2;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RankSumTest.java
@@ -17,7 +17,7 @@ import java.util.*;
 /**
  * Abstract root for all RankSum based annotations
  */
-public abstract class RankSumTest extends InfoFieldAnnotation implements Annotation {
+public abstract class RankSumTest implements InfoFieldAnnotation, Annotation {
     protected final static double INVALID_ELEMENT_FROM_READ = Double.NEGATIVE_INFINITY;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/ReferenceBases.java
@@ -27,7 +27,7 @@ import java.util.Map;
  *
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Annotate with local reference bases (REF_BASES)")
-public class ReferenceBases extends InfoFieldAnnotation {
+public class ReferenceBases implements InfoFieldAnnotation {
     public static final String REFERENCE_BASES_KEY = "REF_BASES";
 
     private int NUM_BASES_ON_EITHER_SIDE = 10;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/SampleList.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * difficult to manually match with sample names.</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="List of samples that are not homozygous reference at a variant site (Samples)")
-public final class SampleList extends InfoFieldAnnotation {
+public final class SampleList implements InfoFieldAnnotation {
 
     @Override
     public Map<String, Object> annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
@@ -51,7 +51,7 @@ import java.util.List;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Number of forward and reverse reads that support REF and ALT alleles (SB)")
-public final class StrandBiasBySample extends GenotypeAnnotation implements StandardMutectAnnotation {
+public final class StrandBiasBySample implements GenotypeAnnotation, StandardMutectAnnotation {
     private final static Logger logger = LogManager.getLogger(StrandBiasBySample.class);
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasTest.java
@@ -8,7 +8,6 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
-import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
@@ -17,7 +16,7 @@ import java.util.*;
 /**
  * Class of tests to detect strand bias.
  */
-public abstract class StrandBiasTest extends InfoFieldAnnotation {
+public abstract class StrandBiasTest implements InfoFieldAnnotation {
 
     protected static final int ARRAY_DIM = 2;
     protected static final int ARRAY_SIZE = ARRAY_DIM * ARRAY_DIM;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/TandemRepeat.java
@@ -22,7 +22,7 @@ import java.util.*;
  * <p>A tandem repeat unit is composed of one or more nucleotides that are repeated multiple times in series. Repetitive sequences are difficult to map to the reference because they are associated with multiple alignment possibilities. Knowing the number of repeat units in a set of tandem repeats tells you the number of different positions the tandem repeat can be placed in. The observation of many tandem repeat units multiplies the number of possible representations that can be made of the region.
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Tandem repeat unit composition and counts per allele (STR, RU, RPA)")
-public final class TandemRepeat extends InfoFieldAnnotation implements StandardMutectAnnotation {
+public final class TandemRepeat implements InfoFieldAnnotation, StandardMutectAnnotation {
 
     @Override
     public Map<String, Object> annotate(final ReferenceContext ref,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/UniqueAltReadCount.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/UniqueAltReadCount.java
@@ -15,7 +15,9 @@ import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 import picard.sam.markduplicates.MarkDuplicates;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -36,7 +38,7 @@ import java.util.stream.Collectors;
  * <p>This annotation does not require or use any BAM file duplicate flags or UMI information, just the read alignments.</p>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Number of non-duplicate-insert ALT reads (AS_UNIQ_ALT_READ_COUNT)")
-public class UniqueAltReadCount extends InfoFieldAnnotation implements AlleleSpecificAnnotation {
+public class UniqueAltReadCount implements InfoFieldAnnotation, AlleleSpecificAnnotation {
     public static final String KEY = GATKVCFConstants.AS_UNIQUE_ALT_READ_SET_COUNT_KEY;
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotation.java
@@ -3,17 +3,12 @@ package org.broadinstitute.hellbender.tools.walkers.annotator;
 import java.util.List;
 
 /**
- * Superclass of all variant annotations.
+ * Interface of all variant annotations. See also InfoFieldAnnotation and GenotypeFieldAnnotation
  */
-public abstract class VariantAnnotation implements Annotation{
+public interface VariantAnnotation extends Annotation {
 
     /**
      * Return the keys
      */
-    public abstract List<String> getKeyNames();
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName();
-    }
+    List<String> getKeyNames();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotatorEngine.java
@@ -525,4 +525,5 @@ public final class VariantAnnotatorEngine {
         return ret;
     }
 
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_InbreedingCoeff.java
@@ -39,7 +39,7 @@ import java.util.*;
  */
 //TODO: this can't extend InbreedingCoeff because that one is Standard and it would force this to be output all the time; should fix code duplication nonetheless
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Allele-specific likelihood-based test for the consanguinity among samples (AS_InbreedingCoeff)")
-public final class AS_InbreedingCoeff extends InfoFieldAnnotation implements AS_StandardAnnotation, AlleleSpecificAnnotation {
+public final class AS_InbreedingCoeff implements InfoFieldAnnotation, AS_StandardAnnotation, AlleleSpecificAnnotation {
 
     public static final int MIN_SAMPLES = 10;
     private Set<String> founderIds;    //TODO: either use this or enter a bug report

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Allele-specific call confidence normalized by depth of sample reads supporting the allele (AS_QD)")
-public class AS_QualByDepth extends InfoFieldAnnotation implements ReducibleAnnotation, AS_StandardAnnotation, AlleleSpecificAnnotation {
+public class AS_QualByDepth implements InfoFieldAnnotation, ReducibleAnnotation, AS_StandardAnnotation, AlleleSpecificAnnotation {
 
     @Override
     public List<String> getKeyNames() { return Arrays.asList(GATKVCFConstants.AS_QUAL_BY_DEPTH_KEY); }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RMSMappingQuality.java
@@ -11,8 +11,8 @@ import org.broadinstitute.hellbender.tools.walkers.annotator.InfoFieldAnnotation
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
-import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.help.HelpConstants;
+import org.broadinstitute.hellbender.utils.logging.OneShotLogger;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
@@ -44,7 +44,7 @@ import java.util.*;
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Allele-specific root-mean-square of the mapping quality of reads across all samples (AS_MQ)")
-public final class AS_RMSMappingQuality extends InfoFieldAnnotation implements AS_StandardAnnotation, ReducibleAnnotation, AlleleSpecificAnnotation {
+public final class AS_RMSMappingQuality implements InfoFieldAnnotation, AS_StandardAnnotation, ReducibleAnnotation, AlleleSpecificAnnotation {
 
     private final String printFormat = "%.2f";
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKAnnotationPluginDescriptorUnitTest.java
@@ -623,7 +623,7 @@ public class GATKAnnotationPluginDescriptorUnitTest extends GATKBaseTest {
 
     private interface ParentAnnotationGroup extends Annotation { }
     private interface ChildAnnotationGroup extends ParentAnnotationGroup { }
-    static class testChildAnnotation extends InfoFieldAnnotation implements ChildAnnotationGroup  {
+    static class testChildAnnotation implements InfoFieldAnnotation, ChildAnnotationGroup  {
         public int argument = 5;
 
         @Override
@@ -636,7 +636,7 @@ public class GATKAnnotationPluginDescriptorUnitTest extends GATKBaseTest {
         }
     }
 
-    static class testParentAnnotation extends InfoFieldAnnotation implements ParentAnnotationGroup  {
+    static class testParentAnnotation implements InfoFieldAnnotation, ParentAnnotationGroup  {
         boolean dontAnnotate = false;
 
         testParentAnnotation() { }


### PR DESCRIPTION
@jamesemery This is related to #6930 

The background is that PedigreeAnnotation is special-cased in GATK, which provides better command-line argument validation, and it will also be used to inject the PedigreeFile, create the SampleDB, etc. This is currently a subclass of InfoFieldAnnotation, and therefore cant be used for GenotypeFieldAnnotation. There shouldnt be this limitation, and this PR tried to address that.

The way I propose to do this is to make InfoFieldAnnotation and GenotypeAnnotation into interfaces, with default methods where possible. The existing subclasses all switch from extending them to implementing them. This is generally a trivial difference, but it touches a lot of classes. 

All existing classes that previously extended PedigreeAnnotation (formerly a subclass of InfoFieldAnnotation), now extend PedigreeAnnotation and implement InfoFieldAnnotation. This is a minimal difference, but it makes it possible for future classes to extend PedigreeAnnotation, and then implement GenotypeAnnotation.

The only part this includes that I didnt like was the fact that the existing InfoFieldAnnotation overrides toString(), which I cant do in an interface. So I created AbstractInfoFieldAnnotation, and all existing InfoFieldAnnotation classes extend that. It's not currently clear to me how critical that override of toString() is. The weakness of this PR is that classes outside the GATK project that currently extend InfoFieldAnnotation would not inherit this. I could keep InfoFieldAnnotation a class as-is, and make a differently named interface behind it. 

