### PR TITLE
Add task for VAT validation #4

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -106,6 +106,7 @@ workflows:
      filters:
        branches:
          - ah_var_store
+         - rsa_add_vat_val_4
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -236,7 +236,7 @@ task SchemaOnlyOneRowPerNullTranscript {
         fi
         echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
 
-        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT * FROM (SELECT
+        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT
             vid,
             COUNT(vid) AS num_rows
         FROM
@@ -244,8 +244,8 @@ task SchemaOnlyOneRowPerNullTranscript {
         WHERE
             transcript_source is NULL AND
             transcript is NULL
-        GROUP BY vid) null_transcripts
-        WHERE num_rows > 1' > bq_variant_count.csv
+        GROUP BY vid
+        HAVING num_rows = 1' > bq_variant_count.csv
 
         # get number of lines in bq query output
         NUMRESULTS=$(awk 'END{print NR}' bq_variant_count.csv)

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,6 +27,14 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
+    call SpotCheckForExpectedTranscripts {
+        input:
+            query_project_id = query_project_id,
+            fq_vat_table = fq_vat_table,
+            service_account_json_path = service_account_json_path,
+            last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
+    }
+
     call SchemaOnlyOneRowPerNullTranscript {
         input:
             query_project_id = query_project_id,
@@ -36,7 +44,7 @@ workflow GvsValidateVatTable {
     }
 
     output {
-        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, SchemaOnlyOneRowPerNullTranscript.result]
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, SpotCheckForExpectedTranscripts.result, SchemaOnlyOneRowPerNullTranscript.result]
     }
 }
 
@@ -87,6 +95,35 @@ task EnsureVatTableHasVariants {
     # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
         Map[String, String] result = {"EnsureVatTableHasVariants": read_string('validation_results.txt')}
+    }
+}
+
+task SpotCheckForExpectedTranscripts {
+    input {
+        String query_project_id
+        String fq_vat_table
+        String? service_account_json_path
+        String last_modified_timestamp
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    command <<<
+
+    >>>
+
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "1 GB"
+        preemptible: 3
+        cpu: "1"
+        disks: "local-disk 100 HDD"
+    }
+
+    output {
+        Map[String, String] result = {"SpotCheckForExpectedTranscripts": read_string('validation_results.txt')}
     }
 }
 

--- a/scripts/variantstore/wdl/GvsValidateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVAT.wdl
@@ -27,11 +27,16 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
-    # once there is more than one check, they will be gathered into this workflow output, in the format
-    # [{ValidationRule1: "PASS/FAIL Extra info from this test"},
-    #  {ValidationRule2: "PASS/FAIL Extra from this test"}]
+    call SchemaOnlyOneRowPerNullTranscript {
+        input:
+            query_project_id = query_project_id,
+            fq_vat_table = fq_vat_table,
+            service_account_json_path = service_account_json_path,
+            last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
+    }
+
     output {
-        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result]
+        Array[Map[String, String]] validation_results = [EnsureVatTableHasVariants.result, SchemaOnlyOneRowPerNullTranscript.result]
     }
 }
 
@@ -82,6 +87,63 @@ task EnsureVatTableHasVariants {
     # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
         Map[String, String] result = {"EnsureVatTableHasVariants": read_string('validation_results.txt')}
+    }
+}
+
+task SchemaOnlyOneRowPerNullTranscript {
+    input {
+        String query_project_id
+        String fq_vat_table
+        String? service_account_json_path
+        String last_modified_timestamp
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    command <<<
+        if [ ~{has_service_account_file} = 'true' ]; then
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            gcloud auth activate-service-account --key-file=local.service_account.json
+            gcloud config set project ~{query_project_id}
+        fi
+        echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
+
+        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT * FROM (SELECT
+            vid,
+            COUNT(vid) AS num_rows
+        FROM
+            ~{fq_vat_table}
+        WHERE
+            transcript_source is NULL AND
+            transcript is NULL
+        GROUP BY vid) null_transcripts
+        WHERE num_rows > 1' > bq_variant_count.csv
+
+        # get number of lines in bq query output
+        NUMRESULTS=$(awk 'END{print NR}' bq_variant_count.csv)
+
+        # if the result of the query has any rows, that means there were vids will null transcripts and multiple
+        # rows in the VAT, which should not be the case
+        if [[ $NUMRESULTS = "0" ]]; then
+            echo "PASS: The VAT table ~{fq_vat_table} only has 1 row per vid with a null transcript" > validation_results.txt
+        else
+            echo "FAIL: The VAT table ~{fq_vat_table} had at least one vid with a null transcript and more than one row: [csv output follows] " > validation_results.txt
+            cat bq_variant_count.csv >> validation_results.txt
+        fi
+    >>>
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "1 GB"
+        preemptible: 3
+        cpu: "1"
+        disks: "local-disk 100 HDD"
+    }
+    # ------------------------------------------------
+    # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
+    output {
+        Map[String, String] result = {"SchemaOnlyOneRowPerNullTranscript": read_string('validation_results.txt')}
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/broadinstitute/dsp-spec-ops/issues/367 by translating this English into a SQL query:
> If a vid has a null transcript, then the vid is only in one row of the VAT.