### PR TITLE
Add -m flag to gsutil mv step

### DIFF
--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -333,7 +333,7 @@ task LoadTable {
     if [ $NUM_FILES -gt 0 ]; then
         bq load --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" $TABLE $DIR$FILES ~{schema} || exit 1
         echo "ingested ${FILES} file from $DIR into table $TABLE"
-        gsutil mv $DIR$FILES ${DIR}done/
+        gsutil -m mv $DIR$FILES ${DIR}done/
     else
         echo "no ${FILES} files to process in $DIR"
     fi


### PR DESCRIPTION
I added -m to `gsutil cp` in a previous PR but missed the `gsutil mv` step post-`bq load` - so here that is. tested it from the command line, works well. also confirmed that it will throw an error if one (or more) files has an error:

```
$ cat test_files_bucket.txt | gsutil -m mv -I gs://dsp-fieldeng-dev/test_mv/

If you experience problems with multiprocessing on MacOS, they might be related to https://bugs.python.org/issue33725. You can disable multiprocessing by editing your .boto config or by adding the following flag to your command: `-o "GSUtil:parallel_process_count=1"`. Note that multithreading is still available even if you disable multiprocessing.

Copying gs://dsp-fieldeng-dev/test_cp/test1.txt [Content-Type=text/plain]...
Copying gs://dsp-fieldeng-dev/test_cp/test2.txt [Content-Type=text/plain]...
CommandException: No URLs matched: gs://dsp-fieldeng-dev/test_cp/test4.txt
Copying gs://dsp-fieldeng-dev/test_cp/test3.txt [Content-Type=text/plain]...
Copying gs://dsp-fieldeng-dev/test_cp/test5.txt [Content-Type=text/plain]...
Copying gs://dsp-fieldeng-dev/test_cp/test6.txt [Content-Type=text/plain]...
Removing gs://dsp-fieldeng-dev/test_cp/test1.txt...
Removing gs://dsp-fieldeng-dev/test_cp/test2.txt...
Removing gs://dsp-fieldeng-dev/test_cp/test3.txt...
Removing gs://dsp-fieldeng-dev/test_cp/test5.txt...
Removing gs://dsp-fieldeng-dev/test_cp/test6.txt...
- [5/5 files][   37.0 B/   37.0 B] 100% Done
Operation completed over 5 objects/37.0 B.
CommandException: 1 file/object could not be transferred.
```