### PR TITLE
Bug with passing max_alternate_alleles to GenomicsDB

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -314,8 +314,6 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
             Utils.nonNull(genomicsDBOptions, "GenomicsDBOptions must not be null. Calling tool may not read from a GenomicsDB data source.");
         }
 
-        logger.info("max_alt_alleles={}, max_genotype_count={}", genomicsDBOptions.getMaxDiploidAltAllelesThatCanBeGenotyped(), genomicsDBOptions.getMaxGenotypeCount());
-
         // Create a feature reader without requiring an index.  We will require one ourselves as soon as
         // a query by interval is attempted.
         this.featureReader = getFeatureReader(featureInput, targetFeatureType,

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -314,6 +314,8 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
             Utils.nonNull(genomicsDBOptions, "GenomicsDBOptions must not be null. Calling tool may not read from a GenomicsDB data source.");
         }
 
+        logger.info("max_alt_alleles={}, max_genotype_count={}", genomicsDBOptions.getMaxDiploidAltAllelesThatCanBeGenotyped(), genomicsDBOptions.getMaxGenotypeCount());
+
         // Create a feature reader without requiring an index.  We will require one ourselves as soon as
         // a query by interval is attempted.
         this.featureReader = getFeatureReader(featureInput, targetFeatureType,

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
@@ -25,18 +25,24 @@ public final class GenomicsDBOptions {
     }
 
     public GenomicsDBOptions(final Path reference, GenomicsDBArgumentCollection genomicsdbArgs) {
-        this(reference, genomicsdbArgs, new GenotypeCalculationArgumentCollection(), false);
+        this(reference, genomicsdbArgs, new GenotypeCalculationArgumentCollection());
     }
 
     public GenomicsDBOptions(final Path reference, final GenomicsDBArgumentCollection genomicsdbArgs,
-                             final GenotypeCalculationArgumentCollection genotypeCalcArgs, final boolean forceCallGenotypes) {
+                             final GenotypeCalculationArgumentCollection genotypeCalcArgs) {
         this.reference = reference;
-        this.callGenotypes = genomicsdbArgs.callGenotypes || forceCallGenotypes;
-        this.maxDiploidAltAllelesThatCanBeGenotyped = genomicsdbArgs.maxDiploidAltAllelesThatCanBeGenotyped;
-        this.maxGenotypeCount = genotypeCalcArgs.MAX_GENOTYPE_COUNT;
+        this.callGenotypes = genomicsdbArgs.callGenotypes;
         this.useBCFCodec = genomicsdbArgs.useBCFCodec;
         this.sharedPosixFSOptimizations = genomicsdbArgs.sharedPosixFSOptimizations;
         this.useGcsHdfsConnector = genomicsdbArgs.useGcsHdfsConnector;
+        if (genotypeCalcArgs != null) {
+            this.maxDiploidAltAllelesThatCanBeGenotyped = genotypeCalcArgs.MAX_ALTERNATE_ALLELES;
+            this.maxGenotypeCount = genotypeCalcArgs.MAX_GENOTYPE_COUNT;
+        } else {
+            // Some defaults
+            this.maxDiploidAltAllelesThatCanBeGenotyped = genomicsdbArgs.maxDiploidAltAllelesThatCanBeGenotyped;
+            this.maxGenotypeCount = GenotypeCalculationArgumentCollection.DEFAULT_MAX_GENOTYPE_COUNT;
+        }
     }
 
     public Path getReference() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBOptions.java
@@ -36,8 +36,8 @@ public final class GenomicsDBOptions {
         this.sharedPosixFSOptimizations = genomicsdbArgs.sharedPosixFSOptimizations;
         this.useGcsHdfsConnector = genomicsdbArgs.useGcsHdfsConnector;
         if (genotypeCalcArgs != null) {
-            this.maxDiploidAltAllelesThatCanBeGenotyped = genotypeCalcArgs.MAX_ALTERNATE_ALLELES;
-            this.maxGenotypeCount = genotypeCalcArgs.MAX_GENOTYPE_COUNT;
+            this.maxDiploidAltAllelesThatCanBeGenotyped = genotypeCalcArgs.maxAlternateAlleles;
+            this.maxGenotypeCount = genotypeCalcArgs.maxGenotypeCount;
         } else {
             // Some defaults
             this.maxDiploidAltAllelesThatCanBeGenotyped = genomicsdbArgs.maxDiploidAltAllelesThatCanBeGenotyped;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -208,9 +208,10 @@ public final class GenotypeGVCFs extends VariantLocusWalker {
 
     @Override
     protected GenomicsDBOptions getGenomicsDBOptions() {
-        //extract called genotypes so hom refs with no PLs aren't ambiguous
         if (genomicsDBOptions == null) {
-            genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), genomicsdbArgs, genotypeArgs, true);
+            //extract called genotypes so hom refs with no PLs aren't ambiguous
+            genomicsdbArgs.callGenotypes = true;
+            genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), genomicsdbArgs, genotypeArgs);
         }
         return genomicsDBOptions;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsEngine.java
@@ -300,7 +300,7 @@ public class GenotypeGVCFsEngine
         final VariantContextBuilder builder = new VariantContextBuilder(vc);
         final VariantContext regenotypedVC = builder.genotypes(newGenotypes).make();
 
-        final int maxAltAlleles = genotypingEngine.getConfiguration().genotypeArgs.MAX_ALTERNATE_ALLELES;
+        final int maxAltAlleles = genotypingEngine.getConfiguration().genotypeArgs.maxAlternateAlleles;
         List<Allele> allelesToKeep;
 
         //we need to make sure all alleles pass the tlodThreshold

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -5,7 +5,6 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.variant.HomoSapiensConstants;
 
 import java.io.Serializable;
@@ -127,7 +126,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * Note that the default was changed from 10.0 to 30.0 in version 4.1.0.0 to accompany the switch to use the the new quality score by default.
      */
     @Argument(fullName = CALL_CONFIDENCE_LONG_NAME, shortName = CALL_CONFIDENCE_SHORT_NAME, doc = "The minimum phred-scaled confidence threshold at which variants should be called", optional = true)
-    public double STANDARD_CONFIDENCE_FOR_CALLING = DEFAULT_STANDARD_CONFIDENCE_FOR_CALLING;
+    public double standardConfidenceForCalling = DEFAULT_STANDARD_CONFIDENCE_FOR_CALLING;
 
     /**
      * If there are more than this number of alternate alleles presented to the genotyper (either through discovery or GENOTYPE_GIVEN ALLELES),
@@ -135,11 +134,11 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * scales exponentially based on the number of alternate alleles.  Unless there is a good reason to change the default value, we highly recommend
      * that you not play around with this parameter.
      *
-     * See also {@link #MAX_GENOTYPE_COUNT}.
+     * See also {@link #maxGenotypeCount}.
      */
     @Advanced
     @Argument(fullName = MAX_ALTERNATE_ALLELES_LONG_NAME, doc = "Maximum number of alternate alleles to genotype", optional = true)
-    public int MAX_ALTERNATE_ALLELES = DEFAULT_MAX_ALTERNATE_ALLELES;
+    public int maxAlternateAlleles = DEFAULT_MAX_ALTERNATE_ALLELES;
 
     /**
      * If there are more than this number of genotypes at a locus presented to the genotyper, then only this many genotypes will be used.
@@ -152,17 +151,18 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
      * Unless there is a good reason to change the default value, we highly recommend that you not play around with this parameter.
      *
      * The maximum number of alternative alleles used in the genotyping step will be the lesser of the two:
-     * 1. the largest number of alt alleles, given ploidy, that yields a genotype count no higher than {@link #MAX_GENOTYPE_COUNT}
-     * 2. the value of {@link #MAX_ALTERNATE_ALLELES}
+     * 1. the largest number of alt alleles, given ploidy, that yields a genotype count no higher than {@link #maxGenotypeCount}
+     * 2. the value of {@link #maxAlternateAlleles}
      *
-     * See also {@link #MAX_ALTERNATE_ALLELES}.
+     * See also {@link #maxAlternateAlleles}.
      */
     @Advanced
     @Argument(fullName = MAX_GENOTYPE_COUNT_LONG_NAME, doc = "Maximum number of genotypes to consider at any site", optional = true)
-    public int MAX_GENOTYPE_COUNT = DEFAULT_MAX_GENOTYPE_COUNT;
+    public int maxGenotypeCount = DEFAULT_MAX_GENOTYPE_COUNT;
 
     /**
-     *   Sample ploidy - equivalent to number of chromosomes per pool. In pooled experiments this should be = # of samples in pool * individual sample ploidy
+     *   Sample ploidy - equivalent to number of chromoso
+     *   mes per pool. In pooled experiments this should be = # of samples in pool * individual sample ploidy
      */
     @Argument(shortName = SAMPLE_PLOIDY_SHORT_NAME, fullName = SAMPLE_PLOIDY_LONG_NAME, doc="Ploidy (number of chromosomes) per sample. For pooled data, set to (Number of samples in each pool * Sample Ploidy).", optional=true)
     public int samplePloidy = HomoSapiensConstants.DEFAULT_PLOIDY;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -127,7 +127,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
         }
 
         final int defaultPloidy = configuration.genotypeArgs.samplePloidy;
