### PR TITLE
Add XGBoostGqVariantFilter, a tool to recalibrate GQ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,8 @@ configurations {
 final javadocJDKFiles = ToolProvider.getSystemToolClassLoader() == null ? files([]) : files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs())
 
 dependencies {
+    implementation 'org.jetbrains:annotations:19.0.0'
+
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
     compileOnly(javadocJDKFiles)
     testCompile(javadocJDKFiles)
@@ -370,6 +372,7 @@ dependencies {
     
     // Required for SV Discovery machine learning
     compile group: 'biz.k11i', name: 'xgboost-predictor', version: '0.3.0'
+    compile group: 'ml.dmlc', name: 'xgboost4j_2.12', version: '1.5.2'
 
     // natural sort
     compile('net.grey-panther:natural-comparator:1.1')

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/BinnedFilterSummaries.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/BinnedFilterSummaries.java
@@ -1,0 +1,36 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+class BinnedFilterSummaries extends ArrayList<FilterSummary> {
+    private static final long serialVersionUID = 0;
+
+    BinnedFilterSummaries(final Collection<FilterSummary> filterSummaries) {
+        super(filterSummaries);
+    }
+
+    BinnedFilterSummaries(final FilterSummary filterSummary, final int binIndex, final int numBins) {
+        this(
+                IntStream.range(0, numBins)
+                        .mapToObj(i -> i == binIndex ? filterSummary : FilterSummary.EMPTY)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    BinnedFilterSummaries add(final BinnedFilterSummaries other) {
+        return this.equals(BinnedFilterSummaries.EMPTY) ?
+                other :
+                other.equals(BinnedFilterSummaries.EMPTY) ?
+                        this :
+                        new BinnedFilterSummaries(
+                                IntStream.range(0, this.size()).mapToObj(
+                                        i -> this.get(i).add(other.get(i))).collect(Collectors.toList()
+                                )
+                        );
+    }
+
+    static BinnedFilterSummaries EMPTY = new BinnedFilterSummaries(FilterSummary.EMPTY, 0, 1);
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/FilterLoss.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/FilterLoss.java
@@ -1,0 +1,216 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import org.apache.commons.math3.util.FastMath;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class FilterLoss implements Comparable<FilterLoss> {
+    final double inheritanceLoss;
+    final double truthLoss;
+    final double inheritanceWeight;
+    final double truthWeight;
+    final String label;
+    static final double targetPrecision = MinGqVariantFilterBase.targetPrecision;
+    static final int minVariantsToEstimateRecall = MinGqVariantFilterBase.minVariantsToEstimateRecall;
+
+    FilterLoss(final double inheritanceLoss, final double truthLoss,
+               final double inheritanceWeight, final double truthWeight, final String label) {
+        if(inheritanceWeight < 0) {
+            throw new IllegalArgumentException("inheritanceWeight (" + inheritanceWeight + ") < 0");
+        }
+        if(truthWeight < 0) {
+            throw new IllegalArgumentException("truthWeight (" + truthWeight + ") < 0");
+        }
+        this.inheritanceLoss = inheritanceLoss;
+        this.truthLoss = truthLoss;
+        this.inheritanceWeight = inheritanceWeight;
+        this.truthWeight = truthWeight;
+        this.label = label;
+    }
+
+
+    FilterLoss(final FilterSummary filterSummary) {
+        this(1.0 - getInheritanceF1(filterSummary),
+             1.0 - getTruthF1(filterSummary),
+             filterSummary.inheritanceWeight * inheritanceAlleleFrequencyWeight(filterSummary),
+             filterSummary.truthWeight,
+             filterSummary.toTableLine());
+    }
+
+    FilterLoss(final FilterLoss copyLoss, final String label) {
+        this(copyLoss.inheritanceLoss, copyLoss.truthLoss, copyLoss.inheritanceWeight, copyLoss.truthWeight, label);
+    }
+
+    FilterLoss(final Collection<FilterSummary> filterSummaries, final List<String> labelColumns) {
+        this(
+            filterSummaries.stream()
+                .map(FilterLoss::new)
+                .reduce(FilterLoss::add).orElse(EMPTY),
+            getHeader(labelColumns) + "\n" +
+                filterSummaries.stream()
+                    .filter(FilterSummary::isNotEmpty)
+                    .map(FilterLoss::new)
+                    .map(FilterLoss::toString)
+                    .collect(Collectors.joining("\n"))
+                    + "\n" + filterSummaries.stream()
+                        .filter(FilterSummary::isNotEmpty)
+                        .reduce(FilterSummary::add).orElse(FilterSummary.EMPTY)
+                        .setLabel(getOverallLabel(labelColumns))
+                        .toTableLine()
+        );
+    }
+
+    protected static String getHeader(final List<String> labelColumns){
+        return FilterSummary.tableHeader(labelColumns) + "\tinheritLoss\ttruthLoss";
+    }
+
+    protected static String getOverallLabel(final List<String> labelColumns) {
+        return labelColumns.stream()
+            .map(col -> MinGqVariantFilterBase.padWidth("all", col.length()))
+            .collect(Collectors.joining("\t"));
+    }
+
+    protected static double inheritanceAlleleFrequencyWeight(final FilterSummary filterSummary) {
+        return filterSummary.isLargeAlleleFrequency ? 1e-4 : 1.0;
+    }
+
+    protected static double getInheritanceF1(final FilterSummary filterSummary) {
+        // calculate f1 score:
+        //     recall = numPassedAlleleCount / maxPassedAlleleCount
+        //     precision = numMendelian / numDiscoverableTrios
+        //     f1 = 2.0 / (1.0 / recall + 1.0 / precision)
+        // No data to filter? -> no loss -> f1 = 1.0
+        if(filterSummary.numMendelianTrios == 0) {
+            // No way to score this if no Mendelian trios are discoverable
+            return Double.NaN;
+        } else if(filterSummary.numTriosPassed == 0) {
+            return 0.0;  // Discovered nothing -> get bad score if you passed nothing
+        }
+        final double precision = filterSummary.numMendelianTriosPassed / (double)filterSummary.numTriosPassed;
+        if(precision > targetPrecision) { // in high-precision regime, maximize f1
+            final double recall = filterSummary.numMendelianTriosPassed / (double)filterSummary.numMendelianTrios;
+            final double f1 = 2.0 / (1.0 / recall + 1.0 / precision);
+            return f1 * (1.0 - targetPrecision) + targetPrecision;  // join continuously to low-precision regime
+        } else {
+            return precision; // in low-precision regime, just maximize precision
+        }
+    }
+
+    protected static double getTruthF1(final FilterSummary filterSummary) {
+        // NOTE: calls are compared against list of true variants and false variants
+        // calculate f1 score:
+        //     f1 = 2.0 / (1.0 / recall + 1.0 / precision)
+        //     recall = numTruePositive / (numTruePositive + numFalseNegative)
+        //     precision = numTruePositive / (numTruePositive + numFalsePositive)
+        //     -> f1 = 2.0 * numTruePositive / (2 * numTruePositive + numFalseNegative + numFalsePositive)
+        // No data to filter? -> no loss -> f1 = 1.0
+        final long numPassedTruthKnown = filterSummary.numTruePositive + filterSummary.numFalsePositive;
+
+        if(numPassedTruthKnown == 0) {
+            // no truth information known, don't try to score
+            return Double.NaN;
+        }
+        final double precision = filterSummary.numTruePositive / (double)numPassedTruthKnown;
+        if(precision > targetPrecision) { // in high-precision regime, maximize f1
+            final long numActuallyTrue = filterSummary.numTruePositive + filterSummary.numFalseNegative;
+            // try to use only truth data to estimate recall, but if there isn't enough, fall back to using fraction
+            // of variants passed
+            final double recall = numActuallyTrue >= minVariantsToEstimateRecall ?
+                filterSummary.numTruePositive / (double)numActuallyTrue :
+                filterSummary.numVariantsPassed / (double)filterSummary.numVariants;
+
+            final double f1 = 2.0 / (1.0 / recall + 1.0 / precision);
+            return f1 * (1.0 - targetPrecision) + targetPrecision;  // join continuously to low-precision regime
+        } else {
+            return precision; // in low-precision regime, just maximize precision
+        }
+    }
+
+
+    static FilterLoss add(final FilterLoss lossA, final FilterLoss lossB) {
+        return new FilterLoss(addLosses(lossA.inheritanceLoss, lossA.inheritanceWeight,
+                                        lossB.inheritanceLoss, lossB.inheritanceWeight),
+                              addLosses(lossA.truthLoss, lossA.truthWeight,
+                                        lossB.truthLoss, lossB.truthWeight),
+                              lossA.inheritanceWeight + lossB.inheritanceWeight,
+                              lossA.truthWeight + lossB.truthWeight,
+                              lossA.label == null ? lossB.label : lossA.label);
+    }
+
+    static private double addLosses(final double lossA, final double weightA, final double lossB, final double weightB) {
+        final double weight = (weightA + weightB);
+        if(weight <= 0) {
+            return Double.NaN;
+        }
+        if(Double.isFinite(lossA)) {
+            if(Double.isFinite(lossB)) {
+                return (lossA * weightA + lossB * weightB) / weight;
+            } else {
+                return lossA * weightA / weight;
+            }
+        } else {
+            return lossB * weightB / weight;
+        }
+    }
+
+    // NaN is a crap result, so treat it accordingly
+    public boolean ge(final FilterLoss other) {
+        return toDouble() >= other.toDouble();
+    }
+
+    public boolean gt(final FilterLoss other) {
+        return toDouble() > other.toDouble();
+    }
+
+    public boolean le(final FilterLoss other) {
+        return toDouble() <= other.toDouble();
+    }
+
+    public boolean lt(final FilterLoss other) {
+        return toDouble() < other.toDouble();
+    }
+
+    @Override
+    public int compareTo(final @NotNull FilterLoss other) {
+        final double thisVal = this.toDouble();
+        final double  otherVal = other.toDouble();
+        if(Double.isNaN(thisVal)) {
+            return Double.isNaN(otherVal) ? 0 : 1;
+        } else if(Double.isNaN(otherVal)) {
+            return -1;
+        } else {
+            return Double.compare(thisVal, otherVal);
+        }
+    }
+
+    private static String getDescription(final double inheritanceLoss, final double truthLoss) {
+        return String.format("%11.9f\t%11.9f", inheritanceLoss, truthLoss);
+    }
+
+    @Override
+    public String toString() {
+        return label == null ?
+                getDescription(inheritanceLoss, truthLoss) :
+                label + "\t" + getDescription(inheritanceLoss, truthLoss);
+    }
+
+    double toDouble() {
+        final double weightedInheritanceLoss = Double.isFinite(inheritanceLoss) ?
+            inheritanceWeight * inheritanceLoss :
+            inheritanceWeight;
+        final double weightedTruthLoss = Double.isFinite(truthLoss) ?
+            truthWeight * truthLoss :
+            truthWeight;
+        return FastMath.sqrt(weightedInheritanceLoss * weightedInheritanceLoss +
+                                 weightedTruthLoss * weightedTruthLoss);
+    }
+
+    float toFloat() {
+        return (float) toDouble();
+    }
+
+    static final FilterLoss EMPTY = new FilterLoss(Double.NaN, Double.NaN, 0.0, 0.0, null);
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/FilterSummary.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/FilterSummary.java
@@ -1,0 +1,189 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import org.apache.commons.math3.util.FastMath;
+
+import java.util.List;
+
+class FilterSummary {
+    final MinGq minGq;
+    final long numMendelianTriosPassed;
+    final long numMendelianTrios;
+    final long numTriosPassed;
+    final long numVariants;
+    final long numVariantsPassed;
+    final long numTruePositive;
+    final long numFalsePositive;
+    final long numFalseNegative;
+    final long numTrueNegative;
+    final boolean isLargeAlleleFrequency;
+    final double truthWeight;
+    final double inheritanceWeight;
+    final String label;
+
+    FilterSummary(final MinGq minGq,
+                  final long numMendelianTriosPassed, final long numMendelianTrios, final long numTriosPassed,
+                  final long numVariants, final long numVariantsPassed, final long numTruePositive,
+                  final long numFalsePositive, final long numFalseNegative, final long numTrueNegative,
+                  final boolean isLargeAlleleFrequency, final double truthWeight, final double inheritanceWeight,
+                  final String label) {
+        if(minGq == null) {
+            throw new IllegalArgumentException("Null minGq in FilterSummary constructor");
+        }
+        this.minGq = minGq;
+        this.numMendelianTriosPassed = numMendelianTriosPassed;
+        this.numMendelianTrios = numMendelianTrios;
+        this.numTriosPassed = numTriosPassed;
+        this.numVariants = numVariants;
+        this.numVariantsPassed = numVariantsPassed;
+        this.numTruePositive = numTruePositive;
+        this.numFalsePositive = numFalsePositive;
+        this.numFalseNegative = numFalseNegative;
+        this.numTrueNegative = numTrueNegative;
+        this.isLargeAlleleFrequency = isLargeAlleleFrequency;
+        this.truthWeight = truthWeight;
+        this.inheritanceWeight = inheritanceWeight;
+        this.label = label;
+        this.check();
+    }
+
+    FilterSummary(final FilterSummary other) {
+        this.minGq = other.minGq;
+        this.numMendelianTriosPassed = other.numMendelianTriosPassed;
+        this.numMendelianTrios = other.numMendelianTrios;
+        this.numTriosPassed = other.numTriosPassed;
+        this.numVariants = other.numVariants;
+        this.numVariantsPassed = other.numVariantsPassed;
+        this.numTruePositive = other.numTruePositive;
+        this.numFalsePositive = other.numFalsePositive;
+        this.numFalseNegative = other.numFalseNegative;
+        this.numTrueNegative = other.numTrueNegative;
+        this.isLargeAlleleFrequency = other.isLargeAlleleFrequency;
+        this.truthWeight = other.truthWeight;
+        this.inheritanceWeight = other.inheritanceWeight;
+        this.label = other.label;
+    }
+
+    static final FilterSummary EMPTY = new FilterSummary(
+            MinGq.Empty,
+            0L, 0L, 0L,
+            0L, 0L,
+            0L, 0L, 0L, 0L,
+            false, 0.0, 0.0, null
+    );
+
+    void check() {
+        if(numMendelianTrios < 0) {
+            throw new IllegalArgumentException("numMendelianTrios (" + numMendelianTrios + ") < 0");
+        }
+        if(numMendelianTriosPassed < 0) {
+            throw new IllegalArgumentException("numMendelianTriosPassed  (" + numMendelianTriosPassed + ") < 0");
+        }
+        if(numTriosPassed < 0) {
+            throw new IllegalArgumentException("numTriosPassed  (" + numTriosPassed + ") < 0");
+        }
+        if(numMendelianTriosPassed > numMendelianTrios) {
+            throw new IllegalArgumentException("numMendelianTriosPassed (" + numMendelianTriosPassed + ") > numMendelianTrios (" + numMendelianTrios + ")");
+        }
+        if(numMendelianTriosPassed > numTriosPassed) {
+            throw new IllegalArgumentException("numMendelianTriosPassed (" + numMendelianTriosPassed + ") > numTriosPassed (" + numTriosPassed + ")");
+        }
+        if(numVariantsPassed > numVariants) {
+            throw new IllegalArgumentException("numVariantsPassed (" + numVariantsPassed + ") > numVariants (" + numVariants + ")");
+        }
+        if(numVariants < 0) {
+            throw new IllegalArgumentException("numVariants (" + numVariants + ") < 0");
+        }
+        if(numVariantsPassed < 0) {
+            throw new IllegalArgumentException("numVariantsPassed (" + numVariantsPassed + ") < 0");
+        }
+        if(numTruePositive < 0) {
+            throw new IllegalArgumentException("numTruePositive  (" + numTruePositive + ") < 0");
+        }
+        if(numTrueNegative < 0) {
+            throw new IllegalArgumentException("numTrueNegative  (" + numTrueNegative + ") < 0");
+        }
+        if(numFalseNegative < 0) {
+            throw new IllegalArgumentException("numFalseNegative  (" + numFalseNegative + ") < 0");
+        }
+        if(numFalsePositive < 0) {
+            throw new IllegalArgumentException("numFalsePositive  (" + numFalsePositive + ") < 0");
+        }
+    }
+
+    boolean hasInheritanceData() { return this.numMendelianTrios > 0; }
+
+    boolean hasOverlapData() {
+        return this.numFalsePositive + this.numTruePositive + this.numFalseNegative + this.numTrueNegative > 0;
+    }
+
+    boolean isNotEmpty() {
+        return hasInheritanceData() || hasOverlapData();
+    }
+
+    FilterSummary setLabel(final String newLabel) {
+        return new FilterSummary(minGq, numMendelianTriosPassed, numMendelianTrios, numTriosPassed, numVariants,
+                numVariantsPassed, numTruePositive, numFalsePositive, numFalseNegative, numTrueNegative,
+                isLargeAlleleFrequency, truthWeight, inheritanceWeight, newLabel);
+    }
+
+    FilterSummary add(final FilterSummary other) {
+        return new FilterSummary(
+            minGq == null || minGq.isEmpty() ? other.minGq : minGq,
+            numMendelianTriosPassed + other.numMendelianTriosPassed,
+            numMendelianTrios + other.numMendelianTrios,
+            numTriosPassed + other.numTriosPassed,
+            numVariants + other.numVariants,
+            numVariantsPassed + other.numVariantsPassed,
+            numTruePositive + other.numTruePositive,
+            numFalsePositive + other.numFalsePositive,
+            numFalseNegative + other.numFalseNegative,
+            numTrueNegative + other.numTrueNegative,
+            isLargeAlleleFrequency || other.isLargeAlleleFrequency,
+            FastMath.max(truthWeight, other.truthWeight),
+            FastMath.max(inheritanceWeight, other.inheritanceWeight),
+            label == null ? other.label : label
+        );
+    }
+
+    FilterSummary subtract(final FilterSummary other) {
+        return new FilterSummary(
+            minGq == null || minGq.isEmpty() ? other.minGq : minGq,
+            numMendelianTriosPassed - other.numMendelianTriosPassed,
+            numMendelianTrios - other.numMendelianTrios,
+            numTriosPassed - other.numTriosPassed,
+            numVariants - other.numVariants,
+            numVariantsPassed - other.numVariantsPassed,
+            numTruePositive - other.numTruePositive,
+            numFalsePositive - other.numFalsePositive,
+            numFalseNegative - other.numFalseNegative,
+            numTrueNegative - other.numTrueNegative,
+            isLargeAlleleFrequency,
+            FastMath.max(truthWeight, other.truthWeight),
+            FastMath.max(inheritanceWeight, other.inheritanceWeight),
+            label == null ? other.label : label
+        );
+    }
+
+    public static String tableHeader(final List<String> labelHeader) {
+        return String.join("\t", labelHeader) +
+            String.format("\t%9s\t%9s\t%9s", "nMendPass", "nMendTrio", "nTrioPass") +
+            String.format("\t%9s\t%9s", "nVar", "nVarPass") +
+            String.format("\t%6s\t%6s\t%6s\t%6s", "nTrue+", "nFalse+", "nTrue-", "nFalse-");
+    }
+
+    public String toTableLine() {
+        return String.format("%s\t%9d\t%9d\t%9d", label, numMendelianTriosPassed, numMendelianTrios, numTriosPassed)
+            + String.format("\t%9d\t%9d", numVariants, numVariantsPassed )
+            + String.format("\t%6d\t%6d\t%6d\t%6d", numTruePositive, numFalsePositive, numTrueNegative, numFalseNegative);
+    }
+
+    @Override
+    public String toString() {
+        return label + ":{minGq:" + minGq
+                + ",  numMendelian/MendPassed/Passed Trios:" + numMendelianTrios + "/" + numMendelianTriosPassed + "/" + numTriosPassed
+                + ", numVariantsPassed:" + numVariantsPassed + "/" + numVariants
+                + ", numTruePositive:" + numTruePositive
+                + ", numFalsePositive:" + numFalsePositive + ", numFalseNegative: " + numFalseNegative
+                + ", numTrueNegative:" + numTrueNegative + ", largeAlleleFrequency:" + isLargeAlleleFrequency + "}";
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/MinGq.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/MinGq.java
@@ -1,0 +1,29 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+public class MinGq implements Comparable<MinGq> {
+    final short minGqHet;
+    final short minGqHomVar;
+
+    MinGq(final short minGqHet, final short minGqHomVar) {
+        this.minGqHet = minGqHet;
+        this.minGqHomVar = minGqHomVar;
+    }
+
+    static final MinGq Empty = new MinGq(Short.MIN_VALUE, Short.MIN_VALUE);
+
+    public boolean isEmpty() { return minGqHet == Short.MIN_VALUE && minGqHomVar == Short.MIN_VALUE; }
+
+    @Override
+    public String toString() {
+        return String.format("(minGqHet:%d, minGqHomVar:%d)", minGqHet, minGqHomVar);
+    }
+
+    @Override
+    public int compareTo(final MinGq other) {
+        // prioritize het, since that's the main intent of the filtering.
+        final int hetCompare = Integer.compare(minGqHet, other.minGqHet);
+        return hetCompare == 0 ?
+            Integer.compare(minGqHomVar, other.minGqHomVar) :
+            hetCompare;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/MinGqVariantFilterBase.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/MinGqVariantFilterBase.java
@@ -1,0 +1,2425 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import htsjdk.samtools.util.Locatable;
+import htsjdk.variant.variantcontext.*;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.vcf.*;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import net.minidev.json.parser.ParseException;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.samples.PedigreeValidationType;
+import org.broadinstitute.hellbender.utils.samples.SampleDBBuilder;
+import org.broadinstitute.hellbender.utils.samples.Trio;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.*;
+
+import org.apache.commons.math3.util.FastMath;
+import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils;
+import org.jetbrains.annotations.NotNull;
+
+import static org.apache.commons.math3.util.FastMath.*;
+
+
+/**
+ * Extract matrix of properties for each variant.
+ * Also extract, numVariants x numTrios x 3 tensors of allele count and genotype quality.
+ * These data will be used to train a variant filter based on min GQ (and stratified by other variant properties) that
+ * maximizes the admission of variants with Mendelian inheritance pattern while omitting non-Mendelian variants.
+ *
+ * Derived class must implement abstract method trainFilter()
+ */
+public abstract class MinGqVariantFilterBase extends VariantWalker {
+    @Argument(fullName=StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME,
+              shortName=StandardArgumentDefinitions.PEDIGREE_FILE_SHORT_NAME,
+              doc="Pedigree file, necessary for \"Train\" mode, ignored in \"Filter\" mode.", optional=true)
+    public GATKPath pedigreeFile = null;
+
+    @Argument(fullName=StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+              shortName=StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+              doc="Output VCF produced in \"Filter\" mode, ignored in \"Train\" mode.", optional=true)
+    public GATKPath outputFile = null;
+
+    @Argument(fullName="model-file", shortName="m",
+              doc="Path to saved pre-existing filter model. In \"Filter\" mode, this is a mandatory argument."
+                 +" In \"Train\" mode, this is an optional argument for additional training based on an existing model.")
+    public GATKPath modelFile = null;
+
+    @Argument(fullName="properties-table-file", optional=true,
+            doc="Path to save properties table as JSON for analysis outside of this program. Only has an effect in TRAIN mode.")
+    public GATKPath propertiesTableFile = null;
+
+    @Argument(fullName="truth-file", shortName="t", optional=true,
+              doc="Path to JSON file with truth data. Keys are sample IDs and values are objects with key \"good\""
+                 +" corresponding to a list of known true variant IDs, and key \"bad\" corresponding to a list of known"
+                 +" bad variant IDs")
+    public GATKPath truthFile = null;
+
+    enum RunMode {Train, Filter}
+    @Argument(fullName="mode", doc="Mode of operation: either \"Train\" or \"Filter\"")
+    public RunMode runMode;
+
+    @Argument(fullName="keep-homvar", shortName="kh", doc="Keep homvar variants even if their GQ is less than min-GQ", optional=true)
+    public boolean keepHomvar = true;
+
+    @Argument(fullName="train-homref", doc="Do not train xgboost classifier with HOMREF genotypes", optional=true)
+    public boolean trainHomref = false;
+
+    @Argument(fullName="keep-multiallelic", shortName="km", doc="Keep multiallelic variants even if their GQ is less than min-GQ", optional=true)
+    public boolean keepMultiallelic = true;
+
+    @Argument(fullName="validation-proportion", shortName="vp", doc="Proportion of variants to set aside for cross-validation",
+              optional=true, minValue=0.0, maxValue=1.0)
+    public double validationProportion = 0.2;
+
+    @Argument(fullName="report-min-gq-filter-threshold", shortName="rf", optional=true, minValue=0.0, maxValue=1.0,
+              doc="Add \"" + EXCESSIVE_MIN_GQ_FILTER_KEY + "\" to FILTER if the proportion of samples with calls filtered by "
+                 + MIN_GQ_KEY + " is greater than this threshold.")
+    public double reportMinGqFilterThreshold = 0.005;
+
+    @Argument(fullName="truth-weight", shortName="tw", optional=true, minValue=0.0, maxValue=1.0,
+            doc="Weight for truth data in loss function.")
+    public static double truthWeight = 0.5;
+
+    @Argument(fullName="progress-verbosity", shortName="p",
+              doc="Level of verbosity for progress log", optional = true)
+    public int progressVerbosity = 2;
+
+    static final String minSamplesToEstimateAlleleFrequencyKey = "min-samples-to-estimate-allele-frequency";
+    @Argument(fullName=minSamplesToEstimateAlleleFrequencyKey, shortName="ms", optional=true,
+              doc="If the VCF does not have allele frequency, estimate it from the sample population if there are at least this many samples. Otherwise throw an exception.")
+    public int minSamplesToEstimateAlleleFrequency = 100;
+
+    @Argument(fullName="genome-tract", shortName="gt", optional=true)
+    final List<String> genomeTractFiles = new ArrayList<>();
+
+    @Argument(fullName="minGQ", shortName="gq", optional=true)
+    short minAdjustedGq = (short)p_to_scaled_logits(0.5);
+
+    @Argument(fullName="target-precision", doc="Desired minimum precision to achieve before maximizing recall", optional=true)
+    public static double targetPrecision = 0.90;
+
+    @Argument(fullName="min-truth-variants-to-estimate-recall",
+              doc="Minimum number of variants with truth data to estimate recall", optional=true)
+    public static int minVariantsToEstimateRecall = 50;
+
+    @Argument(fullName="max-inheritance-af", optional=true,
+        doc="Max allele frequency where inheritance will be considered truthful. AF in range (mIAf, 1.0 - mIAf) have no score")
+    public static double maxInheritanceAf = 0.05;
+
+    @Argument(fullName="large-af-weight-penalty", optional=true,
+        doc="Multiplicative penalty for learning weights based on inheritance for variants with large allele frequency.")
+    public static double largeAfWeightPenalty = 1e-6;
+
+    @Argument(fullName="strict-mendelian", optional=true,
+            doc="If true, apply normal rules for mendelian inheritance; if false, allow confusion between HET and HOMVAR"
+    )
+    public static boolean strictMendelian = true;
+
+    @Argument(fullName="min-bin-weight", optional=true,
+            doc="Minimum value of weight for a given SV category bin"
+    )
+    public static double minBinWeight = 0.01;
+
+    List<TractOverlapDetector> tractOverlapDetectors = null;
+
+    static final double PHRED_COEF = FastMath.log(10.0) / 10.0;
+    static final Map<String, double[]> propertyBinsMap = new LinkedHashMap<>();
+    // numVariants array of property-category bins
+    protected int[] propertyBins = null;
+    int numPropertyBins;
+    protected String[] propertyBinLabels = null;
+    protected List<String> propertyBinLabelColumns = null;
+    protected double[] propertyBinInheritanceWeights = null;
+    protected double[] propertyBinTruthWeights = null;
+    protected float[] propertyBinMinGqWeights = null;
+    protected float[] propertyBinGoodInheritanceWeights = null;
+    protected float[] propertyBinBadInheritanceWeights = null;
+    protected float[] propertyBinGoodTruthWeights = null;
+    protected float[] propertyBinBadTruthWeights = null;
+    protected boolean[] propertyBinIsLargeAlleleFraction = null;
+
+    protected List<String> sampleIds = null; // numSamples list of IDs for samples that will be used for training
+    protected int[][] trioSampleIndices = null; // numTrios x 3 matrix of sample indices (paternal, maternal, child) for each trio
+    protected Set<Integer> allTrioSampleIndices; // set of all sample indices that are in a trio
+    protected final Map<String, Integer> sampleIndices = new HashMap<>(); // map from sampleId to numerical index, for samples used in training
+    protected final PropertiesTable propertiesTable = new PropertiesTable();
+    // direct links to important properties, so they don't need to be looked up in the table each time they are used:
+    protected PropertiesTable.ShortMatProperty sampleVariantGenotypeQualities = null;
+    protected PropertiesTable.ByteMatProperty sampleVariantAlleleCounts = null;
+    protected PropertiesTable.ByteMatProperty sampleVariantNoCallCounts = null;
+    protected List<String> variantIds = new ArrayList<>();
+    // map from variantIndex to array of known good/bad sample indices for that variant
+    protected final Map<Integer, Set<Integer>> goodSampleVariantIndices = new HashMap<>();
+    protected final Map<Integer, Set<Integer>> badSampleVariantIndices = new HashMap<>();
+
+    protected Random randomGenerator = Utils.getRandomGenerator();
+
+    private VariantContextWriter vcfWriter = null;
+
+    private int numVariants;
+    private int numSamples;
+    private int numTrios;
+
+    private static final float PROB_EPS = 1.0e-3F;
+    private static final Set<String> BREAKPOINT_SV_TYPES = new HashSet<>(Arrays.asList("BND", "CTX"));
+    private static final double SV_EXPAND_RATIO = 1.0; // ratio of how much to expand SV gain range to SVLEN
+    private static final int BREAKPOINT_HALF_WIDTH = 50; // how wide to make breakpoint intervals for tract overlap
+    private static final String[] DISTAL_TARGETS_KEYS = {"SOURCE", "CPX_INTERVALS"}; // keys for distal targets in VCF entries
+    private static final String NO_CALL_COUNTS_KEY = "NO_CALL_COUNTS";
+    private static final String SVLEN_KEY = "SVLEN";
+    private static final String EVIDENCE_KEY = "EVIDENCE";
+    private static final String FILTER_KEY = "FILTER";
+    private static final String NO_EVIDENCE = "NO_EVIDENCE";
+    private static final String ALGORITHMS_KEY = "ALGORITHMS";
+    private static final String NO_ALGORITHM = "NO_ALGORITHM";
+    private static final String MIN_GQ_KEY = "MINGQ";
+    private static final String EXCESSIVE_MIN_GQ_FILTER_KEY = "LOW_QUALITY";
+    private static final String MULTIALLELIC_FILTER = "MULTIALLELIC";
+    private static final String GOOD_VARIANT_TRUTH_KEY = "good_variant_ids";
+    private static final String BAD_VARIANT_TRUTH_KEY = "bad_variant_ids";
+    private static final String CHR2_KEY = "CHR2";
+
+    protected static final int FATHER_IND = 0;
+    protected static final int MOTHER_IND = 1;
+    protected static final int CHILD_IND = 2;
+
+    private static final String PE_GQ_KEY = "PE_GQ";
+    private static final String RD_GQ_KEY = "RD_GQ";
+    private static final String SR_GQ_KEY = "SR_GQ";
+    private static final short MISSING_GQ_VAL = -1;
+
+    // properties used to gather main matrix / tensors during apply()
+    private Set<Trio> pedTrios = null;
+    private Map<String, Set<String>> goodSampleVariants = null;
+    private Map<String, Set<String>> badSampleVariants = null;
+
+
+    // train/validation split indices
+    private int[] trainingIndices;
+    private int[] validationIndices;
+
+    // properties for calculating f1 score or estimating its pseudo-derivatives
+    private MinGq[] perVariantOptimalMinGq = null;
+    protected double optimalProportionOfSampleVariantsPassing;
+
+    protected final int getNumVariants() { return propertiesTable.getNumRows(); }
+    protected final int getNumSamples() { return numSamples; }
+    protected final int getNumTrios() { return numTrios; }
+    protected final int getNumProperties() { return propertiesTable.getNumProperties(); }
+    protected final int[] getTrainingIndices() { return trainingIndices; }
+    protected final int[] getValidationIndices() { return validationIndices; }
+
+    // stats on tool actions, input/output VCFs
+    private int numFilterableGenotypes;
+    private int numFilteredGenotypes;
+    private int numInputVar;
+    private int numInputRef;
+    private int numInputNoCall;
+    private int numOutputVar;
+    private int numOutputRef;
+    private int numOutputNoCall;
+
+    /**
+     * Entry-point function to initialize the samples database from input data
+     */
+    private void getPedTrios() {
+        if(pedigreeFile == null) {
+            throw new UserException.BadInput(StandardArgumentDefinitions.PEDIGREE_FILE_LONG_NAME
+                                             + " must be specified in \"TRAIN\" mode");
+        }
+        final SampleDBBuilder sampleDBBuilder = new SampleDBBuilder(PedigreeValidationType.STRICT);
+        sampleDBBuilder.addSamplesFromPedigreeFiles(Collections.singletonList(pedigreeFile));
+
+        final Set<String> vcfSamples = new HashSet<>(getHeaderForVariants().getGenotypeSamples());
+        // get the trios from the pedigree file, keeping only those that are fully present in the input VCF
+        pedTrios = sampleDBBuilder.getFinalSampleDB()
+            .getTrios()
+            .stream()
+            .filter(trio -> vcfSamples.contains(trio.getPaternalID()) && vcfSamples.contains(trio.getMaternalID())
+                            && vcfSamples.contains(trio.getChildID()))
+            .collect(Collectors.toSet());
+        if(pedTrios.isEmpty()) {
+            throw new UserException.BadInput(
+                "The pedigree file (" + pedigreeFile + ") does not contain any trios that are present in the input VCF "
+                + "(" + drivingVariantFile + ")"
+            );
+        }
+        numTrios = pedTrios.size();
+        // collect ped trios into training samples
+        pedTrios.stream()
+                .flatMap(trio -> Stream.of(trio.getPaternalID(), trio.getMaternalID(), trio.getChildID()))
+                .forEach(this::addSampleIndex);
+        // keep track of the samples that are in trios (those will always have "truth" through inheritance)
+        trioSampleIndices = pedTrios.stream()
+                .map(
+                    trio -> Stream.of(trio.getPaternalID(), trio.getMaternalID(), trio.getChildID())
+                            .mapToInt(sampleIndices::get)
+                            .toArray()
+                )
+                .toArray(int[][]::new);
+
+        allTrioSampleIndices = pedTrios.stream()
+                .flatMap(trio -> Stream.of(trio.getPaternalID(), trio.getMaternalID(), trio.getChildID()))
+                .map(sampleIndices::get)
+                .collect(Collectors.toSet());
+
+    }
+
+    private void loadVariantTruthData() {
+        if(truthFile == null) {
+            System.out.println("No truth file specified. Not using truth data.");
+            return;
+        } else {
+            System.out.println("Loading truth data from " + truthFile);
+        }
+        final JSONObject jsonObject;
+        try (final InputStream fileInputStream = truthFile.getInputStream()){
+            jsonObject = (JSONObject) JSONValue.parseWithException(fileInputStream);
+        } catch (IOException | ParseException ioException) {
+            throw new GATKException("Unable to parse JSON from inputStream", ioException);
+        }
+        final Set<String> vcfSamples = new HashSet<>(getHeaderForVariants().getGenotypeSamples());
+        goodSampleVariants = new HashMap<>();
+        badSampleVariants = new HashMap<>();
+        for(final Map.Entry<String, Object> sampleTruthEntry : jsonObject.entrySet()) {
+            final String sampleId = sampleTruthEntry.getKey();
+            if(!vcfSamples.contains(sampleId)) {
+                continue; // don't bother storing truth data that doesn't overlap the input VCF
+            }
+            final JSONObject sampleTruth = (JSONObject)sampleTruthEntry.getValue();
+            for(final Object variantIdObj : (JSONArray)sampleTruth.get(GOOD_VARIANT_TRUTH_KEY)) {
+                final String variantId = (String)variantIdObj;
+                if(goodSampleVariants.containsKey(variantId)) {
+                    goodSampleVariants.get(variantId).add(sampleId);
+                } else {
+                    goodSampleVariants.put(variantId, new HashSet<>(Collections.singleton(sampleId)) );
+                }
+            }
+            for(final Object variantIdObj : (JSONArray)sampleTruth.get(BAD_VARIANT_TRUTH_KEY)) {
+                final String variantId = (String)variantIdObj;
+                if(badSampleVariants.containsKey(variantId)) {
+                    badSampleVariants.get(variantId).add(sampleId);
+                } else {
+                    badSampleVariants.put(variantId, new HashSet<>(Collections.singleton(sampleId)));
+                }
+            }
+        }
+        if(goodSampleVariants.isEmpty() && badSampleVariants.isEmpty()) {
+            System.out.println("Truth file specified (" + truthFile + "), but no samples/variants overlap with input VCF ("
+                               + drivingVariantFile + "). Not using truth data.");
+            goodSampleVariants = null;
+            badSampleVariants = null;
+            return;
+        }
+        // Add any new samples that have truth but are not in trios file to the training samples
+        goodSampleVariants.values().stream().flatMap(Collection::stream).forEach(this::addSampleIndex);
+        badSampleVariants.values().stream().flatMap(Collection::stream).forEach(this::addSampleIndex);
+    }
+
+    private void addSampleIndex(final String sampleId) {
+        if(!sampleIndices.containsKey(sampleId)) {
+            sampleIndices.put(sampleId, sampleIndices.size());
+        }
+    }
+
+    private void setSampleIds() {
+        sampleIds = sampleIndices.entrySet()
+            .stream()
+            .sorted(Comparator.comparingInt(Map.Entry::getValue))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+        numSamples = sampleIndices.size();
+    }
+
+    private void initializeVcfWriter() {
+        List<Options> options = new ArrayList<>();
+        //if (createOutputVariantIndex) {
+            options.add(Options.INDEX_ON_THE_FLY);
+        //}
+        vcfWriter = GATKVariantContextUtils.createVCFWriter(
+                outputFile.toPath(),
+                getHeaderForVariants().getSequenceDictionary(),
+                createOutputVariantMD5,
+                options.toArray(new Options[0]));
+        //vcfWriter = createVCFWriter(outputFile);
+        final Set<VCFHeaderLine> hInfo = new LinkedHashSet<>(getHeaderForVariants().getMetaDataInInputOrder());
+        final String filterableVariant = (keepMultiallelic ? "biallelic " : "") +
+                                         (keepHomvar ? "non-homvar" : "") +
+                                         "variant";
+        hInfo.add(new VCFInfoHeaderLine(MIN_GQ_KEY, 1, VCFHeaderLineType.Integer,
+                            "Minimum passing GQ for each " + filterableVariant));
+        hInfo.add(new VCFFilterHeaderLine(EXCESSIVE_MIN_GQ_FILTER_KEY,
+                               "More than " + (100 * reportMinGqFilterThreshold) + "% of sample GTs were masked as no-call GTs due to low GQ"));
+        final VCFHeader vcfHeader = new VCFHeader(hInfo, getHeaderForVariants().getGenotypeSamples());
+        vcfWriter.setHeader(vcfHeader);
+        vcfWriter.writeHeader(vcfHeader);
+    }
+
+    @Override
+    public void onTraversalStart() {
+        // set propertyBinsMap bins
+        propertyBinsMap.put(SVLEN_KEY, new double[] {50.0, 500.0, 5000.0});
+        propertyBinsMap.put(VCFConstants.ALLELE_FREQUENCY_KEY, new double[] {maxInheritanceAf, 1.0 - maxInheritanceAf});
+
+        loadTrainedModel();  // load model and saved properties stats
+        tractOverlapDetectors = genomeTractFiles.stream()  // load genome tracts
+            .map(genomeTractFile -> {
+                    try {
+                        return new TractOverlapDetector(genomeTractFile);
+                    } catch(IOException ioException) {
+                        throw new GATKException("Error loading " + genomeTractFile, ioException);
+                    }
+                })
+            .collect(Collectors.toList());
+
+        numInputVar = 0;
+        numInputRef = 0;
+        numInputNoCall = 0;
+        if(runMode == RunMode.Train) {
+            getPedTrios();  // get trios from pedigree file
+            loadVariantTruthData(); // load variant truth data from JSON file
+            // at this point, included samples will only be those that are in a trio or have some variant truth data
+            setSampleIds(); // set data organizing training samples
+        } else {
+            getHeaderForVariants().getGenotypeSamples().forEach(this::addSampleIndex); // use all samples in VCF
+            setSampleIds();
+            initializeVcfWriter();  // initialize vcfWriter and write header
+            numFilterableGenotypes = 0;
+            numFilteredGenotypes = 0;
+            numOutputVar = 0;
+            numOutputRef = 0;
+            numOutputNoCall = 0;
+            propertiesTable.setNumAllocatedRows(1);
+            System.out.println("minAdjustedGq=" + minAdjustedGq);
+        }
+    }
+
+    private boolean getIsMultiallelic(final VariantContext variantContext) {
+        return variantContext.getNAlleles() > 2 || variantContext.getFilters().contains(MULTIALLELIC_FILTER);
+    }
+
+    private boolean getVariantIsTrainable(final VariantContext variantContext,
+                                          final Map<String, Integer> sampleAlleleCounts,
+                                          final Map<String, Integer> sampleNoCallCounts) {
+        if(keepMultiallelic && getIsMultiallelic(variantContext)) {
+            return false;  // can't filter it, so can't train
+        }
+
+        // check if any of the samples have truth data and can be filtered. If so, the variant is trainable.
+        // first check if any member of trios are filterable
+        final boolean inheritanceTrainable = pedTrios.stream().anyMatch(
+            trio -> {  // trainable if any trio is filterable: all samples present, no no-calls, at least one
+                       //                                      non-ref sample, and at leas tone filterable allele count
+                final String paternalId = trio.getPaternalID();
+                final String maternalId = trio.getMaternalID();
+                final String childId = trio.getChildID();
+                if(Stream.of(paternalId, maternalId, childId)
+                    .mapToInt(id -> sampleNoCallCounts.getOrDefault(id, 2))
+                    .max().orElse(2) > 0) {
+                    return false;  // missing member of trio, or trio has no-calls
+                }
+                final int fatherAc = sampleAlleleCounts.get(paternalId);
+                final int motherAc = sampleAlleleCounts.get(maternalId);
+                final int childAc = sampleAlleleCounts.get(childId);
+                return (fatherAc > 0 || motherAc > 0 || childAc > 0) &&
+                       (alleleCountIsFilterable(fatherAc) || alleleCountIsFilterable(motherAc) ||
+                        alleleCountIsFilterable(childAc));
+            }
+        );
+        if(inheritanceTrainable) {
+            return true;
+        }
+        // next check if there are any samples in the truth set that are filterable
+        if(goodSampleVariants != null &&
+           !getFilterableTruthSampleIndices(variantContext, goodSampleVariants, sampleAlleleCounts,
+                                            sampleNoCallCounts).isEmpty()) {
+           return true;
+        }
+        return badSampleVariants != null &&
+              !getFilterableTruthSampleIndices(variantContext, badSampleVariants, sampleAlleleCounts,
+                                               sampleNoCallCounts).isEmpty();
+    }
+
+    /**
+     * form numTrios x 3 matrix of allele counts for specified variantIndex (paternal, maternal, child)
+     */
+    protected int[][] getTrioAlleleCountsMatrix(final int variantIndex) {
+        return Arrays.stream(trioSampleIndices)
+            .map(
+                trioIndices -> Arrays.stream(trioIndices)
+                                .map(sampleIndex -> sampleVariantAlleleCounts.getAsInt(variantIndex, sampleIndex))
+                                .toArray()
+            )
+            .toArray(int[][]::new);
+    }
+
+    /**
+     * form numTrios x 3 matrix of no-call counts for specified variantIndex (paternal, maternal, child)
+     */
+    protected int[][] getTrioNoCallCountsMatrix(final int variantIndex) {
+        return Arrays.stream(trioSampleIndices)
+                .map(
+                        trioIndices -> Arrays.stream(trioIndices)
+                                .map(sampleIndex -> sampleVariantNoCallCounts.getAsInt(variantIndex, sampleIndex))
+                                .toArray()
+                )
+                .toArray(int[][]::new);
+    }
+
+    /**
+     * form numTrios x 3 matrix of genotype qualities for specified variantIndex (paternal, maternal, child)
+     */
+    protected short[][] getTrioGenotypeQualitiesMatrix(final int variantIndex) {
+        final short[] sampleGenotypeQualities =  sampleVariantGenotypeQualities.values[variantIndex];
+        return Arrays.stream(trioSampleIndices)
+            .map(trioIndices -> new short[] {sampleGenotypeQualities[trioIndices[0]],
+                                             sampleGenotypeQualities[trioIndices[1]],
+                                             sampleGenotypeQualities[trioIndices[2]]}
+            )
+            .toArray(short[][]::new);
+    }
+
+
+    protected boolean getSampleVariantIsFilterable(final int variantIndex, final int sampleIndex) {
+        return genotypeIsFilterable(
+                sampleVariantAlleleCounts.getAsInt(variantIndex, sampleIndex),
+                sampleVariantNoCallCounts.getAsInt(variantIndex, sampleIndex)
+        );
+    }
+
+    /**
+     * A genotype is filterable if its allele count is filterable and it isn't fully no-call
+     */
+    protected boolean genotypeIsFilterable(final int alleleCount, final int noCallCount) {
+        return noCallCount < 2 && alleleCountIsFilterable(alleleCount);
+    }
+
+    /**
+     * An allele count is filterable if it's HOMREF or HET, or if it's HOMVAR and keepHomvar is not true,
+     */
+    protected boolean alleleCountIsFilterable(final int alleleCount) {
+        return !keepHomvar || alleleCount < 2;
+    }
+
+
+    protected Set<Integer> getInheritanceTrainableSampleIndices(final int variantIndex) {
+        final byte[] sampleAlleleCounts = sampleVariantAlleleCounts.values[variantIndex];
+        final byte[] sampleNoCallCounts = sampleVariantNoCallCounts.values[variantIndex];
+        return Arrays.stream(trioSampleIndices)
+                .filter(
+                        trio -> trioPasses(
+                                sampleAlleleCounts[trio[FATHER_IND]], sampleAlleleCounts[trio[MOTHER_IND]],
+                                sampleAlleleCounts[trio[CHILD_IND]],
+                                sampleNoCallCounts[trio[FATHER_IND]], sampleNoCallCounts[trio[MOTHER_IND]],
+                                sampleNoCallCounts[trio[CHILD_IND]]
+                        )
+                )
+                .flatMapToInt(Arrays::stream)
+                .boxed()
+                .collect(Collectors.toSet());
+    }
+
+    private List<Set<Integer>> filterableButNotTrainable = null;
+    /**
+     * A sample Variant is trainable if a) it is filterable, and b) there is truth data (inheritance or known good/bad)
+     */
+    protected boolean getSampleVariantIsTrainable(final int variantIndex, final int sampleIndex) {
+        if(filterableButNotTrainable == null) {
+            filterableButNotTrainable = IntStream.range(0, numVariants)
+                .mapToObj(
+                    vIndex -> {
+                        final Set<Integer> inheritanceTrainable = getInheritanceTrainableSampleIndices(vIndex);
+                        final Set<Integer> goodSampleIndices = goodSampleVariantIndices.getOrDefault(vIndex, Collections.emptySet());
+                        final Set<Integer> badSampleIndices = badSampleVariantIndices.getOrDefault(vIndex, Collections.emptySet());
+                        return IntStream.range(0, numSamples)
+                            .filter(sIndex -> getSampleVariantIsFilterable(vIndex, sIndex))
+                            .filter(sIndex -> !inheritanceTrainable.contains(sIndex))
+                            .filter(sIndex -> !goodSampleIndices.contains(sIndex))
+                            .filter(sIndex -> !badSampleIndices.contains(sIndex))
+                            .boxed()
+                            .collect(Collectors.toSet());
+                    }
+                )
+                .collect(Collectors.toList());
+        }
+        if(getSampleVariantIsFilterable(variantIndex, sampleIndex)) {
+            // don't train on data with any no-call counts, or with no training data
+            // return !filterableButNotTrainable.get(variantIndex).contains(sampleIndex);
+            return trainHomref || sampleVariantAlleleCounts.getAsInt(variantIndex, sampleIndex) > 0;
+        } else {
+            return false;
+        }
+    }
+
+    private SimpleInterval getDistalTarget(final String targetString) {
+        return new SimpleInterval(targetString.substring(targetString.indexOf("_") + 1));
+    }
+
+    private void getTractProperties(final TractOverlapDetector tractOverlapDetector,
+                                    final VariantContext variantContext) {
+        // get range of variant (use expanded location for insertions or duplications)
+        final List<Locatable> overlapCheckLocations = new ArrayList<>();
+        final String svType = variantContext.getAttributeAsString(VCFConstants.SVTYPE, null);
+        if(BREAKPOINT_SV_TYPES.contains(svType)) {
+            // Add checks at the breakpoint locations. They are points so we want to check tract overlaps in the regions
+            // around them
+            overlapCheckLocations.add(
+                new SimpleInterval(variantContext.getContig(),
+                             FastMath.max(1, variantContext.getStart() - BREAKPOINT_HALF_WIDTH),
+                             variantContext.getStart() + BREAKPOINT_HALF_WIDTH)
+            );
+            overlapCheckLocations.add(
+                new SimpleInterval(variantContext.getAttributeAsString(CHR2_KEY, null),
+                             FastMath.max(1, variantContext.getEnd() - BREAKPOINT_HALF_WIDTH),
+                              variantContext.getEnd() + BREAKPOINT_HALF_WIDTH)
+            );
+        } else {
+            // Insertions can have zero width but they have uncertainty in their true location. Expand their central
+            // interval for the purpose of checking tract overlap. Do this for any type that's "narrow"
+            final int width = variantContext.getEnd() - variantContext.getStart();
+            final boolean is_narrow = width < 2 * BREAKPOINT_HALF_WIDTH;
+            final int expand = is_narrow ?
+                max(
+                    (int)(abs(variantContext.getAttributeAsInt(SVLEN_KEY, 0)) * SV_EXPAND_RATIO),
+                    BREAKPOINT_HALF_WIDTH
+                ) :
+                0;
+            overlapCheckLocations.add(
+                new SimpleInterval(variantContext.getContig(),
+                    FastMath.max(1, variantContext.getStart() - expand),
+                    variantContext.getStart() + expand)
+            );
+            // if the interval isn't narrow, add the end points as potential breakpoints to check
+            if(!is_narrow) {
+                overlapCheckLocations.add(
+                    new SimpleInterval(variantContext.getContig(),
+                                      FastMath.max(1, variantContext.getStart() - BREAKPOINT_HALF_WIDTH),
+                                      variantContext.getStart() + BREAKPOINT_HALF_WIDTH)
+                );
+                overlapCheckLocations.add(
+                    new SimpleInterval(variantContext.getContig(),
+                                 FastMath.max(1, variantContext.getEnd() - BREAKPOINT_HALF_WIDTH),
+                                 variantContext.getEnd() + BREAKPOINT_HALF_WIDTH)
+                );
+            }
+        }
+        // Check for other distal locations in "SOURCE" field
+        //   they may be null (filter out)
+        //   they may be of form SVTYPE_SIMPLEINTERVAL (chop off everything before "_")
+        Arrays.stream(DISTAL_TARGETS_KEYS)
+                .map(key -> variantContext.getAttributeAsStringList(key, null))
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .map(this::getDistalTarget)
+                .forEach(overlapCheckLocations::add);
+
+        final double[] overlaps;
+        if(tractOverlapDetector.hasOther()) { // This tract has paired intervals
+            overlaps = overlapCheckLocations.stream()
+                    .mapToDouble(location -> tractOverlapDetector.getPrimaryOverlapFraction(location)
+                                             + tractOverlapDetector.getOtherOverlapfraction(location))
+                    .toArray();
+            // check for spanning by streaming over all possible pairs
+            final boolean spans = IntStream.range(0, overlapCheckLocations.size() - 1)
+                .anyMatch(
+                    i -> IntStream.range(i + 1, overlapCheckLocations.size()).anyMatch(
+                        j -> tractOverlapDetector.spansPrimaryAndOther(overlapCheckLocations.get(i),
+                                                                       overlapCheckLocations.get(j))
+                    )
+                );
+            propertiesTable.append(
+                tractOverlapDetector.getName() + "_spans",
+                spans
+            );
+        } else {  // this tract has simple intervals
+            overlaps = overlapCheckLocations.stream()
+                .mapToDouble(tractOverlapDetector::getPrimaryOverlapFraction)
+                .toArray();
+        }
+        // breakpoint types have no "center", otherwise get overlap of primary location
+        propertiesTable.append(
+            tractOverlapDetector.getName() + "_center",
+            BREAKPOINT_SV_TYPES.contains(svType) ? 0.0 : overlaps[0]
+        );
+        propertiesTable.append(
+            tractOverlapDetector.getName() + "_min",
+            Arrays.stream(overlaps).min().orElse(0.0)
+        );
+        propertiesTable.append(
+            tractOverlapDetector.getName() + "_max",
+            Arrays.stream(overlaps).max().orElse(0.0)
+        );
+    }
+
+    public short getGenotypeAttributeAsShort(final Genotype genotype, final String key, Short defaultValue) {
+        if(key.equals(VCFConstants.GENOTYPE_QUALITY_KEY)) {
+            return (short)genotype.getGQ();
+        }
+        Object x = genotype.getExtendedAttribute(key);
+        if ( x == null || x == VCFConstants.MISSING_VALUE_v4 ) {
+            if(defaultValue == null) {
+                throw new IllegalArgumentException("Genotype is missing value of " + key);
+            } else {
+                return defaultValue;
+            }
+        }
+        if ( x instanceof Short ) return (Short)x;
+        return Short.parseShort((String)x); // throws an exception if this isn't a string
+    }
+
+    private short[] getGenotypeAttributeAsShort(final Iterable<Genotype> sampleGenotypes, final String attributeKey,
+                                            @SuppressWarnings("SameParameterValue")final Short missingAttributeValue) {
+        short[] values = new short[sampleIds.size()];
+        int index = 0;
+        for(final Genotype genotype : sampleGenotypes) {
+            values[index] = getGenotypeAttributeAsShort(genotype, attributeKey, missingAttributeValue);
+            ++index;
+        }
+        return values;
+    }
+
+    private final Map<String, Integer> applySampleAlleleCounts = new HashMap<>();  // allocate once to avoid thrashing memory
+    private final Map<String, Integer> applySampleNoCallCounts = new HashMap<>();  // allocate once to avoid thrashing memory
+
+    private byte[] getCountsAsByteArray(final Map<String, Integer> counts) {
+        final byte[] byteArr = new byte[sampleIds.size()];
+        int idx = 0;
+        for(final String sampleId : sampleIds) {
+            final int count = counts.get(sampleId);
+            byteArr[idx] = (byte)count;
+            ++idx;
+        }
+        return byteArr;
+    }
+
+    private Set<Integer> getFilterableTruthSampleIndices(final VariantContext variantContext,
+                                                         final Map<String, Set<String>> truthSampleIds,
+                                                         final Map<String, Integer> sampleAlleleCounts,
+                                                         final Map<String, Integer> sampleNoCallCounts) {
+        if(truthSampleIds.containsKey(variantContext.getID())) {
+            // Get sample IDs of known bad variants that are filterable
+            final String[] filterableTruthSampleIds = truthSampleIds.get(variantContext.getID())
+                    .stream()
+                    .filter(sampleId -> genotypeIsFilterable(sampleAlleleCounts.get(sampleId),
+                                                             sampleNoCallCounts.get(sampleId)))
+                    .toArray(String[]::new);
+            if(filterableTruthSampleIds.length > 0) {
+                // get indices and GQ values of good samples for this variant
+                return Arrays.stream(filterableTruthSampleIds).map(sampleIndices::get).collect(Collectors.toSet());
+            }
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Accumulate properties for variant matrix, and allele counts, genotype quality for trio tensors
+     */
+    @Override
+    public void apply(VariantContext variantContext, ReadsContext readsContext, ReferenceContext ref, FeatureContext featureContext) {
+        // get per-sample allele counts as a map indexed by sample ID
+        int numCalledAlleles = 0;
+        int numNonRefAlleles = 0;
+        int numVariantInputVar = 0;
+        int numVariantInputNoCall = 0;
+        int numVariantInputRef = 0;
+        for(final Genotype genotype : variantContext.getGenotypes()) {
+            int noCallCounts = 0;
+            int nonRefCounts = 0;
+            for(final Allele allele : genotype.getAlleles()) {
+                if(allele.isNoCall()) {
+                    ++noCallCounts;
+                } else if(!allele.isReference()) {
+                    ++nonRefCounts;
+                }
+            }
+            applySampleAlleleCounts.put(genotype.getSampleName(), nonRefCounts);
+            applySampleNoCallCounts.put(genotype.getSampleName(), noCallCounts);
+            if(nonRefCounts > 0) {
+                ++numVariantInputVar;
+            } else if(noCallCounts > 0) {
+                ++numVariantInputNoCall;
+            } else {
+                ++numVariantInputRef;
+            }
+            numNonRefAlleles += nonRefCounts;
+            numCalledAlleles += genotype.getAlleles().size() - noCallCounts;
+        }
+        numInputVar += numVariantInputVar;
+        numInputNoCall += numVariantInputNoCall;
+        numInputRef += numVariantInputRef;
+
+        if(runMode == RunMode.Train && !getVariantIsTrainable(variantContext, applySampleAlleleCounts,
+                                                               applySampleNoCallCounts)) {
+            // no need to train on unfilterable variants
+            return;
+        }
+        ++numVariants;
+
+        float alleleFrequency = (float)variantContext.getAttributeAsDouble(VCFConstants.ALLELE_FREQUENCY_KEY, -1.0);
+        if(alleleFrequency <= 0) {
+            if(variantContext.getNSamples() <= minSamplesToEstimateAlleleFrequency) {
+                throw new GATKException("VCF does not have " + VCFConstants.ALLELE_FREQUENCY_KEY + " annotated or enough samples to estimate it ("
+                                        + minSamplesToEstimateAlleleFrequencyKey + "=" + minSamplesToEstimateAlleleFrequency + " but there are "
+                                        + variantContext.getNSamples() + " samples)");
+            }
+            // VCF not annotated with allele frequency, guess it from allele counts. If somehow we have a variant with
+            // no called alleles, just set alleleFrequency to 0. There's nothing to do with it anyway, so it hardly
+            // matters
+            alleleFrequency = numCalledAlleles > 0 ? numNonRefAlleles / (float) numCalledAlleles : 0F;
+        }
+        propertiesTable.append(VCFConstants.ALLELE_FREQUENCY_KEY, alleleFrequency);
+
+        final String svType = variantContext.getAttributeAsString(VCFConstants.SVTYPE, null);
+        if(svType == null) {
+            throw new GATKException("Missing " + VCFConstants.SVTYPE + " for variant " + variantContext.getID());
+        }
+        propertiesTable.append(VCFConstants.SVTYPE, svType);
+
+        final int svLen = variantContext.getAttributeAsInt(SVLEN_KEY, Integer.MIN_VALUE);
+        if(svLen == Integer.MIN_VALUE) {
+            throw new GATKException("Missing " + SVLEN_KEY + " for variant " + variantContext.getID());
+        }
+        propertiesTable.append(SVLEN_KEY, svLen);
+
+        propertiesTable.append(FILTER_KEY, variantContext.getFilters());
+
+        final Set<String> vcEvidence = Arrays.stream(
+                    variantContext.getAttributeAsString(EVIDENCE_KEY, NO_EVIDENCE)
+                        .replaceAll("[\\[\\] ]", "").split(",")
+            ).map(ev -> ev.equals(".") ? NO_EVIDENCE : ev).collect(Collectors.toSet());
+        if(vcEvidence.isEmpty()) {
+            throw new GATKException("Missing " + EVIDENCE_KEY + " for variant " + variantContext.getID());
+        }
+        propertiesTable.append(EVIDENCE_KEY, vcEvidence);
+
+
+        final Set<String> vcAlgorithms = Arrays.stream(
+                variantContext.getAttributeAsString(ALGORITHMS_KEY, NO_ALGORITHM)
+                        .replaceAll("[\\[\\] ]", "").split(",")
+        ).map(ev -> ev.equals(".") ? NO_ALGORITHM : ev).collect(Collectors.toSet());
+        if(vcAlgorithms.isEmpty()) {
+            throw new GATKException("Missing " + ALGORITHMS_KEY + " for variant " + variantContext.getID());
+        }
+        propertiesTable.append(ALGORITHMS_KEY, vcAlgorithms);
+
+        for(final TractOverlapDetector tractOverlapDetector : tractOverlapDetectors) {
+            getTractProperties(tractOverlapDetector, variantContext);
+        }
+
+        propertiesTable.append(
+            VCFConstants.ALLELE_COUNT_KEY,
+            getCountsAsByteArray(applySampleAlleleCounts)
+        );
+
+        propertiesTable.append(
+            NO_CALL_COUNTS_KEY,
+            getCountsAsByteArray(applySampleNoCallCounts)
+        );
+
+        final Iterable<Genotype> sampleGenotypes = variantContext.getGenotypesOrderedBy(sampleIds);
+        Stream.of(VCFConstants.GENOTYPE_QUALITY_KEY, PE_GQ_KEY, RD_GQ_KEY, SR_GQ_KEY).forEach(
+            genotypeAttributeKey -> propertiesTable.append(
+                    genotypeAttributeKey,
+                    getGenotypeAttributeAsShort(sampleGenotypes, genotypeAttributeKey, MISSING_GQ_VAL)
+            )
+        );
+
+        if(runMode == RunMode.Train) {
+            variantIds.add(variantContext.getID());
+            if(goodSampleVariants != null) {
+                goodSampleVariantIndices.put(
+                        numVariants - 1,
+                        getFilterableTruthSampleIndices(
+                                variantContext, goodSampleVariants, applySampleAlleleCounts, applySampleNoCallCounts
+                        )
+                );
+            }
+            if(badSampleVariants != null) {
+                badSampleVariantIndices.put(
+                        numVariants - 1,
+                        getFilterableTruthSampleIndices(
+                                variantContext, badSampleVariants, applySampleAlleleCounts, applySampleNoCallCounts
+                        )
+                );
+            }
+        } else {
+            if(sampleVariantGenotypeQualities == null) {
+                sampleVariantGenotypeQualities = (PropertiesTable.ShortMatProperty) propertiesTable.get(VCFConstants.GENOTYPE_QUALITY_KEY);
+                sampleVariantAlleleCounts = (PropertiesTable.ByteMatProperty) propertiesTable.get(VCFConstants.ALLELE_COUNT_KEY);
+                sampleVariantNoCallCounts = (PropertiesTable.ByteMatProperty) propertiesTable.get(NO_CALL_COUNTS_KEY);
+                propertiesTable.validateAndFinalize();
+            } else {
+                propertiesTable.oneHot();
+            }
+
+            vcfWriter.add(filterVariantContext(variantContext));
+
+            propertiesTable.clearRows();
+        }
+    }
+
+    Genotype[] filterGenotypes = null;
+    float[] variantPropertiesForFilterVariantContext = null;
+    boolean[] sampleVariantFilterableForFilterVariantContext = null;
+    private VariantContext filterVariantContext(final VariantContext variantContext) {
+        final int numProperties = getNumProperties();
+        final int numSamples;
+        if(filterGenotypes == null) {
+            numSamples = variantContext.getNSamples();
+            filterGenotypes = new Genotype[numSamples];
+            variantPropertiesForFilterVariantContext = new float[numSamples * numProperties];
+            sampleVariantFilterableForFilterVariantContext = new boolean[numSamples];
+        } else {
+            numSamples = filterGenotypes.length;
+            if(numSamples != variantContext.getNSamples()) {
+                throw new IllegalArgumentException("At " + variantContext.getID() + ": number of samples changed from "
+                                                   + numSamples + " to " + variantContext.getNSamples());
+            }
+        }
+
+        // filter all samples for this variant context in a batch to avoid DMatrix creation / prediction overhead
+        final boolean maybeFilterable = !(keepMultiallelic && getIsMultiallelic(variantContext));
+        final int[] adjustedGq;
+        if(maybeFilterable) {
+//            int numFilterableSamples = 0;
+//            int sampleIndex = 0;
+//            int flatPropertyIndex = 0;
+//            for (final Genotype genotype : variantContext.getGenotypes()) {
+//                filterGenotypes[sampleIndex] = genotype;
+//                sampleVariantFilterableForFilterVariantContext[sampleIndex] =
+//                    getSampleVariantIsFilterable(0, sampleIndex);
+//                if (sampleVariantFilterableForFilterVariantContext[sampleIndex]) {
+//                    System.arraycopy(
+//                            propertiesTable.getPropertiesRow(0, sampleIndex, needsNormalizedProperties()),
+//                            0,
+//                            variantPropertiesForFilterVariantContext,
+//                            flatPropertyIndex, numProperties
+//                    );
+//                    ++numFilterableSamples;
+//                    flatPropertyIndex += numProperties;
+//                }
+//                ++sampleIndex;
+//            }
+//            numFilterableGenotypes += numFilterableSamples;
+//            adjustedGq = adjustedGqBatch(variantPropertiesForFilterVariantContext, numFilterableSamples, numProperties);
+            int numFilterableSamples = 0;
+            int sampleIndex = 0;
+            for (final Genotype genotype : variantContext.getGenotypes()) {
+                filterGenotypes[sampleIndex] = genotype;
+                sampleVariantFilterableForFilterVariantContext[sampleIndex] =
+                        getSampleVariantIsFilterable(0, sampleIndex);
+                if (sampleVariantFilterableForFilterVariantContext[sampleIndex]) {
+                    ++numFilterableSamples;
+                }
+                ++sampleIndex;
+            }
+            numFilterableGenotypes += numFilterableSamples;
+            adjustedGq = adjustedGqBatch();
+        } else {
+            adjustedGq = null;
+            int sampleIndex = 0;
+            for(final Genotype genotype : variantContext.getGenotypes()) {
+                filterGenotypes[sampleIndex] = genotype;
+                sampleVariantFilterableForFilterVariantContext[sampleIndex] = false;
+                ++sampleIndex;
+            }
+        }
+
+        int numFiltered = 0;
+        int predictSampleIndex = 0;
+        for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+            final Genotype genotype = filterGenotypes[sampleIndex];
+            final int gq;
+            if(sampleVariantFilterableForFilterVariantContext[sampleIndex]) {
+                //noinspection ConstantConditions
+                gq = adjustedGq[predictSampleIndex];
+                ++predictSampleIndex;
+            } else {
+                // still need to move GQ from phred scale to logit scale
+                gq = p_to_scaled_logits(1.0 - phredToProb(genotype.getGQ()));
+            }
+            final Genotype filteredGenotype;
+            if (gq >= minAdjustedGq) {
+                filteredGenotype = new GenotypeBuilder(genotype).GQ(gq).make();
+            } else {
+                filteredGenotype = new GenotypeBuilder(genotype)
+                        .alleles(GATKVariantContextUtils.noCallAlleles(genotype.getPloidy()))
+                        .GQ(gq)
+                        .make();
+                ++numFiltered;
+            }
+            filterGenotypes[sampleIndex] = filteredGenotype;
+            int noCallCounts = 0;
+            int nonRefCounts = 0;
+            for (final Allele allele : filteredGenotype.getAlleles()) {
+                if (allele.isNoCall()) {
+                    ++noCallCounts;
+                } else if (!allele.isReference()) {
+                    ++nonRefCounts;
+                }
+            }
+            if (nonRefCounts > 0) {
+                ++numOutputVar;
+            } else if (noCallCounts > 0) {
+                ++numOutputNoCall;
+            } else {
+                ++numOutputRef;
+            }
+        }
+
+        final VariantContextBuilder variantContextBuilder = new VariantContextBuilder(variantContext)
+            .genotypes(filterGenotypes).attribute(MIN_GQ_KEY, minAdjustedGq);
+        if(numFiltered > variantContext.getNSamples() * reportMinGqFilterThreshold) {
+            variantContextBuilder.filter(EXCESSIVE_MIN_GQ_FILTER_KEY);
+        }
+
+        numFilteredGenotypes += numFiltered;
+        return variantContextBuilder.make();
+    }
+
+
+    private boolean notCloseEnough(final String strRep, final double val,
+                                   @SuppressWarnings("SameParameterValue") final double tol) {
+        return FastMath.abs(Double.parseDouble(strRep) - val) > FastMath.abs(tol * val);
+    }
+
+    static String padWidth(final String baseString, final int width) {
+        return baseString.length() >= width ?
+            baseString :
+            baseString + String.join("", Collections.nCopies(width - baseString.length(), " "));
+    }
+
+    static private String edgeValueToString(final double binEdge, final int precision) {
+        return String.format("%." + precision + "f", binEdge);
+    }
+
+    static private String[] edgeValuesToStrings(final double[] binEdges, final int precision) {
+        return Arrays.stream(binEdges)
+                .mapToObj(binEdge -> edgeValueToString(binEdge, precision))
+                .toArray(String[]::new);
+    }
+
+    static private boolean edgeStringsRepeat(final String[] edgeStrings) {
+        return IntStream.range(0, edgeStrings.length - 1)
+            .anyMatch(i -> edgeStrings[i].equals(edgeStrings[i + 1]));
+    }
+
+    private String[] getPropertyBinNames( final PropertiesTable.Property property, final double[] bins) {
+        double minVal = bins[0];
+        double maxVal = bins[bins.length - 1];
+        for(int variantIndex = 0; variantIndex < property.getNumRows(); ++variantIndex) {
+            final float val = property.getAsFloat(variantIndex, 0, false);
+            if(val < minVal) {
+                minVal = val;
+            } else if(val > maxVal) {
+                maxVal = val;
+            }
+        }
+        final boolean addLeftEdge = minVal < bins[0];
+        final boolean addRightEdge = maxVal > bins[bins.length - 1];
+        final double[] fullBinEdges = new double[bins.length + (addLeftEdge ? 1 : 0) + (addRightEdge ? 1: 0)];
+        System.arraycopy(bins, 0, fullBinEdges, addLeftEdge ? 1 : 0, bins.length);
+        if(addLeftEdge) {
+            fullBinEdges[0] = minVal;
+        }
+        if(addRightEdge) {
+            fullBinEdges[fullBinEdges.length - 1] = maxVal;
+        }
+
+        // increase precision of string representation of all bin edges until there is no confusion
+        int precision = 0;
+        String[] binEdgeNames = edgeValuesToStrings(fullBinEdges, precision);
+        while(edgeStringsRepeat(binEdgeNames)) {
+            ++precision;
+            binEdgeNames = edgeValuesToStrings(fullBinEdges, precision);
+        }
+        // increase precision of string representation of individual bin edges until they are accurate enough
+        for(int i = 0; i < binEdgeNames.length; ++i) {
+            int precision_i = precision;
+            while (notCloseEnough(binEdgeNames[i], fullBinEdges[i], 0.1)) {
+                ++precision_i;
+                binEdgeNames[i] = edgeValueToString(fullBinEdges[i], precision_i);
+            }
+        }
+        // form the bin names, keeping track of the width
+        int maxWidth = property.name.length();
+        String[] propertyBinNames = new String[binEdgeNames.length - 1];
+        for(int i = 0; i < propertyBinNames.length; ++i) {
+            propertyBinNames[i] = binEdgeNames[i] + "-" + binEdgeNames[i + 1];
+            maxWidth = max(maxWidth, propertyBinNames[i].length());
+        }
+        // pad bin names so they are all the same length, for easy table viewing
+        for(int i = 0; i < propertyBinNames.length; ++i) {
+            propertyBinNames[i] = padWidth(propertyBinNames[i], maxWidth);
+        }
+
+        return propertyBinNames;
+    }
+
+    private void setPropertyBins() {
+        propertyBins = new int[numVariants]; // guaranteed to be all zeros by Java spec
+
+        // Bin variants by SVTYPE
+        propertyBinLabelColumns = new ArrayList<>(1 + propertyBinsMap.size());
+
+        propertyBinLabelColumns.add(VCFConstants.SVTYPE);
+        final PropertiesTable.StringArrProperty svType =
+            (PropertiesTable.StringArrProperty) propertiesTable.get(VCFConstants.SVTYPE);
+        final List<String> allSvTypes = svType.getAllLabels();
+
+        final Map<String, Integer> binNames = IntStream.range(0, allSvTypes.size())
+            .boxed()
+            .collect(Collectors.toMap(allSvTypes::get, i -> i));
+        IntStream.range(0, numVariants).forEach(variantIndex ->
+            propertyBins[variantIndex] = binNames.get(svType.getAsString(variantIndex))
+        );
+
+        // Successively refine bins by each element of propertyBinsMap
+        for(Map.Entry<String, double[]> propertyBinsEntry : propertyBinsMap.entrySet()) {
+            final String propertyName = propertyBinsEntry.getKey();
+            final double[] bins = propertyBinsEntry.getValue();
+
+            // get the old bin names as an ordered list, so that existing propertyBins map correctly to oldBinNames
+            final List<String> oldBinNames = binNames.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+            binNames.clear();
+
+            // get the property values, and strings representing the bins we'll use
+            final PropertiesTable.Property property = propertiesTable.get(propertyName);
+            final String[] propertyBinNames = getPropertyBinNames(property, bins);
+            // add property name to the header with extra padding if needed
+            propertyBinLabelColumns.add(padWidth(propertyName, propertyBinNames[0].length()));
+
+            IntStream.range(0, numVariants).forEach(variantIndex -> {
+                // for each variant, find which of the new bins it should index into
+                int propertyBin = Arrays.binarySearch(bins, property.getAsFloat(variantIndex, 0, false));
+                if(propertyBin < 0) { propertyBin = ~propertyBin; }
+                // form the new bin name by adding a new column with the appropriate binned value
+                final String newBinName = oldBinNames.get(propertyBins[variantIndex]) + "\t" + propertyBinNames[propertyBin];
+                if(binNames.containsKey(newBinName)) {  // this bin exists, just get its index
+                    propertyBins[variantIndex] = binNames.get(newBinName);
+                } else {  // this is a new bin, create it and get its index
+                    final int newBin = binNames.size();
+                    binNames.put(newBinName, newBin);
+                    propertyBins[variantIndex] = newBin;
+                }
+            });
+        }
+
+        numPropertyBins = binNames.size();
+        propertyBinLabels = new String[numPropertyBins];
+        binNames.forEach((key, value) -> propertyBinLabels[value] = key);
+
+        // Finally, want the property bin descriptions to be in sorted order for easier reading out fitting results
+        final int[] sortInds = IntStream.range(0, numPropertyBins)
+            .boxed()
+            .sorted(Comparator.comparing(i -> propertyBinLabels[i]))
+            .mapToInt(Integer::new)
+            .toArray();
+        propertyBinLabels = IntStream.range(0, numPropertyBins)
+            .mapToObj(i -> propertyBinLabels[sortInds[i]])
+            .toArray(String[]::new);
+
+        final int[] unsortInds = new int[numPropertyBins];
+        IntStream.range(0, numPropertyBins).forEach(i -> unsortInds[sortInds[i]] = i);
+        propertyBins = Arrays.stream(propertyBins)
+            .map(i -> unsortInds[i])
+            .toArray();
+    }
+
+    private void setPropertyBinIsLargeAlleleFraction() {
+        propertyBinIsLargeAlleleFraction = new boolean[numPropertyBins];
+        final boolean[] isSet = new boolean[numPropertyBins];
+        int numSet = 0;
+        for(int variantIndex = 0; variantIndex < numVariants; ++variantIndex) {
+            final int propertyBin = propertyBins[variantIndex];
+            if(!isSet[propertyBin]) {
+                final float alleleFrequency = getAlleleFrequency(variantIndex);
+                propertyBinIsLargeAlleleFraction[propertyBin] = alleleFrequency > maxInheritanceAf;
+                isSet[propertyBin] = true;
+                ++numSet;
+                if(numSet == numPropertyBins) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private IntStream streamFilterableGq(final int variantIndex) {
+        return IntStream.range(0, numSamples)
+                .filter(
+                    sampleIndex -> getSampleVariantIsFilterable(variantIndex, sampleIndex)
+                )
+                .map(sampleIndex -> sampleVariantGenotypeQualities.getAsInt(variantIndex, sampleIndex));
+    }
+
+    private IntStream streamFilterableGq() {
+        return IntStream.range(0, numVariants).flatMap(this::streamFilterableGq);
+    }
+
+    protected Stream<MinGq> getCandidateMinGqs(final int variantIndex) {
+        final Stream.Builder<Short> hetBuilder = Stream.builder();
+        final Stream.Builder<Short> homvarBuilder = Stream.builder();
+        final byte[] sampleAlleleCounts = sampleVariantAlleleCounts.values[variantIndex];
+        final short[] sampleGqs = sampleVariantGenotypeQualities.values[variantIndex];
+        for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+            final byte alleleCount = sampleAlleleCounts[sampleIndex];
+            if(alleleCount <= 1) {
+                hetBuilder.add(sampleGqs[sampleIndex]);
+            } else if(!keepHomvar) {
+                homvarBuilder.add(sampleGqs[sampleIndex]);
+            }
+        }
+        final List<Short> candidateHetGq = hetBuilder.build().sorted().distinct().collect(Collectors.toList());
+        final List<Short> candidateHomVarGq = homvarBuilder.build().sorted().distinct().collect(Collectors.toList());
+        if(candidateHetGq.isEmpty()) {
+            if(candidateHomVarGq.isEmpty()) {
+                return null; // no candidate minGq, this variant can't really be filtered
+            } else {  // can filter some HOMVAR GQs, so just make trivial HET filter
+                candidateHetGq.add(Short.MIN_VALUE);
+            }
+        } else {
+            // consider filtering out all HET variants by adding 1 to highest filterable GQ value
+            candidateHetGq.add((short) (candidateHetGq.get(candidateHetGq.size() - 1) + 1));
+        }
+        if(!candidateHomVarGq.isEmpty()) {
+            // consider filtering out all HOMVAR variants by adding 1 to highest filterable GQ value
+            candidateHomVarGq.add((short) (candidateHomVarGq.get(candidateHomVarGq.size() - 1) + 1));
+        }
+        return candidateHetGq.stream()
+            .map(
+                hetGq -> {
+                    final List<MinGq> hetList = candidateHomVarGq.stream()
+                        .filter(homVarGq -> homVarGq >= hetGq)
+                        .map(homVarGq -> new MinGq(hetGq, homVarGq))
+                        .collect(Collectors.toList());
+                    if(hetList.isEmpty()) {
+                        hetList.add(new MinGq(hetGq, hetGq));
+                    }
+                    return hetList;
+                }
+            )
+            .flatMap(Collection::stream);
+    }
+
+    @SuppressWarnings("RedundantIfStatement")
+    private boolean maybeMendelian(final int fatherAc, final int motherAc, final int childAc,
+                                   final int fatherNoCalls, final int motherNoCalls, final int childNoCalls) {
+        if (fatherNoCalls > 0 || motherNoCalls > 0 || childNoCalls > 0) {
+            return false; // don't try to figure out what happened if there are no-calls
+        } else if(fatherAc == 0 && motherAc == 0 && childAc == 0) {
+            return false; // okay, technically Mendelian, but there's no transmission. All REF is not a useful signal
+        } else if(keepHomvar) {
+            // since homvar can't be filtered, there are some allele count combos that can't ever be Mendelian
+            if(strictMendelian) {
+                final int minAc = fatherAc / 2 + motherAc / 2;
+                if(childAc < minAc) {
+                    return false;
+                } else if(childAc == 2 && (fatherAc == 0 || motherAc == 0)) {
+                    return false;
+                }
+            } else if(childAc == 2 && (fatherAc == 0 && motherAc == 0)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isMendelian(final int[] trioAc, final int[] trioNoCalls) {
+        return isMendelian(trioAc[FATHER_IND], trioAc[MOTHER_IND], trioAc[CHILD_IND],
+                           trioNoCalls[FATHER_IND], trioNoCalls[MOTHER_IND], trioNoCalls[CHILD_IND]);
+    }
+
+    private boolean isMendelian(final int fatherAc, final int motherAc, final int childAc,
+                                final int fatherNoCalls, final int motherNoCalls, final int childNoCalls) {
+        if(fatherNoCalls > 0 || motherNoCalls > 0 || childNoCalls > 0 ||
+           (fatherAc == 0 && motherAc == 0 && childAc == 0)) {
+            // don't try to figure out what happened if there are no-calls, don't count trios with all HOMREF
+            return false;
+        } else if(strictMendelian) {
+            // child allele counts should not exhibit de-novo mutations nor be missing inherited homvar
+            final int maxAc = (fatherAc > 0 ? 1 : 0) + (motherAc > 0 ? 1 : 0);
+            final int minAc = fatherAc / 2 + motherAc / 2;
+            return (minAc <= childAc) && (childAc <= maxAc);
+        } else {
+            // child allele counts should not exhibit de-novo mutations
+            final int maxAc = fatherAc > 0 || motherAc > 0 ? 2 : 0;
+            return childAc <= maxAc;
+        }
+    }
+
+    private boolean trioPasses(final int[] trioAc, final int[] trioNoCalls) {
+        return trioPasses(trioAc[FATHER_IND], trioAc[MOTHER_IND], trioAc[CHILD_IND],
+                          trioNoCalls[FATHER_IND], trioNoCalls[MOTHER_IND], trioNoCalls[CHILD_IND]);
+    }
+
+    private boolean trioPasses(final int fatherAc, final int motherAc, final int childAc,
+                               final int fatherNoCalls, final int motherNoCalls, final int childNoCalls) {
+        return (fatherAc > 0 || motherAc > 0 || childAc > 0) &&
+                fatherNoCalls == 0 && motherNoCalls == 0 && childNoCalls == 0;
+    }
+
+
+    final void setSampleIndexToPredictionIndex(final Integer[] sampleIndexToPredictionIndex, final int variantIndex) {
+        int predictionIndex = 0;
+        for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+            if(getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                sampleIndexToPredictionIndex[sampleIndex] = predictionIndex;
+                ++predictionIndex;
+            } else {
+                sampleIndexToPredictionIndex[sampleIndex] = null;
+            }
+        }
+    }
+
+    /**
+     * Convert from dLoss / dProb to dLoss / dLogits (assumes prob = sigma(logits))
+     * @param prob: probability predicted by classifier
+     * @param d1LossDProb:  1st derivative of loss with respect to prob
+     * @param d2LossDProb: 2nd derivative of loss with respect to prob
+     * @param weight: weight of this prediction
+     * @param d1LossDLogits: array to hold 1st derivative of loss with respect to logits
+     * @param d2LossDLogits: array to hold 2nd derivative of loss with respect to logits
+     * @param predictionIndex: index into arrays of dLoss/dLogits arrays
+     */
+    protected void setLossDerivs(final double prob, final double d1LossDProb, final double d2LossDProb,
+                                 final double weight, final float[] d1LossDLogits, final float[] d2LossDLogits,
+                                 final int predictionIndex) {
+        final double d1ProbDLogit = prob * (1.0 - prob) / LOGIT_SCALE;
+        final double d2ProbDLogit = d1ProbDLogit * (1.0 - 2.0 * prob) / LOGIT_SCALE;
+        final double scaledWeight = weight * 4.0 * LOGIT_SCALE; // help scale derivatives to be close to 1.0
+        d1LossDLogits[predictionIndex] += (float)(scaledWeight * d1LossDProb * d1ProbDLogit);
+        d2LossDLogits[predictionIndex] += (float)(scaledWeight * (d2LossDProb * d1ProbDLogit * d1ProbDLogit
+                                                                  + d1LossDProb * d2ProbDLogit));
+    }
+
+    private float getAlleleFrequency(final int variantIndex) {
+        return propertiesTable.get(VCFConstants.ALLELE_FREQUENCY_KEY).getAsFloat(variantIndex, 0);
+    }
+
+    protected FilterSummary getFilterSummary(final MinGq minGq, final int variantIndex, final String label) {
+        final int[][] trioAlleleCountsMatrix = getTrioAlleleCountsMatrix(variantIndex);
+        final int[][] trioNoCallCountsMatrix = getTrioNoCallCountsMatrix(variantIndex);
+        final short[][] trioGenotypeQualitiesMatrix = getTrioGenotypeQualitiesMatrix(variantIndex);
+        final float variantAlleleFrequency = getAlleleFrequency(variantIndex);
+        final int propertyBin = propertyBins[variantIndex];
+        final double variantTruthWeight = propertyBinTruthWeights[propertyBin];
+        final double variantInheritanceWeight = propertyBinInheritanceWeights[propertyBin];
+        return getFilterSummary(minGq, trioAlleleCountsMatrix, trioNoCallCountsMatrix,
+                                trioGenotypeQualitiesMatrix, variantAlleleFrequency, new GoodBadGqs(variantIndex),
+                                variantTruthWeight, variantInheritanceWeight, label);
+    }
+
+    protected BinnedFilterSummaries getBinnedFilterSummary(final MinGq minGq, final int variantIndex) {
+        final int propertyBin = propertyBins[variantIndex];
+        return new BinnedFilterSummaries(getFilterSummary(minGq, variantIndex, propertyBinLabels[propertyBin]),
+                                         propertyBin, numPropertyBins);
+    }
+
+    private void filterTrioCall(final int[] alleleCounts, final int[] noCallCounts, final int sampleIndex,
+                                final boolean callPasses) {
+        if (!callPasses && alleleCountIsFilterable(alleleCounts[sampleIndex])) {
+            alleleCounts[sampleIndex] = 0;
+            noCallCounts[sampleIndex] = 2;
+        }
+    }
+
+    private void filterTrioCallsByMinGq(final int[] alleleCounts, final int[] noCallCounts, final short[] trioGqs,
+                                        final MinGq minGq) {
+        for(int indexInTrio = 0; indexInTrio < 3; ++indexInTrio) {
+            final boolean callPasses = trioGqs[indexInTrio] >= (alleleCounts[indexInTrio] <= 1 ? minGq.minGqHet :
+                                                                minGq.minGqHomVar);
+            filterTrioCall(alleleCounts, noCallCounts, indexInTrio, callPasses);
+        }
+    }
+
+    private int countTrioVariantPassing(final int[] trioAcs, final int[] trioNoCalls) {
+        int numPassing = 0;
+        for(int i = 0; i < 3; ++i) {
+            if(trioAcs[i] > 0 && trioNoCalls[i] == 0) {
+                ++numPassing;
+            }
+        }
+        return numPassing;
+    }
+
+    protected FilterSummary getFilterSummary(final MinGq minGq,
+                                             final int[][] trioAlleleCountsMatrix, final int[][] trioNoCallCountsMatrix,
+                                             final short[][] trioGenotypeQualitiesMatrix, final float alleleFrequency,
+                                             GoodBadGqs goodBadGqs,
+                                             final double variantTruthWeight, final double variantInheritanceWeight,
+                                             final String label) {
+        long numVariantsPassed = 0;
+        long numVariants = 0;
+        long numMendelianTrios = 0;
+        long numMendelianTriosPassed = 0;
+        long numTriosPassed = 0;
+        long numTruePositives = 0;
+        long numFalsePositives = 0;
+        long numFalseNegatives = 0;
+        long numTrueNegatives = 0;
+        for (final int gq : goodBadGqs.goodHetGqs) {
+            if(gq >= minGq.minGqHet) {
+                ++numTruePositives;
+            } else {
+                ++numFalseNegatives;
+            }
+        }
+        if(!keepHomvar) {
+            for (final int gq : goodBadGqs.goodHomVarGqs) {
+                if(gq >= minGq.minGqHomVar) {
+                    ++numTruePositives;
+                } else {
+                    ++numFalseNegatives;
+                }
+            }
+        }
+        for(final int gq : goodBadGqs.badHetGqs) {
+            if(gq >= minGq.minGqHet) {
+                ++numFalsePositives;
+            } else {
+                ++numTrueNegatives;
+            }
+        }
+        if(!keepHomvar) {
+            for(final int gq : goodBadGqs.badHomVarGqs) {
+                if(gq >= minGq.minGqHomVar) {
+                    ++numFalsePositives;
+                } else {
+                    ++numTrueNegatives;
+                }
+            }
+        }
+
+        final int[] trioAc = new int[3];
+        final int[] trioNoCalls = new int[3];
+        for (int trioIndex = 0; trioIndex < numTrios; ++trioIndex) {
+            System.arraycopy(trioAlleleCountsMatrix[trioIndex], 0, trioAc, 0, 3);
+            System.arraycopy(trioNoCallCountsMatrix[trioIndex], 0, trioNoCalls, 0, 3);
+            final short[] trioGq = trioGenotypeQualitiesMatrix[trioIndex];
+            final int numVariantsTrio = countTrioVariantPassing(trioAc, trioNoCalls);
+            numVariants += numVariantsTrio;
+            final boolean trioIsMendelian = isMendelian(trioAc, trioNoCalls);
+            if(trioIsMendelian) {
+                ++numMendelianTrios;
+            }
+
+            filterTrioCallsByMinGq(trioAc, trioNoCalls, trioGq, minGq);
+            numVariantsPassed += countTrioVariantPassing(trioAc, trioNoCalls);
+            if(trioPasses(trioAc, trioNoCalls)) {
+                ++numTriosPassed;
+                if(trioIsMendelian) {
+                    ++numMendelianTriosPassed;
+                }
+            }
+        }
+
+        return new FilterSummary(minGq, numMendelianTriosPassed, numMendelianTrios, numTriosPassed, numVariants,
+                                 numVariantsPassed, numTruePositives, numFalsePositives, numFalseNegatives,
+                                 numTrueNegatives,alleleFrequency > maxInheritanceAf,
+                                 variantTruthWeight, variantInheritanceWeight, label);
+    }
+
+    protected FilterSummary getFilterSummary(final boolean[] samplePasses, final int variantIndex, final int propertyBin) {
+        long numVariantsPassed = 0;
+        long numVariants = 0;
+        long numMendelianTrios = 0;
+        long numMendelianTriosPassed = 0;
+        long numTriosPassed = 0;
+        long numTruePositives = 0;
+        long numFalsePositives = 0;
+        long numFalseNegatives = 0;
+        long numTrueNegatives = 0;
+
+        final Set<Integer> goodSampleIndices = goodSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet());
+        final Set<Integer> badSampleIndices = badSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet());
+        // copy these arrays so that a) I can make them ints without taking a huge amount of memory, and
+        //                           b) I don't have to make two versions of filterTrioCall()
+        final Integer[] sampleIndexToPredictionIndex = new Integer[numSamples];
+        setSampleIndexToPredictionIndex(sampleIndexToPredictionIndex, variantIndex);
+        for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+            final Integer predictionIndex = sampleIndexToPredictionIndex[sampleIndex];
+            if(predictionIndex == null) {
+                continue;
+            }
+            if(goodSampleIndices.contains(sampleIndex)) {
+                if(samplePasses[predictionIndex]) {
+                    ++numTruePositives;
+                } else {
+                    ++numFalseNegatives;
+                }
+            } else if(badSampleIndices.contains(sampleIndex)) {
+                if(samplePasses[predictionIndex]) {
+                    ++numFalsePositives;
+                } else {
+                    ++numTrueNegatives;
+                }
+            }
+        }
+
+        final byte[] sampleAlleleCounts = sampleVariantAlleleCounts.values[variantIndex];
+        final byte[] sampleNoCallCounts = sampleVariantNoCallCounts.values[variantIndex];
+        final int[] trioAc = new int[3];
+        final int[] trioNoCalls = new int[3];
+        for(int trioIndex = 0; trioIndex < numTrios; ++trioIndex) {
+            final int[] sampleIndices = trioSampleIndices[trioIndex];
+
+            // copy trio allele counts / no-call counts into temporary buffers (so they can be filtered cleanly)
+            // copy samplePasses just to keep things in the same form
+            for(int indexInTrio = 0; indexInTrio < 3; ++indexInTrio) {
+                final int sampleIndex = sampleIndices[indexInTrio];
+                trioAc[indexInTrio] = sampleAlleleCounts[sampleIndex];
+                trioNoCalls[indexInTrio] = sampleNoCallCounts[sampleIndex];
+            }
+            numVariants += countTrioVariantPassing(trioAc, trioNoCalls);
+            final boolean trioIsMendelian = isMendelian(trioAc, trioNoCalls);
+            if(trioIsMendelian) {
+                ++numMendelianTrios;
+            }
+
+            for(int indexInTrio = 0; indexInTrio < 3; ++indexInTrio) {
+                final int sampleIndex = sampleIndices[indexInTrio];
+                final Integer predictionIndex = sampleIndexToPredictionIndex[sampleIndex];
+                filterTrioCall(trioAc, trioNoCalls, indexInTrio,
+                        predictionIndex == null || samplePasses[predictionIndex]);
+            }
+
+            numVariantsPassed += countTrioVariantPassing(trioAc, trioNoCalls);
+            if(trioPasses(trioAc, trioNoCalls)) {
+                ++numTriosPassed;
+                if(trioIsMendelian) {
+                    ++numMendelianTriosPassed;
+                }
+            }
+        }
+
+        final String label = propertyBinLabels[propertyBin];
+        final double variantTruthWeight = propertyBinTruthWeights[propertyBin];
+        final double variantInheritanceWeight = propertyBinInheritanceWeights[propertyBin];
+        final boolean isLargeAlleleFrequency = propertyBinIsLargeAlleleFraction[propertyBin];
+        final MinGq minGq = new MinGq(minAdjustedGq, minAdjustedGq);
+        return new FilterSummary(minGq, numMendelianTriosPassed, numMendelianTrios, numTriosPassed, numVariants,
+                numVariantsPassed, numTruePositives, numFalsePositives, numFalseNegatives, numTrueNegatives,
+                isLargeAlleleFrequency, variantTruthWeight, variantInheritanceWeight, label);
+    }
+
+    protected BinnedFilterSummaries getBinnedFilterSummary(final boolean[] samplePasses, final int variantIndex) {
+        final int propertyBin = propertyBins[variantIndex];
+        return new BinnedFilterSummaries(getFilterSummary(samplePasses, variantIndex, propertyBin),
+                                         propertyBin, numPropertyBins);
+    }
+
+    static protected class FilterQuality extends FilterSummary implements Comparable<FilterQuality> {
+        final FilterLoss loss;
+
+        FilterQuality(final FilterSummary filterSummary) {
+            super(filterSummary);
+            this.loss = new FilterLoss(filterSummary);
+        }
+
+        @Override
+        public int compareTo(final MinGqVariantFilterBase.@NotNull FilterQuality other) {
+            final int lossCompare = this.loss.compareTo(other.loss);
+            // for two equivalent-loss filters, take the more permissive one
+            return lossCompare == 0 ? this.minGq.compareTo(other.minGq) : lossCompare;
+        }
+
+        static final FilterQuality EMPTY = new FilterQuality(FilterSummary.EMPTY);
+    }
+
+    class GoodBadGqs {
+        // not worth fighting Java's inability to stream short here
+        final int[] goodHetGqs;
+        final int[] badHetGqs;
+        final int[] goodHomVarGqs;
+        final int[] badHomVarGqs;
+
+        GoodBadGqs(final int variantIndex) {
+            final int[] emptyGqs = new int[0];
+            final Set<Integer> goodSampleIndices = goodSampleVariantIndices.get(variantIndex);
+            final Set<Integer> badSampleIndices = badSampleVariantIndices.get(variantIndex);
+            final byte[] sampleAlleleCounts = sampleVariantAlleleCounts.values[variantIndex];
+            final short[] sampleGenotypeQualities = sampleVariantGenotypeQualities.values[variantIndex];
+            this.goodHetGqs = goodSampleIndices == null ?
+                emptyGqs :
+                goodSampleIndices.stream()
+                    .filter(sampleIndex -> sampleAlleleCounts[sampleIndex] == 1)
+                    .mapToInt(sampleIndex -> sampleGenotypeQualities[sampleIndex])
+                    .toArray();
+            this.badHetGqs = badSampleIndices == null ?
+                emptyGqs :
+                badSampleIndices.stream()
+                    .filter(sampleIndex -> sampleAlleleCounts[sampleIndex] == 1)
+                    .mapToInt(sampleIndex -> sampleGenotypeQualities[sampleIndex])
+                    .toArray();
+            this.goodHomVarGqs = keepHomvar || goodSampleIndices == null ?
+                emptyGqs :
+                goodSampleIndices.stream()
+                    .filter(sampleIndex -> sampleAlleleCounts[sampleIndex] > 1)
+                    .mapToInt(sampleIndex -> sampleGenotypeQualities[sampleIndex])
+                    .toArray();
+            this.badHomVarGqs = keepHomvar || badSampleIndices == null ?
+                emptyGqs :
+                badSampleIndices.stream()
+                    .filter(sampleIndex -> sampleAlleleCounts[sampleIndex] > 1)
+                    .mapToInt(sampleIndex -> sampleGenotypeQualities[sampleIndex])
+                    .toArray();
+        }
+    }
+
+
+    protected FilterQuality getOptimalVariantMinGq(final int variantIndex, final FilterSummary backgroundFilterSummary) {
+        final Stream<MinGq> candidateMinGqs = getCandidateMinGqs(variantIndex);
+        if(candidateMinGqs == null) {
+            // minGq doesn't matter for this row, so return previous optimal filter or trivial filter
+            return backgroundFilterSummary == null ? FilterQuality.EMPTY : new FilterQuality(backgroundFilterSummary);
+        }
+
+        final int[][] trioAlleleCountsMatrix = getTrioAlleleCountsMatrix(variantIndex);
+        final int[][] trioNoCallCountsMatrix = getTrioNoCallCountsMatrix(variantIndex);
+        final short[][] trioGenotypeQualitiesMatrix = getTrioGenotypeQualitiesMatrix(variantIndex);
+        final float variantAlleleFrequency = getAlleleFrequency(variantIndex);
+        final String label = propertyBinLabels[propertyBins[variantIndex]];
+        if(backgroundFilterSummary == null) {
+            // doing optimization only considering loss of each individual variant
+            return candidateMinGqs
+                    .parallel()
+                    .map(minGq -> new FilterQuality(
+                            getFilterSummary(
+                                minGq, trioAlleleCountsMatrix, trioNoCallCountsMatrix, trioGenotypeQualitiesMatrix,
+                                variantAlleleFrequency, new GoodBadGqs(variantIndex), truthWeight,
+                                 1.0 - truthWeight, label
+                            )
+                        ))
+                    .min(FilterQuality::compareTo)
+                    .orElseThrow(RuntimeException::new);
+        } else {
+            // doing optimization considering overall loss
+            return candidateMinGqs
+                    .parallel()
+                    .map(minGq -> new FilterQuality(
+                            getFilterSummary(
+                                minGq, trioAlleleCountsMatrix, trioNoCallCountsMatrix, trioGenotypeQualitiesMatrix,
+                                variantAlleleFrequency, new GoodBadGqs(variantIndex), truthWeight,
+                                 1.0 - truthWeight, label
+                            )
+                            .add(backgroundFilterSummary)
+                    ))
+                    .min(FilterQuality::compareTo)
+                    .orElseThrow(RuntimeException::new);
+        }
+    }
+
+    private static double assignWeightFromLoss(final double loss, final boolean isLargeAlleleFrequency) {
+        final double baseWeight = Double.isFinite(loss) ?
+                                    FastMath.max(1.0 - 2 * loss, minBinWeight) :
+                                    0.0;
+        return isLargeAlleleFrequency ? largeAfWeightPenalty * baseWeight : baseWeight;
+    }
+
+    private void scalePropertyBinWeights(
+        final int propertyBinIndex, final double[] rawBinWeights, final double rawTotalWeight,
+        final boolean isTruthWeight, final int numTrainableSampleVariants,
+        final float[] goodWeights, final float[] badWeights
+    ) {
+        // scale weights so that:
+        //    -overall average weight across variants is 1.0
+        //    -each bin has weight proportional to evidence strength (inheritance or truth)
+        //    -each bin has weight inversely proportional to number of variants in that bin, so that rare variant types
+        //     are not swamped in the optimization
+        //    -passing variants and failing variants have their weights balanced
+        int numGoodBin = 0;
+        int numBadBin = 0;
+        int numTrainable = 0;
+        for (final int variantIndex : trainingIndices) {
+            final Set<Integer> trainableSampleIndices;
+            if(isTruthWeight) {
+                trainableSampleIndices = new HashSet<>(
+                        goodSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+                );
+                trainableSampleIndices.addAll(
+                        badSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+                );
+            } else {
+                trainableSampleIndices = getInheritanceTrainableSampleIndices(variantIndex);
+            }
+            numTrainable += trainableSampleIndices.size();
+            if(propertyBins[variantIndex] != propertyBinIndex) {
+                continue;
+            }
+            for(final int trainableSampleIndex : trainableSampleIndices) {
+                if(samplePasses(variantIndex, trainableSampleIndex)) {
+                    ++numGoodBin;
+                } else {
+                    ++numBadBin;
+                }
+            }
+        }
+
+        // ws_b = c * wr_b / T_b
+        //totSVW = sum_b T_b * ws_b = sum_b c * wr_b = c rawTotalWeight
+        // meanSVW = totSVW / sum_b T_b = 1.0
+        // c * rawTotalWeight = sum_b T_b
+        // c = NT / rawTotalWeight
+
+        final double rawBinWeight = rawBinWeights[propertyBinIndex];
+        final double weightScale = isTruthWeight ? truthWeight : 1.0 - truthWeight;
+        final double averageBinWeight = rawTotalWeight / numPropertyBins;
+        final int numBinVariants = FastMath.max(numGoodBin + numBadBin, 1);
+        final double averageBinVariants = numTrainableSampleVariants / (float)numPropertyBins;
+
+//        final double overallScaledWeight = weightScale * rawBinWeight / averageBinWeight
+//                                         * averageBinVariants / FastMath.max(numBinVariants, 1);
+        final double overallScaledWeight = weightScale * rawBinWeight * averageBinVariants / FastMath.max(numBinVariants, 1);;
+        rawBinWeights[propertyBinIndex] = overallScaledWeight;
+        final double goodWeight, badWeight;
+        if(numGoodBin == 0 || numBadBin == 0) {  // so unbalanced don't attempt scaling, just evenly distribute weight
+            goodWeight = overallScaledWeight;
+            badWeight = overallScaledWeight;
+        } else {
+            badWeight = overallScaledWeight * numBinVariants / numBadBin / 2.0;
+            goodWeight = overallScaledWeight * numBinVariants / numGoodBin / 2.0;
+        }
+        goodWeights[propertyBinIndex] = (float)goodWeight;
+        badWeights[propertyBinIndex] = (float)badWeight;
+    }
+
+    private void setPerVariantOptimalMinGq() {
+        // Get initial optimal filter qualities, optimizing each variant separately
+        // Collect total summary stats, store min GQ
+        final List<List<Integer>> indicesList = IntStream.range(0, numPropertyBins)
+            .mapToObj(propertyBin -> new ArrayList<Integer>())
+            .collect(Collectors.toList());
+        IntStream.range(0, numVariants)
+            .forEach(index -> indicesList.get(propertyBins[index]).add(index));
+
+        perVariantOptimalMinGq = new MinGq[numVariants];
+        propertyBinInheritanceWeights = new double[numPropertyBins];
+        propertyBinTruthWeights = new double[numPropertyBins];
+
+        FilterSummary unbinnedFilterSummary = FilterSummary.EMPTY;
+        double totalInheritWeight = 0;
+        double totalTruthWeight = 0;
+        for(int propertyBin = 0; propertyBin < numPropertyBins; ++propertyBin) {
+            final List<Integer> indices = indicesList.get(propertyBin);
+            final FilterQuality binFilterQuality = setBinOptimalMinGq(indices, propertyBin);
+            unbinnedFilterSummary = unbinnedFilterSummary.add(binFilterQuality);
+            // set weight for truth and inheritance for this bin based on the loss / performance
+            final double inheritanceLoss = binFilterQuality.loss.inheritanceLoss;
+            propertyBinInheritanceWeights[propertyBin] = assignWeightFromLoss(inheritanceLoss,
+                                                                              binFilterQuality.isLargeAlleleFrequency);
+            totalInheritWeight += propertyBinInheritanceWeights[propertyBin];
+            final double truthLoss = binFilterQuality.loss.truthLoss;
+            propertyBinTruthWeights[propertyBin] = assignWeightFromLoss(truthLoss, false);
+            totalTruthWeight += propertyBinTruthWeights[propertyBin];
+        }
+
+        if(progressVerbosity > 0) {
+            System.out.format("Done setting optimal minGQ.\n");
+            System.out.format("totalInheritWeight = %f, totalTruthWeight = %f\n",
+                              totalInheritWeight, totalTruthWeight);
+        }
+
+        // scale weights so that:
+        //    -overall average weight across variants is 1.0
+        //    -each bin has weight proportional to evidence strength (inheritance or truth)
+        //    -each bin has weight inversely proportional to number of variants in that bin, so that rare variant types
+        //     are not swamped in the optimization
+        //    -passing variants and failing variants have their weights balanced
+        propertyBinMinGqWeights = new float[numPropertyBins];
+        propertyBinGoodTruthWeights = new float[numPropertyBins];
+        propertyBinBadTruthWeights = new float[numPropertyBins];
+        propertyBinGoodInheritanceWeights = new float[numPropertyBins];
+        propertyBinBadInheritanceWeights = new float[numPropertyBins];
+        final int numTrainableSampleVariants = getNumTrainableSampleVariants(trainingIndices);
+
+        for(int propertyBin = 0; propertyBin < numPropertyBins; ++propertyBin) {
+            long onlyMinGqTrainable = 0;
+            for (final int variantIndex : trainingIndices) {
+                if(propertyBins[variantIndex] != propertyBin) {
+                    continue;
+                }
+                final Set<Integer> trainableSampleIndices = getInheritanceTrainableSampleIndices(variantIndex);
+                        trainableSampleIndices.addAll(
+                            goodSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+                        );
+                        trainableSampleIndices.addAll(
+                                badSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+                        );
+                onlyMinGqTrainable += getNumTrainableSamples(variantIndex) - trainableSampleIndices.size();
+            }
+            propertyBinMinGqWeights[propertyBin] = (float)minBinWeight * numTrainableSampleVariants / numPropertyBins
+                                                    / FastMath.max(onlyMinGqTrainable, 1);
+
+            scalePropertyBinWeights(propertyBin, propertyBinInheritanceWeights, totalInheritWeight,false,
+                                    numTrainableSampleVariants, propertyBinGoodInheritanceWeights,
+                                    propertyBinBadInheritanceWeights);
+            scalePropertyBinWeights(propertyBin, propertyBinTruthWeights, totalTruthWeight,true,
+                                    numTrainableSampleVariants, propertyBinGoodTruthWeights, propertyBinBadTruthWeights);
+        }
+
+        if(progressVerbosity > 0) {
+            System.out.println("got propertyBin weights");
+            final int labelWidth = Arrays.stream(propertyBinLabels).mapToInt(String::length).max()
+                .orElseThrow(RuntimeException::new);
+            final String labelFormat = "%" + labelWidth + "s";
+            System.out.format(String.join("\t", propertyBinLabelColumns) +
+                                 "\t%9s\t%9s\t%9s\t%9s\t%9s\t%9s\t%9s\n",
+                              "minGqWeight", "inh weight", "+inh weight", "-inh weight",
+                                        "true weight", "+true weight", "-true weight");
+            for(int propertyBin = 0; propertyBin < numPropertyBins; ++propertyBin) {
+                System.out.format(labelFormat + "\t%9.4g\t%9.4g\t%9.4g\t%9.4g\t%9.4g\t%9.4g\t%9.4g\n",
+                    propertyBinLabels[propertyBin], propertyBinMinGqWeights[propertyBin],
+                    propertyBinInheritanceWeights[propertyBin], propertyBinGoodInheritanceWeights[propertyBin],
+                    propertyBinBadInheritanceWeights[propertyBin],
+                    propertyBinTruthWeights[propertyBin], propertyBinGoodTruthWeights[propertyBin],
+                    propertyBinBadTruthWeights[propertyBin]
+                );
+            }
+        }
+
+        // compute the proportion of filterable variants that passed the optimal minGQ filter
+        final long numFilterable = IntStream.range(0, numVariants)
+                .mapToLong(
+                        variantIndex -> IntStream.range(0, numSamples)
+                                .filter(sampleIndex -> getSampleVariantIsFilterable(variantIndex, sampleIndex))
+                                .count()
+                )
+                .sum();
+        if(progressVerbosity > 0) {
+            System.out.format("%d filterable variant x sample genotypes\n", numFilterable);
+        }
+
+        optimalProportionOfSampleVariantsPassing = unbinnedFilterSummary.numVariantsPassed
+                                                 / (double)unbinnedFilterSummary.numVariants;
+        if(progressVerbosity > 0) {
+            System.out.format("Optimal proportion of variants passing: %.3f\n", optimalProportionOfSampleVariantsPassing);
+        }
+    }
+
+    FilterQuality setBinOptimalMinGq(final List<Integer> indices, final int propertyBin) {
+        System.out.println(
+            "Optimizing minGqs for\t" + String.join("\t", propertyBinLabelColumns) + "\n" +
+            "                     \t" + propertyBinLabels[propertyBin]
+        );
+        System.out.println();
+        FilterSummary overallSummary = FilterSummary.EMPTY;
+        final FilterSummary[] filterSummaries = new FilterSummary[indices.size()];
+        for(int i = 0; i < indices.size(); ++i) {
+            final int variantIndex = indices.get(i);
+            final FilterQuality greedyFilter = getOptimalVariantMinGq(variantIndex, null);
+            filterSummaries[i] = greedyFilter;
+            overallSummary = overallSummary.add(greedyFilter);
+            perVariantOptimalMinGq[variantIndex] = greedyFilter.minGq;
+        }
+
+        // Iteratively improve filters, optimizing for OVERALL loss
+        boolean anyImproved = true;
+        int numIterations = 0;
+        FilterLoss previousLoss = new FilterLoss(overallSummary);
+        System.out.println("           \t" + FilterLoss.getHeader(propertyBinLabelColumns));
+        System.out.println("Iteration " + numIterations + "\t" + previousLoss);
+        while(anyImproved) {
+            ++numIterations;
+            anyImproved = false;
+            for(int i = 0; i < indices.size(); ++i) {
+                final int variantIndex = indices.get(i);
+                final FilterSummary previousFilter = filterSummaries[i];
+                final FilterSummary backgroundFilter = overallSummary.subtract(previousFilter);
+                final FilterQuality greedyFilter = getOptimalVariantMinGq(variantIndex, backgroundFilter);
+
+                if(greedyFilter.loss.lt(previousLoss)) {
+                    anyImproved = true;
+                    overallSummary = greedyFilter;
+                    perVariantOptimalMinGq[variantIndex] = greedyFilter.minGq;
+                    filterSummaries[i] = greedyFilter.subtract(backgroundFilter);
+                } else if(greedyFilter.loss.gt(previousLoss)) {
+                    throw new GATKException(
+                            "Loss increased. This is a bug!\n" +
+                            "previous:" + previousLoss + "\n" +
+                            "current: " + greedyFilter.loss
+                    );
+                }
+                previousLoss = greedyFilter.loss;
+            }
+            System.out.println("Iteration " + numIterations + "\t" + previousLoss);
+        }
+        displayHistogram(keepHomvar ? "Optimal minGq histogram" : "Optimal minGqHet histogram",
+                indices.stream().mapToInt(index -> perVariantOptimalMinGq[index].minGqHet),
+                true);
+        if(!keepHomvar) {
+            displayHistogram("Optimal minGqHomVar histogram",
+                    indices.stream().mapToInt(index -> perVariantOptimalMinGq[index].minGqHomVar),
+                    true);
+        }
+        return new FilterQuality(overallSummary);
+    }
+
+    protected int getNumTrainableSamples(final int variantIndex) {
+        return (int)IntStream.range(0, getNumSamples())
+                .filter(sampleIndex -> getSampleVariantIsTrainable(variantIndex, sampleIndex))
+                .count();
+    }
+    /**
+     * Get number of rows, account for the fact that unfilterable (e.g. already HOMREF) samples will not be used
+     */
+    private final Map<int[], Integer> numTrainableSampleVariantsMap = new HashMap<>();
+    protected int getNumTrainableSampleVariants(final int[] variantIndices) {
+        if(!numTrainableSampleVariantsMap.containsKey(variantIndices)) {
+            final long numTrainableSampleVariants = Arrays.stream(variantIndices)
+                    .mapToLong(this::getNumTrainableSamples)
+                    .sum();
+            if(numTrainableSampleVariants > Integer.MAX_VALUE) {
+                throw new GATKException("This data has " + numTrainableSampleVariants + " trainable samples x variants,"
+                                        + " which is more than Integer.MAX_VALUE. It is not possible to make large"
+                                        + " enough arrays for training");
+            }
+            numTrainableSampleVariantsMap.put(variantIndices, (int)numTrainableSampleVariants);
+            return (int)numTrainableSampleVariants;
+        }
+        return numTrainableSampleVariantsMap.get(variantIndices);
+    }
+
+    protected boolean samplePasses(final MinGq minGq, final short gq, final byte alleleCount) {
+        return gq >= (alleleCount > 1 ? minGq.minGqHomVar : minGq.minGqHet);
+    }
+
+    protected boolean samplePasses(final int variantIndex, final int sampleIndex) {
+        return samplePasses(perVariantOptimalMinGq[variantIndex],
+                            sampleVariantGenotypeQualities.values[variantIndex][sampleIndex],
+                            sampleVariantAlleleCounts.values[variantIndex][sampleIndex]);
+    }
+
+    protected int fillSamplePasses(final int variantIndex, int flatIndex, final boolean[] samplePasses) {
+        final short[] sampleGqs = sampleVariantGenotypeQualities.values[variantIndex];
+        final byte[] sampleAlleleCounts = sampleVariantAlleleCounts.values[variantIndex];
+        final MinGq minGq = perVariantOptimalMinGq[variantIndex];
+        for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+            if(getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                samplePasses[flatIndex] = samplePasses(minGq, sampleGqs[sampleIndex], sampleAlleleCounts[sampleIndex]);
+                ++flatIndex;
+            }
+        }
+        return flatIndex;
+    }
+
+    private final Map<int[], boolean[]> sampleVariantTruthMap = new HashMap<>();
+    protected boolean[] getSampleVariantTruth(final int[] variantIndices) {
+        if(sampleVariantTruthMap.containsKey(variantIndices)) {
+            return sampleVariantTruthMap.get(variantIndices);
+        }
+        final int numRows = getNumTrainableSampleVariants(variantIndices);
+        final boolean[] sampleVariantTruth = new boolean[numRows];
+
+        int flatIndex = 0;
+        for(final int variantIndex : variantIndices) {
+            flatIndex = fillSamplePasses(variantIndex, flatIndex, sampleVariantTruth);
+        }
+        sampleVariantTruthMap.put(variantIndices, sampleVariantTruth);
+        return sampleVariantTruth;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    protected void displayHistogram(final String description, final IntStream intStream, boolean binValues) {
+        final Map<Integer, Integer> rawValuesMap = new HashMap<>();
+        intStream.forEach(gq -> {
+            if (rawValuesMap.containsKey(gq)) {
+                rawValuesMap.put(gq, 1 + rawValuesMap.get(gq));
+            } else {
+                rawValuesMap.put(gq, 1);
+            }
+        });
+        if(rawValuesMap.size() == 0) {
+            System.out.println(description + ": no data");
+        }
+        final int minGqValue = rawValuesMap.keySet().stream().min(Integer::compareTo).orElseThrow(RuntimeException::new);
+        final int maxGqValue = rawValuesMap.keySet().stream().max(Integer::compareTo).orElseThrow(RuntimeException::new);
+
+        final Map<Integer, Integer> displayValuesMap;
+        if(binValues) {
+            displayValuesMap = new HashMap<>();
+            rawValuesMap.forEach((gq, numGq) -> {
+                final int binGq;
+                if (gq == 0) {
+                    binGq = gq;
+                } else {
+                    final int magnitude = (int) Math.pow(10.0, Math.floor(Math.log10(Math.abs(gq))));
+                    binGq = magnitude * (gq / magnitude);
+                }
+
+                if (displayValuesMap.containsKey(binGq)) {
+                    displayValuesMap.put(binGq, numGq + displayValuesMap.get(binGq));
+                } else {
+                    displayValuesMap.put(binGq, numGq);
+                }
+            });
+        } else {
+            displayValuesMap = rawValuesMap;
+        }
+        System.out.println(description + ":");
+        System.out.println("min=" + minGqValue + ", max=" + maxGqValue);
+        displayValuesMap.keySet()
+            .stream()
+            .sorted()
+            .forEach(minGq -> System.out.println(minGq + ": " + displayValuesMap.get(minGq)));
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    protected void displayHistogram(final String description, final DoubleStream doubleStream, final int numBins,
+                                    final double minValue, final double maxValue) {
+        final double safety = 100;
+        final double valueEps = safety * FastMath.max(FastMath.ulp(FastMath.abs(minValue)),
+                                                      FastMath.ulp(FastMath.abs(maxValue)));
+        final double numBinsEps = safety * FastMath.ulp((double)numBins);
+        final double valueOffset = minValue - valueEps;
+        final double binScale = (numBins - numBinsEps) / (maxValue - valueOffset);
+        final long[] valueBins = new long [numBins];
+        double[] valueRange = new double[] {Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+        doubleStream.forEach(value -> {
+            final int bin = (int)FastMath.floor((value - valueOffset) * binScale);
+            try {
+                ++valueBins[bin];
+            } catch(ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
+                final String errStr = String.format("bad bin: min: %f, max: %f, scale: %f, offset: %f, value: %f\n",
+                                                    minValue, maxValue, binScale, valueOffset, value);
+                throw new GATKException(errStr, arrayIndexOutOfBoundsException);
+            }
+            if(value < valueRange[0]) {
+                valueRange[0] = value;
+            }
+            if(value > valueRange[1]) {
+                valueRange[1] = value;
+            }
+        });
+        final long numValues = Arrays.stream(valueBins).sum();
+        if(valueRange[0] > valueRange[1]) {
+            System.out.println(description + ": no data");
+        } else {
+            System.out.format("%s: %d values\n", description, numValues);
+            System.out.format("\tactual range: [%f, %f]\n", valueRange[0], valueRange[1]);
+            System.out.println("\t low - high    %");
+            double high = minValue;
+            for(int bin = 0; bin < numBins; ++bin) {
+                double low = high;
+                high = low + 1.0 / binScale;
+                System.out.format("\t%.2f - %.2f   %.1f\n", low, high, valueBins[bin] * 100.0 / numValues);
+            }
+        }
+    }
+
+    protected void displayPercentiles(final String description, final DoubleStream doubleStream) {
+        final int[] numNans = new int[1];
+        final double[] values = doubleStream
+            .filter(v -> {if(Double.isNaN(v)) { ++numNans[0]; return false;} else return true;})
+            .sorted()
+            .toArray();
+        if(values.length == 0) {
+            if(numNans[0] == 0) {
+                System.out.println(description + ": no data");
+            } else {
+                System.out.format("%s: %d values 100%% are NaN\n", description, numNans[0]);
+            }
+        } else if(values[0] == values[values.length - 1]) {
+            System.out.format("%s: %d NaNs, %d non-NaN values 100%% equal %.3g\n",
+                              description, numNans[0], values.length, values[0]);
+        } else {
+            System.out.format("%s: %d NaNs, %d non-NaN values\n", description, numNans[0], values.length);
+            System.out.format("\tmin: %.3g\n", values[0]);
+            for(final int percentile : new int[]{25, 50, 75}) {
+                final int percentileIndex = (int)FastMath.round((percentile / 100.0) * (values.length - 1));
+                System.out.format("\t%d%%: %.3g\n", percentile, values[percentileIndex]);
+            }
+            System.out.format("\tmax: %.3g\n", values[values.length - 1]);
+        }
+    }
+
+    void printPropertiesValuesSummary() {
+        final int nameWidth = FastMath.max(
+            "propertyName".length(),
+            StreamSupport.stream(propertiesTable.spliterator(), false)
+                .mapToInt(prop -> prop.name.length())
+                .max().orElse(0)
+        );
+        final String nameFormat = "%"+ nameWidth + "s";
+        System.out.format("index\t" + nameFormat + "\tnRows\tnColumns\t%10s\t%10s\n",
+                          "propertyName", "baseline", "scale");
+        int idx = 0;
+        for(final PropertiesTable.Property property : propertiesTable) {
+            System.out.format("%d\t" + nameFormat + "\t%d\t%8d\t%10.5g\t%10.5g\n",
+                              idx, property.name, property.getNumRows(), property.getNumColumns(),
+                                        property.getBaseline(), property.getScale());
+            ++idx;
+        }
+    }
+
+    void printPropertiesDebugInfo() {
+        System.out.println("########################################");
+        System.out.println("numVariants: " + getNumVariants());
+        System.out.println("numTrios: " + getNumTrios());
+        System.out.println("numProperties: " + getNumProperties());
+        System.out.format("Input VCF had %.1f variants per sample.\n", numInputVar / (double)numSamples);
+        printPropertiesValuesSummary();
+
+        final Map<String, List<String>> labelsEncoding = propertiesTable.getLabelsEncoding();
+        for(final Map.Entry<String, List<String>> entry : labelsEncoding.entrySet()) {
+            System.out.println(entry.getKey() + ":");
+            int idx = 0;
+            for(final String label : entry.getValue()) {
+                System.out.println(idx + "\t" + label);
+                ++idx;
+            }
+        }
+
+        displayHistogram("Filterable alleles Gq histogram:", streamFilterableGq(),true);
+
+        System.out.println("########################################");
+    }
+
+
+    protected FilterLoss getTrainingLoss(final float[] pSampleVariantIsGood, final float[] d1Loss, final float[] d2Loss,
+                                         final int[] variantIndices) {
+        final boolean[] sampleVariantIsGood = getSampleVariantTruth(variantIndices);
+        // zero out derivative arrays
+        for(int predictIndex = 0; predictIndex < pSampleVariantIsGood.length; ++predictIndex) {
+            d1Loss[predictIndex] = 0F;
+            d2Loss[predictIndex] = 0F;
+        }
+
+        int predictIndex = 0;
+        FilterLoss loss = FilterLoss.EMPTY;
+        for(final int variantIndex : variantIndices) {
+            final Set<Integer> inheritanceTrainableSampleIndices = getInheritanceTrainableSampleIndices(variantIndex);
+            final Set<Integer> truthTrainableSampleIndices = new HashSet<>(
+                    goodSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+            );
+            truthTrainableSampleIndices.addAll(
+                    badSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+            );
+            final int propertyBin = propertyBins[variantIndex];
+            final float minGqWeight = propertyBinMinGqWeights[propertyBin];
+            final float halfMinGqWeight = minGqWeight / 2F;
+            final float goodTruthWeight = halfMinGqWeight + propertyBinGoodTruthWeights[propertyBin];
+            final float badTruthWeight = halfMinGqWeight + propertyBinBadTruthWeights[propertyBin];
+            final float goodInheritanceWeight = halfMinGqWeight + propertyBinGoodInheritanceWeights[propertyBin];
+            final float badInheritanceWeight = halfMinGqWeight + propertyBinBadInheritanceWeights[propertyBin];
+            final float truthWeight = halfMinGqWeight + (float)propertyBinTruthWeights[propertyBin];
+            final float inheritanceWeight = halfMinGqWeight + (float)propertyBinInheritanceWeights[propertyBin];
+
+            for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+                if(!getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                    continue;
+                }
+                final double p = pSampleVariantIsGood[predictIndex];
+                final boolean sampleIsGood = sampleVariantIsGood[predictIndex];
+                final double delta, deltaLoss, d1, d2;
+                if(sampleIsGood) {
+                    delta = FastMath.max(PROB_EPS, p);
+                    deltaLoss = -FastMath.log(delta);
+                    d1 = -1.0 / delta;
+                    d2 = -d1 / delta;
+                } else {
+                    delta = FastMath.max(PROB_EPS, 1.0 - p);
+                    deltaLoss = -FastMath.log(delta);
+                    d1 = 1.0 / delta;
+                    d2 = d1 / delta;
+                }
+
+                final double sampleInheritanceWeight, sampleTruthWeight;
+                if(inheritanceTrainableSampleIndices.contains(sampleIndex)) {
+                    sampleInheritanceWeight = sampleIsGood ? goodInheritanceWeight : badInheritanceWeight;
+                    //sampleInheritanceWeight = inheritanceWeight;
+                } else {
+                    sampleInheritanceWeight = halfMinGqWeight;
+                }
+                if(truthTrainableSampleIndices.contains(sampleIndex)) {
+                    sampleTruthWeight = sampleIsGood ? goodTruthWeight : badTruthWeight;
+                    //sampleTruthWeight = truthWeight;
+                } else {
+                    sampleTruthWeight = halfMinGqWeight;
+                }
+                final double derivWeight = sampleInheritanceWeight + sampleTruthWeight;
+
+                setLossDerivs(p, d1, d2, derivWeight, d1Loss, d2Loss, predictIndex);
+                final FilterLoss sampleVariantLoss =
+                    new FilterLoss(deltaLoss, deltaLoss, sampleInheritanceWeight, sampleTruthWeight, null);
+                loss = FilterLoss.add(loss, sampleVariantLoss);
+                ++predictIndex;
+            }
+        }
+        return loss;
+    }
+
+    private boolean[][] getSampleVariantPasses(final float[] pSampleVariantIsGood, final int[] variantIndices) {
+        final boolean[][] sampleVariantPasses = new boolean[variantIndices.length][];
+        int flatIndex = 0;
+        for(int row = 0; row < variantIndices.length; ++row) {
+            final int variantIndex = variantIndices[row];
+            final boolean[] samplePasses = new boolean[getNumTrainableSamples(variantIndex)];
+            sampleVariantPasses[row] = samplePasses;
+            for(int col = 0; col < samplePasses.length; ++col) {
+                samplePasses[col] = pSampleVariantIsGood[flatIndex] >= 0.5F;
+                ++flatIndex;
+            }
+        }
+        return sampleVariantPasses;
+    }
+
+    protected FilterLoss getLoss(final float[] pSampleVariantIsGood, final int[] variantIndices) {
+        final boolean[][] sampleVariantPasses = getSampleVariantPasses(pSampleVariantIsGood, variantIndices);
+
+        return new FilterLoss(
+            IntStream.range(0, variantIndices.length)
+                .mapToObj(i -> getBinnedFilterSummary(sampleVariantPasses[i], variantIndices[i]))
+                .reduce(BinnedFilterSummaries::add).orElse(BinnedFilterSummaries.EMPTY),
+            propertyBinLabelColumns
+        );
+    }
+
+    protected FilterLoss getLoss(final MinGq[] minGq, final int[] variantIndices) {
+        if(minGq.length != variantIndices.length) {
+            throw new GATKException(
+                    "Length of minGq (" + minGq.length + ") does not match length of variantIndices (" + variantIndices.length + ")"
+            );
+        }
+        return new FilterLoss(
+            IntStream.range(0, minGq.length)
+                .mapToObj(i -> getBinnedFilterSummary(minGq[i], variantIndices[i]))
+                .reduce(BinnedFilterSummaries::add).orElse(BinnedFilterSummaries.EMPTY),
+            propertyBinLabelColumns
+        );
+    }
+
+    private void displayNaiveLoss(final int[] variantIndices, final String name) {
+        final MinGq[] minGq = Arrays.stream(variantIndices).mapToObj(i -> new MinGq((short)0, (short)0)).toArray(MinGq[]::new);
+        final FilterLoss loss = getLoss(minGq, variantIndices);
+        System.out.format("\tNaive loss for %s\n\t\t%s\n", name, loss.toString().replaceAll("\n", "\n\t\t"));
+    }
+
+    private void displayNaiveLoss() {
+        if(progressVerbosity > 0) {
+            displayNaiveLoss(trainingIndices, "training");
+            displayNaiveLoss(validationIndices, "validation");
+        }
+    }
+
+    private void setTrainingAndValidationIndices() {
+        final int numValidationIndices = (int)round(validationProportion * numVariants);
+        final List<Integer> shuffleIndices = IntStream.range(0, numVariants).boxed().collect(Collectors.toList());
+        Collections.shuffle(shuffleIndices, randomGenerator);
+
+        validationIndices = shuffleIndices.subList(0, numValidationIndices).stream()
+            .sorted().mapToInt(Integer::intValue).toArray();
+        trainingIndices = shuffleIndices.subList(numValidationIndices, numVariants).stream()
+            .sorted().mapToInt(Integer::intValue).toArray();
+    }
+
+    private void saveTrainedModel() {
+        try (final OutputStream outputStream = modelFile.getOutputStream()) {
+            final OutputStream unclosableOutputStream = new FilterOutputStream(outputStream) {
+                @Override
+                public void close() {
+                    // don't close the stream in one of the subroutines
+                }
+            };
+            propertiesTable.saveDataEncoding(unclosableOutputStream);
+            saveModel(unclosableOutputStream);
+        } catch(IOException ioException) {
+            throw new GATKException("Error saving modelFile " + modelFile, ioException);
+        }
+    }
+
+    private void savePropertiesTable() {
+        if(propertiesTableFile == null) {
+            return;
+        }
+        try (final OutputStream outputStream = propertiesTableFile.getOutputStream()) {
+            final OutputStream unclosableOutputStream = new FilterOutputStream(outputStream) {
+                @Override
+                public void close() {
+                    // don't close the stream in one of the subroutines
+                }
+            };
+            propertiesTable.save(unclosableOutputStream);
+        } catch(IOException ioException) {
+            throw new GATKException("Error saving propertiesTable " + propertiesTableFile, ioException);
+        }
+    }
+
+    private void loadTrainedModel() {
+        if(modelFile == null || !Files.exists(modelFile.toPath())) {
+            if(runMode == RunMode.Filter) {
+                throw new UserException("mode=FILTER, but trained model file was not provided.");
+            }
+            return;
+        }
+        try (final InputStream inputStream = modelFile.getInputStream()) {
+            final InputStream unclosableInputStream = new FilterInputStream(inputStream) {
+                @Override
+                public void close() {
+                    // don't close the stream in one of the subroutines
+                }
+            };
+            propertiesTable.loadDataEncoding(unclosableInputStream);
+            loadModel(unclosableInputStream );
+        } catch (Exception exception) {
+            throw new GATKException("Error loading modelFile " + modelFile + " (malformed file?)", exception);
+        }
+        System.out.println("loadTrainedModel complete");
+    }
+
+    private byte[] modelCheckpoint = null;
+
+    protected void saveModelCheckpoint() {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        saveModel(outputStream);
+        modelCheckpoint = outputStream.toByteArray();
+    }
+
+    protected void loadModelCheckpoint() {
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(modelCheckpoint);
+        loadModel(inputStream);
+    }
+
+    protected void clearUnneededProperties() {
+        // clear properties that are only used for training (e.g. keep allele counts, which are used for scoring too)
+        // as those properties have all been copied into DMatrices, and aren't needed anymore
+        final Set<String> neededProperties = new HashSet<>(Arrays.asList(
+            VCFConstants.ALLELE_COUNT_KEY, NO_CALL_COUNTS_KEY
+        ));
+
+        for (final String propertyName : propertiesTable.getPropertyNames()) {
+            if(!neededProperties.contains(propertyName)) {
+                propertiesTable.get(propertyName).clearAllocatedRows();
+            }
+        }
+    }
+
+    protected abstract boolean needsNormalizedProperties();
+    protected abstract void predictBatch(final float[] sampleVariantProperties, final int numRows, final int numColumns,
+                                         final float[] outputProbabilites);
+    protected abstract int predictBatch(final float[] outputProbabilities);
+    protected abstract void trainFilter();
+    protected abstract void saveModel(final OutputStream outputStream);
+    protected abstract void loadModel(final InputStream inputStream);
+
+    protected int phredScale(final double p) {
+        return (int)FastMath.round(-10.0 * FastMath.log10(p));
+    }
+    protected double phredToProb(final double phred) {
+        return FastMath.exp(-PHRED_COEF * phred);
+    }
+
+    private float[] outputProbabilitiesForAdjustedGq = null;
+    private int[] outputGqForAdjustedGq = null;
+    private int[] adjustedGqBatch(final float[] sampleVariantProperties, final int numRows, final int numColumns) {
+        if(numRows == 0) {
+            return outputGqForAdjustedGq;
+        } else if(numRows > outputProbabilitiesForAdjustedGq.length) {
+            outputProbabilitiesForAdjustedGq = new float[numRows];
+            outputGqForAdjustedGq = new int[numRows];
+        }
+        predictBatch(sampleVariantProperties, numRows, numColumns, outputProbabilitiesForAdjustedGq);
+        for(int row = 0; row < numRows; ++row) {
+            outputGqForAdjustedGq[row] = p_to_scaled_logits(outputProbabilitiesForAdjustedGq[row]);
+        }
+        return outputGqForAdjustedGq;
+    }
+    private int[] adjustedGqBatch() {
+        if(outputProbabilitiesForAdjustedGq == null) {
+            outputProbabilitiesForAdjustedGq = new float[numSamples];
+            outputGqForAdjustedGq = new int[numSamples];
+        }
+        final int numRows = predictBatch(outputProbabilitiesForAdjustedGq);
+        for(int row = 0; row < numRows; ++row) {
+            outputGqForAdjustedGq[row] = p_to_scaled_logits(outputProbabilitiesForAdjustedGq[row]);
+        }
+        return outputGqForAdjustedGq;
+    }
+
+    // near p=0.5, each scaled logit is ~ 0.1% change in likelihood
+    static final double LOGIT_SCALE = 1.0 / FastMath.log(0.501 / 0.499);
+
+    protected int p_to_scaled_logits(final double p) {
+        return p == 0 ? Short.MIN_VALUE :
+                        p == 1 ? Short.MAX_VALUE :
+                                 (int)FastMath.floor(LOGIT_SCALE * FastMath.log(p / (1.0 - p)));
+    }
+
+    protected double scaled_logits_to_p(final int scaled_logits) {
+        return 1.0 / (1.0 + FastMath.exp(-scaled_logits / LOGIT_SCALE));
+    }
+
+    protected float scaled_logits_to_p(final float scaled_logits) {
+        return (float)(1.0 / (1.0 + FastMath.exp(-scaled_logits / LOGIT_SCALE)));
+    }
+
+    @Override
+    public Object onTraversalSuccess() {
+        if(runMode == RunMode.Train) {
+            if(numVariants == 0) {
+                throw new GATKException("No variants contained in vcf: " + drivingVariantFile);
+            }
+
+            if(goodSampleVariants != null) {
+                // no longer needed, clear them out
+                goodSampleVariants.clear();
+                goodSampleVariants = null;
+                badSampleVariants.clear();
+                badSampleVariants = null;
+            }
+
+            setPropertyBins();
+            setPropertyBinIsLargeAlleleFraction();
+            propertiesTable.validateAndFinalize();
+            sampleVariantGenotypeQualities = (PropertiesTable.ShortMatProperty) propertiesTable.get(VCFConstants.GENOTYPE_QUALITY_KEY);
+            sampleVariantAlleleCounts = (PropertiesTable.ByteMatProperty) propertiesTable.get(VCFConstants.ALLELE_COUNT_KEY);
+            sampleVariantNoCallCounts = (PropertiesTable.ByteMatProperty) propertiesTable.get(NO_CALL_COUNTS_KEY);
+
+            printPropertiesDebugInfo();
+
+            savePropertiesTable();
+            setTrainingAndValidationIndices();
+            setPerVariantOptimalMinGq();
+            displayNaiveLoss();
+
+            trainFilter();
+            saveTrainedModel();
+        } else {
+            System.out.println("Filter summary:");
+            System.out.println("\tFiltered " + numFilteredGenotypes + " of " + numFilterableGenotypes +
+                               " filterable genotypes in " + numVariants + " variants x " + numSamples + " samples");
+            System.out.format("\t\t = %.1f%% of genotypes filtered.\n",
+                              100.0 * numFilteredGenotypes / (double)(numFilterableGenotypes));
+            System.out.format("\tInput VCF had %.1f variants per sample\n",
+                              numInputVar / (double)numSamples);
+            System.out.format("\t\t(%d ref, %d non-ref, %d no-call)\n", numInputRef, numInputVar, numInputNoCall);
+            System.out.format("\tOutput VCF had %.1f variants per sample\n",
+                             numOutputVar / (double)numSamples);
+            System.out.format("\t\t(%d ref, %d non-ref, %d no-call)\n", numOutputRef, numOutputVar, numOutputNoCall);
+        }
+        return null;
+    }
+
+    @Override
+    public void closeTool() {
+        if (vcfWriter != null) {
+            vcfWriter.close();
+            System.out.println("Closed " + outputFile);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/PropertiesTable.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/PropertiesTable.java
@@ -1,0 +1,1421 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import net.minidev.json.parser.ParseException;
+import org.apache.commons.math3.util.FastMath;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Class to manage table with mixed columnar and matrix properties; with different primitive types. Supported types:
+ *     boolean, int, long, float, double
+ *
+ * This class is useful for cases when the exact properties are not necessarily fixed in advance and it is desirable to
+ * build records dynamically from (name, value) pairs.
+ *
+ * Conceptually the table is organized as numRows x numProperties x numColumns
+ * Properties are stored as Object that can be cast to primitive arrays or array-of-arrays (matrix) in their original
+ *     primitive type
+ * Rows are extracted as float[] (suitable for machine learning), with one of two options
+ *    normalize = false: translated to float type but otherwise unchanged from raw values
+ *    normalize = true: shifted so the median is 0, and scaled so the standard deviation (over the central half of the
+ *                      data) is 1.0. This is done on the fly when extracting rows.
+ *                      The baseline and scale can be provided when adding a column (to provide consistency between
+ *                      training and inference data) or computed automatically.
+ */
+class PropertiesTable implements Iterable<PropertiesTable.Property> {
+    private static final String PROPERTY_NAMES_KEY = "propertyNames";
+    private static final String PROPERTY_CLASSES_KEY = "propertyClasses";
+    private static final String PROPERTY_BASELINE_KEY = "propertyBaseline";
+    private static final String PROPERTY_SCALE_KEY = "propertyScale";
+    private static final int DEFAULT_INITIAL_NUM_ALLOCATED_ROWS = 1000;
+    private boolean allNumeric = true;
+
+    enum PropertyClass {
+        BooleanArrProperty, BooleanMatProperty,
+        ByteArrProperty, ByteMatProperty,
+        ShortArrProperty, ShortMatProperty,
+        IntArrProperty, IntMatProperty,
+        LongArrProperty, LongMatProperty,
+        FloatArrProperty, FloatMatProperty,
+        DoubleArrProperty, DoubleMatProperty,
+        StringArrProperty, StringMatProperty,
+        StringSetArrProperty, StringSetMatProperty,
+    }
+
+    //private final List<Property> properties = new ArrayList<>();
+    private final Map<String, Property> properties = new HashMap<>();
+    private final Map<String, List<String>> labelsEncoding = new HashMap<>();
+    private List<String> orderedPropertyNames = null;
+    private float[] propertiesRow = null;
+    private int initialNumAllocatedRows;
+
+    PropertiesTable(final int initialNumAllocatedRows) { this.initialNumAllocatedRows = initialNumAllocatedRows; }
+    PropertiesTable() { this(DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+    @NotNull @Override public Iterator<Property> iterator() {
+        if(orderedPropertyNames == null) {
+            setOrderedPropertyNames();
+        }
+        return orderedPropertyNames.stream().map(properties::get).iterator();
+    }
+
+    public List<String> getPropertyNames() {
+        if(orderedPropertyNames == null) {
+            setOrderedPropertyNames();
+        }
+        return orderedPropertyNames;
+    }
+
+    private void setOrderedPropertyNames() {
+        orderedPropertyNames = properties.keySet().stream().sorted().collect(Collectors.toList());
+    }
+
+    public Property get(final String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    public Property getOrCreateProperty(final String propertyName, final PropertyClass propertyClass) {
+        return getOrCreateProperty(propertyName, propertyClass, initialNumAllocatedRows);
+    }
+
+    public Property getOrCreateProperty(final String propertyName, final PropertyClass propertyClass,
+                                        final int numAllocatedRows) {
+        Property property = properties.getOrDefault(propertyName, null);
+        if(property == null) {
+            property = Property.create(propertyClass, propertyName, numAllocatedRows);
+            if(!property.isNumeric()) {
+                allNumeric = false;
+            }
+            properties.put(propertyName, property);
+        } else if(property.getAllocatedRows() < numAllocatedRows) {
+            property.setAllocatedRows(numAllocatedRows);
+        }
+        return property;
+    }
+
+    public void setBaselineAndScale(final String propertyName, final PropertyClass propertyClass,
+                                    final double baseline, final double scale) {
+        getOrCreateProperty(propertyName, propertyClass).setBaselineAndScale(baseline, scale);
+    }
+
+    public void addLabelEncoding(final String propertyName, final List<String> propertyLabels) {
+        labelsEncoding.put(propertyName, propertyLabels.stream().sorted().collect(Collectors.toList()));
+    }
+
+    public void remove(final String propertyName) {
+        properties.remove(propertyName);
+    }
+
+    public void insert(final Property property) {
+        if(!property.isNumeric()) {
+            allNumeric = false;
+        }
+        if (properties.containsKey(property.name)) {
+            final Property oldProperty = properties.get(property.name);
+            if(oldProperty.getNumRows() > 0) {
+                throw new IllegalArgumentException("PropertiesTable already contains property: " + property.name);
+            } else {
+                // property exists but it's empty. If it has useful baseline and scale information, transfer those,
+                // then overwrite with new property
+                if(oldProperty.normalizationIsSet()) {
+                    property.setBaselineAndScale(oldProperty.getBaseline(), oldProperty.getScale());
+                }
+                properties.put(property.name, property);
+            }
+        } else {
+            properties.put(property.name, property);
+        }
+    }
+
+    /**
+     * "clear" existing data by setting numRows to 0. Property types and memory allocation is not altered so that any
+     * subsequent data can be written to first row without continual reallocation
+     */
+    public void clearRows() {
+        setNumRows(0);
+    }
+
+    public void setNumRows(final int numRows) {
+        for(final Property property : properties.values()) {
+            property.numRows = numRows;
+        }
+    }
+
+    public void setNumAllocatedRows(final int numRows) {
+        this.initialNumAllocatedRows = numRows;
+        for(final Property property : properties.values()) {
+            property.setAllocatedRows(numRows);
+        }
+    }
+
+    public void append(final String propertyName, final boolean value) {
+        getOrCreateProperty(propertyName, PropertyClass.BooleanArrProperty).append(value);
+    }
+    public void append(final String propertyName, final boolean[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.BooleanMatProperty).append(value);
+    }
+    public void append(final String propertyName, final byte value) {
+        getOrCreateProperty(propertyName, PropertyClass.ByteArrProperty).append(value);
+    }
+    public void append(final String propertyName, final byte[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.ByteMatProperty).append(value);
+    }
+    public void append(final String propertyName, final short value) {
+        getOrCreateProperty(propertyName, PropertyClass.ShortArrProperty).append(value);
+    }
+    public void append(final String propertyName, final short[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.ShortMatProperty).append(value);
+    }
+    public void append(final String propertyName, final int value) {
+        getOrCreateProperty(propertyName, PropertyClass.IntArrProperty).append(value);
+    }
+    public void append(final String propertyName, final int[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.IntMatProperty).append(value);
+    }
+    public void append(final String propertyName, final long value) {
+        getOrCreateProperty(propertyName, PropertyClass.LongArrProperty).append(value);
+    }
+    public void append(final String propertyName, final long[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.LongMatProperty).append(value);
+    }
+    public void append(final String propertyName, final float value) {
+        getOrCreateProperty(propertyName, PropertyClass.FloatArrProperty).append(value);
+    }
+    public void append(final String propertyName, final float[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.FloatMatProperty).append(value);
+    }
+    public void append(final String propertyName, final double value) {
+        getOrCreateProperty(propertyName, PropertyClass.DoubleArrProperty).append(value);
+    }
+    public void append(final String propertyName, final double[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.DoubleMatProperty).append(value);
+    }
+    public void append(final String propertyName, final String value) {
+        getOrCreateProperty(propertyName, PropertyClass.StringArrProperty).append(value);
+    }
+    public void append(final String propertyName, final String[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.StringMatProperty).append(value);
+    }
+    public void append(final String propertyName, final Set<String> value) {
+        getOrCreateProperty(propertyName, PropertyClass.StringSetArrProperty).append(value);
+    }
+    public void append(final String propertyName, final Set<String>[] value) {
+        getOrCreateProperty(propertyName, PropertyClass.StringSetMatProperty).append(value);
+    }
+
+    public void set(final String propertyName, final boolean[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.BooleanArrProperty).set(values);
+    }
+    public void set(final String propertyName, final boolean[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.BooleanMatProperty).set(values);
+    }
+    public void set(final String propertyName, final byte[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.ByteArrProperty).set(values);
+    }
+    public void set(final String propertyName, final byte[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.ByteMatProperty).set(values);
+    }
+    public void set(final String propertyName, final short[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.ShortArrProperty).set(values);
+    }
+    public void set(final String propertyName, final short[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.ShortMatProperty).set(values);
+    }
+    public void set(final String propertyName, final int[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.IntArrProperty).set(values);
+    }
+    public void set(final String propertyName, final int[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.IntMatProperty).set(values);
+    }
+    public void set(final String propertyName, final long[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.LongArrProperty).set(values);
+    }
+    public void set(final String propertyName, final long[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.LongMatProperty).set(values);
+    }
+    public void set(final String propertyName, final float[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.FloatArrProperty).set(values);
+    }
+    public void set(final String propertyName, final float[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.FloatMatProperty).set(values);
+    }
+    public void set(final String propertyName, final double[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.DoubleArrProperty).set(values);
+    }
+    public void set(final String propertyName, final double[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.DoubleMatProperty).set(values);
+    }
+    public void set(final String propertyName, final String[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.StringArrProperty).set(values);
+    }
+    public void set(final String propertyName, final String[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.StringMatProperty).set(values);
+    }
+    public void set(final String propertyName, final Set<String>[] values) {
+        getOrCreateProperty(propertyName, PropertyClass.StringSetArrProperty).set(values);
+    }
+    public void set(final String propertyName, final Set<String>[][] values) {
+        getOrCreateProperty(propertyName, PropertyClass.StringSetMatProperty).set(values);
+    }
+
+    protected int getConsistentIntPropertyValue(ToIntFunction<Property> method, final String valuesLabel) {
+        final int[] distinctValues = properties.values().stream()
+                .mapToInt(method)
+                .filter(c -> c >= 0)
+                .distinct()
+                .toArray();
+        switch(distinctValues.length) {
+            case 0: // no values
+                return -1;
+            case 1: // consistent value
+                return distinctValues[0];
+            default: // inconsistent values
+                System.out.println(valuesLabel + ":");
+                properties.forEach(
+                    (propertyName, property) -> System.out.println("\t" + propertyName + ": " +
+                                                                   method.applyAsInt(property))
+                );
+                throw new IllegalArgumentException("PropertiesTable contains inconsistent numbers of " + valuesLabel);
+        }
+    }
+
+    public int getNumColumns() {
+        return getConsistentIntPropertyValue(Property::getNumColumns, "columns");
+    }
+
+    public int getNumRows() {
+        return getConsistentIntPropertyValue(Property::getNumRows, "rows");
+    }
+
+    public int getNumProperties() {
+        if(allNumeric) {
+            return properties.size();
+        }
+        return properties.values().stream()
+                .mapToInt(
+                        property -> {
+                            final List<String> allLabels = labelsEncoding.containsKey(property.name) ?
+                                    labelsEncoding.get(property.name) :
+                                    property.getAllLabels();
+                            return allLabels == null ?
+                                    1 :
+                                    allLabels.size() > 2 ?
+                                            allLabels.size() :
+                                            allLabels.size() == 2 ? 1 : 0;
+                        }
+                )
+                .sum();
+    }
+
+    protected void trim() {
+        // save memory by right-sizing the dynamically allocated arrays
+        for(final Property property : properties.values()){
+            property.setAllocatedRows(property.getNumRows());
+        }
+    }
+
+    protected void oneHot() {
+        for(final Property property : new ArrayList<>(properties.values())) {
+            final List<String> allLabels = labelsEncoding.containsKey(property.name) ?
+                labelsEncoding.get(property.name) :
+                property.getAllLabels();
+            if(allLabels != null) {
+                if(!labelsEncoding.containsKey(property.name)) {
+                    addLabelEncoding(property.name, allLabels);
+                }
+                remove(property.name);
+                property.oneHot(allLabels, this);
+            }
+        }
+        allNumeric = true;
+    }
+
+    protected void setBaselineAndScales() {
+        int numNormalizationsCalculated = 0;
+        for(final Property property : properties.values()) {
+            if(!property.normalizationIsSet()) {
+                property.calculateBaselineAndScale();
+                ++numNormalizationsCalculated;
+            }
+        }
+        if(numNormalizationsCalculated != 0 && numNormalizationsCalculated != properties.size()) {
+            throw new IllegalArgumentException("Some but not all properties have baseline and scale set.");
+        }
+    }
+
+    /**
+     * Once all data has been added to the table
+     *   1) check to make sure number of rows and columns are consistent
+     *   2) right-size memory (match number of allocated and actual rows)
+     *   3) one-hot encode any label properties
+     *   4) ensure that baseline and scale are appropriately set for every Property
+     *   5) allocate float[] propertiesRow so that rows can be efficiently queried for inference
+     */
+    public void validateAndFinalize() {
+        oneHot();
+        setOrderedPropertyNames();
+        getNumColumns();
+        getNumRows();
+        trim();
+        setBaselineAndScales();
+        propertiesRow = new float[getNumProperties()];
+    }
+
+    /**
+     * Copy table data from specified row into prepared array buffer
+     * @param outArray array buffer to copy into
+     * @param outIndex offset of buffer to start copying
+     * @param rowIndex requested row from table
+     * @param columnIndex requested column from table (properties without columns will ignore this value)
+     * @param normalize if true, normalize (stable z-score) data, if false, copy raw data
+     * @return next outIndex for writing
+     */
+    public int copyPropertiesRow(final float[] outArray, int outIndex,
+                                 final int rowIndex, final int columnIndex, final boolean normalize) {
+        if(orderedPropertyNames == null) {
+            setOrderedPropertyNames();
+        }
+        for(final String propertyName : orderedPropertyNames) {
+            final Property property = properties.get(propertyName);
+            outArray[outIndex] = property.getAsFloat(rowIndex, columnIndex, normalize);
+            if(!Float.isFinite(outArray[outIndex])) {
+                System.out.println(propertyName + " = " + outArray[outIndex] + " at row " + rowIndex + ", column " + columnIndex);
+            }
+            ++outIndex;
+        }
+        return outIndex;
+    }
+
+    public float[] getPropertiesRow(final int rowIndex, final int columnIndex, final boolean normalize) {
+        copyPropertiesRow(propertiesRow, 0, rowIndex, columnIndex, normalize);
+        return propertiesRow;
+    }
+
+    public Map<String, List<String>> getLabelsEncoding() {
+        // don't want anyone messing with this, just want to expose the information
+        return Collections.unmodifiableMap(labelsEncoding);
+    }
+
+    protected void saveNormalizationStats(final OutputStream outputStream) {
+        final JSONArray propNames = new JSONArray();
+        final JSONArray propClasses = new JSONArray();
+        final JSONArray propBase = new JSONArray();
+        final JSONArray propScale = new JSONArray();
+        if(orderedPropertyNames == null) {
+            setOrderedPropertyNames();
+        }
+        for (final String propertyName : orderedPropertyNames) {
+            final Property property = properties.get(propertyName);
+            propNames.add(propertyName);
+            propClasses.add(property.getClass().getSimpleName());
+            propBase.add(property.baseline);
+            propScale.add(property.scale);
+        }
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put(PROPERTY_NAMES_KEY, propNames);
+        jsonObject.put(PROPERTY_CLASSES_KEY, propClasses);
+        jsonObject.put(PROPERTY_BASELINE_KEY, propBase);
+        jsonObject.put(PROPERTY_SCALE_KEY, propScale);
+
+        try {
+            outputStream.write(jsonObject.toJSONString().getBytes(StandardCharsets.UTF_8));
+            outputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+        } catch(IOException ioException) {
+            throw new GATKException("Error saving data summary json", ioException);
+        }
+    }
+
+    protected void saveLabelsEncoding(final OutputStream outputStream) {
+        final JSONObject jsonObject = new JSONObject();
+        for(final Map.Entry<String, List<String>> encodingEntry : labelsEncoding.entrySet()) {
+            final JSONArray labels = new JSONArray();
+            labels.addAll(encodingEntry.getValue());
+            jsonObject.put(encodingEntry.getKey(), labels);
+        }
+        try {
+            outputStream.write(jsonObject.toJSONString().getBytes(StandardCharsets.UTF_8));
+            outputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+        } catch(IOException ioException) {
+            throw new GATKException("Error saving data summary json", ioException);
+        }
+
+    }
+
+    public void saveDataEncoding(final OutputStream outputStream) throws IOException {
+        saveNormalizationStats(outputStream);
+        saveLabelsEncoding(outputStream);
+    }
+
+    public void saveTable(final OutputStream outputStream) throws IOException {
+        if(orderedPropertyNames == null) {
+            setOrderedPropertyNames();
+        }
+        final JSONObject jsonObject = new JSONObject();
+        for(final String propertyName : orderedPropertyNames) {
+            final Property property = properties.get(propertyName);
+            jsonObject.put(property.name, property.getJSON());
+        }
+        outputStream.write(jsonObject.toJSONString().getBytes());
+    }
+
+    public void save(final OutputStream outputStream) throws IOException {
+        saveDataEncoding(outputStream);
+        outputStream.write("\n".getBytes());
+        saveTable(outputStream);
+    }
+
+    protected static long getNumTrue(final boolean[] values) {
+        return getNumTrue(values, values.length);
+    }
+    protected static long getNumTrue(final boolean[] values, final int numRows) {
+        long numTrue = 0;
+        for(int i = 0; i < numRows; ++i) {
+            if(values[i]) {
+                ++numTrue;
+            }
+        }
+        return numTrue;
+    }
+
+    protected static double getBaselineOrdered(final double[] orderedValues) {
+        // get baseline as median of values
+        return orderedValues.length == 0 ?
+                0 :
+                orderedValues.length % 2 == 1 ?
+                        orderedValues[orderedValues.length / 2] :
+                        (orderedValues[orderedValues.length / 2 - 1] + orderedValues[orderedValues.length / 2]) / 2.0;
+    }
+
+    protected static double getScaleOrdered(final double[] orderedValues, final double baseline) {
+        // get scale as root-mean-square difference from baseline, over central half of data (to exclude outliers)
+        switch(orderedValues.length) {
+            case 0:
+            case 1:
+                return 1.0;
+            default:
+                final int q1 = orderedValues.length / 4;
+                // this formula can have early problems with indices larger than 2^31
+                // final int q3 = 3 * orderedValues.length / 4;
+                // this is equivalent
+                final int q3 = orderedValues.length - 1 - q1;
+                final int start, stop;
+                if(orderedValues[q1] == orderedValues[q3]) {
+                    // the center of the distribution is effectively discrete, quantiles won't work
+                    start = 0; stop = orderedValues.length;
+                } else {
+                    start = q1; stop = q3;
+                }
+                double scale = 0.0;
+                for(int idx = start; idx < stop; ++idx) {
+                    scale += (orderedValues[idx] - baseline) * (orderedValues[idx] - baseline);
+                }
+                return FastMath.max(FastMath.sqrt(scale / (1 + stop - start)), 1.0e-6);
+        }
+    }
+
+    protected static double getDoubleFromJSON(final Object jsonObject) {
+        if(jsonObject instanceof Double) {
+            return (Double) jsonObject;
+        } else if(jsonObject instanceof BigDecimal) {
+            return ((BigDecimal)jsonObject).doubleValue();
+        } else {
+            throw new GATKException("Unknown conversion to double for " + jsonObject.getClass().getName());
+        }
+    }
+
+
+    final String getNextLine(final InputStream inputStream) {
+        try {
+            byte[] bytes = new byte[1000];
+            int ind = 0;
+            for(int c = inputStream.read(); (byte)c != '\n' && c != -1; c = inputStream.read()) {
+                bytes[ind] = (byte)c;
+                ++ind;
+                if(ind == bytes.length) {
+                    bytes = Arrays.copyOf(bytes, bytes.length * 2);
+                }
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException ioException) {
+            throw new GATKException("Unable to get next line from inputStream", ioException);
+        }
+    }
+
+    final JSONObject getNextJSONObject(final InputStream inputStream) {
+        final String nextLine = getNextLine(inputStream);
+        try {
+            return (JSONObject) JSONValue.parseWithException(nextLine);
+        } catch (ParseException | ClassCastException parseException) {
+            throw new GATKException("Unable to parse JSON from inputStream", parseException);
+        }
+    }
+
+    protected void loadNormalizations(final InputStream inputStream) {
+        final JSONObject jsonObject = getNextJSONObject(inputStream);
+        final JSONArray propNames = ((JSONArray) jsonObject.get(PROPERTY_NAMES_KEY));
+        final JSONArray propClasses = ((JSONArray) jsonObject.get(PROPERTY_CLASSES_KEY));
+        final JSONArray propBase = ((JSONArray) jsonObject.get(PROPERTY_BASELINE_KEY));
+        final JSONArray propScale = ((JSONArray) jsonObject.get(PROPERTY_SCALE_KEY));
+        for (int idx = 0; idx < propNames.size(); ++idx) {
+            setBaselineAndScale(
+                    (String)propNames.get(idx), PropertyClass.valueOf((String)propClasses.get(idx)),
+                    getDoubleFromJSON(propBase.get(idx)), getDoubleFromJSON(propScale.get(idx))
+            );
+        }
+    }
+
+    protected void loadEncodings(final InputStream inputStream) {
+        final JSONObject jsonObject = getNextJSONObject(inputStream);
+        for(final String propertyName : jsonObject.keySet()) {
+            final JSONArray labels = (JSONArray) jsonObject.get(propertyName);
+            addLabelEncoding(propertyName, labels.stream().map(label -> (String)label).collect(Collectors.toList()));
+        }
+    }
+
+    public void loadDataEncoding(final InputStream inputStream) {
+        loadNormalizations(inputStream);
+        loadEncodings(inputStream);
+    }
+
+    static abstract class Property {
+        public final String name;
+        private Float baseline = null;
+        private Float scale = null;
+        protected int numRows;
+
+        static final int ALLOCATION_GROWTH_SCALE = 2;
+
+        Property(final String name) { this.name = name; }
+
+        abstract void set(final Object values);
+        abstract public float getAsFloat(final int rowIndex, final int hyperIndex);
+        abstract protected int getAllocatedRows();
+        abstract public void setAllocatedRowsUnguarded(final int numRows);
+        abstract protected void assignNextValue(final Object value);
+        abstract protected double[] getValuesAsOrderedDoubles();
+
+        public Float getBaseline() { return baseline; }
+        public Float getScale() { return scale; }
+        public boolean normalizationIsSet() {
+            if(baseline == null || scale == null) {
+                if(!(baseline == null && scale == null)) {
+                    throw new IllegalArgumentException("baseline or scale assigned a null value");
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
+        public boolean isNumeric() { return true; }
+        public List<String> getAllLabels() { return null; }
+        public void oneHot(final List<String> allLabels, final PropertiesTable propertiesTable) {}
+
+        public static Property create(final PropertyClass propertyClass, final String name) {
+            return create(propertyClass, name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS);
+        }
+
+        public static Property create(final PropertyClass propertyClass, final String name, final int numRows) {
+            switch(propertyClass) {
+                case BooleanArrProperty: return new BooleanArrProperty(name, numRows);
+                case BooleanMatProperty: return new BooleanMatProperty(name, numRows);
+                case ByteArrProperty: return new ByteArrProperty(name, numRows);
+                case ByteMatProperty: return new ByteMatProperty(name, numRows);
+                case ShortArrProperty: return new ShortArrProperty(name, numRows);
+                case ShortMatProperty: return new ShortMatProperty(name, numRows);
+                case IntArrProperty: return new IntArrProperty(name, numRows);
+                case IntMatProperty: return new IntMatProperty(name, numRows);
+                case LongArrProperty: return new LongArrProperty(name, numRows);
+                case LongMatProperty: return new LongMatProperty(name, numRows);
+                case FloatArrProperty: return new FloatArrProperty(name, numRows);
+                case FloatMatProperty: return new FloatMatProperty(name, numRows);
+                case DoubleArrProperty: return new DoubleArrProperty(name, numRows);
+                case DoubleMatProperty: return new DoubleMatProperty(name, numRows);
+                case StringArrProperty: return new StringArrProperty(name, numRows);
+                case StringMatProperty: return new StringMatProperty(name, numRows);
+                case StringSetArrProperty: return new StringSetArrProperty(name, numRows);
+                case StringSetMatProperty: return new StringSetMatProperty(name, numRows);
+                default: throw new IllegalArgumentException("Unable to create Property of type " + propertyClass);
+            }
+        }
+
+        public int getNumColumns() {
+            final int[] numColumns = getArrayOfDistinctNumColumns();
+            switch(numColumns.length) {
+                case 0: // no data in property or an Array property
+                    return -1;
+                case 1: // normal case for matrix property
+                    return numColumns[0];
+                default: // error, inconsistent numbers of columns
+                    throw new IllegalArgumentException("Inconsistent number of columns in matrix property: " + name);
+            }
+        }
+        protected int[] getArrayOfDistinctNumColumns() { return new int[0]; }
+
+        public int getNumRows() { return numRows; }
+
+        public void setAllocatedRows(final int numRows) {
+            if(numRows <= getNumRows()) {
+                if(numRows < getNumRows()) {
+                    throw new IllegalArgumentException("Can't shrink allocated memory for property to less than used space.");
+                }
+            } else {
+                setAllocatedRowsUnguarded(numRows);
+            }
+        }
+
+        public void clearAllocatedRows() {
+            setAllocatedRowsUnguarded(0);
+        }
+
+        public float getAsFloat(final int rowIndex, final int hyperIndex, final boolean normalize) {
+            final float rawValue = getAsFloat(rowIndex, hyperIndex);
+            return normalize ?
+                    (rawValue - baseline) / scale :
+                    rawValue;
+        }
+        public boolean getAsBool(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("getAsBool() not defined for Property of type " + this.getClass().getSimpleName());
+        }
+        public int getAsInt(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("getAsInt() not defined for Property of type " + this.getClass().getSimpleName());
+        }
+        public long getAsLong(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("getAsLong() not defined for Property of type " + this.getClass().getSimpleName());
+        }
+
+        abstract public JSONArray getJSON();
+
+        public void append(final Object value) {
+            if(getNumRows() >= getAllocatedRows()) {
+                setAllocatedRows(FastMath.max(DEFAULT_INITIAL_NUM_ALLOCATED_ROWS, getNumRows() * ALLOCATION_GROWTH_SCALE));
+            }
+            assignNextValue(value);
+            ++this.numRows;
+        }
+
+        public void setBaselineAndScale(final double baseline, final double scale) {
+            this.baseline = (float)baseline;
+            this.scale = (float)scale;
+        }
+
+        protected void calculateBaselineAndScale() {
+            final double[] orderedValues = getValuesAsOrderedDoubles();
+            final double baseline = getBaselineOrdered(orderedValues);
+            this.baseline = (float)baseline;
+            scale = (float)getScaleOrdered(orderedValues, baseline);
+        }
+    }
+
+    static public class BooleanArrProperty extends Property {
+        public boolean[] values;
+
+        BooleanArrProperty(final String name, final int numValues) { super(name); values = new boolean[numValues]; }
+        BooleanArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (boolean[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex] ? 1F : 0F;
+        }
+        @Override public boolean getAsBool(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (boolean)value; }
+        @Override protected void calculateBaselineAndScale() {
+            // special case for booleans
+            final long numTrue = getNumTrue(values, numRows);
+            final double baseline = numTrue / (double) numRows;
+            final double scale = numTrue == 0 || numTrue == numRows ?
+                    1.0 :
+                    FastMath.sqrt(baseline * (1.0 - baseline));
+            setBaselineAndScale(baseline, scale);
+        }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            // special case for booleans
+            throw new GATKException("Method not needed for booleans");
+        }
+    }
+
+    static public class BooleanMatProperty extends Property {
+        public boolean[][] values;
+
+        BooleanMatProperty(final String name, final int numValues) { super(name); values = new boolean[numValues][]; }
+        BooleanMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (boolean[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex] ? 1F : 0F;
+        }
+        @Override public boolean getAsBool(final int rowIndex, final int hyperIndex) {
+            return this.values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (boolean[])value; }
+        protected void assignColumnValue(final int column, final boolean value) {
+            this.values[numRows][column] = value;
+        }
+        @Override protected void calculateBaselineAndScale() {
+            // special case for booleans
+            final long numTrue = IntStream.range(0, numRows).mapToLong(i -> getNumTrue(values[i])).sum();
+            final double baseline = numTrue / (double) numRows;
+            final double scale = numTrue == 0 || numTrue == numRows ?
+                    1.0 :
+                    FastMath.sqrt(baseline * (1.0 - baseline));
+            setBaselineAndScale(baseline, scale);
+        }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            // special case for booleans
+            throw new GATKException("Method not needed for booleans");
+        }
+    }
+
+    static public class ByteArrProperty extends Property {
+        public byte[] values;
+
+        ByteArrProperty(final String name, final int numValues) { super(name); values = new byte[numValues]; }
+        ByteArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (byte[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) { return this.values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (byte)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return IntStream.range(0, numRows).mapToDouble(i -> (double)values[i]).sorted().toArray();
+        }
+    }
+
+    static public class ByteMatProperty extends Property {
+        public byte[][] values;
+
+        ByteMatProperty(final String name, final int numValues) { super(name); values = new byte[numValues][]; }
+        ByteMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (byte[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex];
+        }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) {
+            return this.values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (byte[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows)
+                    .flatMapToDouble(arr -> IntStream.range(0, arr.length).mapToDouble(i -> arr[i]))
+                    .sorted()
+                    .toArray();
+        }
+    }
+
+    static public class ShortArrProperty extends Property {
+        public short[] values;
+
+        ShortArrProperty(final String name, final int numValues) { super(name); values = new short[numValues]; }
+        ShortArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (short[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) { return this.values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (short)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return IntStream.range(0, numRows).mapToDouble(i -> (double)values[i]).sorted().toArray();
+        }
+    }
+
+    static public class ShortMatProperty extends Property {
+        public short[][] values;
+
+        ShortMatProperty(final String name, final int numValues) { super(name); values = new short[numValues][]; }
+        ShortMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (short[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex];
+        }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) {
+            return this.values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (short[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows)
+                    .flatMapToDouble(arr -> IntStream.range(0, arr.length).mapToDouble(i -> arr[i]))
+                    .sorted()
+                    .toArray();
+        }
+    }
+
+    static public class IntArrProperty extends Property {
+        public int[] values;
+
+        IntArrProperty(final String name, final int numValues) { super(name); values = new int[numValues]; }
+        IntArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (int[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) { return this.values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (int)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).sorted().mapToDouble(x -> x).toArray();
+        }
+    }
+
+    static public class IntMatProperty extends Property {
+        public int[][] values;
+
+        IntMatProperty(final String name, final int numValues) { super(name); values = new int[numValues][]; }
+        IntMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (int[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex];
+        }
+        @Override public int getAsInt(final int rowIndex, final int hyperIndex) {
+            return this.values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (int[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).flatMapToInt(Arrays::stream).sorted()
+                .mapToDouble(x -> x).toArray();
+        }
+    }
+
+    static public class LongArrProperty extends Property {
+        public long[] values;
+
+        LongArrProperty(final String name, final int numValues) { super(name); values = new long[numValues]; }
+        LongArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (long[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public long getAsLong(final int rowIndex, final int hyperIndex) { return this.values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (long)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).sorted().mapToDouble(x -> x).toArray();
+        }
+    }
+
+    static public class LongMatProperty extends Property {
+        public long[][] values;
+
+        LongMatProperty(final String name, final int numValues) { super(name); values = new long[numValues][]; }
+        LongMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (long[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex];
+        }
+        @Override public long getAsLong(final int rowIndex, final int hyperIndex) {
+            return this.values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (long[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).flatMapToLong(Arrays::stream).sorted()
+                .mapToDouble(x -> x).toArray();
+        }
+    }
+
+    static public class FloatArrProperty extends Property {
+        public float[] values;
+
+        FloatArrProperty(final String name, final int numValues) { super(name); values = new float[numValues]; }
+        FloatArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (float[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (float)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return IntStream.range(0, numRows).mapToDouble(i -> (double)values[i]).sorted().toArray();
+        }
+    }
+
+    static public class FloatMatProperty extends Property {
+        public float[][] values;
+
+        FloatMatProperty(final String name, final int numValues) { super(name); values = new float[numValues][]; }
+        FloatMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (float[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            IntStream.range(0, numRows).forEach(i -> jsonArray.add(values[i]));
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (float[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows)
+                .flatMapToDouble(arr -> IntStream.range(0, arr.length).mapToDouble(i -> arr[i]))
+                .sorted()
+                .toArray();
+        }
+    }
+
+    static public class DoubleArrProperty extends Property {
+        public double[] values;
+
+        DoubleArrProperty(final String name, final int numValues) { super(name); values = new double[numValues]; }
+        DoubleArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (double[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        public double getAsDouble(final int rowIndex) { return values[rowIndex]; }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) { return (float)values[rowIndex]; }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (double)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).sorted().toArray();
+        }
+    }
+
+    static public class DoubleMatProperty extends Property {
+        public double[][] values;
+
+        DoubleMatProperty(final String name, final int numValues) { super(name); values = new double[numValues][]; }
+        DoubleMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (double[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            return (float)values[rowIndex][hyperIndex];
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (double[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            return Arrays.stream(values, 0, numRows).flatMapToDouble(Arrays::stream).sorted().toArray();
+        }
+    }
+
+    static public class StringArrProperty extends Property {
+        public String[] values;
+
+        StringArrProperty(final String name, final int numValues) { super(name); values = new String[numValues]; }
+        StringArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (String[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        public String getAsString(final int rowIndex) {
+            return values[rowIndex];
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("String properties cannot be converted to Float, they must be one-hot-encoded");
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (String)value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            throw new IllegalArgumentException("String properties cannot be converted to double, they must be one-hot-encoded");
+        }
+        @Override public boolean isNumeric() { return false; }
+        @Override public List<String> getAllLabels() {
+            return Arrays.stream(values, 0, numRows).distinct().sorted().collect(Collectors.toList());
+        }
+        @Override public void oneHot(final List<String> allLabels, final PropertiesTable propertiesTable) {
+            switch(allLabels.size()) {
+                case 0:
+                case 1:  // no actual property
+                    return;
+                case 2:  // have a single new boolean property
+                    final String trueLabel = allLabels.get(1);
+                    final BooleanArrProperty boolProperty = (BooleanArrProperty)propertiesTable.getOrCreateProperty(
+                        trueLabel, PropertyClass.BooleanArrProperty, numRows
+                    );
+                    boolProperty.numRows = 0;
+                    for(int row = 0; row < numRows; ++row) {
+                        boolProperty.append(this.values[row].equals(trueLabel));
+                    }
+                    return;
+                default:  // have new one-hot encoded set of multiple properties
+                    final int numProperties = allLabels.size();
+                    final List<Property> properties = IntStream.range(0, numProperties)
+                        .mapToObj(i ->
+                            (BooleanArrProperty)propertiesTable.getOrCreateProperty(
+                               allLabels.get(i), PropertyClass.BooleanArrProperty, numRows
+                            )
+                        )
+                        .collect(Collectors.toList());
+                    properties.forEach(p -> p.numRows = 0);
+                    for(int row = 0; row < numRows; ++row) {
+                        final String label = this.values[row];
+                        for(int propertyIndex = 0; propertyIndex < numProperties; ++propertyIndex) {
+                            properties.get(propertyIndex).append(label.equals(allLabels.get(propertyIndex)));
+                        }
+                    }
+            }
+        }
+    }
+
+    static public class StringMatProperty extends Property {
+        public String[][] values;
+
+        StringMatProperty(final String name, final int numValues) { super(name); values = new String[numValues][]; }
+        StringMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (String[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("String properties cannot be converted to Float, they must be one-hot-encoded");
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (String[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            throw new IllegalArgumentException("String properties cannot be converted to double, they must be one-hot-encoded");
+        }
+        @Override public boolean isNumeric() { return false; }
+        @Override public List<String> getAllLabels() {
+            return Arrays.stream(values, 0, numRows).flatMap(Arrays::stream).distinct().sorted()
+                .collect(Collectors.toList());
+        }
+        @Override public void oneHot(final List<String> allLabels, final PropertiesTable propertiesTable) {
+            switch(allLabels.size()) {
+                case 0:
+                case 1:  // no actual property
+                    return;
+                case 2:  // have a single new boolean property
+                    final String trueLabel = allLabels.get(1);
+                    final BooleanMatProperty boolProperty = (BooleanMatProperty)propertiesTable.getOrCreateProperty(
+                            trueLabel, PropertyClass.BooleanMatProperty, numRows
+                    );
+                    boolProperty.numRows = 0;
+                    for(int row = 0; row < numRows; ++row) {
+                        final String[] colLabels = this.values[row];
+                        for(int col = 0; col < colLabels.length; ++col) {
+                            boolProperty.assignColumnValue(col, colLabels[col].equals(trueLabel));
+                        }
+                        ++boolProperty.numRows;
+                    }
+                    return;
+                default:  // have new one-hot encoded set of multiple properties
+                    final int numProperties = allLabels.size();
+                    final List<BooleanMatProperty> properties = IntStream.range(0, numProperties)
+                        .mapToObj(i ->
+                            (BooleanMatProperty)propertiesTable.getOrCreateProperty(
+                                allLabels.get(i), PropertyClass.BooleanMatProperty, numRows
+                            )
+                        )
+                        .collect(Collectors.toList());
+                    properties.forEach(p -> p.numRows = 0);
+                    for(int row = 0; row < numRows; ++row) {
+                        final String[] colLabels = this.values[row];
+                        for(int propertyIndex = 0; propertyIndex < numProperties; ++propertyIndex) {
+                            final String propertyLabel = allLabels.get(propertyIndex);;
+                            final BooleanMatProperty booleanMatProperty = properties.get(propertyIndex);
+                            for(int col = 0; col < colLabels.length; ++col) {
+                                booleanMatProperty.assignColumnValue(col, colLabels[col].equals(propertyLabel));
+                            }
+                            ++booleanMatProperty.numRows;
+                        }
+                    }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static public class StringSetArrProperty extends Property {
+        // Note: can't store as Set<String>[] because:
+        // A) it may be called upon to add UnmodifiableSet<String>
+        // B) that class is private, so values must be initialized as a HashSet<?>
+        // C) the resulting conflict causes an ArrayStoreException
+        public Object[] values;
+
+        StringSetArrProperty(final String name, final int numValues) {
+            super(name); values = new Object[numValues];
+        }
+        StringSetArrProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (Object[]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("String properties cannot be converted to Float, they must be one-hot-encoded");
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            throw new IllegalArgumentException("String properties cannot be converted to double, they must be one-hot-encoded");
+        }
+        @Override public boolean isNumeric() { return false; }
+        @Override public List<String> getAllLabels() {
+            return Arrays.stream(values, 0, numRows).flatMap(o -> ((Set<String>)o).stream())
+                .distinct().sorted().collect(Collectors.toList());
+        }
+        @Override public void oneHot(final List<String> allLabels, final PropertiesTable propertiesTable) {
+            switch(allLabels.size()) {
+                case 0:
+                case 1:  // no actual property
+                    return;
+                case 2:  // have a single new boolean property
+                    final String trueLabel = allLabels.get(1);
+                    final BooleanArrProperty boolProperty = (BooleanArrProperty)propertiesTable.getOrCreateProperty(
+                            trueLabel, PropertyClass.BooleanArrProperty, numRows
+                    );
+                    boolProperty.numRows = 0;
+                    for(int row = 0; row < numRows; ++row) {
+                        boolProperty.append(((Set<String>)this.values[row]).contains(trueLabel));
+                    }
+                    return;
+                default:  // have new one-hot encoded set of multiple properties
+                    final int numProperties = allLabels.size();
+                    final List<Property> properties = IntStream.range(0, numProperties)
+                        .mapToObj(i ->
+                            (BooleanArrProperty)propertiesTable.getOrCreateProperty(
+                                    allLabels.get(i), PropertyClass.BooleanArrProperty, numRows
+                            )
+                        )
+                        .collect(Collectors.toList());
+                    properties.forEach(p -> p.numRows = 0);
+                    for(int row = 0; row < numRows; ++row) {
+                        final Set<String> rowLabels = (Set<String>)this.values[row];
+                        for(int propertyIndex = 0; propertyIndex < numProperties; ++propertyIndex) {
+                            properties.get(propertyIndex).append(rowLabels.contains(allLabels.get(propertyIndex)));
+                        }
+                    }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static public class StringSetMatProperty extends Property {
+        public Set<String>[][] values;
+
+        StringSetMatProperty(final String name, final int numValues) {
+            super(name); values = (Set<String>[][])new HashSet<?>[numValues][];
+        }
+        StringSetMatProperty(final String name) { this(name, DEFAULT_INITIAL_NUM_ALLOCATED_ROWS); }
+
+        @Override public void set(Object values) { this.values = (Set<String>[][]) values; }
+        @Override public JSONArray getJSON() {
+            final JSONArray jsonArray = new JSONArray();
+            Arrays.stream(values, 0, numRows).forEach(jsonArray::add);
+            return jsonArray;
+        }
+        @Override public float getAsFloat(final int rowIndex, final int hyperIndex) {
+            throw new IllegalArgumentException("String properties cannot be converted to Float, they must be one-hot-encoded");
+        }
+        @Override protected int[] getArrayOfDistinctNumColumns() {
+            return IntStream.range(0, numRows).map(i -> values[i].length).distinct().toArray();
+        }
+        @Override public int getAllocatedRows() { return values.length; }
+        @Override public void setAllocatedRowsUnguarded(final int numRows) {
+            this.values = Arrays.copyOf(this.values, numRows);
+        }
+        @Override protected void assignNextValue(final Object value) { this.values[numRows] = (Set<String>[])value; }
+        @Override protected double[] getValuesAsOrderedDoubles() {
+            throw new IllegalArgumentException("String properties cannot be converted to double, they must be one-hot-encoded");
+        }
+        @Override public boolean isNumeric() { return false; }
+        @Override public List<String> getAllLabels() {
+            return Arrays.stream(values, 0, numRows).flatMap(Arrays::stream)
+                .flatMap(Collection::stream).distinct().sorted().collect(Collectors.toList());
+        }
+        @Override public void oneHot(final List<String> allLabels, final PropertiesTable propertiesTable) {
+            switch(allLabels.size()) {
+                case 0:
+                case 1:  // no actual property
+                    return;
+                case 2:  // have a single new boolean property
+                    final String trueLabel = allLabels.get(1);
+                    final BooleanMatProperty boolProperty = (BooleanMatProperty)propertiesTable.getOrCreateProperty(
+                        trueLabel, PropertyClass.BooleanMatProperty, numRows
+                    );
+                    boolProperty.numRows = 0;
+                    for(int row = 0; row < numRows; ++row) {
+                        final Set<String>[] colLabels = this.values[row];
+                        for(int col = 0; col < colLabels.length; ++col) {
+                            boolProperty.assignColumnValue(col, colLabels[col].contains(trueLabel));
+                        }
+                        ++boolProperty.numRows;
+                    }
+                    return;
+                default:  // have new one-hot encoded set of multiple properties
+                    final int numProperties = allLabels.size();
+                    final List<BooleanMatProperty> properties = IntStream.range(0, numProperties)
+                        .mapToObj(i ->
+                            (BooleanMatProperty)propertiesTable.getOrCreateProperty(
+                                allLabels.get(i), PropertyClass.BooleanMatProperty, numRows
+                            )
+                        )
+                        .collect(Collectors.toList());
+                    properties.forEach(p -> p.numRows = 0);
+                    for(int row = 0; row < numRows; ++row) {
+                        final Set<String>[] colLabels = this.values[row];
+                        for(int propertyIndex = 0; propertyIndex < numProperties; ++propertyIndex) {
+                            final BooleanMatProperty booleanMatProperty = properties.get(propertyIndex);
+                            final String propertyLabel = allLabels.get(propertyIndex);;
+                            for(int col = 0; col < colLabels.length; ++col) {
+                                booleanMatProperty.assignColumnValue(col,colLabels[col].contains(propertyLabel));
+                            }
+                            ++booleanMatProperty.numRows;
+                        }
+                    }
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/TractOverlapDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/TractOverlapDetector.java
@@ -1,0 +1,285 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import htsjdk.samtools.util.CoordMath;
+import htsjdk.samtools.util.Locatable;
+import org.apache.commons.math3.util.FastMath;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.SVInterval;
+import org.broadinstitute.hellbender.utils.SVIntervalTree;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.tsv.DataLine;
+import org.broadinstitute.hellbender.utils.tsv.TableReader;
+import org.broadinstitute.hellbender.utils.tsv.TableReaderOptions;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.List;
+
+public class TractOverlapDetector {
+    final Path tractPath;
+    final SVIntervalTree<TractInterval> primaryOverlapDetector;
+    final SVIntervalTree<TractInterval> otherOverlapDetector;
+
+
+    public TractOverlapDetector(final String tractPath) throws IOException {
+        this(Paths.get(tractPath));
+    }
+
+    public TractOverlapDetector(final Path tractPath) throws IOException {
+        this.tractPath = tractPath;
+        primaryOverlapDetector = new SVIntervalTree<>();
+        final Iterator<TractIntervalAndOther> tractIntervalIterator = new TractTableReader(tractPath).iterator();
+        final TractIntervalAndOther firstTractIntervalAndOther = tractIntervalIterator.next();
+        primaryOverlapDetector.put(firstTractIntervalAndOther.primaryInterval.svInterval, firstTractIntervalAndOther.primaryInterval);
+        System.out.format("Loading %s ...", tractPath);
+        if(firstTractIntervalAndOther.otherInterval == null) {
+            otherOverlapDetector = null;
+            while(tractIntervalIterator.hasNext()) {
+                final TractInterval primaryInterval = tractIntervalIterator.next().primaryInterval;
+                primaryOverlapDetector.put(primaryInterval.svInterval, primaryInterval);
+            }
+        } else {
+            otherOverlapDetector = new SVIntervalTree<>();
+            otherOverlapDetector.put(firstTractIntervalAndOther.otherInterval.svInterval, firstTractIntervalAndOther.otherInterval);
+            while(tractIntervalIterator.hasNext()) {
+                final TractIntervalAndOther tractIntervalAndOther = tractIntervalIterator.next();
+                primaryOverlapDetector.put(tractIntervalAndOther.primaryInterval.svInterval, tractIntervalAndOther.primaryInterval);
+                otherOverlapDetector.put(tractIntervalAndOther.otherInterval.svInterval, tractIntervalAndOther.otherInterval);
+            }
+        }
+        System.out.println("ok.");
+    }
+
+    public String getName() {
+        final String fileName = tractPath.getFileName().toString();
+        final int dotIndex = fileName.indexOf(".");
+        return dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+    }
+
+    public boolean hasOther() { return otherOverlapDetector != null; }
+
+    public double getPrimaryOverlapFraction(final Locatable location) {
+        return getOverlapFraction(location, primaryOverlapDetector);
+    }
+
+    public double getOtherOverlapfraction(final Locatable location) {
+        return getOverlapFraction(location, otherOverlapDetector);
+    }
+
+    public Set<Long> getPrimaryOverlapperIds(final Locatable location) {
+        return getOverlapIds(location, primaryOverlapDetector);
+    }
+
+    public Set<Long> getOtherOverlapperIds(final Locatable location) {
+        return getOverlapIds(location, otherOverlapDetector);
+    }
+
+    public boolean spansPrimaryAndOther(final Locatable location1, final Locatable location2) {
+        if(otherOverlapDetector == null || location1 == null || location2 == null) {
+            return false;
+        }
+        return !(
+            setIntersect(getPrimaryOverlapperIds(location1), getOtherOverlapperIds(location2)).isEmpty()
+            || setIntersect(getPrimaryOverlapperIds(location2), getOtherOverlapperIds(location1)).isEmpty()
+        );
+    }
+
+    public static class UnionIterator implements Iterator<Locatable> {
+        private final Iterator<SVIntervalTree.Entry<TractInterval>> tractOverlappers;
+        private Locatable currentUnionLocatable;
+
+        UnionIterator(Iterator<SVIntervalTree.Entry<TractInterval>> tractOverlappers) {
+            this.tractOverlappers = tractOverlappers;
+            currentUnionLocatable = null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return tractOverlappers.hasNext() || currentUnionLocatable != null;
+        }
+
+        @Override
+        public Locatable next() {
+            while(tractOverlappers.hasNext()) {
+                final Locatable rawLocation = tractOverlappers.next().getValue();
+                if(rawLocation == null) {
+                    throw new GATKException("Got null Locatable");
+                }
+                if(currentUnionLocatable == null) {
+                    currentUnionLocatable = rawLocation;
+                } else if(rawLocation.overlaps(currentUnionLocatable)) {
+                    // interval tree is sorted by start, then end. So subsequent overlappers from the tree will have a
+                    // start position at least as high as currentUnionLocatable, eliminating the need for comparison
+                    currentUnionLocatable = new SimpleInterval(
+                            currentUnionLocatable.getContig(),
+                            currentUnionLocatable.getStart(),
+                            FastMath.max(currentUnionLocatable.getEnd(), rawLocation.getEnd())
+                    );
+                } else {
+                    final Locatable unionLocatable = currentUnionLocatable;
+                    currentUnionLocatable = rawLocation;
+                    return unionLocatable;
+                }
+
+            }
+            final Locatable unionLocatable = currentUnionLocatable;
+            currentUnionLocatable = null;
+            return unionLocatable;
+        }
+    }
+
+    private static int getOverlapBasepairs(final Locatable loc1, final Locatable loc2) {
+        return CoordMath.getOverlap(loc1.getStart(), loc1.getEnd(), loc2.getStart(), loc2.getEnd());
+    }
+
+    private static double getOverlapFraction(final Locatable location, final SVIntervalTree<TractInterval> detector) {
+        if(location == null) {
+            return 0.0;
+        }
+        final Iterator<Locatable> unionIterator = new UnionIterator(
+            detector.overlappers(TractInterval.locatableToSVInterval(location))
+        );
+        long overlapBasePairs = 0;
+        while(unionIterator.hasNext()) {
+            overlapBasePairs += getOverlapBasepairs(unionIterator.next(), location);
+        }
+        return overlapBasePairs / (double) location.getLengthOnReference();
+    }
+
+    private static Set<Long> getOverlapIds(final Locatable location, final SVIntervalTree<TractInterval> detector) {
+        final Set<Long> overlapIds = new HashSet<>();
+        if(detector != null) {
+            for (Iterator<SVIntervalTree.Entry<TractInterval>> it = detector.overlappers(TractInterval.locatableToSVInterval(location)); it.hasNext(); ) {
+                overlapIds.add(it.next().getValue().uid);
+            }
+        }
+        return overlapIds;
+    }
+
+    private static <T> Set<T> setIntersect(final Set<T> set1, final Set<T> set2) {
+        final Set<T> intersection = new HashSet<>(set1);
+        intersection.retainAll(set2);
+        return intersection;
+    }
+
+
+    static class TractInterval implements Locatable, Comparable<Locatable> {
+        final Long uid;
+        final SVInterval svInterval;
+        static final Map<String, Integer> contigMap = new HashMap<>();
+        static final List<String> contigs = new ArrayList<>();
+
+        TractInterval(final Long uid, final String contig, final int start, final int end) {
+            this.uid = uid;
+            this.svInterval = getSVInterval(contig, start, end);
+        }
+
+        public static SVInterval getSVInterval(final String contig, final int start, final int end) {
+            final int contigCode;
+            if(contigMap.containsKey(contig)) {
+                contigCode = contigMap.get(contig);
+            } else {
+                contigCode = contigMap.size();
+                contigMap.put(contig, contigCode);
+                contigs.add(contig);
+            }
+            return new SVInterval(contigCode, start, end);
+        }
+
+        public static SVInterval locatableToSVInterval(final Locatable locatable) {
+            return getSVInterval(locatable.getContig(), locatable.getStart(), locatable.getEnd());
+        }
+
+        public int getContigCode() { return svInterval.getContig(); }
+
+        @Override
+        public String getContig() { return contigs.get(svInterval.getContig()); }
+
+        @Override
+        public int getStart() { return svInterval.getStart(); }
+
+        @Override
+        public int getEnd() { return svInterval.getEnd(); }
+
+        @Override
+        public int compareTo(final Locatable other) {
+            final int contigCompare = getContig().compareTo(other.getContig());
+            if(contigCompare == 0) {
+                final int startCompare = Integer.compare(getStart(), other.getStart());
+                return startCompare == 0 ?
+                    Integer.compare(getEnd(), other.getEnd()) :
+                    startCompare;
+            } else {
+                return contigCompare;
+            }
+        }
+
+    }
+
+    static class TractIntervalAndOther {
+        final TractInterval primaryInterval;
+        final TractInterval otherInterval;
+
+        TractIntervalAndOther(final TractInterval primaryInterval, final TractInterval otherInterval) {
+            if(otherInterval != null && !primaryInterval.uid.equals(otherInterval.uid)) {
+                throw new GATKException("primaryInterval.uid (" + primaryInterval.uid
+                                        + ") not equal to otherInterval.uid (" + otherInterval.uid + ")");
+            }
+            this.primaryInterval = primaryInterval;
+            this.otherInterval = otherInterval;
+        }
+    }
+
+    static class TractTableReader extends TableReader<TractIntervalAndOther> {
+        final static String UID_FIELD = "uid";
+        final static String PRIMARY_CONTIG_FIELD = "chrom";
+        final static String PRIMARY_START_FIELD = "chromStart";
+        final static String PRIMARY_END_FIELD = "chromEnd";
+        final static String OTHER_CONTIG_FIELD = "otherChrom";
+        final static String OTHER_START_FIELD = "otherStart";
+        final static String OTHER_END_FIELD = "otherEnd";
+        final static TableReaderOptions defaultTableReaderOptions = new TableReaderOptions(
+            true,
+            new HashMap<String, String>() {
+                private final static long serialVersionUID = 0;
+                {
+                    put("genoName", PRIMARY_CONTIG_FIELD);
+                    put("genoStart", PRIMARY_START_FIELD);
+                    put("genoEnd", PRIMARY_END_FIELD);
+                }
+            }
+        );
+
+        public TractTableReader(Path path, final TableReaderOptions tableReaderOptions) throws IOException {
+            super(path, tableReaderOptions);
+        }
+
+        public TractTableReader(Path path) throws IOException {
+            this(path, defaultTableReaderOptions);
+        }
+
+        @Override
+        protected TractIntervalAndOther createRecord(DataLine dataLine) {
+            try {
+                final boolean hasOther = dataLine.columns().contains(OTHER_CONTIG_FIELD);
+                final TractInterval primaryInterval = new TractInterval(
+                        hasOther ? dataLine.getLong(UID_FIELD) : null, dataLine.get(PRIMARY_CONTIG_FIELD),
+                        dataLine.getInt(PRIMARY_START_FIELD), dataLine.getInt(PRIMARY_END_FIELD)
+                );
+                final TractInterval otherInterval = hasOther ?
+                        new TractInterval(
+                                dataLine.getLong(UID_FIELD), dataLine.get(OTHER_CONTIG_FIELD),
+                                dataLine.getInt(OTHER_START_FIELD), dataLine.getInt(OTHER_END_FIELD)
+                        ) :
+                        null;
+                return new TractIntervalAndOther(primaryInterval, otherInterval);
+            }
+            catch(RuntimeException exception){
+                System.out.println("columns: " + dataLine.columns().names());
+                throw new RuntimeException("Error opening " + getSource() + ":\n" + exception.toString(), exception);
+            }
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/XGBoostMinGqVariantFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/GqRecalibrator/XGBoostMinGqVariantFilter.java
@@ -1,0 +1,714 @@
+package org.broadinstitute.hellbender.tools.walkers.sv.GqRecalibrator;
+
+import ml.dmlc.xgboost4j.LabeledPoint;
+import ml.dmlc.xgboost4j.java.*;
+import ml.dmlc.xgboost4j.java.util.BigDenseMatrix;
+import org.apache.commons.math3.util.FastMath;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.programgroups.StructuralVariantDiscoveryProgramGroup;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+
+@CommandLineProgramProperties(
+        summary = "Extract matrix of properties for each variant. Also extract, num_variants x num_trios x 3 tensors of" +
+                "allele count and genotype quality. These data will be used to train a variant filter based on min GQ" +
+                "(and stratified by other variant properties) that maximizes the admission of variants with Mendelian" +
+                "inheritance pattern while omitting non-Mendelian variants." +
+                "Derived class must implement abstract method train_filter()",
+        oneLineSummary = "Extract data for training min GQ variant filter from .vcf and .ped file with trios.",
+        programGroup = StructuralVariantDiscoveryProgramGroup.class
+)
+@DocumentedFeature
+public class XGBoostMinGqVariantFilter extends MinGqVariantFilterBase {
+    @Argument(fullName="max-training-rounds", shortName="tr", doc="Maximum number of rounds of training", optional=true, minValue=1)
+    public int maxTrainingRounds = 100;
+    @Argument(fullName="early-stopping-rounds", shortName="e", doc="Stop training if no improvement is made in validation set for this many rounds. Set <= 0 to disable.", optional=true)
+    public int earlyStoppingRounds = 10;
+    @Argument(fullName="learning-rate", shortName="lr", doc="Learning rate for xgboost", optional=true)
+    public double eta = 0.1;
+    @Argument(fullName="max-depth", shortName="d", doc="Max depth of boosted decision tree", optional=true, minValue=1)
+    public int maxDepth = 10;
+    @Argument(fullName="gamma", doc="Regularization factor for xgboost", optional=true)
+    public double gamma = 1.0e-3;
+    @Argument(fullName="subsample", doc="Proportion of data selected for each tree", optional=true)
+    public double subsample = 0.9;
+    @Argument(fullName="colsample-by-tree", doc="Proportion of columns selected for each tree", optional=true)
+    public double colsampleByTree = 0.9;
+    @Argument(fullName="colsample-by-level", doc="Proportion of columns selected for each level of each tree", optional=true)
+    public double colsampleByLevel = 1.0;
+    @Argument(fullName="min-child-weight", doc="Minimum sum of hessian weight for each node of tree", optional=true, minValue=0.0)
+    public double minChildWeight = 10000;
+    @Argument(fullName="n-threads-xgboost", doc="Number of threads to use for xgboost training", optional=true)
+    public int numThreadsXgBoost = -1;
+    @Argument(fullName="temp-dir", doc="path to directory for temporary files", optional=true)
+    File tempDir = null;
+
+    private Booster booster = null;
+
+    private static final String TRAIN_MAT_KEY = "train";
+    private static final String VALIDATION_MAT_KEY = "validation";
+
+    private enum DMatrixFillMethod {RowMajorArray, BigDenseMatrix, LabeledPointIterator}
+    @Argument(fullName="dmatrix-fill-method", doc="Method of filling dMatrix: \"RowMajorArray\", \"BigDenseMatrix\" or \"LabeledPointIterator\"")
+    private final DMatrixFillMethod dMatrixFillMethod = DMatrixFillMethod.LabeledPointIterator;
+
+    private DMatrix getDMatrixRowMajorArray(int[] variantIndices) throws XGBoostError {
+        // Get number of rows, account for the fact that unfilterable (e.g. already HOMREF) samples will not be used
+        final int numRows = getNumTrainableSampleVariants(variantIndices);
+
+        final int numProperties = getNumProperties();
+        final float[] rowMajorVariantProperties = new float[numRows * numProperties];
+        // Loop over variants and filterable samples. Store properties for each sample in a single flat array
+        final int numSamples = getNumSamples();
+        int flatIndex = 0;
+        for(final int variantIndex : variantIndices) {
+            for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+                if(!getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                    continue;
+                }
+                flatIndex = propertiesTable.copyPropertiesRow(
+                    rowMajorVariantProperties, flatIndex, variantIndex, sampleIndex, needsNormalizedProperties()
+                );
+            }
+        }
+
+        if(progressVerbosity > 1) {
+            System.out.format("\t\tgot %d property entries\n", rowMajorVariantProperties.length);
+        }
+
+        return new DMatrix(
+            rowMajorVariantProperties, numRows, numProperties, Float.NaN
+        );
+    }
+
+    private DMatrix getDMatrixBigDenseMatrix(int[] variantIndices) throws XGBoostError {
+        // Get number of rows, account for the fact that unfilterable (e.g. already HOMREF) samples will not be used
+        final int numRows = getNumTrainableSampleVariants(variantIndices);
+
+        final int numProperties = getNumProperties();
+        final BigDenseMatrix variantSampleProperties = new BigDenseMatrix(numRows, numProperties);
+        // Loop over variants and filterable samples. Store properties for each sample in a single flat array
+        final int numSamples = getNumSamples();
+        int row = 0;
+        for(final int variantIndex : variantIndices) {
+            for(int sampleIndex = 0; sampleIndex < numSamples; ++sampleIndex) {
+                if(!getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                    continue;
+                }
+                final float[] sampleProperties = propertiesTable.getPropertiesRow(variantIndex, sampleIndex,
+                                                                                  needsNormalizedProperties());
+                for(int column = 0; column < sampleProperties.length; ++column) {
+                    variantSampleProperties.set(row, column, sampleProperties[column]);
+                }
+                ++row;
+            }
+        }
+        if(progressVerbosity > 1) {
+            System.out.format("\t\tgot %d property entries\n",
+                    variantSampleProperties.nrow * (long)variantSampleProperties.ncol);
+        }
+
+        return new DMatrix(variantSampleProperties, Float.NaN);
+    }
+
+    private int fillVariantWeights(final int variantIndex, final int numSamples,
+                                   final boolean[] sampleVariantTruth, int row, final float[] weights) {
+        final int propertyBin = propertyBins[variantIndex];
+        final Set<Integer> inheritanceTrainableSampleIndices = getInheritanceTrainableSampleIndices(variantIndex);
+        final Set<Integer> truthTrainableSampleIndices = new HashSet<>(
+                goodSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+        );
+        truthTrainableSampleIndices.addAll(
+                badSampleVariantIndices.getOrDefault(variantIndex, Collections.emptySet())
+        );
+
+        final float minGqWeight = propertyBinMinGqWeights[propertyBin];
+        final float goodTruthWeight = minGqWeight + propertyBinGoodTruthWeights[propertyBin];
+        final float badTruthWeight = minGqWeight + propertyBinBadTruthWeights[propertyBin];
+        final float truthWeight = minGqWeight + (float)propertyBinTruthWeights[propertyBin];
+        final float goodInheritanceWeight = minGqWeight + propertyBinGoodInheritanceWeights[propertyBin];
+        final float badInheritanceWeight = minGqWeight + propertyBinBadInheritanceWeights[propertyBin];
+        final float inheritanceWeight = minGqWeight + (float)propertyBinInheritanceWeights[propertyBin];
+        final float goodBothWeights = minGqWeight + (
+                propertyBinGoodTruthWeights[propertyBin] +
+                        propertyBinGoodInheritanceWeights[propertyBin]
+        );
+        final float badBothWeights = minGqWeight + (
+                propertyBinGoodTruthWeights[propertyBin] +
+                        propertyBinGoodInheritanceWeights[propertyBin]
+        );
+        final float bothWeights = minGqWeight + (float)(propertyBinTruthWeights[propertyBin] +
+                                                        propertyBinInheritanceWeights[propertyBin]);
+
+        for(int sampleNum = 0; sampleNum < numSamples; ++sampleNum) {
+            if(getSampleVariantIsTrainable(variantIndex, sampleNum)) {
+                if(inheritanceTrainableSampleIndices.contains(sampleNum)) {
+                    if(truthTrainableSampleIndices.contains(sampleNum)) {
+                        weights[row] = sampleVariantTruth[row] ? goodBothWeights : badBothWeights;
+                        //weights[row] = bothWeights;
+                    } else {
+                        weights[row] = sampleVariantTruth[row] ? goodInheritanceWeight : badInheritanceWeight;
+                        //weights[row] = inheritanceWeight;
+                    }
+                } else if(truthTrainableSampleIndices.contains(sampleNum)) {
+                    weights[row] = sampleVariantTruth[row] ? goodTruthWeight : badTruthWeight;
+                    //weights[row] = truthWeight;
+                } else {  // this sample is only trainable because we've set minGQ. Take the mean of the two weights
+                    weights[row] = minGqWeight;
+                }
+                ++row;
+            }
+        }
+        return row;
+    }
+
+    private float[] getDMatrixWeights(final int[] variantIndices, final boolean[] sampleVariantTruth) {
+        final int numRows = sampleVariantTruth.length;
+        final float[] sampleVariantWeights = new float[numRows];
+        final int numSamples = getNumSamples();
+        int row = 0;
+        for(int variantIndex : variantIndices) {
+            row = fillVariantWeights(variantIndex, numSamples, sampleVariantTruth, row, sampleVariantWeights);
+        }
+        if(progressVerbosity > 1) {
+            System.out.format("\t\tgot %d row weights\n", row);
+        }
+        return sampleVariantWeights;
+    }
+
+    private float[] getDMatrixLabels(final boolean[] sampleVariantTruth) {
+        final float[] labels = new float[sampleVariantTruth.length];
+        for(int i = 0; i < sampleVariantTruth.length; ++i) {
+            labels[i] = sampleVariantTruth[i] ? 1F : -1F;
+        }
+        return labels;
+    }
+
+    class DMatrixDataIterator implements Iterator<LabeledPoint> {
+        private final int[] variantIndices;
+        private final int numSamples;
+        private final int numProperties;
+        private int variantIterIndex;
+        private int variantIndex;
+        private int sampleIndex;
+        private final float[] weights;
+        private int trainableSamplesIndex;
+        private final boolean[] samplePasses;
+        private final float[][] sparseValuesBuffer;
+        private final int[][] sparseIndicesBuffer;
+        private final int[] copySparseIndicesBuffer;
+        private final float[] copySparseValuesBuffer;
+        private int valuesBufferIndex;
+
+        private static final int defaultBufferLen = 1 + 32 << 10;
+
+        DMatrixDataIterator(final int[] variantIndices) {
+            this.variantIndices = variantIndices;
+            this.variantIterIndex = 0;
+            this.variantIndex = variantIndices.length > 0 ? variantIndices[this.variantIterIndex] : -1;
+            this.sampleIndex = 0;
+            this.numSamples = getNumSamples();
+            this.numProperties = getNumProperties();
+            this.samplePasses = new boolean[numSamples];
+            this.weights = new float[numSamples];
+            trainableSamplesIndex = 0;
+            if(runMode == RunMode.Train && variantIndices.length > 0) {
+                fillSamplePasses(variantIndex, 0, samplePasses);
+                fillVariantWeights(variantIndex, numSamples, samplePasses, 0, weights);
+            }
+
+            this.copySparseIndicesBuffer = new int[numProperties];
+            this.copySparseValuesBuffer = new float[numProperties];
+            final int bufferLen = (int) FastMath.min(defaultBufferLen, variantIndices.length * (long) numSamples);
+            this.sparseValuesBuffer = new float[bufferLen][];
+            this.sparseIndicesBuffer = new int[bufferLen][];
+            valuesBufferIndex = 0;
+        }
+
+        private boolean increment() {
+            if(variantIterIndex >= variantIndices.length) {
+                return false;
+            }
+            ++sampleIndex;
+            if(sampleIndex == numSamples) {
+                ++variantIterIndex;
+                if(variantIterIndex >= variantIndices.length) {
+                    return false;
+                }
+                variantIndex = variantIndices[variantIterIndex];
+                sampleIndex = 0;
+                trainableSamplesIndex = 0;
+                if(runMode == RunMode.Train) {
+                    fillSamplePasses(variantIndex, 0, samplePasses);
+                    fillVariantWeights(variantIndex, numSamples, samplePasses, 0, weights);
+                }
+            }
+            return true;
+        }
+
+        @Override public boolean hasNext() {
+            if(variantIterIndex >= variantIndices.length) {
+                return false;
+            }
+            if(runMode == RunMode.Train) {
+                while (!getSampleVariantIsTrainable(variantIndex, sampleIndex)) {
+                    if (!increment()) {
+                        return false;
+                    }
+                }
+            } else {
+                while (!getSampleVariantIsFilterable(variantIndex, sampleIndex)) {
+                    if (!increment()) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public LabeledPoint next() {
+            if(!hasNext()) {
+                throw new RuntimeException("Iterated past end");
+            }
+            getSparseValues();
+            final float[] values = sparseValuesBuffer[valuesBufferIndex];
+            final int[] indices = sparseIndicesBuffer[valuesBufferIndex];
+            ++valuesBufferIndex;
+            if(valuesBufferIndex >= sparseValuesBuffer.length) {
+                valuesBufferIndex = 0;
+            }
+            final float label;
+            final float weight;
+            final int group;
+            if(runMode == RunMode.Train) {
+                label = samplePasses[trainableSamplesIndex] ? 1F : -1F;
+                weight = weights[trainableSamplesIndex];
+                group = propertyBins[variantIndex];
+            } else {
+                label = 0F;
+                weight = 1F;
+                group = 0;
+            }
+            ++trainableSamplesIndex;
+            final LabeledPoint labeledPoint = new LabeledPoint(label, numProperties, indices, values,
+                                                               weight, group, 0);
+            increment();
+            return labeledPoint;
+        }
+
+        private void getSparseValues() {
+            int flatIndex = 0;
+            int propertyIndex = 0;
+            for (final String propertyName : propertiesTable.getPropertyNames()) {
+                final PropertiesTable.Property property = propertiesTable.get(propertyName);
+                if (property instanceof PropertiesTable.BooleanArrProperty) {
+                    final boolean value = ((PropertiesTable.BooleanArrProperty) property).values[variantIndex];
+                    if (value) {
+                        copySparseIndicesBuffer[flatIndex] = propertyIndex;
+                        copySparseValuesBuffer[flatIndex] = 1F;
+                        ++flatIndex;
+                    }
+                } else if (property instanceof PropertiesTable.BooleanMatProperty) {
+                    final boolean value = ((PropertiesTable.BooleanMatProperty) property).values[variantIndex][sampleIndex];
+                    if (value) {
+                        copySparseIndicesBuffer[flatIndex] = propertyIndex;
+                        copySparseValuesBuffer[flatIndex] = 1F;
+                        ++flatIndex;
+                    }
+                } else {
+                    copySparseIndicesBuffer[flatIndex] = propertyIndex;
+                    copySparseValuesBuffer[flatIndex] = property.getAsFloat(variantIndex, sampleIndex);
+                    ++flatIndex;
+                }
+                ++propertyIndex;
+            }
+            sparseIndicesBuffer[valuesBufferIndex] = Arrays.copyOf(copySparseIndicesBuffer, flatIndex);
+            sparseValuesBuffer[valuesBufferIndex] = Arrays.copyOf(copySparseValuesBuffer, flatIndex);
+        }
+    }
+
+    private DMatrix getDMatrixLabeledPoint(final int[] variantIndices, boolean cacheDMatrix) throws XGBoostError {
+        if(cacheDMatrix) {
+            final File cacheFile;
+            try {
+                cacheFile = File.createTempFile("temp", ".dmatrix.cache", tempDir);
+            } catch (IOException e) {
+                throw new GATKException("Error creating temp file for DMatrix cache", e);
+            }
+            cacheFile.deleteOnExit();
+
+            return new DMatrix(new DMatrixDataIterator(variantIndices), cacheFile.getAbsolutePath());
+        } else {
+            return new DMatrix(new DMatrixDataIterator(variantIndices), null);
+        }
+    }
+
+    private DMatrix getDMatrix(final int[] variantIndices) throws XGBoostError {
+        if(progressVerbosity > 1) {
+            System.out.println("\tgetDMatrix");
+        }
+        final DMatrix dMatrix;
+        switch(dMatrixFillMethod) {
+            case BigDenseMatrix:
+                dMatrix = getDMatrixBigDenseMatrix(variantIndices);
+                break;
+            case RowMajorArray:
+                dMatrix = getDMatrixRowMajorArray(variantIndices);
+                break;
+            case LabeledPointIterator:
+                dMatrix = getDMatrixLabeledPoint(variantIndices, true);
+                if(progressVerbosity > 2) {
+                    System.out.println("\tgetDMatrix complete");
+                }
+                return dMatrix;  // don't try to set other properties, they're already handled
+            default:
+                throw new IllegalArgumentException("Unknown DMatrixFillMethod: " + dMatrixFillMethod);
+        }
+        final boolean[] sampleVariantTruth = getSampleVariantTruth(variantIndices);
+        dMatrix.setWeight(getDMatrixWeights(variantIndices, sampleVariantTruth));
+        dMatrix.setLabel(getDMatrixLabels(sampleVariantTruth));
+        dMatrix.setBaseMargin(new float[sampleVariantTruth.length]);
+        if(progressVerbosity > 2) {
+            System.out.println("\tgetDMatrix complete");
+        }
+        return dMatrix;
+    }
+
+    private DMatrix getDMatrixForPrediction(final float[] sampleVariantProperties,
+                                            final int numRows, final int numColumns) throws XGBoostError {
+        final DMatrix dMatrix = new DMatrix(sampleVariantProperties, numRows, numColumns, Float.NaN);
+        dMatrix.setBaseMargin(new float[numRows]);
+        return dMatrix;
+    }
+
+    final int[] variantIndicesForFiltering = new int[1];  // always the first variant index
+    DMatrix getDMatrixForFiltering() throws XGBoostError {
+        return getDMatrixLabeledPoint(variantIndicesForFiltering, false);
+    }
+
+    private Map<String, Object> getXgboostParams() {
+        return new HashMap<String, Object>() {
+            private static final long serialVersionUID = 0L;
+            {
+                put("eta", eta);
+                put("max_depth", maxDepth);
+                put("gamma", gamma);
+                put("subsample", subsample);
+                put("colsample_bytree", colsampleByTree);
+                put("colsample_bylevel", colsampleByLevel);
+                put("min_child_weight", minChildWeight);
+                put("validate_parameters", true);
+                put("objective", "binary:logistic");
+                put("eval_metric", "logloss");
+                if(numThreadsXgBoost > 0) {
+                    put("nthread", numThreadsXgBoost);
+                }
+            }
+        };
+    }
+
+    private class DataSubset {
+        final String name;
+        final int[] variantIndices;
+        final boolean isTrainingSet;
+        final int numTrainableSampleVariants;
+
+        final List<Float> scores;
+        private int bestScoreInd;
+        private float bestScore;
+
+        final DMatrix dMatrix;
+        final float[] pSampleVariantGood;
+        final float[] d1Loss;
+        final float[] d2Loss;
+
+        DataSubset(final String name, final int[] variantIndices, final boolean isTrainingSet) {
+            System.out.println("Building DataSubset " + name);
+            this.name = name;
+            this.variantIndices = variantIndices;
+            this.isTrainingSet = isTrainingSet;
+            numTrainableSampleVariants = getNumTrainableSampleVariants(variantIndices);
+            if(progressVerbosity > 1) {
+                System.out.format("\t%d variants, %d sample x variants, %d properties, %d entries\n",
+                                   variantIndices.length, numTrainableSampleVariants, getNumProperties(),
+                                   numTrainableSampleVariants * (long)getNumProperties());
+            }
+
+            scores = new ArrayList<>();
+            bestScore = Float.POSITIVE_INFINITY;
+            bestScoreInd = 0;
+
+            try {
+                this.dMatrix = getDMatrix(variantIndices);
+            } catch(XGBoostError xgBoostError) {
+                throw new GATKException("Error constructing DMatrix", xgBoostError);
+            }
+            pSampleVariantGood = new float[numTrainableSampleVariants];
+
+            // pre-allocate derivative arrays if they are needed (i.e. this is the training set)
+            d1Loss = isTrainingSet ? new float[numTrainableSampleVariants] : null;
+            d2Loss = isTrainingSet ? new float[numTrainableSampleVariants] : null;
+
+            final boolean[] sampleVariantTruth = getSampleVariantTruth(variantIndices);
+            final float[] tempTruthProbs = new float[numTrainableSampleVariants];
+            for(int idx = 0; idx < numTrainableSampleVariants; ++idx) {
+                tempTruthProbs[idx] = sampleVariantTruth[idx] ? 1F : 0F;
+            }
+            System.out.println("Best possible " + name + " loss:\n\t" +
+                               getLoss(tempTruthProbs, variantIndices).toString().replaceAll("\n", "\n\t"));
+        }
+
+        public int size() { return numTrainableSampleVariants; }
+
+        private float[][] getRawPredictions(final Booster booster, final DMatrix dMatrix) {
+            try {
+                return booster.predict(dMatrix, true, 0);
+            } catch(XGBoostError xgBoostError) {
+                throw new GATKException("In " + name + " DataSubset: Predict error", xgBoostError);
+            }
+        }
+
+        private void displayQuantilesFloat(final float[] arr, final String description) {
+            DoubleStream.Builder builder = DoubleStream.builder();
+            for (float v : arr) {
+                builder.add(v);
+            }
+            displayPercentiles(description, builder.build());
+        }
+
+        private FilterLoss getRoundLoss(final Booster booster, final boolean training) {
+            final float[][] rawPredictions = getRawPredictions(booster, dMatrix);
+            for(int idx = 0; idx < rawPredictions.length; ++idx) {
+                pSampleVariantGood[idx] = scaled_logits_to_p(rawPredictions[idx][0]);
+            }
+
+            if(isTrainingSet && training) {
+                final FilterLoss lossForTraining = getTrainingLoss(pSampleVariantGood, d1Loss, d2Loss, variantIndices);
+                System.out.format("\t%s\n\t\t%s\n", "optimizer objective",
+                                  lossForTraining.toString().replaceAll("\n", "\n\t\t"));
+                if(progressVerbosity > 0) {
+                    System.out.format("\tBoosting round %d on %s\n", 1 + getRound(), name);
+                }
+                if(progressVerbosity > 1) {
+                    displayQuantilesFloat(pSampleVariantGood, "pSampleVariantIsGood");
+                    displayQuantilesFloat(d1Loss, "d1Loss");
+                    displayQuantilesFloat(d2Loss, "d2Loss");
+                }
+                try {
+                    booster.boost(dMatrix, d1Loss, d2Loss);
+                } catch(XGBoostError xgBoostError) {
+                    throw new GATKException("In " + name + " DataSubset: Boost error", xgBoostError);
+                }
+            }
+
+            final FilterLoss lossForDiagnostics = getLoss(pSampleVariantGood, variantIndices);
+
+
+            if(progressVerbosity > 0) {
+                System.out.format("\t%s\n\t\t%s\n", name, lossForDiagnostics.toString().replaceAll("\n", "\n\t\t"));
+            }
+            return lossForDiagnostics;
+        }
+
+        public DoubleStream streamPredictions(final Booster booster) {
+            return Arrays.stream(getRawPredictions(booster, dMatrix))
+                .mapToDouble(rawPrediction -> scaled_logits_to_p(rawPrediction[0]));
+        }
+
+
+        public float getLastScore() { return scores.get(scores.size() - 1); }
+
+        public void appendScore(final float score) {
+            scores.add(score);
+            if(score < bestScore) {
+                bestScore = score;
+                bestScoreInd = getRound();
+            }
+        }
+
+        public int getRound() {
+            return scores.size() - 1;
+        }
+
+        public boolean isBestScore() {
+            return bestScoreInd == getRound();
+        }
+
+        public boolean stop() {
+            return getRound() == maxTrainingRounds || stopEarly();
+        }
+
+        public boolean stopEarly() {
+            return earlyStoppingRounds > 0 && getRound() - bestScoreInd > earlyStoppingRounds;
+        }
+    }
+
+    @Override
+    protected boolean needsNormalizedProperties() { return false; }
+
+    @Override
+    protected void predictBatch(final float[] variantProperties, final int numRows, final int numColumns,
+                                final float[] outputProbabilities) {
+        try {
+            final float[][] rawPredictions = booster.predict(
+                getDMatrixForPrediction(variantProperties, numRows, numColumns), true, 0
+            );
+            for(int row = 0; row < numRows; ++ row) {
+                outputProbabilities[row] = scaled_logits_to_p(rawPredictions[row][0]);
+            }
+        } catch(XGBoostError xgBoostError) {
+            throw new GATKException("Error predicting", xgBoostError);
+        }
+    }
+
+    @Override
+    protected int predictBatch(final float[] outputProbabilities) {
+        final float[][] rawPredictions;
+        try {
+            final DMatrix dMatrix = getDMatrixForFiltering();
+            if(dMatrix.rowNum() == 0) {
+                return 0;  // don't try to predict on empty DMatrix, XGBoost doesn't like it.
+            }
+            rawPredictions = booster.predict(
+                    getDMatrixForFiltering(), true, 0
+            );
+            for(int row = 0; row < rawPredictions.length; ++ row) {
+                outputProbabilities[row] = scaled_logits_to_p(rawPredictions[row][0]);
+            }
+        } catch(XGBoostError xgBoostError) {
+            throw new GATKException("Error predicting", xgBoostError);
+        }
+        return rawPredictions.length;
+    }
+
+    @Override
+    protected void loadModel(final InputStream inputStream) {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            int readValue = inputStream.read();
+            while(readValue >= 0) {
+                os.write(readValue);
+                readValue = inputStream.read();
+            }
+
+            booster = XGBoost.loadModel(Base64.getDecoder().decode(os.toByteArray()));
+        } catch(XGBoostError | IOException xgBoostError) {
+            throw new GATKException("Error loading XGBoost model", xgBoostError);
+        }
+    }
+
+    @Override
+    protected void saveModel(final OutputStream outputStream) {
+        try {
+            outputStream.write(Base64.getEncoder().encode(booster.toByteArray()));
+        } catch(XGBoostError | IOException xgBoostError) {
+            throw new GATKException("Error saving XGBoost model", xgBoostError);
+        }
+    }
+
+    private Booster initializeBooster(final List<DataSubset> dataSubsets) {
+        final DataSubset trainingSubset = dataSubsets.stream()
+            .filter(dataSubset -> dataSubset.isTrainingSet)
+            .findFirst()
+            .orElseThrow(() -> new GATKException("dataSubsets does not contain a training set"));
+        final Map<String, DMatrix> watches = new HashMap<>();
+        // add watches for any DataSubset that a) is not the main training set, and
+        //                                     b) does not use mini batches (it can comfortably hang out in memory)
+        for(final DataSubset dataSubset : dataSubsets) {
+            if(!dataSubset.equals(trainingSubset)) {
+                watches.put(dataSubset.name, dataSubset.dMatrix);
+            }
+        }
+
+        try {
+            // Do 0 rounds of training on the first mini-batch (if using, otherwise whole dMatrix) of training DataSubset
+            return XGBoost.train(trainingSubset.dMatrix, getXgboostParams(), 0, watches, null, null);
+        } catch(XGBoostError xgBoostError) {
+            throw new GATKException("Error creating Booster", xgBoostError);
+        }
+    }
+
+    private boolean trainOneRound(final Booster booster, final List<DataSubset> dataSubsets) {
+        // evaluate booster on all data sets, calculate derivatives on training set
+        if(progressVerbosity > 0) {
+            System.out.println("Training round " + (dataSubsets.get(0).getRound() + 1));
+        }
+
+        boolean needSaveCheckpoint = !dataSubsets.isEmpty();
+        boolean needStop = !dataSubsets.isEmpty();
+        for(final DataSubset dataSubset : dataSubsets) {
+            final FilterLoss roundLoss = dataSubset.getRoundLoss(booster, true);
+            dataSubset.appendScore(roundLoss.toFloat());
+            if(!dataSubset.isTrainingSet) {
+                // check if need to stop iterating or save model checkpoint
+                needSaveCheckpoint = needSaveCheckpoint && dataSubset.isBestScore();
+                needStop = needStop && dataSubset.stop();
+            }
+        }
+
+        // check if booster needs to be saved, or if early stopping is necessary
+        if(needSaveCheckpoint) {
+            saveModelCheckpoint();
+        }
+        return !needStop;
+    }
+
+    void displayFeatureImportance(final Booster booster) {
+        final List<String> propertyNames = propertiesTable.getPropertyNames();
+        final Map<String, Integer> featureScore;
+        try {
+            featureScore = booster.getFeatureScore((String) null).entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        entry -> propertyNames.get(Integer.parseInt(entry.getKey().substring(1))),
+                        Map.Entry::getValue
+                    )
+                );
+        } catch(XGBoostError xgBoostError) {
+            throw new GATKException("Error getting feature score", xgBoostError);
+        }
+
+        System.out.println("Feature importance:");
+        featureScore.entrySet().stream()
+            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            .forEachOrdered(entry -> System.out.format("\t%s: %d\n", entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    protected void trainFilter() {
+        final List<DataSubset> dataSubsets = new ArrayList<DataSubset>() {
+            private static final long serialVersionUID = 0L;
+            {
+                add(new DataSubset(TRAIN_MAT_KEY, getTrainingIndices(), true));
+                add(new DataSubset(VALIDATION_MAT_KEY, getValidationIndices(), false));
+            }
+        };
+
+        clearUnneededProperties();
+
+        booster = initializeBooster(dataSubsets);
+        //noinspection StatementWithEmptyBody
+        while (trainOneRound(booster, dataSubsets))
+            ;
+
+        loadModelCheckpoint();
+        if(progressVerbosity > 0) {
+            System.out.println("Losses of final trained classifier:");
+            for (final DataSubset dataSubset : dataSubsets) {
+                dataSubset.getRoundLoss(booster, false);
+            }
+        }
+        displayHistogram("Final training adjusted GQ histogram",
+                          dataSubsets.get(0).streamPredictions(booster).mapToInt(this::p_to_scaled_logits),true);
+        displayHistogram("Final training probability histogram",
+                          dataSubsets.get(0).streamPredictions(booster),20, 0.0, 1.0);
+        displayFeatureImportance(booster);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableReaderOptions.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableReaderOptions.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.hellbender.utils.tsv;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TableReaderOptions {
+    boolean headerIsLastComment = false;
+
+    Map<String, String> columnRenamer = new HashMap<>();
+
+    public TableReaderOptions() {}
+
+    public TableReaderOptions(final boolean headerIsLastComment, final Map<String, String> columnRenamer) {
+        this.headerIsLastComment = headerIsLastComment;
+        this.columnRenamer = columnRenamer;
+    }
+}


### PR DESCRIPTION
* Added MinGqVariantFilterBase
* * loads VCF, pedigree, UCSC genome tract, and truth data
* * calculates variant overlap with genome tracts
* * forms matrices, tensors, and other helping data for machine learning
* * provides for TRAIN and FILTER modes
* * provides functions for calculating loss given assigned min GQ values
* * computes best estimate of truth data used for training xgboost model
* Added XGBoostMinGqVariantFilter
* * calculates new GQ based on gradient boosting
* Added PropertiesTable for loading VCF properties into tensors
* Added TractOverlapDetector for computing overlap properties with
  UCSC genome tracts

Training loss is based on weighted combination of heredity and truth
data, broken down by variant category.