### PR TITLE
install lfs with --force

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /gatk
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN add-apt-repository universe && apt update
 RUN apt-get --assume-yes install git-lfs
-RUN git lfs install
+RUN git lfs install --force
 
 RUN git lfs pull
 


### PR DESCRIPTION
This should fix the travis failure by forcing lfs to overwrite the existing commit hooks.

The issue seems to be this:

We install lfs in the first part of the travis build, and then we run a docker build and mount the git folder into it.  Docker then installs lfs again.  The problem is occurring because git lfs 3.1.1 which released 2 days ago changed the format of the pre-push and other git hooks.  Then it throws an error when it's installed again and there are hooks that look different than it expects already in place.  Running install with `--force` fixes it.

The lfs devs actually have a system for ignoring these differences, but they forgot to update their list of allowed differences ( or however they match it) in 3.1.1.  They then released 3.1.2  today which fixes this.  In most cases this would fix the issue, except the git-lfs installed INSIDE the docker image is on an ancient version and never updates since the ancient image ubuntu is pegged to an out of date one. While the one in travis outside of docker gets updated to the most recent one.  So we have to manually force this.

We should probably also update our ubuntu image to a newer one.

Of note, we don't actually NEED lfs in the docker for the tests at all, since we've already downloaded the files outside of docker and are mounting them in.  Here's a passing build where I remove it https://app.travis-ci.com/github/broadinstitute/gatk/builds/246595037. I'm afraid though that some other system depends on it so I don't want to change it.   

Rebasing on this should fix the stuck branches.

@droazen @jonn-smith @ldgauthier @jamesemery 