### PR TITLE
Another approach to conditionally store FeatureInput name in VC

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantDataSource.java
@@ -88,7 +88,7 @@ public final class MultiVariantDataSource implements GATKDataSource<VariantConte
         featureInputs.forEach(
                 featureInput -> featureDataSources.add(
                         new FeatureDataSource<>(featureInput, queryLookaheadBases, VariantContext.class, cloudPrefetchBuffer, cloudIndexPrefetchBuffer,
-                                                reference)));
+                                                reference, true)));
 
         // Ensure that the merged header and sequence dictionary that we use are in sync with each
         // other, and reflect the actual dictionaries used to do validation:

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
@@ -176,16 +176,20 @@ public final class MultiVariantDataSourceUnitTest extends GATKBaseTest {
 
             Iterator<VariantContext> it = multiVariantSource.query(new SimpleInterval("1", 1, 1200));
             while (it.hasNext()) {
-                it.next();
+                VariantContext vc = it.next();
                 count++;
+
+                Assert.assertNotNull(vc.getSource());
             };
             Assert.assertEquals(count, 14);
 
             count = 0;
             it = multiVariantSource.query(new SimpleInterval("2", 200, 600));
             while (it.hasNext()) {
-                it.next();
+                VariantContext vc = it.next();
                 count++;
+
+                Assert.assertNotNull(vc.getSource());
             };
             Assert.assertEquals(count, 3);
         }


### PR DESCRIPTION
Rationale: MultiVariantWalkers, including iterators like MultiVariantWalkerGroupedOnStart, are a useful and efficient iteration pattern. However, it is often essential to know the FeatureInput source of the variant. 

