### PR TITLE
Adding the subpopulation calculations to the VAT creation WDL

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -100,6 +100,7 @@ workflows:
      filters:
        branches:
          - ah_var_store
+         - rc-vs-164-subpop
    - name: GvsValidateVatTable
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -100,7 +100,6 @@ workflows:
      filters:
        branches:
          - ah_var_store
-         - rc-vs-164-subpop
    - name: GvsValidateVatTable
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl

--- a/scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl
@@ -81,6 +81,14 @@ workflow GvsValidateVatTable {
             last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
     }
 
+    call SubpopulationMax {
+        input:
+            query_project_id = query_project_id,
+            fq_vat_table = fq_vat_table,
+            service_account_json_path = service_account_json_path,
+            last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp
+    }
+
     output {
         Array[Map[String, String]] validation_results = [
             EnsureVatTableHasVariants.result,
@@ -90,7 +98,8 @@ workflow GvsValidateVatTable {
             SchemaNoNullRequiredFields.result,
             SchemaPrimaryKey.result,
             SchemaEnsemblTranscripts.result,
-            SchemaNonzeroAcAn.result
+            SchemaNonzeroAcAn.result,
+            SubpopulationMax.result
         ]
     }
 }
@@ -594,9 +603,9 @@ task SchemaNullTranscriptsExist {
         set -e
 
         if [ ~{has_service_account_file} = 'true' ]; then
-        gsutil cp ~{service_account_json_path} local.service_account.json
-        gcloud auth activate-service-account --key-file=local.service_account.json
-        gcloud config set project ~{query_project_id}
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            gcloud auth activate-service-account --key-file=local.service_account.json
+            gcloud config set project ~{query_project_id}
         fi
         echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
 
@@ -631,5 +640,63 @@ task SchemaNullTranscriptsExist {
     # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
     output {
         Map[String, String] result = {"SchemaNullTranscriptsExist": read_string('validation_results.txt')}
+    }
+}
+
+task SubpopulationMax {
+    input {
+        String query_project_id
+        String fq_vat_table
+        String? service_account_json_path
+        String last_modified_timestamp
+    }
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+
+    command <<<
+        set -e
+
+        if [ ~{has_service_account_file} = 'true' ]; then
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            gcloud auth activate-service-account --key-file=local.service_account.json
+            gcloud config set project ~{query_project_id}
+        fi
+        echo "project_id = ~{query_project_id}" > ~/.bigqueryrc
+
+        # gvs subpopulations:  [ "afr", "amr", "eas", "eur", "mid", "oth", "sas"]
+
+        bq query --nouse_legacy_sql --project_id=~{query_project_id} --format=csv 'SELECT
+            vid
+        FROM
+            ~{fq_vat_table}
+        WHERE
+            gvs_max_af < gvs_afr_af OR
+            gvs_max_af < gvs_amr_af OR
+            gvs_max_af < gvs_eas_af OR
+            gvs_max_af < gvs_eur_af OR
+            gvs_max_af < gvs_mid_af OR
+            gvs_max_af < gvs_oth_af OR
+            gvs_max_af < gvs_sas_af'
+
+        # if the result of the query has any rows, that means there were null transcripts
+        if [[ $NUMRESULTS != "0" ]]; then
+          echo "PASS: The VAT table ~{fq_vat_table} has a correct calculation for subpopulation" > validation_results.txt
+        else
+          echo "FAIL: The VAT table ~{fq_vat_table} has an incorrect calculation for subpopulation" > validation_results.txt
+        fi
+    >>>
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        memory: "1 GB"
+        preemptible: 3
+        cpu: "1"
+        disks: "local-disk 100 HDD"
+    }
+    # ------------------------------------------------
+    # Output: {"Name of validation rule": "PASS/FAIL plus additional validation results"}
+    output {
+        Map[String, String] result = {"SubpopulationMax": read_string('validation_results.txt')}
     }
 }

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
@@ -1,15 +1,16 @@
 {
-  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcfs": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz", "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/Data/gvs_features_0.vcf.gz"],
-  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcf_indices": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz.tbi", "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/Data/gvs_features_0.vcf.gz.tbi"],
+  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcfs": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz"],
+  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcf_indices": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz.tbi"],
   "GvsSitesOnlyVCF.output_sites_only_file_name": "hello_did_I_sites_only",
   "GvsSitesOnlyVCF.output_annotated_file_name": "hello_did_I_annotate",
   "GvsSitesOnlyVCF.nirvana_data_directory": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/NirvanaData.tar.gz",
   "GvsSitesOnlyVCF.vat_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/vat_schema.json",
   "GvsSitesOnlyVCF.variant_transcript_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/vt_schema.json",
   "GvsSitesOnlyVCF.genes_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/genes_schema.json",
