### PR TITLE
refactor print sv evidence tool to use a single output stream

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/BafEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/BafEvidence.java
@@ -5,7 +5,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Objects;
 
-public final class BafEvidence implements Feature {
+public final class BafEvidence implements SVEvidence {
 
     final String sample;
     final String contig;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/DepthEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/DepthEvidence.java
@@ -1,12 +1,11 @@
 package org.broadinstitute.hellbender.tools.sv;
 
-import htsjdk.tribble.Feature;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Arrays;
 import java.util.Objects;
 
-public final class DepthEvidence implements Feature {
+public final class DepthEvidence implements SVEvidence {
 
     final String contig;
     final int start;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/DiscordantPairEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/DiscordantPairEvidence.java
@@ -6,7 +6,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Objects;
 
-public final class DiscordantPairEvidence implements Feature {
+public final class DiscordantPairEvidence implements SVEvidence {
 
     final String sample;
     final String startContig;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVEvidence.java
@@ -1,0 +1,6 @@
+package org.broadinstitute.hellbender.tools.sv;
+
+import htsjdk.tribble.Feature;
+
+public interface SVEvidence extends Feature {
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SplitReadEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SplitReadEvidence.java
@@ -5,7 +5,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Objects;
 
-public final class SplitReadEvidence implements Feature {
+public final class SplitReadEvidence implements SVEvidence {
 
     final String sample;
     final String contig;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/PairedEndAndSplitReadEvidenceCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/PairedEndAndSplitReadEvidenceCollection.java
@@ -108,8 +108,8 @@ public class PairedEndAndSplitReadEvidenceCollection extends ReadWalker {
         super.onTraversalStart();
         sequenceDictionary = getBestAvailableSequenceDictionary();
         final FeatureOutputStreamFactory outputFactory = new FeatureOutputStreamFactory();
-        peWriter = outputFactory.create(peFile, DiscordantPairEvidenceCodec::encode, sequenceDictionary, compressionLevel);
-        srWriter = outputFactory.create(srFile, SplitReadEvidenceCodec::encode, sequenceDictionary, compressionLevel);
+        peWriter = outputFactory.create(peFile, new DiscordantPairEvidenceCodec()::encode, sequenceDictionary, compressionLevel);
+        srWriter = outputFactory.create(srFile, new SplitReadEvidenceCodec()::encode, sequenceDictionary, compressionLevel);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/BafEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/BafEvidenceCodec.java
@@ -6,11 +6,12 @@ import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import org.broadinstitute.hellbender.tools.sv.BafEvidence;
+import org.broadinstitute.hellbender.tools.sv.SVEvidence;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class BafEvidenceCodec extends AsciiFeatureCodec<BafEvidence> {
+public class BafEvidenceCodec extends SVEvidenceCodec<BafEvidence> {
 
     public static final String FORMAT_SUFFIX = ".baf.txt";
     public static final String COL_DELIMITER = "\t";
@@ -52,7 +53,7 @@ public class BafEvidenceCodec extends AsciiFeatureCodec<BafEvidence> {
     @Override
     public Object readActualHeader(final LineIterator reader) { return null; }
 
-    public static String encode(final BafEvidence ev) {
+    public String encode(final BafEvidence ev) {
         final List<String> columns = Arrays.asList(
                 ev.getContig(),
                 Integer.toString(ev.getStart() - 1),
@@ -61,4 +62,5 @@ public class BafEvidenceCodec extends AsciiFeatureCodec<BafEvidence> {
         );
         return String.join(COL_DELIMITER, columns);
     }
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/DepthEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/DepthEvidenceCodec.java
@@ -7,11 +7,12 @@ import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.sv.DepthEvidence;
+import org.broadinstitute.hellbender.tools.sv.SVEvidence;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class DepthEvidenceCodec extends AsciiFeatureCodec<DepthEvidence> {
+public class DepthEvidenceCodec extends SVEvidenceCodec<DepthEvidence> {
 
     public static final String FORMAT_SUFFIX = ".rd.txt";
     public static final String COL_DELIMITER = "\t";
@@ -62,7 +63,7 @@ public class DepthEvidenceCodec extends AsciiFeatureCodec<DepthEvidence> {
         return reader.next();
     }
 
-    public static String encode(final DepthEvidence ev) {
+    public String encode(final DepthEvidence ev) {
         final int[] counts = ev.getCounts();
         final int numCounts = counts.length;
         final List<String> columns = new ArrayList<>(3 + numCounts);

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/DiscordantPairEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/DiscordantPairEvidenceCodec.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.utils.codecs;
 
 import com.google.common.base.Splitter;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import org.broadinstitute.hellbender.tools.sv.DiscordantPairEvidence;
@@ -10,7 +9,7 @@ import org.broadinstitute.hellbender.tools.sv.DiscordantPairEvidence;
 import java.util.Arrays;
 import java.util.List;
 
-public class DiscordantPairEvidenceCodec extends AsciiFeatureCodec<DiscordantPairEvidence> {
+public class DiscordantPairEvidenceCodec extends SVEvidenceCodec<DiscordantPairEvidence> {
 
     public static final String FORMAT_SUFFIX = ".pe.txt";
     public static final String COL_DELIMITER = "\t";
@@ -55,7 +54,8 @@ public class DiscordantPairEvidenceCodec extends AsciiFeatureCodec<DiscordantPai
     @Override
     public Object readActualHeader(final LineIterator reader) { return null; }
 
-    public static String encode(final DiscordantPairEvidence ev) {
+    @Override
+    public String encode(final DiscordantPairEvidence ev) {
         final List<String> columns = Arrays.asList(
                 ev.getContig(),
                 Integer.toString(ev.getStart() - 1),

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SVEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SVEvidenceCodec.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.hellbender.utils.codecs;
+
+import htsjdk.tribble.AsciiFeatureCodec;
+import org.broadinstitute.hellbender.tools.sv.SVEvidence;
+
+public abstract class SVEvidenceCodec<T extends SVEvidence> extends AsciiFeatureCodec<T> {
+    protected SVEvidenceCodec(final Class<T> myClass) {
+        super(myClass);
+    }
+
+    public abstract String encode(T ev);
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SplitReadEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SplitReadEvidenceCodec.java
@@ -5,12 +5,13 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
+import org.broadinstitute.hellbender.tools.sv.SVEvidence;
 import org.broadinstitute.hellbender.tools.sv.SplitReadEvidence;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class SplitReadEvidenceCodec extends AsciiFeatureCodec<SplitReadEvidence> {
+public class SplitReadEvidenceCodec extends SVEvidenceCodec<SplitReadEvidence> {
 
     public static final String FORMAT_SUFFIX = ".sr.txt";
     public static final String COL_DELIMITER = "\t";
@@ -58,7 +59,7 @@ public class SplitReadEvidenceCodec extends AsciiFeatureCodec<SplitReadEvidence>
     @Override
     public Object readActualHeader(final LineIterator reader) { return null; }
 
-    public static String encode(final SplitReadEvidence ev) {
+    public String encode(final SplitReadEvidence ev) {
         final List<String> columns = Arrays.asList(
                 ev.getContig(),
                 Integer.toString(ev.getStart() - 1),

--- a/src/test/java/org/broadinstitute/hellbender/utils/io/FeatureOutputStreamUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/io/FeatureOutputStreamUnitTest.java
@@ -131,13 +131,13 @@ public class FeatureOutputStreamUnitTest extends GATKBaseTest {
 
     private static String encodeSVEvidenceFeature(final Object feature) {
         if (feature instanceof BafEvidence) {
-            return BafEvidenceCodec.encode((BafEvidence) feature);
+            return new BafEvidenceCodec().encode((BafEvidence) feature);
         } else if (feature instanceof DepthEvidence) {
-            return DepthEvidenceCodec.encode((DepthEvidence) feature);
+            return new DepthEvidenceCodec().encode((DepthEvidence) feature);
         } else if (feature instanceof DiscordantPairEvidence) {
-            return DiscordantPairEvidenceCodec.encode((DiscordantPairEvidence) feature);
+            return new DiscordantPairEvidenceCodec().encode((DiscordantPairEvidence) feature);
         } else if (feature instanceof SplitReadEvidence) {
-            return SplitReadEvidenceCodec.encode((SplitReadEvidence) feature);
+            return new SplitReadEvidenceCodec().encode((SplitReadEvidence) feature);
         }
         throw new IllegalArgumentException("Unsupported SV evidence class: " + feature.getClass().getSimpleName());
     }


### PR DESCRIPTION
This is a suggested refactor of PrintSVEvidence to use a single output stream and parameterize the type of evidence. 