### PR TITLE
Separate bigquery table creation and data loading in LoadData 

### DIFF
--- a/scripts/variantstore/wdl/ImportGenomes.example.inputs.json
+++ b/scripts/variantstore/wdl/ImportGenomes.example.inputs.json
@@ -11,9 +11,7 @@
 
   "ImportGenomes.sample_map": "gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/test_sample_map.csv",
 
-  "ImportGenomes.input_vcfs": ["gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/9a5be44d-c032-40ef-bd4f-8de736299484/ReblockGVCF/65c5b1d0-4aeb-44cc-a696-710dbc5f60f1/call-Reblock/BI_NA14170_A11_99000142090_SM-GXZV3_1.vcf.gz",
-    "gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/9a5be44d-c032-40ef-bd4f-8de736299484/ReblockGVCF/f02d7f4e-a19b-4d84-b0de-0750c9b3cfd9/call-Reblock/BI_NA23079_1_99000142156_SM-GXZVL_1.vcf.gz",
-    "gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/9a5be44d-c032-40ef-bd4f-8de736299484/ReblockGVCF/dc63b7c7-9d13-4674-8680-072ee04e9237/call-Reblock/BI_NA21987_1_99000142135_SM-GXZVB_1.vcf.gz"],
+  "ImportGenomes.input_vcfs_list": "gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/input_vcfs.txt",
 
   "ImportGenomes.output_directory": "gs://fc-50fc04ca-572b-4cba-82d5-4af10722cdc7/testrun2_importdir"
 }

