### PR TITLE
fix empty flush

### DIFF
--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -24,7 +24,7 @@ workflow GvsCreateFilterSet {
         File? excluded_intervals
 
         String output_file_base_name
-        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/ah_var_store_20211217/gatk-package-4.2.0.0-448-gff251d6-SNAPSHOT-local.jar"
+        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_fix_flush_20220105/gatk-package-4.2.0.0-452-gb9496ed-SNAPSHOT-local.jar"
 
         File dbsnp_vcf
         File dbsnp_vcf_index

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -46,7 +46,7 @@ workflow GvsExtractCallset {
 
         String output_file_base_name
         String? output_gcs_dir
-        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_fix_type_20211222/gatk-package-4.2.0.0-451-gbfb465a-SNAPSHOT-local.jar"
+        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_fix_flush_20220105/gatk-package-4.2.0.0-452-gb9496ed-SNAPSHOT-local.jar"
         Int local_disk_for_extract = 150
 
         String fq_samples_to_extract_table = "~{data_project}.~{default_dataset}.~{extract_table_prefix}__SAMPLES"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -17,7 +17,7 @@ workflow GvsImportGenomes {
     Int batch_size = 1
 
     Int? preemptible_tries
-    File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_fix_type_20211222/gatk-package-4.2.0.0-451-gbfb465a-SNAPSHOT-local.jar"
+    File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_fix_flush_20220105/gatk-package-4.2.0.0-452-gb9496ed-SNAPSHOT-local.jar"
     String? docker
   }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/PendingBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/PendingBQWriter.java
@@ -14,7 +14,9 @@ public class PendingBQWriter extends CommittedBQWriter {
 
     public void flushBuffer() {
         try {
-            writeJsonArray(0);
+            if (jsonArr.length() > 0) {
+                writeJsonArray(0);
+            }
         } catch (Exception ex) {
             throw new GATKException("Caught exception writing last records on close of " + writeStream.getName(), ex);
         }


### PR DESCRIPTION
@mmorgantaylor was seeing 

| Caused by: java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Rows must be specified.

Due to flush() trying to write an empty buffer