### PR TITLE
Fixes #7338 Java11 problem with log4j2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,8 @@ tasks.withType(Jar) {
                 'Main-Class': project.mainClassName,
                 'Picard-Version': picardVersion,
                 'htsjdk-Version': htsjdkVersion,
-                'Spark-Version': sparkVersion
+                'Spark-Version': sparkVersion,
+                'Multi-Release': 'true'
     }
 }
 


### PR DESCRIPTION
Generate multi-release jars, to automatically select the implementation version when running under Java 9 or newer.

This fixes https://github.com/broadinstitute/gatk/issues/7338