### PR TITLE
Fixed a bug where force calling alleles were lost upon trimming by placing allele injection after trimming

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -600,6 +600,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
 
         final SortedSet<VariantContext> allVariationEvents = untrimmedAssemblyResult.getVariationEvents(hcArgs.maxMnpDistance);
         for (final VariantContext given : givenAlleles) {
+            //these are events from single haplotypes, so we can do a simple comparison without trimming
             if (allVariationEvents.stream().noneMatch(vc -> vc.getStart() == given.getStart() && vc.getAlternateAllele(0).basesMatch(given.getAlternateAllele(0)))) {
                 allVariationEvents.add(given);
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/realignmentfilter/FilterAlignmentArtifacts.java
@@ -213,7 +213,7 @@ public class FilterAlignmentArtifacts extends MultiVariantWalkerGroupedOnStart {
 
 
             // TODO: give this tool M2 Assembler args to allow override default M2ArgumentCollection?
-            final AssemblyResultSet assemblyResult = AssemblyBasedCallerUtils.assembleReads(assemblyRegion, Collections.emptyList(), MTAC, bamHeader, samplesList, logger, referenceReader, assemblyEngine, smithWatermanAligner, false);
+            final AssemblyResultSet assemblyResult = AssemblyBasedCallerUtils.assembleReads(assemblyRegion, MTAC, bamHeader, samplesList, logger, referenceReader, assemblyEngine, smithWatermanAligner, false);
             final AssemblyRegion regionForGenotyping = assemblyResult.getRegionForGenotyping();
 
             final Map<String,List<GATKRead>> reads = AssemblyBasedCallerUtils.splitReadsBySample(samplesList, bamHeader, regionForGenotyping.getReads());

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
@@ -212,9 +212,17 @@ public final class Haplotype extends Allele {
         Utils.validateArg( this.cigar.getReadLength() == length(), () -> "Read length " + length() + " not equal to the read length of the cigar " + cigar.getReadLength() + " " + this.cigar);
     }
 
-    public Haplotype insertAllele( final Allele refAllele, final Allele altAllele, final int refInsertLocation, final int genomicInsertLocation ) {
-        // refInsertLocation is in ref haplotype offset coordinates NOT genomic coordinates
-        final Pair<Integer, CigarOperator> haplotypeInsertLocationAndOperator = ReadUtils.getReadIndexForReferenceCoordinate(alignmentStartHapwrtRef, cigar, refInsertLocation);
+    /**
+     *
+     * @param refAllele             allele, contained in this haplotype, to be replaced
+     * @param altAllele             new allele, the bases of which replace those of refAllele
+     * @param insertLocation     location in the genome at which the new allele starts
+     *
+     * Example: suppose this haplotype starts at position 100 on its contig and has bases ACCGTTATATCG and we wish to
+     * delete the GTT.  Then refAllele = CGTT, alt allele = C, and insertLocation = 102.
+     */
+    public Haplotype insertAllele(final Allele refAllele, final Allele altAllele, final int insertLocation) {
+        final Pair<Integer, CigarOperator> haplotypeInsertLocationAndOperator = ReadUtils.getReadIndexForReferenceCoordinate((int) getStartPosition(), cigar, insertLocation);
 
         // can't insert outside the haplotype or into a deletion
         if( haplotypeInsertLocationAndOperator.getLeft() == ReadUtils.READ_INDEX_NOT_FOUND || !haplotypeInsertLocationAndOperator.getRight().consumesReadBases() ) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtilsUnitTest.java
@@ -328,7 +328,7 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
     }
 
     private Haplotype applyVariant(final VariantContext vc, final Haplotype refHaplotype, final int altIndex) {
-        Haplotype retHaplotype = refHaplotype.insertAllele(vc.getReference(), vc.getAlternateAllele(altIndex), vc.getStart() - (int) refHaplotype.getStartPosition(), vc.getStart());
+        Haplotype retHaplotype = refHaplotype.insertAllele(vc.getReference(), vc.getAlternateAllele(altIndex), vc.getStart());
         if (retHaplotype == null) {
             return refHaplotype;
         }
@@ -1270,22 +1270,22 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final VariantContext givenVC = new VariantContextBuilder("test", "chr", 2, 2,
                 Arrays.asList(Allele.create((byte) 'A', true), Allele.create((byte) 'C', false))).make();
 
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 2);
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(1).getBaseString(), "ACAACCCCGGGGTTTT");
 
 
         // adding the same VC should have no effect
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 2);
 
         // add another SNP
         final VariantContext givenVC2 = new VariantContextBuilder("test", "chr", 5, 5,
                 Arrays.asList(Allele.create((byte) 'C', true), Allele.create((byte) 'G', false))).make();
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC2), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC2), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         // SNP is not found in existing variation, so it's added to the ref and the first SNP
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 4);
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(2).getBaseString(), "AAAAGCCCGGGGTTTT");
@@ -1295,8 +1295,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         // haplotype that contains the overlapping 2nd SNP
         final VariantContext givenVC3 = new VariantContextBuilder("test", "chr", 5, 7,
                 Arrays.asList(Allele.create("CCC".getBytes(), true), Allele.create((byte) 'C', false))).make();
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC3), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC3), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 6);
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(4).getBaseString(), "AAAACCGGGGTTTT");
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(5).getBaseString(), "ACAACCGGGGTTTT");
@@ -1304,8 +1304,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         // adding an equivalent deletion should do nothing
         final VariantContext givenVC4 = new VariantContextBuilder("test", "chr", 5, 8,
                 Arrays.asList(Allele.create("CCCC".getBytes(), true), Allele.create("CC".getBytes(), false))).make();
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC4), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC4), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 6);
 
         // finally, add a haplotype with two new phased SNPs, after which adding an allele with one of these SNPs does nothing
