### PR TITLE
Add load lock file to prevent accidental re-loading of data to BQ

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -57,6 +57,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - mmt_lock_load
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -57,7 +57,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - mmt_lock_load
    - name: funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -27,8 +27,7 @@ workflow ImportGenomes {
   call SetLock {
     input:
       output_directory = output_directory,
-      preemptible_tries = preemptible_tries,
-      docker = docker_final
+      preemptible_tries = preemptible_tries
   }
 
   call GetMaxTableId {
@@ -160,8 +159,7 @@ workflow ImportGenomes {
       load_metadata_done = LoadMetadataTable.done,
       load_pet_done = LoadPetTable.done,
       load_vet_done = LoadVetTable.done,
-      preemptible_tries = preemptible_tries,
-      docker = docker_final
+      preemptible_tries = preemptible_tries
   }
 }
 
@@ -178,7 +176,6 @@ task SetLock {
 
     # runtime
     Int? preemptible_tries
-    String docker
   }
 
   command <<<
@@ -230,7 +227,6 @@ task ReleaseLock {
 
     # runtime
     Int? preemptible_tries
-    String docker
   }
 
   command <<<

--- a/scripts/variantstore/wdl/ImportGenomes.wdl
+++ b/scripts/variantstore/wdl/ImportGenomes.wdl
@@ -339,16 +339,6 @@ task CreateImportTsvs {
   command <<<
       set -e
 
-      # check for existence of the correct lockfile
-      LOCKFILE="~{output_directory}/LOCKFILE"
-      EXISTING_LOCK_ID=$(gsutil cat ${LOCKFILE}) || { echo "Error retrieving lockfile from ${LOCKFILE}" 1>&2 ; exit 1; }
-      CURRENT_RUN_ID="~{run_uuid}"
-
-      if [ ${EXISTING_LOCK_ID} != ${CURRENT_RUN_ID} ]; then
-        echo "ERROR: found mismatched lockfile containing run ${EXISTING_LOCK_ID}, which does not match this run ${CURRENT_RUN_ID}." 1>&2
-        exit 1
-      fi
-
       # workaround for https://github.com/broadinstitute/cromwell/issues/3647
       export TMPDIR=/tmp
 
@@ -359,6 +349,16 @@ task CreateImportTsvs {
         gcloud auth activate-service-account --key-file='~{service_account_json}'
         gsutil cp ~{input_vcf} .
         gsutil cp ~{input_vcf_index} .
+      fi
+
+      # check for existence of the correct lockfile
+      LOCKFILE="~{output_directory}/LOCKFILE"
+      EXISTING_LOCK_ID=$(gsutil cat ${LOCKFILE}) || { echo "Error retrieving lockfile from ${LOCKFILE}" 1>&2 ; exit 1; }
+      CURRENT_RUN_ID="~{run_uuid}"
+
+      if [ ${EXISTING_LOCK_ID} != ${CURRENT_RUN_ID} ]; then
+        echo "ERROR: found mismatched lockfile containing run ${EXISTING_LOCK_ID}, which does not match this run ${CURRENT_RUN_ID}." 1>&2
+        exit 1
       fi
       
       gatk --java-options "-Xmx7000m" CreateVariantIngestFiles \


### PR DESCRIPTION
spec ops issue #248

process implemented here:
- new task `SetLoadLock` is called at the beginning of `ImportGenomes` - it generates a UUID for the submission, writes that run_uuid to a lock file, and uploads that lock file to the output_directory (where the tsvs will be generated). 
- CreateImportTsvs and LoadTables take the run_uuid as an input, compare it against the contents of the lock file in the bucket, and only proceed if the uuids match. otherwise they exit out.
- after all LoadTables tasks have completed, a new task `ReleaseLoadLock` is called that removes the lock file from the bucket (again only if the uuid in the lockfile matches this run)

tested and confirmed that:
- the `loadlock` file is created and removed: https://app.terra.bio/#workspaces/broad-dsp-spec-ops-fc/1000G-high-coverage-2019_specops_mmt_test_memory/job_history/b0b9c7a1-70fd-4d44-a76e-b5604a5068f0
- the task fails if the lock file is present: https://app.terra.bio/#workspaces/broad-dsp-spec-ops-fc/1000G-high-coverage-2019_specops_mmt_test_memory/job_history/293687f9-e7b9-474b-bfe8-e50f4c555199