### PR TITLE
WIP extract for ranges

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -118,6 +118,7 @@ workflows:
          - ah_var_store
          - rsa_rescattering_wf
          - rc_add_dropstate_extract_wdl
+         - kc_ranges_prepare
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -137,6 +138,16 @@ workflows:
          - master
          - ah_var_store
          - ah_flag_in_prepare
+   - name: GvsPrepareCallset
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+     testParameterFiles:
+       - /scripts/variantstore/wdl/GvsPrepareRangesCallset.example.inputs.json
+     filters:
+       branches:
+         - master
+         - ah_var_store
+         - kc_ranges_prepare
    - name: GvsSitesOnlyVCF
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsSitesOnlyVCF.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -138,7 +138,7 @@ workflows:
          - master
          - ah_var_store
          - ah_flag_in_prepare
-   - name: GvsPrepareCallset
+   - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
      testParameterFiles:

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -217,7 +217,7 @@ task ExtractTask {
 
         if [ ~{mode} = "RANGES-RAW" ]; then
             MODE_ARGS="--mode RANGES --vet-ranges-fq-dataset ~{fq_ranges_dataset} "
-        elif [ ~{mode} = "RANGES-PREPARED"]
+        elif [ ~{mode} = "RANGES-PREPARED" ]; then
             MODE_ARGS="--mode RANGES --vet-ranges-extract-fq-table ~{fq_ranges_cohort_vet_extract_table} --ref-ranges-extract-fq-table ~{fq_ranges_cohort_ref_extract_table} "
         else
             MODE_ARGS="--mode PET --cohort-extract-table ~{fq_cohort_extract_table} "

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -46,7 +46,7 @@ workflow GvsExtractCallset {
 
         String output_file_base_name
         String? output_gcs_dir
-        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_ranges_prepare_20220118/gatk-package-4.2.0.0-457-g95280a4-SNAPSHOT-local.jar"
+        File? gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_ranges_prepare_20220118/gatk-package-4.2.0.0-462-gc0e684c-SNAPSHOT-local.jar"
         Int local_disk_for_extract = 150
 
         String fq_samples_to_extract_table = "~{data_project}.~{default_dataset}.~{extract_table_prefix}__SAMPLES"

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,0 +1,150 @@
+version 1.0
+
+workflow GvsPrepareCallset {
+   input {
+        String data_project
+        String default_dataset
+        String destination_cohort_table_prefix
+        File? sample_names_to_extract
+
+        # inputs with defaults
+        String query_project = data_project
+        Array[String]? query_labels
+        String destination_project = data_project
+        String destination_dataset = default_dataset
+
+        String fq_petvet_dataset = "~{data_project}.~{default_dataset}"
+        String fq_sample_mapping_table = "~{data_project}.~{default_dataset}.sample_info"
+        String fq_temp_table_dataset = "~{destination_project}.temp_tables"
+        String fq_destination_dataset = "~{destination_project}.~{destination_dataset}"
+
+        Int temp_table_ttl_in_hours = 72
+        Boolean skip_vet_new_insert = false
+        String? service_account_json_path
+        String? docker
+    }
+
+    String docker_final = select_first([docker, "us.gcr.io/broad-dsde-methods/variantstore:kc_ranges_prepare_2022_01_18"])
+
+    call PrepareRangesCallsetTask {
+        input:
+            destination_cohort_table_prefix = destination_cohort_table_prefix,
+            sample_names_to_extract         = sample_names_to_extract,
+            query_project                   = query_project,
+            query_labels                    = query_labels,
+            fq_petvet_dataset               = fq_petvet_dataset,
+            fq_sample_mapping_table         = fq_sample_mapping_table,
+            fq_temp_table_dataset           = fq_temp_table_dataset,
+            fq_destination_dataset          = fq_destination_dataset,
+            temp_table_ttl_in_hours         = temp_table_ttl_in_hours,
+            service_account_json_path       = service_account_json_path,
+            docker                          = docker_final
+    }
+
+    output {
+      String fq_cohort_extract_table_prefix = PrepareRangesCallsetTask.fq_cohort_extract_table_prefix
+    }
+
+}
+
+task PrepareRangesCallsetTask {
+    # indicates that this task should NOT be call cached
+    meta {
+       volatile: true
+    }
+
+    input {
+        String destination_cohort_table_prefix
+        File? sample_names_to_extract
+        String query_project
+        Array[String]? query_labels
+
+        String fq_petvet_dataset
+        String fq_sample_mapping_table
+        String fq_temp_table_dataset
+        String fq_destination_dataset
+        Int temp_table_ttl_in_hours
+
+        String? service_account_json_path
+        String docker
+    }
+    # Note the coercion of optional query_labels using select_first([expr, default])
+    Array[String] query_label_args = if defined(query_labels) then prefix("--query_labels ", select_first([query_labels])) else []
+
+    String has_service_account_file = if (defined(service_account_json_path)) then 'true' else 'false'
+    String use_sample_names_file = if (defined(sample_names_to_extract)) then 'true' else 'false'
+    String sample_list_param = if (defined(sample_names_to_extract)) then '--sample_names_to_extract sample_names_file' else '--fq_cohort_sample_names ' + fq_sample_mapping_table
+
+    parameter_meta {
+      sample_names_to_extract: {
+        localization_optional: true
+      }
+    }
+
+    command <<<
+        set -e
+
+        echo ~{sample_list_param}
+
+        if [ ~{has_service_account_file} = 'true' ]; then
+            gsutil cp ~{service_account_json_path} local.service_account.json
+            SERVICE_ACCOUNT_STANZA="--sa_key_path local.service_account.json "
+        fi
+
+        if [ ~{use_sample_names_file} = 'true' ]; then
+            gsutil cp  ~{sample_names_to_extract} sample_names_file
+        fi
+
+        python3 /app/create_ranges_cohort_extract_data_table \
+            --fq_ranges_dataset ~{fq_petvet_dataset} \
+            --fq_temp_table_dataset ~{fq_temp_table_dataset} \
+            --fq_destination_dataset ~{fq_destination_dataset} \
+            --destination_cohort_table_prefix ~{destination_cohort_table_prefix} \
+            ~{sample_list_param} \
+            --query_project ~{query_project} \
+            ~{sep=" " query_label_args} \
+            --fq_sample_mapping_table ~{fq_sample_mapping_table} \
+            --ttl ~{temp_table_ttl_in_hours} \
+            $SERVICE_ACCOUNT_STANZA
+    >>>
+
+    output {
+      String fq_cohort_extract_table_prefix = "~{fq_destination_dataset}.~{destination_cohort_table_prefix}" # implementation detail of create_cohort_extract_data_table.py
+    }
+
+    runtime {
+        docker: docker
+        memory: "3 GB"
+        disks: "local-disk 100 HDD"
+        bootDiskSizeGb: 15
+        preemptible: 0
+        cpu: 1
+    }
+
+ }
+
+task LocalizeFile {
+  input {
+    String file
+    String service_account_json_path
+  }
+
+  command {
+    set -euo pipefail
+
+    gsutil cp ~{service_account_json_path} local.service_account.json
+    gcloud auth activate-service-account --key-file=local.service_account.json
+    gsutil cp '~{file}' .
+  }
+
+  output {
+    File localized_file = basename(file)
+  }
+
+  runtime {
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    memory: "3.75 GiB"
+    cpu: "1"
+    disks: "local-disk 50 HDD"
+  }
+}

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -95,7 +95,7 @@ task PrepareRangesCallsetTask {
             gsutil cp  ~{sample_names_to_extract} sample_names_file
         fi
 
-        python3 /app/create_ranges_cohort_extract_data_table \
+        python3 /app/create_ranges_cohort_extract_data_table.py \
             --fq_ranges_dataset ~{fq_petvet_dataset} \
             --fq_temp_table_dataset ~{fq_temp_table_dataset} \
             --fq_destination_dataset ~{fq_destination_dataset} \

--- a/scripts/variantstore/wdl/extract/Dockerfile
+++ b/scripts/variantstore/wdl/extract/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install bcftools
 # Copy the application source code.
 COPY create_cohort_extract_data_table.py /app
 COPY create_variant_annotation_table.py /app
+COPY create_ranges_cohort_extract_data_table.py /app
 COPY extract_subpop.py /app
 COPY populate_alt_allele_table.py /app
 COPY alt_allele_positions.sql /app

--- a/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+import uuid
+import datetime
+import argparse
+import re
+
+from google.cloud import bigquery
+from google.cloud.bigquery.job import QueryJobConfig
+from google.oauth2 import service_account
+
+import utils
+
+JOB_IDS = set()
+
+#
+# CONSTANTS
+#
+REF_TABLE_PREFIX = "ref_ranges_"
+VET_TABLE_PREFIX = "vet_"
+SAMPLES_PER_PARTITION = 4000
+
+FINAL_TABLE_TTL = ""
+#FINAL_TABLE_TTL = " OPTIONS( expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 72 HOUR)) "
+
+# temp-table-uuid
+output_table_prefix = str(uuid.uuid4()).split("-")[0]
+print(f"running with prefix {output_table_prefix}")
+
+PET_VET_TABLE_COUNT = -1
+client = None
+
+EXTRACT_SAMPLE_TABLE = f"{output_table_prefix}_sample_names"
+
+def dump_job_stats():
+  total = 0
+
+  for jobid in JOB_IDS:
+    job = client.get_job(jobid[1])
+
+    bytes_billed = int(0 if job.total_bytes_billed is None else job.total_bytes_billed)
+    total = total + bytes_billed
+
+    print(jobid[0], "jobid:  (", jobid[1], ") <====> Cache Hit:", job.cache_hit, bytes_billed/(1024 * 1024), " MBs")
+
+  print(" Total GBs billed ", total/(1024 * 1024 * 1024), " GBs")
+
+def get_partition_range(i):
+  if i < 1 or i > PET_VET_TABLE_COUNT:
+    raise ValueError(f"out of partition range")
+
+  return { 'start': (i-1)*SAMPLES_PER_PARTITION + 1, 'end': i*SAMPLES_PER_PARTITION }
+
+def get_samples_for_partition(sample_ids, i):
+  return [ s for s in sample_ids if s >= get_partition_range(i)['start'] and s <= get_partition_range(i)['end'] ]
+
+def split_lists(samples, n):
+  return [samples[i * n:(i + 1) * n] for i in range((len(samples) + n - 1) // n )]
+
+def load_sample_names(sample_names_to_extract, fq_temp_table_dataset):
+  schema = [ bigquery.SchemaField("sample_name", "STRING", mode="REQUIRED") ]
+  fq_sample_table = f"{fq_temp_table_dataset}.{EXTRACT_SAMPLE_TABLE}"
+
+  job_labels = client._default_query_job_config.labels
+  job_labels["gvs_query_name"] = "load-sample-names"
+
+  job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.CSV, skip_leading_rows=0, schema=schema, labels=job_labels)
+
+  with open(sample_names_to_extract, "rb") as source_file:
+    job = client.load_table_from_file(source_file, fq_sample_table, job_config=job_config)
+
+  job.result()  # Waits for the job to complete.
+
+  # setting the TTL needs to be done as a second API call
+  table = bigquery.Table(fq_sample_table, schema=schema)
+  expiration = datetime.datetime.utcnow() + datetime.timedelta(hours=TEMP_TABLE_TTL_HOURS)
+  table.expires = expiration
+  table = client.update_table(table, ["expires"])
+
+  return fq_sample_table
+
+def get_all_sample_ids(fq_destination_table_samples):
+  sql = f"select sample_id from `{fq_destination_table_samples}`"
+
+  results = utils.execute_with_retry(client, "read cohort sample table", sql)
+  sample_ids = [row.sample_id for row in list(results)]
+  sample_ids.sort()
+  return sample_ids
+
+def create_extract_samples_table(fq_destination_table_samples, fq_sample_name_table, fq_sample_mapping_table):
+  sql = f"CREATE OR REPLACE TABLE `{fq_destination_table_samples}` AS (" \
+        f"SELECT m.sample_id, m.sample_name, m.is_loaded FROM `{fq_sample_name_table}` s JOIN `{fq_sample_mapping_table}` m ON (s.sample_name = m.sample_name) " \
+        f"WHERE m.is_loaded is TRUE)"
+
+  results = utils.execute_with_retry(client, "create extract sample table", sql)
+  return results
+
+def get_table_count(fq_pet_vet_dataset):
+  sql = f"SELECT MAX(CAST(SPLIT(table_name, '_')[OFFSET(1)] AS INT64)) max_table_number " \
+        f"FROM `{fq_pet_vet_dataset}.INFORMATION_SCHEMA.TABLES` " \
+        f"WHERE REGEXP_CONTAINS(lower(table_name), r'^(pet_[0-9]+)$') "
+  results = utils.execute_with_retry(client, "get max table", sql)
+  return int([row.max_table_number for row in list(results)][0])
+
+def create_final_extract_vet_table(fq_destination_table_vet_data):
+  # first, create the table structure
+
+  sql = f"""
+        CREATE OR REPLACE TABLE `{fq_destination_table_vet_data}` 
+        (
+              location      INT64,
+              sample_id	    INT64,
+              ref           STRING,
+              alt           STRING,
+              call_GT       STRING,
+              call_GQ       INT64,
+              AS_QUALapprox STRING,
+              QUALapprox    STRING,
+              call_PL       STRING	
+        )
+          PARTITION BY RANGE_BUCKET(location, GENERATE_ARRAY(0, 26000000000000, 6500000000))
+          CLUSTER BY location
+          {FINAL_TABLE_TTL}        
+        """
+  print(sql)
+  results = utils.execute_with_retry(client, "create-final-export-table", sql)
+
+def create_final_extract_ref_table(fq_destination_table_ref_data):
+  # first, create the table structure
+  sql = f"""
+        CREATE OR REPLACE TABLE `{fq_destination_table_ref_data}` 
+        (
+              location      INT64,
+              sample_id	    INT64,
+              length        INT64,
+              state	        STRING	
+        )
+          PARTITION BY RANGE_BUCKET(location, GENERATE_ARRAY(0, 26000000000000, 6500000000))
+          CLUSTER BY location
+          {FINAL_TABLE_TTL}        
+        """
+  print(sql)
+  results = utils.execute_with_retry(client, "create-final-export-table", sql)
+
+
+def populate_final_extract_table_with_ref(fq_ranges_dataset, fq_destination_table_data, sample_ids):
+  def get_ref_subselect(fq_ref_table, samples, id):
+    sample_stanza = ','.join([str(s) for s in samples])
+    sql = f"    q_{id} AS (SELECT location, sample_id, length, state FROM \n" \
+          f" `{fq_ref_table}` WHERE sample_id IN ({sample_stanza})), "
+    return sql
+
+  for i in range(1, PET_VET_TABLE_COUNT+1):
+    partition_samples = get_samples_for_partition(sample_ids, i)  #sample ids for the partition
+
+    if len(partition_samples) > 0:
+      subs = {}
+      insert = f"\nINSERT INTO `{fq_destination_table_data}` (location, sample_id, length, state) \n WITH \n"
+      fq_ref_table = f"{fq_ranges_dataset}.{REF_TABLE_PREFIX}{i:03}"
+      j = 1
+
+      for samples in split_lists(partition_samples, 1000):
+        id = f"{i}_{j}"
+        subs[id] = get_ref_subselect(fq_ref_table, samples, id)
+        j = j + 1
+
+      sql = insert + ("\n".join(subs.values())) + "\n" + \
+            "q_all AS (" + (" union all ".join([ f"(SELECT * FROM q_{id})" for id in subs.keys()]))  + ")\n" + \
+            f" (SELECT * FROM q_all)"
+
+      print(sql)
+      print(f"{fq_ref_table} query is {utils.utf8len(sql)/(1024*1024)} MB in length")
+
+      # KCIBUL: whenever this was refactored, we lost the JOB_ID reference to be able to dump stats at the end
+      utils.execute_with_retry(client, "populate destination table with reference data", sql)
+
+  return
+
+def populate_final_extract_table_with_vet(fq_ranges_dataset, fq_destination_table_data, sample_ids):
+  def get_ref_subselect(fq_vet_table, samples, id):
+    sample_stanza = ','.join([str(s) for s in samples])
+    sql = f"    q_{id} AS (SELECT location, sample_id, ref, alt, call_GT, call_GQ, AS_QUALapprox, QUALapprox, CALL_PL FROM \n" \
+          f" `{fq_vet_table}` WHERE sample_id IN ({sample_stanza})), "
+    return sql
+
+  for i in range(1, PET_VET_TABLE_COUNT+1):
+    partition_samples = get_samples_for_partition(sample_ids, i)  #sample ids for the partition
+
+    if len(partition_samples) > 0:
+      subs = {}
+      insert = f"\nINSERT INTO `{fq_destination_table_data}` (location, sample_id, ref, alt, call_GT, call_GQ, AS_QUALapprox, QUALapprox, CALL_PL) \n WITH \n"
+      fq_vet_table = f"{fq_ranges_dataset}.{VET_TABLE_PREFIX}{i:03}"
+      j = 1
+
+      for samples in split_lists(partition_samples, 1000):
+        id = f"{i}_{j}"
+        subs[id] = get_ref_subselect(fq_vet_table, samples, id)
+        j = j + 1
+
+      sql = insert + ("\n".join(subs.values())) + "\n" + \
+            "q_all AS (" + (" union all ".join([ f"(SELECT * FROM q_{id})" for id in subs.keys()]))  + ")\n" + \
+            f" (SELECT * FROM q_all)"
+
+      print(sql)
+      print(f"{fq_vet_table} query is {utils.utf8len(sql)/(1024*1024)} MB in length")
+      utils.execute_with_retry(client, "populate destination table with variant data", sql)
+
+  return
+
+def make_extract_table(fq_ranges_dataset,
+                       max_tables,
+                       sample_names_to_extract,
+                       fq_cohort_sample_names,
+                       query_project,
+                       query_labels,
+                       fq_temp_table_dataset,
+                       fq_destination_dataset,
+                       destination_table_prefix,
+                       min_variant_samples,
+                       fq_sample_mapping_table,
+                       sa_key_path,
+                       temp_table_ttl_hours
+                       ):
+  try:
+    fq_destination_table_ref_data = f"{fq_destination_dataset}.{destination_table_prefix}__REF_DATA"
+    fq_destination_table_vet_data = f"{fq_destination_dataset}.{destination_table_prefix}__VET_DATA"
+    fq_destination_table_samples = f"{fq_destination_dataset}.{destination_table_prefix}__SAMPLES"
+
+    global client
+    # this is where a set of labels are being created for the cohort extract
+    query_labels_map = {}
+    query_labels_map["id"]= output_table_prefix
+    query_labels_map["gvs_tool_name"]= "gvs_prepare_ranges_callset"
+
+    # query_labels is string that looks like 'key1=val1, key2=val2'
+    if query_labels is not None and len(query_labels) != 0:
+      for query_label in query_labels:
+        kv = query_label.split("=", 2)
+        key = kv[0].strip().lower()
+        value = kv[1].strip().lower()
+        query_labels_map[key] = value
+
+        if not (bool(re.match(r"[a-z0-9_-]+$", key)) & bool(re.match(r"[a-z0-9_-]+$", value))):
+          raise ValueError(f"label key or value did not pass validation--format should be 'key1=val1, key2=val2'")
+
+    #Default QueryJobConfig will be merged into job configs passed in
+    #but if a specific default config is being updated (eg labels), new config must be added
+    #to the client._default_query_job_config that already exists
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=True)
+
+    if sa_key_path:
+      credentials = service_account.Credentials.from_service_account_file(
+        sa_key_path, scopes=["https://www.googleapis.com/auth/cloud-platform"],
+      )
+
+      client = bigquery.Client(credentials=credentials,
+                               project=query_project,
+                               default_query_job_config=default_config)
+    else:
+      client = bigquery.Client(project=query_project,
+                               default_query_job_config=default_config)
+
+    ## TODO -- provide a cmdline arg to override this (so we can simulate smaller datasets)
+
+    global PET_VET_TABLE_COUNT
+    PET_VET_TABLE_COUNT = max_tables
+
+    global TEMP_TABLE_TTL_HOURS
+    TEMP_TABLE_TTL_HOURS = temp_table_ttl_hours
+
+    global TEMP_TABLE_TTL
+    TEMP_TABLE_TTL = f" OPTIONS( expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {TEMP_TABLE_TTL_HOURS} HOUR)) "
+
+    print(f"Using {PET_VET_TABLE_COUNT} tables in {fq_ranges_dataset}...")
+
+    # if we have a file of sample names, load it into a temporary table
+    if (sample_names_to_extract):
+      fq_sample_name_table = load_sample_names(sample_names_to_extract, fq_temp_table_dataset)
+    else:
+      fq_sample_name_table = fq_cohort_sample_names
+
+    # At this point one way or the other we have a table of sample names in BQ,
+    # join it to the sample_info table to drive the extract
+    create_extract_samples_table(fq_destination_table_samples, fq_sample_name_table, fq_sample_mapping_table)
+
+    # pull the sample ids back down
+    sample_ids = get_all_sample_ids(fq_destination_table_samples)
+    print(f"Discovered {len(sample_ids)} samples in {fq_destination_table_samples}...")
+
+    # create the tables for exract data
+    create_final_extract_ref_table(fq_destination_table_ref_data)
+    create_final_extract_vet_table(fq_destination_table_vet_data)
+
+    populate_final_extract_table_with_ref(fq_ranges_dataset, fq_destination_table_ref_data, sample_ids)
+    populate_final_extract_table_with_vet(fq_ranges_dataset, fq_destination_table_vet_data, sample_ids)
+
+  finally:
+    dump_job_stats()
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(allow_abbrev=False, description='Extract a cohort from BigQuery Variant Store ')
+
+  parser.add_argument('--fq_ranges_dataset',type=str, help='project.dataset location of ranges/vet data', required=True)
+  parser.add_argument('--fq_temp_table_dataset',type=str, help='project.dataset location where results should be stored', required=True)
+  parser.add_argument('--fq_destination_dataset',type=str, help='project.dataset location where results should be stored', required=True)
+  parser.add_argument('--destination_cohort_table_prefix',type=str, help='prefix used for destination cohort extract tables (e.g. my_fantastic_cohort)', required=True)
+  parser.add_argument('--query_project',type=str, help='Google project where query should be executed', required=True)
+  parser.add_argument('--query_labels',type=str, action='append', help='Labels to put on the BQ query that will show up in the billing. Ex: --query_labels key1=value1 --query_labels key2=value2', required=False)
+  parser.add_argument('--min_variant_samples',type=int, help='Minimum variant samples at a site required to be emitted', required=False, default=0)
+  parser.add_argument('--fq_sample_mapping_table',type=str, help='Mapping table from sample_id to sample_name', required=True)
+  parser.add_argument('--sa_key_path',type=str, help='Path to json key file for SA', required=False)
+  parser.add_argument('--max_tables',type=int, help='Maximum number of PET/VET tables to consider', required=False, default=250)
+  parser.add_argument('--ttl',type=int, help='Temp table TTL in hours', required=False, default=72)
+
+  sample_args = parser.add_mutually_exclusive_group(required=True)
+  sample_args.add_argument('--sample_names_to_extract',type=str, help='File containing list of samples to extract, 1 per line')
+  sample_args.add_argument('--fq_cohort_sample_names',type=str, help='FQN of cohort table to extract, contains "sample_name" column')
+
+
+  # Execute the parse_args() method
+  args = parser.parse_args()
+
+  make_extract_table(args.fq_ranges_dataset,
+                     args.max_tables,
+                     args.sample_names_to_extract,
+                     args.fq_cohort_sample_names,
+                     args.query_project,
+                     args.query_labels,
+                     args.fq_temp_table_dataset,
+                     args.fq_destination_dataset,
+                     args.destination_cohort_table_prefix,
+                     args.min_variant_samples,
+                     args.fq_sample_mapping_table,
+                     args.sa_key_path,
+                     args.ttl)

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -86,6 +86,21 @@ public class ExtractCohort extends ExtractTool {
     )
     private String vetRangesFQDataSet = null;
 
+
+    @Argument(
+            fullName = "vet-ranges-extract-fq-table",
+            doc = "EXPERIMENTAL - ",
+            optional = true
+    )
+    private String fqRangesExtractVetTable = null;
+
+    @Argument(
+            fullName = "ref-ranges-extract-fq-table",
+            doc = "EXPERIMENTAL - ",
+            optional = true
+    )
+    private String fqRangesExtractRefTable = null;
+
     @Argument(
             fullName = "vet-avro-file-name",
             doc = "Path to data from Vet table in Avro format",
@@ -287,10 +302,11 @@ public class ExtractCohort extends ExtractTool {
 
         // if there is an avro file, the BQ specific parameters are unnecessary,
         // but they all are required if there is no avro file
-        if ((cohortAvroFileName == null && vetAvroFileName == null && refRangesAvroFileName == null) && (projectID == null || (cohortTable == null && vetRangesFQDataSet == null))) {
-            throw new UserException("Project id (--project-id) and cohort table (--cohort-extract-table) are required " +
-                "if no avro file (--cohort-avro-file-name or --vet-avro-file-name and --ref-ranges-avro-file-name) is provided.");
-        }
+        // KCIBUL: revisit!!!
+//        if ((cohortAvroFileName == null && vetAvroFileName == null && refRangesAvroFileName == null) && (projectID == null || (cohortTable == null && vetRangesFQDataSet == null))) {
+//            throw new UserException("Project id (--project-id) and cohort table (--cohort-extract-table) are required " +
+//                "if no avro file (--cohort-avro-file-name or --vet-avro-file-name and --ref-ranges-avro-file-name) is provided.");
+//        }
 
         // if there is a sample file, the BQ specific parameters are unnecessary,
         // but without a sample file, both a sample-table and a project-id are needed
@@ -310,6 +326,8 @@ public class ExtractCohort extends ExtractTool {
                 cohortTable,
                 cohortAvroFileName,
                 vetRangesFQDataSet,
+                fqRangesExtractVetTable,
+                fqRangesExtractRefTable,
                 vetAvroFileName,
                 refRangesAvroFileName,
                 traversalIntervals,

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -270,15 +270,15 @@ public class ExtractCohortEngine {
         final Comparator<GenericRecord> sortingCollectionComparator = new Comparator<GenericRecord>() {
             @Override
             public int compare( GenericRecord o1, GenericRecord o2 ) {
-                final long firstPosition = Long.parseLong(o1.get(SchemaUtils.LOCATION_FIELD_NAME).toString());
-                final long secondPosition = Long.parseLong(o2.get(SchemaUtils.LOCATION_FIELD_NAME).toString());
+                final long firstPosition = (Long) o1.get(SchemaUtils.LOCATION_FIELD_NAME);
+                final long secondPosition = (Long) o2.get(SchemaUtils.LOCATION_FIELD_NAME);
 
                 final int result = Long.compare(firstPosition, secondPosition);
                 if (result != 0) {
                     return result;
                 } else {
-                    final long firstSample = Long.parseLong(o1.get(SchemaUtils.SAMPLE_ID_FIELD_NAME).toString());
-                    final long secondSample = Long.parseLong(o2.get(SchemaUtils.SAMPLE_ID_FIELD_NAME).toString());
+                    final long firstSample = (Long) o1.get(SchemaUtils.SAMPLE_ID_FIELD_NAME);
+                    final long secondSample = (Long) o2.get(SchemaUtils.SAMPLE_ID_FIELD_NAME);
                     return Long.compare(firstSample, secondSample);
                 }
             }
@@ -330,7 +330,7 @@ public class ExtractCohortEngine {
 
         for (final GenericRecord queryRow : avroReader) {
             long location = (Long) queryRow.get(SchemaUtils.LOCATION_FIELD_NAME);
-            int length = Integer.parseInt(queryRow.get(SchemaUtils.LENGTH_FIELD_NAME).toString());
+            int length = ((Long) queryRow.get(SchemaUtils.LENGTH_FIELD_NAME)).intValue();
 
             if (vbs.containsVariant(location, location + length) ) {
                 sortingCollection.add(queryRow);

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -80,6 +80,10 @@ public class ExtractCohortEngine {
     private final GATKPath cohortAvroFileName;
 
     private final String vetRangesFQDataSet;
+
+    private final String fqRangesExtractVetTable;
+    private final String fqRangesExtractRefTable;
+
     private final GATKPath vetAvroFileName;
     private final GATKPath refRangesAvroFileName;
     private final String filterSetName;
@@ -97,6 +101,8 @@ public class ExtractCohortEngine {
                                final String cohortTableName,
                                final GATKPath cohortAvroFileName,
                                final String vetRangesFQDataSet,
+                               final String fqRangesExtractVetTable,
+                               final String fqRangesExtractRefTable,
                                final GATKPath vetAvroFileName,
                                final GATKPath refRangesAvroFileName,
                                final List<SimpleInterval> traversalIntervals,
@@ -130,6 +136,8 @@ public class ExtractCohortEngine {
                 new TableReference(cohortTableName, emitPLs ? SchemaUtils.COHORT_FIELDS : SchemaUtils.COHORT_FIELDS_NO_PL);
 
         this.vetRangesFQDataSet = vetRangesFQDataSet;
+        this.fqRangesExtractVetTable = fqRangesExtractVetTable;
+        this.fqRangesExtractRefTable = fqRangesExtractRefTable;
 
         this.cohortAvroFileName = cohortAvroFileName;
         this.vetAvroFileName = vetAvroFileName;
@@ -233,8 +241,9 @@ public class ExtractCohortEngine {
             }
 
             SortedSet<Long> sampleIdsToExtract = new TreeSet<>(this.sampleIdToName.keySet());
-
-            if (vetRangesFQDataSet != null) {
+            if (fqRangesExtractVetTable != null) {
+                createVariantsFromUnsortedExtractTableBigQueryRanges(fqRangesExtractVetTable, fqRangesExtractRefTable, sampleIdsToExtract, minLocation, maxLocation, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
+            } else if (vetRangesFQDataSet != null) {
                 createVariantsFromUnsortedBigQueryRanges(vetRangesFQDataSet, sampleIdsToExtract, minLocation, maxLocation, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
             } else {
                 createVariantsFromUnsortedAvroRanges(vetAvroFileName, refRangesAvroFileName, sampleIdsToExtract, minLocation, maxLocation, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested, presortedAvroFiles);
@@ -925,6 +934,94 @@ public class ExtractCohortEngine {
         createVariantsFromSortedRanges(sampleIdsToExtract, sortedVet, sortedReferenceRange, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
     }
 
+    //
+    // BEGIN REF RANGES COHORT EXTACT
+    //
+    private void createVariantsFromUnsortedExtractTableBigQueryRanges(
+            final String fqVetTable,
+            final String fqRefTable,
+            final SortedSet<Long> sampleIdsToExtract,
+            final Long minLocation,
+            final Long maxLocation,
+            final HashMap<Long, HashMap<Allele, HashMap<Allele, Double>>> fullVqsLodMap,
+            final HashMap<Long, HashMap<Allele, HashMap<Allele, String>>> fullYngMap,
+            final HashMap<Long, List<String>> siteFilterMap,
+            final boolean noVqslodFilteringRequested) {
+
+        // We could handle this by making a map of BitSets or something, but it seems unnecessary to support this
+        if (!SchemaUtils.decodeContig(minLocation).equals(SchemaUtils.decodeContig(maxLocation))) {
+            throw new GATKException("Can not process cross-contig boundaries");
+        }
+
+        VariantBitSet vbs = new VariantBitSet(minLocation, maxLocation);
+
+        SortingCollection<GenericRecord> sortedVet = createSortedVetCollectionFromExtractTableBigQuery(projectID,
+                fqVetTable,
+                minLocation,
+                maxLocation,
+                localSortMaxRecordsInRam,
+                vbs);
+
+
+        SortingCollection<GenericRecord> sortedReferenceRange = createSortedReferenceRangeCollectionFromExtractTableBigQuery(projectID,
+                fqRefTable,
+                minLocation,
+                maxLocation,
+                localSortMaxRecordsInRam,
+                vbs);
+
+        createVariantsFromSortedRanges(sampleIdsToExtract, sortedVet, sortedReferenceRange, fullVqsLodMap, fullYngMap, siteFilterMap, noVqslodFilteringRequested);
+    }
+
+    private SortingCollection<GenericRecord> createSortedVetCollectionFromExtractTableBigQuery(final String projectID,
+                                                                                   final String fqVetTable,
+                                                                                   final Long minLocation,
+                                                                                   final Long maxLocation,
+                                                                                   final int localSortMaxRecordsInRam,
+                                                                                   final VariantBitSet vbs
+    ) {
+
+        TableReference tableRef =
+                new TableReference(fqVetTable, SchemaUtils.EXTRACT_VET_FIELDS);
+
+        // We need to look upstream MAX_DELETION_SIZE bases in case there is a deletion that begins before
+        // the requested range, but spans into our processing range.  We don't use a "length" or end position
+        // because it would break the clustering indexing
+        final String vetRowRestriction =
+                "location >= " + (minLocation - IngestConstants.MAX_DELETION_SIZE + 1)+ " AND location <= " + maxLocation;
+        try (StorageAPIAvroReader vetReader = new StorageAPIAvroReader(tableRef, vetRowRestriction, projectID)) {
+            SortingCollection<GenericRecord> sortedVet = getAvroSortingCollection(vetReader.getSchema(), localSortMaxRecordsInRam);
+            addToVetSortingCollection(sortedVet, vetReader, vbs);
+            processBytesScanned(vetReader);
+            return sortedVet;
+        }
+    }
+
+    private SortingCollection<GenericRecord> createSortedReferenceRangeCollectionFromExtractTableBigQuery(final String projectID,
+                                                                                              final String fqRefTable,
+                                                                                              final Long minLocation,
+                                                                                              final Long maxLocation,
+                                                                                              final int localSortMaxRecordsInRam,
+                                                                                              final VariantBitSet vbs
+    ) {
+
+        TableReference tableRef = new TableReference(fqRefTable, SchemaUtils.EXTRACT_REF_FIELDS);
+
+        // NOTE: MUST be written as location >= minLocation - MAX_REFERENCE_BLOCK_BASES +1 to not break cluster pruning in BigQuery
+        final String refRowRestriction =
+                "location >= " + (minLocation - IngestConstants.MAX_REFERENCE_BLOCK_BASES + 1) + " AND location <= " + maxLocation;
+
+        try (StorageAPIAvroReader refReader = new StorageAPIAvroReader(tableRef, refRowRestriction, projectID)) {
+            SortingCollection<GenericRecord> sortedReferenceRange = getAvroSortingCollection(refReader.getSchema(), localSortMaxRecordsInRam);
+            addToRefSortingCollection(sortedReferenceRange, refReader, vbs);
+            processBytesScanned(refReader);
+            return sortedReferenceRange;
+        }
+    }
+
+    //
+    // END REF RANGES COHORT EXTRACT
+    //
     private void createVariantsFromUnsortedAvroRanges(
             final GATKPath vetAvroFileName,
             final GATKPath refRangesAvroFileName,

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortRemoveAnnotationsUnitTest.java
@@ -38,6 +38,8 @@ public class ExtractCohortRemoveAnnotationsUnitTest extends GATKBaseTest{
                 null,
                 null,
                 null,
+                null,
+                null,
                 0,
                 false,
                 0.0,


### PR DESCRIPTION
Some notes from the 10k tieout:
### Prepare Step
 - ~20 min per full ref_ranges table to insert
 - ~7 min per full vet table to insert
 - "bytes scanned" are same as data table size

### Extract

**Original Run - 293 min**

- 103 minutes pulling down data, scanning 237 GB
   - 43 min on 20m vet records (20:26 - > 21:09)
   -  60 min on 291m vet records (21:09 -> 22:10)

- 190 minutes writing the VCF
 
**Prepare Extract with minor tuning of sorting  - 134 min**

 - 25 minutes pulling down data ( faster), scanning 10 GB (50x reduction)
   - 4 min on 20m vet records(02:43 -> 02:47)    - NOTE 103s of that was sorting (44s) and spilling to disk (59 s)
   - 21 min on 291m vet records (02:47 -> 03:08) - NOTE 9 min of that was sorting (6 min) and spilling to disk (3 min)

 - 109 minutes writing the VCF (this is the change to pre-sort the sample set merged to ah_var_store on 1/12/22) 

**Tieout is identical**

```
kcibul@kc-specops-tiny:~/stroke_tieout$ md5sum gold.jointcallset_0.vcf.gz
496178eae4afe63c4391d8eba64a9947  gold.jointcallset_0.vcf.gz

kcibul@kc-specops-tiny:~/stroke_tieout$ md5sum trial.full.jointcallset_0.vcf.gz
496178eae4afe63c4391d8eba64a9947  trial.full.jointcallset_0.vcf.gz
```