### PR TITLE
Attempt to surgically store FeatureInput name into VC source field

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantDataSourceUnitTest.java
@@ -176,16 +176,20 @@ public final class MultiVariantDataSourceUnitTest extends GATKBaseTest {
 
             Iterator<VariantContext> it = multiVariantSource.query(new SimpleInterval("1", 1, 1200));
             while (it.hasNext()) {
-                it.next();
+                VariantContext vc = it.next();
                 count++;
+
+                Assert.assertNotNull(vc.getSource());
             };
             Assert.assertEquals(count, 14);
 
             count = 0;
             it = multiVariantSource.query(new SimpleInterval("2", 200, 600));
             while (it.hasNext()) {
-                it.next();
+                VariantContext vc = it.next();
                 count++;
+
+                Assert.assertNotNull(vc.getSource());
             };
             Assert.assertEquals(count, 3);
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStartUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStartUnitTest.java
@@ -29,7 +29,8 @@ public class MultiVariantWalkerGroupedOnStartUnitTest extends GATKBaseTest {
         List<List<VariantContext>> seenVariants = new ArrayList<>();
         @Override
         public void apply(List<VariantContext> variantContexts, ReferenceContext referenceContext, final List<ReadsContext> readsContexts) {
-            seenVariants.add(variantContexts);
+            //NOTE: MultiVariantDataSource stores the FeatureInput name as the source, which is machine-specific, so remove it:
+            seenVariants.add(variantContexts.stream().map(vc -> new VariantContextBuilder(vc).source("Unknown").make()).collect(Collectors.toList()));
         }
     }
 


### PR DESCRIPTION
Rationale: MultiVariantWalkers, including iterators like MultiVariantWalkerGroupedOnStart, are a useful and efficient iteration pattern. However, it is often essential to know the FeatureInput source of the variant. 

This PR would set the value of source only for MultiVariantDataSource. It does so by wrapping the iterator. I probably prefer the alternate approach proposed here: #7219 though, since it avoids re-creating the VC. If #7219 is merged we would close this PR. 

@cmnbroad this is related to discussion on #6973.