### PR TITLE
Add VAT validation rule #2 [VS-19]

### DIFF
--- a/custom_annotations_template.tsv
+++ b/custom_annotations_template.tsv
@@ -1,0 +1,7 @@
+#title=gvsAnnotations
+#assembly=GRCh38
+#matchVariantsBy=allele
+#CHROM	POS	REF	ALT	AN	AC	AF
+#categories	.	.	.	AlleleNumber	AlleleCount	AlleleFrequency
+#descriptions	.	.	.	.	.	.
+#type	.	.	.	number	number	number

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -488,7 +488,7 @@ task BigQuerySmokeTest {
             gcloud auth activate-service-account --key-file=local.service_account.json
             gcloud config set project ~{project_id}
         fi
-        echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
+        echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
         # ------------------------------------------------
         # VALIDATION CALCULATION
@@ -497,7 +497,7 @@ task BigQuerySmokeTest {
         INITIAL_VARIANT_COUNT=$(python -c "print(sum([~{sep=', ' counts_variants}]))")
 
         # Count number of variants in the VAT
-        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT COUNT (DISTINCT vid) AS count FROM `~{dataset_name}.~{vat_table}`' > bq_variant_count.csv
+        bq query --nouse_legacy_sql --project_id=~{project_id} --format=csv 'SELECT COUNT (DISTINCT vid) AS count FROM `~{dataset_name}.~{vat_table}`' > bq_variant_count.csv
         VAT_COUNT=$(python3 -c "csvObj=open('bq_variant_count.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
         # if the result of the bq call and the csv parsing is a series of digits, then check that it matches the input
         if [[ $VAT_COUNT =~ ^[0-9]+$ ]]; then

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -25,15 +25,14 @@ workflow GvsSitesOnlyVCF {
             input_vcf = gvs_extract_cohort_filtered_vcfs[i],
             input_vcf_index = gvs_extract_cohort_filtered_vcf_indices[i],
             service_account_json_path = service_account_json_path,
-            output_filename = "${output_sites_only_file_name}_${i}.sites_only.vcf.gz",
-            custom_annotations_template = AnAcAf_annotations_template
+            output_filename = "${output_sites_only_file_name}_${i}.sites_only.vcf.gz"
         }
 
         call ExtractAnAcAfFromVCF {
           input:
             input_vcf = SitesOnlyVcf.output_vcf,
             input_vcf_index = SitesOnlyVcf.output_vcf_idx,
-            custom_annotations_template = SitesOnlyVcf.annotations_template
+            custom_annotations_template = AnAcAf_annotations_template
         }
 
         call AnnotateVCF {
@@ -85,7 +84,6 @@ task SitesOnlyVcf {
         File input_vcf_index
         String? service_account_json_path
         String output_filename
-        File custom_annotations_template
     }
     String output_vcf_idx = basename(output_filename) + ".tbi"
 
@@ -124,9 +122,6 @@ task SitesOnlyVcf {
                 --sites-only-vcf-output \
                 -O ~{output_filename}
 
-
-        gsutil cp ~{custom_annotations_template} .
-
      >>>
     # ------------------------------------------------
     # Runtime settings:
@@ -142,7 +137,6 @@ task SitesOnlyVcf {
     output {
         File output_vcf="~{output_filename}"
         File output_vcf_idx="~{output_vcf_idx}"
-        File annotations_template="~{custom_annotations_template}"
     }
 }
 

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -165,7 +165,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "biocontainers/bcftools:v1.9-1-deb_cv1"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210726"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -287,7 +287,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20200718"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210726"
         memory: "3 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
+++ b/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
@@ -175,11 +175,10 @@ def make_annotated_json_row(row_position, variant_line, transcript_line):
       row["revel"] = variant_line.get("revel").get("score")
 
     gvs_annotations = variant_line["gvsAnnotations"]
-    if gvs_annotations.get("AC") < 19: # if AC is between 1-18, make the value 19 and then recalculate AF as 19 / AN (we already checked for AC=0)
-      print("I am 19!", variant_line.get("vid"))
-      row["gvs_all_ac"] = 19
+    if gvs_annotations.get("AC") < 20: # if AC is between 1-19, make the value 20 and then recalculate AF as 20 / AN (we already checked for AC=0)
+      row["gvs_all_ac"] = 20
       row["gvs_all_an"] = gvs_annotations.get("AN")
-      row["gvs_all_af"] = 19 / gvs_annotations.get("AN")
+      row["gvs_all_af"] = 20 / gvs_annotations.get("AN")
     else:
       for vat_gvs_alleles_fieldname in vat_nirvana_gvs_alleles_dictionary.keys():  # like "gvs_all_ac"
         nirvana_gvs_alleles_fieldname = vat_nirvana_gvs_alleles_dictionary.get(vat_gvs_alleles_fieldname)


### PR DESCRIPTION
Unlike the other validation rules, this does not test the validity of the VAT, but whether the pipeline completed as we expected it to--so I have added this as the singular test that runs during the pipeline.

Validation Rule 2: The number of passing variants in GVS matches the number of variants in the VAT. Please note that we are counting the number of variants in GVS, not the number of sites, which may add a difficulty to this task.

Another way to phrase it: "If I were to make a sites only VCF of GVS and split each passing variant into it's own line, that number should equal the number of unique VIDs in the VAT."

Measure number of unique variants in sites only VCF that is generated.

We don't want to count filtered variants so we can't count the GVS table.


NOTE:

this pr also has some general cleanup as per discussion with Andrea. 
where would y'all suggest I put the template file for the custom annotations?


