### PR TITLE
Replace service_account_json (file) with service_account_json_path (string) to allow call-caching

### DIFF
--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -520,8 +520,7 @@ task CreateFilterSetFiles {
     # ------------------------------------------------
     # Run our command:
     command <<<
-        set -eo pipefail
-
+        GvsImportGenomes.wdl
         if [ ~{has_service_account_file} = 'true' ]; then
             gsutil cp ~{service_account_json_path} local.service_account.json
             export GOOGLE_APPLICATION_CREDENTIALS=local.service_account.json

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -520,7 +520,8 @@ task CreateFilterSetFiles {
     # ------------------------------------------------
     # Run our command:
     command <<<
-        GvsImportGenomes.wdl
+        set -eo pipefail
+
         if [ ~{has_service_account_file} = 'true' ]; then
             gsutil cp ~{service_account_json_path} local.service_account.json
             export GOOGLE_APPLICATION_CREDENTIALS=local.service_account.json

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -654,6 +654,7 @@ task LoadTable {
     if [ ~{has_service_account_file} = 'true' ]; then
       gsutil cp ~{service_account_json_path} local.service_account.json
       gcloud auth activate-service-account --key-file=local.service_account.json
+      gcloud config set project ~{project_id}
     fi
 
     DIR="~{storage_location}/~{datatype}_tsvs/"


### PR DESCRIPTION
Otherwise, when json is refreshed, contents of the file are different, hash of the file is different, and call-caching will not register a match, despite the same "account" being used.

- changed input type from `File` to `String`
- changed the name to make it more obvious/clear

Closes https://github.com/broadinstitute/dsp-spec-ops/issues/327