### PR TITLE
Fix surprisingly harmless typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get --assume-yes install git-lfs
 RUN git lfs install --force
 
 #Download only resources required for the build, not for testing
-RUN git lfs pull -include src/main/resources/large
+RUN git lfs pull --include src/main/resources/large
 
 RUN export GRADLE_OPTS="-Xmx4048m -Dorg.gradle.daemon=false" && /gatk/gradlew clean collectBundleIntoDir shadowTestClassJar shadowTestJar -Drelease=$RELEASE
 RUN cp -r $( find /gatk/build -name "*bundle-files-collected" )/ /gatk/unzippedJar/


### PR DESCRIPTION
There's a dash missing in what should be the `--include` argument to a `git lfs pull` invocation in the Dockerfile that appears to have the net effect of `git lfs pull` doing nothing at all. This adds back the dash so the command does what it was intended to do, but I was a bit surprised the build doesn't seem to care if the `git lfs pull` actually pulls anything or not. 🤔 

Before:

<img width="798" alt="Screen Shot 2022-04-25 at 11 15 58 AM" src="https://user-images.githubusercontent.com/10790523/165120146-3877196c-1927-4930-a25b-c2733bccb500.png">
