### PR TITLE
Making GetSampleIds volatile 

### DIFF
--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -865,6 +865,10 @@ task SetIsLoadedColumn {
 }
 
 task GetSampleIds {
+  meta {
+    volatile: true
+  }
+
   input {
     Array[String] external_sample_names
     String project_id


### PR DESCRIPTION
Making GetSampleIds volatile so it doesn't call cache to outdated information (since BQ could have changed, and cromwell wouldn't know it)