### PR TITLE
Disable the red "X" from failing codeCov builds and delay the posting of coverage information to complete test.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,15 +12,18 @@ coverage:
         target: auto
         threshold: null
         branches: null
+        informational: true
 
     patch:
       default:
         target: auto
         branches: null
+        informational: true
 
     changes:
       default:
         branches: null
+        informational: true
 
 
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,4 +30,4 @@ comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"
   branches: null
   behavior: default
-  after_n_builds: 8
+  after_n_builds: 8 # Wait until all 8 of the test suite jacoco test builds have been uploaded before writing a comment to the pr (no more incomplete coverage report emails)

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,3 +30,4 @@ comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"
   branches: null
   behavior: default
+  after_n_builds: 8


### PR DESCRIPTION
Repost of #7815 to test the "after_n_builds" functionality