### PR TITLE
Deterministic Sample ID assignments [VS-371]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -65,6 +65,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_371_assignids_deterministic
    - name: GvsAoUReblockGvcf
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsAoUReblockGvcf.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -65,7 +65,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_371_assignids_deterministic
    - name: GvsAoUReblockGvcf
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsAoUReblockGvcf.wdl

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -129,11 +129,11 @@ task AssignIds {
     NAMES_FILE=~{write_lines(sample_names)}
 
     # first load name into the lock table - will check for dupes when adding to sample_info table
-    bq load --project_id=~{project_id} ~{dataset_name}.sample_id_assignment_lock "${NAMES_FILE}" "sample_name:STRING"
+    bq load --project_id=~{project_id} ~{dataset_name}.sample_id_assignment_lock $NAMES_FILE "sample_name:STRING"
 
     # add sample_name to sample_info_table
     bq --project_id=~{project_id} query --use_legacy_sql=false \
-      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) select sample_name, ~{samples_are_controls} from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`) order by m.sample_name'
+      'INSERT into `~{dataset_name}.~{sample_info_table}` (sample_name, is_control) select sample_name, ~{samples_are_controls} from `~{dataset_name}.sample_id_assignment_lock` m where m.sample_name not in (SELECT sample_name FROM `~{dataset_name}.~{sample_info_table}`)'
 
     # get the current maximum id, or 0 if there are none
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false 'SELECT IFNULL(MAX(sample_id),0) FROM `~{dataset_name}.~{sample_info_table}`' > maxid
@@ -141,7 +141,7 @@ task AssignIds {
 
     # perform actual id assignment
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false --parameter=offset:INTEGER:$offset \
-      'UPDATE `~{dataset_name}.~{sample_info_table}` m SET m.sample_id = id_assign.id FROM (SELECT sample_name, @offset + ROW_NUMBER() OVER() as id FROM `~{dataset_name}.~{sample_info_table}` WHERE sample_id IS NULL) id_assign WHERE m.sample_name = id_assign.sample_name;'
+      'UPDATE `~{dataset_name}.~{sample_info_table}` m SET m.sample_id = id_assign.id FROM (SELECT sample_name, @offset + ROW_NUMBER() OVER(order by sample_name) as id FROM `~{dataset_name}.~{sample_info_table}` WHERE sample_id IS NULL) id_assign WHERE m.sample_name = id_assign.sample_name;'
 
     # retrieve the list of assigned ids and samples to update the datamodel
     echo "entity:sample_id,gvs_id" > update.tsv

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -128,25 +128,33 @@ task AssignIds {
 
     NAMES_FILE=~{write_lines(sample_names)}
 
-    # In a bash shell in the us.gcr.io/broad-gatk/gatk:4.1.7.0 Docker image
+    # Make a file with a large number of lines of random 32-character strings to test sorting speed in the
+    # us.gcr.io/broad-gatk/gatk:4.1.7.0 Docker image.
     #
-    # Make a file with 200K lines of random 32-character strings to test sorting speed.
+    # Steps in the line generation process:
+    # * Time the command that follows.
+    # * Take input from the /dev/urandom device, an infinite stream of random bytes.
+    # * Delete any bytes that are not alphanumeric characters.
+    # * Take 1000000 * 32 of these random alphanumeric characters.
+    # * Break this giant string into 32 character chunks, yielding 1 million lines.
     #
     # root@eb0d1b5fa72b:/gatk# \
-    #   time                      `# Time the command that follows.` \
-    #   < /dev/urandom            `# Take input from the /dev/urandom device, a source of infinite random bytes.` \
-    #   tr -dc "[:alnum:]"        `# Delete any bytes that do not correspond to alphanumeric characters.` | \
-    #   head -c $((200000 * 32))  `# Take 200000 * 32 of these random alphanumeric characters.` | \
-    #   fold -w 32 > out          `# Break this giant string into 32 character chunks, yielding 200K lines.`
+    #   time \
+    #   < /dev/urandom \
+    #   tr -dc "[:alnum:]" | \
+    #   head -c $((1000000 * 32)) | \
+    #   fold -w 32 > out
     #
