### PR TITLE
Update Broken Links in Tool Docs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/Funcotator.java
@@ -699,7 +699,7 @@ import java.util.*;
  *
  * <h3>Notes</h3>
  * <ul>
- *     <li>This tool is the spiritual successor to <a href="http://portals.broadinstitute.org/oncotator/">Oncotator</a>, with better support for germline data, numerous fixes for correctness, and many other features.</li>
+ *     <li>This tool is the spiritual successor to <a href="https://github.com/broadinstitute/oncotator">Oncotator</a>, with better support for germline data, numerous fixes for correctness, and many other features.</li>
  *     <li>REMEMBER: <strong>Funcotator is NOT Oncotator.</strong></li>
  * </ul>
  *

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/ASEReadCounter.java
@@ -66,7 +66,7 @@ import java.util.List;
  * <ul>
  * <li>This tool will only process biallelic het SNP sites. If your callset contains multiallelic sites, they will be ignored.
  * Optionally, you can subset your callset to just biallelic variants using e.g.
- * <a href="org_broadinstitute_gatk_tools_walkers_variantutils_SelectVariants.php">SelectVariants</a>
+ * SelectVariants
  * with the option "-restrictAllelesTo BIALLELIC".</li>
  * </ul>
  * <p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/VariantRecalibrator.java
@@ -66,9 +66,8 @@ import java.util.*;
  * assigned a score and filter status.</p>
  *
  * <p>VQSR is probably the hardest part of the Best Practices to get right, so be sure to read the
- * <a href='https://software.broadinstitute.org/gatk/guide/article?id=39'>method documentation</a>,
- * <a href='https://software.broadinstitute.org/gatk/guide/article?id=1259'>parameter recommendations</a> and
- * <a href='https://software.broadinstitute.org/gatk/guide/article?id=2805'>tutorial</a> to really understand what these
+ * <a href='https://gatk.broadinstitute.org/hc/en-us/articles/360035531612-Variant-Quality-Score-Recalibration-VQSR-'>method documentation</a> and
+ * <a href='https://gatk.broadinstitute.org/hc/en-us/articles/360035531112--How-to-Filter-variants-either-with-VQSR-or-by-hard-filtering'>tutorial</a> to really understand what these
  * tools do and how to use them for best results on your own data.</p>
  *
  * <h3>Inputs</h3>


### PR DESCRIPTION
We found some links that needed to be fixed in the Funcotator, ASEReadCounter, and VariantRecalibrator tool docs. We updated them or removed the links as needed.