### PR TITLE
Add log4j.properties back to gatk jar

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -125,6 +125,17 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - kc_wdl_gatk_override
+         - gg_VS-360_QuietLog4J
+   - name: GvsPrepareCallset
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl
+     testParameterFiles:
+       - /scripts/variantstore/wdl/GvsPrepareCallset.example.inputs.json
+     filters:
+       branches:
+         - master
+         - ah_var_store
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ final bigQueryVersion = System.getProperty('bigQuery.version', '2.5.1')
 final bigQueryStorageVersion = System.getProperty('bigQueryStorage.version', '2.7.0')
 
 final guavaVersion = System.getProperty('guava.version', '27.1-jre')
-final log4j2Version = System.getProperty('log4j2Version', '2.17.0')
+final log4j2Version = System.getProperty('log4j2Version', '2.17.1')
 final testNGVersion = '7.0.0'
 
 // Using the shaded version to avoid conflicts between its protobuf dependency
@@ -450,7 +450,6 @@ tasks.withType(ShadowJar) {
     mergeServiceFiles()
     relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
     zip64 true
-    exclude 'log4j.properties' // from adam jar as it clashes with hellbender's log4j2.xml
     exclude '**/*.SF' // these are Manifest signature files and
     exclude '**/*.RSA' // keys which may accidentally be imported from other signed projects and then fail at runtime
 

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -158,7 +158,7 @@ task AssignIds {
     bq --project_id=~{project_id} rm -f -t ~{dataset_name}.sample_id_assignment_lock
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.7.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.6.0"
     memory: "3.75 GB"
     disks: "local-disk " + 10 + " HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -14,7 +14,7 @@ workflow GvsImportGenomes {
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     Int? load_data_preemptible_override
     Int? load_data_maxretries_override
-    File? load_data_gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/ah_var_store_20220415/gatk-package-4.2.0.0-492-g1387d47-SNAPSHOT-local.jar"
+    File? load_data_gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/gg_UpdateBuidDotGradle_20220426/gatk-package-4.2.0.0-504-g14b1fb3-SNAPSHOT-local.jar"
     String? service_account_json_path
   }
 
@@ -279,7 +279,7 @@ task LoadData {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.7.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.6.0"
     maxRetries: select_first([load_data_maxretries_override, 3])
     memory: "3.75 GB"
     disks: "local-disk 50 HDD"

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -73,7 +73,7 @@ task WithdrawSamples {
 
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.2.5.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.6.0"
     memory: "3.75 GB"
     disks: "local-disk 10 HDD"
     cpu: 1


### PR DESCRIPTION
To remove warning about unfound logger.
Also updated latest version in gatk
Updated to latest version of gatk in wdls.
