### PR TITLE
Fixed error in FilterIntervals logic when filtering on annotations with -XL.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/FilterIntervalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/FilterIntervalsIntegrationTest.java
@@ -111,6 +111,7 @@ public final class FilterIntervalsIntegrationTest extends CommandLineProgramTest
                 {intervalsFile, Collections.emptyList(), annotatedIntervalsFile, 0., 1., 0.1, 0.9, 0.1, 0.9, Arrays.asList(2, 3, 5)},
                 {intervalsFile, Collections.emptyList(), annotatedIntervalsFile, 0.1, 0.9, 0.1, 0.9, 0.1, 0.9, Arrays.asList(2, 5)},
                 {intervalsFile, Collections.singletonList("20:1-10"), annotatedIntervalsFile, 0., 1., 0., 1., 0., 1., Arrays.asList(1, 2, 3, 4, 5)},
+                {intervalsFile, Collections.singletonList("20:1-15"), annotatedIntervalsFile, 0.1, 0.9, 0., 1., 0., 1., Arrays.asList(2, 5)}, //regression test for https://github.com/broadinstitute/gatk/pull/7046
                 {intervalsFile, Arrays.asList("20:1-15", "20:35-45"), annotatedIntervalsFile, 0., 1., 0., 1., 0., 1., Arrays.asList(2, 5)},
                 {intervalsFile, Collections.singletonList("20:25-50"), annotatedIntervalsFile, 0.1, 0.9, 0., 1., 0., 1., Arrays.asList(0, 1, 5)},
                 {intervalsWithExtraIntervalFile, Collections.emptyList(), annotatedIntervalsFile, 0., 1., 0., 1., 0., 1., Arrays.asList(0, 1, 2, 3, 4, 5)},


### PR DESCRIPTION
Fixes a bug that I inadvertently introduced long ago in #5408. A method there originally assumed that the intervals to be filtered coincide with the annotated intervals when filtering on annotations, but this assumption can be violated when e.g. using `-XL` to further exclude intervals. This breaks the annotation-based filtering and will result in incorrectly retained/dropped intervals. Unfortunately, the integration test cases were not quite complete enough to catch this.

Fortunately, for typical data and parameters, the number of affected intervals is typically a very small percentage, especially in human (e.g., the default GC filters of [0.1, 0.9] affect <0.1% of 250bp bins); I only caught this when running on malaria data, since GC filtering has more impact there. I would also expect count-based filters to mitigate some of the effects (e.g., a bin with extreme GC that was erroneously retained when filtering on annotations might later be filtered because it has poor coverage). Downstream results are also all correct---they're just given for a slightly different set of intervals than would be expected.

This bug would affect users that made use of the `blacklist_intervals_for_filter_intervals` option in the gCNV WDLs, but my feeling is this functionality is not used that frequently.

@droazen I think this is a relatively minor bug, but it might be good to mention it in the release notes.