### PR TITLE
add mem input

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -135,6 +135,7 @@ workflow Mutect2 {
       File? gatk_override
       String basic_bash_docker = "ubuntu:16.04"
       Boolean? filter_funcotations
+      Int? mem
 
       Int? preemptible
       Int? max_retries
@@ -242,7 +243,8 @@ workflow Mutect2 {
                 gatk_override = gatk_override,
                 gatk_docker = gatk_docker,
                 disk_space = m2_per_scatter_size,
-                gcs_project_for_requester_pays = gcs_project_for_requester_pays
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+                mem = mem
         }
     }
 

--- a/scripts/mutect2_wdl/mutect2_pon.wdl
+++ b/scripts/mutect2_wdl/mutect2_pon.wdl
@@ -44,6 +44,7 @@ workflow Mutect2_Panel {
     Int small_task_mem = 4
     Int small_task_disk = 100
     Int boot_disk_size = 12
+    Int? m2_mem
 
     # Use as a last resort to increase the disk given to every task in case of ill behaving data
     Int? emergency_extra_disk
@@ -73,7 +74,8 @@ workflow Mutect2_Panel {
                 gatk_docker = gatk_docker,
                 preemptible = preemptible,
                 max_retries = max_retries,
-                gcs_project_for_requester_pays = gcs_project_for_requester_pays
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+                mem = m2_mem
         }
     }
 


### PR DESCRIPTION
A user was running the mutect2_pon.wdl workflow on Terra and wanted to increase the runtime memory for the [Mutect2.M2](https://github.com/broadinstitute/gatk/blob/4.1.8.1/scripts/mutect2_wdl/mutect2.wdl#L631) task that was being called in the mutect2_pon.wdl workflow. There is currently no way for the user to increase the memory in the pon workflow because the [m2](https://github.com/broadinstitute/gatk/blob/297f24e642b0181d9ec4150be693905a80ded68b/scripts/mutect2_wdl/mutect2_pon.wdl#L60) task doesn't set `mem` as a possible input.