### PR TITLE
Annotate downsampled VCs in HC active regions with `DS` flag

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegion.java
@@ -71,6 +71,11 @@ public final class AssemblyRegion implements Locatable {
     private boolean hasBeenFinalized;
 
     /**
+     * Indicates whether reads in the region have been downsampled
+     */
+    private boolean hasBeenDownsampled;
+
+    /**
      * Create a new AssemblyRegion containing no reads
      *  @param activeSpan the span of this active region
      * @param isActive indicates whether this is an active region, or an inactive one
@@ -356,5 +361,9 @@ public final class AssemblyRegion implements Locatable {
     public boolean isFinalized() {
         return hasBeenFinalized;
     }
+
+    public void setWasDownsampled(final boolean value) { hasBeenDownsampled = value; }
+
+    public boolean wasDownsampled() { return hasBeenDownsampled; }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AssemblyRegionWalker.java
@@ -196,6 +196,7 @@ public abstract class AssemblyRegionWalker extends WalkerBase {
 
             logger.debug("Processing assembly region at " + assemblyRegion.getSpan() + " isActive: " + assemblyRegion.isActive() + " numReads: " + assemblyRegion.getReads().size());
             writeAssemblyRegion(assemblyRegion);
+            if (shard.wasDownsampled()) { assemblyRegion.setWasDownsampled(true); }
 
             apply(assemblyRegion,
                     new ReferenceContext(reference, assemblyRegion.getPaddedSpan()),

--- a/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/MultiIntervalLocalReadShard.java
@@ -111,6 +111,10 @@ public final class MultiIntervalLocalReadShard implements MultiIntervalShard<GAT
         this.downsampler = downsampler;
     }
 
+    public boolean wasDownsampled() {
+        return downsampler.getNumberOfDiscardedItems() > 0;
+    }
+
     /**
      * Reads in this shard will be transformed after filtering and before downsampling
      *

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DownsampledFlag.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/DownsampledFlag.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.hellbender.tools.walkers.annotator;
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
+
+import java.util.*;
+
+public class DownsampledFlag extends InfoFieldAnnotation implements StandardHCAnnotation {
+    /**
+     * Computes the annotation for the given variant and the likelihoods per read.
+     * Returns a map from annotation keys to values (may be empty if no annotation is to be added).
+     *
+     * @param ref         Reference context, may be null
+     * @param vc          Variant to be annotated. Not null.
+     * @param likelihoods likelihoods indexed by sample, allele, and read within sample
+     */
+    @Override
+    public Map<String, Object> annotate(ReferenceContext ref, VariantContext vc, AlleleLikelihoods<GATKRead, Allele> likelihoods) {
+        if (likelihoods.getCoverageDownsamplingHistory()) {
+            return Collections.singletonMap(getKeyNames().get(0), null);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Return the keys
+     */
+    @Override
+    public List<String> getKeyNames() {
+        return Arrays.asList(GATKVCFConstants.DOWNSAMPLED_KEY);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -673,6 +673,9 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         // Calculate the likelihoods: CPU intensive part.
         final AlleleLikelihoods<GATKRead, Haplotype> readLikelihoods =
                 likelihoodCalculationEngine.computeReadLikelihoods(assemblyResult, samplesList, reads);
+        if (region.wasDownsampled()) {
+            readLikelihoods.setCoverageDownsamplingTrue();
+        }
 
         // Realign reads to their best haplotype.
         final SWParameters readToHaplotypeSWParameters = hcArgs.getReadToHaplotypeSWParameters();

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
@@ -38,6 +38,8 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
     private boolean isNaturalLog = false;
     private SimpleInterval subsettedGenomicLoc;
 
+    private boolean wasCoverageDownsampled = false;
+
     public boolean isNaturalLog() {
         return isNaturalLog;
     }
@@ -366,6 +368,10 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
             removeEvidence(s, evidenceToRemove);
         }
     }
+
+    public void setCoverageDownsamplingTrue() { wasCoverageDownsampled = true; }
+
+    public boolean getCoverageDownsamplingHistory() { return wasCoverageDownsampled; }
 
     /**
      * Adjusts likelihoods so that for each unit of evidence, the best allele likelihood is 0 and caps the minimum likelihood
@@ -706,6 +712,7 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
                 filteredEvidenceBySampleIndex,
                 newLikelihoodValues);
         result.isNaturalLog = isNaturalLog;
+        result.wasCoverageDownsampled = wasCoverageDownsampled;
         return result;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -1556,6 +1556,34 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
         Assert.assertTrue(has28BaseDeletion);
     }
 
+    @Test
+    public void testDownsamplingAnnotation() {
+        final File outputFromDownsampledReads = createTempFile("downsampledCalls", ".vcf");
+        final String bam = largeFileTestDir + "downsamplingInput.bam";
+        final String reference = hg38Reference;
+        final String intervalString = "chr4:49105537";
+        final String additionalArg = "-ip 300";
+
+        // Run both with and without --max-alternate-alleles over our interval, so that we can
+        // prove that the argument is working as intended.
+        final String[] argsForDownsampling = {
+                "-I", bam,
+                "-R", reference,
+                "-L", intervalString,
+                "-O", outputFromDownsampledReads.getAbsolutePath(),
+                "-ip", "300"
+        };
+        runCommandLine(argsForDownsampling);
+
+        //this is only 19 VCs so we can read it all into memory
+        final List<VariantContext> downsampledCalls = VariantContextTestUtils.readEntireVCFIntoMemory(outputFromDownsampledReads.getAbsolutePath()).getRight();
+        for (final VariantContext vc : downsampledCalls) {
+            Assert.assertTrue(vc.hasAttribute(GATKVCFConstants.DOWNSAMPLED_KEY));
+        }
+
+
+    }
+
     /**
      * Helper method for testMaxAlternateAlleles
      *

--- a/src/test/resources/large/downsamplingInput.bai
+++ b/src/test/resources/large/downsamplingInput.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b1b5a164d19c2f0c7acd0b4f15b8f91090aceaee329fe45560a0f28b0a61c1
+size 50992

--- a/src/test/resources/large/downsamplingInput.bam
+++ b/src/test/resources/large/downsamplingInput.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48944f8df740d216157ba417b860597662b1c433b17007ec06e97a2c41a92e8
+size 4265036


### PR DESCRIPTION
I found this useful to debug some results that varied under different test conditions (different processors or something like that).  It could be useful for debugging in the future.