### PR TITLE
Disabling some spark dataproc tests because of dependency issues.

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/DataprocIntegrationTest.java
@@ -46,7 +46,7 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
         };
     }
 
-    @Test(dataProvider = "getCloudPaths", groups = {"cloud", "bucket"})
+    @Test(dataProvider = "getCloudPaths", groups = {"cloud", "bucket"}, enabled = false)
     public void printReadSparkOnDataproc(final String input) throws IOException {
         final String gcsInputPath = getGCPTestInputPath() + input;
         final String outputPath = BucketUtils.getTempFilePath(getGCPTestStaging(), ".bam");
@@ -102,7 +102,8 @@ public class DataprocIntegrationTest extends CommandLineProgramTest{
     }
 
     //test that MarkDuplicatesSpark doesn't explode on a tiny file
-    @Test(groups = {"cloud", "bucket"})
+    //TODO: Re-enable when dataproc tests pass again!
+    @Test(groups = {"cloud", "bucket"}, enabled = false)
     public void markDuplicatesSparkOnDataproc() throws IOException {
         final String gcsInputPath = getGCPTestInputPath() + "large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.tiny.queryname.noMD.bam";
         final String bamOut = BucketUtils.getTempFilePath(getGCPTestStaging(), ".bam");


### PR DESCRIPTION
We should fix the dependency issue and then re-enable them.