### PR TITLE
fix bug in ExtractCohortEngine

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
@@ -505,7 +505,7 @@ public class ExtractCohortEngine {
         final VariantContextBuilder builder = new VariantContextBuilder(mergedVC);
 
         builder.attribute(GATKVCFConstants.AS_VQS_LOD_KEY, relevantVqsLodMap.values().stream().map(val -> val.equals(Double.NaN) ? VCFConstants.EMPTY_INFO_FIELD : val.toString()).collect(Collectors.toList()));
-        builder.attribute(GATKVCFConstants.AS_YNG_STATUS_KEY, relevantYngMap.values());
+        builder.attribute(GATKVCFConstants.AS_YNG_STATUS_KEY, relevantYngMap.values().stream().collect(Collectors.toList()));
 
         int refLength = mergedVC.getReference().length();
 


### PR DESCRIPTION
when extracting more than one sample using ExtractCohort, multi-allelic sites get written with bad formatting for the AS_YNG field:
`AC=2,1;AF=0.028,0.014;AN=72;AS_QD=.;AS_VQSLOD=-6.7307,.;AS_YNG=[G, .];ExcessHet=0.0927;FS=0.000;SOR=0.693`

this PR processes the AS_YNG field properly, resulting in properly formatted AS_YNG fields:
`AC=2,1;AF=0.028,0.014;AN=72;AS_QD=.;AS_VQSLOD=-6.7307,.;AS_YNG=G,.;ExcessHet=0.0927;FS=0.000;SOR=0.693`