### PR TITLE
VAT changes for alpha1

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -101,6 +101,7 @@ workflows:
      filters:
        branches:
          - rc-318-sites-only-filtered-vcf-then-annotate-wdl
+         - kc_vat
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
@@ -10,5 +10,6 @@
   "GvsSitesOnlyVCF.output_path": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/output/jul6/",
   "GvsSitesOnlyVCF.table_id": "jul6",
   "GvsSitesOnlyVCF.project_id": "spec-ops-aou",
-  "GvsSitesOnlyVCF.dataset_name": "anvil_100_for_testing"
+  "GvsSitesOnlyVCF.dataset_name": "anvil_100_for_testing",
+  "GvsSitesOnlyVCF.service_account_json": "gs://fc-secure-e91afe60-ca52-48fa-b4a9-c76fed5a0449/keys/aou_wgs_vumc_prod.json"
 }

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -199,7 +199,7 @@ task AnnotateShardedVCF {
         docker: "annotation/nirvana:3.14" # this download is too slow---can we beef this up?
         memory: "5 GB"
         cpu: "2"
-        disks: "local-disk 100 HDD"
+        disks: "local-disk 100 SSD"
     }
     # ------------------------------------------------
     # Outputs:

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -103,9 +103,13 @@ task SitesOnlyVcf {
             gsutil cp ~{input_vcf_index} .
         fi
 
+        # Adding `--add-output-vcf-command-line false` so that the VCF header doesn't have a timestamp
+        # in it so that downstream steps can call cache
+
         gatk --java-options "-Xmx2048m" \
             SelectVariants \
                 -V ~{updated_input_vcf} \
+                --add-output-vcf-command-line false \
                 --exclude-filtered \
                 --sites-only-vcf-output \
                 -O ~{output_filename}
@@ -134,14 +138,11 @@ task ExtractACANAF {
     }
     String output_vcf_idx = basename(output_filename) + ".tbi" # or will this be .idx if from .vcf.gz? or ".tbi" if a .vcf
     command <<<
-        # Adding `--add-output-vcf-command-line false` so that the VCF header doesn't have a timestamp
-        # in it so that downstream steps can call cache
 
         set -e
         gatk --java-options "-Xmx2048m" \
             SelectVariants \
                 -V ~{vcf_bgz_gts} \
-                --add-output-vcf-command-line false \
                 --exclude-filtered \
                 --sites-only-vcf-output \
                 -O ~{output_filename}
@@ -439,7 +440,7 @@ task BigQuerySmokeTest {
 
     command <<<
         set +e
-        
+
         if [ ~{has_service_account_file} = 'true' ]; then
             export GOOGLE_APPLICATION_CREDENTIALS=~{service_account_json}
             gcloud auth activate-service-account --key-file='~{service_account_json}'

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -237,7 +237,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20200707"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20200709"
         memory: "10 GB"
         cpu: "2"
         disks: "local-disk 100 HDD"

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -13,6 +13,8 @@ workflow GvsSitesOnlyVCF {
         File vat_genes_schema_json_file
         String output_path # TODO Is there a Path wdl type?
         String table_id
+
+        File? service_account_json
         File? gatk_override
     }
 
@@ -21,8 +23,9 @@ workflow GvsSitesOnlyVCF {
     scatter(i in range(length(gvs_extract_cohort_filtered_vcfs)) ) {
         call SitesOnlyVcf {
           input:
-            vcf_bgz_gts = gvs_extract_cohort_filtered_vcfs[i],
-            vcf_index = gvs_extract_cohort_filtered_vcf_indices[i],
+            input_vcf = gvs_extract_cohort_filtered_vcfs[i],
+            input_vcf_index = gvs_extract_cohort_filtered_vcf_indices[i],
+            service_account_json = service_account_json,
             output_filename = "${output_sites_only_file_name}_${i}.sites_only.vcf.gz",
         }
 
@@ -68,16 +71,39 @@ workflow GvsSitesOnlyVCF {
 ################################################################################
 task SitesOnlyVcf {
     input {
-        File vcf_bgz_gts
-        File vcf_index
+        File input_vcf
+        File input_vcf_index
+        File? service_account_json
         String output_filename
     }
     String output_vcf_idx = basename(output_filename) + ".tbi" # or will this be .idx if from .vcf.gz? or ".tbi" if a .vcf
+
+    String has_service_account_file = if (defined(service_account_json)) then 'true' else 'false'
+    String input_vcf_basename = basename(input_vcf)
+    String updated_input_vcf = if (defined(service_account_json)) then input_vcf_basename else input_vcf
+
+    parameter_meta {
+        input_vcf: {
+            localization_optional: true
+        }
+        input_vcf_index: {
+            localization_optional: true
+        }
+    }
     command <<<
         set -e
+
+        if [ ~{has_service_account_file} = 'true' ]; then
+            export GOOGLE_APPLICATION_CREDENTIALS=~{service_account_json}
+            gcloud auth activate-service-account --key-file='~{service_account_json}'
+
+            gsutil cp ~{input_vcf} .
+            gsutil cp ~{input_vcf_index} .
+        fi
+
         gatk --java-options "-Xmx2048m" \
             SelectVariants \
-                -V ~{vcf_bgz_gts} \
+                -V ~{updated_input_vcf} \
                 --exclude-filtered \
                 --sites-only-vcf-output \
                 -O ~{output_filename}
@@ -234,6 +260,7 @@ task BigQueryLoadJson {
         String dataset_name
         String output_path
         String table_id
+        File? service_account_json
         Array[String] prep_jsons_done
     }
 
@@ -246,8 +273,15 @@ task BigQueryLoadJson {
     String vt_path = output_path + 'vt/*'
     String genes_path = output_path + 'genes/*'
 
+    String has_service_account_file = if (defined(service_account_json)) then 'true' else 'false'
 
     command <<<
+
+       if [ ~{has_service_account_file} = 'true' ]; then
+           export GOOGLE_APPLICATION_CREDENTIALS=~{service_account_json}
+           gcloud auth activate-service-account --key-file='~{service_account_json}'
+           gcloud config set project ~{project_id}
+       fi
 
        bq show --project_id ~{project_id} ~{dataset_name}.~{variant_transcript_table} > /dev/null
        BQ_SHOW_RC=$?

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -136,6 +136,7 @@ task ExtractACANAF {
         gatk --java-options "-Xmx2048m" \
             SelectVariants \
                 -V ~{vcf_bgz_gts} \
+                --add-output-vcf-command-line false \
                 --exclude-filtered \
                 --sites-only-vcf-output \
                 -O ~{output_filename}
@@ -199,7 +200,8 @@ task AnnotateShardedVCF {
         docker: "annotation/nirvana:3.14" # this download is too slow---can we beef this up?
         memory: "5 GB"
         cpu: "2"
-        disks: "local-disk 100 SSD"
+        preemptible: 5
+        disks: "local-disk 250 SSD"
     }
     # ------------------------------------------------
     # Outputs:

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -132,6 +132,9 @@ task ExtractACANAF {
     }
     String output_vcf_idx = basename(output_filename) + ".tbi" # or will this be .idx if from .vcf.gz? or ".tbi" if a .vcf
     command <<<
+        # Adding `--add-output-vcf-command-line false` so that the VCF header doesn't have a timestamp
+        # in it so that downstream steps can call cache
+        
         set -e
         gatk --java-options "-Xmx2048m" \
             SelectVariants \


### PR DESCRIPTION
Added:

- service account support for SitesOnly task, added GATK flag to not output a timestamp info VCF to help Call Caching
- switch to SSD, increased size and moved to pre-emptibles for Annotate task
- service account support for BQ Loading
- service account support for BQ Smoke Test 