### PR TITLE
baf fixes

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/BafEvidence.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/BafEvidence.java
@@ -20,8 +20,6 @@ public final class BafEvidence implements SVFeature {
         Utils.nonNull(sample);
         Utils.nonNull(contig);
         Utils.validateArg(position > 0, "starting position must be positive");
-        Utils.validateArg(value >= 0. || value == MISSING_VALUE,
-                "value must be non-negative or missing");
         this.sample = sample;
         this.contig = contig;
         this.position = position;

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/LocusDepthtoBAFUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/LocusDepthtoBAFUnitTest.java
@@ -13,12 +13,12 @@ public class LocusDepthtoBAFUnitTest {
         final int altIndex = 1;
         final String smpl = "s";
         // too shallow
-        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 4, 4, 0, 0), refIndex, altIndex), BafEvidence.MISSING_VALUE);
+        Assert.assertNull(instance.calcBAF(new LocusDepth(tig, pos, smpl, 4, 4, 0, 0), refIndex, altIndex));
         // just deep enough
-        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 5, 5, 0, 0), refIndex, altIndex), .5);
+        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 5, 5, 0, 0), refIndex, altIndex).getValue(), .5);
         // too unequal
-        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 7, 3, 0, 0), refIndex, altIndex), BafEvidence.MISSING_VALUE);
+        Assert.assertNull(instance.calcBAF(new LocusDepth(tig, pos, smpl, 7, 3, 0, 0), refIndex, altIndex));
         // sufficiently equal
-        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 6, 4, 0, 0), refIndex, altIndex), .4);
+        Assert.assertEquals(instance.calcBAF(new LocusDepth(tig, pos, smpl, 6, 4, 0, 0), refIndex, altIndex).getValue(), .4);
     }
 }


### PR DESCRIPTION
1. Allows negative BAFs (so that we can process legacy files).
2. Skips same-site vcf records so that we can glide over the redundancies in the dbsnp sites vcf.