### PR TITLE
Ingest 10K [VS-344]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -124,6 +124,7 @@ workflows:
          - master
          - ah_var_store
          - rc-vs-418-allow-withdrawn
+         - vs_344_ingest_10k
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -14,7 +14,7 @@ workflow GvsImportGenomes {
     Array[File] input_vcf_indexes
 
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
-    # If increasing this also consider increasing `load_data_preemptible_override` and `load_data_maxretries_override`.
+    # If increasing this, also consider increasing `load_data_preemptible_override` and `load_data_maxretries_override`.
     Int load_data_batch_size = 5
     Int? load_data_preemptible_override
     Int? load_data_maxretries_override

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -18,6 +18,7 @@ workflow GvsImportGenomes {
     Int? load_data_maxretries_override
     File? load_data_gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/ah_var_store_20220415/gatk-package-4.2.0.0-492-g1387d47-SNAPSHOT-local.jar"
     String? service_account_json_path
+    Int cromwell_parallelism = 2000
   }
 
   # return an error if the lengths are not equal
@@ -49,9 +50,11 @@ workflow GvsImportGenomes {
       service_account_json_path = service_account_json_path
   }
 
+  Int batch_size = if (len(external_sample_names) / cromwell_parallelism < 1) then 1 else len(external_sample_names) / cromwell_parallelism
+
   call CreateFOFNs {
     input:
-      batch_size = 1,
+      batch_size = batch_size,
       input_vcf_index_list = write_lines(input_vcf_indexes),
       input_vcf_list = write_lines(input_vcfs),
       sample_name_list = write_lines(external_sample_names),

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -50,7 +50,7 @@ workflow GvsImportGenomes {
       service_account_json_path = service_account_json_path
   }
 
-  Int batch_size = if (len(external_sample_names) / cromwell_parallelism < 1) then 1 else len(external_sample_names) / cromwell_parallelism
+  Int batch_size = if (length(external_sample_names) / cromwell_parallelism < 1) then 1 else length(external_sample_names) / cromwell_parallelism
 
   call CreateFOFNs {
     input:

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -14,11 +14,12 @@ workflow GvsImportGenomes {
     Array[File] input_vcf_indexes
 
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
+    # If increasing this also consider increasing `load_data_preemptible_override` and `load_data_maxretries_override`.
+    Int load_data_batch_size = 5
     Int? load_data_preemptible_override
     Int? load_data_maxretries_override
     File? load_data_gatk_override = "gs://broad-dsp-spec-ops/scratch/bigquery-jointcalling/jars/ah_var_store_20220415/gatk-package-4.2.0.0-492-g1387d47-SNAPSHOT-local.jar"
     String? service_account_json_path
-    Int cromwell_parallelism = 2000
   }
 
   # return an error if the lengths are not equal
@@ -50,11 +51,9 @@ workflow GvsImportGenomes {
       service_account_json_path = service_account_json_path
   }
 
-  Int batch_size = if (length(external_sample_names) / cromwell_parallelism < 1) then 1 else length(external_sample_names) / cromwell_parallelism
-
   call CreateFOFNs {
     input:
-      batch_size = batch_size,
+      batch_size = load_data_batch_size,
       input_vcf_index_list = write_lines(input_vcf_indexes),
       input_vcf_list = write_lines(input_vcfs),
       sample_name_list = write_lines(external_sample_names),

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -26,7 +26,7 @@ workflow GvsUnified {
         File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
 
         # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
-        # BigQuery errors. So if increasing the batch size then preemptible and maxretries should also be increased.
+        # BigQuery errors. So if increasing the batch size, then preemptible and maxretries should also be increased.
         Int load_data_batch_size = 5
         Int? load_data_preemptible_override
         Int? load_data_maxretries_override

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -27,6 +27,7 @@ workflow GvsUnified {
 
         Int? load_data_preemptible_override
         Int? load_data_maxretries_override
+        Int cromwell_parallelism = 2000
         # End GvsImportGenomes
 
         # Begin GvsCreateFilterSet
@@ -90,7 +91,8 @@ workflow GvsUnified {
             load_data_preemptible_override = load_data_preemptible_override,
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_gatk_override = gatk_override,
-            service_account_json_path = service_account_json_path
+            service_account_json_path = service_account_json_path,
+            cromwell_parallelism = cromwell_parallelism
     }
 
     call CreateAltAllele.GvsCreateAltAllele {

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -94,7 +94,7 @@ workflow GvsUnified {
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_gatk_override = gatk_override,
             service_account_json_path = service_account_json_path,
-            import_batch_size = load_data_batch_size
+            load_data_batch_size = load_data_batch_size
     }
 
     call CreateAltAllele.GvsCreateAltAllele {

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -25,9 +25,11 @@ workflow GvsUnified {
         Array[File] input_vcf_indexes
         File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
 
+        # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
+        # BigQuery errors. So if increasing the batch size then preemptible and maxretries should also be increased.
+        Int load_data_batch_size = 5
         Int? load_data_preemptible_override
         Int? load_data_maxretries_override
-        Int cromwell_parallelism = 2000
         # End GvsImportGenomes
 
         # Begin GvsCreateFilterSet
@@ -92,7 +94,7 @@ workflow GvsUnified {
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_gatk_override = gatk_override,
             service_account_json_path = service_account_json_path,
-            cromwell_parallelism = cromwell_parallelism
+            import_batch_size = load_data_batch_size
     }
 
     call CreateAltAllele.GvsCreateAltAllele {

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -128,6 +128,7 @@ public class CommittedBQWriter implements AutoCloseable {
                             // In practice with a PENDING WriteStream.Type the advice above does not work out;
                             // everything that has been `append`ed prior to the writer being closed is lost. Instead,
                             // just throw and let `maxRetries` start up a subsequent attempt from the beginning.
+                            logger.warn("Caught StatusRuntimeException with status code {}, throwing", code);
                             throw e;
                     }
                     writeJsonArray(retryCount + 1);

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -119,7 +119,10 @@ public class CommittedBQWriter implements AutoCloseable {
                             }
                             logger.warn("Caught exception writing to BigQuery, " + (maxRetries - retryCount - 1) + " retries remaining.", e);
                             long backOffMillis = backoff.nextBackOffMillis();
+                            logger.warn("Sleeping for {} milliseconds before retrying.", backOffMillis);
                             Thread.sleep(backOffMillis);
+
+                            writeJsonArray(retryCount + 1);
                             break;
                         default:
                             // If you receive an error that's not listed above, then try to open a new connection by closing the
@@ -131,7 +134,6 @@ public class CommittedBQWriter implements AutoCloseable {
                             logger.warn("Caught StatusRuntimeException with status code {}, throwing", code);
                             throw e;
                     }
-                    writeJsonArray(retryCount + 1);
             }
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -69,11 +69,11 @@ public class CommittedBQWriter implements AutoCloseable {
         }
     }
 
-    protected void writeJsonArray() throws ExecutionException, InterruptedException, IOException {
+    protected void writeJsonArray() throws InterruptedException, IOException {
         writeJsonArray(0);
     }
 
-    protected void writeJsonArray(int retryCount) throws ExecutionException, InterruptedException, IOException {
+    protected void writeJsonArray(int retryCount) throws InterruptedException, IOException {
         try {
             ApiFuture<AppendRowsResponse> future = writer.append(jsonArr);
             future.get();

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -122,7 +122,6 @@ public class CommittedBQWriter implements AutoCloseable {
                             logger.warn("Sleeping for {} milliseconds before retrying.", backOffMillis);
                             Thread.sleep(backOffMillis);
 
-                            writeJsonArray(retryCount + 1);
                             break;
                         default:
                             // If you receive an error that's not listed above, then try to open a new connection by closing the
@@ -133,6 +132,7 @@ public class CommittedBQWriter implements AutoCloseable {
                             // just throw and let `maxRetries` start up a subsequent attempt from the beginning.
                             throw new GATKException("Caught StatusRuntimeException with status code "  + code + " which is not known to be retryable, throwing", e);
                     }
+                    writeJsonArray(retryCount + 1);
             }
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/bigquery/CommittedBQWriter.java
@@ -107,7 +107,7 @@ public class CommittedBQWriter implements AutoCloseable {
                     // successful write. This error can also happen if the application sets the wrong offset value.
                     //
                     // PERMISSION_DENIED. The application does not have permission to write to this table.
-                    throw e;
+                    throw new GATKException("Caught StatusRuntimeException with unretryable status code " + code + ", throwing", e);
                 default:
                     switch (code) {
                         case INTERNAL:
@@ -131,8 +131,7 @@ public class CommittedBQWriter implements AutoCloseable {
                             // In practice with a PENDING WriteStream.Type the advice above does not work out;
                             // everything that has been `append`ed prior to the writer being closed is lost. Instead,
                             // just throw and let `maxRetries` start up a subsequent attempt from the beginning.
-                            logger.warn("Caught StatusRuntimeException with status code {}, throwing", code);
-                            throw e;
+                            throw new GATKException("Caught StatusRuntimeException with status code "  + code + " which is not known to be retryable, throwing", e);
                     }
             }
         }


### PR DESCRIPTION
Setting a default batch size of 5 since that seemed to work out well in the two Stroke Anderson runs, overridable at the workflow level. Also cleaned up some logging and wrapping exceptions before throwing to avoid confusing stack traces when scanning through logs.