### PR TITLE
Support for FORMAT/FT VQSLod Filtering and cohort-wide LowQual filter

### DIFF
--- a/scripts/variantstore/tieout/add_max_as_vqslod.py
+++ b/scripts/variantstore/tieout/add_max_as_vqslod.py
@@ -46,6 +46,15 @@ with gzip.open(sys.argv[1], 'rt') as file1:
         
         if gt == "0/0" or gt == "./.":
             continue;
+            
+        if 'FT' in sample_data:
+            ft = sample_data['FT']
+
+            if ft != "PASS" or ft != ".":
+                if (parts[6] == "PASS" or parts[6] == "."):
+                    parts[6] = ft
+                else:
+                    parts[6] = parts[6] + "," + ft
         
         if "AS_VQSLOD" not in d:
             sys.exit(f"Cannot find AS_VQSLOD in {line}")

--- a/scripts/variantstore/tieout/add_max_as_vqslod.py
+++ b/scripts/variantstore/tieout/add_max_as_vqslod.py
@@ -19,23 +19,10 @@ with gzip.open(sys.argv[1], 'rt') as file1:
 
         parts = line.split("\t")
         
-        if ("ExcessHet" in parts[6]):
+        # strip out hard filtered sites, so vcfeval can use "all-records" to plot the ROC curves
+        if ("ExcessHet" in parts[6] or "LowQual" in parts[6] or "NO_HQ_GENOTYPES" in parts[6]):
             continue
 
-        # if the "loose" argument is specified, we remove the non Excess Het site-specific filers
-        # of EXCESS_ALLELES and NO_HQ_GENOTYPES.  This is used to measure the effect of these filters
-        # when comparing to WARP (which doesn't employ these filters).
-        if (len(sys.argv) > 2 and sys.argv[2] == "loose"):
-            # undo 
-            x = parts[6].replace("EXCESS_ALLELES","").replace("NO_HQ_GENOTYPES","").strip(";")
-            if x == "":
-                parts[6] = "PASS"
-            else:
-                parts[6] = x
-        else:
-            if ("EXCESS_ALLELES" in parts[6] or "NO_HQ_GENOTYPES" in parts[6]):
-                continue;
-            
         info = parts[7]    
         d = dict([ tuple(x.split("=")) for x in info.split(";") if "=" in x]) 
 

--- a/scripts/variantstore/tieout/add_max_as_vqslod.py
+++ b/scripts/variantstore/tieout/add_max_as_vqslod.py
@@ -30,10 +30,11 @@ with gzip.open(sys.argv[1], 'rt') as file1:
         sample_data = dict(zip(format_key, parts[9].split(":")))
 
         gt = sample_data['GT']
-        
+
         if gt == "0/0" or gt == "./.":
             continue;
-            
+
+        # if there is an FT tag on the genotype, move it to the FILTER field (since this is single sample)
         if 'FT' in sample_data:
             ft = sample_data['FT']
 

--- a/scripts/variantstore/tieout/add_max_as_vqslod.py
+++ b/scripts/variantstore/tieout/add_max_as_vqslod.py
@@ -30,17 +30,20 @@ with gzip.open(sys.argv[1], 'rt') as file1:
         sample_data = dict(zip(format_key, parts[9].split(":")))
 
         gt = sample_data['GT']
-
+        
         if gt == "0/0" or gt == "./.":
             continue;
-
-        # if there is an FT tag on the genotype, move it to the FILTER field (since this is single sample)
+            
         if 'FT' in sample_data:
             ft = sample_data['FT']
 
-            if ft != "PASS" or ft != ".":
+            # if there is a non-passing FT value
+            if not (ft == "PASS" or ft == "."):
+                
+                # overwrite FILTER if it was PASS or "."
                 if (parts[6] == "PASS" or parts[6] == "."):
                     parts[6] = ft
