### PR TITLE
Update .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -60,7 +60,7 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl
      testParameterFiles:
-          -  /scripts/mitochondria_m2_wdl/test_mitochondria_m2_wdl.json
+          -  /scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json
      filters:
          branches:
              - master
@@ -74,7 +74,7 @@ workflows:
              - master
    - name: mutect2_pon
      subclass: WDL
-     primaryDescriptorPath: /scripts/mutect2_wdl/mutect2_pon.wd
+     primaryDescriptorPath: /scripts/mutect2_wdl/mutect2_pon.wdl
      filters:
          branches:
              - master


### PR DESCRIPTION
_Requesting pulling directly into master because the .dockstore.yml files act upon master._

Two small fixes to the .dockstore.yml, which will fix two entries on Dockstore:
* https://dockstore.org/workflows/github.com/broadinstitute/gatk/MitochondriaPipeline:master?tab=files
* https://dockstore.org/workflows/github.com/broadinstitute/gatk/mutect2_pon:master?tab=files (the default version 4.1.8.1 does have its WDL show up, but master is not functional)