### PR TITLE
Reduce memory and CPU for CreateImportTsvs task, check for files before attempting load

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -57,7 +57,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - mmt_reduce_mem
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -57,6 +57,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - mmt_reduce_mem
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -210,10 +210,10 @@ task CreateImportTsvs {
   >>>
   runtime {
       docker: docker
-      memory: "10 GB"
+      memory: "3.75 GB"
       disks: "local-disk " + disk_size + " HDD"
       preemptible: select_first([preemptible_tries, 5])
-      cpu: 2
+      cpu: 1
   }
   output {
       String done = "true"

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -322,15 +322,22 @@ task LoadTable {
     # even for non-superpartitioned tables (e.g. metadata), the TSVs do have the suffix
     FILES="~{datatype}_${PADDED_TABLE_ID}_*"
 
+    NUM_FILES=$(gsutil ls "${DIR}${FILES}" | wc -l)
+
     if [ ~{superpartitioned} = "true" ]; then
       TABLE="~{dataset_name}.${PREFIX}~{datatype}_${PADDED_TABLE_ID}"
     else
       TABLE="~{dataset_name}.${PREFIX}~{datatype}"
     fi
 
-    bq load --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" $TABLE $DIR$FILES ~{schema} || exit 1
-    echo "ingested ${FILES} file from $DIR into table $TABLE"
-    gsutil mv $DIR$FILES ${DIR}done/
+    if [ $NUM_FILES -gt 0 ]; then
+        bq load --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" $TABLE $DIR$FILES ~{schema} || exit 1
+        echo "ingested ${FILES} file from $DIR into table $TABLE"
+        gsutil mv $DIR$FILES ${DIR}done/
+    else
+        echo "no ${FILES} files to process in $DIR"
+    fi
+
   >>>
 
   runtime {


### PR DESCRIPTION
both of these are updates to the ImportGenomes wdl:
- reduce memory/cpus for the CreateImportTsvs task from 10GB to 3.75GB and 2 CPU to 1 CPU. these settings were tested on 3000 gvcfs and none errored out because of memory. this ties out spec-ops issues #211 and #233
- before loading files using `bq load`, check for existing files in the gs bucket. only run `bq load` if there are matching files in the bucket. this will prevent an error if you run a subset of samples corresponding to a larger sample map such that you've created a pet_002 table but there aren't any samples to load for pet_002 yet. this was tested in Terra and worked as expected.