### PR TITLE
Fixed bug resulting from prefix strings of less than 3 characters when creating temporary files in GermlineCNVCaller and improved documentation of corresponding utility methods.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
@@ -431,7 +431,8 @@ public final class GermlineCNVCaller extends CommandLineProgram {
         final List<File> intervalSubsetReadCountFiles = new ArrayList<>(inputReadCountPaths.size());
         streamOfSubsettedAndValidatedReadCounts(inputReadCountPaths, specifiedIntervals, logger)
                 .forEach(subsetReadCounts -> {
-                    final File intervalSubsetReadCountFile = IOUtils.createTempFile(subsetReadCounts.getMetadata().getSampleName(), ".tsv");
+                    final File intervalSubsetReadCountFile = IOUtils.createTempFile(
+                            subsetReadCounts.getMetadata().getSampleName() + ".rc", ".tsv"); // we add ".rc" to ensure prefix will be >= 3 characters, see https://github.com/broadinstitute/gatk/issues/7410
                     subsetReadCounts.write(intervalSubsetReadCountFile);
                     intervalSubsetReadCountFiles.add(intervalSubsetReadCountFile);
                 });

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -97,7 +97,7 @@ public final class IOUtils {
      * Writes content to a temp file and returns the path to the temporary file.
      *
      * @param content   to write.
-     * @param prefix    Prefix for the temp file.
+     * @param prefix    Prefix for the temp file; {@link File#createTempFile(String, String, File)} requires that this be >= 3 characters
      * @param suffix    Suffix for the temp file.
      * @return the path to the temp file.
      */
@@ -109,7 +109,7 @@ public final class IOUtils {
      * Writes content to a temp file and returns the path to the temporary file.
      *
      * @param content   to write.
-     * @param prefix    Prefix for the temp file.
+     * @param prefix    Prefix for the temp file; {@link File#createTempFile(String, String, File)} requires that this be >= 3 characters
      * @param suffix    Suffix for the temp file.
      * @param directory Directory for the temp file.
      * @return the path to the temp file.
@@ -658,7 +658,7 @@ public final class IOUtils {
      * Creates a temp file that will be deleted on exit
      *
      * This will also mark the corresponding Tribble/Tabix/BAM indices matching the temp file for deletion.
-     * @param name Prefix of the file.
+     * @param name Prefix of the file; {@link File#createTempFile(String, String, File)} requires that this be >= 3 characters
      * @param extension Extension to concat to the end of the file.
      * @return A file in the temporary directory starting with name, ending with extension, which will be deleted after the program exits.
      */
@@ -670,7 +670,7 @@ public final class IOUtils {
      * Creates a temp file in a target directory that will be deleted on exit
      *
      * This will also mark the corresponding Tribble/Tabix/BAM indices matching the temp file for deletion.
-     * @param name Prefix of the file.
+     * @param name Prefix of the file; {@link File#createTempFile(String, String, File)} requires that this be >= 3 characters
      * @param extension Extension to concat to the end of the file name.
      * @param targetDir Directory in which to create the temp file. If null, the default temp directory is used.
      * @return A file in the temporary directory starting with name, ending with extension, which will be deleted after the program exits.


### PR DESCRIPTION
Closes #7410.