+                # otherwise append it to the end
                 else:
                     parts[6] = parts[6] + "," + ft
         

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/SchemaUtils.java
@@ -97,7 +97,7 @@ public class SchemaUtils {
     public static final List<String> VET_FIELDS = Arrays.asList(SAMPLE_ID_FIELD_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, AS_RAW_MQ,
             AS_RAW_MQRankSum, QUALapprox, AS_QUALapprox, AS_RAW_ReadPosRankSum, AS_SB_TABLE, AS_VarDP, CALL_GT, CALL_AD, CALL_GQ, CALL_PGT, CALL_PID, CALL_PL);
     public static final List<String> ALT_ALLELE_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_ID_FIELD_NAME, REF_ALLELE_FIELD_NAME, "allele", ALT_ALLELE_FIELD_NAME, "allele_pos", CALL_GT, AS_RAW_MQ, RAW_MQ, AS_RAW_MQRankSum, "raw_mqranksum_x_10", AS_QUALapprox, "qual", AS_RAW_ReadPosRankSum, "raw_readposranksum_x_10", AS_SB_TABLE, "SB_REF_PLUS","SB_REF_MINUS","SB_ALT_PLUS","SB_ALT_MINUS", CALL_AD, "ref_ad", "ad");
-    public static final List<String> FEATURE_EXTRACT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, "allele", RAW_QUAL, "ref_ad", AS_MQRankSum, "AS_MQRankSum_ft", AS_ReadPosRankSum, "AS_ReadPosRankSum_ft", RAW_MQ, RAW_AD, "RAW_AD_GT_1", "SB_REF_PLUS","SB_REF_MINUS","SB_ALT_PLUS","SB_ALT_MINUS","num_het_samples","num_homvar_samples","distinct_alleles","hq_genotype_samples");
+    public static final List<String> FEATURE_EXTRACT_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, "allele", RAW_QUAL, "ref_ad", AS_MQRankSum, "AS_MQRankSum_ft", AS_ReadPosRankSum, "AS_ReadPosRankSum_ft", RAW_MQ, RAW_AD, "RAW_AD_GT_1", "SB_REF_PLUS","SB_REF_MINUS","SB_ALT_PLUS","SB_ALT_MINUS","num_het_samples","num_homvar_samples","distinct_alleles","hq_genotype_samples", "sum_qualapprox", "num_snp_alleles");
 
 
     public static final long chromAdjustment = 1000000000000L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
@@ -19,7 +19,6 @@ import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 
 import java.util.*;
 
