### PR TITLE
Allow MultiVariantWalkerGroupedOnStart sublcasses to view/set ignoreIntervalsOutsideStart

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStart.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiVariantWalkerGroupedOnStart.java
@@ -50,7 +50,7 @@ public abstract class MultiVariantWalkerGroupedOnStart extends MultiVariantWalke
     @Argument(fullName = IGNORE_VARIANTS_THAT_START_OUTSIDE_INTERVAL,
             doc = "Restrict variant output to sites that start within provided intervals (only applies when an interval is specified)",
             optional = true)
-    private boolean ignoreIntervalsOutsideStart = false;
+    protected boolean ignoreIntervalsOutsideStart = false;
 
     @Advanced
     @Argument(fullName = COMBINE_VARIANTS_DISTANCE, doc = "Maximum distance for variants to be grouped together", optional = true)


### PR DESCRIPTION
This is related to #7287. 

By default MultiVariantWalkerGroupedOnStart will iterate over any variant that spans the user-provided intervals. This is not what one would typically want when running scatter/gather jobs, since variants spanning interval borders would be included in both jobs. There is a variable/argument for  IGNORE_VARIANTS_THAT_START_OUTSIDE_INTERVAL, but it's private and therefore subclasses cant read it. I would like our MultiVariantWalkerGroupedOnStart to view this value and at least log a warning if the current job hasUserSuppliedIntervals(), and ignoreIntervalsOutsideStart=false.

In this PR I just make that variable protected, but I could also add formal getter/setters if you prefer.