@@ -1321,8 +1321,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
 
         final VariantContext givenVC5 = new VariantContextBuilder("test", "chr", 8, 8,
                 Arrays.asList(Allele.create((byte) 'C', true), Allele.create((byte) 'T', false))).make();
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC5), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC5), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 7);
     }
 
@@ -1346,8 +1346,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final VariantContext givenVC = new VariantContextBuilder("test", "chr", 2, 2,
                 Arrays.asList(Allele.create((byte) 'A', true), Allele.create((byte) 'C', false), Allele.create((byte) 'T', false))).make();
 
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 3);
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(1).getBaseString(), "ACAACCCCGGGGTTTT");
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(2).getBaseString(), "ATAACCCCGGGGTTTT");
@@ -1378,8 +1378,8 @@ public class AssemblyBasedCallerUtilsUnitTest extends GATKBaseTest {
         final VariantContext givenVC = new VariantContextBuilder("test", "chr", 2, 2,
                 Arrays.asList(Allele.create((byte) 'A', true), Allele.create('A' + new String(insertedBases), false))).make();
 
-        addGivenAlleles(assemblyRegionStart, Collections.singletonList(givenVC), maxMnpDistance,
-                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, refHaplotype, assemblyResultSet);
+        addGivenAlleles(Collections.singletonList(givenVC), maxMnpDistance,
+                aligner, HAPLOTYPE_TO_REFERENCE_SW_PARAMETERS, assemblyResultSet);
         Assert.assertEquals(assemblyResultSet.getHaplotypeCount(), 2);
         Assert.assertEquals(assemblyResultSet.getHaplotypeList().get(1).getBaseString(), "AA" + new String(insertedBases) + "AACCCCGGGGTTTT");
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2IntegrationTest.java
@@ -13,6 +13,8 @@ import org.broadinstitute.hellbender.Main;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.engine.spark.AssemblyRegionArgumentCollection;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
@@ -51,7 +53,6 @@ import java.util.stream.Collectors;
 public class Mutect2IntegrationTest extends CommandLineProgramTest {
     // positions 10,000,000 - 11,000,000 of chr 20 and with most annotations removed
     private static final File GNOMAD = new File(largeFileTestDir, "very-small-gnomad.vcf");
-
     private static final String DREAM_BAMS_DIR = largeFileTestDir + "mutect/dream_synthetic_bams/";
     private static final File DREAM_4_NORMAL = new File(DREAM_BAMS_DIR, "normal_4.bam");
     private static final File DREAM_3_NORMAL = new File(DREAM_BAMS_DIR, "normal_3.bam");
@@ -619,6 +620,42 @@ public class Mutect2IntegrationTest extends CommandLineProgramTest {
         Assert.assertTrue(variantKeys.containsAll(expectedKeys));
 
         Assert.assertEquals(variants.get(0).getAttributeAsInt(GATKVCFConstants.ORIGINAL_CONTIG_MISMATCH_KEY, 0), 1741);
+    }
+
+    /**
+     * Several difficult force calling sites including regression test for a thorny force calling bug involving
+     * T -> A at chrM:8316.  Previously this call was lost while trimming the assemblyResultSet because every haplotype
+     * containing the allele contained a deletion that terminated exactly where trimming occurred, thereby causing the
+     * GATK to discard the trimmed haplotype.
+     */
+    @Test
+    public void testDifficultForceCalling() {
+        final File dir = new File(largeFileTestDir + "mutect/mito/");
+        final File ref = new File(dir, "mito_shifted_8000.fasta");
+        final File bam = new File(dir, "mito.bam");
+        final File force = new File(dir, "alleles.vcf");
+        final String interval = "chrM:8023-9140";
+
+        final File output = createTempFile("output", ".bam");
+
+        runMutect2(bam, output, interval, ref.getAbsolutePath(), Optional.empty(),
+                args -> args.add(AssemblyBasedCallerArgumentCollection.FORCE_CALL_ALLELES_LONG_NAME, force),
+                args -> args.addFlag(M2ArgumentCollection.MITOCHONDRIA_MODE_LONG_NAME),
+                args -> args.add(AssemblyRegionArgumentCollection.MAX_STARTS_LONG_NAME, 75));
+
+        final SimpleInterval callingInterval = new SimpleInterval(interval);
+
+        final Map<Integer, VariantContext> callsByLocus = VariantContextTestUtils.getVariantContexts(output).stream()
+                .collect(Collectors.toMap(vc -> vc.getStart(), vc -> vc));
+
+        final List<VariantContext> forceCallingVariants = VariantContextTestUtils.getVariantContexts(force).stream()
+                .filter(vc -> vc.overlaps(callingInterval))
+                .collect(Collectors.toList());
+
+        for (final VariantContext vc : forceCallingVariants) {
+            Assert.assertTrue(callsByLocus.containsKey(vc.getStart()));
+            Assert.assertTrue(callsByLocus.get(vc.getStart()).hasAllele(vc.getAlternateAllele(0)));
+        }
     }
 
     @DataProvider(name = "vcfsForFiltering")

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeUnitTest.java
@@ -125,17 +125,20 @@ public final class HaplotypeUnitTest extends GATKBaseTest {
         basicInsertTest("G", "C", 17, h1Cigar, bases, h1bases);
     }
 
-    private void basicInsertTest(String ref, String alt, int loc, Cigar cigar, String hap, String newHap) {
+    private void basicInsertTest(String ref, String alt, int locWrtHaplotype, Cigar cigar, String hap, String newHap) {
         final Haplotype h = new Haplotype(hap.getBytes());
+        final int haplotypeStart = 1;
+        final int loc = locWrtHaplotype + haplotypeStart;
         final Allele h1refAllele = Allele.create(ref, true);
         final Allele h1altAllele = Allele.create(alt, false);
         final ArrayList<Allele> alleles = new ArrayList<>();
         alleles.add(h1refAllele);
         alleles.add(h1altAllele);
         final VariantContext vc = new VariantContextBuilder().alleles(alleles).loc("1", loc, loc + h1refAllele.getBases().length - 1).make();
+        h.setGenomeLocation(new SimpleInterval("1", haplotypeStart, haplotypeStart + cigar.getReferenceLength()));
         h.setAlignmentStartHapwrtRef(0);
         h.setCigar(cigar);
-        final Haplotype h1 = h.insertAllele(vc.getReference(), vc.getAlternateAllele(0), loc, vc.getStart());
+        final Haplotype h1 = h.insertAllele(vc.getReference(), vc.getAlternateAllele(0), loc);
         final Haplotype h1expected = new Haplotype(newHap.getBytes());
         Assert.assertEquals(h1, h1expected);
     }

--- a/src/test/resources/large/mutect/mito/alleles.vcf
+++ b/src/test/resources/large/mutect/mito/alleles.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ed18135e4129214acb963d1e1c0c9050e3798c00f8d5f8827f157e24c27d269
+size 924

--- a/src/test/resources/large/mutect/mito/alleles.vcf.idx
+++ b/src/test/resources/large/mutect/mito/alleles.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f28bd5f4bc71be4028f3498d711eff153e79936665371681c84af7dde19d361e
+size 297

--- a/src/test/resources/large/mutect/mito/mito.bam
+++ b/src/test/resources/large/mutect/mito/mito.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aee91e68d94d83b53c4093ea400c8ce765885928f36b7c34f539b2b2e0180577
+size 1142052

--- a/src/test/resources/large/mutect/mito/mito.bam.bai
+++ b/src/test/resources/large/mutect/mito/mito.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e2ac1b77938280b294188491780498bf31b18626bf91cb5bffe9ebb495d403
+size 96

--- a/src/test/resources/large/mutect/mito/mito_shifted_8000.dict
+++ b/src/test/resources/large/mutect/mito/mito_shifted_8000.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db8acf91efc0f5662a253799c292abcd69ff4daf2a3f050c2256ade1f5e9e61b
+size 135

--- a/src/test/resources/large/mutect/mito/mito_shifted_8000.fasta
+++ b/src/test/resources/large/mutect/mito/mito_shifted_8000.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4639e6bb2ad6becd1def1038dea11df11d646418e68579194069b330382e29f
+size 16966

--- a/src/test/resources/large/mutect/mito/mito_shifted_8000.fasta.fai
+++ b/src/test/resources/large/mutect/mito/mito_shifted_8000.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13141b05eab2381204224cab1e7daec0cdf780b37b3448685db579d61fa77539
+size 21


### PR DESCRIPTION
Closes #7672.

@ldgauthier This is the bug fix for Sarah Calvo.  The allele was lost when trimming caused its haplotype to start with a deletion.  The solution is to inject force-calling alleles after trimming.  Are you able to review?