### PR TITLE
Hook up GATKTool.disableProgressMeter() to allow the ProgressMeter to be completely disabled for all tools / traversals

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -740,7 +740,7 @@ public abstract class GATKTool extends CommandLineProgram {
      * Helper method to initialize the progress meter without exposing engine level arguements.
      */
     protected final void initializeProgressMeter(final String progressMeterRecordLabel) {
-        progressMeter = new ProgressMeter(secondsBetweenProgressUpdates);
+        progressMeter = new ProgressMeter(secondsBetweenProgressUpdates, disableProgressMeter());
         progressMeter.setRecordLabel(progressMeterRecordLabel);
     }
 
@@ -1081,11 +1081,9 @@ public abstract class GATKTool extends CommandLineProgram {
     protected final Object doWork() {
         try {
             onTraversalStart();
-            if (!disableProgressMeter()) {
-                progressMeter.start();
-            }
+            progressMeter.start();
             traverse();
-            if (!disableProgressMeter() && !progressMeter.stopped()) {
+            if (!progressMeter.stopped()) {
                 progressMeter.stop();
             }
             return onTraversalSuccess();

--- a/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/ProgressMeterUnitTest.java
@@ -174,4 +174,15 @@ public class ProgressMeterUnitTest extends GATKBaseTest {
         Assert.assertTrue(pm.stopped());
     }
 
+    @Test
+    public void testDisabledProgressMeter() {
+        final ProgressMeter disabledPM = new ProgressMeter(ProgressMeter.DEFAULT_SECONDS_BETWEEN_UPDATES, true);
+
+        disabledPM.start();
+        Assert.assertFalse(disabledPM.started());
+        disabledPM.update(new SimpleInterval("1", 1, 1));
+        Assert.assertEquals(disabledPM.numRecordsProcessed(), 0);
+        disabledPM.stop();
+        Assert.assertFalse(disabledPM.stopped());
+    }
 }


### PR DESCRIPTION
Added a master "disable" switch to the GATK ProgressMeter, and hooked it up to
GATKTool.disableProgressMeter(). This allows the ProgressMeter to be easily disabled
for all tools / traversals by overriding a single method.