### PR TITLE
Add option to save output for a small set of tools

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.cmdline.argumentcollections;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.exceptions.UserException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -27,7 +28,7 @@ import java.nio.file.StandardOpenOption;
  * <p>
  * The code will only attempt to write to the output if -o (or --output) has been assigned on the commandline.
  */
-public class SimpleOutputCollection implements Serializable {
+public class OptionalTextOutputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
@@ -36,15 +37,24 @@ public class SimpleOutputCollection implements Serializable {
             optional = true)
     public GATKPath output = null;
 
-
-    public void writeToOutput(Object value) {
+    /**
+     * Print value (value.toString()) to the output path, if output is not null
+     */
+    public void print(Object value) {
         if (output != null) {
             try {
                 Files.write(output.toPath(), value.toString().getBytes());
-                Files.write(output.toPath(), "\n".getBytes(), StandardOpenOption.APPEND);
             } catch (IOException e) {
-                e.printStackTrace();
+                throw new UserException.CouldNotCreateOutputFile(output.toString(), e);
             }
         }
+    }
+
+    /**
+     * Print value (value.toString() + "\n") to the output path, if output is not null
+     */
+    public void println(Object value) {
+        print(value);
+        print("\n");
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollection.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
@@ -11,34 +12,49 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 
 /**
- * To Use this class add a @ArgumentCollection variable like so:
+ * An ArgumentCollection with an optional output argument, and utility methods for printing String output to it
+ *
+ * To use this class add an @ArgumentCollection variable to your tool like so:
  *
  * <code>
- *
- * @ArgumentCollection public final out = new SimpleOutput();
+ * @ArgumentCollection
+ * public final out = new OptionalTextOutputArgumentCollection();
  * </code>
  * <p>
  * and in the method <code>onTraversalSuccess</code> instead of just outputting to the terminal, also call
  *
  * <code>
- * out.writeToOutput(value)
+ * out.println(value)
+ * </code>
+ * or
+ * <code>
+ * out.print(value)
  * </code>
  * <p>
  * where <code>value</code> is the object to be written to the file.
  * <p>
- * The code will only attempt to write to the output if -o (or --output) has been assigned on the commandline.
+ * The code will only attempt to write to the output if -O (or --output) has been specified on the commandline.
  */
 public class OptionalTextOutputArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
-            doc = "Optional file for the output value.",
+            doc = "Optional output file",
             optional = true)
-    public GATKPath output = null;
+    @VisibleForTesting
+    GATKPath output = null;
 
     /**
-     * Print value (value.toString()) to the output path, if output is not null
+     * @return The -O/--output Path specified on the command line, or null if there was none
+     */
+    public GATKPath getOutputPath() {
+        return output;
+    }
+    
+    /**
+     * Prints value (value.toString()) to the output path, if output is not null
+     * Overwrites any pre-existing output file rather than appending.
      */
     public void print(Object value) {
         if (output != null) {
@@ -51,10 +67,10 @@ public class OptionalTextOutputArgumentCollection implements Serializable {
     }
 
     /**
-     * Print value (value.toString() + "\n") to the output path, if output is not null
+     * Prints value (value.toString() + "\n") to the output path, if output is not null
+     * Overwrites any pre-existing output file rather than appending.
      */
     public void println(Object value) {
-        print(value);
-        print("\n");
+        print(value.toString() + "\n");
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SimpleOutputCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SimpleOutputCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.GATKPath;
 
 import java.io.IOException;
@@ -12,29 +13,31 @@ import java.nio.file.StandardOpenOption;
  * To Use this class add a @ArgumentCollection variable like so:
  *
  * <code>
- * @ArgumentCollection
- * public final out = new SimpleOutput();
- * </code>
  *
+ * @ArgumentCollection public final out = new SimpleOutput();
+ * </code>
+ * <p>
  * and in the method <code>onTraversalSuccess</code> instead of just outputting to the terminal, also call
  *
  * <code>
- *     out.writeToOutput(value)
+ * out.writeToOutput(value)
  * </code>
- *
+ * <p>
  * where <code>value</code> is the object to be written to the file.
- *
+ * <p>
  * The code will only attempt to write to the output if -o (or --output) has been assigned on the commandline.
- *
  */
 public class SimpleOutputCollection implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Argument(shortName = "o", doc = "Optional output file for the output value.", optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            doc = "Optional file for the output value.",
+            optional = true)
     public GATKPath output = null;
 
 
-    public void writeToOutput(Object value)  {
+    public void writeToOutput(Object value) {
         if (output != null) {
             try {
                 Files.write(output.toPath(), value.toString().getBytes());

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SimpleOutputCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/SimpleOutputCollection.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.GATKPath;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * To Use this class add a @ArgumentCollection variable like so:
+ *
+ * <code>
+ * @ArgumentCollection
+ * public final out = new SimpleOutput();
+ * </code>
+ *
+ * and in the method <code>onTraversalSuccess</code> instead of just outputting to the terminal, also call
+ *
+ * <code>
+ *     out.writeToOutput(value)
+ * </code>
+ *
+ * where <code>value</code> is the object to be written to the file.
+ *
+ * The code will only attempt to write to the output if -o (or --output) has been assigned on the commandline.
+ *
+ */
+public class SimpleOutputCollection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(shortName = "o", doc = "Optional output file for the output value.", optional = true)
+    public GATKPath output = null;
+
+
+    public void writeToOutput(Object value)  {
+        if (output != null) {
+            try {
+                Files.write(output.toPath(), value.toString().getBytes());
+                Files.write(output.toPath(), "\n".getBytes(), StandardOpenOption.APPEND);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -4,7 +4,7 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalTextOutputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * Calculate and print to the standard output the overall number of bases in a SAM/BAM/CRAM file
+ * Calculate and print to the standard output (and optionally a file) the overall number of bases in a SAM/BAM/CRAM file
  *
  * <h3>Input</h3>
  * <ul>
@@ -28,7 +28,19 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  */
 @DocumentedFeature
 @CommandLineProgramProperties(
-	summary = "Counts bases in a SAM/BAM/CRAM file",
+	summary = " Calculate and print to the standard output (and optionally a file) the overall number of bases in a SAM/BAM/CRAM file\n" +
+            "\n" +
+            " <h3>Input</h3>\n" +
+            " <ul>\n" +
+            "     <li> A single BAM file</li>\n" +
+            " </ul>\n" +
+            "\n" +
+            " <h3>Example</h3>\n" +
+            "\n" +
+            " <pre>\n" +
+            "   gatk CountBases \\\n" +
+            "     -I input_reads.bam\n" +
+            " </pre>",
 	oneLineSummary = "Count bases in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )
@@ -38,7 +50,7 @@ public final class CountBases extends ReadWalker {
     private long count = 0;
 
     @ArgumentCollection
-    final public SimpleOutputCollection out = new SimpleOutputCollection();
+    final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
 
     @Override
     public void apply( GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext ) {
@@ -47,7 +59,7 @@ public final class CountBases extends ReadWalker {
 
     @Override
     public Object onTraversalSuccess() {
-        out.writeToOutput(count);
+        out.print(count);
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.tools;
 
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -35,6 +37,9 @@ public final class CountBases extends ReadWalker {
 
     private long count = 0;
 
+    @ArgumentCollection
+    final public SimpleOutputCollection out = new SimpleOutputCollection();
+
     @Override
     public void apply( GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         count += read.getLength();
@@ -42,6 +47,7 @@ public final class CountBases extends ReadWalker {
 
     @Override
     public Object onTraversalSuccess() {
+        out.writeToOutput(count);
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountBases.java
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * Calculate and print to the standard output (and optionally a file) the overall number of bases in a SAM/BAM/CRAM file
+ * Count and print to standard output (and optionally to a file) the total number of bases in a SAM/BAM/CRAM file
  *
  * <h3>Input</h3>
  * <ul>
@@ -28,19 +28,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  */
 @DocumentedFeature
 @CommandLineProgramProperties(
-	summary = " Calculate and print to the standard output (and optionally a file) the overall number of bases in a SAM/BAM/CRAM file\n" +
-            "\n" +
-            " <h3>Input</h3>\n" +
-            " <ul>\n" +
-            "     <li> A single BAM file</li>\n" +
-            " </ul>\n" +
-            "\n" +
-            " <h3>Example</h3>\n" +
-            "\n" +
-            " <pre>\n" +
-            "   gatk CountBases \\\n" +
-            "     -I input_reads.bam\n" +
-            " </pre>",
+	summary = "Count and print to standard output (and optionally to a file) the total number of bases in a SAM/BAM/CRAM file",
 	oneLineSummary = "Count bases in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -4,7 +4,7 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalTextOutputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * Calculate and print to the standard output the overall number of reads in a SAM/BAM/CRAM file
+ * Calculate and print to the standard output (and optionally a file) the overall number of reads in a SAM/BAM/CRAM file.
  *
  * <h3>Input</h3>
  * <ul>
@@ -27,7 +27,18 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  * </pre>
  */
 @CommandLineProgramProperties(
-	summary = "Count reads in a SAM/BAM/CRAM file.",
+	summary = "Calculate and print to the standard output (and optionally a file) the overall number of reads in a SAM/BAM/CRAM file.\n" +
+            "\n" +
+            "<h3>Input</h3>\n" +
+            "<ul>\n" +
+            "    <li>A single BAM file</li>\n" +
+            "</ul>\n" +
+            "\n" +
+            "<h3>Example</h3>\n" +
+            "<pre>\n" +
+            "  gatk CountReads \\\n" +
+            "    -I input_reads.bam\n" +
+            "</pre>",
 	oneLineSummary = "Count reads in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )
@@ -38,7 +49,8 @@ public final class CountReads extends ReadWalker {
     private long count = 0;
 
     @ArgumentCollection
-    final public SimpleOutputCollection out = new SimpleOutputCollection();
+    final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
+
     @Override
     public void apply( final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext ) {
         ++count;
@@ -47,7 +59,7 @@ public final class CountReads extends ReadWalker {
     @Override
     public Object onTraversalSuccess() {
         logger.info("CountReads counted " + count + " total reads");
-        out.writeToOutput(count);
+        out.print(count);
 
         return count;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
 /**
- * Calculate and print to the standard output (and optionally a file) the overall number of reads in a SAM/BAM/CRAM file.
+ * Count and print to standard output (and optionally to a file) the total number of reads in a SAM/BAM/CRAM file.
  *
  * <h3>Input</h3>
  * <ul>
@@ -27,18 +27,7 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
  * </pre>
  */
 @CommandLineProgramProperties(
-	summary = "Calculate and print to the standard output (and optionally a file) the overall number of reads in a SAM/BAM/CRAM file.\n" +
-            "\n" +
-            "<h3>Input</h3>\n" +
-            "<ul>\n" +
-            "    <li>A single BAM file</li>\n" +
-            "</ul>\n" +
-            "\n" +
-            "<h3>Example</h3>\n" +
-            "<pre>\n" +
-            "  gatk CountReads \\\n" +
-            "    -I input_reads.bam\n" +
-            "</pre>",
+	summary = "Count and print to standard output (and optionally to a file) the total number of reads in a SAM/BAM/CRAM file",
 	oneLineSummary = "Count reads in a SAM/BAM/CRAM file",
     programGroup = CoverageAnalysisProgramGroup.class
 )

--- a/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/CountReads.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.tools;
 
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.CoverageAnalysisProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -34,6 +36,9 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 public final class CountReads extends ReadWalker {
 
     private long count = 0;
+
+    @ArgumentCollection
+    final public SimpleOutputCollection out = new SimpleOutputCollection();
     @Override
     public void apply( final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext ) {
         ++count;
@@ -42,6 +47,8 @@ public final class CountReads extends ReadWalker {
     @Override
     public Object onTraversalSuccess() {
         logger.info("CountReads counted " + count + " total reads");
+        out.writeToOutput(count);
+
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -4,7 +4,7 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalTextOutputArgumentCollection;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -17,7 +17,7 @@ import java.text.NumberFormat;
 
 /**
  * Accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set, number of
- * duplicates, percentage mapped etc.
+ * duplicates, percentage mapped etc. and output summary to standard output (and optionally a file.)
  *
  * <h3>Input</h3>
  * <ul>
@@ -36,8 +36,24 @@ import java.text.NumberFormat;
  * </pre>
  */
 @CommandLineProgramProperties(
-	summary = "Accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set, " +
-            "number of duplicates, percentage mapped etc.",
+	summary = "Accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set, number of\n" +
+            "duplicates, percentage mapped etc. and output summary to standard output (and optionally a file.)\n" +
+            "\n" +
+            "<h3>Input</h3>\n" +
+            "<ul>\n" +
+            "    <li>A BAM file containing aligned read data</li>\n" +
+            "</ul>\n" +
+            "\n" +
+            "<h3>Output</h3>\n" +
+            "<ul>\n" +
+            "    <li>Accumulated flag statistics</li>\n" +
+            "</ul>\n" +
+            "\n" +
+            "<h3>Example Usage</h3>\n" +
+            "<pre>\n" +
+            "  gatk FlagStat \\\n" +
+            "    -I input.bam\n" +
+            "</pre>",
 	oneLineSummary = "Accumulate flag statistics given a BAM file",
     programGroup = DiagnosticsAndQCProgramGroup.class
 )
@@ -48,7 +64,8 @@ public final class FlagStat extends ReadWalker {
     private final FlagStatus sum = new FlagStatus();
 
     @ArgumentCollection
-    final public SimpleOutputCollection out = new SimpleOutputCollection();
+    final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
+
     @Override
     public void apply( GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         sum.add(read);
@@ -56,7 +73,7 @@ public final class FlagStat extends ReadWalker {
 
     @Override
     public Object onTraversalSuccess() {
-        out.writeToOutput(sum);
+        out.print(sum);
         return sum;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.tools;
 
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.WorkflowProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -45,6 +47,8 @@ public final class FlagStat extends ReadWalker {
 
     private final FlagStatus sum = new FlagStatus();
 
+    @ArgumentCollection
+    final public SimpleOutputCollection out = new SimpleOutputCollection();
     @Override
     public void apply( GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext ) {
         sum.add(read);
@@ -52,6 +56,7 @@ public final class FlagStat extends ReadWalker {
 
     @Override
     public Object onTraversalSuccess() {
+        out.writeToOutput(sum);
         return sum;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FlagStat.java
@@ -17,7 +17,7 @@ import java.text.NumberFormat;
 
 /**
  * Accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set, number of
- * duplicates, percentage mapped etc. and output summary to standard output (and optionally a file.)
+ * duplicates, percentage mapped etc. and output summary to standard output (and optionally to a file.)
  *
  * <h3>Input</h3>
  * <ul>
@@ -37,23 +37,7 @@ import java.text.NumberFormat;
  */
 @CommandLineProgramProperties(
 	summary = "Accumulate flag statistics given a BAM file, e.g. total number of reads with QC failure flag set, number of\n" +
-            "duplicates, percentage mapped etc. and output summary to standard output (and optionally a file.)\n" +
-            "\n" +
-            "<h3>Input</h3>\n" +
-            "<ul>\n" +
-            "    <li>A BAM file containing aligned read data</li>\n" +
-            "</ul>\n" +
-            "\n" +
-            "<h3>Output</h3>\n" +
-            "<ul>\n" +
-            "    <li>Accumulated flag statistics</li>\n" +
-            "</ul>\n" +
-            "\n" +
-            "<h3>Example Usage</h3>\n" +
-            "<pre>\n" +
-            "  gatk FlagStat \\\n" +
-            "    -I input.bam\n" +
-            "</pre>",
+            "duplicates, percentage mapped etc. and output summary to standard output (and optionally to a file).",
 	oneLineSummary = "Accumulate flag statistics given a BAM file",
     programGroup = DiagnosticsAndQCProgramGroup.class
 )

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
@@ -10,8 +10,8 @@ import picard.cmdline.programgroups.VariantEvaluationProgramGroup;
 
 /**
  *
- * Count variant records in a VCF file, regardless of filter status. The tool gives the count at end of the standard out
- * (and optionally write it in a file).
+ * Count variant records in a VCF file, regardless of filter status. The tool prints the count to standard output
+ * (and can optionally write it to a file).
  *
  * <h3> Input </h3>
  * <ul>
@@ -34,19 +34,9 @@ public final class CountVariants extends VariantWalker {
     private long count = 0;
 
     static final String USAGE_ONE_LINE_SUMMARY = "Counts variant records in a VCF file, regardless of filter status.";
-    static final String USAGE_SUMMARY = "T Count variant records in a VCF file, regardless of filter status. The tool gives the count at end of the standard out\n" +
-            " (and optionally write it in a file).\n" +
-            "\n" +
-            " <h3> Input </h3>\n" +
-            " <ul>\n" +
-            "     <li> A single VCF file. </li>\n" +
-            " </ul>\n" +
-            "\n" +
-            " <h3> Usage example: </h3>\n" +
-            " <pre>\n" +
-            "  gatk CountVariants \\\n" +
-            "      -V input_variants.vcf\n" +
-            " </pre>";
+    static final String USAGE_SUMMARY = "This tool counts the variant records in a VCF file, regardless of filter status. " +
+            "Because it counts the number of rows in the VCF, it does not necessarily reflect the number of variant " +
+            "alleles. The count is printed to standard output (and may optionally be written to a file)";
 
     @ArgumentCollection
     final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
@@ -1,13 +1,12 @@
 package org.broadinstitute.hellbender.tools.walkers;
 
 import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.engine.*;
 import picard.cmdline.programgroups.VariantEvaluationProgramGroup;
-import org.broadinstitute.hellbender.engine.FeatureContext;
-import org.broadinstitute.hellbender.engine.ReadsContext;
-import org.broadinstitute.hellbender.engine.ReferenceContext;
-import org.broadinstitute.hellbender.engine.VariantWalker;
 
 /**
  *
@@ -38,13 +37,16 @@ public final class CountVariants extends VariantWalker {
             "Because it counts the number of rows in the VCF, it does not necessarily reflect the number of variant " +
             "alleles. The count is returned at the end of the standard out.";
 
+    @ArgumentCollection
+    final public SimpleOutputCollection out = new SimpleOutputCollection();
     @Override
-    public void apply( final VariantContext variant, final ReadsContext readsContext, final ReferenceContext referenceContext, final FeatureContext featureContext ) {
+    public void apply(final VariantContext variant, final ReadsContext readsContext, final ReferenceContext referenceContext, final FeatureContext featureContext) {
         count++;
     }
 
     @Override
     public Object onTraversalSuccess() {
+        out.writeToOutput(count);
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/CountVariants.java
@@ -4,13 +4,14 @@ import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalTextOutputArgumentCollection;
 import org.broadinstitute.hellbender.engine.*;
 import picard.cmdline.programgroups.VariantEvaluationProgramGroup;
 
 /**
  *
- * Count variant records in a VCF file, regardless of filter status. The tool gives the count at end of the standard out.
+ * Count variant records in a VCF file, regardless of filter status. The tool gives the count at end of the standard out
+ * (and optionally write it in a file).
  *
  * <h3> Input </h3>
  * <ul>
@@ -33,12 +34,23 @@ public final class CountVariants extends VariantWalker {
     private long count = 0;
 
     static final String USAGE_ONE_LINE_SUMMARY = "Counts variant records in a VCF file, regardless of filter status.";
-    static final String USAGE_SUMMARY = "This tool counts the variant records in a VCF file, regardless of filter status. " +
-            "Because it counts the number of rows in the VCF, it does not necessarily reflect the number of variant " +
-            "alleles. The count is returned at the end of the standard out.";
+    static final String USAGE_SUMMARY = "T Count variant records in a VCF file, regardless of filter status. The tool gives the count at end of the standard out\n" +
+            " (and optionally write it in a file).\n" +
+            "\n" +
+            " <h3> Input </h3>\n" +
+            " <ul>\n" +
+            "     <li> A single VCF file. </li>\n" +
+            " </ul>\n" +
+            "\n" +
+            " <h3> Usage example: </h3>\n" +
+            " <pre>\n" +
+            "  gatk CountVariants \\\n" +
+            "      -V input_variants.vcf\n" +
+            " </pre>";
 
     @ArgumentCollection
-    final public SimpleOutputCollection out = new SimpleOutputCollection();
+    final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
+
     @Override
     public void apply(final VariantContext variant, final ReadsContext readsContext, final ReferenceContext referenceContext, final FeatureContext featureContext) {
         count++;
@@ -46,7 +58,7 @@ public final class CountVariants extends VariantWalker {
 
     @Override
     public Object onTraversalSuccess() {
-        out.writeToOutput(count);
+        out.print(count);
         return count;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
@@ -4,7 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalTextOutputArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadsContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
@@ -14,12 +14,14 @@ import picard.cmdline.programgroups.ReferenceProgramGroup;
 @DocumentedFeature
 @CommandLineProgramProperties(
         oneLineSummary = "Count the numbers of each base in a reference file",
-        summary = "Count the number of times each individual base occurs in a reference file.",
+        summary = "Count the number of times each individual base occurs in a reference file and output to stadard out " +
+                "(and optionally a file).",
         programGroup = ReferenceProgramGroup.class
 )
 public class CountBasesInReference extends ReferenceWalker {
+
     @ArgumentCollection
-    final public SimpleOutputCollection out = new SimpleOutputCollection();
+    final public OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
 
     @VisibleForTesting
     final long[] baseCounts = new long[256];
@@ -38,7 +40,7 @@ public class CountBasesInReference extends ReferenceWalker {
                 sb.append((char) i).append(" : ").append(count).append("\n");
             }
         }
-        out.writeToOutput(sb.toString().getBytes());
+        out.print(sb);
         System.out.print(sb.toString());
 
         return 0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
@@ -11,11 +11,26 @@ import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceWalker;
 import picard.cmdline.programgroups.ReferenceProgramGroup;
 
+/**
+ * Counts the number of times each base occurs in a reference, and prints the counts to standard output
+ * (and optionally to a file).
+ *
+ * <h3> Input </h3>
+ * <ul>
+ *     <li> A single reference file. </li>
+ * </ul>
+ *
+ * <h3> Usage example: </h3>
+ * <pre>
+ *  gatk CountBasesInReference \
+ *       -R reference.fasta
+ * </pre>
+ */
 @DocumentedFeature
 @CommandLineProgramProperties(
         oneLineSummary = "Count the numbers of each base in a reference file",
-        summary = "Count the number of times each individual base occurs in a reference file and output to stadard out " +
-                "(and optionally a file).",
+        summary = "Count the number of times each individual base occurs in a reference file and print to standard output " +
+                "(and optionally to a file).",
         programGroup = ReferenceProgramGroup.class
 )
 public class CountBasesInReference extends ReferenceWalker {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReference.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.hellbender.tools.walkers.fasta;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.SimpleOutputCollection;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadsContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
@@ -16,22 +18,29 @@ import picard.cmdline.programgroups.ReferenceProgramGroup;
         programGroup = ReferenceProgramGroup.class
 )
 public class CountBasesInReference extends ReferenceWalker {
+    @ArgumentCollection
+    final public SimpleOutputCollection out = new SimpleOutputCollection();
+
     @VisibleForTesting
     final long[] baseCounts = new long[256];
 
     @Override
     public void apply(ReferenceContext referenceContext, ReadsContext read, FeatureContext featureContext) {
-      baseCounts[referenceContext.getBase()]++;
+        baseCounts[referenceContext.getBase()]++;
     }
 
     @Override
-    public Object onTraversalSuccess(){
+    public Object onTraversalSuccess() {
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < baseCounts.length; i++) {
             final long count = baseCounts[i];
-            if (count > 0){
-                System.out.println((char)i + " : " + count );
+            if (count > 0) {
+                sb.append((char) i).append(" : ").append(count).append("\n");
             }
         }
+        out.writeToOutput(sb.toString().getBytes());
+        System.out.print(sb.toString());
+
         return 0;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalTextOutputArgumentCollectionUnitTest.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class OptionalTextOutputArgumentCollectionUnitTest extends GATKBaseTest {
+
+    @Test
+    public void testPrintToOutput() throws IOException {
+        final OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
+        final File tempOutput = createTempFile("testPrintToOutput", ".txt");
+        out.output = new GATKPath(tempOutput.getAbsolutePath());
+
+        out.print("test");
+
+        final byte[] result = Files.readAllBytes(out.output.toPath());
+        Assert.assertEquals(result.length, 4);
+        Assert.assertEquals(result, "test".getBytes());
+    }
+
+    @Test
+    public void testPrintlnToOutput() throws IOException {
+        final OptionalTextOutputArgumentCollection out = new OptionalTextOutputArgumentCollection();
+        final File tempOutput = createTempFile("testPrintlnToOutput", ".txt");
+        out.output = new GATKPath(tempOutput.getAbsolutePath());
+
+        out.println("test");
+
+        final byte[] result = Files.readAllBytes(out.output.toPath());
+        Assert.assertEquals(result.length, 5);
+        Assert.assertEquals(result, "test\n".getBytes());
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountBasesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountBasesIntegrationTest.java
@@ -7,24 +7,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 
 public final class CountBasesIntegrationTest extends CommandLineProgramTest {
-
-    @Test(dataProvider = "filenames")
-    public void testCountBases(final String fileIn, final String referenceName) throws Exception {
-        final File ORIG_BAM = new File(getTestDataDir(), fileIn);
-        final ArgumentsBuilder args = new ArgumentsBuilder();
-        args.addRaw("--input");
-        args.addRaw(ORIG_BAM.getAbsolutePath());
-        if (null != referenceName) {
-            final File REF = new File(getTestDataDir(), referenceName);
-            args.addRaw("-R");
-            args.addRaw(REF.getAbsolutePath());
-        }
-
-        final Object res = this.runCommandLine(args.getArgsArray());
-        Assert.assertEquals(res, 808l);
-    }
 
     @DataProvider(name="filenames")
     public Object[][] filenames() {
@@ -35,4 +20,38 @@ public final class CountBasesIntegrationTest extends CommandLineProgramTest {
         };
     }
 
+    @Test(dataProvider = "filenames")
+    public void testCountBases(final String fileIn, final String referenceName) throws Exception {
+        final File input = new File(getTestDataDir(), fileIn);
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+
+        args.addInput(input);
+        if (null != referenceName) {
+            final File ref = new File(getTestDataDir(), referenceName);
+            args.addReference(ref);
+        }
+
+        final Object res = runCommandLine(args);
+        Assert.assertEquals(res, 808l);
+    }
+
+    @Test(dataProvider = "filenames")
+    public void testCountBasesWithOutputFile(final String fileIn, final String referenceName) throws Exception {
+        final File input = new File(getTestDataDir(), fileIn);
+        final File output = createTempFile("testCountBasesWithOutputFile", ".txt");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+
+        args.addInput(input);
+        args.addOutput(output);
+        if (null != referenceName) {
+            final File ref = new File(getTestDataDir(), referenceName);
+            args.addReference(ref);
+        }
+
+        final Object res = runCommandLine(args);
+        Assert.assertEquals(res, 808l);
+
+        Assert.assertEquals(Files.readAllBytes(output.toPath()), "808".getBytes());
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountReadsIntegrationTest.java
@@ -9,22 +9,42 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 
 public final class CountReadsIntegrationTest extends CommandLineProgramTest {
 
     @Test(dataProvider = "filenames")
     public void testCountReads(final String fileIn, final String referenceName) throws Exception {
-        final File ORIG_BAM = new File(getTestDataDir(), fileIn);
+        final File input = new File(getTestDataDir(), fileIn);
         final ArgumentsBuilder args = new ArgumentsBuilder();
-        args.addRaw("--input");
-        args.addRaw(ORIG_BAM.getAbsolutePath());
+
+        args.addInput(input);
         if (null != referenceName) {
-            final File REF = new File(getTestDataDir(), referenceName);
-            args.addRaw("-R");
-            args.addRaw(REF.getAbsolutePath());
+            final File ref = new File(getTestDataDir(), referenceName);
+            args.addReference(ref);
         }
-        final Object res = this.runCommandLine(args.getArgsArray());
+
+        final Object res = runCommandLine(args);
         Assert.assertEquals(res, 8l);
+    }
+
+    @Test(dataProvider = "filenames")
+    public void testCountReadsWithOutputFile(final String fileIn, final String referenceName) throws Exception {
+        final File input = new File(getTestDataDir(), fileIn);
+        final File output = createTempFile("testCountReadsWithOutputFile", ".txt");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+
+        args.addInput(input);
+        args.addOutput(output);
+        if (null != referenceName) {
+            final File ref = new File(getTestDataDir(), referenceName);
+            args.addReference(ref);
+        }
+
+        final Object res = runCommandLine(args);
+        Assert.assertEquals(res, 8l);
+        Assert.assertEquals(Files.readAllBytes(output.toPath()), "8".getBytes());
     }
 
     @DataProvider(name="filenames")

--- a/src/test/java/org/broadinstitute/hellbender/tools/CountVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/CountVariantsIntegrationTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 
 public final class CountVariantsIntegrationTest extends CommandLineProgramTest {
 
@@ -21,8 +22,23 @@ public final class CountVariantsIntegrationTest extends CommandLineProgramTest {
         final ArgumentsBuilder ab = new ArgumentsBuilder();
         ab.addVCF(fileIn);
         ab.addRaw(moreArgs);
-        final Object res = runCommandLine(ab.getArgsArray());
+        final Object res = runCommandLine(ab);
         Assert.assertEquals(res, expectedCount);
+    }
+
+    @Test(dataProvider = "countVariantsVCFInputs")
+    public void testCountVariantsWithOutputFile(final File fileIn, final String moreArgs, final long expectedCount) throws Exception {
+        final File output = createTempFile("testCountVariantsWithOutputFile", ".txt");
+
+        final ArgumentsBuilder ab = new ArgumentsBuilder();
+        ab.addVCF(fileIn);
+        ab.addOutput(output);
+        ab.addRaw(moreArgs);
+
+        final Object res = runCommandLine(ab);
+        Assert.assertEquals(res, expectedCount);
+
+        Assert.assertEquals(Files.readAllBytes(output.toPath()), Long.toString(expectedCount).getBytes());
     }
 
     @DataProvider(name="countVariantsVCFInputs")

--- a/src/test/java/org/broadinstitute/hellbender/tools/FlagStatIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/FlagStatIntegrationTest.java
@@ -1,11 +1,14 @@
 package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
 
 public final class FlagStatIntegrationTest extends CommandLineProgramTest{
 
@@ -31,6 +34,22 @@ public final class FlagStatIntegrationTest extends CommandLineProgramTest{
         l.with_mate_mapped_to_a_different_chr = 0;
         l.with_mate_mapped_to_a_different_chr_maq_greaterequal_than_5 = 0;
         Assert.assertEquals(res, l);
+    }
+
+    @Test(dataProvider = "filenames")
+    public void testWriteStatsToFile(String fileIn) throws Exception {
+        final File input = new File(getTestDataDir(), fileIn);
+        final File output = createTempFile("testWriteStatsToFile", ".txt");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(input);
+        args.addOutput(output);
+
+        runCommandLine(args);
+
+        final List<String> result = Files.readAllLines(output.toPath());
+        Assert.assertEquals(result.size(), 12);
+        Assert.assertEquals(result.get(0), "19 in total");
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReferenceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/fasta/CountBasesInReferenceIntegrationTest.java
@@ -6,6 +6,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 public class CountBasesInReferenceIntegrationTest extends CommandLineProgramTest {
 
@@ -21,10 +23,12 @@ public class CountBasesInReferenceIntegrationTest extends CommandLineProgramTest
         Assert.assertEquals(baseCounts['N'], 1001L);
     }
 
+
     @Test
     public void testCountBasesInReferenceFull(){
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.addReference(new File(hg19MiniReference));
+
         final CountBasesInReference walker = new CountBasesInReference();
         walker.instanceMain(args.getArgsArray());
         final long[] baseCounts = walker.baseCounts;
@@ -34,5 +38,26 @@ public class CountBasesInReferenceIntegrationTest extends CommandLineProgramTest
         Assert.assertEquals(baseCounts['G'], 4559);
         Assert.assertEquals(baseCounts['T'], 3900);
         Assert.assertEquals(baseCounts['N'], 46000);
+    }
+
+    @Test
+    public void testCountBasesInReferenceWithOutputFile() throws IOException {
+        final File output = createTempFile("testCountBasesInReferenceWithOutputFile", ".txt");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addReference(new File(hg19MiniReference));
+        args.addOutput(output);
+
+        final CountBasesInReference walker = new CountBasesInReference();
+        walker.instanceMain(args.getArgsArray());
+        final long[] baseCounts = walker.baseCounts;
+
+        Assert.assertEquals(baseCounts['A'], 4546);
+        Assert.assertEquals(baseCounts['C'], 4995);
+        Assert.assertEquals(baseCounts['G'], 4559);
+        Assert.assertEquals(baseCounts['T'], 3900);
+        Assert.assertEquals(baseCounts['N'], 46000);
+
+        Assert.assertEquals(Files.readAllBytes(output.toPath()), "A : 4546\nC : 4995\nG : 4559\nN : 46000\nT : 3900\n".getBytes());
     }
 }


### PR DESCRIPTION
There's a small set of tools that only outputs their results to stdout, making it difficult to use the output in a pipeline/script. This PR adds a way to output simple results from such tools to an (optional) output file.

I Added this option to the following tools:
- CountBases
- CountBasesInReference
- CountReads
- CountVariants
- FlagStat

Other tools that might benefit from this (but it will require an API change, so I didn't do it):
- CompareIntervalLists
- ValidateVariants