### PR TITLE
Remove an old "temp table" dataset

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -117,7 +117,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rc-vs-225-add-AD
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -128,15 +127,6 @@ workflows:
          - master
          - ah_var_store
          - kc_wdl_gatk_override
-   - name: GvsPrepareCallset
-     subclass: WDL
-     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareCallset.wdl
-     testParameterFiles:
-       - /scripts/variantstore/wdl/GvsPrepareCallset.example.inputs.json
-     filters:
-       branches:
-         - master
-         - ah_var_store
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -146,7 +136,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rc-vs-225-add-AD
+         - rc-vs-227-no-temp
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -13,7 +13,7 @@ workflow GvsPrepareCallset {
     String query_project = project_id
     String destination_project = project_id
     String destination_dataset = dataset_name
-    String fq_temp_table_dataset = "~{destination_project}.~{destination_dataset}"
+    String fq_temp_table_dataset = "~{destination_project}.~{destination_dataset}" # This only gets used if we have a file of sample names
 
     Array[String]? query_labels
     File? sample_names_to_extract

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -13,7 +13,7 @@ workflow GvsPrepareCallset {
     String query_project = project_id
     String destination_project = project_id
     String destination_dataset = dataset_name
-    String fq_temp_table_dataset = "~{destination_project}.temp_tables"
+    String fq_temp_table_dataset = "~{destination_project}.~{destination_dataset}"
 
     Array[String]? query_labels
     File? sample_names_to_extract


### PR DESCRIPTION
We haven't stumbled on this recently because it's only used in the case where we provide a file of sample names to extract

But it shouldn't exist, so I'm cleaning it up

I also cleaned up some of dockstore while here!