### PR TITLE
Variant Store extraction - Add VCF size to output

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -90,7 +90,7 @@ workflow GvsExtractCallset {
 
     call SumBytes {
       input:
-        file_sizes_bytes = [ExtractTask.output_vcf_bytes, ExtractTask.output_vcf_index_bytes]
+        file_sizes_bytes = flatten([ExtractTask.output_vcf_bytes, ExtractTask.output_vcf_index_bytes])
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -91,6 +91,7 @@ workflow GvsExtractCallset {
     output {
       Array[File] output_vcfs = ExtractTask.output_vcf
       Array[File] output_vcf_indexes = ExtractTask.output_vcf_index
+      Int total_vcfs_size = size(ExtractTask.output_vcf) + size(ExtractTask.output_vcf_index)
     }
 }
 
@@ -182,6 +183,8 @@ task ExtractTask {
           gsutil cp ~{output_file} ${OUTPUT_GCS_DIR}/
           gsutil cp ~{output_file}.tbi ${OUTPUT_GCS_DIR}/
         fi
+
+        du -b ~{output_file}* | awk '{sum += $0} END {print sum}' > bytes.txt
     >>>
 
     # ------------------------------------------------
@@ -201,6 +204,7 @@ task ExtractTask {
     output {
         File output_vcf = "~{output_file}"
         File output_vcf_index = "~{output_file}.tbi"
+        Int payload_bytes = read_int("bytes.txt")
     }
  }
 

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -181,8 +181,8 @@ task ExtractTask {
                 ~{true='--emit-pls' false='' emit_pls} \
                 ${FILTERING_ARGS}
 
-        du -b ~{output_file} > vcf_bytes.txt
-        du -b ~{output_file}.tbi > vcf_index_bytes.txt
+        du -b ~{output_file} | cut -f1 > vcf_bytes.txt
+        du -b ~{output_file}.tbi | cut -f1 > vcf_index_bytes.txt
 
         # Drop trailing slash if one exists
         OUTPUT_GCS_DIR=$(echo ~{output_gcs_dir} | sed 's/\/$//')

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -91,7 +91,7 @@ workflow GvsExtractCallset {
     output {
       Array[File] output_vcfs = ExtractTask.output_vcf
       Array[File] output_vcf_indexes = ExtractTask.output_vcf_index
-      Int total_vcfs_size = size(ExtractTask.output_vcf) + size(ExtractTask.output_vcf_index)
+      Float total_vcfs_size_mb = size(ExtractTask.output_vcf, "MB") + size(ExtractTask.output_vcf_index, "MB")
     }
 }
 
@@ -183,8 +183,6 @@ task ExtractTask {
           gsutil cp ~{output_file} ${OUTPUT_GCS_DIR}/
           gsutil cp ~{output_file}.tbi ${OUTPUT_GCS_DIR}/
         fi
-
-        du -b ~{output_file}* | awk '{sum += $0} END {print sum}' > bytes.txt
     >>>
 
     # ------------------------------------------------
@@ -204,7 +202,6 @@ task ExtractTask {
     output {
         File output_vcf = "~{output_file}"
         File output_vcf_index = "~{output_file}.tbi"
-        Int payload_bytes = read_int("bytes.txt")
     }
  }
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -47,7 +47,7 @@ workflow GvsExtractCohortFromSampleNames {
     input:
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
-      data_project                    = query_project,
+      data_project                    = gvs_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",
       fq_sample_mapping_table         = "~{gvs_project}.~{gvs_dataset}.sample_info",

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -81,4 +81,8 @@ workflow GvsExtractCohortFromSampleNames {
       gatk_override = gatk_override
   }
 
+  output {
+    Float total_vcfs_size_mb = GvsExtractCallset.total_vcfs_size_mb
+  }
+
 }

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -48,6 +48,7 @@ workflow GvsExtractCohortFromSampleNames {
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
       data_project                    = gvs_project,
+      query_project                   = query_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",
       fq_sample_mapping_table         = "~{gvs_project}.~{gvs_dataset}.sample_info",


### PR DESCRIPTION
I tried implementing this with https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#float-sizefile-string but the workflow runtime went from 1h to 4h with that implementation. Not sure why that is but the runtime went back to normal levels after implementing it directly into the extract workflow.