### PR TITLE
Make the pre-vat tables temp tables

### DIFF
--- a/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
+++ b/scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl
@@ -517,6 +517,9 @@ task BigQueryLoadJson {
 
        echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
+       DATE = 86400 ## 24 hours in seconds
+
+
        if [ ~{has_service_account_file} = 'true' ]; then
             gsutil cp ~{service_account_json_path} local.service_account.json
             export GOOGLE_APPLICATION_CREDENTIALS=local.service_account.json
@@ -531,7 +534,7 @@ task BigQueryLoadJson {
 
        if [ $BQ_SHOW_RC -ne 0 ]; then
          echo "Creating a pre-vat table ~{dataset_name}.~{variant_transcript_table}"
-         bq --location=US mk --project_id=~{project_id}  ~{dataset_name}.~{variant_transcript_table} ~{vt_schema}
+         bq --location=US mk --expiration=$DATE --project_id=~{project_id}  ~{dataset_name}.~{variant_transcript_table} ~{vt_schema}
        fi
 
        echo "Loading data into a pre-vat table ~{dataset_name}.~{variant_transcript_table}"
@@ -546,7 +549,7 @@ task BigQueryLoadJson {
 
        if [ $BQ_SHOW_RC -ne 0 ]; then
          echo "Creating a pre-vat table ~{dataset_name}.~{genes_table}"
-         bq --location=US mk --project_id=~{project_id}  ~{dataset_name}.~{genes_table} ~{genes_schema}
+         bq --location=US mk --expiration=$DATE --project_id=~{project_id}  ~{dataset_name}.~{genes_table} ~{genes_schema}
        fi
 
        echo "Loading data into a pre-vat table ~{dataset_name}.~{genes_table}"


### PR DESCRIPTION
The VAT pipeline creates 3 tables, 2 are intermediary tables used to create the third.

I was tired of deleting them, so I made them temp tables


<img width="565" alt="Screen Shot 2021-09-16 at 10 44 09 AM" src="https://user-images.githubusercontent.com/6863459/133633262-a41466a9-2cae-4b69-8c61-28e81d1a8706.png">
