### PR TITLE
Allow interval lists that require the SA to see

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -115,6 +115,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rc-use-SA-for-Interval-List
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl


### PR DESCRIPTION
Currently, only a public interval list is allowed--this changes that and copies down the SA before the interval list is used

used here:
https://app.terra.bio/#workspaces/allofus-drc-wgs-dev/AoU_DRC_WGS_12-6-21_beta_ingest/job_history/f5ca0b70-1ae2-4e86-b4fc-3d7d19674347 

with interval list: 	gs://prod-drc-broad/beta-release-99k-v3/0000000000-scattered.interval_list