### PR TITLE
Scaling the VAT -- switch the input to take in a file of vcf shard file names

### DIFF
--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.example.inputs.json
@@ -1,6 +1,6 @@
 {
-  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcfs": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz"],
-  "GvsSitesOnlyVCF.gvs_extract_cohort_filtered_vcf_indices": ["gs://broad-dsp-spec-ops/kcibul/ft/gvs.chr20.vcf.gz.tbi"],
+  "GvsSitesOnlyVCF.inputFileofFileNames": "GS_PATH_TO_FILE_OF_FILE_NAMES",
+  "GvsSitesOnlyVCF.inputFileofIndexFileNames": "GS_PATH_TO_FILE_OF_FILE_INDICES",
   "GvsSitesOnlyVCF.output_sites_only_file_name": "hello_did_I_sites_only",
   "GvsSitesOnlyVCF.output_annotated_file_name": "hello_did_I_annotate",
   "GvsSitesOnlyVCF.nirvana_data_directory": "gs://broad-dsp-spec-ops/scratch/rcremer/Nirvana/NirvanaData.tar.gz",

--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -1,8 +1,8 @@
 version 1.0
 workflow GvsSitesOnlyVCF {
    input {
-        Array[File] gvs_extract_cohort_filtered_vcfs
-        Array[File] gvs_extract_cohort_filtered_vcf_indices
+        File inputFileofFileNames
+        File inputFileofIndexFileNames
         String output_sites_only_file_name
         String output_annotated_file_name
         String project_id
@@ -19,6 +19,8 @@ workflow GvsSitesOnlyVCF {
         File AnAcAf_annotations_template
         File ancestry_file
     }
+    Array[File] gvs_extract_cohort_filtered_vcfs = read_lines(inputFileofFileNames)
+    Array[File] gvs_extract_cohort_filtered_vcf_indices  = read_lines(inputFileofIndexFileNames)
 
     call MakeSubpopulationFiles {
         input:


### PR DESCRIPTION
Should I make this backward compatible and allow either this input as a file of file names OR an array of files?

