### PR TITLE
Fix bug when disabling optimizations #7123

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -592,7 +592,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             return referenceModelForNoVariation(region, false, VCpriors);
         }
 
-        final AssemblyResultSet assemblyResult = untrimmedAssemblyResult.trimTo(trimmingResult.getVariantRegion());
+        final AssemblyResultSet assemblyResult = trimmingResult.isVariationPresent() ? untrimmedAssemblyResult.trimTo(trimmingResult.getVariantRegion()) : untrimmedAssemblyResult;
 
         final AssemblyRegion regionForGenotyping = assemblyResult.getRegionForGenotyping();
         final List<GATKRead> readStubs = regionForGenotyping.getReads().stream()


### PR DESCRIPTION
I think #7123 goes back to this commit: https://github.com/broadinstitute/gatk/commit/1353e3201bb11e29039efd89359b0a4cfc11e5c0

In particular, this diff:
<img width="1234" alt="Screen Shot 2021-03-03 at 10 43 29 PM" src="https://user-images.githubusercontent.com/846274/109922264-eaf4ea00-7c71-11eb-802d-cc259718bf6c.png">

The conditional that was removed protected against the case when there is no variation present, and returned the _untrimmed_ region as a result.  This restores that.

The `src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java` source probably also needs to be changed here too (tough to edit in via a browser, so please feel free to push an appropriate commit).