### PR TITLE
JCenter as a backstop for retrieving biz.k11i:xgboost-predictor:0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ repositories {
     }
 
     mavenLocal()
+    
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ task downloadGsaLibFile(type: Download) {
 repositories {
     mavenCentral()
 
+    jcenter()
     maven {
         url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for htsjdk snapshots
     }
@@ -370,7 +371,7 @@ dependencies {
 
     // Required for COSMIC Funcotator data source:
     implementation 'org.xerial:sqlite-jdbc:3.20.1'
-    
+
     // Required for SV Discovery machine learning
     implementation group: 'biz.k11i', name: 'xgboost-predictor', version: '0.3.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ task downloadGsaLibFile(type: Download) {
 repositories {
     mavenCentral()
 
-    jcenter()
     maven {
         url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for htsjdk snapshots
     }
@@ -58,6 +57,7 @@ repositories {
     }
 
     mavenLocal()
+    jcenter()
 }
 
 final htsjdkVersion = System.getProperty('htsjdk.version','2.24.1-1-gf0c975a-SNAPSHOT')


### PR DESCRIPTION
Without JCenter the retrieval of this artifact is failing like:

```
#16 21.85 A problem occurred evaluating root project 'gatk'.
#16 21.85 > Could not resolve all files for configuration ':runtimeClasspath'.
#16 21.85    > Could not find biz.k11i:xgboost-predictor:0.3.0.
#16 21.85      Searched in the following locations:
#16 21.85        - https://repo.maven.apache.org/maven2/biz/k11i/xgboost-predictor/0.3.0/xgboost-predictor-0.3.0.pom
#16 21.85        - https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/biz/k11i/xgboost-predictor/0.3.0/xgboost-predictor-0.3.0.pom
#16 21.85        - https://oss.sonatype.org/content/repositories/snapshots/biz/k11i/xgboost-predictor/0.3.0/xgboost-predictor-0.3.0.pom
#16 21.85        - file:/root/.m2/repository/biz/k11i/xgboost-predictor/0.3.0/xgboost-predictor-0.3.0.pom
#16 21.85      Required by:
#16 21.85          project :
```