### PR TITLE
close vet writer

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
@@ -136,6 +136,8 @@ public class VetCreator {
                 throw new IllegalArgumentException("Couldn't close VET writer", e);
             }
         }
-
+        if (vetBQJsonWriter != null) {
+            vetBQJsonWriter.close();
+        }
     }
 }


### PR DESCRIPTION
To test I ran this before and after the fix.  Before it would sit there after the line 

```
Tool returned:
0
```
for ~10 minutes before it would time out and exit.  After the fix it shuts down cleanly


```
gatk --java-options -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 \
CreateVariantIngestFiles \
    -V gs://fc-e2f6ffa2-4033-4517-98fc-889bee4cc7a6/5e6b194b-5f69-40f2-a6de-f4f3f80ce05a/ReblockGVCF/702cdbf7-0666-4ee5-b889-91ba0ffa90bd/call-Reblock/HG00405.haplotypeCalls.er.raw.vcf.gz.rb.g.vcf.gz \
    -L chr20:1-100000 \
    -IG FORTY \
    --ignore-above-gq-threshold false \
    --project-id broad-dsp-spec-ops \
    --dataset-name gvs_qs_v2_kc \
    --output-type BQ \
    --enable-reference-ranges true \
    --enable-pet false \
    --enable-vet true \
    -SN ERS4367795 \
    --gvs-sample-id 99 \
    --ref-version 38
```