### PR TITLE
Add manifest summary file to GvsExtractCallset

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -387,7 +387,7 @@ task CreateManifest {
 
     command <<<
         set -e
-        MANIFEST_LINES_TXT=~{write_object(manifest_intervals)}
+        MANIFEST_LINES_TXT=~{write_map(as_map(manifest_intervals))}
         cat ${MANIFEST_LINES_TXT}
         echo "interval_number, vcf_file_location, vcf_file_bytes, vcf_index_location, vcf_index_bytes" >> manifest.txt
         sort -n ${MANIFEST_LINES_TXT} >> manifest.txt

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -193,7 +193,7 @@ task ExtractTask {
                 ~{true='--emit-pls' false='' emit_pls} \
                 ${FILTERING_ARGS}
 
-        INTERVAL_NUMBER=$(echo ~{output_file} | grep -oEi '\d+\.vcf\.gz' | cut -d'.' -f1)
+        INTERVAL_NUMBER=$(echo ~{output_file} | grep -oEi '[0-9]+\.vcf\.gz' | cut -d'.' -f1)
 
         OUTPUT_FILE_BYTES=$(du -b ~{output_file} | cut -f1)
         echo ${OUTPUT_FILE_BYTES} > vcf_bytes.txt

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -214,7 +214,7 @@ task ExtractTask {
           OUTPUT_FILE_INDEX_DEST=~{output_file}.tbi
         fi
 
-        # Parent Task will collect manifest files and create a summary
+        # Parent Task will collect manifest lines and create a joined file
         # Currently, the schema is `[interval_number], [output_file_location], [output_file_size_bytes], [output_file_index_location], [output_file_size_bytes]`
         echo ${INTERVAL_NUMBER},${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
     >>>

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.1
 
 workflow GvsExtractCallset {
    input {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -160,7 +160,7 @@ task ExtractTask {
     # Run our command:
     command <<<
         set -e
-        export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
+        export GATK_LOCAL_JAR="~{default="/root/gatk.jar" gatk_override}"
 
         if [ ~{has_service_account_file} = 'true' ]; then
             gsutil cp ~{service_account_json_path} local.service_account.json
@@ -197,23 +197,23 @@ task ExtractTask {
                 ~{true='--emit-pls' false='' emit_pls} \
                 ${FILTERING_ARGS}
 
-        OUTPUT_FILE_BYTES=$(du -b ~{output_file} | cut -f1)
+        OUTPUT_FILE_BYTES="$(du -b ~{output_file} | cut -f1)"
         echo ${OUTPUT_FILE_BYTES} > vcf_bytes.txt
 
-        OUTPUT_FILE_INDEX_BYTES=$(du -b ~{output_file}.tbi | cut -f1)
+        OUTPUT_FILE_INDEX_BYTES="$(du -b ~{output_file}.tbi | cut -f1)"
         echo ${OUTPUT_FILE_INDEX_BYTES} > vcf_index_bytes.txt
 
         # Drop trailing slash if one exists
-        OUTPUT_GCS_DIR=$(echo ~{output_gcs_dir} | sed 's/\/$//')
+        OUTPUT_GCS_DIR="$(echo ~{output_gcs_dir} | sed 's/\/$//')"
 
         if [ -n "${OUTPUT_GCS_DIR}" ]; then
           gsutil cp ~{output_file} ${OUTPUT_GCS_DIR}/
           gsutil cp ~{output_file}.tbi ${OUTPUT_GCS_DIR}/
-          OUTPUT_FILE_DEST=${OUTPUT_GCS_DIR}/~{output_file}
-          OUTPUT_FILE_INDEX_DEST=${OUTPUT_GCS_DIR}/~{output_file}.tbi
+          OUTPUT_FILE_DEST="${OUTPUT_GCS_DIR}/~{output_file}"
+          OUTPUT_FILE_INDEX_DEST="${OUTPUT_GCS_DIR}/~{output_file}.tbi"
         else
-          OUTPUT_FILE_DEST=~{output_file}
-          OUTPUT_FILE_INDEX_DEST=~{output_file}.tbi
+          OUTPUT_FILE_DEST="~{output_file}"
+          OUTPUT_FILE_INDEX_DEST="~{output_file}.tbi"
         fi
 
         # Parent Task will collect manifest lines and create a joined file

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -193,6 +193,8 @@ task ExtractTask {
                 ~{true='--emit-pls' false='' emit_pls} \
                 ${FILTERING_ARGS}
 
+        INTERVAL_NUMBER=$(echo ~{output_file} | grep -oEi '\d+\.vcf\.gz' | cut -d'.' -f1)
+
         OUTPUT_FILE_BYTES=$(du -b ~{output_file} | cut -f1)
         echo ${OUTPUT_FILE_BYTES} > vcf_bytes.txt
 
@@ -213,8 +215,8 @@ task ExtractTask {
         fi
 
         # Parent Task will collect manifest files and create a summary
-        # Currently, the schema is `[output_file_location], [output_file_size_bytes], [output_file_index_location], [output_file_size_bytes]`
-        echo ${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
+        # Currently, the schema is `[interval_number], [output_file_location], [output_file_size_bytes], [output_file_index_location], [output_file_size_bytes]`
+        echo ${INTERVAL_NUMBER},${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
     >>>
 
     # ------------------------------------------------
@@ -382,8 +384,8 @@ task CreateManifest {
     command <<<
         set -e
         MANIFEST_LINES_TXT=~{write_lines(manifest_lines)}
-        echo "vcf_file_location, vcf_file_bytes, vcf_index_location, vcf_index_bytes" >> manifest.txt
-        sort ${MANIFEST_LINES_TXT} >> manifest.txt
+        echo "interval_number, vcf_file_location, vcf_file_bytes, vcf_index_location, vcf_index_bytes" >> manifest.txt
+        sort -n ${MANIFEST_LINES_TXT} >> manifest.txt
     >>>
 
     output {

--- a/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
@@ -334,9 +334,6 @@ def make_extract_table(fq_pet_vet_dataset,
           if not (bool(re.match(r"[a-z0-9_-]+$", key)) & bool(re.match(r"[a-z0-9_-]+$", value))):
             raise ValueError(f"label key or value did not pass validation--format should be 'key1=val1, key2=val2'")
 
-    print(query_labels_map)
-    exit
-
     #Default QueryJobConfig will be merged into job configs passed in
     #but if a specific default config is being updated (eg labels), new config must be added
     #to the client._default_query_job_config that already exists

--- a/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_cohort_extract_data_table.py
@@ -168,7 +168,7 @@ def make_new_vet_union_all(fq_pet_vet_dataset, fq_temp_table_dataset, sample_ids
         execute_with_retry("create and populate vet new table", sql)
       else:
         execute_with_retry("populate vet new table", sql)
-  return 
+  return
 
 
 
@@ -333,6 +333,9 @@ def make_extract_table(fq_pet_vet_dataset,
 
           if not (bool(re.match(r"[a-z0-9_-]+$", key)) & bool(re.match(r"[a-z0-9_-]+$", value))):
             raise ValueError(f"label key or value did not pass validation--format should be 'key1=val1, key2=val2'")
+
+    print(query_labels_map)
+    exit
 
     #Default QueryJobConfig will be merged into job configs passed in
     #but if a specific default config is being updated (eg labels), new config must be added


### PR DESCRIPTION
The manifest file describes the files produced by the GvsExtractCallset task and is uploaded to GCS once all the shards have finished running.

The existence of the manifest.txt file can be used to determine if the extraction is complete or not by just using `gsutil` command and not going through Cromwell/Terra.

Here's a snippet of what that looks like.

```
interval_number, vcf_file_location, vcf_file_bytes, vcf_index_location, vcf_index_bytes
0,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_0.vcf.gz,879403,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_0.vcf.gz.tbi,1682
1,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_1.vcf.gz,871855,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_1.vcf.gz.tbi,1670
2,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_2.vcf.gz,710617,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_2.vcf.gz.tbi,1629
3,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_3.vcf.gz,715565,gs://fc-secure-765db3ba-3e2d-432e-89eb-9efda7430f93/genomic-extractions/66f225d3-35cf-4ff7-a4ec-3d887a86ea8b/vcfs/interval_3.vcf.gz.tbi,1645
...
```