### PR TITLE
Add flag to (optionally) zero pad the vcf filename.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -117,6 +117,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-373_ZeroPadVcfNames
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -65,6 +65,7 @@ task SplitIntervals {
     File ref_dict
     Int scatter_count
     File? interval_weights_bed
+    String? intervals_file_extension
     String? split_intervals_extra_args
     Int? split_intervals_disk_size_override
     Int? split_intervals_mem_override
@@ -114,6 +115,7 @@ task SplitIntervals {
       ~{"--weight-bed-file " + interval_weights_bed} \
       -scatter ~{scatter_count} \
       -O interval-files \
+      ~{"--extension " + intervals_file_extension} \
       --interval-file-num-digits 10 \
       ~{split_intervals_extra_args}
     cp interval-files/*.interval_list .

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/WeightedSplitIntervals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/WeightedSplitIntervals.java
@@ -96,7 +96,7 @@ public class WeightedSplitIntervals extends GATKTool {
         }
         final float targetWeightPerScatter = totalWeight / (float) scatterCount;
 
-        logger.info("Total Weight:"+totalWeight + " scatterCount: " + scatterCount + " target:" + targetWeightPerScatter);
+        logger.info("Total Weight: " + totalWeight + " scatterCount: " + scatterCount + " target: " + targetWeightPerScatter);
 
         final int maxNumberOfPlaces = Math.max((int)Math.floor(Math.log10(scatterCount-1))+1, numDigits);
         final String formatString = "%0" + maxNumberOfPlaces + "d";


### PR DESCRIPTION
This PR changes GvsExtractCallset to optionally pad the output VCFs with a leading zero. They are named in a similar fashion to the (also optionally renamed) interval list shards.

If the input `zero_pad_output_vcf_filenames` is set to **true** (the default) the VCFs and interval files will be named as such:
- 0000000000-gg_filterset.vcf.gz
- 0000000000-gg_filterset.vcf.gz.tbi
- 0000000000-gg_filterset.vcf.gz.interval_list
- 0000000001-gg_filterset.vcf.gz
- 0000000001-gg_filterset.vcf.gz.tbi
- 0000000001-gg_filterset.vcf.gz.interval_list
- ...

An example workflow is [here](https://app.terra.bio/#workspaces/warp-pipelines/ggrant%20-%20GVS%20Quickstart%20V2%20copy/job_history/3d3fc1e4-7f83-40d7-8f8c-115d4a4de158)

If the input `zero_pad_output_vcf_filenames` is set to **false**, the workflow will name things as it has in the past:
- gg_filterset_0.vcf.gz
- gg_filterset_0.vcf.gz.tbi
- 0000000000-scattered.interval_list
- gg_filterset_1.vcf.gz
- gg_filterset_1.vcf.gz.tbi
- 0000000001-scattered.interval_list
- ...

An example workflow is [here](https://app.terra.bio/#workspaces/warp-pipelines/ggrant%20-%20GVS%20Quickstart%20V2%20copy/job_history/27bd9b06-4400-4db1-89b4-4bdb5856aaff)