### PR TITLE
Update the gcloud package signing key during the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN ls .
 ADD . /gatk
 WORKDIR /gatk
 
+# Get an updated gcloud signing key, in case the one in the base image has expired
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN add-apt-repository universe && apt update
 RUN apt-get --assume-yes install git-lfs
 RUN git lfs install


### PR DESCRIPTION
Previously we were relying on the gcloud package signing key retrieved
during build of the GATK base image. However, the base image is updated
so infrequently that it's possible that the key it uses has expired. To
address this, we now retrieve an updated key at the start of the Docker
build.