### PR TITLE
Added custom `VariantClassification` severity ordering.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
@@ -5,13 +5,14 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public abstract class BaseFuncotatorArgumentCollection implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -115,4 +116,11 @@ public abstract class BaseFuncotatorArgumentCollection implements Serializable {
             doc = "The minimum number of bases for a variant to be annotated as a segment.  Recommended to be changed only for use with FuncotateSegments.  Defaults to " + FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT
     )
     public int minNumBasesForValidSegment = FuncotatorUtils.DEFAULT_MIN_NUM_BASES_FOR_VALID_SEGMENT;
+
+    @Argument(
+            fullName = FuncotatorArgumentDefinitions.CUSTOM_VARIANT_CLASS_ORDER_FILE,
+            optional = true,
+            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICAITON must match one of the VariantClassification names (" + Arrays.stream(GencodeFuncotation.VariantClassification.values()).map(vc -> vc.toString()).collect(Collectors.joining(",")) + ").  SEV is an unsigned integer, where lower is sorted first."
+    )
+    public GATKPath customVariantClassificationOrderFile = null;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
@@ -120,7 +120,7 @@ public abstract class BaseFuncotatorArgumentCollection implements Serializable {
     @Argument(
             fullName = FuncotatorArgumentDefinitions.CUSTOM_VARIANT_CLASS_ORDER_FILE,
             optional = true,
-            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICATION must match one of the VariantClassification names (" + GencodeFuncotation.VariantClassification.ALL_VC_NAMES + ").  SEV is an unsigned integer, where lower is sorted first."
+            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICATION must match one of the VariantClassification names (" + GencodeFuncotation.VariantClassification.ALL_VC_NAMES + ").  SEV is an unsigned integer, where lower is sorted first.  When using this option it is HIGHLY recommended you also use the `BEST_EFFECT` transcript selection mode."
     )
     public GATKPath customVariantClassificationOrderFile = null;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
@@ -120,7 +120,7 @@ public abstract class BaseFuncotatorArgumentCollection implements Serializable {
     @Argument(
             fullName = FuncotatorArgumentDefinitions.CUSTOM_VARIANT_CLASS_ORDER_FILE,
             optional = true,
-            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICAITON must match one of the VariantClassification names (" + GencodeFuncotation.VariantClassification.ALL_VC_NAMES + ").  SEV is an unsigned integer, where lower is sorted first."
+            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICATION must match one of the VariantClassification names (" + GencodeFuncotation.VariantClassification.ALL_VC_NAMES + ").  SEV is an unsigned integer, where lower is sorted first."
     )
     public GATKPath customVariantClassificationOrderFile = null;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/BaseFuncotatorArgumentCollection.java
@@ -120,7 +120,7 @@ public abstract class BaseFuncotatorArgumentCollection implements Serializable {
     @Argument(
             fullName = FuncotatorArgumentDefinitions.CUSTOM_VARIANT_CLASS_ORDER_FILE,
             optional = true,
-            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICAITON must match one of the VariantClassification names (" + Arrays.stream(GencodeFuncotation.VariantClassification.values()).map(vc -> vc.toString()).collect(Collectors.joining(",")) + ").  SEV is an unsigned integer, where lower is sorted first."
+            doc = "TSV File containing custom Variant Classification severity map of the form: VARIANT_CLASSIFICATION\tSEV.  VARIANT_CLASSIFICAITON must match one of the VariantClassification names (" + GencodeFuncotation.VariantClassification.ALL_VC_NAMES + ").  SEV is an unsigned integer, where lower is sorted first."
     )
     public GATKPath customVariantClassificationOrderFile = null;
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -67,6 +67,8 @@ public class FuncotatorArgumentDefinitions {
     public static final String FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION = "force-b37-to-hg19-reference-contig-conversion";
     public static final String MIN_NUM_BASES_FOR_SEGMENT_FUNCOTATION = "min-num-bases-for-segment-funcotation";
 
+    public static final String CUSTOM_VARIANT_CLASS_ORDER_FILE = "custom-variant-classifiation-order";
+
     // ------------------------------------------------------------
     // Helper Types:
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorArgumentDefinitions.java
@@ -67,7 +67,7 @@ public class FuncotatorArgumentDefinitions {
     public static final String FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION = "force-b37-to-hg19-reference-contig-conversion";
     public static final String MIN_NUM_BASES_FOR_SEGMENT_FUNCOTATION = "min-num-bases-for-segment-funcotation";
 
-    public static final String CUSTOM_VARIANT_CLASS_ORDER_FILE = "custom-variant-classifiation-order";
+    public static final String CUSTOM_VARIANT_CLASS_ORDER_FILE = "custom-variant-classification-order";
 
     // ------------------------------------------------------------
     // Helper Types:

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -111,6 +111,11 @@ public final class FuncotatorEngine implements AutoCloseable {
 
         // Determine whether we have to convert given variants from B37 to HG19:
         mustConvertInputContigsToHg19 = determineReferenceAndDatasourceCompatibility();
+
+        // Read in the custom variant classification order file here so that it can be shared across all engines:
+        if (funcotatorArgs.customVariantClassificationOrderFile != null) {
+            FuncotatorUtils.setVariantClassificationCustomSeverity(funcotatorArgs.customVariantClassificationOrderFile);
+        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -2357,7 +2357,7 @@ public final class FuncotatorUtils {
             logger.info("Setting custom variant classification severities from: " + customSeverityFile);
 
             if ( !Files.exists(customSeverityFile.toPath()) ) {
-                throw new UserException("Custom severity file does not exist: " + customSeverityFile);
+                throw new UserException.CouldNotReadInputFile("Custom severity file does not exist: " + customSeverityFile);
             }
             try (final BufferedReader reader = new BufferedReader(new InputStreamReader(customSeverityFile.getInputStream()))) {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -2354,6 +2355,10 @@ public final class FuncotatorUtils {
     public static void setVariantClassificationCustomSeverity(final GATKPath customSeverityFile) {
         try {
             logger.info("Setting custom variant classification severities from: " + customSeverityFile);
+
+            if ( !Files.exists(customSeverityFile.toPath()) ) {
+                throw new UserException("Custom severity file does not exist: " + customSeverityFile);
+            }
             final BufferedReader reader = new BufferedReader(new InputStreamReader(customSeverityFile.getInputStream()));
 
             int lineNum = 1;

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorVariantArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorVariantArgumentCollection.java
@@ -2,6 +2,12 @@ package org.broadinstitute.hellbender.tools.funcotator;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.funcotator.dataSources.gencode.GencodeFuncotation;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * Arguments to be be used by the {@link Funcotator} {@link org.broadinstitute.hellbender.engine.GATKTool},
@@ -47,6 +53,4 @@ public class FuncotatorVariantArgumentCollection extends BaseFuncotatorArgumentC
             doc = "When input VCF has already been annotated, still annotate again."
     )
     public boolean reannotateVCF = false;
-
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A class to represent a Functional Annotation.  Each instance represents the annotations on a single transcript.
@@ -822,6 +823,13 @@ public class GencodeFuncotation implements Funcotation {
         RNA("RNA", 4),
         /** Variant lies on one of the lincRNAs. */
         LINCRNA("LINCRNA", 4);
+
+        /**
+         * Variable to store the list of all valid {@link VariantClassification} types.
+         * This is used for command-line argument documentation and MUST be maintained if / when any of the
+         * VariantClassification values / names are updated.
+         */
+        public static final String ALL_VC_NAMES = "COULD_NOT_DETERMINE, INTRON, FIVE_PRIME_UTR, THREE_PRIME_UTR, IGR, FIVE_PRIME_FLANK, THREE_PRIME_FLANK, MISSENSE, NONSENSE, NONSTOP, SILENT, SPLICE_SITE, IN_FRAME_DEL, IN_FRAME_INS, FRAME_SHIFT_INS, FRAME_SHIFT_DEL, START_CODON_SNP, START_CODON_INS, START_CODON_DEL, DE_NOVO_START_IN_FRAME, DE_NOVO_START_OUT_FRAME, RNA, LINCRNA";
 
         /**
          * The relative severity of each {@link VariantClassification}.

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
@@ -754,6 +754,18 @@ public class GencodeFuncotation implements Funcotation {
      */
     public enum VariantClassification {
 
+        // __        ___    ____  _   _ ___ _   _  ____
+        // \ \      / / \  |  _ \| \ | |_ _| \ | |/ ___|
+        //  \ \ /\ / / _ \ | |_) |  \| || ||  \| | |  _
+        //   \ V  V / ___ \|  _ <| |\  || || |\  | |_| |
+        //    \_/\_/_/   \_\_| \_\_| \_|___|_| \_|\____|
+        //
+        // When new types are added to VariantClassification
+        // or when existing types are modified, they MUST
+        // also be added to the ALL_VC_NAMES variable.
+        //
+        // There does not seem to be a good way around this.
+
         /** Variant classification could not be determined. */
         COULD_NOT_DETERMINE("COULD_NOT_DETERMINE",99),
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotation.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A class to represent a Functional Annotation.  Each instance represents the annotations on a single transcript.
@@ -829,20 +828,45 @@ public class GencodeFuncotation implements Funcotation {
          * Lower numbers are considered more severe.
          * Higher numbers are considered less severe.
          */
-        final private int relativeSeverity;
+        private int relativeSeverity;
+
+        /**
+         * The default value for the {@link VariantClassification#relativeSeverity} of this {@link VariantClassification}.
+         */
+        final private int defaultRelativeSeverity;
 
         /** The serialized version of this {@link VariantClassification} */
         final private String serialized;
 
         VariantClassification(final String serialized, final int sev) {
             this.serialized = serialized;
+            defaultRelativeSeverity = sev;
             relativeSeverity = sev;
+        }
+
+        /**
+         * Reset the severities of all {@link VariantClassification}s to their default values.
+         */
+        public static void resetSeveritiesToDefault() {
+            for (VariantClassification vc : VariantClassification.values()) {
+                vc.setSeverity(vc.getDefaultSeverity());
+            }
         }
 
         /**
          * @return The {@link VariantClassification#relativeSeverity} of {@code this} {@link VariantClassification}.
          */
         public int getSeverity() { return relativeSeverity; }
+
+        /**
+         * @return The {@link VariantClassification#defaultRelativeSeverity} of {@code this} {@link VariantClassification}.
+         */
+        public int getDefaultSeverity() { return defaultRelativeSeverity; }
+
+        /**
+         * Set the {@link VariantClassification#relativeSeverity} of {@code this} {@link VariantClassification}.
+         */
+        public void setSeverity(final int sev) { this.relativeSeverity = sev; }
 
         @Override
         public String toString() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -2114,11 +2114,6 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
 
         Assert.assertEquals(variantContexts.size(), expectedVariantContexts.size());
 
-        System.out.println("VC Severities:");
-        for ( GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
-            System.out.println(vc.toString() + " : " + vc.getSeverity());
-        }
-
         try {
             IntegrationTestSpec.assertEqualTextFiles(outputFile, new File(expectedFilePath), "#");
         }
@@ -2128,11 +2123,6 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
 
         // Reset severity:
         GencodeFuncotation.VariantClassification.resetSeveritiesToDefault();
-
-        System.out.println("VC Severities:");
-        for ( GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
-            System.out.println(vc.toString() + " : " + vc.getSeverity());
-        }
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorIntegrationTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.GATKPath;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
@@ -33,11 +34,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.sql.Timestamp;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,6 +80,9 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
 
     // TODO: Get rid of this variable and use the general data sources path (issue #5350 - https://github.com/broadinstitute/gatk/issues/5350):
     private static final String DS_PIK3CA_DIR            = largeFileTestDir + "funcotator" + File.separator + "small_ds_pik3ca" + File.separator;
+
+    private static final String  MEDIUM_DATASOURCES_DIR     = largeFileTestDir + "funcotator" + File.separator + "funcotator_dataSources" + File.separator;
+
     private static final String MAF_TEST_CONFIG          = toolsTestDir + "funcotator" + File.separator + "maf.config";
     private static final String XSV_CLINVAR_COL_TEST_VCF = toolsTestDir + "funcotator" + File.separator + "clinvar_hg19_column_test.vcf";
     private static final String DS_XSV_CLINVAR_COL_TEST  = largeFileTestDir + "funcotator" + File.separator + "small_ds_clinvar_hg19" + File.separator;
@@ -2073,6 +2075,66 @@ public class FuncotatorIntegrationTest extends CommandLineProgramTest {
 
     }
 
+    @Test
+    public void testCustomVariantClassificationOrder() {
+
+        final FuncotatorArgumentDefinitions.OutputFormatType outputFormatType = FuncotatorArgumentDefinitions.OutputFormatType.VCF;
+        final File outputFile = getOutputFile(outputFormatType);
+
+        final ArgumentsBuilder arguments = createBaselineArgumentsForFuncotator(
+                largeFileTestDir + "funcotator" + File.separator + "custom_vc_order_files" + File.separator + "custom_vc_input_test.vcf",
+                outputFile,
+                b37Reference,
+                MEDIUM_DATASOURCES_DIR,
+                FuncotatorTestConstants.REFERENCE_VERSION_HG19,
+                outputFormatType,
+                false);
+
+        // We need this argument since we are testing on a subset of b37
+        arguments.add(FuncotatorArgumentDefinitions.FORCE_B37_TO_HG19_REFERENCE_CONTIG_CONVERSION, true);
+
+        // It's best to make this run on BEST_EFFECT with this test
+        arguments.add(FuncotatorArgumentDefinitions.TRANSCRIPT_SELECTION_MODE_LONG_NAME, TranscriptSelectionMode.BEST_EFFECT);
+
+        // Add the new ordering of the variant classifications:
+        final GATKPath custom_vc_path = new GATKPath(largeFileTestDir + "funcotator" + File.separator
+                + "custom_vc_order_files" + File.separator + "custom_vc_order_for_int_test.tsv");
+        arguments.add(FuncotatorArgumentDefinitions.CUSTOM_VARIANT_CLASS_ORDER_FILE, custom_vc_path.toPath().toUri().toString());
+
+        // Run Funcotator:
+        runCommandLine(arguments);
+
+        // Validate results:
+        final String expectedFilePath = largeFileTestDir + "funcotator" + File.separator + "custom_vc_order_files" + File.separator + "custom_vc_expected_out.vcf";
+
+        final Pair<VCFHeader, List<VariantContext>> vcfInfo = VariantContextTestUtils.readEntireVCFIntoMemory(outputFile.getAbsolutePath());
+        final List<VariantContext> variantContexts = vcfInfo.getRight();
+        final Pair<VCFHeader, List<VariantContext>> expectedVcfInfo = VariantContextTestUtils.readEntireVCFIntoMemory(expectedFilePath);
+        final List<VariantContext> expectedVariantContexts = expectedVcfInfo.getRight();
+
+        Assert.assertEquals(variantContexts.size(), expectedVariantContexts.size());
+
+        System.out.println("VC Severities:");
+        for ( GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
+            System.out.println(vc.toString() + " : " + vc.getSeverity());
+        }
+
+        try {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, new File(expectedFilePath), "#");
+        }
+        catch ( final IOException ex ) {
+            throw new GATKException("Error opening expected file: " + expectedFilePath, ex);
+        }
+
+        // Reset severity:
+        GencodeFuncotation.VariantClassification.resetSeveritiesToDefault();
+
+        System.out.println("VC Severities:");
+        for ( GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
+            System.out.println(vc.toString() + " : " + vc.getSeverity());
+        }
     }
+
+}
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -2475,49 +2475,51 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
 
     @DataProvider
     public Object[][] provideForTestSetVariantClassificationCustomSeverity() {
+
+        final Map<GencodeFuncotation.VariantClassification, Integer> expected1 = new HashMap<>();
+        expected1.put(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE, 0);
+        expected1.put(GencodeFuncotation.VariantClassification.INTRON, 1);
+        expected1.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, 2);
+        expected1.put(GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 4);
+        expected1.put(GencodeFuncotation.VariantClassification.IGR, 8);
+        expected1.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_FLANK, 16);
+        expected1.put(GencodeFuncotation.VariantClassification.THREE_PRIME_FLANK, 32);
+        expected1.put(GencodeFuncotation.VariantClassification.MISSENSE, 64);
+        expected1.put(GencodeFuncotation.VariantClassification.NONSENSE, 128);
+        expected1.put(GencodeFuncotation.VariantClassification.NONSTOP, 256);
+        expected1.put(GencodeFuncotation.VariantClassification.SILENT, 512);
+        expected1.put(GencodeFuncotation.VariantClassification.SPLICE_SITE, 1024);
+        expected1.put(GencodeFuncotation.VariantClassification.IN_FRAME_DEL, 2048);
+        expected1.put(GencodeFuncotation.VariantClassification.IN_FRAME_INS, 4096);
+        expected1.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_INS, 8192);
+        expected1.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_DEL, 16384);
+        expected1.put(GencodeFuncotation.VariantClassification.START_CODON_SNP, 32768);
+        expected1.put(GencodeFuncotation.VariantClassification.START_CODON_INS, 65536);
+        expected1.put(GencodeFuncotation.VariantClassification.START_CODON_DEL, 131072);
+        expected1.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, 262144);
+        expected1.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_OUT_FRAME, 524288);
+        expected1.put(GencodeFuncotation.VariantClassification.RNA, 1048576);
+        expected1.put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
+
+        final Map<GencodeFuncotation.VariantClassification, Integer> expected2 = new HashMap<>();
+        expected2.put(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE, 0);
+        expected2.put(GencodeFuncotation.VariantClassification.INTRON, 1);
+        expected2.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, 2);
+        expected2.put(GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 4);
+        expected2.put(GencodeFuncotation.VariantClassification.IGR, 8);
+        expected2.put(GencodeFuncotation.VariantClassification.SPLICE_SITE, 1024);
+        expected2.put(GencodeFuncotation.VariantClassification.IN_FRAME_DEL, 2048);
+        expected2.put(GencodeFuncotation.VariantClassification.IN_FRAME_INS, 4096);
+        expected2.put(GencodeFuncotation.VariantClassification.RNA, 1048576);
+        expected2.put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
+
+        final Map<GencodeFuncotation.VariantClassification, Integer> expected3 = new HashMap<>();
+        expected3.put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
+
         return new Object[][] {
-                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test1.tsv"), new HashMap<GencodeFuncotation.VariantClassification, Integer>() {{
-                    put(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE, 0);
-                    put(GencodeFuncotation.VariantClassification.INTRON, 1);
-                    put(GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, 2);
-                    put(GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 4);
-                    put(GencodeFuncotation.VariantClassification.IGR, 8);
-                    put(GencodeFuncotation.VariantClassification.FIVE_PRIME_FLANK, 16);
-                    put(GencodeFuncotation.VariantClassification.THREE_PRIME_FLANK, 32);
-                    put(GencodeFuncotation.VariantClassification.MISSENSE, 64);
-                    put(GencodeFuncotation.VariantClassification.NONSENSE, 128);
-                    put(GencodeFuncotation.VariantClassification.NONSTOP, 256);
-                    put(GencodeFuncotation.VariantClassification.SILENT, 512);
-                    put(GencodeFuncotation.VariantClassification.SPLICE_SITE, 1024);
-                    put(GencodeFuncotation.VariantClassification.IN_FRAME_DEL, 2048);
-                    put(GencodeFuncotation.VariantClassification.IN_FRAME_INS, 4096);
-                    put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_INS, 8192);
-                    put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_DEL, 16384);
-                    put(GencodeFuncotation.VariantClassification.START_CODON_SNP, 32768);
-                    put(GencodeFuncotation.VariantClassification.START_CODON_INS, 65536);
-                    put(GencodeFuncotation.VariantClassification.START_CODON_DEL, 131072);
-                    put(GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, 262144);
-                    put(GencodeFuncotation.VariantClassification.DE_NOVO_START_OUT_FRAME, 524288);
-                    put(GencodeFuncotation.VariantClassification.RNA, 1048576);
-                    put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
-                }}},
-
-                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test2.tsv"), new HashMap<GencodeFuncotation.VariantClassification, Integer>() {{
-                    put(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE, 0);
-                    put(GencodeFuncotation.VariantClassification.INTRON, 1);
-                    put(GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, 2);
-                    put(GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 4);
-                    put(GencodeFuncotation.VariantClassification.IGR, 8);
-                    put(GencodeFuncotation.VariantClassification.SPLICE_SITE, 1024);
-                    put(GencodeFuncotation.VariantClassification.IN_FRAME_DEL, 2048);
-                    put(GencodeFuncotation.VariantClassification.IN_FRAME_INS, 4096);
-                    put(GencodeFuncotation.VariantClassification.RNA, 1048576);
-                    put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
-                }}},
-
-                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test3.tsv"), new HashMap<GencodeFuncotation.VariantClassification, Integer>() {{
-                    put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
-                }}},
+                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test1.tsv"), expected1},
+                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test2.tsv"), expected2},
+                {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test3.tsv"), expected3},
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -2513,8 +2513,47 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
         expected2.put(GencodeFuncotation.VariantClassification.RNA, 1048576);
         expected2.put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
 
+        // Check for default values:
+        expected2.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_FLANK, 15);
+        expected2.put(GencodeFuncotation.VariantClassification.THREE_PRIME_FLANK, 16);
+        expected2.put(GencodeFuncotation.VariantClassification.MISSENSE, 1);
+        expected2.put(GencodeFuncotation.VariantClassification.NONSENSE, 0);
+        expected2.put(GencodeFuncotation.VariantClassification.NONSTOP, 0);
+        expected2.put(GencodeFuncotation.VariantClassification.SILENT, 5);
+        expected2.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_INS, 2);
+        expected2.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_DEL, 2);
+        expected2.put(GencodeFuncotation.VariantClassification.START_CODON_SNP, 3);
+        expected2.put(GencodeFuncotation.VariantClassification.START_CODON_INS, 3);
+        expected2.put(GencodeFuncotation.VariantClassification.START_CODON_DEL, 3);
+        expected2.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, 1);
+        expected2.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_OUT_FRAME, 0);
+
         final Map<GencodeFuncotation.VariantClassification, Integer> expected3 = new HashMap<>();
         expected3.put(GencodeFuncotation.VariantClassification.LINCRNA, 2097152);
