### PR TITLE
Update sqllite library to support M1 Macs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,7 +366,7 @@ dependencies {
     compile 'org.broadinstitute:http-nio:0.1.0-rc1'
 
     // Required for COSMIC Funcotator data source:
-    compile 'org.xerial:sqlite-jdbc:3.20.1'
+    compile 'org.xerial:sqlite-jdbc:3.36.0.3'
     
     // Required for SV Discovery machine learning
     compile group: 'biz.k11i', name: 'xgboost-predictor', version: '0.3.0'


### PR DESCRIPTION
Funcotator currently fails when running natively on m1 because the cosmic datasource uses a native sqllite library.  This version of the library supports m1 macs natively.  

* updating org.xerial:sqlite-jdbc:3.20.1 -> 3.36.0.3
* this adds native support for M1 macs