### PR TITLE
clustering vqsr tables by location

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -89,6 +89,7 @@ workflows:
          - master
          - ah_var_store
          - rsa_split_intervals_part_2
+         - kc_cluster_vqsr
    - name: GvsCreateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateAltAllele.wdl

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -466,6 +466,8 @@ task PopulateFilterSetInfo {
 
         echo "Loading combined TSV into ~{fq_info_destination_table}"
         bq load --project_id=~{query_project} --skip_leading_rows 0 -F "tab" \
+        --range_partitioning=location,0,26000000000000,6500000000 \
+        --clustering_fields=location \
         --schema "filter_set_name:string,type:string,location:integer,ref:string,alt:string,vqslod:float,culprit:string,training_label:string,yng_status:string" \
         ${bq_table} \
         ~{filter_set_name}.filter_set_load.tsv > status_load_filter_set_info
@@ -526,6 +528,8 @@ task PopulateFilterSetSites {
 
         echo "Loading filter set sites TSV into ~{fq_filter_sites_destination_table}"
         bq load --project_id=~{query_project} --skip_leading_rows 1 -F "tab" \
+        --range_partitioning=location,0,26000000000000,6500000000 \
+        --clustering_fields=location \
         --schema "filter_set_name:string,location:integer,filters:string" \
         ${bq_table} \
         ~{filter_set_name}.filter_sites_load.tsv > status_load_filter_set_sites


### PR DESCRIPTION
I was bugged by the fact that @rsasch calculated the latest callset read 1957 TB of data via the Read API when we knew the core extract tables were only ~100 TB.  Turns out that 90% of that scanning was actually reading the various un-partitioned, un-clustered VQSR related tables.  Each shard read the entire table (which is ~80 GB), multiplied by 20k shards --> is about 1600 TB of reads.  The cost of that represents ~20% of the total cost of making the 100k callset, so a big cost savings.

Clustering and partitioning these tables allows each shard to just consume the data it needs.