-    # real	0m0.460s
-    # user	0m0.117s
-    # sys	0m0.457s
+    # real	0m1.126s
+    # user	0m0.545s
+    # sys	0m1.002s
+    #
+    # Sorting is a lot more straightforward.
     # root@eb0d1b5fa72b:/gatk# time sort out > out.sorted
     #
-    # real	0m0.166s
-    # user	0m0.068s
-    # sys	0m0.124s
+    # real	0m0.564s
+    # user	0m0.718s
+    # sys	0m0.390s
     # root@eb0d1b5fa72b:/gatk#
 
     # Sort sample names for reproducibility.

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -130,7 +130,14 @@ task AssignIds {
 
     # In a bash shell in the us.gcr.io/broad-gatk/gatk:4.1.7.0 Docker image
     #
-    # root@eb0d1b5fa72b:/gatk# time < /dev/urandom tr -dc "[:alnum:]" | head -c $((200000 * 32)) | fold -w 32 > out
+    # Make a file with 200K lines of random 32-character strings to test sorting speed.
+    #
+    # root@eb0d1b5fa72b:/gatk# \
+    #   time                      `# Time the command that follows.` \
+    #   < /dev/urandom            `# Take input from the /dev/urandom device, a source of infinite random bytes.` \
+    #   tr -dc "[:alnum:]"        `# Delete any bytes that do not correspond to alphanumeric characters.` | \
+    #   head -c $((200000 * 32))  `# Take 200000 * 32 of these random alphanumeric characters.` | \
+    #   fold -w 32 > out          `# Break this giant string into 32 character chunks, yielding 200K lines.`
     #
     # real	0m0.460s
     # user	0m0.117s

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -128,8 +128,26 @@ task AssignIds {
 
     NAMES_FILE=~{write_lines(sample_names)}
 
+    # In a bash shell in the us.gcr.io/broad-gatk/gatk:4.1.7.0 Docker image
+    #
+    # root@eb0d1b5fa72b:/gatk# time < /dev/urandom tr -dc "[:alnum:]" | head -c $((200000 * 32)) | fold -w 32 > out
+    #
+    # real	0m0.460s
+    # user	0m0.117s
+    # sys	0m0.457s
+    # root@eb0d1b5fa72b:/gatk# time sort out > out.sorted
+    #
+    # real	0m0.166s
+    # user	0m0.068s
+    # sys	0m0.124s
+    # root@eb0d1b5fa72b:/gatk#
+
+    # Sort sample names for reproducibility.
+    SORTED_NAMES_FILE="${NAMES_FILE}.sorted"
+    sort "${NAMES_FILE}" > "${SORTED_NAMES_FILE}"
+
     # first load name into the lock table - will check for dupes when adding to sample_info table
-    bq load --project_id=~{project_id} ~{dataset_name}.sample_id_assignment_lock $NAMES_FILE "sample_name:STRING"
+    bq load --project_id=~{project_id} ~{dataset_name}.sample_id_assignment_lock "${SORTED_NAMES_FILE}" "sample_name:STRING"
 
     # add sample_name to sample_info_table
     bq --project_id=~{project_id} query --use_legacy_sql=false \


### PR DESCRIPTION
The syntax is a little 🙁 but this does appear to work. Sample ids should now be assigned according to the sort order of the names of the samples being uploaded in this invocation of `GvsAssignIds` (existing sample ids should not be affected).

Before:

<img width="837" alt="Screen Shot 2022-04-11 at 1 28 32 PM" src="https://user-images.githubusercontent.com/10790523/162798648-8a9c6904-bea4-4800-b40c-66f8a5f096d0.png">

After:

<img width="909" alt="Screen Shot 2022-04-11 at 1 29 07 PM" src="https://user-images.githubusercontent.com/10790523/162798669-8344418d-89fd-49e1-a4d5-5e00d1c752ea.png">

