### PR TITLE
Remove file causing git-lfs error

### DIFF
--- a/src/test/resources/large/mitochondria_references/.gitattributes
+++ b/src/test/resources/large/mitochondria_references/.gitattributes
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb156adb10b491dd3ba88c2b491bfb021b3c94fc956d36310c67492504fcdc58
-size 946


### PR DESCRIPTION
Prevent a git lfs error that was caused by accidentally checking storing a .gitattributes file
in gitlfs.

When checkout out the repository for the first time or moving from an old commit to a newish one, there's been an error report from git lfs.  This was caused by accidentally checking a .gitattributes file into git-lfs which then is read as part of the git lfs checkout process, but since the file is tracked by lfs at the point of checkout it is an lfs stub and throws an error.

The problem was introduced here:  #6694

See below to reproduce:
```
git checkout 9951f77c6
git checkout f548ccd708009ddcdfead6525edd23a68d73027b
https://git-lfs.github.com/spec/v1 is not a valid attribute name: src/test/resources/large/mitochondria_references/.gitattributes:1
sha256:cb156adb10b491dd3ba88c2b491bfb021b3c94fc956d36310c67492504fcdc58 is not a valid attribute name: src/test/resources/large/mitochondria_references/.gitattributes:2
Updating files: 100% (363/363), done.
Note: switching to 'f548ccd708009ddcdfead6525edd23a68d73027b'.
```

This fixes the problem going forward by removing the file. 