### PR TITLE
Add extraction uuid BQ label to GvsPrepareCallstep from GvsExtractCohortFromSampleNames

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -48,7 +48,7 @@ workflow GvsExtractCohortFromSampleNames {
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
       data_project                    = gvs_project,
-      query_labels                    = ["extraction_uuid=~{extraction_uuid}", "wdl_task=GvsPrepareCallset"],
+      query_labels                    = ["extraction_uuid=~{extraction_uuid}"],
       query_project                   = query_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -48,7 +48,7 @@ workflow GvsExtractCohortFromSampleNames {
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
       data_project                    = gvs_project,
-      query_labels                    = ["extraction_uuid,~{extraction_uuid}"],
+      query_labels                    = ["extraction_uuid=~{extraction_uuid}"],
       query_project                   = query_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -48,6 +48,7 @@ workflow GvsExtractCohortFromSampleNames {
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
       data_project                    = gvs_project,
+      query_labels                    = ["extraction_uuid,~{extraction_uuid}"],
       query_project                   = query_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -48,7 +48,7 @@ workflow GvsExtractCohortFromSampleNames {
       destination_cohort_table_prefix = extraction_uuid,
       sample_names_to_extract         = cohort_sample_names,
       data_project                    = gvs_project,
-      query_labels                    = ["extraction_uuid=~{extraction_uuid}"],
+      query_labels                    = ["extraction_uuid=~{extraction_uuid}", "wdl_task=GvsPrepareCallset"],
       query_project                   = query_project,
       default_dataset                 = gvs_dataset, # unused if fq_* args are given
       fq_petvet_dataset               = "~{gvs_project}.~{gvs_dataset}",

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -68,7 +68,7 @@ task PrepareCallsetTask {
         String docker
     }
     # Note the coercion of optional query_labels using select_first([expr, default])
-    Array[String] query_label_args = prefix("--query_labels ", select_first([query_labels, []]))
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
 
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
     String use_sample_names_file = if (defined(sample_names_to_extract)) then 'true' else 'false'

--- a/scripts/variantstore/wdl/GvsPrepareCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareCallset.wdl
@@ -68,7 +68,7 @@ task PrepareCallsetTask {
         String docker
     }
     # Note the coercion of optional query_labels using select_first([expr, default])
-    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
+    Array[String] query_label_args = prefix("--query_labels ", select_first([query_labels, []]))
 
     String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
     String use_sample_names_file = if (defined(sample_names_to_extract)) then 'true' else 'false'


### PR DESCRIPTION
Adds the extraction uuid for the current job to the GvsPrepareCallset step so that we can calculate the billing cost of an extraction run.