### PR TITLE
close StorageAPIAvroReader appropriately

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -43,7 +43,7 @@ workflow GvsExtractCallset {
 
         String output_file_base_name
         String? output_gcs_dir
-        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_ranges_extract_20211024/gatk-package-4.2.0.0-424-g366f2df-SNAPSHOT-local.jar"
+        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/ah_var_store_20211124/gatk-package-4.2.0.0-444-g7148df0-SNAPSHOT-local.jar"
         Int local_disk_for_extract = 150
 
         String fq_samples_to_extract_table = "~{data_project}.~{default_dataset}.~{extract_table_prefix}__SAMPLES"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -227,8 +227,9 @@ public class ExtractCohortEngine {
             }
         } else {
             if (cohortTableRef != null) {
-                final StorageAPIAvroReader storageAPIAvroReader = new StorageAPIAvroReader(cohortTableRef, rowRestriction, projectID);
-                createVariantsFromUnsortedResult(storageAPIAvroReader, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
+                try (StorageAPIAvroReader storageAPIAvroReader = new StorageAPIAvroReader(cohortTableRef, rowRestriction, projectID)) {
+                    createVariantsFromUnsortedResult(storageAPIAvroReader, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
+                }
             } else {
                 final AvroFileReader avroFileReader = new AvroFileReader(cohortAvroFileName);
                 createVariantsFromUnsortedResult(avroFileReader, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
@@ -816,12 +817,13 @@ public class ExtractCohortEngine {
                 // because it would break the clustering indexing
                 final String vetRowRestriction =
                         "location >= " + (minLocation - IngestConstants.MAX_DELETION_SIZE + 1)+ " AND location <= " + maxLocation + sampleRestriction;
-                final StorageAPIAvroReader vetReader = new StorageAPIAvroReader(vetTableRef, vetRowRestriction, projectID);
-                if (sortedVet == null) {
-                    sortedVet = getAvroSortingCollection(vetReader.getSchema(), localSortMaxRecordsInRam);
-                }
+                try (StorageAPIAvroReader vetReader = new StorageAPIAvroReader(vetTableRef, vetRowRestriction, projectID)) {
+                    if (sortedVet == null) {
+                        sortedVet = getAvroSortingCollection(vetReader.getSchema(), localSortMaxRecordsInRam);
+                    }
 
-                addToVetSortingCollection(sortedVet, vetReader, vbs);
+                    addToVetSortingCollection(sortedVet, vetReader, vbs);
+                }
             }
         }
         return sortedVet;
@@ -848,12 +850,13 @@ public class ExtractCohortEngine {
                 // NOTE: MUST be written as location >= minLocation - MAX_REFERENCE_BLOCK_BASES +1 to not break cluster pruning in BigQuery
                 final String refRowRestriction =
                         "location >= " + (minLocation - IngestConstants.MAX_REFERENCE_BLOCK_BASES + 1) + " AND location <= " + maxLocation + sampleRestriction;
-                final StorageAPIAvroReader refReader = new StorageAPIAvroReader(refTableRef, refRowRestriction, projectID);
-                if (sortedReferenceRange == null) {
-                    sortedReferenceRange = getAvroSortingCollection(refReader.getSchema(), localSortMaxRecordsInRam);
-                }
 
-                addToRefSortingCollection(sortedReferenceRange, refReader, vbs);
+                try (StorageAPIAvroReader refReader = new StorageAPIAvroReader(refTableRef, refRowRestriction, projectID)) {
+                    if (sortedReferenceRange == null) {
+                        sortedReferenceRange = getAvroSortingCollection(refReader.getSchema(), localSortMaxRecordsInRam);
+                    }
+                    addToRefSortingCollection(sortedReferenceRange, refReader, vbs);
+                }
             }
         }
 


### PR DESCRIPTION
When running with multiple table (ie _001, _002) this would show up in the logs due to the bigquery client not being closed.  It didn't cause any harm, but is alarming!  Closing the ranges-based readers appropriately now.

```
Nov 23, 2021 5:45:53 AM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=121, target=bigquerystorage.googleapis.com:443} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:93)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:53)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:44)
	at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:615)
	at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:261)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:360)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.access$1800(InstantiatingGrpcChannelProvider.java:81)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider$1.createSingleChannel(InstantiatingGrpcChannelProvider.java:231)
	at com.google.api.gax.grpc.ChannelPool.create(ChannelPool.java:72)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:241)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:219)
	at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:199)
	at com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub.create(EnhancedBigQueryReadStub.java:89)
	at com.google.cloud.bigquery.storage.v1.BigQueryReadClient.<init>(BigQueryReadClient.java:129)
	at com.google.cloud.bigquery.storage.v1.BigQueryReadClient.create(BigQueryReadClient.java:110)
	at com.google.cloud.bigquery.storage.v1.BigQueryReadClient.create(BigQueryReadClient.java:102)
	at org.broadinstitute.hellbender.utils.bigquery.StorageAPIAvroReader.<init>(StorageAPIAvroReader.java:60)
	at org.broadinstitute.hellbender.tools.gvs.extract.ExtractCohortEngine.createSortedReferenceRangeCollectionFromBigQuery(ExtractCohortEngine.java:851)
	at org.broadinstitute.hellbender.tools.gvs.extract.ExtractCohortEngine.createVariantsFromUnsortedBigQueryRanges(ExtractCohortEngine.java:891)
	at org.broadinstitute.hellbender.tools.gvs.extract.ExtractCohortEngine.traverse(ExtractCohortEngine.java:224)
	at org.broadinstitute.hellbender.tools.gvs.extract.ExtractCohort.traverse(ExtractCohort.java:335)
	at org.broadinstitute.hellbender.engine.GATKTool.doWork(GATKTool.java:1058)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.runTool(CommandLineProgram.java:140)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMainPostParseArgs(CommandLineProgram.java:192)
	at org.broadinstitute.hellbender.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:211)
	at org.broadinstitute.hellbender.Main.runCommandLineProgram(Main.java:160)
	at org.broadinstitute.hellbender.Main.mainEntry(Main.java:203)
	at org.broadinstitute.hellbender.Main.main(Main.java:289)
```