### PR TITLE
Batching of samples for create import TSVs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -83,6 +83,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - kc_batch_tsv
    - name: GvsPrepareCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -424,8 +424,8 @@ task CreateFOFNs {
          set -e
 
          split -d -a 5 -l ~{batch_size} ~{input_vcf_list} batched_vcfs.
-         split -d -a 5 -l ~{batch_size} ~{input_vcf_list} batched_vcf_indexes.
-         split -d -a 5 -l ~{batch_size} ~{input_vcf_list} batched_sample_names.
+         split -d -a 5 -l ~{batch_size} ~{input_vcf_index_list} batched_vcf_indexes.
+         split -d -a 5 -l ~{batch_size} ~{sample_name_list} batched_sample_names.
      }
 
      runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -512,9 +512,9 @@ task CreateImportTsvs {
       fi
 
       # translate WDL arrays into BASH arrays
-      VCFS_ARRAY="(~{sep=" " input_vcfs})"
-      VCF_INDEXES_ARRAY="(~{sep=" " input_vcf_indexes})"
-      SAMPLE_NAMES_ARRAY="(~{sep=" " sample_names})"
+      VCFS_ARRAY=(~{sep=" " input_vcfs})
+      VCF_INDEXES_ARRAY=(~{sep=" " input_vcf_indexes})
+      SAMPLE_NAMES_ARRAY=(~{sep=" " sample_names})
 
       # loop over the BASH arrays (See https://stackoverflow.com/questions/6723426/looping-over-arrays-printing-both-index-and-value)
       for i in "${!VCFS_ARRAY[@]}"; do


### PR DESCRIPTION
Processing an exome takes ~1 minute, which means most of the time is spent on spinning up a VM, pulling docker images, etc.  This is not very cost efficient.  This PR allows for a `batch_size` to be set and then each task processes that many samples as a unit.  The default is `1` which yields the current behavior, but in exomes I have set it to 20 and seen the cost to ingest drop dramatically

The GitHub PR makes it look like a lot has changed but really the changes are:
 - a new parameter
 - a new task to turn the Array[File] for the VCFs into set of FOFNs (file-of-file-names) similar to how we split up intervals
 - a loop in the actual Create TSV task to loop over the files in the FOFNs.  For SA mode we copy down each file, and for non-SA mode we rely on the fact that localization is optional and we read them directly anywy