### PR TITLE
Allow users to specify VQSLOD sensitivity and apply threshold in ExtractCohort

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
@@ -155,8 +155,9 @@ public class CommonCode {
 
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.SB_TABLE_KEY));
 
-        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_SNP));
-        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_INDEL));
+//        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_SNP));
+//        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_INDEL));
+        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_FAILURE));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NAY_FROM_YNG));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_HET_KEY));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
@@ -164,9 +164,6 @@ public class CommonCode {
 
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.SB_TABLE_KEY));
 
-//        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_SNP));
-//        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_INDEL));
-
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NAY_FROM_YNG));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_HET_KEY));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/CommonCode.java
@@ -79,17 +79,26 @@ public class CommonCode {
         return header;
     }
 
-    public static VCFHeader generateVcfHeader(Set<String> sampleNames,//) { //final Set<VCFHeaderLine> defaultHeaderLines,
-                                        final SAMSequenceDictionary sequenceDictionary) {
+    public static VCFHeader generateVcfHeader(Set<String> sampleNames,
+                                              final SAMSequenceDictionary sequenceDictionary,
+                                              final Set<VCFHeaderLine> extraHeaders) {
         final Set<VCFHeaderLine> headerLines = new HashSet<>();
 
         headerLines.addAll( getEvoquerVcfHeaderLines() );
+        headerLines.addAll( extraHeaders );
 //        headerLines.addAll( defaultHeaderLines );
 
         final VCFHeader header = new VCFHeader(headerLines, sampleNames);
         header.setSequenceDictionary(sequenceDictionary);
 
         return header;
+    }
+
+    public static VCFHeader generateVcfHeader(Set<String> sampleNames,
+                                        final SAMSequenceDictionary sequenceDictionary) {
+
+        Set<VCFHeaderLine> noExtraHeaders = new HashSet<>();
+        return generateVcfHeader(sampleNames, sequenceDictionary, noExtraHeaders);
     }
 
 
@@ -157,7 +166,7 @@ public class CommonCode {
 
 //        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_SNP));
 //        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_TRANCHE_INDEL));
-        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.VQSR_FAILURE));
+
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NAY_FROM_YNG));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_HET_KEY));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
@@ -67,6 +67,12 @@ public class SchemaUtils {
     public static final String TRAINING_LABEL = "training_label";
     public static final String YNG_STATUS = "yng_status";
 
+    //Tranches table
+    public static final String TARGET_TRUTH_SENSITIVITY = "target_truth_sensitivity";
+    public static final String MIN_VQSLOD = "min_vqslod";
+    public static final String TRANCHE_FILTER_NAME = "filter_name";
+    public static final String SNP_OR_INDEL_MODEL = "model";
+
     public static final List<String> COHORT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_NAME_FIELD_NAME, STATE_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALL_GT, CALL_GQ, CALL_RGQ, QUALapprox, AS_QUALapprox, CALL_PL);//, AS_VarDP);
     public static final List<String> ARRAY_COHORT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_NAME_FIELD_NAME, STATE_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALL_GT, CALL_GQ);
 
@@ -79,6 +85,7 @@ public class SchemaUtils {
 
     public static final List<String> SAMPLE_FIELDS = Arrays.asList(SchemaUtils.SAMPLE_NAME_FIELD_NAME, SchemaUtils.SAMPLE_ID_FIELD_NAME);
     public static final List<String> YNG_FIELDS = Arrays.asList(FILTER_SET_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, VQSLOD, YNG_STATUS);
+    public static final List<String> TRANCHE_FIELDS = Arrays.asList(TARGET_TRUTH_SENSITIVITY, MIN_VQSLOD, TRANCHE_FILTER_NAME);
 
 
     public static final List<String> PET_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_ID_FIELD_NAME, STATE_FIELD_NAME);

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
@@ -71,7 +71,7 @@ public class SchemaUtils {
     public static final String TARGET_TRUTH_SENSITIVITY = "target_truth_sensitivity";
     public static final String MIN_VQSLOD = "min_vqslod";
     public static final String TRANCHE_FILTER_NAME = "filter_name";
-    public static final String SNP_OR_INDEL_MODEL = "model";
+    public static final String TRANCHE_MODEL = "model";
 
     public static final List<String> COHORT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_NAME_FIELD_NAME, STATE_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALL_GT, CALL_GQ, CALL_RGQ, QUALapprox, AS_QUALapprox, CALL_PL);//, AS_VarDP);
     public static final List<String> ARRAY_COHORT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_NAME_FIELD_NAME, STATE_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALL_GT, CALL_GQ);
@@ -85,7 +85,7 @@ public class SchemaUtils {
 
     public static final List<String> SAMPLE_FIELDS = Arrays.asList(SchemaUtils.SAMPLE_NAME_FIELD_NAME, SchemaUtils.SAMPLE_ID_FIELD_NAME);
     public static final List<String> YNG_FIELDS = Arrays.asList(FILTER_SET_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, VQSLOD, YNG_STATUS);
-    public static final List<String> TRANCHE_FIELDS = Arrays.asList(TARGET_TRUTH_SENSITIVITY, MIN_VQSLOD, TRANCHE_FILTER_NAME);
+    public static final List<String> TRANCHE_FIELDS = Arrays.asList(TARGET_TRUTH_SENSITIVITY, MIN_VQSLOD, TRANCHE_FILTER_NAME, TRANCHE_MODEL);
 
 
     public static final List<String> PET_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_ID_FIELD_NAME, STATE_FIELD_NAME);

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.hellbender.tools.variantdb.nextgen;
 
+import htsjdk.variant.vcf.VCFFilterHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Advanced;
@@ -13,8 +16,12 @@ import org.broadinstitute.hellbender.tools.variantdb.CommonCode;
 import org.broadinstitute.hellbender.tools.variantdb.SampleList;
 import org.broadinstitute.hellbender.tools.variantdb.SchemaUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.bigquery.StorageAPIAvroReader;
