### PR TITLE
Prevent close from hiding causal exceptions #528

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -1088,8 +1088,11 @@ public abstract class GATKTool extends CommandLineProgram {
     public Object onTraversalSuccess() { return null; }
 
     @Override
+    @SuppressWarnings("try")
     protected final Object doWork() {
-        try {
+        //this makes use of try-with-resource exception suppression to ensure that onShutdown()
+        //doesn't hide casual exceptions thrown during onStartup() or doWork()
+        try(final AutoCloseableNoCheckedExceptions thisTool = this::closeTool){
             onTraversalStart();
             progressMeter.start();
             traverse();
@@ -1097,8 +1100,6 @@ public abstract class GATKTool extends CommandLineProgram {
                 progressMeter.stop();
             }
             return onTraversalSuccess();
-        } finally {
-            closeTool();
         }
     }
 


### PR DESCRIPTION
* Exceptions thrown by a tool can be hidden by unsafe close methods throwing additional exceptions.
  Avoid this by making use of try-with-resources suppressed exception handling in order to surface the
  primary exception as well as the secondary ones.

* Fixes #528