### PR TITLE
CreateVariantIngestFiles robust to partially / fully loaded samples [VS-262]

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/LoadStatus.java
@@ -69,7 +69,6 @@ public class LoadStatus {
             } else if (LoadStatusValues.FINISHED.toString().equals(status)) {
                 finishedCount++;
             }
-
         }
 
         // if fully loaded, exit successfully!

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
@@ -13,10 +13,10 @@ import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.GenomeLocSortedSet;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +37,10 @@ public final class RefCreator {
     private static final String PREFIX_SEPARATOR = "_";
     private final static String REF_RANGES_FILETYPE_PREFIX = "ref_ranges_";
 
+    public static boolean doRowsExistFor(CommonCode.OutputType outputType, String projectId, String datasetName, String tableNumber, String sampleId) {
+        if (outputType != CommonCode.OutputType.BQ) return false;
+        return BigQueryUtils.doRowsExistFor(projectId, datasetName, REF_RANGES_FILETYPE_PREFIX + tableNumber, sampleId);
+    }
 
     public RefCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumber, SAMSequenceDictionary seqDictionary, GQStateEnum gqStateToIgnore, final boolean dropAboveGqThreshold, final File outputDirectory, final CommonCode.OutputType outputType, final boolean writeReferenceRanges, final String projectId, final String datasetName) {
         this.sampleId = sampleId;
@@ -152,49 +156,6 @@ public final class RefCreator {
         final GenomeLoc possiblyMergedGenomeLoc = coverageLocSortedSet.getGenomeLocParser().createGenomeLoc(variantInterval.getContig(), intervalStart, intervalEnd);
         coverageLocSortedSet.add(possiblyMergedGenomeLoc, true);
         previousInterval = new SimpleInterval(possiblyMergedGenomeLoc);
-    }
-
-    public List<List<String>> createRows(final long start, final long end, final VariantContext variant, final String sampleId) {
-
-        List<List<String>> rows = new ArrayList<>();
-
-        // if the variant is no call, set the "state" to GQ ZERO
-        if (CreateVariantIngestFiles.isNoCall(variant)) {
-            List<String> row = new ArrayList<>();
-            row.add(String.valueOf(start));
-            row.add(sampleId);
-            row.add(GQStateEnum.ZERO.getValue());
-            rows.add(row);
-        } else if (!variant.isReferenceBlock()) {
-            List<String> row = new ArrayList<>();
-            row.add(String.valueOf(start));
-            row.add(sampleId);
-            row.add(GQStateEnum.VARIANT.getValue());
-            rows.add(row);
-
-            //if variant is variant and has additional positions--must be a deletion: add `*` state
-            for (long i = start + 1 ; i <= end; i++){
-                row = new ArrayList<>();
-                row.add(String.valueOf(i));
-                row.add(sampleId);
-                row.add(GQStateEnum.STAR.getValue());
-                rows.add(row);
-            }
-        } else {
-            // TODO check in the tool to make sure it's only one sample
-            GQStateEnum state = getGQStateEnum(variant.getGenotype(0).getGQ());
-
-            for (long position = start; position <= end; position++){ // break up ref blocks
-                List<String> row = new ArrayList<>();
-
-                row.add(String.valueOf(position));
-                row.add(sampleId);
-                row.add(state.getValue());
-                rows.add(row);
-            }
-        }
-
-        return rows;
     }
 
     public void writeMissingPositions(long start, long end) throws IOException {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.gvs.common.CommonCode;
 import org.broadinstitute.hellbender.tools.gvs.common.IngestConstants;
 import org.broadinstitute.hellbender.tools.gvs.common.SchemaUtils;
+import org.broadinstitute.hellbender.utils.bigquery.BigQueryUtils;
 import org.broadinstitute.hellbender.utils.bigquery.PendingBQWriter;
 import org.broadinstitute.hellbender.utils.tsv.SimpleXSVWriter;
 import org.json.JSONObject;
@@ -27,13 +28,19 @@ public class VetCreator {
     private PendingBQWriter vetBQJsonWriter = null;
     private final boolean forceLoadingFromNonAlleleSpecific;
 
+    private static final String VET_FILETYPE_PREFIX = "vet_";
+
+    public static boolean doRowsExistFor(CommonCode.OutputType outputType, String projectId, String datasetName, String tableNumber, String sampleId) {
+        if (outputType != CommonCode.OutputType.BQ) return false;
+        return BigQueryUtils.doRowsExistFor(projectId, datasetName, VET_FILETYPE_PREFIX + tableNumber, sampleId);
+    }
+
     public VetCreator(String sampleIdentifierForOutputFileName, String sampleId, String tableNumber, final File outputDirectory, final CommonCode.OutputType outputType, final String projectId, final String datasetName, final boolean forceLoadingFromNonAlleleSpecific) {
         this.sampleId = sampleId;
         this.outputType = outputType;
         this.forceLoadingFromNonAlleleSpecific = forceLoadingFromNonAlleleSpecific;
 
         try {
-            String VET_FILETYPE_PREFIX = "vet_";
             String PREFIX_SEPARATOR = "_";
             switch (outputType) {
                 case BQ:


### PR DESCRIPTION
Makes CreateVariantIngestFiles robust to partially or fully loaded samples.

Commit 21828af8f5a925cc331dce6093c0d510042d7b64 is what I actually propose to merge, while commit de673204183a4c45059dc9ea4e05868e2ea6ae59 randomly injects failures covering all the known failure modes. I tested these changes using both commits and was able to verify that partially loaded samples were handled correctly on subsequent attempts to load the sample (unfortunately we can't actually prevent these partial loadings from happening in the first place because preemptions, among other possible reasons).