### PR TITLE
Added filter for only master branch

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -4,57 +4,93 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_case_workflow.wdl
      testParameterFiles:
-     -  /scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
+          -  /scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
+     filters:
+         branches:
+             - master
    - name: cnv_germline_cohort_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/germline/cnv_germline_cohort_workflow.wdl
      testParameterFiles:
-     -  /scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
+          -  /scripts/cnv_cromwell_tests/germline/cnv_germline_cohort_workflow.json
+     filters:
+         branches:
+             - master
    - name: cnv_somatic_pair_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_pair_workflow.wdl
      testParameterFiles: 
-     -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_do-gc_workflow.json
+          -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_pair_wes_do-gc_workflow.json
+     filters:
+         branches:
+             - master
    - name: cnv_somatic_panel_workflow
      subclass: WDL
      primaryDescriptorPath: /scripts/cnv_wdl/somatic/cnv_somatic_panel_workflow.wdl
      testParameterFiles:
-     -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_panel_wes_do-gc_workflow.json
+          -  /scripts/cnv_cromwell_tests/somatic/cnv_somatic_panel_wes_do-gc_workflow.json
+     filters:
+         branches:
+             - master
    - name: cram2filtered
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2filtered.wdl
      testParameterFiles:
-     - /scripts/cnn_variant_wdl/jsons/cram2filtered.json
+          - /scripts/cnn_variant_wdl/jsons/cram2filtered.json
+     filters:
+         branches:
+             - master
    - name: cram2model
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/cram2model.wdl
      testParameterFiles:
-     - /scripts/cnn_variant_wdl/jsons/cram2model.json
-   - name: funcotator
+          - /scripts/cnn_variant_wdl/jsons/cram2model.json
+     filters:
+         branches:
+             - master
+   - name: Funcotator
      subclass: WDL
      primaryDescriptorPath: /scripts/funcotator_wdl/funcotator.wdl
      testParameterFiles:
-     - /scripts/funcotator_wdl/funcotator.json
+          - /scripts/funcotator_wdl/funcotator.json
+     filters:
+         branches:
+             - master
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
      testParameterFiles:
-     -  /scripts/mitochondria_m2_wdl/test_mitochondria_m2_wdl.json
+          -  /scripts/mitochondria_m2_wdl/test_mitochondria_m2_wdl.json
+     filters:
+         branches:
+             - master
    - name: mutect2
      subclass: WDL
      primaryDescriptorPath: /scripts/mutect2_wdl/mutect2.wdl
      testParameterFiles:
-     - /scripts/m2_cromwell_tests/mutect2.inputs.json
+          - /scripts/m2_cromwell_tests/mutect2.inputs.json
+     filters:
+         branches:
+             - master
    - name: mutect2_pon
      subclass: WDL
      primaryDescriptorPath: /scripts/mutect2_wdl/mutect2_pon.wd
+     filters:
+         branches:
+             - master
    - name: run_happy
      subclass: WDL
      primaryDescriptorPath: /scripts/cnn_variant_wdl/run_happy.wdl
      testParameterFiles:
-     - /scripts/cnn_variant_wdl/jsons/run_happy.json
+          - /scripts/cnn_variant_wdl/jsons/run_happy.json
+     filters:
+         branches:
+             - master
    - name: pathseq_pipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/pathseq/wdl/pathseq_pipeline.wdl
      testParameterFiles:
-     - /scripts/pathseq/wdl/pathseq_pipeline_template.json
+          - /scripts/pathseq/wdl/pathseq_pipeline_template.json
+     filters:
+         branches:
+             - master


### PR DESCRIPTION
A while back I added a .dockstore.yml file to the gatk repo so that gatk workflows in the /script/ folder would be automatically synced in Dockstore after every push or release. This also allowed the workflows in every branch/release to be readily available in Terra. However, GATK’s 700+ branches has been causing problems for Dockstore syncs and in some instances associated released tags to be missing ([forum discussion](https://discuss.dockstore.org/t/dockstore-could-not-find-a-workflow-in-git-using-yml-though-it-worked-previously/4255/5)). 

This PR adds filters to the dockstore.yml so that only the master branch and the releases gets synced to dockstore, also any future branches aren’t automatically synced.  If anyone wants to sync their branch they’ll have to add their branch name to the dockstore.yml file in their branch.
More info on dockstore yml and filters can be found [here](https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html)