### PR TITLE
Do not add artificial haplotype read group to bamout when --bam-writer-type NO_HAPLOTYPES

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.SAMReadGroupRecord;
 
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
@@ -25,7 +25,8 @@ public abstract class HaplotypeBAMDestination {
      * Create a new HaplotypeBAMDestination
      *
      * @param sourceHeader SAMFileHeader used to seed the output SAMFileHeader for this destination.
-     * @param haplotypeReadGroupID read group ID used when writing haplotypes as reads
+     * @param haplotypeReadGroupID read group ID used when writing haplotypes as reads. Empty if
+     *                             {@link HaplotypeBAMWriter.WriterType} == NO_HAPLOTYPES.
      */
     protected HaplotypeBAMDestination(SAMFileHeader sourceHeader, final Optional<String> haplotypeReadGroupID) {
         Utils.nonNull(sourceHeader, "sourceHeader cannot be null");
@@ -37,11 +38,11 @@ public abstract class HaplotypeBAMDestination {
         bamOutputHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
         final List<SAMReadGroupRecord> readGroups = new ArrayList<>();
-        readGroups.addAll(sourceHeader.getReadGroups()); // include the original read groups
+        readGroups.addAll(sourceHeader.getReadGroups()); // include the original read groups...
 
         // plus an artificial read group for the haplotypes
         if (haplotypeReadGroupID.isPresent()){
-            final SAMReadGroupRecord rgRec = new SAMReadGroupRecord(getHaplotypeReadGroupID());
+            final SAMReadGroupRecord rgRec = new SAMReadGroupRecord(haplotypeReadGroupID.get());
             rgRec.setSample(haplotypeSampleTag);
             rgRec.setSequencingCenter("BI");
             readGroups.add(rgRec);
@@ -62,15 +63,12 @@ public abstract class HaplotypeBAMDestination {
 
     /**
      * Get the read group ID that is used by this writer when writing halpotypes as reads.
+     * If {@link HaplotypeBAMWriter.WriterType} is NO_HAPLOTYPES, then returns Optional.empty()
      *
      * @return read group ID
      */
-    public String getHaplotypeReadGroupID() {
-        if (!haplotypeReadGroupID.isPresent()) {
-            throw new UserException("haplotypeReadGroupID was requested but is not defined.");
-        } else {
-            return haplotypeReadGroupID.get();
-        }
+    public Optional<String> getHaplotypeReadGroupID() {
+        return haplotypeReadGroupID;
     }
     /**
      * Get the sample tag that is used by this writer when writing halpotypes as reads.

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMDestination.java
@@ -40,7 +40,7 @@ public abstract class HaplotypeBAMDestination {
         readGroups.addAll(sourceHeader.getReadGroups()); // include the original read groups
 
         // plus an artificial read group for the haplotypes
-        if (haplotypeReadGroupID.isPresent()){ // sato: replace true with haplotypeReadGroupID exists.
+        if (haplotypeReadGroupID.isPresent()){
             final SAMReadGroupRecord rgRec = new SAMReadGroupRecord(getHaplotypeReadGroupID());
             rgRec.setSample(haplotypeSampleTag);
             rgRec.setSequencingCenter("BI");

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -36,7 +36,7 @@ public class HaplotypeBAMWriter implements AutoCloseable {
 
     private final HaplotypeBAMDestination output;
     private WriterType writerType;
-    private boolean writeHaplotypes = true;
+
     /**
      * Possible modes for writing haplotypes to BAMs
      */
@@ -57,7 +57,6 @@ public class HaplotypeBAMWriter implements AutoCloseable {
          * With this option, haplotypes will not be included in the output bam.
          */
         NO_HAPLOTYPES
-
     }
 
     /**
@@ -186,10 +185,8 @@ public class HaplotypeBAMWriter implements AutoCloseable {
         Utils.nonNull(bestHaplotypes, "bestHaplotypes cannot be null");
         Utils.nonNull(paddedReferenceLoc, "paddedReferenceLoc cannot be null");
 
-        if (writeHaplotypes) {
-            for (final Haplotype haplotype : haplotypes) {
-                writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype), callableRegion);
-            }
+        for (final Haplotype haplotype : haplotypes) {
+            writeHaplotype(haplotype, paddedReferenceLoc, bestHaplotypes.contains(haplotype), callableRegion);
         }
     }
 
@@ -226,13 +223,5 @@ public class HaplotypeBAMWriter implements AutoCloseable {
         }
 
         output.add(new SAMRecordToGATKReadAdapter(record));
-    }
-
-    /**
-     * Set the HaplotypeBAMWriter to write out the haplotypes as reads.
-     * @param writeHaplotypes true if haplotypes should be written as reads
-     */
-    public void setWriteHaplotypes(final boolean writeHaplotypes) {
-        this.writeHaplotypes = writeHaplotypes;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -216,7 +216,8 @@ public class HaplotypeBAMWriter implements AutoCloseable {
         record.setAttribute(output.getHaplotypeSampleTag(), haplotype.hashCode());
         record.setReadUnmappedFlag(false);
         record.setReferenceIndex(output.getBAMOutputHeader().getSequenceIndex(paddedRefLoc.getContig()));
-        record.setAttribute(SAMTag.RG.toString(), output.getHaplotypeReadGroupID());
+        // If we get here, the WriterType is not NO_HAPLOTYPES, so it is safe to call .get().
+        record.setAttribute(SAMTag.RG.toString(), output.getHaplotypeReadGroupID().get());
         record.setFlags(SAMFlag.READ_REVERSE_STRAND.intValue());
         if (callableRegion != null) {
             record.setAttribute(AssemblyBasedCallerUtils.CALLABLE_REGION_TAG, callableRegion.toString());

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriter.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -75,8 +76,8 @@ public class HaplotypeBAMWriter implements AutoCloseable {
             final boolean createBamOutIndex,
             final boolean createBamOutMD5,
             final SAMFileHeader sourceHeader) {
-
-        this(type, new SAMFileDestination(outputPath, createBamOutIndex, createBamOutMD5, sourceHeader, DEFAULT_HAPLOTYPE_READ_GROUP_ID));
+        this(type, new SAMFileDestination(outputPath, createBamOutIndex, createBamOutMD5, sourceHeader,
+                type == WriterType.NO_HAPLOTYPES ? Optional.empty() : Optional.of(DEFAULT_HAPLOTYPE_READ_GROUP_ID)));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
@@ -7,7 +7,6 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 
-import java.io.File;
 import java.util.Optional;
 
 /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
@@ -23,7 +23,8 @@ public final class SAMFileDestination extends HaplotypeBAMDestination {
      * @param createBamOutIndex true to create an index file for the bamout
      * @param createBamOutMD5 true to create an md5 file for the bamout
      * @param sourceHeader SAMFileHeader used to seed the output SAMFileHeader for this destination, must not be null
-     * @param haplotypeReadGroupID  read group ID used when writing haplotypes as reads
+     * @param haplotypeReadGroupID  read group ID used when writing haplotypes as reads. Empty if
+     *                              {@link HaplotypeBAMWriter.WriterType} == NO_HAPLOTYPES.
      */
     public SAMFileDestination(
             final Path outPath,

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/SAMFileDestination.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
 
 import java.io.File;
+import java.util.Optional;
 
 /**
  * Class used to direct output from a HaplotypeBAMWriter to a bam/sam file.
@@ -29,7 +30,7 @@ public final class SAMFileDestination extends HaplotypeBAMDestination {
             final boolean createBamOutIndex,
             final boolean createBamOutMD5,
             final SAMFileHeader sourceHeader,
-            final String haplotypeReadGroupID)
+            final Optional<String> haplotypeReadGroupID)
     {
         super(sourceHeader, haplotypeReadGroupID);
         samWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
@@ -125,7 +125,7 @@ public class HaplotypeBAMWriterUnitTest extends GATKBaseTest {
 
         Assert.assertEquals(getReadCounts(outPath), 5);
         final List<SAMReadGroupRecord> readGroups = getReadGroups(outPath);
-        Assert.assertTrue(readGroups.stream().map(rg -> rg.getId()).allMatch(id -> id.equals(readGroupID)));
+        Assert.assertTrue(readGroups.stream().map(rg -> rg.getId()).anyMatch(id -> id.equals(readGroupID)));
         final File expectedMD5File = new File(outPath.toFile().getAbsolutePath() + ".md5");
         Assert.assertEquals(expectedMD5File.exists(), createMD5);
         if (createIndex) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
@@ -1,14 +1,8 @@
 package org.broadinstitute.hellbender.utils.haplotype;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.TextCigarCodec;
-import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.*;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Locatable;
-import htsjdk.samtools.SamFiles;
 
 import java.nio.file.Path;
 import org.broadinstitute.hellbender.GATKBaseTest;

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
@@ -116,7 +116,7 @@ public class HaplotypeBAMWriterUnitTest extends GATKBaseTest {
         ) throws IOException
     {
         final Path outPath = GATKBaseTest.createTempFile("haplotypeBamWriterTest", outputFileExtension).toPath();
-        final SAMFileDestination fileDest = new SAMFileDestination(outPath, createIndex, createMD5, samHeader, "TestHaplotypeRG");
+        final SAMFileDestination fileDest = new SAMFileDestination(outPath, createIndex, createMD5, samHeader, Optional.of("TestHaplotypeRG"));
 
         try (final HaplotypeBAMWriter haplotypeBAMWriter = new HaplotypeBAMWriter(HaplotypeBAMWriter.WriterType.ALL_POSSIBLE_HAPLOTYPES, fileDest)) {
             haplotypeBAMWriter.writeReadsAlignedToHaplotypes(
@@ -273,7 +273,7 @@ public class HaplotypeBAMWriterUnitTest extends GATKBaseTest {
         public boolean foundBases = false;  // true we've seen a read that contains the expectedBaseSignature
 
         private MockValidatingDestination(String baseSignature) {
-            super(samHeader, "testGroupID");
+            super(samHeader, Optional.of("testGroupID"));
             expectedBaseSignature = baseSignature;
         }
 


### PR DESCRIPTION
In #6991 I introduced an option for HC to not print artificial haplotypes in the bamout. I overlooked the fact that when this option is enabled we should not include the read group for the artificial haplotypes in the header. The present PR fixes this and adds tests. 