### PR TITLE
Update -autosomal-coverage description

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilterMutectCalls.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/FilterMutectCalls.java
@@ -67,9 +67,6 @@ import java.util.stream.Collectors;
  * </pre>
  *
  *
- * When running on unfiltered output of Mutect2 in --mitochondria mode, setting the advanced option --autosomal-coverage
- * argument (default 0) activates a recommended filter against likely erroneously mapped  <a href="https://en.wikipedia.org/wiki/NUMT">NuMTs (nuclear mitochondrial DNA segments)</a>.
- * For the value, provide the median coverage expected in autosomal regions with coverage.
  *
  */
 @CommandLineProgramProperties(


### PR DESCRIPTION
The --autosomal-coverage option is described but it is no longer an option — is there a different method for mitochondrial filtering? I am here removing the following section from the description:

> When running on unfiltered output of Mutect2 in --mitochondria mode, setting the advanced option --autosomal-coverage argument (default 0) activates a recommended filter against likely erroneously mapped  <a href="https://en.wikipedia.org/wiki/NUMT">NuMTs (nuclear mitochondrial DNA segments)</a>. For the value, provide the median coverage expected in autosomal regions with coverage.