### PR TITLE
Remove trailing tab in VariantsToTable output header

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTable.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTable.java
@@ -240,10 +240,8 @@ public final class VariantsToTable extends VariantWalker {
             final List<String> fields = new ArrayList<>();
             fields.addAll(fieldsToTake);
             fields.addAll(asFieldsToTake);
-            final String header = new StringBuilder(Utils.join("\t", fields))
-                    .append("\t")
-                    .append(createGenotypeHeader())
-                    .toString();
+            fields.addAll(createGenotypeFields());
+            final String header = Utils.join("\t", fields);
             outputStream.println(header);
         }
     }
@@ -273,26 +271,21 @@ public final class VariantsToTable extends VariantWalker {
         return s.endsWith("*");
     }
 
-    private String createGenotypeHeader() {
-        boolean firstEntry = true;
+    private List<String> createGenotypeFields() {
         final List<String> allGenotypeFieldsToTake = new ArrayList<>(genotypeFieldsToTake);
         allGenotypeFieldsToTake.addAll(asGenotypeFieldsToTake);
 
-        final StringBuilder sb = new StringBuilder();
+        final List<String> genotypeFields = new ArrayList<>();
         for ( final String sample : samples ) {
             for ( final String gf : allGenotypeFieldsToTake ) {
-                if ( firstEntry ) {
-                    firstEntry = false;
-                } else {
-                    sb.append("\t");
-                }
                 // spaces in sample names are legal but wreak havoc in R data frames
-                sb.append(sample.replace(" ","_"));
-                sb.append('.');
-                sb.append(gf);
+                final StringBuilder sb = new StringBuilder(sample.replace(" ","_"))
+                        .append(".")
+                        .append(gf);
+                genotypeFields.add(sb.toString());
             }
         }
-        return sb.toString();
+        return genotypeFields;
     }
 
     private void emitMoltenizedOutput(final List<String> record) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
@@ -31,6 +31,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 " --variant does_not_exist.vcf -O %s",
                 1, UserException.CouldNotReadInputFile.class);
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testComplexVariantsToTable-FAIL", this);
     }
 
@@ -40,6 +41,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                 " --variant " + getToolTestDataDir() + "soap_gatk_annotated.noChr_lines.vcf" +
                 " -O /does_not_exists/txt.table",
                 1, UserException.CouldNotCreateOutputFile.class);
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testComplexVariantsToTable-FAIL", this);
     }
 
@@ -48,6 +50,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 variantsToTableCmd("--error-if-missing-data"),
                 1, UserException.class);
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testComplexVariantsToTable-FAIL", this);
     }
 
@@ -59,6 +62,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -O %s",
                 1,
                 UserException.class);
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testUnfilteredGenotypeFields-FAIL", this);
     }
 
@@ -67,6 +71,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 variantsToTableCmdNoSamples(" -F CHROM -F POS -F ID -F REF -F ALT -F QUAL -F FILTER -F TRANSITION -F EVENTLENGTH"),
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample.noSamples.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testNoSamples", this);
     }
 
@@ -76,6 +81,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                 variantsToTableCmdNoSamples(" -GF DP"),
                 1,
                 UserException.class);
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testNoSamples", this);
     }
 
@@ -84,6 +90,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 variantsToTableCmd(""),
                 Arrays.asList(getToolTestDataDir() + "expected.soap_gatk_annotated.noChr_lines.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testComplexVariantsToTable", this);
     }
 
@@ -92,6 +99,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 variantsToTableMultiAllelicCmd(""),
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMultiAllelicOneRecord", this);
     }
 
@@ -100,6 +108,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
         final IntegrationTestSpec spec = new IntegrationTestSpec(
                 variantsToTableMultiAllelicCmd(" -SMA"),
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic.SMA.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMultiAllelicSplitRecords", this);
     }
 
@@ -110,6 +119,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -GF RD" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testGenotypeFields", this);
     }
 
@@ -120,6 +130,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -GF RD -GF FT" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.FT.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testUnfilteredGenotypeFields", this);
     }
 
@@ -132,6 +143,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -SMA" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic_gt.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMultiallelicGenotypeFields", this);
     }
 
@@ -142,6 +154,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -GF RD -GF GT -GF GQ" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.GF_GT.GF_GT.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testGenotypeFieldsWithInline", this);
     }
 
@@ -155,6 +168,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -SMA -F CHROM -F POS -F REF -F ALT -F FOO -ASF TLOD -ASGF TLOD -ASGF AD -ASGF MMQ -ASGF BAR -raw" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.threeSamples.2alts.MT.txt"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testGenotypeFieldsWithInline", this);
 
         //asking for allele-specific fields without splitting produces reasonable output
@@ -163,6 +177,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -F CHROM -F POS -F REF -F ALT -ASGF TLOD -ASGF AD -ASGF MMQ -raw" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.threeSamples.2alts.MT.noSplit.txt"));
+        spec2.setTrimWhiteSpace(false);
         spec2.executeTest("testGenotypeFieldsWithInline", this);
 
         //A-type INFO annotations work
