### PR TITLE
Add withdrawn and is_control columns [VS-70] [VS-213]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -117,6 +117,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_add_sample_columns
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -137,7 +138,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_add_sample_columns
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -147,6 +147,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_add_sample_columns
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -65,6 +65,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_add_sample_columns
    - name: GvsAoUReblockGvcf
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsAoUReblockGvcf.wdl
@@ -88,6 +89,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_add_sample_columns
    - name: GvsCreateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -125,6 +127,7 @@ workflows:
          - master
          - ah_var_store
          - kc_vqsr_magic
+         - rsa_add_sample_columns
    - name: GvsPrepareCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -137,6 +137,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_add_sample_columns
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/scripts/variantstore/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/AOU_DELIVERABLES.md
@@ -6,7 +6,7 @@
 3. Run the workflows outlined in the Quickstart description in the workspace that contains the data by using the "Copy to Another Workspace" function.  In addition to having to pass a GCP project ID and BigQuery dataset to all workflows, you will also need to know the path to a service account JSON file with permissions to AoU-specific projects and data. The first two steps (GvsAssignIds and GvsImportGenomes) can be run multiple times to load all necessary sample sets into one "instance" of GVS (if there are control samples included, they should be assigned IDs of 50 or fewer).  The rest of the steps are only run once, in order, and only after all the samples for the callset are loaded.
     1. GvsAssignIds at the sample set level ("Step 1" in workflow submission)
     2. GvsImportGenomes at the sample set level ("Step 1" in workflow submission)
-    	- Make sure that any samples that have been withdrawn or that have been loaded but should not be in the callset have the is_loaded column set to false.
+    	- Make sure that any samples that have been withdrawn or that have been loaded but should not be in the callset have the withdrawn column set.
     3. GvsCreateAltAllele
     4. GvsCreateFilterSet
         - make note of the "filter_set_name" input used

--- a/scripts/variantstore/AOU_GVS_WORKSPACE.md
+++ b/scripts/variantstore/AOU_GVS_WORKSPACE.md
@@ -92,15 +92,6 @@ They may have been loaded into neither, in which case they will need to be loade
 `DELETE FROM <DATASET>.sample_load_status WHERE sample_id IN (56238)`
 
 
-### 3.3 Update the is_loaded field
-This is currently a manual step.
-Run
-
-> update `<PROJECT>.<DATASET>.sample_info` set is_loaded = TRUE where cast(sample_id as STRING) in (
-select partition_id from `<PROJECT>.<DATASET>.INFORMATION_SCHEMA.PARTITIONS` where total_logical_bytes > 0 AND table_name like 'vet_%'
-)
-
-
 ## 4. Create Alt Allele Table
 This step loads data into the ALT_ALLELE table from the `vet_*` tables.
 

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -133,7 +133,7 @@ task AssignIds {
 
     # add sample_name to sample_info_table
     bq --project_id=~{project_id} query --use_legacy_sql=false \
-      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) (select sample_name from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`), ~{samples_are_controls})'
+      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) (select sample_name, ~{samples_are_controls} from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`)'
 
     # get the current maximum id, or 0 if there are none
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false 'SELECT IFNULL(MAX(sample_id),0) FROM `~{dataset_name}.~{sample_info_table}`' > maxid

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -9,13 +9,14 @@ workflow GvsAssignIds {
     String project_id
 
     Array[String] external_sample_names
+    Boolean samples_are_controls = false
 
     File? assign_ids_gatk_override
     String? service_account_json_path
   }
 
   String sample_info_table = "sample_info"
-  String sample_info_schema_json = '[{"name": "sample_name","type": "STRING","mode": "REQUIRED"},{"name": "sample_id","type": "INTEGER","mode": "NULLABLE"},{"name":"is_loaded","type":"BOOLEAN","mode":"NULLABLE"}]'
+  String sample_info_schema_json = '[{"name": "sample_name","type": "STRING","mode": "REQUIRED"},{"name": "sample_id","type": "INTEGER","mode": "NULLABLE"},{"name":"is_loaded","type":"BOOLEAN","mode":"NULLABLE"},{"name":"is_control","type":"BOOLEAN","mode":"REQUIRED"},{"name":"withdrawn","type":"TIMESTAMP","mode":"NULLABLE"}]'
   String sample_load_status_json = '[{"name": "sample_id","type": "INTEGER","mode": "REQUIRED"},{"name":"status","type":"STRING","mode":"REQUIRED"}, {"name":"event_timestamp","type":"TIMESTAMP","mode":"REQUIRED"}]'
 
 
