### PR TITLE
Mirror of Picard metrics documentation generation changes.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/InsertSizeMetrics.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.hellbender.metrics;
 
 import htsjdk.samtools.SamPairUtil.PairOrientation;
-import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.util.help.HelpConstants;
 
 import java.io.Serializable;
 
@@ -11,6 +12,7 @@ import java.io.Serializable;
  * ".insertSizeMetrics".  In addition the insert size distribution is plotted to
  * a file with the extension ".insertSizeMetrics.pdf".
  */
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public final class InsertSizeMetrics extends MultiLevelMetrics implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/broadinstitute/hellbender/metrics/QualityYieldMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/QualityYieldMetrics.java
@@ -1,13 +1,16 @@
 package org.broadinstitute.hellbender.metrics;
 
 import htsjdk.samtools.metrics.MetricBase;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import picard.util.help.HelpConstants;
 
 import java.io.Serializable;
 
 /** A set of metrics used to describe the general quality of a BAM file */
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public final class QualityYieldMetrics extends MetricBase implements Serializable {
     private static final long serialVersionUID = 1;
 

--- a/src/main/java/org/broadinstitute/hellbender/metrics/analysis/AlleleFrequencyQCMetric.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/analysis/AlleleFrequencyQCMetric.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.metrics.analysis;
 
 import htsjdk.samtools.metrics.MetricBase;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.util.help.HelpConstants;
 
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public class AlleleFrequencyQCMetric extends MetricBase {
 
     public String SAMPLE;

--- a/src/main/java/org/broadinstitute/hellbender/metrics/analysis/BaseDistributionByCycleMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/metrics/analysis/BaseDistributionByCycleMetrics.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.hellbender.metrics.analysis;
 
 import htsjdk.samtools.metrics.MetricBase;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.util.help.HelpConstants;
 
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public final class BaseDistributionByCycleMetrics extends MetricBase {
     public int READ_END;
     public int CYCLE;

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/loggers/PSFilterMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/loggers/PSFilterMetrics.java
@@ -1,10 +1,13 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq.loggers;
 
 import htsjdk.samtools.metrics.MetricBase;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.util.help.HelpConstants;
 
 /**
  * Metrics that are calculated during the PathSeq filter
  */
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public final class PSFilterMetrics extends MetricBase {
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/loggers/PSScoreMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pathseq/loggers/PSScoreMetrics.java
@@ -1,11 +1,14 @@
 package org.broadinstitute.hellbender.tools.spark.pathseq.loggers;
 
 import htsjdk.samtools.metrics.MetricBase;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.util.help.HelpConstants;
 
 /**
  * Metrics that are calculated during the PathSeq scoring
  */
 @SuppressWarnings("serial")
+@DocumentedFeature(groupName = HelpConstants.DOC_CAT_METRICS, summary = HelpConstants.DOC_CAT_METRICS_SUMMARY)
 public final class PSScoreMetrics extends MetricBase {
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -65,6 +65,7 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      * @param currentWorkUnit the work unit for the feature being documented
      */
     @Override
+    @SuppressWarnings("deprecation")
     protected void addCustomBindings(final DocWorkUnit currentWorkUnit) {
         super.addCustomBindings(currentWorkUnit);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -1,9 +1,16 @@
 package org.broadinstitute.hellbender.utils.help;
 
+import com.sun.javadoc.FieldDoc;
+import htsjdk.samtools.metrics.MetricBase;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
 import org.broadinstitute.barclay.help.DocWorkUnit;
 import org.broadinstitute.barclay.help.HelpDoclet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The GATK Documentation work unit handler class that is the companion to GATKHelpDoclet.
@@ -17,6 +24,12 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
     private final static String GATK_JAVADOC_TAG_PREFIX = "GATK"; // prefix for custom javadoc tags used by GATK
 
     private final static String GATK_FREEMARKER_TEMPLATE_NAME = "generic.template.html";
+    private final static String PICARD_METRICS_TEMPLATE_NAME = "metrics.template.html";
+
+    private final static String WORK_UNIT_SUMMARY_KEY = "summary";
+    private final static String METRICS_MAP_ENTRY_KEY = "metrics";
+    private final static String METRICS_MAP_NAME_KEY = "name";
+    private final static String METRICS_MAP_SUMMARY_KEY = "summary";
 
     public GATKHelpDocWorkUnitHandler(final HelpDoclet doclet) {
         super(doclet);
@@ -35,7 +48,14 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      * Javadoc.
      */
     @Override
-    public String getTemplateName(final DocWorkUnit workUnit) { return GATK_FREEMARKER_TEMPLATE_NAME; }
+    public String getTemplateName(final DocWorkUnit workUnit) {
+        Class<?> clazz = workUnit.getClazz();
+        if (MetricBase.class.isAssignableFrom(clazz)) {
+            return PICARD_METRICS_TEMPLATE_NAME;
+        } else {
+            return GATK_FREEMARKER_TEMPLATE_NAME;
+        }
+    }
 
 
     /**
@@ -54,6 +74,19 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
         if (picard.cmdline.CommandLineProgram.class.isAssignableFrom(toolClass)) {
             final CommandLineProgramProperties clpProperties = currentWorkUnit.getCommandLineProperties();
             currentWorkUnit.setProperty("picardsummary", clpProperties.summary());
+        } else if (MetricBase.class.isAssignableFrom(toolClass)) {
+            currentWorkUnit.setProperty(WORK_UNIT_SUMMARY_KEY, currentWorkUnit.getSummary());
+            final List<Map<String, String>> workUnitMetricsList = new ArrayList<>();
+            currentWorkUnit.setProperty(METRICS_MAP_ENTRY_KEY, workUnitMetricsList);
+            final FieldDoc[] fieldDocs = currentWorkUnit.getClassDoc().fields(false);
+            for (final FieldDoc fd : fieldDocs) {
+                if (fd.isPublic()) {
+                    final Map<String, String> metricsFields = new HashMap<>();
+                    metricsFields.put(METRICS_MAP_NAME_KEY, fd.name());
+                    metricsFields.put(METRICS_MAP_SUMMARY_KEY, fd.getRawCommentText());
+                    workUnitMetricsList.add(metricsFields);
+                }
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -47,7 +47,7 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
 
     /**
      * @param workUnit the classdoc object being processed
-     * @return the name of a the freemarker template to be used for the class being documented.
+     * @return the name of the freemarker template to be used for the class being documented.
      * Must reside in the folder passed to the Barclay Doclet via the "-settings-dir" parameter to
      * Javadoc.
      */

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -65,7 +65,7 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      * @param currentWorkUnit the work unit for the feature being documented
      */
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation","removal"})
     protected void addCustomBindings(final DocWorkUnit currentWorkUnit) {
         super.addCustomBindings(currentWorkUnit);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.utils.help;
 
-import com.sun.javadoc.FieldDoc;
 import htsjdk.samtools.metrics.MetricBase;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler;
@@ -79,8 +78,8 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
             currentWorkUnit.setProperty(WORK_UNIT_SUMMARY_KEY, currentWorkUnit.getSummary());
             final List<Map<String, String>> workUnitMetricsList = new ArrayList<>();
             currentWorkUnit.setProperty(METRICS_MAP_ENTRY_KEY, workUnitMetricsList);
-            final FieldDoc[] fieldDocs = currentWorkUnit.getClassDoc().fields(false);
-            for (final FieldDoc fd : fieldDocs) {
+            final com.sun.javadoc.FieldDoc[] fieldDocs = currentWorkUnit.getClassDoc().fields(false);
+            for (final com.sun.javadoc.FieldDoc fd : fieldDocs) {
                 if (fd.isPublic()) {
                     final Map<String, String> metricsFields = new HashMap<>();
                     metricsFields.put(METRICS_MAP_NAME_KEY, fd.name());

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDocWorkUnitHandler.java
@@ -69,7 +69,6 @@ public class GATKHelpDocWorkUnitHandler extends DefaultDocWorkUnitHandler {
      * @param currentWorkUnit the work unit for the feature being documented
      */
     @Override
-    @SuppressWarnings({"deprecation","removal"})
     protected void addCustomBindings(final DocWorkUnit currentWorkUnit) {
         super.addCustomBindings(currentWorkUnit);
 

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/metrics.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/metrics.template.html
@@ -1,0 +1,69 @@
+<?php
+
+    include '../../../common/include/common.php';
+    include_once '../../config.php';
+    $module = modules::GATK;
+    printHeader($module, $name, topSN::guide);
+?>
+
+<link type='text/css' rel='stylesheet' href='gatkDoc.css'>
+
+<div class='row-fluid' id="top">
+
+	<#include "common.html"/>
+
+	<?php $group = '${group}'; ?>
+
+	<section class="span4">
+		<aside class="well">
+			<a href="index.html"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+		</aside>
+		<aside class="well">
+			<h2>Categories</h2>
+			<@getCategories groups=groups />
+		</aside>
+		<?php getForumPosts( '${name}' ) ?>
+
+	</section>
+
+	<div class="span8">
+
+		<h1>${name}</h1>
+
+		<p class="lead">${summary}</p>
+
+		<#if group?? >
+			<h3>Category
+				<small> ${group}</small>
+			</h3>
+		</#if>
+		<hr>
+		<h2>Overview</h2>
+		${description}
+
+			<#-- Create the metrics summary -->
+			<#if metrics?size != 0>
+				<p>This table summarizes the values that are specific to this metric.</p>
+				<table class="table table-striped table-bordered table-condensed">
+					<thead>
+					<tr>
+						<th>Metric</th>
+						<th>Summary</th>
+					</tr>
+					</thead>
+					<#list metrics as metric>
+					<tr>
+						<td>${metric.name}<br />
+						<td>${metric.summary}</td>
+					</tr>
+					</#list>
+					</tbody>
+				</table>
+			</#if>
+
+			<@footerInfo />
+			<@footerClose />
+
+	</div>
+
+	<?php printFooter($module); ?>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/metrics.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/metrics.template.html
@@ -18,10 +18,6 @@
 		<aside class="well">
 			<a href="index.html"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
 		</aside>
-		<aside class="well">
-			<h2>Categories</h2>
-			<@getCategories groups=groups />
-		</aside>
 		<?php getForumPosts( '${name}' ) ?>
 
 	</section>


### PR DESCRIPTION
Reflect the changes from https://github.com/broadinstitute/picard/pull/1782 in the GATK doc build.

Note that this requires a new version of Picard that is not yet released. Also, I suppressed deprecation warnings caused by the use of obsolete Java 8 javadoc classes (FieldDoc) for now, since it causes the Java 11 build to fail.

A new metrics category shows up in the doc now, with all of the Picard and GATK metrics:

<img width="1252" alt="Screen Shot 2022-10-18 at 4 42 37 PM" src="https://user-images.githubusercontent.com/10062863/196540823-a6108b75-c9e7-44c0-a4ba-1d8f927fe5b6.png">
