### PR TITLE
Fix for PossibleDeNovo annotation to work without Genotype Likelihoods

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
@@ -105,7 +105,7 @@ public final class PossibleDeNovo extends PedigreeAnnotation implements InfoFiel
         final List<String> lowConfDeNovoChildren = new ArrayList<>();
         for (final Trio trio : trioSet) {
             if (vc.isBiallelic() &&
-                PossibleDeNovo.contextHasTrioLikelihoods(vc, trio) &&
+                PossibleDeNovo.contextHasTrioGQs(vc, trio) &&
                 mendelianViolation.isViolation(trio.getMother(), trio.getFather(), trio.getChild(), vc) &&
                 mendelianViolation.getParentsRefRefChildHet() > 0) {
 
@@ -135,14 +135,14 @@ public final class PossibleDeNovo extends PedigreeAnnotation implements InfoFiel
         return attributeMap;
     }
 
-    private static boolean contextHasTrioLikelihoods(final VariantContext vc, final Trio trio) {
+    static boolean contextHasTrioGQs(final VariantContext vc, final Trio trio) {
         final String mom = trio.getMaternalID();
         final String dad = trio.getPaternalID();
         final String kid = trio.getChildID();
 
-        return   (!mom.isEmpty() && vc.hasGenotype(mom) && vc.getGenotype(mom).hasLikelihoods())
-              && (!dad.isEmpty() && vc.hasGenotype(dad) && vc.getGenotype(dad).hasLikelihoods())
-              && (!kid.isEmpty() && vc.hasGenotype(kid) && vc.getGenotype(kid).hasLikelihoods());
+        return   (!mom.isEmpty() && vc.hasGenotype(mom) && vc.getGenotype(mom).hasGQ())
+              && (!dad.isEmpty() && vc.hasGenotype(dad) && vc.getGenotype(dad).hasGQ())
+              && (!kid.isEmpty() && vc.hasGenotype(kid) && vc.getGenotype(kid).hasGQ());
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovo.java
@@ -135,7 +135,7 @@ public final class PossibleDeNovo extends PedigreeAnnotation implements InfoFiel
         return attributeMap;
     }
 
-    static boolean contextHasTrioGQs(final VariantContext vc, final Trio trio) {
+    private static boolean contextHasTrioGQs(final VariantContext vc, final Trio trio) {
         final String mom = trio.getMaternalID();
         final String dad = trio.getPaternalID();
         final String kid = trio.getChildID();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovoUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/annotator/PossibleDeNovoUnitTest.java
@@ -117,6 +117,13 @@ public final class PossibleDeNovoUnitTest extends GATKBaseTest {
         tests.add(new Object[]{gNo, gNo, g11, false});
         tests.add(new Object[]{gNo, gNo, gNo, false});
 
+        final Genotype g00NoPl = new GenotypeBuilder("2", homRef).DP(10).GQ(GQ30).make();
+        final Genotype g01NoPl = new GenotypeBuilder("1", het).DP(10).GQ(GQ30).make();
+        final Genotype g11NoPl = new GenotypeBuilder("3", homVar).DP(10).GQ(GQ30).make();
+
+        tests.add(new Object[]{g00NoPl, g01NoPl, g11NoPl, false});
+        tests.add(new Object[]{g00NoPl, g00NoPl, g01NoPl, true});
+
         return tests.toArray(new Object[][]{});
     }
 


### PR DESCRIPTION
PossibleDeNovo checks each trio's genotype (including parent hom ref genotypes) for likelihoods even though it doesn't actually use the PLs. The PLs can get dropped if GVCFs are reblocked which means this annotation no longer works as expected. This changes the check to look for GQs instead of PLs as the GQs are used as part of the annotation.

@ldgauthier Could you please suggest a reviewer?