### PR TITLE
Removed mapping error rate from estimate of denoised copy ratios output by gCNV and updated sklearn.

### DIFF
--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -38,7 +38,7 @@ dependencies:
                                     #   if you wish to update, note that versions of conda-forge::keras after 2.2.5
                                     #   undesirably set the environment variable KERAS_BACKEND = theano by default
 - defaults::intel-openmp=2019.4
-- conda-forge::scikit-learn=0.22.2
+- conda-forge::scikit-learn=0.23.1
 - conda-forge::matplotlib=3.2.1
 - conda-forge::pandas=1.0.3
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
@@ -786,8 +786,7 @@ class DenoisingModel(GeneralizedContinuousModel):
         # the expected number of erroneously mapped reads
         mean_mapping_error_correction_s = eps_mapping * read_depth_s * shared_workspace.average_ploidy_s
 
-        denoised_copy_ratio_st = ((shared_workspace.n_st - mean_mapping_error_correction_s.dimshuffle(0, 'x'))
-                                  / ((1.0 - eps_mapping) * read_depth_s.dimshuffle(0, 'x') * bias_st))
+        denoised_copy_ratio_st = shared_workspace.n_st / (read_depth_s.dimshuffle(0, 'x') * bias_st)
 
         Deterministic(name='denoised_copy_ratio_st', var=denoised_copy_ratio_st)
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/python/PythonEnvironmentIntegrationTest.java
@@ -25,7 +25,7 @@ public class PythonEnvironmentIntegrationTest {
                 { "pymc3",          "3.1" },
                 { "keras",          "2.2.4" },
                 { "h5py",           "2.10.0" },
-                { "sklearn",        "0.22.2.post1" },
+                { "sklearn",        "0.23.1" },
                 { "matplotlib",     "3.2.1" },
                 { "pandas",         "1.0.3" },
                 { "argparse",       null },


### PR DESCRIPTION
@fleharty this is a rebased version of the 17cadfa399643877c70ba830d0b4abf9e5b159a9 branch used to generate the Pf7 CNV call set. There are two minor changes: a) one to remove spurious negative dCR estimates reported by gCNV, which were negatively affecting genotyping of HRP2/3 deletions, and b) updating sklearn to the version used for clustering, so that we can reproduce everything exactly using just the GATK Docker. The latter change probably isn't absolutely necessary, but it doesn't seem to break anything so I'm going to go ahead with it. We might want to update to an even more recent version later on (especially if we make any breaking/non-refactoring improvements to the malaria genotyping code after the initial PR), but unfortunately this slightly changes the clustering assignment for a few samples.

@mwalker174 @asmirnov239 we discussed the first change some time ago, but just a heads up.