### PR TITLE
Improve error message in GenomicsDBImport

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -993,7 +993,8 @@ public final class GenomicsDBImport extends GATKTool {
                 }
             };
         } catch (final TribbleException e){
-            throw new UserException("Failed to create reader from " + variantURI, e);
+            throw new UserException("Failed to create reader from " + variantURI + " because of the following error:\n\t"
+                    + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
* The UserException when failing to open a FeatureReader now includes the message from the underlying TribbleException.
* It was previously hard to understand WHY we had failed to open a reader.