@@ -49,6 +50,7 @@ workflow GvsAssignIds {
       project_id = project_id,
       dataset_name = dataset_name,
       sample_info_table = sample_info_table,
+      samples_are_controls = samples_are_controls,
       table_creation_done = CreateSampleInfoTable.done,
       gatk_override = assign_ids_gatk_override,
       service_account_json_path = service_account_json_path
@@ -75,6 +77,7 @@ task AssignIds {
 
     String sample_info_table
     Array[String] sample_names
+    Boolean samples_are_controls
     String table_creation_done
 
     # runtime
@@ -130,7 +133,7 @@ task AssignIds {
 
     # add sample_name to sample_info_table
     bq --project_id=~{project_id} query --use_legacy_sql=false \
-      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name) select sample_name from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`)'
+      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) (select sample_name from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`), ~{samples_are_controls})'
 
     # get the current maximum id, or 0 if there are none
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false 'SELECT IFNULL(MAX(sample_id),0) FROM `~{dataset_name}.~{sample_info_table}`' > maxid

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -133,7 +133,7 @@ task AssignIds {
 
     # add sample_name to sample_info_table
     bq --project_id=~{project_id} query --use_legacy_sql=false \
-      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) (select sample_name, ~{samples_are_controls} from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`)'
+      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) select sample_name, ~{samples_are_controls} from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`)'
 
     # get the current maximum id, or 0 if there are none
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false 'SELECT IFNULL(MAX(sample_id),0) FROM `~{dataset_name}.~{sample_info_table}`' > maxid

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -25,7 +25,7 @@ workflow GvsCreateFilterSet {
   # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
   Int snps_variant_recalibration_threshold = 20000
 
-  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-477-g55b9ead-SNAPSHOT-local.jar"
+  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-481-g95b9fc2-SNAPSHOT-local.jar"
 
   Array[String] snp_recalibration_tranche_values = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0", "98.0", "97.0", "90.0" ]
 
@@ -275,7 +275,7 @@ task GetNumSamplesLoaded {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
-    'SELECT COUNT(*) as num_rows FROM `~{fq_sample_table}` WHERE is_loaded = true AND widthdrawn IS NULL' > num_rows.csv
+    'SELECT COUNT(*) as num_rows FROM `~{fq_sample_table}` WHERE is_loaded = true AND withdrawn IS NULL' > num_rows.csv
 
     NUMROWS=$(python3 -c "csvObj=open('num_rows.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
 

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -25,7 +25,8 @@ workflow GvsCreateFilterSet {
   # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
   Int snps_variant_recalibration_threshold = 20000
 
-  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-481-g95b9fc2-SNAPSHOT-local.jar"
+#  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-481-g95b9fc2-SNAPSHOT-local.jar"
+  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_vqsr_magic_20220324/gatk-package-4.2.0.0-478-gd0e381c-SNAPSHOT-local.jar"
 
   Array[String] snp_recalibration_tranche_values = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0", "98.0", "97.0", "90.0" ]
 

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -25,7 +25,7 @@ workflow GvsCreateFilterSet {
   # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
   Int snps_variant_recalibration_threshold = 20000
 
-  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_vqsr_magic_20220324/gatk-package-4.2.0.0-478-gd0e381c-SNAPSHOT-local.jar"
+  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-477-g55b9ead-SNAPSHOT-local.jar"
 
   Array[String] snp_recalibration_tranche_values = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0", "98.0", "97.0", "90.0" ]
 
@@ -275,7 +275,7 @@ task GetNumSamplesLoaded {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
-    'SELECT COUNT(*) as num_rows FROM `~{fq_sample_table}` WHERE is_loaded = true' > num_rows.csv
+    'SELECT COUNT(*) as num_rows FROM `~{fq_sample_table}` WHERE is_loaded = true AND widthdrawn IS NULL' > num_rows.csv
 
     NUMROWS=$(python3 -c "csvObj=open('num_rows.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
 

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -25,8 +25,7 @@ workflow GvsCreateFilterSet {
   # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
   Int snps_variant_recalibration_threshold = 20000
 
-#  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-481-g95b9fc2-SNAPSHOT-local.jar"
-  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/kc_vqsr_magic_20220324/gatk-package-4.2.0.0-478-gd0e381c-SNAPSHOT-local.jar"
+  File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rsa_add_sample_columns/gatk-package-4.2.0.0-481-g95b9fc2-SNAPSHOT-local.jar"
 
   Array[String] snp_recalibration_tranche_values = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0", "98.0", "97.0", "90.0" ]
 
@@ -92,6 +91,7 @@ workflow GvsCreateFilterSet {
         output_file               = "${filter_set_name}_${i}.vcf.gz",
         service_account_json_path = service_account_json_path,
         query_project             = project_id,
+        default_dataset_id        = dataset_name
     }
   }
 
@@ -313,6 +313,7 @@ task ExtractFilterTask {
     # Runtime Options:
     File? gatk_override
     String? service_account_json_path
+    String default_dataset_id
     String query_project
   }
 
@@ -341,7 +342,8 @@ task ExtractFilterTask {
       --alt-allele-table ~{fq_alt_allele_table} \
       ~{"--excess-alleles-threshold " + excess_alleles_threshold} \
       -L ~{intervals} \
-      --project-id ~{query_project}
+      --project-id ~{query_project} \
+      --dataset-id ~{default_dataset_id}
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -7,6 +7,7 @@ workflow GvsExtractCallset {
     String dataset_name
     String project_id
 
+    Boolean control_samples = false
     String extract_table_prefix
     String filter_set_name
     String query_project = project_id
@@ -28,16 +29,17 @@ workflow GvsExtractCallset {
   File reference_dict = "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
   File reference_index = "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
 
+  String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
   File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rc-split-intervals-odd-02252022/gatk.jar"
-  String fq_cohort_extract_table  = "~{project_id}.~{dataset_name}.~{extract_table_prefix}__DATA"
+  String fq_cohort_extract_table  = "~{project_id}.~{dataset_name}.~{full_extract_prefix}__DATA"
   String fq_filter_set_info_table = "~{project_id}.~{dataset_name}.filter_set_info"
   String fq_filter_set_site_table = "~{project_id}.~{dataset_name}.filter_set_sites"
   String fq_filter_set_tranches_table = "~{project_id}.~{dataset_name}.filter_set_tranches"
-  String fq_ranges_cohort_ref_extract_table = "~{project_id}.~{dataset_name}.~{extract_table_prefix}__REF_DATA"
-  String fq_ranges_cohort_vet_extract_table = "~{project_id}.~{dataset_name}.~{extract_table_prefix}__VET_DATA"
-  String fq_samples_to_extract_table = "~{project_id}.~{dataset_name}.~{extract_table_prefix}__SAMPLES"
+  String fq_ranges_cohort_ref_extract_table = "~{project_id}.~{dataset_name}.~{full_extract_prefix}__REF_DATA"
+  String fq_ranges_cohort_vet_extract_table = "~{project_id}.~{dataset_name}.~{full_extract_prefix}__VET_DATA"
+  String fq_samples_to_extract_table = "~{project_id}.~{dataset_name}.~{full_extract_prefix}__SAMPLES"
   String fq_ranges_dataset = "~{project_id}.~{dataset_name}"
-  Array[String] tables_patterns_for_datetime_check = ["~{extract_table_prefix}__%"]
+  Array[String] tables_patterns_for_datetime_check = ["~{full_extract_prefix}__%"]
 
   call Utils.SplitIntervals {
     input:

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -125,7 +125,7 @@ task CheckForDuplicateData {
     echo "WITH items as (SELECT s.sample_id, s.sample_name, s.is_loaded, s.withdrawn FROM \`${TEMP_TABLE}\` t left outer join \`${SAMPLE_INFO_TABLE}\` s on (s.sample_name = t.sample_name)) " >> query.sql
     echo "SELECT i.sample_name FROM \`${INFO_SCHEMA_TABLE}\` p JOIN items i ON (p.partition_id = CAST(i.sample_id AS STRING)) WHERE p.total_logical_bytes > 0 AND (table_name like 'ref_ranges_%' OR table_name like 'vet_%' OR table_name like 'pet_%')" >> query.sql
     echo "UNION DISTINCT "  >> query.sql
-    echo "SELECT i.sample_name FROM items i WHERE i.is_loaded = True AND i.widthdrawn IS NULL "  >> query.sql
+    echo "SELECT i.sample_name FROM items i WHERE i.is_loaded = True AND i.withdrawn IS NULL "  >> query.sql
     echo "UNION DISTINCT "  >> query.sql
     echo "SELECT i.sample_name FROM items i WHERE i.sample_id IN (SELECT sample_id FROM \`~{dataset_name}.sample_load_status\`) "  >> query.sql
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -122,10 +122,10 @@ task CheckForDuplicateData {
 
     # check the INFORMATION_SCHEMA.PARTITIONS table to see if any of input sample names/ids have data loaded into their partitions
     # this returns the list of sample names that do already have data loaded
-    echo "WITH items as (SELECT s.sample_id, s.sample_name, s.is_loaded FROM \`${TEMP_TABLE}\` t left outer join \`${SAMPLE_INFO_TABLE}\` s on (s.sample_name = t.sample_name)) " >> query.sql
+    echo "WITH items as (SELECT s.sample_id, s.sample_name, s.is_loaded, s.withdrawn FROM \`${TEMP_TABLE}\` t left outer join \`${SAMPLE_INFO_TABLE}\` s on (s.sample_name = t.sample_name)) " >> query.sql
     echo "SELECT i.sample_name FROM \`${INFO_SCHEMA_TABLE}\` p JOIN items i ON (p.partition_id = CAST(i.sample_id AS STRING)) WHERE p.total_logical_bytes > 0 AND (table_name like 'ref_ranges_%' OR table_name like 'vet_%' OR table_name like 'pet_%')" >> query.sql
     echo "UNION DISTINCT "  >> query.sql
-    echo "SELECT i.sample_name FROM items i WHERE i.is_loaded = True "  >> query.sql
+    echo "SELECT i.sample_name FROM items i WHERE i.is_loaded = True AND i.widthdrawn IS NULL "  >> query.sql
     echo "UNION DISTINCT "  >> query.sql
     echo "SELECT i.sample_name FROM items i WHERE i.sample_id IN (SELECT sample_id FROM \`~{dataset_name}.sample_load_status\`) "  >> query.sql
 

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -100,11 +100,11 @@ task PrepareRangesCallsetTask {
           $SERVICE_ACCOUNT_STANZA
   >>>
   output {
-    String fq_cohort_extract_table_prefix = "~{fq_destination_dataset}.~{destination_cohort_table_prefix}" # implementation detail of create_cohort_extract_data_table.py
+    String fq_cohort_extract_table_prefix = "~{fq_destination_dataset}.~{destination_cohort_table_prefix}" # implementation detail of create_ranges_cohort_extract_data_table.py
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:kc_ranges_prepare_2022_01_18"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_add_sample_columns_2022_03_25_2"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -4,10 +4,12 @@ workflow GvsPrepareCallset {
   input {
     String project_id
     String dataset_name
+
+    # true for control samples only, false for participant samples only
     Boolean control_samples = false
+
     String extract_table_prefix
 
-    # inputs with defaults
     String query_project = project_id
     String destination_project = project_id
     String destination_dataset = dataset_name
@@ -34,6 +36,7 @@ workflow GvsPrepareCallset {
       fq_temp_table_dataset           = fq_temp_table_dataset,
       fq_destination_dataset          = fq_destination_dataset,
       temp_table_ttl_in_hours         = 72,
+      control_samples                 = control_samples,
       service_account_json_path       = service_account_json_path,
   }
 
@@ -53,6 +56,7 @@ task PrepareRangesCallsetTask {
     File? sample_names_to_extract
     String query_project
 
+    Boolean control_samples
     String fq_petvet_dataset
     String fq_sample_mapping_table
     String fq_temp_table_dataset
@@ -90,6 +94,7 @@ task PrepareRangesCallsetTask {
       fi
 
       python3 /app/create_ranges_cohort_extract_data_table.py \
+          --control_samples ~{control_samples} \
           --fq_ranges_dataset ~{fq_petvet_dataset} \
           --fq_temp_table_dataset ~{fq_temp_table_dataset} \
           --fq_destination_dataset ~{fq_destination_dataset} \
@@ -106,7 +111,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_add_sample_columns_2022_03_25_2"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_add_sample_columns_2022_03_26"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -4,6 +4,7 @@ workflow GvsPrepareCallset {
   input {
     String project_id
     String dataset_name
+    Boolean control_samples = false
     String extract_table_prefix
 
     # inputs with defaults
@@ -17,13 +18,14 @@ workflow GvsPrepareCallset {
     String? service_account_json_path
   }
 
+  String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
   String fq_petvet_dataset = "~{project_id}.~{dataset_name}"
   String fq_sample_mapping_table = "~{project_id}.~{dataset_name}.sample_info"
   String fq_destination_dataset = "~{destination_project}.~{destination_dataset}"
 
   call PrepareRangesCallsetTask {
     input:
-      destination_cohort_table_prefix = extract_table_prefix,
+      destination_cohort_table_prefix = full_extract_prefix,
       sample_names_to_extract         = sample_names_to_extract,
       query_project                   = query_project,
       query_labels                    = query_labels,

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -216,7 +216,6 @@ task GetBQTablesMaxLastModifiedTimestamp {
 
     echo "project_id = ~{query_project}" > ~/.bigqueryrc
 
-    # set is_loaded to true if there is a corresponding vet table partition with rows for that sample_id
     bq --location=US --project_id=~{query_project} query --format=csv --use_legacy_sql=false \
     "SELECT UNIX_MICROS(MAX(last_modified_time)) last_modified_time FROM \`~{data_project}\`.~{data_dataset}.INFORMATION_SCHEMA.PARTITIONS WHERE table_name like '~{sep="' OR table_name like '" table_patterns}'" > results.txt
 

--- a/scripts/variantstore/wdl/extract/Dockerfile
+++ b/scripts/variantstore/wdl/extract/Dockerfile
@@ -6,7 +6,6 @@ RUN pip install -r /app/requirements.txt
 RUN apt-get update && apt-get -y upgrade && apt-get -y install bcftools
 
 # Copy the application source code.
-COPY create_cohort_extract_data_table.py /app
 COPY create_variant_annotation_table.py /app
 COPY create_ranges_cohort_extract_data_table.py /app
 COPY extract_subpop.py /app

--- a/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
@@ -88,8 +88,8 @@ def get_all_sample_ids(fq_destination_table_samples):
 
 def create_extract_samples_table(fq_destination_table_samples, fq_sample_name_table, fq_sample_mapping_table):
   sql = f"CREATE OR REPLACE TABLE `{fq_destination_table_samples}` AS (" \
-        f"SELECT m.sample_id, m.sample_name, m.is_loaded FROM `{fq_sample_name_table}` s JOIN `{fq_sample_mapping_table}` m ON (s.sample_name = m.sample_name) " \
-        f"WHERE m.is_loaded is TRUE)"
+        f"SELECT m.sample_id, m.sample_name, m.is_loaded, m.withdrawn FROM `{fq_sample_name_table}` s JOIN `{fq_sample_mapping_table}` m ON (s.sample_name = m.sample_name) " \
+        f"WHERE m.is_loaded is TRUE AND m.withdrawn IS NULL)"
 
   results = utils.execute_with_retry(client, "create extract sample table", sql)
   return results

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SampleList.java
@@ -50,7 +50,7 @@ public class SampleList {
     }
 
     protected void initializeMaps(TableReference sampleTable, String executionProjectId, boolean printDebugInformation, Optional<String> originTool) {
-        TableResult queryResults = querySampleTable(sampleTable.getFQTableName(), "is_loaded is TRUE", executionProjectId, printDebugInformation, originTool);
+        TableResult queryResults = querySampleTable(sampleTable.getFQTableName(), "is_loaded is TRUE AND withdrawn is NULL", executionProjectId, printDebugInformation, originTool);
 
         // Add our samples to our map:
         for (final FieldValueList row : queryResults.iterateAll()) {

--- a/src/main/resources/org/broadinstitute/hellbender/tools/gvs/filtering/feature_extract.sql
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/gvs/filtering/feature_extract.sql
@@ -7,7 +7,7 @@ WITH
         FROM (
                SELECT location, sample_id, MAX(ref_ad) ref_ad
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
                @locationStanza
                GROUP BY 1,2 HAVING SUM(ad) > 1
         )
@@ -20,7 +20,7 @@ WITH
         FROM (
                SELECT DISTINCT location, sample_id, sb_ref_plus, sb_ref_minus
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
                @locationStanza
         )
         GROUP BY location),
@@ -33,7 +33,7 @@ WITH
         FROM (
                SELECT DISTINCT location, sample_id, qualapprox, call_GT
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
                @locationStanza
         )
         GROUP BY location),
@@ -42,13 +42,13 @@ WITH
                COUNT(DISTINCT ref || "," || allele) distinct_alleles,
                COUNTIF(length(ref) = length(allele)) num_snp_alleles
         FROM `@altAllele`
-        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE)
+        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
         @locationStanza
         GROUP BY location),
    hq_genotype_qc AS (
         SELECT location, COUNT(DISTINCT sample_id) hq_genotype_samples
         FROM `@altAllele`
-        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE)
+        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
         @locationStanza
         AND   call_GQ >= @hqGenotypeGQThreshold
         AND   (SELECT SUM(CAST(x AS INT64)) FROM UNNEST(SPLIT(call_AD,",")) x) >= @hqGenotypeDepthThreshold
@@ -100,7 +100,7 @@ WITH
            IFNULL(SUM(SB_ALT_MINUS),0) as SB_ALT_MINUS
     FROM `@altAllele` as aa
     WHERE allele != '*'
-    AND sample_id in (SELECT sample_id from `@sample` WHERE is_loaded is TRUE)
+    AND sample_id in (SELECT sample_id from `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
     @locationStanza
     GROUP BY 1,2,3
     ) ai

--- a/src/main/resources/org/broadinstitute/hellbender/tools/gvs/filtering/feature_extract.sql
+++ b/src/main/resources/org/broadinstitute/hellbender/tools/gvs/filtering/feature_extract.sql
@@ -7,7 +7,7 @@ WITH
         FROM (
                SELECT location, sample_id, MAX(ref_ad) ref_ad
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
                @locationStanza
                GROUP BY 1,2 HAVING SUM(ad) > 1
         )
@@ -20,7 +20,7 @@ WITH
         FROM (
                SELECT DISTINCT location, sample_id, sb_ref_plus, sb_ref_minus
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
                @locationStanza
         )
         GROUP BY location),
@@ -33,7 +33,7 @@ WITH
         FROM (
                SELECT DISTINCT location, sample_id, qualapprox, call_GT
                FROM `@altAllele`
-               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+               WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
                @locationStanza
         )
         GROUP BY location),
@@ -42,13 +42,13 @@ WITH
                COUNT(DISTINCT ref || "," || allele) distinct_alleles,
                COUNTIF(length(ref) = length(allele)) num_snp_alleles
         FROM `@altAllele`
-        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
         @locationStanza
         GROUP BY location),
    hq_genotype_qc AS (
         SELECT location, COUNT(DISTINCT sample_id) hq_genotype_samples
         FROM `@altAllele`
-        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+        WHERE sample_id IN (SELECT sample_id FROM `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
         @locationStanza
         AND   call_GQ >= @hqGenotypeGQThreshold
         AND   (SELECT SUM(CAST(x AS INT64)) FROM UNNEST(SPLIT(call_AD,",")) x) >= @hqGenotypeDepthThreshold
@@ -100,7 +100,7 @@ WITH
            IFNULL(SUM(SB_ALT_MINUS),0) as SB_ALT_MINUS
     FROM `@altAllele` as aa
     WHERE allele != '*'
-    AND sample_id in (SELECT sample_id from `@sample` WHERE is_loaded is TRUE AND withdrawn IS NOT NULL)
+    AND sample_id in (SELECT sample_id from `@sample` WHERE is_loaded is TRUE AND withdrawn IS NULL)
     @locationStanza
     GROUP BY 1,2,3
     ) ai


### PR DESCRIPTION
From https://docs.google.com/document/d/1YxYddVhQ-ZHEjRY9_XRTLCufDAUtq-MDZYpoO1ex0wA
- [ ] add `withdrawn` field (type: TIMESTAMP, nullable) to `sample_info` table
- [ ] add `is_control` field (type: BOOLEAN, required) to `sample_info` table
- [ ] add `samples_are_controls` boolean parameter to GvsAssignIds (false by default) which will populate that field for ingest
- [ ] GvsCreateFilterSet.wdl (and the associated code in GATK) will check for `withdrawn IS NULL`
- [ ] add `control_samples` boolean parameter to GvsPrepareRangesCallset.wdl (false by default)
- [ ] GvsPrepareRangesCallset.wdl (and the associated python script) will only add sample info to the cohort `__SAMPLES table` if `withdrawn IS NULL`
- [ ] add `control_samples` boolean parameter to GvsExtractCallset.wdl (false by default)


Closes
- https://broadworkbench.atlassian.net/browse/VS-70
- https://broadworkbench.atlassian.net/browse/VS-213