### PR TITLE
Adding median coverage metric to mitochondria pipeline

### DIFF
--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -263,7 +263,7 @@ workflow AlignAndCall {
     File theoretical_sensitivity_metrics = CollectWgsMetrics.theoretical_sensitivity
     File contamination_metrics = GetContamination.contamination_file
     Int mean_coverage = CollectWgsMetrics.mean_coverage
-    Int median_coverage = CollectWgsMetrics.median_coverage
+    Float median_coverage = CollectWgsMetrics.median_coverage
     String major_haplogroup = GetContamination.major_hg
     Float contamination = FilterContamination.contamination
   }
@@ -374,7 +374,7 @@ task CollectWgsMetrics {
     R --vanilla <<CODE
       df = read.table("metrics.txt",skip=6,header=TRUE,stringsAsFactors=FALSE,sep='\t',nrows=1)
       write.table(floor(df[,"MEAN_COVERAGE"]), "mean_coverage.txt", quote=F, col.names=F, row.names=F)
-      write.table(round(df[,"MEDIAN_COVERAGE"]), "median_coverage.txt", quote=F, col.names=F, row.names=F)
+      write.table(df[,"MEDIAN_COVERAGE"], "median_coverage.txt", quote=F, col.names=F, row.names=F)
     CODE
   >>>
   runtime {
@@ -387,7 +387,7 @@ task CollectWgsMetrics {
     File metrics = "metrics.txt"
     File theoretical_sensitivity = "theoretical_sensitivity.txt"
     Int mean_coverage = read_int("mean_coverage.txt")
-    Int median_coverage = read_int("median_coverage.txt")
+    Float median_coverage = read_float("median_coverage.txt")
   }
 }
 

--- a/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
+++ b/scripts/mitochondria_m2_wdl/AlignAndCall.wdl
@@ -263,6 +263,7 @@ workflow AlignAndCall {
     File theoretical_sensitivity_metrics = CollectWgsMetrics.theoretical_sensitivity
     File contamination_metrics = GetContamination.contamination_file
     Int mean_coverage = CollectWgsMetrics.mean_coverage
+    Int median_coverage = CollectWgsMetrics.median_coverage
     String major_haplogroup = GetContamination.major_hg
     Float contamination = FilterContamination.contamination
   }
@@ -373,6 +374,7 @@ task CollectWgsMetrics {
     R --vanilla <<CODE
       df = read.table("metrics.txt",skip=6,header=TRUE,stringsAsFactors=FALSE,sep='\t',nrows=1)
       write.table(floor(df[,"MEAN_COVERAGE"]), "mean_coverage.txt", quote=F, col.names=F, row.names=F)
+      write.table(round(df[,"MEDIAN_COVERAGE"]), "median_coverage.txt", quote=F, col.names=F, row.names=F)
     CODE
   >>>
   runtime {
@@ -385,6 +387,7 @@ task CollectWgsMetrics {
     File metrics = "metrics.txt"
     File theoretical_sensitivity = "theoretical_sensitivity.txt"
     Int mean_coverage = read_int("mean_coverage.txt")
+    Int median_coverage = read_int("median_coverage.txt")
   }
 }
 

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -184,6 +184,7 @@ workflow MitochondriaPipeline {
     File contamination_metrics = AlignAndCall.contamination_metrics
     File base_level_coverage_metrics = CoverageAtEveryBase.table
     Int mean_coverage = AlignAndCall.mean_coverage
+    Int median_coverage = AlignAndCall.median_coverage
     String major_haplogroup = AlignAndCall.major_haplogroup
     Float contamination = AlignAndCall.contamination
   }

--- a/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
+++ b/scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
@@ -184,7 +184,7 @@ workflow MitochondriaPipeline {
     File contamination_metrics = AlignAndCall.contamination_metrics
     File base_level_coverage_metrics = CoverageAtEveryBase.table
     Int mean_coverage = AlignAndCall.mean_coverage
-    Int median_coverage = AlignAndCall.median_coverage
+    Float median_coverage = AlignAndCall.median_coverage
     String major_haplogroup = AlignAndCall.major_haplogroup
     Float contamination = AlignAndCall.contamination
   }


### PR DESCRIPTION
This now outputs median coverage in addition to the mean coverage which was already being output before from the Mitochondria pipeline.

@ahaessly Could you please take a look at this?