### PR TITLE
Pinned typing_extensions python package to 4.1.1 to fix conda environment.

### DIFF
--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -41,6 +41,7 @@ dependencies:
 - conda-forge::scikit-learn=0.23.1
 - conda-forge::matplotlib=3.2.1
 - conda-forge::pandas=1.0.3
+- conda-forge::typing_extensions=4.1.1
 
 # core R dependencies; these should only be used for plotting and do not take precedence over core python dependencies!
 - r-base=3.6.2


### PR DESCRIPTION
@lbergelson @jamesemery I'm on vacation, but saw #7800 and #7801 go by in the gatk4-github Slack channel. Just curious to see if this will work on Travis and/or Github Actions---can you take it from here, if needed?

I've confirmed that this branch works locally in my Ubuntu environment and that `import gcnvkernel` and `import sklearn` both work in the resulting environment (whereas these imports failed in master, although the environment built successfully---this seems to mirror what is happening on test infrastructure in #7800).

In contrast, the approach in #7801 doesn't seem to work for me locally, and we've seen that including conda build strings is a bit restrictive. See e.g. https://github.com/broadinstitute/gatk/pull/5026#issuecomment-628860774. 