-  "GvsSitesOnlyVCF.output_path": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/output/jul13/",
-  "GvsSitesOnlyVCF.table_suffix": "jul13",
+  "GvsSitesOnlyVCF.output_path": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/output/aug09/",
+  "GvsSitesOnlyVCF.table_suffix": "aug09",
   "GvsSitesOnlyVCF.project_id": "spec-ops-aou",
   "GvsSitesOnlyVCF.dataset_name": "anvil_100_for_testing",
   "GvsSitesOnlyVCF.AnAcAf_annotations_template": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/custom_annotations_template.tsv",
+  "GvsSitesOnlyVCF.sample_list": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/subpop.tsv"
 }

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
@@ -7,10 +7,10 @@
   "GvsSitesOnlyVCF.vat_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/vat_schema.json",
   "GvsSitesOnlyVCF.variant_transcript_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/vt_schema.json",
   "GvsSitesOnlyVCF.genes_schema_json_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/schemas/genes_schema.json",
-  "GvsSitesOnlyVCF.output_path": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/output/aug09/",
-  "GvsSitesOnlyVCF.table_suffix": "aug09",
+  "GvsSitesOnlyVCF.output_path": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/output/aug12/",
+  "GvsSitesOnlyVCF.table_suffix": "aug12",
   "GvsSitesOnlyVCF.project_id": "spec-ops-aou",
   "GvsSitesOnlyVCF.dataset_name": "anvil_100_for_testing",
   "GvsSitesOnlyVCF.AnAcAf_annotations_template": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/custom_annotations_template.tsv",
