### PR TITLE
Utilise Log4j 2.15.0 to Mitigate CVE-2021-4422

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ final disqVersion = System.getProperty('disq.version','0.3.6')
 final genomicsdbVersion = System.getProperty('genomicsdb.version','1.4.2')
 final bigQueryVersion = System.getProperty('bigQuery.version', '1.117.1')
 final guavaVersion = System.getProperty('guava.version', '27.1-jre')
-final log4j2Version = System.getProperty('log4j2Version', '2.13.1')
+final log4j2Version = System.getProperty('log4j2Version', '2.15.0')
 final testNGVersion = '7.0.0'
 
 // Using the shaded version to avoid conflicts between its protobuf dependency


### PR DESCRIPTION
This bumps the Log4J version to 2.15.0. This is a two version leap from 2.13.1 but 2.14.x -> 2.15.0 was just a fix for CVE-4422 so this shouldn't be too disruptive.