### PR TITLE
Remove broken links to related annotations in tool docs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/AlleleFraction.java
@@ -29,7 +29,7 @@ import java.util.*;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerAlleleBySample.php">DepthPerAlleleBySample</a></b> calculates depth of coverage for each allele per sample (AD).</li>
+ *     <li><b>DepthPerAlleleBySample</b> calculates depth of coverage for each allele per sample (AD).</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/Coverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/Coverage.java
@@ -30,8 +30,8 @@ import java.util.Map;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerAlleleBySample.php">DepthPerAlleleBySample</a></b> calculates depth of coverage for each allele per sample (AD).</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerSampleHC.php">DepthPerSampleHC</a></b> calculates depth of coverage after filtering by HaplotypeCaller.</li>
+ *     <li><b>DepthPerAlleleBySample</b> calculates depth of coverage for each allele per sample (AD).</li>
+ *     <li><b>DepthPerSampleHC</b> calculates depth of coverage after filtering by HaplotypeCaller.</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Total depth of coverage per sample and over all samples (DP)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerAlleleBySample.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  *
  * <p>Also known as the allele depth, this annotation gives the unfiltered count of reads that support a given allele for an individual sample. The values in the field are ordered to match the order of alleles specified in the REF and ALT fields: REF, ALT1, ALT2 and so on if there are multiple ALT alleles.</p>
  *
- * <p>See the method documentation on <a href="http://www.broadinstitute.org/gatk/guide/article?id=4721">using coverage information</a> for important interpretation details.</p>
+ * <p>See the method documentation on <a href="https://gatk.broadinstitute.org/hc/en-us/articles/360035532112-Coverage-Read-depth-metrics">using coverage information</a> for important interpretation details.</p>
  *
  * <h3>Caveats</h3>
  * <ul>
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_Coverage.php">Coverage</a></b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
+ *     <li><b>Coverage</b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Depth of coverage of each allele per sample (AD)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DepthPerSampleHC.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerAlleleBySample.php">DepthPerAlleleBySample</a></b> calculates depth of coverage for each allele per sample (AD).</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_Coverage.php">Coverage</a></b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
+ *     <li><b>DepthPerAlleleBySample</b> calculates depth of coverage for each allele per sample (AD).</li>
+ *     <li><b>Coverage</b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrand.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/FisherStrand.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * </ul>
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_StrandBiasBySample.php">StrandBiasBySample</a></b> outputs counts of read depth per allele for each strand orientation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_StrandOddsRatio.php">StrandOddsRatio</a></b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
+ *     <li><b>StrandBiasBySample</b> outputs counts of read depth per allele for each strand orientation.</li>
+ *     <li><b>StrandOddsRatio</b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityRankSumTest.java
@@ -26,7 +26,7 @@ import java.util.OptionalDouble;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_RMSMappingQuality.php">RMSMappingQuality</a></b> gives an estimation of the overal read mapping quality supporting a variant call.</li>
+ *     <li><b>RMSMappingQuality</b> gives an estimation of the overal read mapping quality supporting a variant call.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZero.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/MappingQualityZero.java
@@ -29,8 +29,8 @@ import java.util.stream.IntStream;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_MappingQualityZeroBySample.php">MappingQualityZeroBySample</a></b> gives the count of reads with MAPQ=0 for each individual sample.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_LowMQ.php">LowMQ</a></b> gives the proportion of reads with low mapping quality (MAPQ below 10, including 0).</li>
+ *     <li><b>MappingQualityZeroBySample</b> gives the count of reads with MAPQ=0 for each individual sample.</li>
+ *     <li><b>LowMQ</b> gives the proportion of reads with low mapping quality (MAPQ below 10, including 0).</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/QualByDepth.java
@@ -38,8 +38,8 @@ import java.util.Map;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_Coverage.php">Coverage</a></b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerAlleleBySample.php">DepthPerAlleleBySample</a></b> calculates depth of coverage for each allele per sample (AD).</li>
+ *     <li><b>Coverage</b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
+ *     <li><b>DepthPerAlleleBySample</b> calculates depth of coverage for each allele per sample (AD).</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Variant confidence normalized by unfiltered depth of variant samples (QD)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/RMSMappingQuality.java
@@ -37,7 +37,7 @@ import java.util.*;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_MappingQualityRankSumTest.php">MappingQualityRankSumTest</a></b> compares the mapping quality of reads supporting the REF and ALT alleles.</li>
+ *     <li><b>MappingQualityRankSumTest</b> compares the mapping quality of reads supporting the REF and ALT alleles.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandBiasBySample.java
@@ -46,8 +46,8 @@ import java.util.List;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_FisherStrand.php">FisherStrand</a></b> uses Fisher's Exact Test to evaluate strand bias.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_StrandOddsRatio.php">StrandOddsRatio</a></b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
+ *     <li><b>FisherStrand</b> uses Fisher's Exact Test to evaluate strand bias.</li>
+ *     <li><b>StrandOddsRatio</b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Number of forward and reverse reads that support REF and ALT alleles (SB)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandOddsRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/StrandOddsRatio.java
@@ -108,12 +108,9 @@ import static java.lang.Math.min;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_allelespecific_AS_StrandOddsRatio.php">AS_StrandOddsRatio</a></b>
- *     allele-specific strand bias estimated by the symmetric odds ratio test.</li>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_StrandBiasBySample.php">StrandBiasBySample</a></b>
- *     outputs counts of read depth per allele for each strand orientation.</li>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_FisherStrand.php">FisherStrand</a></b>
- *     uses Fisher's Exact Test to evaluate strand bias.</li>
+ *     <li><b>AS_StrandOddsRatio</b> allele-specific strand bias estimated by the symmetric odds ratio test.</li>
+ *     <li><b>StrandBiasBySample</b> outputs counts of read depth per allele for each strand orientation.</li>
+ *     <li><b>FisherStrand</b> uses Fisher's Exact Test to evaluate strand bias.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_BaseQualityRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_BaseQualityRankSumTest.java
@@ -30,7 +30,7 @@ import java.util.OptionalDouble;
  *
  * <h3>Related annotations</h3>
  * <ul>