+
+        // Check for default values:
+        expected3.put(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE, 99);
+        expected3.put(GencodeFuncotation.VariantClassification.INTRON, 10);
+        expected3.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_UTR, 6);
+        expected3.put(GencodeFuncotation.VariantClassification.THREE_PRIME_UTR, 6);
+        expected3.put(GencodeFuncotation.VariantClassification.IGR, 20);
+        expected3.put(GencodeFuncotation.VariantClassification.FIVE_PRIME_FLANK, 15);
+        expected3.put(GencodeFuncotation.VariantClassification.THREE_PRIME_FLANK, 16);
+        expected3.put(GencodeFuncotation.VariantClassification.MISSENSE, 1);
+        expected3.put(GencodeFuncotation.VariantClassification.NONSENSE, 0);
+        expected3.put(GencodeFuncotation.VariantClassification.NONSTOP, 0);
+        expected3.put(GencodeFuncotation.VariantClassification.SILENT, 5);
+        expected3.put(GencodeFuncotation.VariantClassification.SPLICE_SITE, 4);
+        expected3.put(GencodeFuncotation.VariantClassification.IN_FRAME_DEL, 1);
+        expected3.put(GencodeFuncotation.VariantClassification.IN_FRAME_INS, 1);
+        expected3.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_INS, 2);
+        expected3.put(GencodeFuncotation.VariantClassification.FRAME_SHIFT_DEL, 2);
+        expected3.put(GencodeFuncotation.VariantClassification.START_CODON_SNP, 3);
+        expected3.put(GencodeFuncotation.VariantClassification.START_CODON_INS, 3);
+        expected3.put(GencodeFuncotation.VariantClassification.START_CODON_DEL, 3);
+        expected3.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_IN_FRAME, 1);
+        expected3.put(GencodeFuncotation.VariantClassification.DE_NOVO_START_OUT_FRAME, 0);
+        expected3.put(GencodeFuncotation.VariantClassification.RNA, 4);
 
         return new Object[][] {
                 {new GATKPath(largeFileTestDir + "funcotator/custom_vc_order_files/" + "test1.tsv"), expected1},

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationUnitTest.java
@@ -399,4 +399,27 @@ public class GencodeFuncotationUnitTest extends GATKBaseTest {
     public void testGetFieldFail(final GencodeFuncotation gencodeFuncotation, final String fieldName) {
         gencodeFuncotation.getField(fieldName);
     }
+
+    @Test
+    public void testVariantClassificationSeverityOverride() {
+
+        // Check that we start with the defaults:
+        for ( final GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
+            Assert.assertEquals(vc.getSeverity(), vc.getDefaultSeverity());
+        }
+
+        // Now set some values and make sure they stick:
+        for (int i = 98; i < 173; ++i) {
+            GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE.setSeverity(i);
+            Assert.assertEquals(GencodeFuncotation.VariantClassification.COULD_NOT_DETERMINE.getSeverity(), i);
+        }
+
+        // Now reset the values:
+        GencodeFuncotation.VariantClassification.resetSeveritiesToDefault();
+
+        // Check that the reset works:
+        for ( final GencodeFuncotation.VariantClassification vc : GencodeFuncotation.VariantClassification.values()) {
+            Assert.assertEquals(vc.getSeverity(), vc.getDefaultSeverity());
+        }
+    }
 }

--- a/src/test/resources/large/funcotator/custom_vc_order_files/bad_vc_name.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/bad_vc_name.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ac894133bacdc03aa6e7cdc8a8145359c5ac8f55b2ed44d7dd6b9e2399ebaa9
+size 39

--- a/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_expected_out.vcf
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_expected_out.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d047664ab092210264fe8085fa67d5e76a73fe59413b6347eafc6cd5124f270
+size 21959

--- a/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_input_test.vcf
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_input_test.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13883b58bb8921fc216be6e825483d40f4649e3afedebdb32917a5ac8886ccac
+size 15597

--- a/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_order_for_int_test.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/custom_vc_order_for_int_test.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:131ed1f87a9839e07b06996557e5dba50b45e1f74aac01ece6fc6c1825ae9705
+size 20

--- a/src/test/resources/large/funcotator/custom_vc_order_files/non_int_sev.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/non_int_sev.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:738c98b60e210425a4d39a260fb3f15811c1aa87e215e5d2d275f6d9671a85be
+size 11

--- a/src/test/resources/large/funcotator/custom_vc_order_files/test1.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/test1.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7549afb1729e6320b5d2f1824f4a964ba41782ab2b3b7e11e5340fda5ce308a4
+size 413

--- a/src/test/resources/large/funcotator/custom_vc_order_files/test2.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/test2.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc17f9607f518852c49dca249a0b419b7af39f3a2acd6071aed081251eb9edee
+size 153

--- a/src/test/resources/large/funcotator/custom_vc_order_files/test3.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/test3.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d979516f56e3d58ab9e7ccc07e091daec87123d0221d1c264a3f6146f1cc41ff
+size 16

--- a/src/test/resources/large/funcotator/custom_vc_order_files/wrong_num_columns.tsv
+++ b/src/test/resources/large/funcotator/custom_vc_order_files/wrong_num_columns.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cd3ec9faff66311ced127eba41b7733ec78c3e820bc8ef1528127d5597d57e9
+size 8


### PR DESCRIPTION
- Added custom `VariantClassification` severity ordering.  This enables users to have variants annotated consistently in an alternate order by the results of their variant classification.  (user requested)