### PR TITLE
Add task for VAT validation #3

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -106,7 +106,6 @@ workflows:
      filters:
        branches:
          - ah_var_store
-         - rsa_add_vat_val_3
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -106,6 +106,7 @@ workflows:
      filters:
        branches:
          - ah_var_store
+         - rsa_add_vat_val_3
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -120,7 +120,7 @@ task SpotCheckForExpectedTranscripts {
             position >= 35740407 AND
             position <= 35740469 AND
             single_consequence NOT IN ("downstream_gene_variant","upstream_gene_variant") AND
-            gene_symbol NOT IN ("IGFLR1","AD000671.2")' > bq_query_output.csv
+            gene_symbol NOT IN ("IGFLR1")' > bq_query_output.csv
 
         # get number of lines in bq query output
         NUMVARS=$(awk 'END{print NR}' bq_query_output.csv)

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,7 +27,7 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
-    call EnsureVatTableHasExpectedTranscriptsAtLocation {
+    call SpotCheckLocationForExpectedGenes {
         input:
             query_project_id = query_project_id,
             fq_vat_table = fq_vat_table,
@@ -39,7 +39,7 @@ workflow GvsValidateVatTable {
     # [{ValidationRule1: "PASS/FAIL Extra info from this test"},
     #  {ValidationRule2: "PASS/FAIL Extra from this test"}]
     output {
-        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, EnsureVatTableHasExpectedTranscriptsAtLocation.result]
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, SpotCheckLocationForExpectedGenes.result]
     }
 }
 
@@ -93,7 +93,7 @@ task EnsureVatTableHasVariants {
     }
 }
 
-task EnsureVatTableHasExpectedTranscriptsAtLocation {
+task SpotCheckLocationForExpectedGenes {
     input {
         String query_project_id
         String fq_vat_table
@@ -120,7 +120,7 @@ task EnsureVatTableHasExpectedTranscriptsAtLocation {
             position >= 35740407 AND
             position <= 35740469 AND
             single_consequence NOT IN ("downstream_gene_variant","upstream_gene_variant") AND
-            gene_symbol NOT IN ("IGFLR1","AD000671.2")' > bq_query_output.txt
+            gene_symbol NOT IN ("IGFLR1")' > bq_query_output.txt
 
         # get number of lines in bq query output
         NUMVARS=$(awk 'END{print NR}' bq_query_output.txt)
@@ -145,7 +145,7 @@ task EnsureVatTableHasExpectedTranscriptsAtLocation {
     # ------------------------------------------------
     # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
-        Map[String, String] result = {"EnsureVatTableHasExpectedTranscriptsAtLocation": read_string('validation_results.txt')}
+        Map[String, String] result = {"SpotCheckLocationForExpectedGenes": read_string('validation_results.txt')}
     }
 }
 

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -133,7 +133,7 @@ task SpotCheckForExpectedTranscripts {
         # if the result of the query has any rows, that means there were unexpected transcripts at the
         # specified location, so report those back in the output
         if [[ $NUMRESULTS = "0" ]]; then
-            echo "PASS: The VAT table ~{fq_vat_table} only has the expected transcripts at the tested location ("IGFLR1" and "AD000671.2" in chromosome 19, between positions 35,740,407 - 35,740,469)." > validation_results.txt
+            echo "PASS: The VAT table ~{fq_vat_table} only has the expected transcripts at the tested location ('IGFLR1' and 'AD000671.2' in chromosome 19, between positions 35,740,407 - 35,740,469)." > validation_results.txt
         else
             echo "FAIL: The VAT table ~{fq_vat_table} had unexpected transcripts at the tested location: [csv output follows] " > validation_results.txt
             cat bq_query_output.csv >> validation_results.txt

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,11 +27,19 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
+    call EnsureVatTableHasExpectedTranscriptsAtLocation {
+        input:
+            query_project_id = query_project_id,
+            fq_vat_table = fq_vat_table,
+            service_account_json_path = service_account_json_path,
+            last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
+    }
+
     # once there is more than one check, they will be gathered into this workflow output, in the format
     # [{ValidationRule1: "PASS/FAIL Extra info from this test"},
     #  {ValidationRule2: "PASS/FAIL Extra from this test"}]
     output {
-        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result]
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, EnsureVatTableHasExpectedTranscriptsAtLocation.result]
     }
 }
 
@@ -82,6 +90,62 @@ task EnsureVatTableHasVariants {
     # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
         Map[String, String] result = {"EnsureVatTableHasVariants": read_string('validation_results.txt')}
+    }
+}
+
+task EnsureVatTableHasExpectedTranscriptsAtLocation {
+    input {
+        String query_project_id
+        String fq_vat_table
+        String? service_account_json_path
+        String last_modified_timestamp
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    command <<<
+        if [ ~{has_service_account_file} = 'true' ]; then
+        gsutil cp ~{service_account_json_path} local.service_account.json
+        gcloud auth activate-service-account --key-file=local.service_account.json
+        gcloud config set project ~{query_project_id}
+        fi
+        echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
+
+        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=sparse 'SELECT
+            contig, position, vid, gene_symbol, single_consequence
+        FROM  ~{fq_vat_table},
+           UNNEST(consequence) as single_consequence
+        WHERE
+            contig = "chr19" AND
+            position >= 35740407 AND
+            position <= 35740469 AND
+            single_consequence NOT IN ("downstream_gene_variant","upstream_gene_variant") AND
+            gene_symbol NOT IN ("IGFLR1","AD000671.2")' > bq_query_output.txt
+
+        # get number of lines in bq query output
+        NUMVARS=$(awk 'END{print NR}' bq_query_output.txt)
+
+        # if the result of the bq call has any rows, that means there were other genes at the specified
+        # location than expected, so report those back
+        if [[ $NUMVARS =~ ^[0-9]+$ && $NUMVARS = "0" ]]; then
+            echo "PASS: The VAT table ~{fq_vat_table} only has the expected genes at the expected location tested ("IGFLR1" and "AD000671.2" in chromosome 19, between positions 35,740,407 - 35,740,469)." > validation_results.txt
+        else
+            echo "FAIL: The VAT table ~{fq_vat_table} had unexpected genes at the expected location tested: " > validation_results.txt
+            cat bq_query_output.txt >> validation_results.txt
+        fi    >>>
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "1 GB"
+        preemptible: 3
+        cpu: "1"
+        disks: "local-disk 100 HDD"
+    }
+    # ------------------------------------------------
+    # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
+    output {
+        Map[String, String] result = {"EnsureVatTableHasExpectedTranscriptsAtLocation": read_string('validation_results.txt')}
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/broadinstitute/dsp-spec-ops/issues/366 by putting into SQL what is in English in that ticket:
> All variants in the region, chr19:35,740,407-35,740,469, overlap transcripts with multiple genes and those genes are always IGFLR1 and AD000671.2. Do not consider rows that include a consequence of downstream_gene_variant or upstream_gene_variant in this validation.