### PR TITLE
Ingest Error Handling Fixes [VS-261]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -203,6 +203,14 @@ workflows:
          - master
          - ah_var_store
          - vs_357_quickstart_integration
+   - name: GvsIngestTieout
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl
+     filters:
+       branches:
+         - master
+         - ah_var_store
+         - vs_261_ingest_errors
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -83,6 +83,7 @@ workflow GvsImportGenomes {
 
   output {
     Boolean done = true
+    Array[File] load_data_stderrs = LoadData.stderr
   }
 }
 
@@ -288,6 +289,7 @@ task LoadData {
   }
   output {
     Boolean done = true
+    File stderr = stderr()
   }
 }
 

--- a/scripts/variantstore/wdl/GvsIngestTieout.wdl
+++ b/scripts/variantstore/wdl/GvsIngestTieout.wdl
@@ -1,0 +1,151 @@
+version 1.0
+
+import "GvsAssignIds.wdl" as GvsAssignIds
+import "GvsImportGenomes.wdl" as GvsImportGenomes
+import "GvsUtils.wdl" as GvsUtils
+
+workflow GvsIngestTieout {
+    input {
+        String project
+        String reference_dataset_name
+        String branch_name
+        Array[String] sample_names
+        Array[File] input_vcfs
+        Array[File] input_vcf_indexes
+        String? service_account_json_path
+    }
+
+    call GvsUtils.BuildGATKJarAndCreateDataset {
+        input:
+            branch_name = branch_name,
+            dataset_prefix = "ingest_tieout"
+    }
+
+    call GvsAssignIds.GvsAssignIds  {
+        input:
+            project_id = project,
+            dataset_name = BuildGATKJarAndCreateDataset.dataset_name,
+            external_sample_names = sample_names,
+            assign_ids_gatk_override = BuildGATKJarAndCreateDataset.jar,
+            service_account_json_path = service_account_json_path
+    }
+
+    call GvsImportGenomes.GvsImportGenomes {
+        input:
+            go = GvsAssignIds.done,
+            dataset_name = BuildGATKJarAndCreateDataset.dataset_name,
+            project_id = project,
+            external_sample_names = sample_names,
+            input_vcfs = input_vcfs,
+            input_vcf_indexes = input_vcf_indexes,
+            load_data_gatk_override = BuildGATKJarAndCreateDataset.jar,
+            service_account_json_path = service_account_json_path
+    }
+
+    call IngestTieout {
+        input:
+            dataset_name = BuildGATKJarAndCreateDataset.dataset_name,
+            reference_dataset_name = reference_dataset_name,
+            project = project,
+            stderrs = GvsImportGenomes.load_data_stderrs
+    }
+}
+
+
+task IngestTieout {
+    input {
+        Boolean? go
+        String dataset_name
+        String reference_dataset_name
+        String project
+        Array[File] stderrs
+    }
+
+    parameter_meta {
+        stderrs: {
+            localization_optional: true
+        }
+    }
+
+    command <<<
+        set -o xtrace
+        fail=0
+
+        check_table() {
+            local table_name=$1
+
+            bq query --location=US --project_id=~{project} --format=csv --use_legacy_sql=false \
+                "select actual.sample_id, expected.sample_id from
+                (select sample_id, count(*) as count from \`spec-ops-aou.~{dataset_name}.${table_name}\` group by sample_id) actual full outer join
+                (select sample_id, count(*) as count from \`spec-ops-aou.~{reference_dataset_name}.${table_name}\` group by sample_id) expected on actual.sample_id = expected.sample_id
+                where actual.count != expected.count OR actual.sample_id is null OR expected.sample_id is null" > differences.txt
+
+            if [[ -s differences.txt ]]; then
+                fail=1
+                echo "${table_name} row counts are mismatched for the following samples:"
+                cat differences.txt
+            fi
+        }
+
+        # This task is currently being called with a sample set of 2000 so it only needs to check a single vet and
+        # ref_ranges table each. If this code were to be called with a sample set of more than 4000 it should test all
+        # the additional vet and ref_ranges tables that would be introduced.
+        if [[ ~{length(stderrs)} -gt 4000 ]]; then
+            echo "IngestTieout invoked with a sample set of size ~{length(stderrs)} but is currently limited to sample sets no larger than 4000."
+            exit 1
+        fi
+
+        check_table "ref_ranges_001"
+        check_table "vet_001"
+
+        mkdir logs
+        cd logs
+
+        # Get everything up to and including the /call-LoadData/ part of the GCS path.
+        gcs_prefix=$(echo ~{stderrs[0]} | sed -E 's!(.*/call-LoadData/).*!\1!')
+
+        # Recursively copy everything under this path.
+        gsutil -m cp -r ${gcs_prefix} .
+
+        # Find the stderr files in the call execution directories but not the ones in the pipelines-logs directories.
+        find call-LoadData -name pipelines-logs -prune -o -name stderr -print > stderr_fofn.txt
+        echo "Found $(wc -l stderr_fofn.txt | awk '{print $1}') stderr files in call directories"
+
+        cat stderr_fofn.txt | xargs grep StatusRuntimeException | tee exceptions.txt
+        if [[ $? -ne 0 ]]; then
+            fail=1
+            echo "Did not find any StatusRuntimeExceptions among the stderr files!"
+        else
+            grep UNAVAILABLE exceptions.txt
+            if [[ $? -ne 0 ]]; then
+                fail=1
+                echo "No UNAVAILABLE StatusRuntimeExceptions found for run!"
+            fi
+            grep -E 'ABORTED|INTERNAL|CANCELLED' exceptions.txt
+            if [[ $? -ne 0 ]]; then
+                fail=1
+                echo "No retryable StatusRuntimeExceptions (ABORTED, INTERNAL, CANCELLED) found for run!"
+            fi
+        fi
+
+        cd ..
+
+        if [[ $fail -ne 0 ]]; then
+            exit 1;
+        fi
+    >>>
+
+    output {
+        File stderr_fofn = "logs/stderr_fofn.txt"
+        File exceptions = "logs/exceptions.txt"
+        Boolean done = true
+    }
+
+    runtime {
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        memory: "14 GB"
+        disks: "local-disk 2000 HDD"
+        preemptible: 3
+        cpu: 4
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
@@ -16,7 +16,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
-import static org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils.handleCausalStatusRuntimeException;
+import static org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils.extractCausalStatusRuntimeExceptionOrThrow;
 
 public class LoadStatus {
     static final Logger logger = LogManager.getLogger(org.broadinstitute.hellbender.tools.gvs.ingest.LoadStatus.class);
@@ -120,7 +120,7 @@ public class LoadStatus {
                 break;
             } catch (Exception e) {
                 @SuppressWarnings("ThrowableNotThrown")
-                StatusRuntimeException se = handleCausalStatusRuntimeException(e);
+                StatusRuntimeException se = extractCausalStatusRuntimeExceptionOrThrow(e);
 
                 if (retryCount >= maxRetries) {
                     throw new GATKException("Caught exception writing to BigQuery and " + maxRetries + " write retries are exhausted", e);

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/BigQueryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/BigQueryUtils.java
@@ -463,7 +463,7 @@ public final class BigQueryUtils {
                 projectID, datasetName, tableName, sampleId));
     }
 
-    private static StatusRuntimeException handleCausalStatusRuntimeException(Throwable original, Throwable current) {
+    private static StatusRuntimeException extractCausalStatusRuntimeExceptionOrThrow(Throwable original, Throwable current) {
         if (current == null) {
             throw new GATKException("No causal StatusRuntimeException found", original);
         }
@@ -477,10 +477,19 @@ public final class BigQueryUtils {
             }
             return (StatusRuntimeException) current;
         }
-        return handleCausalStatusRuntimeException(original, current.getCause());
+        return extractCausalStatusRuntimeExceptionOrThrow(original, current.getCause());
     }
 
-    public static StatusRuntimeException handleCausalStatusRuntimeException(Throwable t) throws GATKException {
-        return handleCausalStatusRuntimeException(t, t);
+    /**
+     * Extracts the `StatusRuntimeException` most closely nested in arbitrarily many layers of exceptions of other
+     * types.
+     *
+     * @param t The `Throwable` whose nested `getCause()`s will be searched for a `StatusRuntimeException`.
+     * @return a `StatusRuntimeException` with a non-null `getStatus().getCode()`.
+     * @throws GATKException If there is no nested `StatusRuntimeException` of there is a nested
+     * `StatusRuntimeException` but either `getStatus()` or `getStatus().getCode()` returns null.
+     */
+    public static StatusRuntimeException extractCausalStatusRuntimeExceptionOrThrow(Throwable t) throws GATKException {
+        return extractCausalStatusRuntimeExceptionOrThrow(t, t);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.bigquery;
 
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.bigquery.storage.v1beta2.*;
 import com.google.protobuf.Descriptors;
@@ -7,47 +8,47 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils.handleCausalStatusRuntimeException;
+
+
 public class CommittedBQWriter implements AutoCloseable {
     static final Logger logger = LogManager.getLogger(CommittedBQWriter.class);
-
     protected BigQueryWriteClient bqWriteClient;
     protected WriteStream writeStream;
     protected JsonStreamWriter writer;
     protected TableName parentTable;
-    protected int MAX_RETRIES = 3;
-    protected WriteStream.Type steamType;
-    protected int BATCH_SIZE = 10000;
+    protected int maxRetries = 3;
+    protected WriteStream.Type streamType;
+    protected int batchSize = 10000;
     protected JSONArray jsonArr = new JSONArray();
 
-
-    public void setMaxRetries(int maxRetries) {
-        MAX_RETRIES = maxRetries;
-    }
-
-    public void setBatchSize(int batchSize) {
-        BATCH_SIZE = batchSize;
-    }
-
-    public CommittedBQWriter(String projectId, String datasetName, String tableName) {
-        this(projectId, datasetName, tableName, WriteStream.Type.COMMITTED);
-    }
+    private final ExponentialBackOff backoff = new ExponentialBackOff.Builder().
+            setInitialIntervalMillis(2000).
+            setMaxIntervalMillis(30000).
+            // The default value is 900000 millis or 900 seconds or 15 minutes which is not long enough given how this
+            // backoff is being used. The retry in this code is limited by number of attempts and not total time.
+            setMaxElapsedTimeMillis(Integer.MAX_VALUE).
+            setMultiplier(2).
+            setRandomizationFactor(0.5).
+            build();
 
     protected CommittedBQWriter(String projectId, String datasetName, String tableName, WriteStream.Type type) {
         this.parentTable = TableName.of(projectId, datasetName, tableName);
-        this.steamType = type;
+        this.streamType = type;
     }
 
     protected void createStream() throws Descriptors.DescriptorValidationException, InterruptedException, IOException {
         if (bqWriteClient == null) {
             bqWriteClient = BigQueryWriteClient.create();
         }
-        WriteStream writeStreamConfig = WriteStream.newBuilder().setType(steamType).build();
+        WriteStream writeStreamConfig = WriteStream.newBuilder().setType(streamType).build();
         CreateWriteStreamRequest createWriteStreamRequest =
                 CreateWriteStreamRequest.newBuilder()
                         .setParent(parentTable.toString())
@@ -57,44 +58,82 @@ public class CommittedBQWriter implements AutoCloseable {
         writer = JsonStreamWriter.newBuilder(writeStream.getName(), writeStream.getTableSchema()).build();
     }
 
-    public AppendRowsResponse addJsonRow(JSONObject row) throws Descriptors.DescriptorValidationException, ExecutionException, InterruptedException, IOException {
-        AppendRowsResponse response = null;
+    public void addJsonRow(JSONObject row) throws Descriptors.DescriptorValidationException, ExecutionException, InterruptedException, IOException {
         if (writer == null) {
             createStream();
         }
         jsonArr.put(row);
 
-        if (jsonArr.length() >= BATCH_SIZE) {
-            response = writeJsonArray();
+        if (jsonArr.length() >= batchSize) {
+            writeJsonArray();
         }
-        return response;
     }
 
-    protected AppendRowsResponse writeJsonArray() throws Descriptors.DescriptorValidationException, ExecutionException, InterruptedException, IOException {
-        return writeJsonArray(0);
+    protected void writeJsonArray() throws ExecutionException, InterruptedException, IOException {
+        writeJsonArray(0);
     }
 
-    protected AppendRowsResponse writeJsonArray(int retryCount) throws Descriptors.DescriptorValidationException, ExecutionException, InterruptedException, IOException {
-        AppendRowsResponse response = null;
+    protected void writeJsonArray(int retryCount) throws ExecutionException, InterruptedException, IOException {
         try {
             ApiFuture<AppendRowsResponse> future = writer.append(jsonArr);
-            response = future.get();
+            future.get();
             jsonArr = new JSONArray();
-        } catch (StatusRuntimeException ex) {
-            Status status = ex.getStatus();
-            if (status == Status.ABORTED || status == Status.INTERNAL || status == Status.CANCELLED) {
-                logger.warn("Caught exception " + ex + "\n Retrying. " + (MAX_RETRIES - retryCount - 1) + " retries remaining.");
-            }
-            if (retryCount < MAX_RETRIES) {
-                createStream();
-                response = writeJsonArray(retryCount + 1);
-            } else {
-                throw ex;
+        } catch (Exception e) {
+            StatusRuntimeException se = handleCausalStatusRuntimeException(e);
+            // Google BigQuery write API error handling
+            // https://cloud.google.com/bigquery/docs/write-api#error_handling
+            // The comments in the case matching below are nearly all quotations from the documentation linked above.
+            Status.Code code = se.getStatus().getCode();
+            switch (code) {
+                case ALREADY_EXISTS:
+                    // ALREADY_EXISTS: The row was already written. This error can happen when you provide stream offsets.
+                    // It indicates that a duplicate record was detected. You can safely ignore this error.
+
+                    // We don't expect to see this, but to "ignore" we should not retry sending the same `jsonArr`.
+                    jsonArr = new JSONArray();
+                    return;
+                case INVALID_ARGUMENT:
+                case NOT_FOUND:
+                case OUT_OF_RANGE:
+                case PERMISSION_DENIED:
+                    // Do not retry these:
+                    //
+                    // INVALID_ARGUMENT: Invalid argument. This error is an application error.
+                    //
+                    // NOT_FOUND: The stream or table was not found.
+                    //
+                    // OUT_OF_RANGE. The offset is beyond the current write offset. This error can happen if you provide
+                    // stream offsets and a previous write operation failed. In that case, you can retry from the last
+                    // successful write. This error can also happen if the application sets the wrong offset value.
+                    //
+                    // PERMISSION_DENIED. The application does not have permission to write to this table.
+                    throw e;
+                default:
+                    switch (code) {
+                        case INTERNAL:
+                        case CANCELLED:
+                        case ABORTED:
+                            // INTERNAL, CANCELLED, or ABORTED: The operation could not be completed. You can safely retry the operation.
+                            if (retryCount >= maxRetries) {
+                                throw new GATKException("Caught exception writing to BigQuery and " + maxRetries + " write retries are exhausted", e);
+                            }
+                            logger.warn("Caught exception writing to BigQuery, " + (maxRetries - retryCount - 1) + " retries remaining.", e);
+                            long backOffMillis = backoff.nextBackOffMillis();
+                            Thread.sleep(backOffMillis);
+                            break;
+                        default:
+                            // If you receive an error that's not listed above, then try to open a new connection by closing the
+                            // writer object and creating a new instance.
+                            //
+                            // In practice with a PENDING WriteStream.Type the advice above does not work out;
+                            // everything that has been `append`ed prior to the writer being closed is lost. Instead,
+                            // just throw and let `maxRetries` start up a subsequent attempt from the beginning.
+                            throw e;
+                    }
+                    writeJsonArray(retryCount + 1);
             }
         }
-    return response;
     }
-
 
     public void close() {
         if (writer != null) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils.handleCausalStatusRuntimeException;
+import static org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils.extractCausalStatusRuntimeExceptionOrThrow;
 
 
 public class CommittedBQWriter implements AutoCloseable {
@@ -79,7 +79,7 @@ public class CommittedBQWriter implements AutoCloseable {
             future.get();
             jsonArr = new JSONArray();
         } catch (Exception e) {
-            StatusRuntimeException se = handleCausalStatusRuntimeException(e);
+            StatusRuntimeException se = extractCausalStatusRuntimeExceptionOrThrow(e);
             // Google BigQuery write API error handling
             // https://cloud.google.com/bigquery/docs/write-api#error_handling
             // The comments in the case matching below are nearly all quotations from the documentation linked above.


### PR DESCRIPTION
The main issue was that the `StatusRuntimeException`s that the baseline error handling code was trying to catch in practice always seem to be wrapped in at least one layer of exception of a different type. There was no catch handing for these wrapper exception types so the `CreateVariantIngestFiles` tool would simply crash.

~The changes here also more generally try to follow the recommendations in the [BQ Write API documentation](https://cloud.google.com/bigquery/docs/write-api#error_handling), in particular `close`ing the `JsonStreamWriter` before retrying error codes not explicitly called out by the documentation.~

EDIT: actually closing the writer didn't work out too well as we use the writer in `PENDING` mode and closing it seems to lose all pending writes. 😬  So in this circumstance we just throw and let WDL-level `maxRetries` start the data loading over from the beginning.

An exponential backoff was also added before retry attempts.

Parallel logic was also added to load status writing which should reduce (but not eliminate) the possibility of inconsistent sample status writes that require manual intervention. There is still the possibility of an inopportunely timed preemption, which is why VS-262 exists.

All of the WDL changes here are in support of a 2000-sample tieout, a large enough set that intermittent BigQuery errors are almost always observed. The tieout confirms that errors of the two major classes are seen (retryable and non-retryable) and that the number of rows per sample in the tieout dataset matches those in a reference dataset.