### PR TITLE
Adding comment to .travis.yml about the checkout depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 dist: bionic
 group: travis_lts
 git:
+  # We intentionally check out the entire repo history because we hit errors during the build if the most recent tag isn't in our history for `git describe`
   depth: 9999999
   lfs_skip_smudge: true
 jdk:


### PR DESCRIPTION
* Adding a comment explaining why we checkout the entire repo history in travis.
* This caused some understandable confusion.  See https://github.com/broadinstitute/gatk/pull/7418
 
@YunLemon I've added a comment to the .travis.yml file about the depth.  It's definitely a bit weird and confusing if you don't know the history of why we ended up doing that.  