### PR TITLE
Add -m flag to gsutil step; add dockstore branch filters to facilitate development

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -13,7 +13,7 @@ workflows:
    - name: cnv_somatic_pair_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
-     testParameterFiles: 
+     testParameterFiles:
      -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_do-gc_workflow.json
    - name: cnv_somatic_panel_workflow
      subclass: WDL
@@ -30,6 +30,9 @@ workflows:
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2model.json
+   - name: ImportGenomes
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -33,6 +33,8 @@ workflows:
    - name: importgenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
+     testParameterFiles:
+      - empty.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -33,6 +33,8 @@ workflows:
    - name: ImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
+     testParameterFiles:
+     - empty.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -57,7 +57,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - mmt_add_gsutil_m_IG
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -30,7 +30,7 @@ workflows:
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2model.json
-   - name: ImportGenomes
+   - name: importgenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
      testParameterFiles:

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -30,11 +30,6 @@ workflows:
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2model.json
-   - name: importgenomes
-     subclass: WDL
-     primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
-     testParameterFiles:
-      - empty.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -5,61 +5,102 @@ workflows:
      primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
      testParameterFiles:
      -  /scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
+     filters:
+       branches:
+        - master
    - name: cnv_germline_cohort_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
      testParameterFiles:
      -  /scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
+     filters:
+       branches:
+         - master
    - name: cnv_somatic_pair_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
      testParameterFiles:
      -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_do-gc_workflow.json
+     filters:
+       branches:
+         - master
    - name: cnv_somatic_panel_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
      testParameterFiles:
      -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_panel_wes_do-gc_workflow.json
+     filters:
+       branches:
+         - master
    - name: cram2filtered
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2filtered.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2filtered.json
+     filters:
+       branches:
+         - master
    - name: cram2model
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2model.json
+     filters:
+       branches:
+         - master
    - name: ImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
      testParameterFiles:
        - /scripts/variantstore/wdl/ImportGenomes.example.inputs.json
+     filters:
+       branches:
+         - master
+         - ah_var_store
+         - mmt_add_gsutil_m_IG
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl
      testParameterFiles:
      - /scripts/funcotator_wdl/funcotator.json
+     filters:
+       branches:
+         - master
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
      testParameterFiles:
      -  /scripts/mitochondria_m2_wdl/test_mitochondria_m2_wdl.json
+     filters:
+       branches:
+         - master
    - name: mutect2
      subclass: WDL
      primaryDescriptorPath: /scripts/mutect2_wdl/mutect2.wdl
      testParameterFiles:
      - /scripts/m2_cromwell_tests/mutect2.inputs.json
+     filters:
+       branches:
+         - master
    - name: mutect2_pon
      subclass: WDL
      primaryDescriptorPath: /scripts/mutect2_wdl/mutect2_pon.wd
+     filters:
+       branches:
+         - master
    - name: run_happy
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/run_happy.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/run_happy.json
+     filters:
+       branches:
+         - master
    - name: pathseq_pipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/pathseq/wdl/pathseq_pipeline.wdl
      testParameterFiles:
      - /scripts/pathseq/wdl/pathseq_pipeline_template.json
+     filters:
+       branches:
+         - master

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -30,6 +30,11 @@ workflows:
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
      - /scripts/cnn_variant_wdl/jsons/cram2model.json
+   - name: ImportGenomes
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
+     testParameterFiles:
+       - empty.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -34,7 +34,7 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
      testParameterFiles:
-       - empty.json
+       - /scripts/variantstore/wdl/ImportGenomes.example.inputs.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -33,8 +33,6 @@ workflows:
    - name: importgenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/ImportGenomes.wdl
