### PR TITLE
Disabling the red 'X' generated by failing codecov deltas

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,15 +12,18 @@ coverage:
         target: auto
         threshold: null
         branches: null
+        informational: true
 
     patch:
       default:
         target: auto
         branches: null
+        informational: true
 
     changes:
       default:
         branches: null
+        informational: true
 
 
 comment:


### PR DESCRIPTION
Turns out we disabled codecov 3 years ago for a reason. We can leave it on for informational purposes with this patch. 