### PR TITLE
279 labels

### DIFF
--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -13,7 +13,7 @@ workflow GvsCreateFilterSet {
         String default_dataset
 
         String query_project = data_project
-        String query_labels = ""
+        String? query_labels
 
         String fq_sample_table = "~{data_project}.~{default_dataset}.sample_info"
         String fq_alt_allele_table = "~{data_project}.~{default_dataset}.alt_allele"
@@ -218,7 +218,7 @@ task ExtractFilterTask {
         File? gatk_override
         File? service_account_json
         String query_project
-        String query_labels
+        String? query_labels
 
         Int? local_sort_max_records_in_ram = 1000000
     }
@@ -249,7 +249,7 @@ task ExtractFilterTask {
                 --sample-table ~{fq_sample_table} \
                 --alt-allele-table ~{fq_alt_allele_table} \
                 ~{"--excess-alleles-threshold " + excess_alleles_threshold} \
-                --query-labels ~{query_labels}  \
+                ~{"--query-labels " + query_labels} \
                 -L ~{intervals} \
                 ~{"-XL " + excluded_intervals} \
                 --project-id ~{read_project_id}

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -225,6 +225,7 @@ task ExtractFilterTask {
 
 
     String has_service_account_file = if (defined(service_account_json)) then 'true' else 'false'
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query-labels ", select_first([query_labels])) else []
 
     # ------------------------------------------------
     # Run our command:
@@ -249,7 +250,7 @@ task ExtractFilterTask {
                 --sample-table ~{fq_sample_table} \
                 --alt-allele-table ~{fq_alt_allele_table} \
                 ~{"--excess-alleles-threshold " + excess_alleles_threshold} \
-                ~{"--query-labels " + query_labels} \
+                ~{sep=" " query_label_args} \
                 -L ~{intervals} \
                 ~{"-XL " + excluded_intervals} \
                 --project-id ~{read_project_id}

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -13,6 +13,7 @@ workflow GvsCreateFilterSet {
         String default_dataset
 
         String query_project = data_project
+        String query_labels = ""
 
         String fq_sample_table = "~{data_project}.~{default_dataset}.sample_info"
         String fq_alt_allele_table = "~{data_project}.~{default_dataset}.alt_allele"
@@ -99,7 +100,8 @@ workflow GvsCreateFilterSet {
                 read_project_id          = query_project,
                 output_file              = "${output_file_base_name}_${i}.vcf.gz",
                 service_account_json     = service_account_json,
-                query_project            = query_project
+                query_project            = query_project,
+                query_labels             = query_labels
         }
     }
 
@@ -216,6 +218,7 @@ task ExtractFilterTask {
         File? gatk_override
         File? service_account_json
         String query_project
+        String query_labels
 
         Int? local_sort_max_records_in_ram = 1000000
     }
@@ -246,7 +249,7 @@ task ExtractFilterTask {
                 --sample-table ~{fq_sample_table} \
                 --alt-allele-table ~{fq_alt_allele_table} \
                 ~{"--excess-alleles-threshold " + excess_alleles_threshold} \
-                --queryLabels '{"label": "without", "a": "cause"}'
+                --query-labels ~{query_labels}  \
                 -L ~{intervals} \
                 ~{"-XL " + excluded_intervals} \
                 --project-id ~{read_project_id}

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -225,7 +225,7 @@ task ExtractFilterTask {
 
 
     String has_service_account_file = if (defined(service_account_json)) then 'true' else 'false'
-    Array[String] query_label_args = if defined(query_labels) then prefix("--query-labels ", select_first([query_labels])) else []
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query-labels ", select_all(query_labels)) else []
 
     # ------------------------------------------------
     # Run our command:

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -13,7 +13,7 @@ workflow GvsCreateFilterSet {
         String default_dataset
 
         String query_project = data_project
-        Array[String] ? query_labels
+        Array[String]? query_labels
 
         String fq_sample_table = "~{data_project}.~{default_dataset}.sample_info"
         String fq_alt_allele_table = "~{data_project}.~{default_dataset}.alt_allele"
@@ -218,14 +218,15 @@ task ExtractFilterTask {
         File? gatk_override
         File? service_account_json
         String query_project
-        Array[String] ? query_labels
+        Array[String]? query_labels
 
         Int? local_sort_max_records_in_ram = 1000000
     }
 
 
     String has_service_account_file = if (defined(service_account_json)) then 'true' else 'false'
-    Array[String] query_label_args = if defined(query_labels) then prefix("--query-labels ", select_all(query_labels)) else []
+    # Note the coercion of optional query_labels using select_first([expr, default])
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query-labels ", select_first([query_labels])) else []
 
     # ------------------------------------------------
     # Run our command:

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -13,7 +13,7 @@ workflow GvsCreateFilterSet {
         String default_dataset
 
         String query_project = data_project
-        String? query_labels
+        Array[String] ? query_labels
 
         String fq_sample_table = "~{data_project}.~{default_dataset}.sample_info"
         String fq_alt_allele_table = "~{data_project}.~{default_dataset}.alt_allele"
@@ -218,7 +218,7 @@ task ExtractFilterTask {
         File? gatk_override
         File? service_account_json
         String query_project
-        String? query_labels
+        Array[String] ? query_labels
 
         Int? local_sort_max_records_in_ram = 1000000
     }

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -246,6 +246,7 @@ task ExtractFilterTask {
                 --sample-table ~{fq_sample_table} \
                 --alt-allele-table ~{fq_alt_allele_table} \
                 ~{"--excess-alleles-threshold " + excess_alleles_threshold} \
+                --queryLabels '{"label": "without", "a": "cause"}'
                 -L ~{intervals} \
                 ~{"-XL " + excluded_intervals} \
                 --project-id ~{read_project_id}

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -63,8 +63,8 @@ task PrepareCallsetTask {
         File? service_account_json
         String docker
     }
-
-    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_all(query_labels)) else []
+    # Note the coercion of optional query_labels using select_first([expr, default])
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
 
     command <<<
         set -e

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -8,7 +8,7 @@ workflow GvsPrepareCallset {
 
         # inputs with defaults
         String query_project = data_project
-        String? query_labels
+        Array[String]? query_labels
         String destination_project = data_project
         String destination_dataset = default_dataset
 
@@ -51,7 +51,7 @@ task PrepareCallsetTask {
     input {
         String destination_cohort_table_name
         String query_project
-        String? query_labels
+        Array[String]? query_labels
 
         String fq_petvet_dataset
         String fq_cohort_sample_table

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -8,6 +8,7 @@ workflow GvsPrepareCallset {
 
         # inputs with defaults
         String query_project = data_project
+        String query_labels = ""
         String destination_project = data_project
         String destination_dataset = default_dataset
 
@@ -28,7 +29,7 @@ workflow GvsPrepareCallset {
         input:
             destination_cohort_table_name   = destination_cohort_table_name,
             query_project                   = query_project,
-
+            query_labels                    = query_labels,
             fq_petvet_dataset               = fq_petvet_dataset,
             fq_cohort_sample_table          = fq_cohort_sample_table,
             fq_sample_mapping_table         = fq_sample_mapping_table,
@@ -50,6 +51,7 @@ task PrepareCallsetTask {
     input {
         String destination_cohort_table_name
         String query_project
+        String query_labels
 
         String fq_petvet_dataset
         String fq_cohort_sample_table
@@ -72,6 +74,7 @@ task PrepareCallsetTask {
             --destination_table ~{destination_cohort_table_name} \
             --fq_cohort_sample_names ~{fq_cohort_sample_table} \
             --query_project ~{query_project} \
+            --query_labels ~{query_labels} \
             --fq_sample_mapping_table ~{fq_sample_mapping_table} \
             --ttl ~{temp_table_ttl_in_hours} \
             ~{"--sa_key_path " + service_account_json}

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -64,7 +64,7 @@ task PrepareCallsetTask {
         String docker
     }
 
-    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_all(query_labels)) else []
 
     command <<<
         set -e

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -8,7 +8,7 @@ workflow GvsPrepareCallset {
 
         # inputs with defaults
         String query_project = data_project
-        String query_labels = ""
+        String? query_labels
         String destination_project = data_project
         String destination_dataset = default_dataset
 
@@ -51,7 +51,7 @@ task PrepareCallsetTask {
     input {
         String destination_cohort_table_name
         String query_project
-        String query_labels
+        String? query_labels
 
         String fq_petvet_dataset
         String fq_cohort_sample_table
@@ -74,7 +74,7 @@ task PrepareCallsetTask {
             --destination_table ~{destination_cohort_table_name} \
             --fq_cohort_sample_names ~{fq_cohort_sample_table} \
             --query_project ~{query_project} \
-            --query_labels ~{query_labels} \
+            ~{"--query_labels " + query_labels} \
             --fq_sample_mapping_table ~{fq_sample_mapping_table} \
             --ttl ~{temp_table_ttl_in_hours} \
             ~{"--sa_key_path " + service_account_json}

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -64,6 +64,8 @@ task PrepareCallsetTask {
         String docker
     }
 
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
+
     command <<<
         set -e
 
@@ -74,7 +76,7 @@ task PrepareCallsetTask {
             --destination_table ~{destination_cohort_table_name} \
             --fq_cohort_sample_names ~{fq_cohort_sample_table} \
             --query_project ~{query_project} \
-            ~{"--query_labels " + query_labels} \
+            ~{sep=" " query_label_args} \
             --fq_sample_mapping_table ~{fq_sample_mapping_table} \
             --ttl ~{temp_table_ttl_in_hours} \
             ~{"--sa_key_path " + service_account_json}

--- a/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
@@ -8,10 +8,7 @@ from google.cloud import bigquery
 from google.cloud.bigquery.job import QueryJobConfig
 from google.oauth2 import service_account
 
-
 import argparse
-
-import json
 import re
 
 JOB_IDS = set()
@@ -59,11 +56,11 @@ def execute_with_retry(label, sql):
   start = time.time()
   while len(retry_delay) > 0:
     try:
-      labelValue = label.replace(" ","-").strip().lower()
+      query_label = label.replace(" ","-").strip().lower()
 
       existing_labels = client._default_query_job_config.labels
       job_labels = existing_labels
-      job_labels["gvs_query_name"] = labelValue
+      job_labels["gvs_query_name"] = query_label
       job_config = bigquery.QueryJobConfig(labels=job_labels)
       query = client.query(sql, job_config=job_config)
 
@@ -316,7 +313,7 @@ if __name__ == '__main__':
   parser.add_argument('--destination_table',type=str, help='destination table', required=True)
   parser.add_argument('--fq_cohort_sample_names',type=str, help='FQN of cohort table to extract, contains "sample_name" column', required=True)
   parser.add_argument('--query_project',type=str, help='Google project where query should be executed', required=True)
-  parser.add_argument('--query_labels',type=str, help='Labels to put on the BQ query that will show up in the billing. Ex: --query-labels key1=value1 --query-labels key2=value2', required=False)
+  parser.add_argument('--query_labels',type=str, help='Labels to put on the BQ query that will show up in the billing. Ex: --query_labels key1=value1 --query_labels key2=value2', required=False)
   parser.add_argument('--min_variant_samples',type=int, help='Minimum variant samples at a site required to be emitted', required=False, default=0)
   parser.add_argument('--fq_sample_mapping_table',type=str, help='Mapping table from sample_id to sample_name', required=True)
   parser.add_argument('--sa_key_path',type=str, help='Path to json key file for SA', required=False)

--- a/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
@@ -11,6 +11,8 @@ from google.oauth2 import service_account
 
 import argparse
 
+import json
+
 JOB_IDS = set()
 
 #
@@ -225,6 +227,7 @@ def make_extract_table(fq_pet_vet_dataset,
                max_tables,
                fq_cohort_sample_names,
                query_project,
+               query_labels,
                fq_temp_table_dataset,
                fq_destination_dataset,
                destination_table,
@@ -235,7 +238,21 @@ def make_extract_table(fq_pet_vet_dataset,
               ):
   try:
     global client
-    default_config = QueryJobConfig(labels={ "id" : f"test_cohort_export_{output_table_prefix}"}, priority="INTERACTIVE", use_query_cache=False )
+    # this is where a set of labels are being created for the cohort extract. Do we want the hardcoded one to be different?
+    query_labels_map = {}
+    query_labels_map["id"]= f"test_cohort_export_{output_table_prefix}"
+    # query_labels is string that looks like '{"success": "true", "status": 200, "message": "Hello"}'
+    query_labels_json = json.loads(query_labels)
+
+    # get all the label keys and loop through them, adding them to the map
+    for key in query_labels_json.keys():
+      print(key)
+      query_labels_map[key] = query_labels_json[key]
+
+    #for label in query_labels:
+     # query_labels_map[label.key] = label.value
+
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=False )
 
     if sa_key_path:
       credentials = service_account.Credentials.from_service_account_file(
@@ -296,6 +313,7 @@ if __name__ == '__main__':
              args.max_tables,
              args.fq_cohort_sample_names,
              args.query_project,
+             args.query_labels,
              args.fq_temp_table_dataset,
              args.fq_destination_dataset,
              args.destination_table,

--- a/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
@@ -248,14 +248,13 @@ def make_extract_table(fq_pet_vet_dataset,
               ):
   try:
     global client
-    # this is where a set of labels are being created for the cohort extract. Do we want the hardcoded one to be different?
+    # this is where a set of labels are being created for the cohort extract
     query_labels_map = {}
-    query_labels_map["id"]= f"test_cohort_export_{output_table_prefix}"
-    query_labels_map["gvs_tool_name"]= f"create_cohort_export_{output_table_prefix}"
+    query_labels_map["id"]= {output_table_prefix}
+    query_labels_map["gvs_tool_name"]= f"gvs_prepare_callset"
     # query_labels is string that looks like 'key1=val1, key2=val2'
-    if query_labels != None:
-        query_labels_list = query_labels.split(",")
-        for query_label in query_labels_list:
+    if len(query_labels) != 0:
+        for query_label in query_labels:
           kv = query_label.split("=", 2)
           key = kv[0].strip().lower()
           value = kv[1].strip().lower()
@@ -313,7 +312,7 @@ if __name__ == '__main__':
   parser.add_argument('--destination_table',type=str, help='destination table', required=True)
   parser.add_argument('--fq_cohort_sample_names',type=str, help='FQN of cohort table to extract, contains "sample_name" column', required=True)
   parser.add_argument('--query_project',type=str, help='Google project where query should be executed', required=True)
-  parser.add_argument('--query_labels',type=str, help='Labels to put on the BQ query that will show up in the billing. Ex: --query_labels key1=value1 --query_labels key2=value2', required=False)
+  parser.add_argument('--query_labels',type=str, action='append', help='Labels to put on the BQ query that will show up in the billing. Ex: --query_labels key1=value1 --query_labels key2=value2', required=False)
   parser.add_argument('--min_variant_samples',type=int, help='Minimum variant samples at a site required to be emitted', required=False, default=0)
   parser.add_argument('--fq_sample_mapping_table',type=str, help='Mapping table from sample_id to sample_name', required=True)
   parser.add_argument('--sa_key_path',type=str, help='Path to json key file for SA', required=False)

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
@@ -82,7 +82,9 @@ public class SampleList {
                 " FROM `" + fqSampleTableName + "`" + whereClause;
 
         // Execute the query:
+        // TODO should we add hardcoded labels here?
         final TableResult result = BigQueryUtils.executeQuery(BigQueryUtils.getBigQueryEndPoint(executionProjectId) , sampleListQueryString, false, null);
+
 
         // Show our pretty results:
         if (printDebugInformation) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
@@ -84,7 +84,7 @@ public class SampleList {
 
         Map<String, String> labelForQuery = new HashMap<String, String>();
         if (originTool.isPresent()) {
-            String originToolName = originTool.get().toLowerCase().strip().replace(" ", "-");
+            String originToolName = originTool.get().replaceAll("\\s","-").toLowerCase();
             labelForQuery.put("gvs_tool_name", originToolName);
             labelForQuery.put("gvs_query_name", "sample-list-creation");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
@@ -81,9 +81,12 @@ public class SampleList {
                 "SELECT " + SchemaUtils.SAMPLE_ID_FIELD_NAME + ", " + SchemaUtils.SAMPLE_NAME_FIELD_NAME +
                 " FROM `" + fqSampleTableName + "`" + whereClause;
 
+        Map<String, String> labelForQuery = new HashMap<String, String>();
+        labelForQuery.put("gvs_tool_name", "sample-list-creation");
+        labelForQuery.put("gvs_query_name", "sample-list-creation");
+
         // Execute the query:
-        // TODO should we add hardcoded labels here?
-        final TableResult result = BigQueryUtils.executeQuery(BigQueryUtils.getBigQueryEndPoint(executionProjectId) , sampleListQueryString, false, null);
+        final TableResult result = BigQueryUtils.executeQuery(BigQueryUtils.getBigQueryEndPoint(executionProjectId) , sampleListQueryString, false, labelForQuery);
 
 
         // Show our pretty results:

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
@@ -19,7 +19,7 @@ public class SampleList {
     private Map<String, Long> sampleNameMap = new HashMap<>();
 
     public SampleList(String sampleTableName, File sampleFile, String executionProjectId, boolean printDebugInformation, String originTool) {
-        if (sampleTableName != null && originTool != null) {
+        if (sampleTableName != null) {
             initializeMaps(new TableReference(sampleTableName, SchemaUtils.SAMPLE_FIELDS), executionProjectId, printDebugInformation, Optional.ofNullable(originTool));
         } else if (sampleFile != null) {
             initializeMaps(sampleFile);

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -160,7 +160,7 @@ public class ExtractCohort extends ExtractTool {
             extraHeaderLines.add(new VCFFormatHeaderLine("FT", 1, VCFHeaderLineType.String, "Genotype Filter Field"));
         }
 
-        SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
+        SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation, "extract-cohort");
         Set<String> sampleNames = new HashSet<>(sampleList.getSampleNames());
 
         VCFHeader header = CommonCode.generateVcfHeader(sampleNames, reference.getSequenceDictionary(), extraHeaderLines);

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
@@ -80,10 +80,10 @@ public class ExtractFeatures extends ExtractTool {
 
     @Argument(
         fullName = "query-labels",
-        doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels '{ \"label1\": 1, \"label2\": \"value2\" }'",
+        doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels label1=value1 --query-labels label2=value2",
         optional = true)
 
-    protected String queryLabels = "";
+    protected List<String> queryLabels = new ArrayList<>();
 
     @Override
     public boolean requiresIntervals() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
@@ -83,7 +83,7 @@ public class ExtractFeatures extends ExtractTool {
         doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels '{ \"label1\": 1, \"label2\": \"value2\" }'",
         optional = true)
 
-    protected List<String> queryLabels = new ArrayList<>();
+    protected String queryLabels = "";
 
     @Override
     public boolean requiresIntervals() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
@@ -80,7 +80,7 @@ public class ExtractFeatures extends ExtractTool {
 
     @Argument(
         fullName = "query-labels",
-        doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels label1=value1 --query-labels label2=value2",
+        doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels key1=value1 --query-labels key2=value2",
         optional = true)
 
     protected List<String> queryLabels = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
@@ -19,6 +19,7 @@ import org.broadinstitute.hellbender.utils.bigquery.TableReference;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -77,6 +78,13 @@ public class ExtractFeatures extends ExtractTool {
         optional = true)
     protected int excessAllelesThreshold = CommonCode.EXCESS_ALLELES_THRESHOLD;
 
+    @Argument(
+        fullName = "query-labels",
+        doc = "Key-value pairs to be added to the extraction BQ query. Ex: --query-labels '{ \"label1\": 1, \"label2\": \"value2\" }'",
+        optional = true)
+
+    protected List<String> queryLabels = new ArrayList<>();
+
     @Override
     public boolean requiresIntervals() {
         return false;
@@ -130,7 +138,8 @@ public class ExtractFeatures extends ExtractTool {
             hqGenotypeGQThreshold,
             hqGenotypeDepthThreshold,
             hqGenotypeABThreshold,
-            excessAllelesThreshold);
+            excessAllelesThreshold,
+            queryLabels);
 
         vcfWriter.writeHeader(header);
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeatures.java
@@ -95,7 +95,7 @@ public class ExtractFeatures extends ExtractTool {
         super.onStartup();
 
         TableReference sampleTableRef = new TableReference(sampleTableName, SchemaUtils.SAMPLE_FIELDS);
-        SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
+        SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation, "extract-features");
 
         Set<VCFHeaderLine> extraHeaderLines = new HashSet<>();
         extraHeaderLines.add(

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.hellbender.tools.gvs.filtering;
 
-import com.google.api.client.util.Lists;
-import com.google.gson.JsonObject;
 import htsjdk.samtools.util.OverlapDetector;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -147,7 +145,7 @@ public class ExtractFeaturesEngine {
         createVQSRInputFromTableResult(storageAPIAvroReader);
     }
 
-    private Map<String, String>  createQueryLabels(List<String> labelStringList) {
+    static Map<String, String>  createQueryLabels(List<String> labelStringList) {
         // static labels are added to the query to make tracking this workflow easier downstream
         Map<String, String> labelForQuery = new HashMap<String, String>();
         labelForQuery.put("gvs_tool_name", "extract-features");
@@ -159,11 +157,14 @@ public class ExtractFeaturesEngine {
 
         if ( labelStringList.size() > 62 ) {
             throw new UserException("Only 62 unique label keys are allowed per resource.");
-            // BQ allows for 64, and we add one below
+            // BQ allows for 64, and we add two above
         }
 
-        for (String labelMap: labelStringList) {
-            String[] label = labelMap.split("=");
+        for (String labelMapString: labelStringList) {
+            if ( !labelMapString.contains("=") ) {
+                throw new UserException("All labels must contain a key and value in key=value format");
+            }
+            String[] label = labelMapString.split("=");
             String labelKey = label[0];
             String labelValue = label[1];
             // validate the label key and label value according to GCP Requirements for labels

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
@@ -148,17 +148,17 @@ public class ExtractFeaturesEngine {
     }
 
     private Map<String, String>  createQueryLabels(List<String> labelStringList) {
-        // hardcoded labels are added to the query to make tracking this workflow easier downstream
+        // static labels are added to the query to make tracking this workflow easier downstream
         Map<String, String> labelForQuery = new HashMap<String, String>();
         labelForQuery.put("gvs_tool_name", "extract-features");
         labelForQuery.put("gvs_query_name", "extract-features");
         // add additional key value pair labels
 
-        // Each resource can have multiple labels, up to a maximum of 64. -- labelKeys has to be !>64
+        // Each resource can have multiple labels, up to a maximum of 64. -- labelStringList cannot be >62
         // The key portion of a label must be unique. However, you can use the same key with multiple resources.
 
-        if ( labelStringList.size() > 63 ) {
-            throw new UserException("Only 63 unique label keys are allowed per resource.");
+        if ( labelStringList.size() > 62 ) {
+            throw new UserException("Only 62 unique label keys are allowed per resource.");
             // BQ allows for 64, and we add one below
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
@@ -132,7 +132,7 @@ public class ExtractFeaturesEngine {
                                                                                              hqGenotypeABThreshold);
 
         final String userDefinedFunctions = ExtractFeaturesBQ.getVQSRFeatureExtractUserDefinedFunctionsString();
-        Map<String, String> labelForQuery = createQueryLabels(queryLabels);
+        Map<String, String> cleanQueryLabels = createQueryLabels(queryLabels);
 
         final StorageAPIAvroReader storageAPIAvroReader = BigQueryUtils.executeQueryWithStorageAPI(
                 featureQueryString,
@@ -140,7 +140,7 @@ public class ExtractFeaturesEngine {
                 projectID,
                 userDefinedFunctions,
                 useBatchQueries,
-                labelForQuery);
+                cleanQueryLabels);
 
         createVQSRInputFromTableResult(storageAPIAvroReader);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
@@ -135,7 +135,6 @@ public class ExtractFeaturesEngine {
 
         final String userDefinedFunctions = ExtractFeaturesBQ.getVQSRFeatureExtractUserDefinedFunctionsString();
         Map<String, String> labelForQuery = createQueryLabels(queryLabels);
-        labelForQuery.put("variant_store", "extra_features");
 
         final StorageAPIAvroReader storageAPIAvroReader = BigQueryUtils.executeQueryWithStorageAPI(
                 featureQueryString,
@@ -149,9 +148,10 @@ public class ExtractFeaturesEngine {
     }
 
     private Map<String, String>  createQueryLabels(List<String> labelStringList) {
-        // a hardcoded label is added to the query to make tracking this workflow easier downstream
+        // hardcoded labels are added to the query to make tracking this workflow easier downstream
         Map<String, String> labelForQuery = new HashMap<String, String>();
-        labelForQuery.put("variant_store", "extra_features");
+        labelForQuery.put("gvs_tool_name", "extract-features");
+        labelForQuery.put("gvs_query_name", "extract-features");
         // add additional key value pair labels
 
         // Each resource can have multiple labels, up to a maximum of 64. -- labelKeys has to be !>64

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngine.java
@@ -148,11 +148,11 @@ public class ExtractFeaturesEngine {
     private Map<String, String>  createQueryLabels(List<String> queryLabels, String projectID) {
         // a hardcoded label is added to the query to make tracking this workflow easier downstream
         Map<String, String> labelForQuery = new HashMap<String, String>();
-        labelForQuery.put("Variant Store", "Extract Features from "+ projectID);
+        labelForQuery.put("variant_store", "Extract Features from "+ projectID);
         // add additional key value pair labels
         // TODO pull this out and add an exception (BQ label exceptions?)
         for (String labelMapString: queryLabels) {
-            String[] labelStrings = labelMapString.split("=");
+            String[] labelStrings = labelMapString.split(":");
             labelForQuery.put(labelStrings[0], labelStrings[1]);
         }
         return labelForQuery;

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngineTest.java
@@ -1,0 +1,66 @@
+package org.broadinstitute.hellbender.tools.gvs.filtering;
+
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ExtractFeaturesEngineTest extends GATKBaseTest {
+
+    @Test
+    public void testExtractFeaturesEngineQueryLabelCorrect() {
+        List<String> labelStringList = new ArrayList<String>();
+        labelStringList.add("labelkey=labelvalue");
+        Map<String, String> labelMap = ExtractFeaturesEngine.createQueryLabels(labelStringList);
+        Assert.assertEquals(labelMap.get("gvs_tool_name"), "extract-features");
+        Assert.assertEquals(labelMap.get("gvs_query_name"), "extract-features");
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelTooMany() {
+        List<String> labelStringList = new ArrayList<>();
+        for(int i=0; i<63; i++) { // up to 64 are allowed, and 2 are static, so only 62 additional can be passed in
+            labelStringList.add("labelkey"+i+"=labelvalue"+i);
+        }
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelKeyTooLong() {
+        List<String> labelStringList = new ArrayList<>();
+        labelStringList.add("labelkey_that_is_quite_long_and_needs_to_be_shortened_in_order_to_be_acceptable_to_BQ=labelvalue");
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelValueTooLong() {
+        List<String> labelStringList = new ArrayList<>();
+        labelStringList.add("labelkey=labelvalue_that_is_quite_long_and_needs_to_be_shortened_in_order_to_be_acceptable_to_BQ");
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelSpaces() {
+        List<String> labelStringList = new ArrayList<>();
+        labelStringList.add("label key=label value");
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelCaps() {
+        List<String> labelStringList = new ArrayList<>();
+        labelStringList.add("labelKey=labelValue");
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+
+    @Test(expectedExceptions = { UserException.class })
+    public void testExtractFeaturesEngineQueryLabelBadDelimiter() {
+        List<String> labelStringList = new ArrayList<>();
+        labelStringList.add("labelkey:labelvalue");
+        ExtractFeaturesEngine.createQueryLabels(labelStringList);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/filtering/ExtractFeaturesEngineTest.java
@@ -18,6 +18,7 @@ public class ExtractFeaturesEngineTest extends GATKBaseTest {
         Map<String, String> labelMap = ExtractFeaturesEngine.createQueryLabels(labelStringList);
         Assert.assertEquals(labelMap.get("gvs_tool_name"), "extract-features");
         Assert.assertEquals(labelMap.get("gvs_query_name"), "extract-features");
+        Assert.assertEquals(labelMap.get("labelkey"), "labelvalue");
     }
 
     @Test(expectedExceptions = { UserException.class })


### PR DESCRIPTION
For GVS Feature Extract, ~Cohort Extract~ and Prepare Callset we should add a bq labels to indicate the query and tool being

gvs_tool_name (e.g. feature-extract)
gvs_query_name (e.g. read-sample-table)

Python Prepare Callset:

<img width="334" alt="Screen Shot 2021-05-19 at 9 31 04 AM" src="https://user-images.githubusercontent.com/6863459/118821262-1193eb80-b885-11eb-8456-71225b40192b.png">

Java GVS Feature Extract:
<img width="346" alt="Screen Shot 2021-05-19 at 9 31 25 AM" src="https://user-images.githubusercontent.com/6863459/118821247-0e006480-b885-11eb-9d95-99441c6dbebd.png">

for Feature Extract
update the wdl to take in a query_labels optional string
update the GATK tool to take in a query_labels param
update the GATK tool to validate labels
update the GATK tool to add constant kv labels: "gvs_tool_name", "extract-features" and "gvs_query_name", "extract-features" (is there a way to get more explicit in the queries? isn't it just one query?)
test that this works with and without a label param passed in

for Prepare Callset
update the wdl to take in a query_labels optional string
update the python script to take in a query_labels param
update the python scrip to validate passed in labels
update the python script  to add constant kv labels for ever single query individually and as a default
test that this works with and without a label param passed in


<img width="717" alt="Screen Shot 2021-05-05 at 2 40 30 PM" src="https://user-images.githubusercontent.com/6863459/117192554-dd61fa80-adaf-11eb-8996-be1dc266dcc2.png">