--- a/scripts/variantstore/wdl/LoadBigQueryData.wdl
+++ b/scripts/variantstore/wdl/LoadBigQueryData.wdl
@@ -140,7 +140,6 @@ task CreateTables {
         PARTITION_STRING="--range_partitioning=$PARTITION_FIELD,$PARTITION_START,$PARTITION_END,$PARTITION_STEP"
       fi
 
-      # we are loading ONLY one table, specified by table_id
       printf -v PADDED_TABLE_ID "_%03d" ${TABLE_ID}
       FILES="~{datatype}${PADDED_TABLE_ID}_*"
 

--- a/scripts/variantstore/wdl/LoadBigQueryData.wdl
+++ b/scripts/variantstore/wdl/LoadBigQueryData.wdl
@@ -1,0 +1,184 @@
+version 1.0
+
+workflow LoadBigQueryData {
+  input {
+    String project_id
+    String dataset_name
+    String storage_location
+    String datatype
+    Int max_table_id
+    
+    File schema
+    String numbered = "true"
+    String partitioned = "true"
+    String load = "true"
+    String uuid = ""
+    Array[String] done
+    Int? preemptible_tries
+    String docker
+    String? for_testing_only
+  }
+  
+  call CreateTables {
+  	input:
+      project_id = project_id,
+      dataset_name = dataset_name,
+      storage_location = storage_location,
+      datatype = datatype,
+      max_table_id = max_table_id,
+      schema = schema,
+      numbered = numbered,
+      partitioned = partitioned,
+      load = load,
+      uuid = uuid,
+      done = done,
+      preemptible_tries = preemptible_tries,
+      docker = docker,
+      for_testing_only = for_testing_only
+  }
+
+  scatter (table_dir_files_str in CreateTables.table_dir_files_list) {
+    call LoadTable {
+      input:
+        table_dir_files_str = table_dir_files_str,
+        project_id = project_id,
+        schema = schema,
+        load = load,
+        preemptible_tries = preemptible_tries,
+        docker = docker
+    }
+  }
+  
+  output {
+    Array[String] table_dir_files_list = CreateTables.table_dir_files_list
+  }
+}
+
+task LoadTable {
+  meta {
+    volatile: true
+  }
+  
+  input {
+    String table_dir_files_str
+    String project_id
+    File schema
+    String load
+    
+    Int? preemptible_tries
+    String docker
+  }
+
+  command <<<
+    TABLE=$(echo ~{table_dir_files_str} | cut -d, -f1)
+    DIR=$(echo ~{table_dir_files_str} | cut -d, -f2)
+    FILES=$(echo ~{table_dir_files_str} | cut -d, -f3)
+
+    #load should be false if using Google Storage Transfer so that the tables will be created by this script, but no data will be uploaded.
+    if [ ~{load} = true ]; then
+      bq load --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" $TABLE $DIR$FILES ~{schema}
+      echo "ingested ${FILES} file from $DIR into table $TABLE"
+      gsutil mv $DIR$FILES ${DIR}done/
+    else
+      echo "${FILES} will be ingested from $DIR by Google Storage Transfer"
+    fi
+  >>>
+  
+  runtime {
+    docker: docker
+    memory: "3 GB"
+    disks: "local-disk 10 HDD"
+    preemptible: select_first([preemptible_tries, 5])
+    cpu: 1
+  }
+}
+
+task CreateTables {
+	meta {
+    	volatile: true
+  	}
+  
+	input {
+      String project_id
+      String dataset_name
+      String storage_location
+      String datatype
+      Int max_table_id
+      File schema
+      String numbered
+      String partitioned
+      String load
+      String uuid
+
+      #input from previous task needed to delay task from running until the other is complete
+      Array[String] done
+
+      # runtime
+      Int? preemptible_tries
+      String docker
+
+      String? for_testing_only
+    }
+
+  command <<<
+    set -x
+    set -e
+    ~{for_testing_only}
+
+    DIR="~{storage_location}/~{datatype}_tsvs/"
+
+    for TABLE_ID in $(seq 1 ~{max_table_id}); do
+      PARTITION_STRING=""
+      if [ ~{partitioned} == "true" ]; then
+        let "PARTITION_START=(${TABLE_ID}-1)*4000+1"
+        let "PARTITION_END=$PARTITION_START+3999"
+        let "PARTITION_STEP=1"
+        PARTITION_FIELD="sample_id"
+        PARTITION_STRING="--range_partitioning=$PARTITION_FIELD,$PARTITION_START,$PARTITION_END,$PARTITION_STEP"
+      fi
+
+      # we are loading ONLY one table, specified by table_id
+      printf -v PADDED_TABLE_ID "_%03d" ${TABLE_ID}
+      FILES="~{datatype}${PADDED_TABLE_ID}_*"
+
+      NUM_FILES=$(gsutil ls $DIR$FILES | wc -l)
+
+      # create the table
+      PREFIX=""
+      if [ -n "~{uuid}" ]; then
+          PREFIX="~{uuid}_"
+      fi
+
+      if [ $NUM_FILES -gt 0 ]; then
+        if [ ~{numbered} != "true" ]; then
+          PADDED_TABLE_ID=""  #override table id to empty string, but it is needed to get the files
+        fi
+
+        TABLE="~{dataset_name}.${PREFIX}~{datatype}${PADDED_TABLE_ID}"
+
+        # Checks that the table has not been created yet
+        if [ ! -f table_dir_files.csv ] || [ "$(cat table_dir_files.csv | cut -d, -f1 | grep -c $TABLE)" = "0" ]; then
+          echo "making table $TABLE"
+          bq --location=US mk ${PARTITION_STRING} --project_id=~{project_id} $TABLE ~{schema}
+        fi
+
+        echo "$TABLE,$DIR,$FILES" >> table_dir_files.csv
+      else
+        echo "no ${FILES} files to process"
+      fi
+
+    done 
+  >>>
+
+  output {
+    Array[String] table_dir_files_list = read_lines("table_dir_files.csv")
+  }
+
+  runtime {
+    docker: docker
+    memory: "3 GB"
+    disks: "local-disk 10 HDD"
+    preemptible: select_first([preemptible_tries, 5])
+    cpu: 1
+  }
+}

--- a/scripts/variantstore/wdl/LoadBigQueryData.wdl
+++ b/scripts/variantstore/wdl/LoadBigQueryData.wdl
@@ -7,7 +7,7 @@ workflow LoadBigQueryData {
     String storage_location
     String datatype
     Int max_table_id
-    
+
     File schema
     String numbered = "true"
     String partitioned = "true"
@@ -18,7 +18,7 @@ workflow LoadBigQueryData {
     String docker
     String? for_testing_only
   }
-  
+
   call CreateTables {
   	input:
       project_id = project_id,
@@ -48,7 +48,7 @@ workflow LoadBigQueryData {
         docker = docker
     }
   }
-  
+
   output {
     Array[String] table_dir_files_list = CreateTables.table_dir_files_list
   }
@@ -58,13 +58,13 @@ task LoadTable {
   meta {
     volatile: true
   }
-  
+
   input {
     String table_dir_files_str
     String project_id
     File schema
     String load
-    
+
     Int? preemptible_tries
     String docker
   }
@@ -83,7 +83,7 @@ task LoadTable {
       echo "${FILES} will be ingested from $DIR by Google Storage Transfer"
     fi
   >>>
-  
+
   runtime {
     docker: docker
     memory: "3 GB"
@@ -93,11 +93,14 @@ task LoadTable {
   }
 }
 
+# Creates all the tables necessary for the LoadData operation
+# As an optimization, I also generate a (table, dir, files) csv file which contains
+# most of inputs necessary for the following LoadTable task.
 task CreateTables {
 	meta {
     	volatile: true
   	}
-  
+
 	input {
       String project_id
       String dataset_name
@@ -167,7 +170,7 @@ task CreateTables {
         echo "no ${FILES} files to process"
       fi
 
-    done 
+    done
   >>>
 
   output {


### PR DESCRIPTION
- I sneaked in another change where I pass in a single file containing a list of input_vcfs instead of an array of input_vcfs. I made this because Terra couldn't save my inputs when I passed in 700 samples.
- Most of the logic was moved into `CreateTables`, including the determination for what files to load. It would have been cleaner to move all of the file loading logic into `LoadTable` but the current approach cuts down the on the number of `gsutil ls` calls made and more importantly, only spins up a shard if there are files to load.
- I pushed the logic into a separate workflow because I wanted to refactor it as two tasks and I couldn't find a way to get a Task to call another Task without wrapping it in a workflow.