### PR TITLE
Fixed a rare non-determinism in the AdaptiveChainPruner

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/AdaptiveChainPruner.java
@@ -78,7 +78,8 @@ public class AdaptiveChainPruner<V extends BaseVertex, E extends BaseEdge> exten
         // Note that chains can we added twice to the queue, once for each side
         final PriorityQueue<Pair<Path<V,E>, Double>> chainsToAdd = new PriorityQueue<>(
                 Comparator.comparingDouble((Pair<Path<V,E>, Double> p) -> -p.getRight())
-                .thenComparing((Pair<Path<V,E>, Double> p) -> p.getLeft().getFirstVertex().getSequence(), BaseUtils.BASES_COMPARATOR));
+                        .thenComparing((Pair<Path<V,E>, Double> p) -> p.getLeft().getFirstVertex().getSequence(), BaseUtils.BASES_COMPARATOR)
+                        .thenComparing((Pair<Path<V,E>, Double> p) -> p.getLeft().getBases(), BaseUtils.BASES_COMPARATOR)); // Handle rare edge case for non-determinism where two chains with equivalent score start on the same vertex
 
         // seed the subgraph of good chains by starting with some definitely-good chains.  These include the max-weight chain
         // and chains emanating from vertices with two incoming or two outgoing chains (plus one outgoing or incoming for a total of 3 or more) with good log odds


### PR DESCRIPTION
It turns out the java PriorityQueue implementation is is undefined in its behavior when elements are equal. It turns out it was possible for there to be non-deterministic behavior for chains that had identical scores and the same starting vertex (but different paths in the graph. I think this comparator should be airtight now. @davidbenjamin let me know what you think. 