### PR TITLE
Enable call caching of TSV generation in GvsImportGenomes

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -83,6 +83,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - mmt_call_cache_IG
    - name: GvsPrepareCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -83,7 +83,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - mmt_call_cache_IG
    - name: GvsPrepareCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -375,7 +375,7 @@ task CreateImportTsvs {
 
       # check whether these files have already been generated
       DO_TSV_GENERATION=true
-      if [ ~{call_cache_tsvs} = 'true' ]; then
+      if [ ~{call_cache_tsvs} = true ]; then
         echo "Checking for files to call cache"
         # currently these will NOT identify files in a done directory OR in a set directory
         SAMPLE_INFO_FILE_PATH="~{sample_info_staging_directory}sample_info_*_~{input_vcf_basename}.tsv"
@@ -387,9 +387,10 @@ task CreateImportTsvs {
 
         ALL_FILES_EXIST=true
         for filepath in ${FILEARRAY[@]}; do
-            result=$(gsutil ls $filepath || echo "error finding file")
+            # output 1 if no file is found
+            result=$(gsutil ls $filepath || echo 1)
 
-            if [ $result == "error finding file" ]; then
+            if [ $result == 1 ]; then
               echo "A file matching $filepath does not exist"
               ALL_FILES_EXIST=false
             else
@@ -397,13 +398,13 @@ task CreateImportTsvs {
             fi
         done
 
-        if [ $ALL_FILES_EXIST = 'true' ]; then
+        if [ $ALL_FILES_EXIST = true ]; then
             DO_TSV_GENERATION=false
             echo "Skipping TSV generation for input file ~{input_vcf_basename} because the output TSV files already exist."
         fi
       fi
 
-      if [ $DO_TSV_GENERATION='true' ]; then
+      if [ $DO_TSV_GENERATION = true ]; then
           echo "Generating TSVs for input file ~{input_vcf_basename}"
           gatk --java-options "-Xmx7000m" CreateVariantIngestFiles \
             -V ~{updated_input_vcf} \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -387,15 +387,13 @@ task CreateImportTsvs {
 
         ALL_FILES_EXIST=true
         for filepath in ${FILEARRAY[@]}; do
-            echo "checking whether file $filepath already exists..."
-            # the following returns 0 if file exists or 1 if file does not exist
-            gsutil -q stat $filepath
-            status=$?
-            if [[ $status == 0 ]]; then
-              echo "File $filepath already exists"
-            else
-              echo "File $filepath does not exist"
+            result=$(gsutil ls $filepath || echo "error finding file")
+
+            if [ $result == "error finding file" ]; then
+              echo "A file matching $filepath does not exist"
               ALL_FILES_EXIST=false
+            else
+              echo "File $result already exists"
             fi
         done
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -385,8 +385,11 @@ task CreateImportTsvs {
               echo "A file matching ${FILEPATH} does not exist"
               ALL_FILES_EXIST='false'
             else
-              echo "File $result already exists"
-              if [[ $result = "~{output_directory}/${TABLETYPE}_tsvs/set_"* ]]; then
+              if [[ $result = *"/done/"* ]]; then
+                echo "File ${FILENAME} seems to have been processed already; found at ${result}"
+                echo "Something is very wrong!"
+                exit 1
+              elif [[ $result = "~{output_directory}/${TABLETYPE}_tsvs/set_"* ]]; then
                 FILENAME=$(basename $result)
                 echo "File ${FILENAME} is in a set directory. Moving out of set directory to ~{output_directory}/${TABLETYPE}_tsvs/${FILENAME}"
                 gsutil mv $result "~{output_directory}/${TABLETYPE}_tsvs/"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -374,8 +374,8 @@ task CreateImportTsvs {
       fi
 
       # check whether these files have already been generated
-      DO_TSV_GENERATION=true
-      if [ ~{call_cache_tsvs} = true ]; then
+      DO_TSV_GENERATION='true'
+      if [ ~{call_cache_tsvs} = 'true' ]; then
         echo "Checking for files to call cache"
         # currently these will NOT identify files in a done directory OR in a set directory
         SAMPLE_INFO_FILE_PATH="~{sample_info_staging_directory}sample_info_*_~{input_vcf_basename}.tsv"
@@ -385,26 +385,32 @@ task CreateImportTsvs {
         declare -a FILEARRAY=($SAMPLE_INFO_FILE_PATH $PET_FILE_PATH $VET_FILE_PATH)
         echo "looking for these files: $FILEARRAY"
 
-        ALL_FILES_EXIST=true
+        ALL_FILES_EXIST='true'
         for filepath in ${FILEARRAY[@]}; do
             # output 1 if no file is found
             result=$(gsutil ls $filepath || echo 1)
 
             if [ $result == 1 ]; then
               echo "A file matching $filepath does not exist"
-              ALL_FILES_EXIST=false
+              ALL_FILES_EXIST='false'
             else
               echo "File $result already exists"
             fi
         done
 
-        if [ $ALL_FILES_EXIST = true ]; then
-            DO_TSV_GENERATION=false
+        echo "All files exist?"
+        echo $ALL_FILES_EXIST
+
+        if [ $ALL_FILES_EXIST = 'true' ]; then
+            DO_TSV_GENERATION='false'
             echo "Skipping TSV generation for input file ~{input_vcf_basename} because the output TSV files already exist."
         fi
       fi
+      
+      echo "do tsv generation?"
+      echo $DO_TSV_GENERATION
 
-      if [ $DO_TSV_GENERATION = true ]; then
+      if [ $DO_TSV_GENERATION = 'true' ]; then
           echo "Generating TSVs for input file ~{input_vcf_basename}"
           gatk --java-options "-Xmx7000m" CreateVariantIngestFiles \
             -V ~{updated_input_vcf} \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -380,13 +380,14 @@ task CreateImportTsvs {
         SAMPLE_INFO_FILE_PATH="~{sample_info_staging_directory}sample_info_*_~{input_vcf_basename}.tsv"
         PET_FILE_PATH="~{pet_staging_directory}pet_*_~{input_vcf_basename}.tsv"
         VET_FILE_PATH="~{vet_staging_directory}vet_*_~{input_vcf_basename}.tsv"
+        declare -a FILEARRAY=($SAMPLE_INFO_FILE_PATH $PET_FILE_PATH $VET_FILE_PATH)
 
         ALL_FILES_EXIST=true
-        for filepath in (SAMPLE_INFO_FILE_PATH PET_FILE_PATH VET_FILE_PATH); do
+        for filepath in ${FILEARRAY[@]}; do
             # the following returns 0 if file exists or 1 if file does not exist
             gsutil -q stat $filepath
-            STATUS=$?
-            if [[ $status == 0 ]] && [ ALL_FILES_EXIST ]; then
+            status=$?
+            if [[ $status == 0 ]]; then
               echo "File $filepath already exists"
             else
               echo "File $filepath does not exist"
@@ -401,6 +402,7 @@ task CreateImportTsvs {
       fi
 
       if [ $DO_TSV_GENERATION='true' ]; then
+          echo "Generating TSVs for input file ~{input_vcf_basename}"
           gatk --java-options "-Xmx7000m" CreateVariantIngestFiles \
             -V ~{updated_input_vcf} \
             -L ~{interval_list} \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -442,6 +442,9 @@ task CreateImportTsvs {
 
 # Creates all the tables necessary for the LoadData operation
 task CreateTables {
+  meta {
+    volatile: true
+  }
 
 	input {
       String project_id

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -406,6 +406,8 @@ task CreateImportTsvs {
 
       if [ $DO_TSV_GENERATION = 'true' ]; then
           echo "Generating TSVs for input file ~{input_vcf_basename}"
+
+          # TODO in future when we pass the source path or gvs_id as an arg here, use a version of that for the filename too
           gatk --java-options "-Xmx7000m" CreateVariantIngestFiles \
             -V ~{updated_input_vcf} \
             -L ~{interval_list} \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -434,9 +434,6 @@ task CreateImportTsvs {
 
 # Creates all the tables necessary for the LoadData operation
 task CreateTables {
-	meta {
-    	volatile: true
-  	}
 
 	input {
       String project_id

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -155,7 +155,7 @@ workflow GvsImportGenomes {
 
   call ReleaseLock {
     input:
-      run_uuid = "" #SetLock.run_uuid,
+      run_uuid = "", #SetLock.run_uuid,
       output_directory = output_directory,
       load_sample_info_done = LoadSampleInfoTable.done,
       load_pet_done = LoadPetTable.done,

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -392,15 +392,14 @@ task CreateImportTsvs {
             result=$(gsutil ls $FILEPATH || echo 1)
 
             if [ $result == 1 ]; then
-              echo "A file matching $FILEPATH does not exist"
+              echo "A file matching ${FILEPATH} does not exist"
               ALL_FILES_EXIST='false'
             else
               echo "File $result already exists"
               if [[ $result = "~{output_directory}/${TABLETYPE}_tsvs/set_"* ]]; then
-                echo "File is in set directory. Moving out of set directory to ~{output_directory}/${TABLETYPE}_tsvs/${FILENAME}"
-                FILENAME=${result##/*/}
-                echo $FILENAME
-                gsutil mv $result "~{output_directory}/${TABLETYPE}_tsvs/${FILENAME}"
+                FILENAME=$(basename $result)
+                echo "File ${FILENAME} is in a set directory. Moving out of set directory to ~{output_directory}/${TABLETYPE}_tsvs/${FILENAME}"
+                gsutil mv $result "~{output_directory}/${TABLETYPE}_tsvs/"
               fi
 
             fi

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -594,6 +594,9 @@ task LoadTable {
           echo "Moving set $set data into separate directory."
           awk -v set="$set" '$4 == set' ~{datatype}_du_sets.txt | cut -f2 | gsutil -m mv -I "${DIR}set_${set}/" 2> copy.log
 
+          echo "TEMPORARILY EXITING TO SIMULATE BQ LOAD FAILURE"
+          exit 1
+
           # execute bq load command, get bq load job id, add details per set to tmp file
           echo "Running BigQuery load for set $set."
           bq load --quiet --nosync --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -376,14 +376,18 @@ task CreateImportTsvs {
       # check whether these files have already been generated
       DO_TSV_GENERATION=true
       if [ ~{call_cache_tsvs} = 'true' ]; then
+        echo "Checking for files to call cache"
         # currently these will NOT identify files in a done directory OR in a set directory
         SAMPLE_INFO_FILE_PATH="~{sample_info_staging_directory}sample_info_*_~{input_vcf_basename}.tsv"
         PET_FILE_PATH="~{pet_staging_directory}pet_*_~{input_vcf_basename}.tsv"
         VET_FILE_PATH="~{vet_staging_directory}vet_*_~{input_vcf_basename}.tsv"
+        echo "setting up FILEARRAY"
         declare -a FILEARRAY=($SAMPLE_INFO_FILE_PATH $PET_FILE_PATH $VET_FILE_PATH)
+        echo "looking for these files: $FILEARRAY"
 
         ALL_FILES_EXIST=true
         for filepath in ${FILEARRAY[@]}; do
+            echo "checking whether file $filepath already exists..."
             # the following returns 0 if file exists or 1 if file does not exist
             gsutil -q stat $filepath
             status=$?

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -329,9 +329,9 @@ task CreateImportTsvs {
   # if we are doing a manual localization, we need to set the filename
   String updated_input_vcf = if (defined(service_account_json)) then input_vcf_basename else input_vcf
 
-  String sample_info_staging_directory = ~{output_directory}/sample_info_tsvs/
-  String pet_staging_directory = ~{output_directory}/pet_tsvs/
-  String vet_staging_directory = ~{output_directory}/vet_tsvs/
+  String sample_info_staging_directory = output_directory + '/sample_info_tsvs/'
+  String pet_staging_directory = output_directory + '/pet_tsvs/'
+  String vet_staging_directory = output_directory + '/vet_tsvs/'
 
   meta {
     description: "Creates a tsv file for import into BigQuery"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -596,9 +596,6 @@ task LoadTable {
           echo "Moving set $set data into separate directory."
           awk -v set="$set" '$4 == set' ~{datatype}_du_sets.txt | cut -f2 | gsutil -m mv -I "${DIR}set_${set}/" 2> copy.log
 
-          echo "TEMPORARILY EXITING TO SIMULATE BQ LOAD FAILURE"
-          exit 1
-
           # execute bq load command, get bq load job id, add details per set to tmp file
           echo "Running BigQuery load for set $set."
           bq load --quiet --nosync --location=US --project_id=~{project_id} --skip_leading_rows=1 --source_format=CSV -F "\t" \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -24,12 +24,12 @@ workflow GvsImportGenomes {
 
   String docker_final = select_first([docker, "us.gcr.io/broad-gatk/gatk:4.1.7.0"])
 
-  call SetLock {
-    input:
-      output_directory = output_directory,
-      service_account_json = service_account_json,
-      preemptible_tries = preemptible_tries
-  }
+  # call SetLock {
+  #   input:
+  #     output_directory = output_directory,
+  #     service_account_json = service_account_json,
+  #     preemptible_tries = preemptible_tries
+  # }
 
   call GetMaxTableId {
     input:
@@ -95,7 +95,7 @@ workflow GvsImportGenomes {
         gatk_override = gatk_override,
         docker = docker_final,
         preemptible_tries = preemptible_tries,
-        run_uuid = SetLock.run_uuid
+        run_uuid = "" # SetLock.run_uuid
     }
   }
 
@@ -113,7 +113,7 @@ workflow GvsImportGenomes {
         table_creation_done = CreateSampleInfoTables.done,
         tsv_creation_done = CreateImportTsvs.done,
         docker = docker_final,
-        run_uuid = SetLock.run_uuid
+        run_uuid = "" #SetLock.run_uuid
     }
   }
 
@@ -131,7 +131,7 @@ workflow GvsImportGenomes {
       table_creation_done = CreatePetTables.done,
       tsv_creation_done = CreateImportTsvs.done,
       docker = docker_final,
-      run_uuid = SetLock.run_uuid
+      run_uuid = "" #SetLock.run_uuid
     }
   }
 
@@ -149,13 +149,13 @@ workflow GvsImportGenomes {
       table_creation_done = CreateVetTables.done,
       tsv_creation_done = CreateImportTsvs.done,
       docker = docker_final,
-      run_uuid = SetLock.run_uuid
+      run_uuid = "" #SetLock.run_uuid
     }
   }
 
   call ReleaseLock {
     input:
-      run_uuid = SetLock.run_uuid,
+      run_uuid = "" #SetLock.run_uuid,
       output_directory = output_directory,
       load_sample_info_done = LoadSampleInfoTable.done,
       load_pet_done = LoadPetTable.done,
@@ -363,15 +363,15 @@ task CreateImportTsvs {
         gsutil cp ~{input_vcf_index} .
       fi
 
-      # check for existence of the correct lockfile
-      LOCKFILE="~{output_directory}/LOCKFILE"
-      EXISTING_LOCK_ID=$(gsutil cat ${LOCKFILE}) || { echo "Error retrieving lockfile from ${LOCKFILE}" 1>&2 ; exit 1; }
-      CURRENT_RUN_ID="~{run_uuid}"
+      # # check for existence of the correct lockfile
+      # LOCKFILE="~{output_directory}/LOCKFILE"
+      # EXISTING_LOCK_ID=$(gsutil cat ${LOCKFILE}) || { echo "Error retrieving lockfile from ${LOCKFILE}" 1>&2 ; exit 1; }
+      # CURRENT_RUN_ID="~{run_uuid}"
 
-      if [ ${EXISTING_LOCK_ID} != ${CURRENT_RUN_ID} ]; then
-        echo "ERROR: found mismatched lockfile containing run ${EXISTING_LOCK_ID}, which does not match this run ${CURRENT_RUN_ID}." 1>&2
-        exit 1
-      fi
+      # if [ ${EXISTING_LOCK_ID} != ${CURRENT_RUN_ID} ]; then
+      #   echo "ERROR: found mismatched lockfile containing run ${EXISTING_LOCK_ID}, which does not match this run ${CURRENT_RUN_ID}." 1>&2
+      #   exit 1
+      # fi
 
       # check whether these files have already been generated
       DO_TSV_GENERATION='true'
@@ -406,7 +406,7 @@ task CreateImportTsvs {
             echo "Skipping TSV generation for input file ~{input_vcf_basename} because the output TSV files already exist."
         fi
       fi
-      
+
       echo "do tsv generation?"
       echo $DO_TSV_GENERATION
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -377,14 +377,8 @@ task CreateImportTsvs {
       DO_TSV_GENERATION='true'
       if [ ~{call_cache_tsvs} = 'true' ]; then
         echo "Checking for files to call cache"
-        # currently these will NOT identify files in a done directory OR in a set directory
-        # SAMPLE_INFO_FILE_PATH="~{sample_info_staging_directory}sample_info_*_~{input_vcf_basename}.tsv"
-        # PET_FILE_PATH="~{pet_staging_directory}pet_*_~{input_vcf_basename}.tsv"
-        # VET_FILE_PATH="~{vet_staging_directory}vet_*_~{input_vcf_basename}.tsv"
-        # declare -a FILEARRAY=($SAMPLE_INFO_FILE_PATH $PET_FILE_PATH $VET_FILE_PATH)
-
+        
         declare -a TABLETYPES=("sample_info" "pet" "vet")
-
         ALL_FILES_EXIST='true'
         for TABLETYPE in ${TABLETYPES[@]}; do
             FILEPATH="~{output_directory}/${TABLETYPE}_tsvs/**${TABLETYPE}_*_~{input_vcf_basename}.tsv"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -329,10 +329,6 @@ task CreateImportTsvs {
   # if we are doing a manual localization, we need to set the filename
   String updated_input_vcf = if (defined(service_account_json)) then input_vcf_basename else input_vcf
 
-  String sample_info_staging_directory = output_directory + '/sample_info_tsvs/'
-  String pet_staging_directory = output_directory + '/pet_tsvs/'
-  String vet_staging_directory = output_directory + '/vet_tsvs/'
-
   meta {
     description: "Creates a tsv file for import into BigQuery"
     volatile: true
@@ -377,7 +373,7 @@ task CreateImportTsvs {
       DO_TSV_GENERATION='true'
       if [ ~{call_cache_tsvs} = 'true' ]; then
         echo "Checking for files to call cache"
-        
+
         declare -a TABLETYPES=("sample_info" "pet" "vet")
         ALL_FILES_EXIST='true'
         for TABLETYPE in ${TABLETYPES[@]}; do

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -387,7 +387,7 @@ task CreateImportTsvs {
 
         ALL_FILES_EXIST='true'
         for TABLETYPE in ${TABLETYPES[@]}; do
-            FILEPATH = "~{output_directory}/${TABLETYPE}_tsvs/**${TABLETYPE}_*_~{input_vcf_basename}.tsv"
+            FILEPATH="~{output_directory}/${TABLETYPE}_tsvs/**${TABLETYPE}_*_~{input_vcf_basename}.tsv"
             # output 1 if no file is found
             result=$(gsutil ls $FILEPATH || echo 1)
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFiles.java
@@ -24,6 +24,7 @@ import org.broadinstitute.hellbender.utils.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -116,6 +117,12 @@ public final class CreateVariantIngestFiles extends VariantWalker {
         return true; // TODO -- do I need to check the boolean flag on this?
     }
 
+    private String getInputFileName() {
+        // this returns the full file name including extensions
+        String[] pathParts = drivingVariantFile.toString().split("/");
+        return pathParts[pathParts.length - 1];
+    }
+
     @Override
     public void onTraversalStart() {
         //set up output directory
@@ -140,6 +147,9 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             sampleId = IngestUtils.getSampleId(sampleName, sampleMap);
         }
 
+        // use input gvcf file name instead of sample name in output filenames
+        System.out.println(getInputFileName());
+        String sampleIdentifierForOutputFileName = getInputFileName();
 
         // Mod the sample directories
         int sampleTableNumber = IngestUtils.getTableNumber(sampleId, IngestConstants.partitionPerTable);
@@ -147,7 +157,7 @@ public final class CreateVariantIngestFiles extends VariantWalker {
 
 //        parentDirectory = parentOutputDirectory.toPath(); // TODO do we need this? More efficient way to do this?
 //        final Path sampleDirectoryPath = IngestUtils.createSampleDirectory(parentDirectory, sampleDirectoryNumber);
-        sampleInfoTsvCreator = new SampleInfoTsvCreator(sampleName, sampleId, tableNumberPrefix, outputDir);
+        sampleInfoTsvCreator = new SampleInfoTsvCreator(sampleIdentifierForOutputFileName, sampleId, tableNumberPrefix, outputDir);
         sampleInfoTsvCreator.createRow(sampleName, sampleId, userIntervals, gqStateToIgnore);
 
         // To set up the missing positions
@@ -157,11 +167,11 @@ public final class CreateVariantIngestFiles extends VariantWalker {
         final GenomeLocSortedSet genomeLocSortedSet = new GenomeLocSortedSet(new GenomeLocParser(seqDictionary));
         intervalArgumentGenomeLocSortedSet = GenomeLocSortedSet.createSetFromList(genomeLocSortedSet.getGenomeLocParser(), IntervalUtils.genomeLocsFromLocatables(genomeLocSortedSet.getGenomeLocParser(), intervalArgumentCollection.getIntervals(seqDictionary)));
 
-        petTsvCreator = new PetTsvCreator(sampleName, sampleId, tableNumberPrefix, seqDictionary, gqStateToIgnore, dropAboveGqThreshold, outputDir, outputType);
+        petTsvCreator = new PetTsvCreator(sampleIdentifierForOutputFileName, sampleId, tableNumberPrefix, seqDictionary, gqStateToIgnore, dropAboveGqThreshold, outputDir, outputType);
         switch (mode) {
             case EXOMES:
             case GENOMES:
-                vetTsvCreator = new VetTsvCreator(sampleName, sampleId, tableNumberPrefix, outputDir);
+                vetTsvCreator = new VetTsvCreator(sampleIdentifierForOutputFileName, sampleId, tableNumberPrefix, outputDir);
                 break;
             case ARRAYS:
                 throw new UserException.BadInput("To ingest Array data, use CreateArrayIngestFiles tool.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFiles.java
@@ -24,7 +24,6 @@ import org.broadinstitute.hellbender.utils.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -147,8 +146,8 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             sampleId = IngestUtils.getSampleId(sampleName, sampleMap);
         }
 
+        // TODO when we pass in the full file path or gvs_id as an input arg, use path here instead or gvs_id in addition
         // use input gvcf file name instead of sample name in output filenames
-        System.out.println(getInputFileName());
         String sampleIdentifierForOutputFileName = getInputFileName();
 
         // Mod the sample directories

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/PetTsvCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/PetTsvCreator.java
@@ -38,7 +38,7 @@ public final class PetTsvCreator {
     private GenomeLocSortedSet coverageLocSortedSet;
     private static String PET_FILETYPE_PREFIX = "pet_";
 
-    public PetTsvCreator(String sampleName, String sampleId, String tableNumberPrefix, SAMSequenceDictionary seqDictionary, GQStateEnum gqStateToIgnore, final boolean dropAboveGqThreshold, final File outputDirectory, final CommonCode.OutputType outputType) {
+    public PetTsvCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumberPrefix, SAMSequenceDictionary seqDictionary, GQStateEnum gqStateToIgnore, final boolean dropAboveGqThreshold, final File outputDirectory, final CommonCode.OutputType outputType) {
         this.sampleId = sampleId;
         this.seqDictionary = seqDictionary;
         this.outputType = outputType;
@@ -46,7 +46,7 @@ public final class PetTsvCreator {
         coverageLocSortedSet = new GenomeLocSortedSet(new GenomeLocParser(seqDictionary));
 
        try {
-            final File petOutputFile = new File(outputDirectory, PET_FILETYPE_PREFIX + tableNumberPrefix + sampleName  + "." + outputType.toString().toLowerCase());
+            final File petOutputFile = new File(outputDirectory, PET_FILETYPE_PREFIX + tableNumberPrefix + sampleIdentifierForOutputFileName + "." + outputType.toString().toLowerCase());
             switch (outputType) {
                 case TSV:
                     List<String> petHeader = PetTsvCreator.getHeaders();

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/SampleInfoTsvCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/SampleInfoTsvCreator.java
@@ -27,9 +27,9 @@ public class SampleInfoTsvCreator {
         inferred_state,
     }
 
-    public SampleInfoTsvCreator(String sampleName, String sampleId, String tableNumberPrefix, final File outputDirectory) {
+    public SampleInfoTsvCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumberPrefix, final File outputDirectory) {
         try {
-            final File sampleInfoFile = new File(outputDirectory, IngestConstants.sampleInfoFilePrefix + tableNumberPrefix + sampleName + IngestConstants.FILETYPE);
+            final File sampleInfoFile = new File(outputDirectory, IngestConstants.sampleInfoFilePrefix + tableNumberPrefix + sampleIdentifierForOutputFileName + IngestConstants.FILETYPE);
             // write header to it
             List<String> sampleListHeader = SampleInfoTsvCreator.getHeaders();
             sampleInfoWriter = new SimpleXSVWriter(sampleInfoFile.toPath(), IngestConstants.SEPARATOR);

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/VetTsvCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/VetTsvCreator.java
@@ -27,12 +27,12 @@ public class VetTsvCreator {
     private static String VET_FILETYPE_PREFIX = "vet_";
 
 
-    public VetTsvCreator(String sampleName, String sampleId, String tableNumberPrefix, final File outputDirectory) {
+    public VetTsvCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumberPrefix, final File outputDirectory) {
         this.sampleId = sampleId;
         // If the vet directory inside it doesn't exist yet -- create it
         // if the pet & vet tsvs don't exist yet -- create them
         try {
-            final File vetOutputFile = new File(outputDirectory, VET_FILETYPE_PREFIX + tableNumberPrefix + sampleName  + IngestConstants.FILETYPE);
+            final File vetOutputFile = new File(outputDirectory, VET_FILETYPE_PREFIX + tableNumberPrefix + sampleIdentifierForOutputFileName + IngestConstants.FILETYPE);
             vetWriter = new SimpleXSVWriter(vetOutputFile.toPath(), IngestConstants.SEPARATOR);
             vetWriter.setHeaderLine(getHeaders());
         } catch (final IOException e) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFilesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/CreateVariantIngestFilesIntegrationTest.java
@@ -4,6 +4,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.annotations.Test;
+import org.testng.Assert;
 
 import java.io.File;
 import java.util.*;
@@ -44,6 +45,16 @@ public class CreateVariantIngestFilesIntegrationTest extends CommandLineProgramT
         );
         Collections.sort(allOutputFiles);
 
+        final List<File> expectedFileNames = new ArrayList<>(Arrays.asList(
+                new File(outputDir + "/pet_001_" + input_vcf_file + ".tsv"),
+                new File(outputDir + "/sample_info_001_" + input_vcf_file + ".tsv"),
+                new File(outputDir + "/vet_001_" + input_vcf_file + ".tsv")
+        ));
+
+        // test contents of files match
         IntegrationTestSpec.assertMatchingFiles(allOutputFiles, expectedOutputFiles, false, STRICT);
+
+        // test file names are expected
+        Assert.assertEquals(allOutputFiles, expectedFileNames);
     }
 }


### PR DESCRIPTION
this PR:
- changes CreateVariantIngestFiles to name the output files in a predictable way - i.e. rather than using a sample_id, it uses the name of the input gvcf. e.g. `pet_001_NA12878.tsv` becomes `pet_001_NA12878.haplotypeCalls.reblocked.vcf.gz.tsv`
    - added a test in CreateVariantIngestFilesIntegrationTest to assert that the files are named as expected

- changes the GvsImportGenomes.wdl to:
    - check whether, for the given input gvcf file and for each of pet, vet, and sample_info, the output TSV already exists somewhere in the output directory. it checks subdirectories.
    - if the output TSV exists in a `set_X` subdirectory, we move that file back into the parent directory so that subsetting works as desired when we get to LoadTables
    - if the output TSV exists in a `done` subdirectory, we exit with an error


notes:
- this does not check whether the sample is in the same table_id (e.g. pet_001 versus pet_002)

this has been tested as follows:
- ran once with an `exit 1` before bq load, to simulate generating TSVs and putting them into set_X subdirectories and then exiting, simulating a permissions or other bq issue
- removed LOCKFILE, removed exit before bq load, then ran again - TSVs were not regenerated, the existing ones were moved into the parent directory and loaded properly into bq
- then ran again with the same samples - as expected, errored out because the TSVs already existed in a `done` folder