-  "GvsSitesOnlyVCF.sample_list": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/subpop.tsv"
+  "GvsSitesOnlyVCF.ancestry_file": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/subpop.tsv"
 }

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -188,7 +188,7 @@ task GetSubpopulationCalculations {
         set -e
 
         # get a list of all samples in this subpopulation
-        grep ~{subpopulation} ~{subpopulation_mapping} | cut -d " " -f1 > ~{subpopulation_sample_list}
+        grep ~{subpopulation} ~{subpopulation_mapping} | awk '{ print $1 }' > ~{subpopulation_sample_list}
 
 
         if [ ~{has_service_account_file} = 'true' ]; then
@@ -213,9 +213,9 @@ task GetSubpopulationCalculations {
         gatk --java-options "-Xmx2048m" \
             SelectVariants \
                 -V ~{updated_input_vcf} \
-                --add-output-vcf-command-line false \
                 -sn ~{subpopulation_sample_list} \
                 --add-output-vcf-command-line false \
+                --allow-nonoverlapping-command-line-samples \
                 --exclude-filtered \
                 -O ~{output_filename}
 

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -121,11 +121,6 @@ task MakeSubpopulationFile {
     String input_file_basename = basename(input_ancestry_file)
     String updated_input_file = if (defined(service_account_json_path)) then input_file_basename else input_ancestry_file
 
-    parameter_meta {
-        input_ancestry_file: {
-          localization_optional: true
-        }
-    }
     command <<<
         set -e
 

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -469,6 +469,7 @@ task PrepAnnotationJson {
     String output_genes_json = "vat_genes_bq_load" + output_file_suffix
     String output_vt_gcp_path = output_path + 'vt/'
     String output_genes_gcp_path = output_path + 'genes/'
+    String output_annotations_gcp_path = output_path + 'annotations/'
 
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
 
@@ -488,6 +489,9 @@ task PrepAnnotationJson {
 
         gsutil cp ~{output_vt_json} '~{output_vt_gcp_path}'
         gsutil cp ~{output_genes_json} '~{output_genes_gcp_path}'
+
+        # for debugging only
+        gsutil cp ~{annotation_json} '~{output_annotations_gcp_path}'
 
      >>>
     # ------------------------------------------------

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -190,7 +190,7 @@ task ExtractAcAnAfFromSubpopulationVCFs {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210808"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210812"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -290,7 +290,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210808"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210812"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -426,7 +426,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210808"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_20210812"
         memory: "3 GB"
         preemptible: 5
         cpu: "1"
@@ -542,6 +542,31 @@ task BigQueryLoadJson {
               v.gvs_all_ac,
               v.gvs_all_an,
               v.gvs_all_af,
+              v.gvs_max_af,
+              v.gvs_max_ac,
+              v.gvs_max_an,
+              v.gvs_max_subpop,
+              v.gvs_afr_ac,
+              v.gvs_afr_an,
+              v.gvs_afr_af,
+              v.gvs_amr_ac,
+              v.gvs_amr_an,
+              v.gvs_amr_af,
+              v.gvs_eas_ac,
+              v.gvs_eas_an,
+              v.gvs_eas_af,
+              v.gvs_eur_ac,
+              v.gvs_eur_an,
+              v.gvs_eur_af,
+              v.gvs_mid_ac,
+              v.gvs_mid_an,
+              v.gvs_mid_af,
+              v.gvs_oth_ac,
+              v.gvs_oth_an,
+              v.gvs_oth_af,
+              v.gvs_sas_ac,
+              v.gvs_sas_an,
+              v.gvs_sas_af,
               v.gene_symbol,
               v.transcript_source,
               v.aa_change,

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -400,7 +400,6 @@ task PrepAnnotationJson {
     String output_genes_json = "vat_genes_bq_load" + output_file_suffix
     String output_vt_gcp_path = output_path + 'vt/'
     String output_genes_gcp_path = output_path + 'genes/'
-    String output_annotations_gcp_path = output_path + 'annotations/'
 
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
 
@@ -418,7 +417,6 @@ task PrepAnnotationJson {
             gcloud auth activate-service-account --key-file=local.service_account.json
         fi
 
-        gsutil cp ~{annotation_json} '~{output_annotations_gcp_path}'
         gsutil cp ~{output_vt_json} '~{output_vt_gcp_path}'
         gsutil cp ~{output_genes_json} '~{output_genes_gcp_path}'
 

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -109,7 +109,7 @@ workflow GvsSitesOnlyVCF {
 
 ################################################################################
 
-task MakeSubpopulationFiles { ## TODO why am I seemingly able to get the ancestry file in Terra? is it cached? I should need the SA for it---so actually, but me worth trying the SA use sooner
+task MakeSubpopulationFiles {
     input {
         File input_ancestry_file
     }
@@ -512,6 +512,8 @@ task BigQueryLoadJson {
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
 
     command <<<
+
+       echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
        if [ ~{has_service_account_file} = 'true' ]; then
             gsutil cp ~{service_account_json_path} local.service_account.json

--- a/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
+++ b/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
@@ -103,6 +103,16 @@ gnomad_ordering = [
 ]
 
 
+gvs_subpopulations = [
+  "afr",
+  "amr",
+  "eas",
+  "eur",
+  "mid",
+  "oth",
+  "sas"
+]
+
 def check_filtering(variant):
     # skip any row (with a warning) if no gvsAnnotations exist
     if variant.get("gvsAnnotations") == None: # <-- enum since we need this to be in tandem with the custom annotations header / template
@@ -126,10 +136,6 @@ def check_filtering(variant):
       return True
 
 def get_gnomad_subpop(gnomad_obj):
-    row = {}
-    max_af = None
-    max_ac = None
-    max_an = None
     max_subpop = ""
     for gnomad_subpop in gnomad_ordering: # since we cycle through this in order, if there is a tie, we just ignore it because we wouldn't chose it anyway based on order
       subpop_af_key = "".join([gnomad_subpop, "Af"])
@@ -156,6 +162,35 @@ def get_gnomad_subpop(gnomad_obj):
     row["gnomad_max_af"] = max_af
     return row
 
+
+def get_subpopulation_calculations(variant):
+    row = {}
+    max_af = None
+    max_ac = None
+    max_an = None
+    for gvs_subpop in gvs_subpopulations: # TODO check with Lee on order
+      subpop_annotations = variant.get("".join([gvs_subpop, "SubpopulationAnnotations"]))
+      if variant.get(subpop_annotations) != None:
+        subpop_ac_val = subpop_annotations.get("AC") # note that these can be null if there is no value in the annotations. They will be null in the VAT
+        subpop_an_val = subpop_annotations.get("AN")
+        subpop_af_val = subpop_annotations.get("AF")
+        # here we set the subpopulation ac/an/af values
+        row["_".join(["gvs", gvs_subpop, "ac"])] = subpop_ac_val
+        row["_".join(["gvs", gvs_subpop, "an"])] = subpop_an_val
+        row["_".join(["gvs", gvs_subpop, "af"])] = subpop_af_val
+        if subpop_af_val != None and max_af == None: # this will set the first max_af value
+          max_af = subpop_af_val
+        if subpop_af_val != None and subpop_af_val > max_af:
+          max_subpop = gvs_subpop
+          max_ac = subpop_ac_val
+          max_an = subpop_an_val
+          max_af = subpop_af_val
+    # here we set the MAX subpopulation ac/an/af values
+    row["gvs_max_subpop"] = max_subpop
+    row["gvs_max_ac"] = max_ac
+    row["gvs_max_an"] = max_an
+    row["gvs_max_af"] = max_af
+    return row
 
 def make_annotated_json_row(row_position, variant_line, transcript_line):
     row = {}
@@ -230,6 +265,8 @@ def make_annotated_json_row(row_position, variant_line, transcript_line):
         nirvana_gvs_alleles_fieldname = vat_nirvana_gvs_alleles_dictionary.get(vat_gvs_alleles_fieldname)
         gvs_alleles_fieldvalue = gvs_annotations.get(nirvana_gvs_alleles_fieldname)
         row[vat_gvs_alleles_fieldname] = gvs_alleles_fieldvalue
+    subpopulation_info = get_subpopulation_calculations(variant_line)
+    row.update(subpopulation_infof)
 
     return row
 

--- a/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
+++ b/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
@@ -151,7 +151,7 @@ def get_gnomad_subpop(gnomad_obj):
       row["_".join(["gnomad", gnomad_subpop, "an"])] = subpop_an_val
       row["_".join(["gnomad", gnomad_subpop, "ac"])] = subpop_ac_val
       row["_".join(["gnomad", gnomad_subpop, "af"])] = subpop_af_val
-      if subpop_af_val != None and (subpop_af_val > max_af or max_af == None): # this will also set the first max_af value
+      if subpop_af_val != None and (max_af == None or subpop_af_val > max_af): # this will also set the first max_af value
         max_subpop = gnomad_subpop
         max_ac = subpop_ac_val
         max_an = subpop_an_val
@@ -180,7 +180,7 @@ def get_subpopulation_calculations(variant_obj):
         row["_".join(["gvs", gvs_subpop, "ac"])] = subpop_ac_val
         row["_".join(["gvs", gvs_subpop, "an"])] = subpop_an_val
         row["_".join(["gvs", gvs_subpop, "af"])] = subpop_af_val
-        if subpop_af_val != None and(subpop_af_val > max_af or max_af == None): # this will also set the first max_af value
+        if subpop_af_val != None and(max_af == None or subpop_af_val > max_af): # this will also set the first max_af value
           max_subpop = gvs_subpop
           max_ac = subpop_ac_val
           max_an = subpop_an_val

--- a/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
+++ b/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
@@ -102,7 +102,6 @@ gnomad_ordering = [
  "sas"
 ]
 
-
 gvs_subpopulations = [
   "afr",
   "amr",
@@ -136,6 +135,10 @@ def check_filtering(variant):
       return True
 
 def get_gnomad_subpop(gnomad_obj):
+    row = {}
+    max_ac = None
+    max_an = None
+    max_af = None
     max_subpop = ""
     for gnomad_subpop in gnomad_ordering: # since we cycle through this in order, if there is a tie, we just ignore it because we wouldn't chose it anyway based on order
       subpop_af_key = "".join([gnomad_subpop, "Af"])
@@ -148,9 +151,7 @@ def get_gnomad_subpop(gnomad_obj):
       row["_".join(["gnomad", gnomad_subpop, "an"])] = subpop_an_val
       row["_".join(["gnomad", gnomad_subpop, "ac"])] = subpop_ac_val
       row["_".join(["gnomad", gnomad_subpop, "af"])] = subpop_af_val
-      if subpop_af_val != None and max_af == None: # this will set the first max_af value
-        max_af = subpop_af_val
-      if subpop_af_val != None and subpop_af_val > max_af:
+      if subpop_af_val != None and (subpop_af_val > max_af or max_af == None): # this will also set the first max_af value
         max_subpop = gnomad_subpop
         max_ac = subpop_ac_val
         max_an = subpop_an_val
@@ -163,14 +164,15 @@ def get_gnomad_subpop(gnomad_obj):
     return row
 
 
-def get_subpopulation_calculations(variant):
+def get_subpopulation_calculations(variant_obj):
     row = {}
-    max_af = None
     max_ac = None
     max_an = None
+    max_af = None
+    max_subpop = ""
     for gvs_subpop in gvs_subpopulations: # TODO check with Lee on order
-      subpop_annotations = variant.get("".join([gvs_subpop, "SubpopulationAnnotations"]))
-      if variant.get(subpop_annotations) != None:
+      subpop_annotations = variant_obj.get("".join([gvs_subpop, "SubpopulationAnnotations"]))
+      if subpop_annotations != None:
         subpop_ac_val = subpop_annotations.get("AC") # note that these can be null if there is no value in the annotations. They will be null in the VAT
         subpop_an_val = subpop_annotations.get("AN")
         subpop_af_val = subpop_annotations.get("AF")
@@ -178,9 +180,7 @@ def get_subpopulation_calculations(variant):
         row["_".join(["gvs", gvs_subpop, "ac"])] = subpop_ac_val
         row["_".join(["gvs", gvs_subpop, "an"])] = subpop_an_val
         row["_".join(["gvs", gvs_subpop, "af"])] = subpop_af_val
-        if subpop_af_val != None and max_af == None: # this will set the first max_af value
-          max_af = subpop_af_val
-        if subpop_af_val != None and subpop_af_val > max_af:
+        if subpop_af_val != None and(subpop_af_val > max_af or max_af == None): # this will also set the first max_af value
           max_subpop = gvs_subpop
           max_ac = subpop_ac_val
           max_an = subpop_an_val
@@ -266,7 +266,7 @@ def make_annotated_json_row(row_position, variant_line, transcript_line):
         gvs_alleles_fieldvalue = gvs_annotations.get(nirvana_gvs_alleles_fieldname)
         row[vat_gvs_alleles_fieldname] = gvs_alleles_fieldvalue
     subpopulation_info = get_subpopulation_calculations(variant_line)
-    row.update(subpopulation_infof)
+    row.update(subpopulation_info)
 
     return row
 

--- a/scripts/variantstore/wdl/extract/extract_subpop.py
+++ b/scripts/variantstore/wdl/extract/extract_subpop.py
@@ -25,6 +25,7 @@ def extract_subpopulation(input_path):
           csvout = csv.writer(output_file, delimiter='\t')
           # add sample name to the subpopulation file
           csvout.writerow([row[0]])
+          output_file.close()
         else:
           seen_subpopulations.append(row_subpopulation)
           # Create a new file for this subpopulation
@@ -32,10 +33,9 @@ def extract_subpopulation(input_path):
           csvout = csv.writer(output_file, delimiter='\t')
           # add sample name to the subpopulation file
           csvout.writerow([row[0]])
-          print(seen_subpopulations)
+          output_file.close()
       else:
         print("WARNING: This list had an unexpected subpopulation", row_subpopulation)
-      ## TODO do I need to close these?
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(allow_abbrev=False, description='Extract subpopulation per sample data out of a callset TSV')

--- a/scripts/variantstore/wdl/extract/extract_subpop.py
+++ b/scripts/variantstore/wdl/extract/extract_subpop.py
@@ -21,14 +21,14 @@ def extract_subpopulation(input_path):
       if row_subpopulation in expected_subpopulations:
         if row_subpopulation in seen_subpopulations:
           # open the correct output file
-          output_file = open(row_subpopulation + "_subpopulation.tsv", 'a', newline='')
+          output_file = open(row_subpopulation + "_subpopulation.args", 'a', newline='')
           csvout = csv.writer(output_file, delimiter='\t')
           # add sample name to the subpopulation file
           csvout.writerow([row[0]])
         else:
           seen_subpopulations.append(row_subpopulation)
           # Create a new file for this subpopulation
-          output_file = open(row_subpopulation + "_subpopulation.tsv", 'w', newline='')
+          output_file = open(row_subpopulation + "_subpopulation.args", 'w', newline='')
           csvout = csv.writer(output_file, delimiter='\t')
           # add sample name to the subpopulation file
           csvout.writerow([row[0]])

--- a/scripts/variantstore/wdl/extract/extract_subpop.py
+++ b/scripts/variantstore/wdl/extract/extract_subpop.py
@@ -1,33 +1,47 @@
 import csv
 import argparse
 
-subpopulations = [
+expected_subpopulations = [
  "afr",
  "amr",
  "eas",
- "fin",
- "nfr",
- "asj",
+ "eur",
+ "mid",
  "oth",
  "sas"
 ]
 
-def extract_subpopulation(input_path, output_path):
-  with open(input_path, newline='') as tsvin, open(output_path, 'w', newline='') as csvout:
+def extract_subpopulation(input_path):
+  seen_subpopulations = []
+  with open(input_path, newline='') as tsvin:
     tsvin = csv.reader(tsvin, delimiter='\t')
-    csvout = csv.writer(csvout, delimiter='\t')
-
+    next(tsvin) # skip the header
     for row in tsvin:
-      csvout.writerow([row[0], row[4]])
-
+      row_subpopulation = row[4]
+      if row_subpopulation in expected_subpopulations:
+        if row_subpopulation in seen_subpopulations:
+          # open the correct output file
+          output_file = open(row_subpopulation + "_subpopulation.tsv", 'a', newline='')
+          csvout = csv.writer(output_file, delimiter='\t')
+          # add sample name to the subpopulation file
+          csvout.writerow([row[0]])
+        else:
+          seen_subpopulations.append(row_subpopulation)
+          # Create a new file for this subpopulation
+          output_file = open(row_subpopulation + "_subpopulation.tsv", 'w', newline='')
+          csvout = csv.writer(output_file, delimiter='\t')
+          # add sample name to the subpopulation file
+          csvout.writerow([row[0]])
+          print(seen_subpopulations)
+      else:
+        print("WARNING: This list had an unexpected subpopulation", row_subpopulation)
+      ## TODO do I need to close these?
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(allow_abbrev=False, description='Extract subpopulation per sample data out of a callset TSV')
   parser.add_argument('--input_path',type=str, metavar='path', help='path to the original callset TSV', required=True)
-  parser.add_argument('--output_path',type=str, metavar='path', help='path for the output TSV', required=True)
 
   args = parser.parse_args()
 
-  extract_subpopulation(args.input_path,
-                        args.output_path)
+  extract_subpopulation(args.input_path)
 

--- a/scripts/variantstore/wdl/extract/extract_subpop.py
+++ b/scripts/variantstore/wdl/extract/extract_subpop.py
@@ -1,6 +1,17 @@
 import csv
 import argparse
 
+subpopulations = [
+ "afr",
+ "amr",
+ "eas",
+ "fin",
+ "nfr",
+ "asj",
+ "oth",
+ "sas"
+]
+
 def extract_subpopulation(input_path, output_path):
   with open(input_path, newline='') as tsvin, open(output_path, 'w', newline='') as csvout:
     tsvin = csv.reader(tsvin, delimiter='\t')

--- a/scripts/variantstore/wdl/schemas/variant_transcript_schema.json
+++ b/scripts/variantstore/wdl/schemas/variant_transcript_schema.json
@@ -126,6 +126,156 @@
     "mode": "Required"
   },
   {
+    "description": "AoU: Max subpopulation frequency",
+    "name": "gvs_max_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation allele count",
+    "name": "gvs_max_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation allele number",
+    "name": "gvs_max_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation ancestry",
+    "name": "gvs_max_subpop",
+    "type": "String",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the afr subpop",
+    "name": "gvs_afr_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the afr subpop",
+    "name": "gvs_afr_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the afr subpop",
+    "name": "gvs_afr_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the amr subpop",
+    "name": "gvs_amr_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the amr subpop",
+    "name": "gvs_amr_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the amr subpop",
+    "name": "gvs_amr_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the eas subpop",
+    "name": "gvs_eas_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the eas subpop",
+    "name": "gvs_eas_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the eas subpop",
+    "name": "gvs_eas_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the eur subpop",
+    "name": "gvs_eur_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the eur subpop",
+    "name": "gvs_eur_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the eur subpop",
+    "name": "gvs_eur_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the mid subpop",
+    "name": "gvs_mid_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the mid subpop",
+    "name": "gvs_mid_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the mid subpop",
+    "name": "gvs_mid_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the oth subpop",
+    "name": "gvs_oth_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the oth subpop",
+    "name": "gvs_oth_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the oth subpop",
+    "name": "gvs_oth_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the sas subpop",
+    "name": "gvs_sas_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the sas subpop",
+    "name": "gvs_sas_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the sas subpop",
+    "name": "gvs_sas_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
     "description": "REVEL",
     "name": "revel",
     "type": "Float",

--- a/scripts/variantstore/wdl/schemas/vat_schema.json
+++ b/scripts/variantstore/wdl/schemas/vat_schema.json
@@ -126,9 +126,159 @@
     "mode": "Required"
   },
   {
+    "description": "AoU: Max subpopulation frequency",
+    "name": "gvs_max_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation allele count",
+    "name": "gvs_max_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation allele number",
+    "name": "gvs_max_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: Max subpopulation ancestry",
+    "name": "gvs_max_subpop",
+    "type": "String",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the afr subpop",
+    "name": "gvs_afr_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the afr subpop",
+    "name": "gvs_afr_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the afr subpop",
+    "name": "gvs_afr_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the amr subpop",
+    "name": "gvs_amr_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the amr subpop",
+    "name": "gvs_amr_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the amr subpop",
+    "name": "gvs_amr_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the eas subpop",
+    "name": "gvs_eas_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the eas subpop",
+    "name": "gvs_eas_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the eas subpop",
+    "name": "gvs_eas_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the eur subpop",
+    "name": "gvs_eur_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the eur subpop",
+    "name": "gvs_eur_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the eur subpop",
+    "name": "gvs_eur_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the mid subpop",
+    "name": "gvs_mid_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the mid subpop",
+    "name": "gvs_mid_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the mid subpop",
+    "name": "gvs_mid_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the oth subpop",
+    "name": "gvs_oth_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the oth subpop",
+    "name": "gvs_oth_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the oth subpop",
+    "name": "gvs_oth_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele count in the sas subpop",
+    "name": "gvs_sas_ac",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele number in the sas subpop",
+    "name": "gvs_sas_an",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
+    "description": "AoU: allele frequency in the sas subpop",
+    "name": "gvs_sas_af",
+    "type": "Float",
+    "mode": "Nullable"
+  },
+  {
     "description": "REVEL",
     "name": "revel",
-    "type": "FLOAT",
+    "type": "Float",
     "mode": "Nullable"
   },
   {


### PR DESCRIPTION
This pr adds the subpopulation AC/AN/AF calculations.
It does this by taking in the ancestry table and making sublists of each---then passing that list of samples into the SelectVariants GATK tool


Updated Lucid chart here: https://lucid.app/lucidchart/fee376a4-4b72-481e-a239-a027f7f6ab1f/edit?page=CsG3hy3S1zEH#

Design Doc for this work:
https://docs.google.com/document/d/1FnPu_Jkz2O9rElApAQld0v6iBEFGe22dKarVWcwNxGI/edit


misc:
how should I add the VAT validation to the VAT pipeline? Should it run automatically?

Anvil data version of this table: spec-ops-aou:anvil_100_for_testing.vat_aug19


<img width="1379" alt="Screen Shot 2021-08-11 at 5 38 22 PM" src="https://user-images.githubusercontent.com/6863459/129606564-bfc20a68-119a-4072-88b4-aeaf011cc965.png">
