### PR TITLE
Adding back jcenter repository resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ task downloadGsaLibFile(type: Download) {
 repositories {
     mavenCentral()
 
+    jcenter()
     maven {
         url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for htsjdk snapshots
     }


### PR DESCRIPTION
We had removed it because it was shutting down and our tests showed it was unnecessary.   It turns out that it's only unnecessary because we're getting jcenter results cached in the artifactory.  JCenter is now planning to remain online for the immediate future in read only mode so it should be fine to put it back.

Fixes https://github.com/broadinstitute/gatk/issues/7636