### PR TITLE
Bug in Histogram.median() implementation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/Histogram.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Histogram.java
@@ -4,6 +4,7 @@ package org.broadinstitute.hellbender.utils;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
 import java.util.Arrays;
+import java.util.TreeSet;
 
 /**
  * Class used for storing a list of doubles as a run length encoded histogram that compresses the data into bins spaced
@@ -110,7 +111,7 @@ public class Histogram {
 
         int counter = 0;
         Double firstMedian = null;
-        for(final Integer key : dataList.valueCounts.keySet()) {
+        for(final Integer key : new TreeSet<>(dataList.valueCounts.keySet())) {
             counter += dataList.valueCounts.get(key);
             if( counter > medianIndex) {
                 if (firstMedian == null) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/HistogramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/HistogramUnitTest.java
@@ -52,6 +52,15 @@ public class HistogramUnitTest {
     }
 
     @Test
+    public void testMedianEnsureNotHashcodeDependent() throws Exception {
+        Histogram bimodalHist = new Histogram(1d);
+        bimodalHist.add(1.0,2);
+        bimodalHist.add(2.0,2);
+        bimodalHist.add(16.0,2);
+        Assert.assertEquals(bimodalHist.median(), 2.0, EPSILON, "");
+    }
+
+    @Test
     public void testMedianOfOdds() throws Exception {
         Histogram bimodalHist = new Histogram();
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
We found this trying to tie out the BQ version of the VQSR annotations with the Evoquer+Gnarly outputs, specifically in the RankSumTest annotations.    This never got merged into master.

The short story is... the implementation of median in the Histogram class is broken.  Precisely, in this line it iterates through the bins of the histogram to find the midpoint index... however the keySet() it gets is from a HashMap and therefore not ordered. That code hasn't been touched in 2 years, so it's been this way for a while.

It's tough to catch because of course there is a non-guaranteed ordering to the keys, and in the case of hashmap today when there are < 16 keys will be the hashcode of the keys modulo 16 until there is collision.  The hashcode of integers is just the integer... so in our tests we have today it just happens to work because we have a small number of keys and they are close to each other so hash in the order we happen to want.  I learned more about [HashMap internals](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/HashMap.java) than I wanted to know in order to make a test case for it :/ .  I

A test on data like this breaks:

1,2,16

as it returns 1 instead of 2 as the median.

I have a test for this, and have a fix (basically sort the keys, running through a TreeSet)

Thanks to @mmorgantaylor and @schaluva for helping with this