- * <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_BaseQualityRankSumTest.php">BaseQualityRankSumTest</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ * <li><b>BaseQualityRankSumTest</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_FisherStrand.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_FisherStrand.java
@@ -35,9 +35,9 @@ import java.util.Map;
  * </ul>
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_AS_FisherStrand.php">AS_FisherStrand</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_StrandBiasBySample.php">StrandBiasBySample</a></b> outputs counts of read depth per allele for each strand orientation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_StrandOddsRatio.php">StrandOddsRatio</a></b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
+ *     <li><b>AS_FisherStrand</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>StrandBiasBySample</b> outputs counts of read depth per allele for each strand orientation.</li>
+ *     <li><b>StrandOddsRatio</b> is an updated form of FisherStrand that uses a symmetric odds ratio calculation.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_InbreedingCoeff.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_InbreedingCoeff.java
@@ -32,8 +32,8 @@ import java.util.*;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_InbreedingCoeff.php">InbreedingCoeff</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_annotator_ExcessHet.php">ExcessHet</a></b> estimates excess heterozygosity in a population of samples.</li>
+ *     <li><b>InbreedingCoeff</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>ExcessHet</b> estimates excess heterozygosity in a population of samples.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_MappingQualityRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_MappingQualityRankSumTest.java
@@ -30,8 +30,8 @@ import java.util.OptionalDouble;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_MappingQualityRankSumTest.php">MappingQualityRankSumTest</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_RMSMappingQuality.php">RMSMappingQuality</a></b> gives an estimation of the overal read mapping quality supporting a variant call.</li>
+ *     <li><b>MappingQualityRankSumTest</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>RMSMappingQuality</b> gives an estimation of the overal read mapping quality supporting a variant call.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_QualByDepth.java
@@ -43,9 +43,9 @@ import java.util.stream.Collectors;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_AS_QualByDepth.php">AS_QualByDepth</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_Coverage.php">Coverage</a></b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_DepthPerAlleleBySample.php">DepthPerAlleleBySample</a></b> calculates depth of coverage for each allele per sample (AD).</li>
+ *     <li><b>AS_QualByDepth</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>Coverage</b> gives the filtered depth of coverage for each sample and the unfiltered depth across all samples.</li>
+ *     <li><b>DepthPerAlleleBySample</b> calculates depth of coverage for each allele per sample (AD).</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Allele-specific call confidence normalized by depth of sample reads supporting the allele (AS_QD)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RMSMappingQuality.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_RMSMappingQuality.java
@@ -39,8 +39,8 @@ import java.util.*;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_RMSMappingQuality.php">RMSMappingQuality</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_MappingQualityRankSumTest.php">MappingQualityRankSumTest</a></b> compares the mapping quality of reads supporting the REF and ALT alleles.</li>
+ *     <li><b>RMSMappingQuality</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>MappingQualityRankSumTest</b> compares the mapping quality of reads supporting the REF and ALT alleles.</li>
  * </ul>
  */
 @DocumentedFeature(groupName=HelpConstants.DOC_CAT_ANNOTATORS, groupSummary=HelpConstants.DOC_CAT_ANNOTATORS_SUMMARY, summary="Allele-specific root-mean-square of the mapping quality of reads across all samples (AS_MQ)")

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_ReadPosRankSumTest.java
@@ -35,7 +35,7 @@ import java.util.OptionalDouble;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_annotator_ReadPosRankSumTest.php">ReadPosRankRankSumTest</a></b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>ReadPosRankRankSumTest</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
  * </ul>
  *
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_StrandOddsRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/allelespecific/AS_StrandOddsRatio.java
@@ -64,12 +64,9 @@ import java.util.Map;
  *
  * <h3>Related annotations</h3>
  * <ul>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_allelespecific_AS_FisherStrand.php">AS_FisherStrand</a></b>
- *     uses Fisher's Exact Test to evaluate strand bias.</li>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_StrandOddsRatio.php">StrandOddsRatio</a></b>
- *     outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
- *     <li><b><a href="https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_hellbender_tools_walkers_annotator_StrandBiasBySample.php">StrandBiasBySample</a></b>
- *     outputs counts of read depth per allele for each strand orientation.</li>
+ *     <li><b>AS_FisherStrand</b> uses Fisher's Exact Test to evaluate strand bias.</li>
+ *     <li><b>StrandOddsRatio</b> outputs a version of this annotation that includes all alternate alleles in a single calculation.</li>
+ *     <li><b>StrandBiasBySample</b> outputs counts of read depth per allele for each strand orientation.</li>
  *
  * </ul>
  *


### PR DESCRIPTION
In the "Related Annotations" section of the annotations tool docs, the links were broken redirecting to the GATK homepage. We decided to remove these links since there is not a good way to link to the mentioned tool without the link becoming outdated with new releases.