@@ -171,6 +186,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -SMA -F CHROM -F POS -F REF -F ALT -ASF AS_BaseQRankSum -ASGF AD -raw -ASF AS_FilterStatus" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.ASindelVQSR.txt"));
+        spec4.setTrimWhiteSpace(false);
         spec4.executeTest("testGenotypeFieldsWithInline", this);
     }
 
@@ -181,6 +197,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " -GF PL" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample.withMLE.GF_PL.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testGenotypeFields", this);
     }
 
@@ -192,6 +209,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " --moltenize" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.moltenize.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMoltenOutput", this);
     }
 
@@ -203,6 +221,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " --moltenize" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.vcfexample2.GF_RD.moltenize.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMoltenOutputWithGenotypeFields", this);
     }
 
@@ -214,6 +233,7 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
                         " --moltenize -SMA" +
                         " -O %s",
                 Arrays.asList(getToolTestDataDir() + "expected.multiallelic.moltenize.SMA.table"));
+        spec.setTrimWhiteSpace(false);
         spec.executeTest("testMoltenOutputWithMultipleAlleles", this);
     }
 }

--- a/src/testUtils/java/org/broadinstitute/hellbender/testutils/IntegrationTestSpec.java
+++ b/src/testUtils/java/org/broadinstitute/hellbender/testutils/IntegrationTestSpec.java
@@ -46,6 +46,7 @@ public final class IntegrationTestSpec {
     private final int nOutputFiles;
     private final List<String> expectedFileNames;
     private String tempExtension;
+    private boolean trimWhiteSpace;
 
     //If this field is set to true, bam files will be compared after they get sorted.
     //This is needed as a workaround because Spark tools don't respect a pre-ordered BAMs
@@ -94,6 +95,10 @@ public final class IntegrationTestSpec {
 
     public void setCompareBamFilesSorted(final boolean compareBamFilesSorted) {
         this.compareBamFilesSorted = compareBamFilesSorted;
+    }
+
+    public void setTrimWhiteSpace(final boolean trimWhiteSpace) {
+        this.trimWhiteSpace = trimWhiteSpace;
     }
 
     public void setValidationStringency(final ValidationStringency validationStringency) {
@@ -154,7 +159,7 @@ public final class IntegrationTestSpec {
         executeTest(testName, testClass, args, expectedException);
 
         if (expectedException == null && !expectedFileNames.isEmpty()) {
-            assertMatchingFiles(tmpFiles, expectedFileNames, compareBamFilesSorted, validationStringency);
+            assertMatchingFiles(tmpFiles, expectedFileNames, compareBamFilesSorted, validationStringency, trimWhiteSpace);
             if (expectedIndexExtension != null) {
                 for (final File f : tmpFiles) {
                     final String indexPath = f.getAbsolutePath() + expectedIndexExtension;
@@ -208,6 +213,10 @@ public final class IntegrationTestSpec {
     }
 
     public static void assertMatchingFiles(final List<File> resultFiles, final List<String> expectedFiles, final boolean compareBamFilesSorted, final ValidationStringency stringency) throws IOException {
+        assertMatchingFiles(resultFiles, expectedFiles, compareBamFilesSorted, stringency, false);
+    }
+
+    public static void assertMatchingFiles(final List<File> resultFiles, final List<String> expectedFiles, final boolean compareBamFilesSorted, final ValidationStringency stringency, final boolean trimWhiteSpace) throws IOException {
         Assert.assertEquals(resultFiles.size(), expectedFiles.size());
         for (int i = 0; i < resultFiles.size(); i++) {
             final File resultFile = resultFiles.get(i);
@@ -219,7 +228,7 @@ public final class IntegrationTestSpec {
             } else if (expectedFileName.endsWith(".bam")) {
                 SamAssertionUtils.assertEqualBamFiles(resultFile, expectedFile, compareBamFilesSorted, stringency);
             } else {
-                assertEqualTextFiles(resultFile, expectedFile);
+                assertEqualTextFiles(resultFile, expectedFile, null, trimWhiteSpace);
             }
         }
     }

--- a/src/testUtils/java/org/broadinstitute/hellbender/testutils/IntegrationTestSpec.java
+++ b/src/testUtils/java/org/broadinstitute/hellbender/testutils/IntegrationTestSpec.java
@@ -64,6 +64,7 @@ public final class IntegrationTestSpec {
         this.compareBamFilesSorted = false;
         this.validationStringency = ValidationStringency.DEFAULT_STRINGENCY;
         this.tempExtension = DEFAULT_TEMP_EXTENSION;
+        this.trimWhiteSpace = true;
     }
 
     public IntegrationTestSpec(String args, int nOutputFiles, Class<?> expectedException) {
@@ -77,6 +78,7 @@ public final class IntegrationTestSpec {
         this.compareBamFilesSorted = false;
         this.validationStringency = ValidationStringency.DEFAULT_STRINGENCY;
         this.tempExtension = DEFAULT_TEMP_EXTENSION;
+        this.trimWhiteSpace = true;
     }
 
     public boolean expectsException() {


### PR DESCRIPTION
If VariantsToTable is run without any genotype field outputs (or on a vcf with no sample data), the header line contains an extra trailing tab, which is not included in the table rows.   This confuses many tsv parsers, which see the header as having an extra (blank) field, and so complain that the rows of the table do not contain enough fields.

This pr fixes this so that there is no longer a trailing tab in this case.