### PR TITLE
Create WDL to validate VAT and add first test

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -106,7 +106,6 @@ workflows:
      filters:
        branches:
          - ah_var_store
-         - rsa_add_vat_val_1
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -100,6 +100,13 @@ workflows:
      filters:
        branches:
          - ah_var_store
+   - name: GvsSitesOnlyVCF
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsValidateVAT.wdl
+     filters:
+       branches:
+         - ah_var_store
+         - rsa_add_vat_val_1
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -100,7 +100,7 @@ workflows:
      filters:
        branches:
          - ah_var_store
-   - name: GvsSitesOnlyVCF
+   - name: GvsValidateVatTable
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsValidateVAT.wdl
      filters:

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,10 +27,10 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
-    String sample_results = "FAIL [SomeStep]: this step failed for reasons."
+    String sample_results = "FAIL: this step failed for reasons."
 
     output {
-        String validation_results = EnsureVatTableHasVariants.result + "\n" + sample_results
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, {"sample_results": sample_results}]
     }
 }
 
@@ -59,9 +59,9 @@ task EnsureVatTableHasVariants {
         # if the result of the bq call and the csv parsing is a series of digits, then check that it isn't 0
         if [[ $NUMVARS =~ ^[0-9]+$ ]]; then
             if [[ $NUMVARS = "0" ]]; then
-                echo "FAIL [EnsureVatTableHasVariants]: The VAT table ~{fq_vat_table} has no variants in it." > validation_results.txt
+                echo "FAIL: The VAT table ~{fq_vat_table} has no variants in it." > validation_results.txt
             else
-                echo "PASS [EnsureVatTableHasVariants]: The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
+                echo "PASS: The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
             fi
         # otherwise, something is off, so return the output from the bq query call
         else
@@ -80,7 +80,7 @@ task EnsureVatTableHasVariants {
     # ------------------------------------------------
     # Outputs:
     output {
-        String result = read_string('validation_results.txt')
+        Map[String, String] result = {"EnsureVatTableHasVariants": read_string('validation_results.txt')}
     }
 }
 

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -26,6 +26,12 @@ workflow GvsValidateVatTable {
             service_account_json_path = service_account_json_path,
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
+
+    String sample_results = "FAIL [SomeStep]: this step failed for reasons."
+
+    output {
+        String validation_results = EnsureVatTableHasVariants.result + "\n" + sample_results
+    }
 }
 
 task EnsureVatTableHasVariants {
@@ -53,9 +59,9 @@ task EnsureVatTableHasVariants {
         # if the result of the bq call and the csv parsing is a series of digits, then check that it isn't 0
         if [[ $NUMVARS =~ ^[0-9]+$ ]]; then
             if [[ $NUMVARS = "0" ]]; then
-                echo "FAIL: The VAT table ~{fq_vat_table} has no variants in it." > validation_results.txt
+                echo "FAIL [EnsureVatTableHasVariants]: The VAT table ~{fq_vat_table} has no variants in it." > validation_results.txt
             else
-                echo "PASS: The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
+                echo "PASS [EnsureVatTableHasVariants]: The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
             fi
         # otherwise, something is off, so return the output from the bq query call
         else

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -12,11 +12,19 @@ workflow GvsValidateVatTable {
 
     String fq_vat_table = "~{query_project_id}.~{default_dataset}.~{vat_table_name}"
 
+    call GetBQTableLastModifiedDatetime {
+        input:
+            query_project = query_project_id,
+            fq_table = fq_vat_table,
+            service_account_json_path = service_account_json_path
+    }
+
     call EnsureVatTableHasVariants {
         input:
             query_project_id = query_project_id,
             fq_vat_table = fq_vat_table,
-            service_account_json_path = service_account_json_path
+            service_account_json_path = service_account_json_path,
+            last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 }
 
@@ -25,6 +33,7 @@ task EnsureVatTableHasVariants {
         String query_project_id
         String fq_vat_table
         String? service_account_json_path
+        String last_modified_timestamp
     }
 
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
@@ -39,7 +48,12 @@ task EnsureVatTableHasVariants {
 
         bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT COUNT (DISTINCT vid) AS count FROM ~{fq_vat_table}' > bq_variant_count.csv
 
+        echo "contents of bq_variant_count.csv:"
+        cat bq_variant_count.csv
+
         NUMVARS=$(python3 -c "csvObj=open('bq_variant_count.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
+
+        echo "contents of NUMVARS: $NUMVARS"
 
         if [[ $NUMVARS =~ ^[0-9]+$ ]]; then
             echo "The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
@@ -60,5 +74,57 @@ task EnsureVatTableHasVariants {
     # Outputs:
     output {
         String result = read_string('validation_results.txt')
+    }
+}
+
+task GetBQTableLastModifiedDatetime {
+    # because this is being used to determine if the data has changed, never use call cache
+    meta {
+        volatile: true
+    }
+
+    input {
+        String query_project
+        String fq_table
+        String? service_account_json_path
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    # ------------------------------------------------
+    # try to get the last modified date for the table in question; fail if something comes back from BigQuery
+    # that isn't in the right format (e.g. an error)
+    command <<<
+        set -e
+
+        if [ ~{has_service_account_file} = 'true' ]; then
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            gcloud auth activate-service-account --key-file=local.service_account.json
+            gcloud config set project ~{query_project}
+        fi
+
+        echo "project_id = ~{query_project}" > ~/.bigqueryrc
+
+        # bq needs the project name to be separate by a colon
+        DATASET_TABLE_COLON=$(echo ~{fq_table} | sed 's/\./:/')
+
+        LASTMODIFIED=$(bq --location=US --project_id=~{query_project} --format=json show ${DATASET_TABLE_COLON} | python3 -c "import sys, json; print(json.load(sys.stdin)['lastModifiedTime']);")
+        if [[ $LASTMODIFIED =~ ^[0-9]+$ ]]; then
+            echo $LASTMODIFIED
+        else
+            exit 1
+        fi
+    >>>
+
+    output {
+        String last_modified_timestamp = read_string(stdout())
+    }
+
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "3 GB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        cpu: 1
     }
 }

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -66,7 +66,7 @@ task EnsureVatTableHasVariants {
             fi
         # otherwise, something is off, so return the output from the bq query call
         else
-            echo "Something went wrong. The attempt to count the variants returned: " + $(cat bq_variant_count.csv) > validation_results.txt
+            echo "Something went wrong. The attempt to count the variants returned: " $(cat bq_variant_count.csv) > validation_results.txt
         fi
     >>>
     # ------------------------------------------------

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -41,7 +41,7 @@ task EnsureVatTableHasVariants {
 
         NUMVARS=$(python3 -c "csvObj=open('bq_variant_count.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
 
-        if [[ $NUMVARS =~ ^[0-9]+$ ]] then
+        if [[ $NUMVARS =~ ^[0-9]+$ ]]; then
             echo "The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
         else
             echo "Something went wrong. The attempt to count the variants returned: " + $(cat bq_variant_count.csv) > validation_results.txt

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -1,0 +1,64 @@
+version 1.0
+
+import "GvsWarpTasks.wdl" as Tasks
+
+workflow GvsValidateVatTable {
+    input {
+        String query_project_id
+        String default_dataset
+        String vat_table_name
+        String? service_account_json_path
+    }
+
+    String fq_vat_table = "~{query_project_id}.~{default_dataset}.~{vat_table_name}"
+
+    call EnsureVatTableHasVariants {
+        input:
+            query_project_id = query_project_id,
+            fq_vat_table = fq_vat_table,
+            service_account_json_path = service_account_json_path
+    }
+}
+
+task EnsureVatTableHasVariants {
+    input {
+        String query_project_id
+        String fq_vat_table
+        String? service_account_json_path
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    command <<<
+        if [ ~{has_service_account_file} = 'true' ]; then
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            gcloud auth activate-service-account --key-file=local.service_account.json
+            gcloud config set project ~{query_project_id}
+        fi
+        echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
+
+        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT COUNT (DISTINCT vid) AS count FROM ~{fq_vat_table}' > bq_variant_count.csv
+
+        NUMVARS=$(python3 -c "csvObj=open('bq_variant_count.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
+
+        if [[ $NUMVARS =~ ^[0-9]+$ ]] then
+            echo "The VAT table ~{fq_vat_table} has $NUMVARS variants in it." > validation_results.txt
+        else
+            echo "Something went wrong. The attempt to count the variants returned: " + $(cat bq_variant_count.csv) > validation_results.txt
+        fi
+    >>>
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "openbridge/ob_google-bigquery:latest"
+        memory: "1 GB"
+        preemptible: 3
+        cpu: "1"
+        disks: "local-disk 100 HDD"
+    }
+    # ------------------------------------------------
+    # Outputs:
+    output {
+        String result = read_string('validation_results.txt')
+    }
+}

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -64,7 +64,7 @@ task EnsureVatTableHasVariants {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "openbridge/ob_google-bigquery:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,10 +27,11 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
-    String sample_results = "FAIL: this step failed for reasons."
-
+    # once there is more than one check, they will be gathered into this workflow output, in the format
+    # [{ValidationRule1: "PASS/FAIL Extra info from this test"},
+    #  {ValidationRule2: "PASS/FAIL Extra from this test"}]
     output {
-        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, {"sample_results": sample_results}]
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result]
     }
 }
 
@@ -78,7 +79,7 @@ task EnsureVatTableHasVariants {
         disks: "local-disk 100 HDD"
     }
     # ------------------------------------------------
-    # Outputs:
+    # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
         Map[String, String] result = {"EnsureVatTableHasVariants": read_string('validation_results.txt')}
     }


### PR DESCRIPTION
The idea is that this WDL will run all the checks for each release of the VAT table, one call for each validation.  The first validation rule ("Validation Check confirms that data is put into the VAT table after completing without an error.") is included as a model for subsequent calls.

- workflow should succeed if it's able to try all tests
- workflow output `validation_results` will contain details of each test result in an array of `{"testName": "result details"}`:
Example 1 — [fail](https://job-manager.dsde-prod.broadinstitute.org/jobs/2728b55b-5344-492a-951a-48fd416e9d0d)
`{ "EnsureVatTableHasVariants": "FAIL: The VAT table spec-ops-aou.rsa_gvs_quickstart.rsa_scratch has no variants in it." }`
Example 2 — [pass](https://job-manager.dsde-prod.broadinstitute.org/jobs/83e3bd5a-9144-452e-93d9-9f273055177f)
`{ "EnsureVatTableHasVariants": "PASS: The VAT table spec-ops-aou.anvil_100_for_testing.aou_shard_223_vat has 294821 variants in it." },`
Example 3 — [the test wasn't able to run](https://job-manager.dsde-prod.broadinstitute.org/jobs/7179d111-02aa-4bca-a0a0-f55e10e43791)
`{ "EnsureVatTableHasVariants": "Something went wrong. The attempt to count the variants returned: Error in query string: Error processing job 'spec-ops- aou:bqjob_r357c4b6fe6b0c6fb_0000017aac301de7_1': Unrecognized name: vid at [1:24]" }`

Closes https://github.com/broadinstitute/dsp-spec-ops/issues/364