-        final int maxAltAlleles = configuration.genotypeArgs.MAX_ALTERNATE_ALLELES;
+        final int maxAltAlleles = configuration.genotypeArgs.maxAlternateAlleles;
 
         VariantContext reducedVC = vc;
         if (maxAltAlleles < vc.getAlternateAlleles().size()) {
@@ -305,7 +305,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
                 // we want to keep the NON_REF symbolic allele but only in the absence of a non-symbolic allele, e.g.
                 // if we combined a ref / NON_REF gVCF with a ref / alt gVCF
                 final boolean isNonRefWhichIsLoneAltAllele = alternativeAlleleCount == 1 && allele.equals(Allele.NON_REF_ALLELE);
-                final boolean isPlausible = afCalculationResult.passesThreshold(allele, configuration.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING);
+                final boolean isPlausible = afCalculationResult.passesThreshold(allele, configuration.genotypeArgs.standardConfidenceForCalling);
 
                 //it's possible that the upstream deletion that spanned this site was not emitted, mooting the symbolic spanning deletion allele
                 final boolean isSpuriousSpanningDeletion = GATKVCFConstants.isSpanningDeletion(allele) && !isVcCoveredByDeletion(vc);
@@ -414,7 +414,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
     }
 
     protected final boolean passesCallThreshold(final double conf) {
-        return conf >= configuration.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING;
+        return conf >= configuration.genotypeArgs.standardConfidenceForCalling;
     }
 
     protected Map<String,Object> composeCallAttributes(final VariantContext vc, final List<Integer> alleleCountsofMLE,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/gnarlyGenotyper/GnarlyGenotyper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/gnarlyGenotyper/GnarlyGenotyper.java
@@ -173,8 +173,9 @@ public final class GnarlyGenotyper extends VariantWalker {
     @Override
     protected GenomicsDBOptions getGenomicsDBOptions() {
         if (genomicsDBOptions == null) {
-            genomicsdbArgs.maxDiploidAltAllelesThatCanBeGenotyped = PIPELINE_MAX_ALT_COUNT;
-            genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), genomicsdbArgs, genotypeArgs, CALL_GENOTYPES);
+            genomicsdbArgs.callGenotypes = CALL_GENOTYPES;
+            genotypeArgs.MAX_ALTERNATE_ALLELES = PIPELINE_MAX_ALT_COUNT;
+            genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), genomicsdbArgs, genotypeArgs);
         }
         return genomicsDBOptions;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/gnarlyGenotyper/GnarlyGenotyper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/gnarlyGenotyper/GnarlyGenotyper.java