-import static org.broadinstitute.hellbender.utils.variant.GATKVCFConstants.ALLELE_FRACTION_KEY;
 
 
 @CommandLineProgramProperties(
@@ -153,7 +152,6 @@ public class ExtractCohort extends ExtractTool {
 
         extraHeaderLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
 
-        // TODO: this is part of the VCF Spec... but I don't see it anywhere in the GATK
         if (performGenotypeVQSLODFiltering) {
             extraHeaderLines.add(new VCFFormatHeaderLine("FT", 1, VCFHeaderLineType.String, "Genotype Filter Field"));
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.hellbender.tools.variantdb.nextgen;
 
-import htsjdk.variant.vcf.*;
+import htsjdk.variant.vcf.VCFFormatHeaderLine;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLineType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.Advanced;
@@ -8,7 +11,6 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.variantdb.CommonCode;
 import org.broadinstitute.hellbender.tools.variantdb.SampleList;

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort.java
@@ -151,8 +151,12 @@ public class ExtractCohort extends ExtractTool {
             }
         }
 
+        extraHeaderLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
+
         // TODO: this is part of the VCF Spec... but I don't see it anywhere in the GATK
-        extraHeaderLines.add(new VCFFormatHeaderLine("FT", 1, VCFHeaderLineType.String, "Genotype Filter Field"));
+        if (performGenotypeVQSLODFiltering) {
+            extraHeaderLines.add(new VCFFormatHeaderLine("FT", 1, VCFHeaderLineType.String, "Genotype Filter Field"));
+        }
 
         SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
         Set<String> sampleNames = new HashSet<>(sampleList.getSampleNames());

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
@@ -551,7 +551,7 @@ public class ExtractCohortEngine {
                 List<Allele> allAlleles = new ArrayList<>();
                 allAlleles.add(entry.getKey());
                 allAlleles.addAll(entry.getValue().keySet());
-                VariantContextBuilder vcb = new VariantContextBuilder("dummy", contig, start, start+refLength-1, allAlleles);
+                VariantContextBuilder vcb = new VariantContextBuilder("unused", contig, start, start+refLength-1, allAlleles);
                 VariantContext newvc = vcb.make();
 
                 //If the length of the reference from the filtering table is longer than the reference in the variantContext, then that allele is not present in the extracted samples and we don't need the data
@@ -623,13 +623,6 @@ public class ExtractCohortEngine {
 
                 final LinkedHashMap<Allele, Double> remappedVqsLodMap = remapAllelesInMap(ref, nonRefAlleles, contig, (int) startPosition, vqsLodMap, Double.NaN);
                 final LinkedHashMap<Allele, String> remappedYngMap = remapAllelesInMap(ref, nonRefAlleles, contig, (int) startPosition, yngMap, VCFConstants.EMPTY_INFO_FIELD);
-
-//                final LinkedHashMap<Allele, Double> relevantVqsLodMap = new LinkedHashMap<>();
-//                nonRefAlleles.forEach(key -> Optional.ofNullable(remappedVqsLodMap.get(key)).ifPresent(value -> relevantVqsLodMap.put(key, value)));
-//                final LinkedHashMap<Allele, String> relevantYngMap = new LinkedHashMap<>();
-//                nonRefAlleles.forEach(key -> Optional.ofNullable(remappedYngMap.get(key)).ifPresent(value -> relevantYngMap.put(key, value)));
-
-
 
                 // see https://github.com/broadinstitute/dsp-spec-ops/issues/291 for rationale
                 // take "worst" outcome for yng/vqslod, evaluate each allele separately

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortEngine.java
@@ -638,19 +638,19 @@ public class ExtractCohortEngine {
                 } else if (anyYays) {
                     // the genotype is passed, nothing to do here as non-filtered is the default
                 } else {
-                    // get the minimum (worst) vqslod for all SNP non-Yay sites, and apply the filter
-                    Optional<Double> snpMin =
+                    // get the max (best) vqslod for all SNP non-Yay sites, and apply the filter
+                    Optional<Double> snpMax =
                             nonRefAlleles.stream().filter(a -> a.length() == ref.length()).map(a -> remappedVqsLodMap.get(a)).filter(Objects::nonNull).max(Double::compareTo);
 
-                    if (snpMin.isPresent() && snpMin.get() < vqsLodSNPThreshold) {
+                    if (snpMax.isPresent() && snpMax.get() < vqsLodSNPThreshold) {
                         genotypeBuilder.filter(GATKVCFConstants.VQSR_FAILURE_SNP);
                     }
 
-                    // get the minimum (worst) vqslod for all INDEL non-Yay sites
-                    Optional<Double> indelMin =
+                    // get the max (best) vqslod for all INDEL non-Yay sites
+                    Optional<Double> indelMax =
                             nonRefAlleles.stream().filter(a -> a.length() != ref.length()).map(a -> remappedVqsLodMap.get(a)).filter(Objects::nonNull).max(Double::compareTo);
 
-                    if (indelMin.isPresent() && indelMin.get() < vqsLodINDELThreshold) {
+                    if (indelMax.isPresent() && indelMax.get() < vqsLodINDELThreshold) {
                         genotypeBuilder.filter(GATKVCFConstants.VQSR_FAILURE_INDEL);
                     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeatures.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.tools.variantdb.SchemaUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.bigquery.TableReference;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFHeaderLines;
 
 import java.util.HashSet;
 import java.util.List;
@@ -86,12 +87,14 @@ public class ExtractFeatures extends ExtractTool {
         TableReference sampleTableRef = new TableReference(sampleTableName, SchemaUtils.SAMPLE_FIELDS);
         SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
 
-        Set<VCFHeaderLine> excessAllelesHeaderLines = new HashSet<>();
-        excessAllelesHeaderLines.add(
+        Set<VCFHeaderLine> extraHeaders = new HashSet<>();
+        extraHeaders.add(
             FilterSensitivityTools.getExcessAllelesHeader(excessAllelesThreshold, GATKVCFConstants.EXCESS_ALLELES));
 
+        extraHeaders.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
+
         VCFHeader header = CommonCode.generateVcfHeader(
-            new HashSet<>(), reference.getSequenceDictionary(), excessAllelesHeaderLines);
+            new HashSet<>(), reference.getSequenceDictionary(), extraHeaders);
 
         final List<SimpleInterval> traversalIntervals = getTraversalIntervals();
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeatures.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeatures.java
@@ -87,14 +87,14 @@ public class ExtractFeatures extends ExtractTool {
         TableReference sampleTableRef = new TableReference(sampleTableName, SchemaUtils.SAMPLE_FIELDS);
         SampleList sampleList = new SampleList(sampleTableName, sampleFileName, projectID, printDebugInformation);
 
-        Set<VCFHeaderLine> extraHeaders = new HashSet<>();
-        extraHeaders.add(
+        Set<VCFHeaderLine> extraHeaderLines = new HashSet<>();
+        extraHeaderLines.add(
             FilterSensitivityTools.getExcessAllelesHeader(excessAllelesThreshold, GATKVCFConstants.EXCESS_ALLELES));
 
-        extraHeaders.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
+        extraHeaderLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
 
         VCFHeader header = CommonCode.generateVcfHeader(
-            new HashSet<>(), reference.getSequenceDictionary(), extraHeaders);
+            new HashSet<>(), reference.getSequenceDictionary(), extraHeaderLines);
 
         final List<SimpleInterval> traversalIntervals = getTraversalIntervals();
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesBQ.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesBQ.java
@@ -19,8 +19,7 @@ public class ExtractFeaturesBQ {
 
     public static String getVQSRFeatureExtractQueryString(final TableReference altAllele, final TableReference sampleList,
                                                           final Long minLocation, final Long maxLocation, final boolean trainingSitesOnly,
-                                                          final int hqGenotypeGQThreshold, final int hqGenotypeDepthThreshold, final double hqGenotypeABThreshold,
-                                                          final double snpQualThreshold, final double indelQualThreshold) {
+                                                          final int hqGenotypeGQThreshold, final int hqGenotypeDepthThreshold, final double hqGenotypeABThreshold) {
 
         String trainingSitesStanza =
             !trainingSitesOnly?"":
@@ -39,8 +38,6 @@ public class ExtractFeaturesBQ {
                 .replaceAll("@trainingSitesStanza", trainingSitesStanza)
                 .replaceAll("@sample", sampleList.getFQTableName())
                 .replaceAll("@altAllele", altAllele.getFQTableName())
-                .replaceAll("@snpQualThreshold", Double.toString(snpQualThreshold))
-                .replaceAll("@indelQualThreshold", Double.toString(indelQualThreshold))
                 .replaceAll("@hqGenotypeGQThreshold", Double.toString(hqGenotypeGQThreshold))
                 .replaceAll("@hqGenotypeDepthThreshold", Double.toString(hqGenotypeDepthThreshold))
                 .replaceAll("@hqGenotypeABThreshold", Double.toString(hqGenotypeABThreshold));

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesEngine.java
@@ -263,7 +263,7 @@ public class ExtractFeaturesEngine {
             builder.filter(GATKVCFConstants.NO_HQ_GENOTYPES);
         }
 
-        boolean isSNP = ref.length() == allele.length();
+        boolean isSNP = rec.getNumSnpAlleles() > 0;
         if (qualapprox < (isSNP ? SNP_QUAL_THRESHOLD : INDEL_QUAL_THRESHOLD)) {
             builder.filter(GATKVCFConstants.LOW_QUAL_FILTER_NAME);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesEngine.java
@@ -126,9 +126,7 @@ public class ExtractFeaturesEngine {
                                                                                              trainingSitesOnly,
                                                                                              hqGenotypeGQThreshold,
                                                                                              hqGenotypeDepthThreshold,
-                                                                                             hqGenotypeABThreshold,
-                                                                                             SNP_QUAL_THRESHOLD,
-                                                                                             INDEL_QUAL_THRESHOLD);
+                                                                                             hqGenotypeABThreshold);
 
         final String userDefinedFunctions = ExtractFeaturesBQ.getVQSRFeatureExtractUserDefinedFunctionsString();
 
@@ -231,12 +229,15 @@ public class ExtractFeaturesEngine {
 
         double mq = Math.sqrt( raw_mq / raw_ad);
 
+        double qualapprox = rec.getQualApprox();
+
         builder.attribute(GATKVCFConstants.AS_QUAL_BY_DEPTH_KEY, String.format("%.2f", as_qd) );
         builder.attribute(GATKVCFConstants.AS_FISHER_STRAND_KEY, String.format("%.3f", fs));
         builder.attribute(GATKVCFConstants.AS_RMS_MAPPING_QUALITY_KEY, String.format("%.2f", mq) );
         builder.attribute(GATKVCFConstants.AS_MAP_QUAL_RANK_SUM_KEY, AS_MQRankSum==null?".":String.format("%.3f", AS_MQRankSum) );
         builder.attribute(GATKVCFConstants.AS_READ_POS_RANK_SUM_KEY, AS_ReadPosRankSum==null?".":String.format("%.3f", AS_ReadPosRankSum));
         builder.attribute(GATKVCFConstants.AS_STRAND_ODDS_RATIO_KEY, String.format("%.3f", sor));
+        builder.attribute(GATKVCFConstants.RAW_QUAL_APPROX_KEY, String.format("%.3f", qualapprox));
 
 //        From the warp JointGenotyping pipeline
 //        # ExcessHet is a phred-scaled p-value. We want a cutoff of anything more extreme
@@ -260,6 +261,11 @@ public class ExtractFeaturesEngine {
 
         if (rec.getHqGenotypeSamples() < 1) {
             builder.filter(GATKVCFConstants.NO_HQ_GENOTYPES);
+        }
+
+        boolean isSNP = ref.length() == allele.length();
+        if (qualapprox < (isSNP ? SNP_QUAL_THRESHOLD : INDEL_QUAL_THRESHOLD)) {
+            builder.filter(GATKVCFConstants.LOW_QUAL_FILTER_NAME);
         }
 
         VariantContext vc = builder.make();

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesRecord.java
@@ -31,6 +31,7 @@ public class ExtractFeaturesRecord implements Locatable {
     private final int numHomvarSamples;
     private final int distinctAlleles;
     private final int hqGenotypeSamples;
+    private final Double qualApprox;
 
     // FEATURE_EXTRACT_FIELDS = Arrays.asList(
     //      LOCATION_FIELD_NAME,
@@ -65,6 +66,8 @@ public class ExtractFeaturesRecord implements Locatable {
         this.rawMQ = Double.valueOf(genericRecord.get(SchemaUtils.RAW_MQ).toString());
         this.rawAD = Double.valueOf(genericRecord.get(SchemaUtils.RAW_AD).toString());
         this.rawADGT1 = Double.valueOf(genericRecord.get("RAW_AD_GT_1").toString());
+        this.qualApprox = Double.valueOf(genericRecord.get("sum_qualapprox").toString());
+
         this.sbRefPlus = Double.valueOf(genericRecord.get("SB_REF_PLUS").toString()).intValue();
         this.sbRefMinus = Double.valueOf(genericRecord.get("SB_REF_MINUS").toString()).intValue();
         this.sbAltPlus = Double.valueOf(genericRecord.get("SB_ALT_PLUS").toString()).intValue();
@@ -122,6 +125,8 @@ public class ExtractFeaturesRecord implements Locatable {
     public Double getRawAD() { return this.rawAD; }
 
     public Double getRawADGT1() { return this.rawADGT1; }
+
+    public Double getQualApprox() { return this.qualApprox; }
 
     public int getSbRefPlus() { return this.sbRefPlus; }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractFeaturesRecord.java
@@ -30,30 +30,11 @@ public class ExtractFeaturesRecord implements Locatable {
     private final int numHetSamples;
     private final int numHomvarSamples;
     private final int distinctAlleles;
+    private final int numSnpAlleles;
     private final int hqGenotypeSamples;
     private final Double qualApprox;
 
-    // FEATURE_EXTRACT_FIELDS = Arrays.asList(
-    //      LOCATION_FIELD_NAME,
-    //      REF_ALLELE_FIELD_NAME,
-    //      "allele",
-    //      RAW_QUAL,
-    //      "ref_ad",
-    //      AS_MQRankSum,
-    //      "AS_MQRankSum_ft",
-    //      AS_ReadPosRankSum,
-    //      "AS_ReadPosRankSum_ft",
-    //      RAW_MQ,
-    //      RAW_AD,
-    //      "RAW_AD_GT_1",
-    //      "SB_REF_PLUS",
-    //      "SB_REF_MINUS",
-    //      "SB_ALT_PLUS",
-    //      "SB_ALT_MINUS",
-    //      "num_het_samples",
-    //      "num_homvar_samples");
-
-
+    // See SchemaUtils.FEATURE_EXTRACT_FIELDS for list of fields
     public ExtractFeaturesRecord(GenericRecord genericRecord) {
         this.location = Long.parseLong(genericRecord.get(SchemaUtils.LOCATION_FIELD_NAME).toString());
         this.contig = SchemaUtils.decodeContig(location);
@@ -66,7 +47,6 @@ public class ExtractFeaturesRecord implements Locatable {
         this.rawMQ = Double.valueOf(genericRecord.get(SchemaUtils.RAW_MQ).toString());
         this.rawAD = Double.valueOf(genericRecord.get(SchemaUtils.RAW_AD).toString());
         this.rawADGT1 = Double.valueOf(genericRecord.get("RAW_AD_GT_1").toString());
-        this.qualApprox = Double.valueOf(genericRecord.get("sum_qualapprox").toString());
 
         this.sbRefPlus = Double.valueOf(genericRecord.get("SB_REF_PLUS").toString()).intValue();
         this.sbRefMinus = Double.valueOf(genericRecord.get("SB_REF_MINUS").toString()).intValue();
@@ -86,6 +66,14 @@ public class ExtractFeaturesRecord implements Locatable {
         Object asReadPosRankSumNullable = genericRecord.get(SchemaUtils.AS_ReadPosRankSum);
         this.asReadPosRankSum = ( asReadPosRankSumNullable == null ) ? null : Float.valueOf(Objects.toString(asReadPosRankSumNullable));
         this.asReadPosRankSumFreqTable = Objects.toString(genericRecord.get(SchemaUtils.AS_ReadPosRankSum + "_ft"));
+
+        // if qualApprox is not defined, set it to zero
+        Object qualApproxNullable = genericRecord.get("sum_qualapprox");
+        this.qualApprox = ( qualApproxNullable == null ) ? 0 : Double.valueOf(Objects.toString(qualApproxNullable));
+
+        // if num_snp_alleles is not defined, set it to zero
+        Object numSnpAllelesNullable = genericRecord.get("num_snp_alleles");
+        this.numSnpAlleles = ( numSnpAllelesNullable == null ) ? 0 : Integer.valueOf(Objects.toString(numSnpAllelesNullable));
 
         // if ref_ad is not defined, set it to zero
         Object refADNullable = genericRecord.get("ref_ad");
@@ -141,6 +129,8 @@ public class ExtractFeaturesRecord implements Locatable {
     public int getNumHomvarSamples() { return this.numHomvarSamples; }
 
     public int getDistinctAlleles() { return this.distinctAlleles; }
+
+    public int getNumSnpAlleles() { return this.numSnpAlleles; }
 
     public int getHqGenotypeSamples() { return this.hqGenotypeSamples; }
     

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/StorageAPIAvroReader.java
@@ -80,13 +80,14 @@ public class StorageAPIAvroReader implements GATKAvroReader {
                     .setFormat(Storage.DataFormat.AVRO);
 
             final Storage.ReadSession session = client.createReadSession(builder.build());
-
             if (session.getStreamsCount() > 0) {
 
                 this.schema = new org.apache.avro.Schema.Parser().parse(session.getAvroSchema().getSchema());
 
                 this.datumReader = new GenericDatumReader<>(
                         new org.apache.avro.Schema.Parser().parse(session.getAvroSchema().getSchema()));
+
+                logger.info("Storage API Session ID: " + session.getName());
 
                 // Use the first stream to perform reading.
                 Storage.StreamPosition readPosition = Storage.StreamPosition.newBuilder()

--- a/src/main/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/feature_extract.sql
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/feature_extract.sql
@@ -77,6 +77,7 @@ WITH
            SB_ALT_MINUS,
            aasi.num_het_samples,
            aasi.num_homvar_samples,
+           IFNULL(aasi.sum_qualapprox,0) as sum_qualapprox,
            IFNULL(aasai.distinct_alleles,0) distinct_alleles,
            IFNULL(hc_gt.hq_genotype_samples,0) hq_genotype_samples
     FROM (
@@ -109,5 +110,4 @@ WITH
     LEFT JOIN aa_site_info aasi ON (ai.location = aasi.location)
     LEFT JOIN aa_site_allele_info aasai ON (ai.location = aasai.location)
     LEFT JOIN hq_genotype_qc hc_gt ON (ai.location = hc_gt.location)
-    WHERE aasi.sum_qualapprox >= CASE WHEN LENGTH(ai.ref) = LENGTH(ai.allele) THEN @snpQualThreshold ELSE @indelQualThreshold END
 

--- a/src/main/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/feature_extract.sql
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/feature_extract.sql
@@ -41,7 +41,9 @@ WITH
         )
         GROUP BY location),
    aa_site_allele_info AS (
-        SELECT location, COUNT(DISTINCT ref || "," || allele) distinct_alleles
+        SELECT location,
+               COUNT(DISTINCT ref || "," || allele) distinct_alleles,
+               COUNTIF(length(ref) = length(allele)) num_snp_alleles
         FROM `@altAllele`
         WHERE sample_id IN (SELECT sample_id FROM `@sample`)
         @locationStanza
@@ -79,6 +81,7 @@ WITH
            aasi.num_homvar_samples,
            IFNULL(aasi.sum_qualapprox,0) as sum_qualapprox,
            IFNULL(aasai.distinct_alleles,0) distinct_alleles,
+           IFNULL(aasai.num_snp_alleles,0) num_snp_alleles,
            IFNULL(hc_gt.hq_genotype_samples,0) hq_genotype_samples
     FROM (
     SELECT aa.location,

--- a/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -40,7 +40,9 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 false,
-                true);
+                true,
+                false);
+
         List<VariantContext> variantContexts = VariantContextTestUtils.getVariantContexts(ORIGINAL_TEST_FILE); // list variantContexts from VCF file
         VariantContext expectedVC = engine.removeAnnotations(variantContexts.get(0)); // single variantContext -- with annotations removed
         Assert.assertFalse(expectedVC.hasAttribute(GATKVCFConstants.FISHER_STRAND_KEY), "removeAnnotations did not remove FS annotation.");

--- a/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohortTest.java
@@ -36,7 +36,8 @@ class ExtractCohortTest extends CommandLineProgramTest {
         .add("cohort-avro-file-name", cohortAvroFileName)
         .add("sample-file", sampleFile)
         .add("emit-pls", false)
-        .add("disable-gnarly", false);
+        .add("disable-gnarly", false)
+        .add("vqslod-filter-genotypes", false);
 
 
     runCommandLine(args);

--- a/src/test/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort/expected.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/variantdb/nextgen/ExtractCohort/expected.vcf
@@ -1,6 +1,7 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=EXCESS_ALLELES,Description="Site has an excess of alternate alleles based on the input threshold (default is 6)">
 ##FILTER=<ID=ExcessHet,Description="Site has excess het value larger than the threshold">
+##FILTER=<ID=LowQual,Description="Low quality">
 ##FILTER=<ID=NAY,Description="Considered a NAY in the Yay, Nay, Grey table">
 ##FILTER=<ID=NO_HQ_GENOTYPES,Description="Site has no high quality variant genotypes">
 ##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">


### PR DESCRIPTION
The overarching goal of this PR is to reduce or eliminate the effect of cohort size on the filtering of variants for a specific sample.  As an example this means the filtering for the genotypes for a GIAB sample should be the same whether you make a VCF of the full cohort and then subset to the GIAB sample (expensive) or you just make a callset with just the GIAB sample.  This is good for users since their results won't get "better" with more samples that they don't care about in their VCF.

- calculate and store LowQual filter as a part of Filter Set creation
- use LowQual filter from filter set rather than recalculating it from QUALapprox at extract time
- flag (default is true) to perform VQSLod filtering at the sample/genotype level

Before/After results showing minimal impact are at:
https://docs.google.com/spreadsheets/d/1LUrssKHBCwIzbA_9M3b01Ul0urMbOOmv4Z703dHwiyg/edit#gid=398306713