+import org.broadinstitute.hellbender.utils.bigquery.TableReference;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
 import java.util.*;
+
 
 
 @CommandLineProgramProperties(
@@ -98,6 +105,12 @@ public class ExtractCohort extends ExtractTool {
             optional=true)
     private Double vqsLodINDELThreshold = null;
 
+    private static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS = 99.7;
+    private static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS = 99.0;
+
+    private Map<Double, Double> snpTranches = new HashMap<Double, Double>();
+    private Map<Double, Double> indelTranches = new HashMap<Double, Double>();
+
     @Override
     protected void onStartup() {
         super.onStartup();
@@ -105,8 +118,14 @@ public class ExtractCohort extends ExtractTool {
         SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
         Set<String> sampleNames = new HashSet<>(sampleList.getSampleNames());
 
-        // TODO add VQSLOD/tranche info to headers
-        VCFHeader header = CommonCode.generateVcfHeader(sampleNames, reference.getSequenceDictionary());
+        Set<VCFHeaderLine> vqsrHeaderLines = new HashSet<>();
+        if (filteringFQTableName != null) {
+            validateFilteringCutoffs();
+            getTranches();
+            vqsrHeaderLines = getVqsLodThresholdsAndHeaders();
+        }
+
+        VCFHeader header = CommonCode.generateVcfHeader(sampleNames, reference.getSequenceDictionary(), vqsrHeaderLines);
 
         final List<SimpleInterval> traversalIntervals = getTraversalIntervals();
 
@@ -134,11 +153,8 @@ public class ExtractCohort extends ExtractTool {
                 minLocation,
                 maxLocation,
                 filteringFQTableName,
-                tranchesTableName,
                 localSortMaxRecordsInRam,
                 printDebugInformation,
-                truthSensitivitySNPThreshold,
-                truthSensitivityINDELThreshold,
                 vqsLodSNPThreshold,
                 vqsLodINDELThreshold,
                 progressMeter,
@@ -146,6 +162,110 @@ public class ExtractCohort extends ExtractTool {
                 filterSetName,
                 emitPLs);
         vcfWriter.writeHeader(header);
+    }
+
+    private void validateFilteringCutoffs() {
+        if (truthSensitivitySNPThreshold != null ^ truthSensitivityINDELThreshold != null) {
+            throw new UserException("If one of (--snps-truth-sensitivity-filter-level, --indels-truth-sensitivity-filter-level) is provided, both must be provided.");
+        } else if (truthSensitivitySNPThreshold != null) {  // at this point, we know that if SNP is defined, INDEL is also defined
+            // if the user specifies both truth sensitivity thresholds and lod cutoffs then throw a user error
+            if (vqsLodSNPThreshold != null || vqsLodINDELThreshold != null) {
+                throw new UserException("Arguments --[snps/indels]-truth-sensitivity-filter-level and --[snps/indels]-lod-score-cutoff are mutually exclusive. Please only specify one set of options.");
+            }
+        } else if (vqsLodSNPThreshold != null ^ vqsLodINDELThreshold != null) {
+            throw new UserException("If one of (--snps-lod-score-cutoff, --indels-lod-score-cutoff) is provided, both must be provided.");
+        } else if (vqsLodSNPThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
+            // defaults if no values are given
+            truthSensitivitySNPThreshold = DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS;
+            truthSensitivityINDELThreshold = DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
+        }
+
+        if (vqsLodSNPThreshold == null) {
+            // user must supply tranches table to look up vqslod score to use for cutoff
+            if (tranchesTableName == null) {
+                throw new UserException("Unless using lod score cutoffs (advanced), you must provide a tranches table using the argument --tranches-table.");
+            }
+        }
+    }
+
+    private void getTranches() {
+        // get tranches from BigQuery
+        final String restrictionWithFilterSetName = SchemaUtils.FILTER_SET_NAME + " = '" + filterSetName + "'";
+        final TableReference tranchesTableRef = new TableReference(tranchesTableName, SchemaUtils.TRANCHE_FIELDS);
+        final StorageAPIAvroReader tranchesTableAvroReader = new StorageAPIAvroReader(tranchesTableRef, restrictionWithFilterSetName, projectID);
+
+        // format list
+        for ( final GenericRecord queryRow : tranchesTableAvroReader ) {
+            switch (queryRow.get(SchemaUtils.TRANCHE_MODEL).toString()) {
+                case "SNP":
+                    double targetSnpTruthSensitivity = Double.parseDouble(queryRow.get(SchemaUtils.TARGET_TRUTH_SENSITIVITY).toString());
+                    double minSnpVqslod = Double.parseDouble(queryRow.get(SchemaUtils.MIN_VQSLOD).toString());
+                    snpTranches.put(targetSnpTruthSensitivity, minSnpVqslod);
+                    break;
+                case "INDEL":
+                    double targetIndelTruthSensitivity = Double.parseDouble(queryRow.get(SchemaUtils.TARGET_TRUTH_SENSITIVITY).toString());
+                    double minIndelVqslod = Double.parseDouble(queryRow.get(SchemaUtils.MIN_VQSLOD).toString());
+                    indelTranches.put(targetIndelTruthSensitivity, minIndelVqslod);
+                    break;
+            }
+        }
+
+        tranchesTableAvroReader.close();
+    }
+
+    private Set<VCFHeaderLine> getVqsLodThresholdsAndHeaders() {
+        Set<VCFHeaderLine> vqsrHeaderLines = new HashSet<>();
+
+        if (vqsLodSNPThreshold != null) { // user provided lod cutoffs
+            vqsrHeaderLines.add(new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_SNP, "Site failed SNP model VQSLOD cutoff of " + vqsLodSNPThreshold.toString()));
+            vqsrHeaderLines.add(new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_INDEL, "Site failed INDEL model VQSLOD cutoff of " + vqsLodINDELThreshold.toString()));
+        } else { // user provided sensitivity or no cutoffs
+            vqsLodSNPThreshold = getVqslodThreshold(snpTranches, truthSensitivitySNPThreshold, "SNP");
+            vqsLodINDELThreshold = getVqslodThreshold(indelTranches, truthSensitivityINDELThreshold, "INDEL");
+
+            vqsrHeaderLines.add(new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_SNP,
+                    "Site failed SNP model sensitivity cutoff (" + truthSensitivitySNPThreshold.toString() + "), corresponding with VQSLOD cutoff of " + vqsLodSNPThreshold.toString()));
+            vqsrHeaderLines.add(new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_INDEL,
+                    "Site failed INDEL model sensitivity cutoff (" + truthSensitivityINDELThreshold.toString() + "), corresponding with VQSLOD cutoff of " + vqsLodINDELThreshold.toString()));
+        }
+
+        return vqsrHeaderLines;
+    }
+
+    private Double getVqslodThreshold(Map<Double, Double> tranches, Double truthSensitivityThreshold, String variantMode) {
+        logger.info("Retrieving the min vqslod threshold for " + variantMode + "s and truth sensitivity of " + truthSensitivityThreshold);
+
+        // We want to find the tranche with the smallest target_truth_sensitivity that is
+        // equal to or greater than our truthSensitivityThreshold.
+        // e.g. if truthSensitivitySNPThreshold is 99.8 and we have tranches with target_truth_sensitivities
+        // of 99.5, 99.7, 99.9, and 100.0, we want the 99.9 sensitivity tranche.
+
+        Double effectiveSensitivity = null;
+
+        List<Double> sortedSensitivities = new ArrayList<>(tranches.keySet());
+        Collections.sort(sortedSensitivities);  // sorts in ASCENDING order
+        if (sortedSensitivities.contains(truthSensitivityThreshold)) {
+            effectiveSensitivity = truthSensitivityThreshold;
+        } else {
+            // find the first sensitivity that's greater than our target truthSensitivityThreshold
+            for ( Double trancheSensitivity : sortedSensitivities ) {
+                if ( trancheSensitivity > truthSensitivityThreshold ) {
+                    effectiveSensitivity = trancheSensitivity;
+                    break;
+                }
+            }
+        }
+
+        if (effectiveSensitivity == null) {
+            throw new UserException("No " + variantMode + " tranches found with target_truth_sensitivity >= " + truthSensitivityThreshold);
+        }
+
+        Double minVqslod = tranches.get(effectiveSensitivity);
+
+        logger.info("Found " + variantMode + " tranche defined by sensitivity " + effectiveSensitivity + " and VQSLOD >= " + minVqslod + "; keeping all variants in this tranche.");
+        logger.info("Passing all " + variantMode + " variants with VQSLOD >= " + minVqslod);
+
+        return minVqslod;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.ProgressMeter;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.variantdb.CommonCode;
 import org.broadinstitute.hellbender.tools.variantdb.SchemaUtils;
 import org.broadinstitute.hellbender.tools.walkers.ReferenceConfidenceVariantContextMerger;
@@ -45,9 +46,12 @@ public class ExtractCohortEngine {
     private final Long minLocation;
     private final Long maxLocation;
     private final TableReference filteringTableRef;
+    private final TableReference tranchesTableRef;
     private final ReferenceDataSource refSource;
-    private double vqsLodSNPThreshold = 0;
-    private double vqsLodINDELThreshold = 0;
+    private Double vqsLodSNPThreshold;
+    private Double vqsLodINDELThreshold;
+    private Double truthSensitivitySNPThreshold;
+    private Double truthSensitivityINDELThreshold;
 
     private final ProgressMeter progressMeter;
     private final String projectID;
@@ -72,6 +76,8 @@ public class ExtractCohortEngine {
      */
     public static int MISSING_CONF_THRESHOLD = 60;
 
+    public static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS = 99.7;
+    public static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS = 99.0;
 
     public ExtractCohortEngine(final String projectID,
                                final VariantContextWriter vcfWriter,
@@ -86,10 +92,13 @@ public class ExtractCohortEngine {
                                final Long minLocation,
                                final Long maxLocation,
                                final String filteringTableName,
+                               final String tranchesTableName,
                                final int localSortMaxRecordsInRam,
                                final boolean printDebugInformation,
-                               final double vqsLodSNPThreshold,
-                               final double vqsLodINDELThreshold,
+                               final Double truthSensitivitySNPThreshold,
+                               final Double truthSensitivityINDELThreshold,
+                               final Double vqsLodSNPThreshold,
+                               final Double vqsLodINDELThreshold,
                                final ProgressMeter progressMeter,
                                final ExtractCohort.QueryMode queryMode,
                                final String filterSetName,
@@ -108,10 +117,13 @@ public class ExtractCohortEngine {
         this.minLocation = minLocation;
         this.maxLocation = maxLocation;
         this.filteringTableRef = filteringTableName == null || "".equals(filteringTableName) ? null : new TableReference(filteringTableName, SchemaUtils.YNG_FIELDS);
+        this.tranchesTableRef = tranchesTableName == null || "".equals(tranchesTableName) ? null : new TableReference(tranchesTableName, SchemaUtils.TRANCHE_FIELDS);
 
         this.printDebugInformation = printDebugInformation;
         this.vqsLodSNPThreshold = vqsLodSNPThreshold;
         this.vqsLodINDELThreshold = vqsLodINDELThreshold;
+        this.truthSensitivitySNPThreshold = truthSensitivitySNPThreshold;
+        this.truthSensitivityINDELThreshold = truthSensitivityINDELThreshold;
         this.progressMeter = progressMeter;
         this.queryMode = queryMode;
 
@@ -141,6 +153,30 @@ public class ExtractCohortEngine {
         boolean noFilteringRequested = (filteringTableRef == null);
 
         if (!noFilteringRequested) {
+            // TODO there must be a less awful way to do this
+            if ( (truthSensitivitySNPThreshold != null && truthSensitivityINDELThreshold == null) || (truthSensitivitySNPThreshold == null && truthSensitivityINDELThreshold != null) ) {
+                throw new UserException("If one of (--snps-truth-sensitivity-filter-level, --indels-truth-sensitivity-filter-level) is provided, both must be provided.");
+            } else if ( truthSensitivitySNPThreshold != null && truthSensitivityINDELThreshold != null ) {
+                // if the user specifies both truth sensitivity thresholds and lod cutoffs then throw a user error
+                if ( vqsLodSNPThreshold != null || vqsLodINDELThreshold != null ) {
+                    throw new UserException("Arguments --[snps/indels]-truth-sensitivity-filter-level and --[snps/indels]-lod-score-cutoff are mutually exclusive. Please only specify one set of options.");
+                }
+            } else if ( ( vqsLodSNPThreshold != null && vqsLodINDELThreshold == null ) || ( vqsLodSNPThreshold == null && vqsLodINDELThreshold != null ) ) {
+                throw new UserException("If one of (--snps-lod-score-cutoff, --indels-lod-score-cutoff) is provided, both must be provided.");
+            } else if ( vqsLodSNPThreshold == null && vqsLodINDELThreshold == null  && truthSensitivitySNPThreshold == null && truthSensitivityINDELThreshold == null) {
+                // defaults if no values are given
+                truthSensitivitySNPThreshold = DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS;
+                truthSensitivityINDELThreshold = DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
+            }
+
+            if ( truthSensitivitySNPThreshold != null && truthSensitivityINDELThreshold != null ) {
+                vqsLodSNPThreshold = getVqslodThreshold(truthSensitivitySNPThreshold, "SNP");
+                vqsLodINDELThreshold = getVqslodThreshold(truthSensitivityINDELThreshold, "INDEL");
+            }
+            // now we have vqslod thresholds set
+
+
+            // get filter info (vqslod & yng values)
             final String rowRestrictionWithFilterSetName = rowRestriction + " AND " + SchemaUtils.FILTER_SET_NAME + " = '" + filterSetName + "'";
 
             final StorageAPIAvroReader filteringTableAvroReader = new StorageAPIAvroReader(filteringTableRef, rowRestrictionWithFilterSetName, projectID);
@@ -184,6 +220,43 @@ public class ExtractCohortEngine {
                 // TODO remove queryMode entirely from ExtractTool
                 throw new NotImplementedException("QUERY mode not supported. Please use `--query-mode LOCAL_SORT`.");
         }
+    }
+
+    private Double getVqslodThreshold(Double truthSensitivityThreshold, String variantMode) {
+        logger.info("Retrieving the min vqslod threshold for " + variantMode + "s and truth sensitivity of " + truthSensitivityThreshold);
+
+        // We want to find (separately for SNP and INDEL tranches) the tranche whose target_truth_sensitivity
+        // is equal to or closest to (but greater than) our truth sensitivity threshold.
+        // e.g. if truthSensitivitySNPThreshold is 99.8 and we have tranches with target_truth_sensitivities
+        // of 99.5, 99.7, 99.9, and 100.0, we want the 99.9 tranche.
+
+        // get tranches for this mode (SNP/INDEL) where the target_truth_sensitivity is >= our truthSensitivityThreshold
+        final String restrictionWithFilterSetName = SchemaUtils.SNP_OR_INDEL_MODEL + " = '" + variantMode + "' AND " +
+                SchemaUtils.TARGET_TRUTH_SENSITIVITY + " >= " + truthSensitivityThreshold.toString() + " AND " +
+                SchemaUtils.FILTER_SET_NAME + " = '" + filterSetName + "'";
+
+        final StorageAPIAvroReader filteringTableAvroReader = new StorageAPIAvroReader(tranchesTableRef, restrictionWithFilterSetName, projectID);
+
+        Double ts = 100.0;
+        String trancheName = null;
+        Double trancheMinVqslod = null;
+
+        for ( final GenericRecord queryRow : filteringTableAvroReader ) {
+            Double thisTs = Double.parseDouble(queryRow.get(SchemaUtils.TARGET_TRUTH_SENSITIVITY).toString());
+            if ( thisTs < ts ) {
+                ts = thisTs;
+                trancheName = queryRow.get(SchemaUtils.TRANCHE_FILTER_NAME).toString();
+                trancheMinVqslod = Double.parseDouble(queryRow.get(SchemaUtils.MIN_VQSLOD).toString());
+            }
+        }
+
+        filteringTableAvroReader.close();
+
+        logger.info("Found " + variantMode + " tranche " + trancheName + ", defined by VQSLOD >= " + trancheMinVqslod + "; keeping all variants in this tranche.");
+        logger.info("Passing all " + variantMode + " variants with VQSLOD >= " + trancheMinVqslod);
+
+        // TODO deal with the case where you don't get any tranches
+        return trancheMinVqslod;
     }
 
     public SortingCollection<GenericRecord> getAvroSortingCollection(org.apache.avro.Schema schema, int localSortMaxRecordsInRam) {
@@ -474,29 +547,29 @@ public class ExtractCohortEngine {
         final VariantContextBuilder builder = new VariantContextBuilder(mergedVC);
 
         builder.attribute(GATKVCFConstants.AS_VQS_LOD_KEY, relevantVqsLodMap.values().stream().map(val -> val.equals(Double.NaN) ? VCFConstants.EMPTY_INFO_FIELD : val.toString()).collect(Collectors.toList()));
-        builder.attribute(GATKVCFConstants.AS_YNG_STATUS_KEY, relevantYngMap.values().stream().collect(Collectors.toList()));
+        builder.attribute(GATKVCFConstants.AS_YNG_STATUS_KEY, new ArrayList<>(relevantYngMap.values()));
 
         int refLength = mergedVC.getReference().length();
 
         // if there are any Yays, the site is PASS
-        if (remappedYngMap.values().contains("Y")) {
+        if (remappedYngMap.containsValue("Y")) {
             builder.passFilters();
-        } else if (remappedYngMap.values().contains("N")) {
+        } else if (remappedYngMap.containsValue("N")) {
             builder.filter(GATKVCFConstants.NAY_FROM_YNG);
         } else {
             // if it doesn't trigger any of the filters below, we assume it passes.
             builder.passFilters();
-            if (remappedYngMap.values().contains("G")) {
+            if (remappedYngMap.containsValue("G")) {
                 // TODO change the initial query to include the filtername from the tranches tables
                 Optional<Double> snpMax = relevantVqsLodMap.entrySet().stream().filter(entry -> entry.getKey().length() == refLength).map(entry -> entry.getValue().equals(Double.NaN) ? 0.0 : entry.getValue()).max(Double::compareTo);
                 if (snpMax.isPresent() && snpMax.get() < vqsLodSNPThreshold) {
                     // TODO: add in sensitivities
-                    builder.filter(GATKVCFConstants.VQSR_TRANCHE_SNP);
+                    builder.filter(GATKVCFConstants.VQSR_FAILURE);
                 }
                 Optional<Double> indelMax = relevantVqsLodMap.entrySet().stream().filter(entry -> entry.getKey().length() != refLength).map(entry -> entry.getValue().equals(Double.NaN) ? 0.0 : entry.getValue()).max(Double::compareTo);
                 if (indelMax.isPresent() && indelMax.get() < vqsLodINDELThreshold) {
                     // TODO: add in sensitivities
-                    builder.filter(GATKVCFConstants.VQSR_TRANCHE_INDEL);
+                    builder.filter(GATKVCFConstants.VQSR_FAILURE);
                     }
             } else {
                 // If VQSR dropped this site (there's no YNG or VQSLOD) then we'll filter it as a NAY.

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.engine.ProgressMeter;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.variantdb.CommonCode;
 import org.broadinstitute.hellbender.tools.variantdb.SchemaUtils;
 import org.broadinstitute.hellbender.tools.walkers.ReferenceConfidenceVariantContextMerger;
@@ -141,6 +142,11 @@ public class ExtractCohortEngine {
         boolean noFilteringRequested = (filteringTableRef == null);
 
         if (!noFilteringRequested) {
+            // ensure vqslod filters are defined. this really shouldn't ever happen, said the engineer.
+            if (vqsLodSNPThreshold == null || vqsLodINDELThreshold == null) {
+                throw new UserException("Vqslod filtering thresholds for SNPs and INDELs must be defined.");
+            }
+
             // get filter info (vqslod & yng values)
             final String rowRestrictionWithFilterSetName = rowRestriction + " AND " + SchemaUtils.FILTER_SET_NAME + " = '" + filterSetName + "'";
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityTools.java
@@ -34,21 +34,21 @@ public class FilterSensitivityTools {
         boolean indelVqslodIsDefined = vqsLodINDELThreshold != null;
 
         if (snpTruthSensIsDefined ^ indelTruthSensIsDefined) {
-            throw new UserException("If one of (--snps-truth-sensitivity-filter-level, --indels-truth-sensitivity-filter-level) is provided, both must be provided.");
+            throw new UserException.BadInput("If one of (--snps-truth-sensitivity-filter-level, --indels-truth-sensitivity-filter-level) is provided, both must be provided.");
         } else if (snpTruthSensIsDefined) {
             // if the user specifies both truth sensitivity thresholds and lod cutoffs then throw a user error
             if (snpVqslodIsDefined || indelVqslodIsDefined) {
-                throw new UserException("Arguments --[snps/indels]-truth-sensitivity-filter-level and --[snps/indels]-lod-score-cutoff are mutually exclusive. Please only specify one set of options.");
+                throw new UserException.BadInput("Arguments --[snps/indels]-truth-sensitivity-filter-level and --[snps/indels]-lod-score-cutoff are mutually exclusive. Please only specify one set of options.");
             }
         } else if (snpVqslodIsDefined ^ indelVqslodIsDefined) {
-            throw new UserException("If one of (--snps-lod-score-cutoff, --indels-lod-score-cutoff) is provided, both must be provided.");
+            throw new UserException.BadInput("If one of (--snps-lod-score-cutoff, --indels-lod-score-cutoff) is provided, both must be provided.");
         }
 
         if (!snpVqslodIsDefined) {
             // we will need to use tranches to look up vqslod thresholds; therefore user must supply
             // a tranches table
             if (tranchesTableName == null) {
-                throw new UserException("Unless using lod score cutoffs (advanced), you must provide a tranches table using the argument --tranches-table.");
+                throw new UserException.BadInput("Unless using lod score cutoffs (advanced), you must provide a tranches table using the argument --tranches-table.");
             }
         }
     }
@@ -87,8 +87,7 @@ public class FilterSensitivityTools {
 
 
     public static Double getVqslodThreshold(Map<Double, Double> trancheMap, Double truthSensitivityThreshold, String model) {
-
-        if (truthSensitivityThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
+        if (truthSensitivityThreshold == null) {
             truthSensitivityThreshold = GATKVCFConstants.SNP.contains(model) ? DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS : DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
             logger.info("No filter thresholds supplied; using default " + model + " truth sensitivity threshold of " + truthSensitivityThreshold);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityTools.java
@@ -1,0 +1,135 @@
+package org.broadinstitute.hellbender.tools.variantdb.nextgen;
+
+import htsjdk.variant.vcf.VCFFilterHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.variantdb.SchemaUtils;
+import org.broadinstitute.hellbender.utils.bigquery.StorageAPIAvroReader;
+import org.broadinstitute.hellbender.utils.bigquery.TableReference;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class FilterSensitivityTools {
+    private static final Logger logger = LogManager.getLogger(FilterSensitivityTools.class);
+
+    private static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS = 99.7;
+    private static double DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS = 99.0;
+
+    public static void validateFilteringCutoffs(
+            Double truthSensitivitySNPThreshold,
+            Double truthSensitivityINDELThreshold,
+            Double vqsLodSNPThreshold,
+            Double vqsLodINDELThreshold,
+            String tranchesTableName) {
+        boolean snpTruthSensIsDefined = truthSensitivitySNPThreshold != null;
+        boolean indelTruthSensIsDefined = truthSensitivityINDELThreshold != null;
+
+        boolean snpVqslodIsDefined = vqsLodSNPThreshold != null;
+        boolean indelVqslodIsDefined = vqsLodINDELThreshold != null;
+
+        if (snpTruthSensIsDefined ^ indelTruthSensIsDefined) {
+            throw new UserException("If one of (--snps-truth-sensitivity-filter-level, --indels-truth-sensitivity-filter-level) is provided, both must be provided.");
+        } else if (snpTruthSensIsDefined) {
+            // if the user specifies both truth sensitivity thresholds and lod cutoffs then throw a user error
+            if (snpVqslodIsDefined || indelVqslodIsDefined) {
+                throw new UserException("Arguments --[snps/indels]-truth-sensitivity-filter-level and --[snps/indels]-lod-score-cutoff are mutually exclusive. Please only specify one set of options.");
+            }
+        } else if (snpVqslodIsDefined ^ indelVqslodIsDefined) {
+            throw new UserException("If one of (--snps-lod-score-cutoff, --indels-lod-score-cutoff) is provided, both must be provided.");
+        }
+
+        if (!snpVqslodIsDefined) {
+            // we will need to use tranches to look up vqslod thresholds; therefore user must supply
+            // a tranches table
+            if (tranchesTableName == null) {
+                throw new UserException("Unless using lod score cutoffs (advanced), you must provide a tranches table using the argument --tranches-table.");
+            }
+        }
+    }
+
+    public static Map<String, Map<Double, Double>> getTrancheMaps(String filterSetName, String tranchesTableName, String projectID) {
+        // get tranches from BigQuery
+        final String restrictionWithFilterSetName = SchemaUtils.FILTER_SET_NAME + " = '" + filterSetName + "'";
+        final TableReference tranchesTableRef = new TableReference(tranchesTableName, SchemaUtils.TRANCHE_FIELDS);
+        final StorageAPIAvroReader tranchesTableAvroReader = new StorageAPIAvroReader(tranchesTableRef, restrictionWithFilterSetName, projectID);
+
+        Map<Double, Double> snpTranches = new TreeMap<>();
+        Map<Double, Double> indelTranches = new TreeMap<>();
+
+        for ( final GenericRecord queryRow : tranchesTableAvroReader ) {
+            double targetTruthSensitivity = Double.parseDouble(queryRow.get(SchemaUtils.TARGET_TRUTH_SENSITIVITY).toString());
+            double minVqslod = Double.parseDouble(queryRow.get(SchemaUtils.MIN_VQSLOD).toString());
+            String model = queryRow.get(SchemaUtils.TRANCHE_MODEL).toString();
+            if (GATKVCFConstants.SNP.equals(model)) {
+                snpTranches.put(targetTruthSensitivity, minVqslod);
+            } else if (GATKVCFConstants.INDEL.equals(model)) {
+                indelTranches.put(targetTruthSensitivity, minVqslod);
+            } else {
+                // should this be an exception instead?
+                logger.warn("Ignoring unrecognized model '" + model + "' found in tranches table " + tranchesTableName + ", filter set " + filterSetName);
+            }
+        }
+
+        tranchesTableAvroReader.close();
+
+        Map<String, Map<Double, Double>> trancheMaps = new HashMap<>();
+        trancheMaps.put(GATKVCFConstants.SNP, snpTranches);
+        trancheMaps.put(GATKVCFConstants.INDEL, indelTranches);
+
+        return trancheMaps;
+    }
+
+
+    public static Double getVqslodThreshold(Map<Double, Double> trancheMap, Double truthSensitivityThreshold, String model) {
+
+        if (truthSensitivityThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
+            truthSensitivityThreshold = GATKVCFConstants.SNP.contains(model) ? DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS : DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
+            logger.info("No filter thresholds supplied; using default " + model + " truth sensitivity threshold of " + truthSensitivityThreshold);
+        }
+
+        logger.info("Retrieving the min vqslod threshold from tranches for " + model + "s with truth sensitivity threshold of " + truthSensitivityThreshold);
+        Double vqslodThreshold = getVqslodThresholdFromTranches(trancheMap, truthSensitivityThreshold);
+        logger.info("Passing all " + model + " variants with VQSLOD >= " + vqslodThreshold);
+        return vqslodThreshold;
+    }
+
+
+    public static Double getVqslodThresholdFromTranches(Map<Double, Double> trancheMap, Double truthSensitivityThreshold) {
+        // We want to find the tranche with the smallest target_truth_sensitivity that is
+        // equal to or greater than our truthSensitivityThreshold.
+        // e.g. if truthSensitivitySNPThreshold is 99.8 and we have tranches with target_truth_sensitivities
+        // of 99.5, 99.7, 99.9, and 100.0, we want the 99.9 sensitivity tranche.
+
+        Double effectiveSensitivity = trancheMap.keySet().stream().filter(ts -> ts >= truthSensitivityThreshold).findFirst().orElse(null);
+
+        if (effectiveSensitivity == null) {
+            throw new UserException("No tranches found with target_truth_sensitivity >= " + truthSensitivityThreshold);
+        }
+
+        Double minVqslod = trancheMap.get(effectiveSensitivity);
+
+        logger.info("Using tranche defined by sensitivity " + effectiveSensitivity + " and VQSLOD >= " + minVqslod + "; keeping all variants in this tranche.");
+
+        return minVqslod;
+    }
+
+
+    public static VCFHeaderLine getVqsLodHeader(Double vqsLodThreshold, String model) {
+        return new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
+                "Site failed " + model + " model VQSLOD cutoff of " + vqsLodThreshold.toString());
+    }
+
+    public static VCFHeaderLine getTruthSensitivityHeader(Double truthSensitivityThreshold, Double vqsLodThreshold, String model) {
+        if (truthSensitivityThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
+            truthSensitivityThreshold = GATKVCFConstants.SNP.contains(model) ? DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS : DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
+        }
+        return new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
+                "Site failed " + model + " model sensitivity cutoff (" + truthSensitivityThreshold.toString() + "), corresponding with VQSLOD cutoff of " + vqsLodThreshold.toString());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -169,9 +169,10 @@ public final class GATKVCFConstants {
     public static final String SITE_LEVEL_FILTERS =                             "SITE";
 
     public static final String NAY_FROM_YNG = "NAY";
-    //TODO: take this out once we have the full tranche sensitivities implemented in ExtractCohort
-    public static final String VQSR_TRANCHE_SNP = "VQSRTrancheSNP";
-    public static final String VQSR_TRANCHE_INDEL = "VQSRTrancheIndel";
+    public static final String VQSR_FAILURE = "LOW_VQSLOD";
+//    //TODO: take this out once we have the full tranche sensitivities implemented in ExtractCohort
+//    public static final String VQSR_TRANCHE_SNP = "VQSRTrancheSNP";
+//    public static final String VQSR_TRANCHE_INDEL = "VQSRTrancheIndel";
 
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -168,9 +168,12 @@ public final class GATKVCFConstants {
     public static final String FAIL =                                           "FAIL";
     public static final String SITE_LEVEL_FILTERS =                             "SITE";
 
+    public static final String SNP = "SNP";
+    public static final String INDEL = "INDEL";
     public static final String NAY_FROM_YNG = "NAY";
-    public static final String VQSR_FAILURE_SNP = "low_VQSLOD_SNP";
-    public static final String VQSR_FAILURE_INDEL = "low_VQSLOD_INDEL";
+    public static final String VQSR_FAILURE_PREFIX = "low_VQSLOD_";
+    public static final String VQSR_FAILURE_SNP = VQSR_FAILURE_PREFIX + SNP;
+    public static final String VQSR_FAILURE_INDEL = VQSR_FAILURE_PREFIX + INDEL;
 
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -169,10 +169,8 @@ public final class GATKVCFConstants {
     public static final String SITE_LEVEL_FILTERS =                             "SITE";
 
     public static final String NAY_FROM_YNG = "NAY";
-    public static final String VQSR_FAILURE = "LOW_VQSLOD";
-//    //TODO: take this out once we have the full tranche sensitivities implemented in ExtractCohort
-//    public static final String VQSR_TRANCHE_SNP = "VQSRTrancheSNP";
-//    public static final String VQSR_TRANCHE_INDEL = "VQSRTrancheIndel";
+    public static final String VQSR_FAILURE_SNP = "low_VQSLOD_SNP";
+    public static final String VQSR_FAILURE_INDEL = "low_VQSLOD_INDEL";
 
 
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -76,8 +76,9 @@ public class GATKVCFHeaderLines {
 
         addFilterLine(new VCFFilterHeaderLine(NAY_FROM_YNG, "Considered a NAY in the Yay, Nay, Grey table"));
         // TODO: take this out once we have the full tranche sensitivities implemented in ExtractCohort
-        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_SNP, "Temporary VQSLOD cutoff for SNPs until we implememnt full tranche sensitivities"));
-        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_INDEL, "Temporary VQSLOD cutoff for INDELs until we implememnt full tranche sensitivities"));
+        addFilterLine(new VCFFilterHeaderLine(VQSR_FAILURE, "Site failed VQSLOD/sensitivity cutoff"));
+//        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_SNP, "Temporary VQSLOD cutoff for SNPs until we implememnt full tranche sensitivities"));
+//        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_INDEL, "Temporary VQSLOD cutoff for INDELs until we implememnt full tranche sensitivities"));
 
         addFilterLine(new VCFFilterHeaderLine(EXCESS_HET_KEY, "Site has excess het value larger than the threshold"));
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -75,11 +75,6 @@ public class GATKVCFHeaderLines {
         addFilterLine(new VCFFilterHeaderLine(VCFConstants.PASSES_FILTERS_v4, "Site contains at least one allele that passes filters"));
 
         addFilterLine(new VCFFilterHeaderLine(NAY_FROM_YNG, "Considered a NAY in the Yay, Nay, Grey table"));
-        // TODO: take this out once we have the full tranche sensitivities implemented in ExtractCohort
-        addFilterLine(new VCFFilterHeaderLine(VQSR_FAILURE, "Site failed VQSLOD/sensitivity cutoff"));
-//        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_SNP, "Temporary VQSLOD cutoff for SNPs until we implememnt full tranche sensitivities"));
-//        addFilterLine(new VCFFilterHeaderLine(VQSR_TRANCHE_INDEL, "Temporary VQSLOD cutoff for INDELs until we implememnt full tranche sensitivities"));
-
         addFilterLine(new VCFFilterHeaderLine(EXCESS_HET_KEY, "Site has excess het value larger than the threshold"));
 
         // M2-related filters

--- a/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityToolsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/FilterSensitivityToolsTest.java
@@ -1,0 +1,122 @@
+package org.broadinstitute.hellbender.tools.variantdb.nextgen;
+
+import htsjdk.variant.vcf.VCFFilterHeaderLine;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.broadinstitute.hellbender.tools.variantdb.nextgen.FilterSensitivityTools.*;
+import static org.testng.Assert.*;
+
+public class FilterSensitivityToolsTest {
+
+    private Map<Double, Double> testTrancheMap = new TreeMap<>();
+
+    @BeforeMethod
+    public void setUp() {
+        // deliberately construct out of order to test ordering of TreeMap
+        testTrancheMap.put(95.0, 2.5);
+        testTrancheMap.put(99.0, -6.0);
+        testTrancheMap.put(92.0, 10.0);
+        testTrancheMap.put(100.0, -42.);
+        testTrancheMap.put(90.0, 12.5);
+    }
+
+
+
+
+    // TODO how to test the exceptions in this method?
+//    @Test
+//    public void testValidateFilteringCutoffs() {
+//        String definedInput = "I'm defined!";
+//        String undefinedInput = null;
+//
+//        assertThrows(new testValidateFilteringCutoffs(definedInput, undefinedInput, undefinedInput, undefinedInput, definedInput));
+//    }
+
+    @Test
+    public void testGetTrancheMaps() {
+
+    }
+
+    // tests for getVqslodThreshold
+
+    @Test
+    public void testGetVqslodThresholdExactMatch() {
+        Double testSensitivityThresh = 92.0;
+        Double expectedVqslod = 10.0;
+        assertEquals(getVqslodThreshold(testTrancheMap, testSensitivityThresh, GATKVCFConstants.SNP), expectedVqslod);
+    }
+
+    @Test
+    public void testGetVqslodThresholdBetweenTranches() {
+        Double testSensitivityThresh = 94.0;
+        Double expectedVqslod = 2.5; // should use next highest tranche, i.e. 95.0
+        assertEquals(getVqslodThreshold(testTrancheMap, testSensitivityThresh, GATKVCFConstants.SNP), expectedVqslod);
+    }
+
+    @Test
+    public void testGetVqslodThresholdLowerThanAll() {
+        Double testSensitivityThresh = 3.0;
+        Double expectedVqslod = 12.5; // should use next highest tranche, i.e. 90.0
+        assertEquals(getVqslodThreshold(testTrancheMap, testSensitivityThresh, GATKVCFConstants.SNP), expectedVqslod);
+    }
+
+    @Test
+    public void testGetVqslodThresholdNullSNP() {
+        Double testSensitivityThresh = null; // should default to 99.7 for snps
+        Double expectedVqslod = -42.0;
+        assertEquals(getVqslodThreshold(testTrancheMap, testSensitivityThresh, GATKVCFConstants.SNP), expectedVqslod);
+    }
+
+    @Test
+    public void testGetVqslodThresholdNullINDEL() {
+        Double testSensitivityThresh = null; // should default to 99.0 for indels
+        Double expectedVqslod = -6.0;
+        assertEquals(getVqslodThreshold(testTrancheMap, testSensitivityThresh, GATKVCFConstants.INDEL), expectedVqslod);
+    }
+
+    // tests for getVqslodThresholdFromTranches
+
+    @Test
+    public void testGetVqslodThresholdFromTranchesExactMatch() {
+        Double testSensitivityThresh = 92.0;
+        Double expectedVqslod = 10.0;
+        assertEquals(getVqslodThresholdFromTranches(testTrancheMap, testSensitivityThresh), expectedVqslod);
+    }
+
+
+    @Test
+    public void testGetVqslodThresholdFromTranchesBetweenTranches() {
+        Double testSensitivityThresh = 94.0;
+        Double expectedVqslod = 2.5; // should use next highest tranche, i.e. 95.0
+        assertEquals(getVqslodThresholdFromTranches(testTrancheMap, testSensitivityThresh), expectedVqslod);
+    }
+
+    @Test
+    public void testGetVqslodThresholdFromTranchesLowerThanAll() {
+        Double testSensitivityThresh = 3.0;
+        Double expectedVqslod = 12.5; // should use next highest tranche, i.e. 90.0
+        assertEquals(getVqslodThresholdFromTranches(testTrancheMap, testSensitivityThresh), expectedVqslod);
+    }
+
+    // tests for getVqsLodHeader
+
+    @Test
+    public void testGetVqsLodHeader() {
+        Double vqsLodSNPThreshold = 90.0;
+        String model = GATKVCFConstants.SNP;
+        VCFFilterHeaderLine expectedHeader = new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
+                "Site failed SNP model VQSLOD cutoff of 90.0");
+
+        assertEquals(getVqsLodHeader(vqsLodSNPThreshold, GATKVCFConstants.SNP), expectedHeader);
+    }
+
+    @Test
+    public void testGetTruthSensitivityHeader() {
+    }
+
+}


### PR DESCRIPTION
specops issue #269 https://github.com/broadinstitute/dsp-spec-ops/issues/269

- user can provide either [snps-truth-sensitivity-filter-level, indels-truth-sensitivity-filter-level] or [snps-lod-score-cutoff, indels-lod-score-cutoff], or neither, in which case default values of snps-truth-sensitivity-filter=99.7 and indels-truth-sensitivity-fitler=99.0 are used.
- regardless of lod score cutoffs or truth sensitivity cutoffs, the filtering string is either "low_VQSLOD_SNP" or "low_VQSLOD_INDEL"
- if lod score cutoffs are provided, those are used for filtering. the header filter message looks like "Site failed INDEL model VQSLOD cutoff of 0.0"
- if truth sensitivity cutoffs are provided, the corresponding lod scores are looked up from the tranche table in BigQuery. the header filter message in this case looks like "Site failed INDEL model sensitivity cutoff (90.0), corresponding with VQSLOD cutoff of 0.0"