-     testParameterFiles:
-     - empty.json
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -141,10 +141,10 @@ task CreateImportTsvs {
   Int disk_size = ceil(size(input_vcf, "GB") * multiplier) + 20
 
   meta {
-    description: "Creates a tsv file for imort into BigQuery"
+    description: "Creates a tsv file for import into BigQuery"
     volatile: true
   }
-  
+
   parameter_meta {
     input_vcf: {
       localization_optional: true
@@ -168,10 +168,10 @@ task CreateImportTsvs {
         --mode GENOMES \
         -SNM ~{sample_map} \
         --ref-version 38
-        
-      gsutil cp metadata_*.tsv ~{output_directory}/metadata_tsvs/
-      gsutil cp pet_*.tsv ~{output_directory}/pet_tsvs/
-      gsutil cp vet_*.tsv ~{output_directory}/vet_tsvs/
+
+      gsutil -m cp metadata_*.tsv ~{output_directory}/metadata_tsvs/
+      gsutil -m cp pet_*.tsv ~{output_directory}/pet_tsvs/
+      gsutil -m cp vet_*.tsv ~{output_directory}/vet_tsvs/
   >>>
   runtime {
       docker: docker

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -169,7 +169,6 @@ task CreateImportTsvs {
         -SNM ~{sample_map} \
         --ref-version 38
 
-      # gsutil -m cp will error out if there's an issue with one or more uploads
       gsutil -m cp metadata_*.tsv ~{output_directory}/metadata_tsvs/
       gsutil -m cp pet_*.tsv ~{output_directory}/pet_tsvs/
       gsutil -m cp vet_*.tsv ~{output_directory}/vet_tsvs/

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -153,7 +153,7 @@ task CreateImportTsvs {
   command <<<
       set -e
 
-      #workaround for https://github.com/broadinstitute/cromwell/issues/3647
+      # workaround for https://github.com/broadinstitute/cromwell/issues/3647
       export TMPDIR=/tmp
 
       export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
@@ -169,6 +169,7 @@ task CreateImportTsvs {
         -SNM ~{sample_map} \
         --ref-version 38
 
+      # gsutil -m cp will error out if there's an issue with one or more uploads
       gsutil -m cp metadata_*.tsv ~{output_directory}/metadata_tsvs/
       gsutil -m cp pet_*.tsv ~{output_directory}/pet_tsvs/
       gsutil -m cp vet_*.tsv ~{output_directory}/vet_tsvs/


### PR DESCRIPTION
This PR addresses spec-ops issue #235 - Use -m flag in final gsutil mv of files in ImportGenomes. 

Additionally, this PR adds branch filters to the dockstore.yml file that will help with development. The filter for each workflow indicates which branch(es) will show up for that workflow in dockstore. If we don't include these filters, dockstore will run checks of ALL workflows on ALL branches, which causes timeouts. We could remove these filters later (before merging to master) or not, but for now this could help us develop on ah_var_store. Note that we'll need to add feature branches to that file as we work on them.

This workflow was tested in Terra and the upload succeeded.

Also confirmed that if one file fails, the entire process throws an error code (i.e. -m flag will not cause failures to silently pass) - in example below, `test_file_list.txt` was a list of 6 files, including 1 file that did not exist.
```
➜  cat test_file_list.txt | gsutil cp -I gs://dsp-fieldeng-dev/test_cp/
Copying file://test1.txt [Content-Type=text/plain]...
Copying file://test2.txt [Content-Type=text/plain]...
Copying file://test3.txt [Content-Type=text/plain]...
CommandException: No URLs matched: test4.txt
➜  cat test_file_list.txt | gsutil -m cp -I gs://dsp-fieldeng-dev/test_cp/
If you experience problems with multiprocessing on MacOS, they might be related to https://bugs.python.org/issue33725. You can disable multiprocessing by editing your .boto config or by adding the following flag to your command: `-o "GSUtil:parallel_process_count=1"`. Note that multithreading is still available even if you disable multiprocessing.

CommandException: No URLs matched: test4.txt
Copying file://test1.txt [Content-Type=text/plain]...
Copying file://test5.txt [Content-Type=text/plain]...
Copying file://test2.txt [Content-Type=text/plain]...
Copying file://test3.txt [Content-Type=text/plain]...
Copying file://test6.txt [Content-Type=text/plain]...
- [5/5 files][   37.0 B/   37.0 B] 100% Done
Operation completed over 5 objects/37.0 B.
CommandException: 1 file/object could not be transferred.
```