@@ -174,7 +174,7 @@ public final class GnarlyGenotyper extends VariantWalker {
     protected GenomicsDBOptions getGenomicsDBOptions() {
         if (genomicsDBOptions == null) {
             genomicsdbArgs.callGenotypes = CALL_GENOTYPES;
-            genotypeArgs.MAX_ALTERNATE_ALLELES = PIPELINE_MAX_ALT_COUNT;
+            genotypeArgs.maxAlternateAlleles = PIPELINE_MAX_ALT_COUNT;
             genomicsDBOptions = new GenomicsDBOptions(referenceArguments.getReferencePath(), genomicsdbArgs, genotypeArgs);
         }
         return genomicsDBOptions;
@@ -196,7 +196,7 @@ public final class GnarlyGenotyper extends VariantWalker {
 
         setupVCFWriter(inputVCFHeader, samples);
 
-        genotyperEngine = new GnarlyGenotyperEngine(keepAllSites, genotypeArgs.MAX_ALTERNATE_ALLELES, SUMMARIZE_PLs, stripASAnnotations);
+        genotyperEngine = new GnarlyGenotyperEngine(keepAllSites, genotypeArgs.maxAlternateAlleles, SUMMARIZE_PLs, stripASAnnotations);
 
         Reflections reflections = new Reflections("org.broadinstitute.hellbender.tools.walkers.annotator.allelespecific");
         //not InfoFieldAnnotation.class because we don't want AS_InbreedingCoeff

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -249,7 +249,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
             hcArgs.likelihoodArgs.enableDynamicReadDisqualification = true;
             hcArgs.likelihoodArgs.expectedErrorRatePerBase = 0.03;
             hcArgs.standardArgs.genotypeArgs.genotypeAssignmentMethod = GenotypeAssignmentMethod.USE_POSTERIOR_PROBABILITIES;
-            hcArgs.standardArgs.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING = 3.0;
+            hcArgs.standardArgs.genotypeArgs.standardConfidenceForCalling = 3.0;
             hcArgs.standardArgs.genotypeArgs.usePosteriorProbabilitiesToCalculateQual = true;
             assemblyRegionArgs.indelPaddingForGenotyping = 150;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -280,7 +280,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         }
 
         if ( emitReferenceConfidence() ) {
-            hcArgs.standardArgs.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING = -0.0;
+            hcArgs.standardArgs.genotypeArgs.standardConfidenceForCalling = -0.0;
 
             logger.info("Standard Emitting and Calling confidence set to 0.0 for reference-model confidence output");
             if ( ! hcArgs.standardArgs.annotateAllSitesWithPLs ) {
@@ -333,7 +333,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         activeRegionArgs.copyStandardCallerArgsFrom(hcArgs.standardArgs);
 
         activeRegionArgs.outputMode = OutputMode.EMIT_VARIANTS_ONLY;
-        activeRegionArgs.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING = Math.min(MAXMIN_CONFIDENCE_FOR_CONSIDERING_A_SITE_AS_POSSIBLE_VARIANT_IN_ACTIVE_REGION_DISCOVERY, hcArgs.standardArgs.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING ); // low values used for isActive determination only, default/user-specified values used for actual calling
+        activeRegionArgs.genotypeArgs.standardConfidenceForCalling = Math.min(MAXMIN_CONFIDENCE_FOR_CONSIDERING_A_SITE_AS_POSSIBLE_VARIANT_IN_ACTIVE_REGION_DISCOVERY, hcArgs.standardArgs.genotypeArgs.standardConfidenceForCalling); // low values used for isActive determination only, default/user-specified values used for actual calling
         activeRegionArgs.CONTAMINATION_FRACTION = 0.0;
         activeRegionArgs.CONTAMINATION_FRACTION_FILE = null;
         // Seems that at least with some test data we can lose genuine haploid variation if we use ploidy == 1

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -71,7 +71,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         genotypingModel = hcArgs.applyBQD || hcArgs.applyFRD ?
                 new DRAGENGenotypesModel(applyBQD, hcArgs.applyFRD, hcArgs.informativeReadOverlapMargin, hcArgs.maxEffectiveDepthAdjustment, dragstrParams) :
                 new IndependentSampleGenotypesModel();
-        maxGenotypeCountToEnumerate = configuration.standardArgs.genotypeArgs.MAX_GENOTYPE_COUNT;
+        maxGenotypeCountToEnumerate = configuration.standardArgs.genotypeArgs.maxGenotypeCount;
         referenceConfidenceMode = configuration.emitReferenceConfidence;
         snpHeterozygosity = configuration.standardArgs.genotypeArgs.snpHeterozygosity;
         indelHeterozygosity = configuration.standardArgs.genotypeArgs.indelHeterozygosity;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
@@ -257,7 +257,7 @@ public final class ReblockGVCF extends MultiVariantWalker {
         hcArgs.standardArgs.annotateAllSitesWithPLs = true;
         hcArgs.standardArgs.genotypeArgs = genotypeArgs.clone();
         hcArgs.emitReferenceConfidence = ReferenceConfidenceMode.GVCF;   //this is important to force emission of all alleles at a multiallelic site
-        hcArgs.standardArgs.genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING = dropLowQuals ? genotypeArgs.STANDARD_CONFIDENCE_FOR_CALLING : 0.0;
+        hcArgs.standardArgs.genotypeArgs.standardConfidenceForCalling = dropLowQuals ? genotypeArgs.standardConfidenceForCalling : 0.0;
         return new HaplotypeCallerGenotypingEngine(hcArgs, samples, true, false);
 
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -265,8 +265,8 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
         args.add("2"); // Too small max_alternate_alleles arg to GenomicsDB, should fail
         try {
             File output = runGenotypeGVCFS(genomicsDBUri, expected, args, reference);
-            Assert.assertTrue(output.exists());
-        } catch (Exception e) {
+            Assert.fail("Expected exception not thrown");
+        } catch (IllegalStateException e) {
            // Pass
         }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -260,10 +260,22 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
     public void assertMatchingGenotypesFromGenomicsDB(File input, File expected, Locatable interval, String reference) throws IOException {
         final File tempGenomicsDB = GenomicsDBTestUtils.createTempGenomicsDB(input, interval);
         final String genomicsDBUri = GenomicsDBTestUtils.makeGenomicsDBUri(tempGenomicsDB);
-        runGenotypeGVCFSAndAssertSomething(genomicsDBUri, expected, NO_EXTRA_ARGS, VariantContextTestUtils::assertVariantContextsHaveSameGenotypes, reference);
+        final List<String> args = new ArrayList<String>();
+        args.add("--"+GenotypeCalculationArgumentCollection.MAX_ALTERNATE_ALLELES_LONG_NAME);
+        args.add("2"); // Too small max_alternate_alleles arg to GenomicsDB, should fail
+        try {
+            File output = runGenotypeGVCFS(genomicsDBUri, expected, args, reference);
+            Assert.assertTrue(output.exists());
+        } catch (Exception e) {
+           // Pass
+        }
+
+        args.clear();
+        args.add("--"+GenotypeCalculationArgumentCollection.MAX_ALTERNATE_ALLELES_LONG_NAME);
+        args.add("8");
+        runGenotypeGVCFSAndAssertSomething(genomicsDBUri, expected, args, VariantContextTestUtils::assertVariantContextsHaveSameGenotypes, reference);
 
         // The default option with GenomicsDB input uses VCFCodec for decoding, test BCFCodec explicitly
-        final List<String> args = new ArrayList<String>();
         args.add("--"+GenomicsDBArgumentCollection.USE_BCF_CODEC_LONG_NAME);
         runGenotypeGVCFSAndAssertSomething(genomicsDBUri, expected, args, VariantContextTestUtils::assertVariantContextsHaveSameGenotypes, reference);
     }
@@ -362,9 +374,8 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
         );
     }
 
-    private void runGenotypeGVCFSAndAssertSomething(String input, File expected, List<String> additionalArguments, BiConsumer<VariantContext, VariantContext> assertion, String reference) throws IOException {
+    private File runGenotypeGVCFS(String input, File expected, List<String> additionalArguments, String reference) {
         final File output = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expected : createTempFile("genotypegvcf", ".vcf");
-
         final ArgumentsBuilder args = new ArgumentsBuilder();
         args.addReference(new File(reference))
                 .add("V", input)
@@ -376,6 +387,13 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
 
         Utils.resetRandomGenerator();
         runCommandLine(args);
+
+        return output;
+    }
+
+    private void runGenotypeGVCFSAndAssertSomething(String input, File expected, List<String> additionalArguments, BiConsumer<VariantContext, VariantContext> assertion, String reference) throws IOException {
+        final File output = runGenotypeGVCFS(input, expected, additionalArguments, reference);
+        Assert.assertTrue(output.exists());
 
         if (! UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS) {
             final List<VariantContext> expectedVC = VariantContextTestUtils.getVariantContexts(expected);


### PR DESCRIPTION
This was unearthed by #7542 and is plumbed correctly in this PR.

Note that we need to still address the broader issue of hooking arguments to GenomicsDB - #6456 . GenomicsDB exposes a whole set of export arguments all added in response of gatk requests, some of them are hardcoded by certain tools(e.g GenotypeGVCFs uses --max-alternate-alleles while SelectVariants does not), many are unused.