### PR TITLE
Allow VariantEvalArgCollection to supply PedigreeValidationType

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalArgumentCollection.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.DbsnpArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.utils.samples.PedigreeValidationType;
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
 
 import java.io.File;
@@ -64,6 +65,9 @@ public class VariantEvalArgumentCollection {
 
     @Argument(fullName = StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME, shortName = StandardArgumentDefinitions.PEDIGREE_FILE_SHORT_NAME, doc="Pedigree file for determining the population \"founders\"", optional=true)
     public GATKPath pedigreeFile;
+
+    @Argument(fullName = "pedigreeValidationType", shortName = "pedValidationType", doc="The strictness for validating the pedigree.  Can be either STRICT or SILENT.  Default is STRICT", optional=true)
+    public PedigreeValidationType pedigreeValidationType = PedigreeValidationType.STRICT;
 
     /**
      * List of feature tracks to be used for specifying "known" variants other than dbSNP.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEvalEngine.java
@@ -157,7 +157,7 @@ public class VariantEvalEngine {
      * Initialize the stratifications, evaluations, evaluation contexts, and reporting object
      */
     protected void validateAndInitialize(@Nullable Collection<String> samples) {
-        sampleDB = SampleDB.createSampleDBFromPedigreeAndDataSources(variantEvalArgs.pedigreeFile, samples, PedigreeValidationType.STRICT);
+        sampleDB = SampleDB.createSampleDBFromPedigreeAndDataSources(variantEvalArgs.pedigreeFile, samples, variantEvalArgs.pedigreeValidationType);
 
         variantEvalArgs.comps.addAll(variantEvalArgs.compsProvided);
         variantEvalArgs.compsProvided.forEach(comp -> inputToNameMap.put(comp, comp.hasUserSuppliedName() ? comp.getName() : StandardArgumentDefinitions.COMPARISON_SHORT_NAME));

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval/expected/testPedigreeValidation.expected.txt
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/varianteval/VariantEval/expected/testPedigreeValidation.expected.txt
@@ -1,0 +1,6 @@
+#:GATKReport.v1.1:1
+#:GATKTable:31:1:%s:%s:%s:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:;
+#:GATKTable:MendelianViolationEvaluator:Mendelian Violation Evaluator
+MendelianViolationEvaluator  CompFeatureInput  EvalFeatureInput  nVariants  nSkipped  nFamCalled  nVarFamCalled  nLowQual  nNoCall  nLociViolations  nViolations  mvRefRef_Var  mvRefRef_Het  mvRefHet_Var  mvRefVar_Var  mvRefVar_Ref  mvVarHet_Ref  mvVarVar_Ref  mvVarVar_Het  HomRefHomRef_HomRef  HetHet_Het  HetHet_HomRef  HetHet_HomVar  HomVarHomVar_HomVar  HomRefHomVAR_Het  HetHet_inheritedRef  HetHet_inheritedVar  HomRefHet_inheritedRef  HomRefHet_inheritedVar  HomVarHet_inheritedRef  HomVarHet_inheritedVar
+MendelianViolationEvaluator  none              eval                     12         0          12             12         0        0               12           12             1             1             2             2             2             2             1             1                    0           0              0              0                    0                 0                    0                    0                       0                       0                       0                       0
+


### PR DESCRIPTION
Rationale: certain evaluators use a pedigree. This PR is a minor change that lets VariantEvalArgCollection supply the PedigreeValidationType. It defaults to the current behavior, which is to always use STRICT. It includes an integration test to cover this feature. 