### PR TITLE
313 Cleanup Extract Cohort params

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -119,7 +119,7 @@ task ExtractTask {
         String fq_filter_set_site_table
         String fq_filter_set_tranches_table
         String? filter_set_name
-        String? filter_type
+        Boolean? vqslod_filter_by_site
         Float? snps_truth_sensitivity_filter_level
         Float? indels_truth_sensitivity_filter_level
 

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -17,6 +17,7 @@ workflow GvsExtractCallset {
 
         Boolean do_not_filter_override = false
         String? filter_set_name
+        String? filter-type
         String fq_filter_set_info_table = "~{data_project}.~{default_dataset}.filter_set_info"
         String fq_filter_set_site_table = "~{data_project}.~{default_dataset}.filter_set_sites"
         String fq_filter_set_tranches_table = "~{data_project}.~{default_dataset}.filter_set_tranches"
@@ -77,6 +78,7 @@ workflow GvsExtractCallset {
                 fq_filter_set_site_table = fq_filter_set_site_table,
                 fq_filter_set_tranches_table = fq_filter_set_tranches_table,
                 filter_set_name          = filter_set_name,
+                filter-type              = filter-type,
                 snps_truth_sensitivity_filter_level = snps_truth_sensitivity_filter_level_override,
                 indels_truth_sensitivity_filter_level = indels_truth_sensitivity_filter_level_override,
                 excluded_intervals       = excluded_intervals,
@@ -112,11 +114,12 @@ task ExtractTask {
         String output_file
         String? output_gcs_dir
 
-        Boolean do_not_filter_override
+        Boolean do_not_filter_override # do we want to keep this in? seems like a breaking change and this might be a nice to have?
         String fq_filter_set_info_table
         String fq_filter_set_site_table
         String fq_filter_set_tranches_table
         String? filter_set_name
+        String? filter_type
         Float? snps_truth_sensitivity_filter_level
         Float? indels_truth_sensitivity_filter_level
 
@@ -151,12 +154,13 @@ task ExtractTask {
         df -h
 
         if [ ~{do_not_filter_override} = 'true' ]; then
-            FILTERING_ARGS='--vqslod-filter-genotypes false'
+            FILTERING_ARGS=''
         else
             FILTERING_ARGS='--filter-set-info-table ~{fq_filter_set_info_table}
                 --filter-set-site-table ~{fq_filter_set_site_table}
                 --tranches-table ~{fq_filter_set_tranches_table}
                 --filter-set-name ~{filter_set_name}
+                --filter-type ~{filter-type}
                 ~{"--snps-truth-sensitivity-filter-level " + snps_truth_sensitivity_filter_level}
                 ~{"--indels-truth-sensitivity-filter-level " + indels_truth_sensitivity_filter_level}'
         fi

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -17,7 +17,7 @@ workflow GvsExtractCallset {
 
         Boolean do_not_filter_override = false
         String? filter_set_name
-        String? filter-type
+        String? filter_type
         String fq_filter_set_info_table = "~{data_project}.~{default_dataset}.filter_set_info"
         String fq_filter_set_site_table = "~{data_project}.~{default_dataset}.filter_set_sites"
         String fq_filter_set_tranches_table = "~{data_project}.~{default_dataset}.filter_set_tranches"
@@ -78,7 +78,7 @@ workflow GvsExtractCallset {
                 fq_filter_set_site_table = fq_filter_set_site_table,
                 fq_filter_set_tranches_table = fq_filter_set_tranches_table,
                 filter_set_name          = filter_set_name,
-                filter-type              = filter-type,
+                filter_type              = filter_type,
                 snps_truth_sensitivity_filter_level = snps_truth_sensitivity_filter_level_override,
                 indels_truth_sensitivity_filter_level = indels_truth_sensitivity_filter_level_override,
                 excluded_intervals       = excluded_intervals,
@@ -160,7 +160,7 @@ task ExtractTask {
                 --filter-set-site-table ~{fq_filter_set_site_table}
                 --tranches-table ~{fq_filter_set_tranches_table}
                 --filter-set-name ~{filter_set_name}
-                --filter-type ~{filter-type}
+                --filter-type ~{filter_type}
                 ~{"--snps-truth-sensitivity-filter-level " + snps_truth_sensitivity_filter_level}
                 ~{"--indels-truth-sensitivity-filter-level " + indels_truth_sensitivity_filter_level}'
         fi

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -17,7 +17,7 @@ workflow GvsExtractCallset {
 
         Boolean do_not_filter_override = false
         String? filter_set_name
-        String? filter_type
+        Boolean? vqslod_filter_by_site
         String fq_filter_set_info_table = "~{data_project}.~{default_dataset}.filter_set_info"
         String fq_filter_set_site_table = "~{data_project}.~{default_dataset}.filter_set_sites"
         String fq_filter_set_tranches_table = "~{data_project}.~{default_dataset}.filter_set_tranches"
@@ -78,7 +78,7 @@ workflow GvsExtractCallset {
                 fq_filter_set_site_table = fq_filter_set_site_table,
                 fq_filter_set_tranches_table = fq_filter_set_tranches_table,
                 filter_set_name          = filter_set_name,
-                filter_type              = filter_type,
+                vqslod_filter_by_site    = vqslod_filter_by_site,
                 snps_truth_sensitivity_filter_level = snps_truth_sensitivity_filter_level_override,
                 indels_truth_sensitivity_filter_level = indels_truth_sensitivity_filter_level_override,
                 excluded_intervals       = excluded_intervals,
@@ -114,7 +114,7 @@ task ExtractTask {
         String output_file
         String? output_gcs_dir
 
-        Boolean do_not_filter_override # do we want to keep this in? seems like a breaking change and this might be a nice to have?
+        Boolean do_not_filter_override
         String fq_filter_set_info_table
         String fq_filter_set_site_table
         String fq_filter_set_tranches_table
@@ -160,7 +160,7 @@ task ExtractTask {
                 --filter-set-site-table ~{fq_filter_set_site_table}
                 --tranches-table ~{fq_filter_set_tranches_table}
                 --filter-set-name ~{filter_set_name}
-                --filter-type ~{filter_type}
+                --vqslod-filter-by-site ~{vqslod_filter_by_site}
                 ~{"--snps-truth-sensitivity-filter-level " + snps_truth_sensitivity_filter_level}
                 ~{"--indels-truth-sensitivity-filter-level " + indels_truth_sensitivity_filter_level}'
         fi

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
@@ -62,18 +62,6 @@ public abstract class ExtractTool extends GATKTool {
     protected boolean printDebugInformation = false;
 
     @Argument(
-            fullName = "vqslog-SNP-threshold",
-            doc = "The minimum value required for a SNP to pass.",
-            optional = true)
-    protected double vqsLodSNPThreshold = 0;
-
-    @Argument(
-            fullName = "vqslog-INDEL-threshold",
-            doc = "The minimum value required for an INDEL to pass.",
-            optional = true)
-    protected double vqsLodINDELThreshold = 0;
-
-    @Argument(
             fullName = "local-sort-max-records-in-ram",
             doc = "When doing local sort, store at most this many records in memory at once",
             optional = true

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -35,20 +35,7 @@ public class ExtractCohort extends ExtractTool {
     private static final Logger logger = LogManager.getLogger(ExtractCohort.class);
     private ExtractCohortEngine engine;
 
-    public enum VQSLODFilteringType {
-      GENOTYPE("genotype"),
-      SITES("sites"),
-      NONE("");
-
-      String value;
-
-      VQSLODFilteringType(String value) {
-      this.value = value;
-    }
-      public String getValue() {
-      return value;
-      }
-    }
+    public enum VQSLODFilteringType { GENOTYPE, SITES, NONE }
 
     @Argument(
             fullName = "filter-set-info-table",
@@ -160,13 +147,8 @@ public class ExtractCohort extends ExtractTool {
 
         Set<VCFHeaderLine> extraHeaderLines = new HashSet<>();
 
-        if (filterSetInfoTableName != null) { // filter using vqslod-- default to GENOTYPE unless SITES specifically selected
-          if (performSiteSpecificVQSLODFiltering) {
-            vqslodfilteringType = VQSLODFilteringType.SITES;
-          } else {
-            vqslodfilteringType = VQSLODFilteringType.GENOTYPE;
-          }
-        }
+        // filter using vqslod-- default to GENOTYPE unless SITES specifically selected
+        vqslodfilteringType = performSiteSpecificVQSLODFiltering ? VQSLODFilteringType.SITES : VQSLODFilteringType.GENOTYPE;
 
         // filter at a site level (but not necesarily use vqslod)
         if ((filterSetSiteTableName != null && filterSetName == null) || (filterSetSiteTableName == null && filterSetName != null)) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -104,7 +104,7 @@ public class ExtractCohort extends ExtractTool {
     // what if this was a flag input only?
 
     @Argument(
-            fullName = "VQSLOD-filter-by-site",
+            fullName = "vqslod-filter-by-site",
             doc = "If VQSLOD filtering is applied, it should be at a site level. Default is false",
             optional = true
     )

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -132,7 +132,7 @@ public class ExtractCohort extends ExtractTool {
             optional = true)
     private Double vqsLodSNPThreshold = null;
 
-  @Advanced
+    @Advanced
     @Argument(
             fullName = "indels-lod-score-cutoff",
             mutex = {"indels-truth-sensitivity-filter-level"},

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -147,8 +147,9 @@ public class ExtractCohort extends ExtractTool {
 
         Set<VCFHeaderLine> extraHeaderLines = new HashSet<>();
 
-        // filter using vqslod-- default to GENOTYPE unless SITES specifically selected
-        vqslodfilteringType = performSiteSpecificVQSLODFiltering ? VQSLODFilteringType.SITES : VQSLODFilteringType.GENOTYPE;
+        if (filterSetInfoTableName != null) { // filter using vqslod-- default to GENOTYPE unless SITES specifically selected
+            vqslodfilteringType = performSiteSpecificVQSLODFiltering ? VQSLODFilteringType.SITES : VQSLODFilteringType.GENOTYPE;
+        }
 
         // filter at a site level (but not necesarily use vqslod)
         if ((filterSetSiteTableName != null && filterSetName == null) || (filterSetSiteTableName == null && filterSetName != null)) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -87,13 +87,6 @@ public class ExtractCohort extends ExtractTool {
     private boolean emitPLs = false;
 
     @Argument(
-            fullName = "disable-gnarly",
-            doc = "Disable use of GnarlyGenotyper",
-            optional = true
-    )
-    private boolean disableGnarlyGenotyper = true;
-
-    @Argument(
             fullName = "vqslod-filter-genotypes",
             doc = "Should VQSLOD filtering be applied at the genotype level",
             optional = true
@@ -231,7 +224,6 @@ public class ExtractCohort extends ExtractTool {
                 progressMeter,
                 filterSetName,
                 emitPLs,
-                disableGnarlyGenotyper,
                 performGenotypeVQSLODFiltering,
                 excludeFilteredSites);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -236,7 +236,7 @@ public class ExtractCohort extends ExtractTool {
         progressMeter.setRecordsBetweenTimeChecks(100L);
 
         if ( filterSetInfoTableName == null || filterSetInfoTableName.equals("") ) {
-            logger.warn("--variant-filter-table is not specified, no filtering of cohort! ");
+            logger.warn("--filter-set-info-table is not specified, no filtering of cohort! ");
         }
 
         engine.traverse();

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -35,7 +35,20 @@ public class ExtractCohort extends ExtractTool {
     private static final Logger logger = LogManager.getLogger(ExtractCohort.class);
     private ExtractCohortEngine engine;
 
-    public enum FilteringType { NONE, GENOTYPE, SITES};
+    public enum FilteringType {
+      GENOTYPE("genotype"),
+      SITES("sites"),
+      NONE("");
+
+      String value;
+
+      FilteringType(String value) {
+      this.value = value;
+    }
+      public String getValue() {
+      return value;
+    }
+  }
 
   @Argument(
             fullName = "filter-set-info-table",
@@ -89,8 +102,8 @@ public class ExtractCohort extends ExtractTool {
     private boolean emitPLs = false;
 
     @Argument(
-            fullName = "vqslod-filter-genotypes",
-            doc = "Should VQSLOD filtering be applied at the genotype level",
+            fullName = "filter-type",
+            doc = "What type of filtering should be applied / at what level",
             optional = true
     )
     private FilteringType filteringType = FilteringType.NONE; // TODO do we want to make sure this is always / required?

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -118,14 +118,15 @@ public class ExtractCohortEngine {
         this.traversalIntervals = traversalIntervals;
         this.minLocation = minLocation;
         this.maxLocation = maxLocation;
-        this.filterSetInfoTableRef = (filterSetInfoTableName == null || "".equals(filterSetInfoTableName)) ? null : new TableReference(filterSetInfoTableName, SchemaUtils.YNG_FIELDS);
-        this.filterSetSiteTableRef = (filterSetSiteTableName == null || "".equals(filterSetSiteTableName)) ? null : new TableReference(filterSetSiteTableName, SchemaUtils.FILTER_SET_SITE_FIELDS);
 
         this.printDebugInformation = printDebugInformation;
         this.vqsLodSNPThreshold = vqsLodSNPThreshold;
         this.vqsLodINDELThreshold = vqsLodINDELThreshold;
         this.VQSLODFilteringType = VQSLODFilteringType;
         this.excludeFilteredSites = excludeFilteredSites;
+
+        this.filterSetInfoTableRef = VQSLODFilteringType.equals(ExtractCohort.VQSLODFilteringType.NONE) ? null : new TableReference(filterSetInfoTableName, SchemaUtils.YNG_FIELDS);
+        this.filterSetSiteTableRef = VQSLODFilteringType.equals(ExtractCohort.VQSLODFilteringType.NONE) ? null : new TableReference(filterSetSiteTableName, SchemaUtils.FILTER_SET_SITE_FIELDS);
 
         this.progressMeter = progressMeter;
 
@@ -134,7 +135,7 @@ public class ExtractCohortEngine {
         this.annotationEngine = annotationEngine;
         this.variantContextMerger = new ReferenceConfidenceVariantContextMerger(annotationEngine, vcfHeader);
     }
-
+    // TODO note that these defaults are never used.
     private final static double INDEL_QUAL_THRESHOLD = GenotypeCalculationArgumentCollection.DEFAULT_STANDARD_CONFIDENCE_FOR_CALLING - 10 * Math.log10(HomoSapiensConstants.INDEL_HETEROZYGOSITY);
     private final static double SNP_QUAL_THRESHOLD = GenotypeCalculationArgumentCollection.DEFAULT_STANDARD_CONFIDENCE_FOR_CALLING - 10 * Math.log10(HomoSapiensConstants.SNP_HETEROZYGOSITY);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -41,7 +41,7 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 false,
-                ExtractCohort.VQSLODFilteringType.SITES, // "sites"
+                ExtractCohort.VQSLODFilteringType.NONE,
                 false
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -41,7 +41,6 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 false,
-                true,
                 false,
                 false
         );

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -41,7 +41,7 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 false,
-                ExtractCohort.FilteringType.SITES, // "sites"
+                ExtractCohort.VQSLODFilteringType.SITES, // "sites"
                 false
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -41,7 +41,7 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 false,
-                false,
+                ExtractCohort.FilteringType.SITES, // "sites"
                 false
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
@@ -42,7 +42,7 @@ class ExtractCohortTest extends CommandLineProgramTest {
     IntegrationTestSpec.assertEqualTextFiles(outputVCF, expectedVCF);
   }
 
-  @Test(expectedExceptions = CommandLineException.class)
+  @Test(expectedExceptions = UserException.class)
   public void testThrowFilterError() throws Exception {
     final ArgumentsBuilder args = new ArgumentsBuilder();
     args
@@ -53,13 +53,14 @@ class ExtractCohortTest extends CommandLineProgramTest {
         .add("local-sort-max-records-in-ram", 10000000)
         .add("cohort-avro-file-name", cohortAvroFileName)
         .add("sample-file", sampleFile)
-        .add("emit-pls", false)
-        .add("filter-type", "foo");
+        .add("filter-set-info-table", "something")
+        .add("filter-set-name", "something")
+        .add("emit-pls", false);
     runCommandLine(args);
   }
 
   @Test(expectedExceptions = CommandLineException.class)
-  public void testLowerCaseFilterError() throws Exception {
+  public void testNoFilteringThresholdsError() throws Exception {
     final ArgumentsBuilder args = new ArgumentsBuilder();
     args
         .add("mode", "GENOMES")
@@ -70,23 +71,7 @@ class ExtractCohortTest extends CommandLineProgramTest {
         .add("cohort-avro-file-name", cohortAvroFileName)
         .add("sample-file", sampleFile)
         .add("emit-pls", false)
-        .add("filter-type", "sites");
-    runCommandLine(args);
-  }
-
-  @Test(expectedExceptions = UserException.class)
-  public void testNoFilteringSetNameError() throws Exception {
-    final ArgumentsBuilder args = new ArgumentsBuilder();
-    args
-        .add("mode", "GENOMES")
-        .add("ref-version", 38)
-        .add("R", hg38Reference)
-        .add("O", "anything")
-        .add("local-sort-max-records-in-ram", 10000000)
-        .add("cohort-avro-file-name", cohortAvroFileName)
-        .add("sample-file", sampleFile)
-        .add("emit-pls", false)
-        .add("filter-type", "SITES");
+        .add("filter-type", "GENOTYPE");
     runCommandLine(args);
   }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.hellbender.tools.gvs.extract;
 
+import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.annotations.Test;
@@ -40,4 +42,51 @@ class ExtractCohortTest extends CommandLineProgramTest {
     IntegrationTestSpec.assertEqualTextFiles(outputVCF, expectedVCF);
   }
 
+  @Test(expectedExceptions = CommandLineException.class)
+  public void testThrowFilterError() throws Exception {
+    final ArgumentsBuilder args = new ArgumentsBuilder();
+    args
+        .add("mode", "GENOMES")
+        .add("ref-version", 38)
+        .add("R", hg38Reference)
+        .add("O", "anything")
+        .add("local-sort-max-records-in-ram", 10000000)
+        .add("cohort-avro-file-name", cohortAvroFileName)
+        .add("sample-file", sampleFile)
+        .add("emit-pls", false)
+        .add("filter-type", "foo");
+    runCommandLine(args);
+  }
+
+  @Test(expectedExceptions = CommandLineException.class)
+  public void testLowerCaseFilterError() throws Exception {
+    final ArgumentsBuilder args = new ArgumentsBuilder();
+    args
+        .add("mode", "GENOMES")
+        .add("ref-version", 38)
+        .add("R", hg38Reference)
+        .add("O", "anything")
+        .add("local-sort-max-records-in-ram", 10000000)
+        .add("cohort-avro-file-name", cohortAvroFileName)
+        .add("sample-file", sampleFile)
+        .add("emit-pls", false)
+        .add("filter-type", "sites");
+    runCommandLine(args);
+  }
+
+  @Test(expectedExceptions = UserException.class)
+  public void testNoFilteringSetNameError() throws Exception {
+    final ArgumentsBuilder args = new ArgumentsBuilder();
+    args
+        .add("mode", "GENOMES")
+        .add("ref-version", 38)
+        .add("R", hg38Reference)
+        .add("O", "anything")
+        .add("local-sort-max-records-in-ram", 10000000)
+        .add("cohort-avro-file-name", cohortAvroFileName)
+        .add("sample-file", sampleFile)
+        .add("emit-pls", false)
+        .add("filter-type", "SITES");
+    runCommandLine(args);
+  }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
@@ -34,8 +34,7 @@ class ExtractCohortTest extends CommandLineProgramTest {
         .add("local-sort-max-records-in-ram", 10000000)
         .add("cohort-avro-file-name", cohortAvroFileName)
         .add("sample-file", sampleFile)
-        .add("emit-pls", false)
-        .add("vqslod-filter-genotypes", false);
+        .add("emit-pls", false);
 
     runCommandLine(args);
     IntegrationTestSpec.assertEqualTextFiles(outputVCF, expectedVCF);

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortTest.java
@@ -59,7 +59,7 @@ class ExtractCohortTest extends CommandLineProgramTest {
     runCommandLine(args);
   }
 
-  @Test(expectedExceptions = CommandLineException.class)
+  @Test(expectedExceptions = UserException.class)
   public void testNoFilteringThresholdsError() throws Exception {
     final ArgumentsBuilder args = new ArgumentsBuilder();
     args
@@ -71,7 +71,26 @@ class ExtractCohortTest extends CommandLineProgramTest {
         .add("cohort-avro-file-name", cohortAvroFileName)
         .add("sample-file", sampleFile)
         .add("emit-pls", false)
-        .add("filter-type", "GENOTYPE");
+        .add("filter-set-info-table", "foo")
+        .add("vqslod-filter-by-site", true);
+    runCommandLine(args);
+  }
+
+  @Test(expectedExceptions = UserException.class)
+  public void testFakeFilteringError() throws Exception {
+    final ArgumentsBuilder args = new ArgumentsBuilder();
+    // No filterSetInfoTableName included, so should throw a user error with the performSiteSpecificVQSLODFiltering flag
+    args
+        .add("mode", "GENOMES")
+        .add("ref-version", 38)
+        .add("R", hg38Reference)
+        .add("O", "anything")
+        .add("local-sort-max-records-in-ram", 10000000)
+        .add("cohort-avro-file-name", cohortAvroFileName)
+        .add("sample-file", sampleFile)
+        .add("emit-pls", false)
+        .add("filter-set-name", "foo")
+        .add("vqslod-filter-by-site", true);
     runCommandLine(args);
   }
 }


### PR DESCRIPTION
There are params in Extract Cohort that can be tightened up

Extract Tool has two params that are not used by Extract Features and are _already_ in Extract Cohort

The filter_set_name is used in the BQ filtering tables and looks like we can set it to be completely required for any type of filtering.

There are 3 BQ filter tables -- 2 are needed for filtering (no matter what?) and 1 (tranches) is needed for thresholding and sensitivity calculations?

Genotype level filtering is true by default, but this doesn't seem like it should effect things after this cleanup. Though technically it should only be true if a filter_set_name has been specified. I will add another comment in the body of the code, but I would like to add this safety gate explicitly


Disable gnarly doesn't need to be a passed in param---so we'll rip it out for now

SNP and INDEL truth sensitivity and SNP and INDEL Lod scores are cumbersome to have to worry about passing in, but I dont see a better alternative. Should there be additional validation on these (where if they are specified, but no filter_set_name is, then they throw an error?)


