### PR TITLE
site depth bug

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthBCICodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthBCICodec.java
@@ -47,11 +47,6 @@ public class SiteDepthBCICodec extends AbstractBCICodec<SiteDepth> {
                                        final SAMSequenceDictionary dict,
                                        final List<String> sampleNames,
                                        final int compressionLevel ) {
-        if ( sampleNames.size() != 1 ) {
-            throw new UserException("SiteDepth records do not encode their sample, and must all " +
-                                    "refer to a single sample, but the list of sample names is of " +
-                                    "size=" + sampleNames.size());
-        }
         final String className = SiteDepth.class.getSimpleName();
         return new Writer<>(path,
                             new SVFeaturesHeader(className, SiteDepth.BCI_VERSION, dict, sampleNames),

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthCodec.java
@@ -58,11 +58,6 @@ public class SiteDepthCodec extends AsciiFeatureCodec<SiteDepth>
                                                     final SAMSequenceDictionary dict,
                                                     final List<String> sampleNames,
                                                     final int compressionLevel ) {
-        if ( sampleNames.size() != 1 ) {
-            throw new UserException("SiteDepth records do not encode their sample, and must all " +
-                    "refer to a single sample, but the list of sample names is of " +
-                    "size=" + sampleNames.size());
-        }
         return new FeatureOutputStream<>(path,
                 getTabixFormat(),
                 SiteDepthCodec::encode,


### PR DESCRIPTION
This was code left over from when we put the sample name in a header line rather than as a column.  It needs to go.