### PR TITLE
CreateVariantIngestFiles handles partially or fully loaded samples [VS-262] [VS-258]

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
@@ -26,6 +26,7 @@ import org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Ingest variant walker
@@ -290,8 +291,13 @@ public final class CreateVariantIngestFiles extends VariantWalker {
 
     @Override
     public Object onTraversalSuccess() {
+        int mod = new Random().nextInt(10);
+
         if (outputType == CommonCode.OutputType.BQ && shouldWriteLoadStatusStarted) {
             loadStatus.writeLoadStatusStarted(Long.parseLong(sampleId));
+            if (mod == 0) {
+                throw new GATKException("VS-262 Robustitude exception for sample id " + sampleId + " after sample load status started");
+            }
         }
 
         if (enableReferenceRanges && refCreator != null) {
@@ -302,10 +308,16 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             }
             // Wait until all data has been submitted and in pending state to commit
             refCreator.commitData();
+            if (mod == 1) {
+                throw new GATKException("VS-262 Robustitude exception for sample id " + sampleId + " after ref range write");
+            }
         }
 
         if (enableVet && vetCreator != null) {
             vetCreator.commitData();
+            if (mod == 2) {
+                throw new GATKException("VS-262 Robustitude exception for sample id " + sampleId + " after vet write");
+            }
         }
 
         // upload the load status table

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
@@ -69,7 +69,6 @@ public class LoadStatus {
             } else if (LoadStatusValues.FINISHED.toString().equals(status)) {
                 finishedCount++;
             }
-
         }
 
         // if fully loaded, exit successfully!

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.GenomeLocSortedSet;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +38,10 @@ public final class RefCreator {
     private static final String PREFIX_SEPARATOR = "_";
     private final static String REF_RANGES_FILETYPE_PREFIX = "ref_ranges_";
 
+    public static boolean doRowsExistFor(CommonCode.OutputType outputType, String projectId, String datasetName, String tableNumber, String sampleId) {
+        if (outputType != CommonCode.OutputType.BQ) return false;
+        return BigQueryUtils.doRowsExistFor(projectId, datasetName, REF_RANGES_FILETYPE_PREFIX + tableNumber, sampleId);
+    }
 
     public RefCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumber, SAMSequenceDictionary seqDictionary, GQStateEnum gqStateToIgnore, final boolean dropAboveGqThreshold, final File outputDirectory, final CommonCode.OutputType outputType, final boolean writeReferenceRanges, final String projectId, final String datasetName) {
         this.sampleId = sampleId;

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.gvs.common.CommonCode;
 import org.broadinstitute.hellbender.tools.gvs.common.IngestConstants;
 import org.broadinstitute.hellbender.tools.gvs.common.SchemaUtils;
+import org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils;
 import org.broadinstitute.hellbender.utils.bigquery.PendingBQWriter;
 import org.broadinstitute.hellbender.utils.tsv.SimpleXSVWriter;
 import org.json.JSONObject;
@@ -27,13 +28,19 @@ public class VetCreator {
     private PendingBQWriter vetBQJsonWriter = null;
     private final boolean forceLoadingFromNonAlleleSpecific;
 
+    private static final String VET_FILETYPE_PREFIX = "vet_";
+
+    public static boolean doRowsExistFor(CommonCode.OutputType outputType, String projectId, String datasetName, String tableNumber, String sampleId) {
+        if (outputType != CommonCode.OutputType.BQ) return false;
+        return BigQueryUtils.doRowsExistFor(projectId, datasetName, VET_FILETYPE_PREFIX + tableNumber, sampleId);
+    }
+
     public VetCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumber, final File outputDirectory, final CommonCode.OutputType outputType, final String projectId, final String datasetName, final boolean forceLoadingFromNonAlleleSpecific) {
         this.sampleId = sampleId;
         this.outputType = outputType;
         this.forceLoadingFromNonAlleleSpecific = forceLoadingFromNonAlleleSpecific;
 
         try {
-            String VET_FILETYPE_PREFIX = "vet_";
             String PREFIX_SEPARATOR = "_";
             switch (outputType) {
                 case BQ:


### PR DESCRIPTION
Makes `CreateVariantIngestFiles` robust to partially or fully loaded samples.

Commit a8dc5ea89653a7f94588aa040b49d0264d17f72d is what I actually propose to merge, while commit 118a44604343e8f77d53bcc6545b2360fefbe1cc randomly injects failures covering all the known failure modes. I tested these changes using both commits and was able to verify that partially loaded samples were handled correctly on subsequent attempts to load the sample (unfortunately we can't actually prevent these partial loadings from happening in the first place because preemptions, among other possible reasons). 