### PR TITLE
317 remove excess header values in VCF extract

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -117,6 +117,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rc-vs-317-remove-excess-headers
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -15,7 +15,7 @@ workflow GvsExtractCallset {
 
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     File interval_weights_bed = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"
-    File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rc-add-AD-04112022/gatk-package-4.2.0.0-498-g1f53709-SNAPSHOT-local.jar"
+    File gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/rc-update-headers-04142022/gatk-package-4.2.0.0-497-gda8a97a-SNAPSHOT-local.jar"
 
     String output_file_base_name = filter_set_name
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -211,7 +211,6 @@ public class ExtractCohort extends ExtractTool {
 
         // Filter fields
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
-        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NAY_FROM_YNG));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_HET_KEY));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NO_HQ_GENOTYPES));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -213,15 +213,13 @@ public class ExtractCohort extends ExtractTool {
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.LOW_QUAL_FILTER_NAME));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NAY_FROM_YNG));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_HET_KEY));
-        headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.EXCESS_ALLELES));
         headerLines.add(GATKVCFHeaderLines.getFilterLine(GATKVCFConstants.NO_HQ_GENOTYPES));
 
         // Info fields
         VCFStandardHeaderLines.addStandardInfoLines( headerLines, true,
                 VCFConstants.ALLELE_COUNT_KEY,
                 VCFConstants.ALLELE_FREQUENCY_KEY,
-                VCFConstants.ALLELE_NUMBER_KEY,
-                VCFConstants.END_KEY
+                VCFConstants.ALLELE_NUMBER_KEY
         );
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_RAW_QUAL_APPROX_KEY));
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.RAW_QUAL_APPROX_KEY));
@@ -231,7 +229,6 @@ public class ExtractCohort extends ExtractTool {
                 VCFConstants.GENOTYPE_QUALITY_KEY
         );
         headerLines.add(GATKVCFHeaderLines.getFormatLine(GATKVCFConstants.REFERENCE_GENOTYPE_QUALITY));
-        headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.EXCESS_HET_KEY));
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_VQS_LOD_KEY));
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_YNG_STATUS_KEY));
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6863459/163501604-73d5fe47-f5e3-4e9a-966b-37f99857d4e7.png)

After:
![image](https://user-images.githubusercontent.com/6863459/163501590-8770d4a2-b23c-45c3-867a-d8356023e39c.png)
