### PR TITLE
Unit tests for Utils.concat() 

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -981,10 +982,10 @@ UtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(actual, expected);
     }
 
-    @DataProvider(name = "concatMultipleArraysData")
-    public Object[][] concatMultipleArraysData() {
+    @DataProvider(name = "concatMultipleByteArraysData")
+    public Object[][] concatMultipleByteArraysData() {
         return new Object[][]{
-                //new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, },
+                // expected, arrays
                 new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { } },
                 new Object[]{ new byte[] {100, 100}, new byte[] {100, 100} },
                 new Object[]{ new byte[] {100, 100}, new byte[] {100, 100}, new byte[] { } },
@@ -993,14 +994,16 @@ UtilsUnitTest extends GATKBaseTest {
         };
     }
 
-    @Test(dataProvider = "concatMultipleArraysData")
-    public void testConcatMultipleArrays(byte[] expected, byte[] ... arrays) {
+    // expected listed first to accomodate varargs arrays having to be last parameter
+    @Test(dataProvider = "concatMultipleByteArraysData")
+    public void testConcatMultipleByteArrays(byte[] expected, byte[] ... arrays) {
         Assert.assertEquals(Utils.concat(arrays), expected);
     }
 
-    @DataProvider(name = "concatTwoArraysData")
-    public Object[][] concatTwoArraysData() {
+    @DataProvider(name = "concatTwoByteArraysData")
+    public Object[][] concatTwoByteArraysData() {
         return new Object[][]{
+                // arr1, arr2, expected
                 new Object[]{ new byte[] { }, new byte[] { }, ArrayUtils.EMPTY_BYTE_ARRAY },
                 new Object[]{ new byte[] {100, 100}, new byte[] { }, new byte[] {100, 100} },
                 new Object[]{ new byte[] { }, new byte[] {100, 100}, new byte[] {100, 100} },
@@ -1008,8 +1011,29 @@ UtilsUnitTest extends GATKBaseTest {
         };
     }
 
-    @Test(dataProvider = "concatTwoArraysData")
-    public void testConcatTwoArrays(byte[] arr1, byte[] arr2, byte[] expected) {
+    @Test(dataProvider = "concatTwoByteArraysData")
+    public void testConcatTwoByteArrays(byte[] arr1, byte[] arr2, byte[] expected) {
         Assert.assertEquals(Utils.concat(arr1, arr2), expected);
     }
+
+    @DataProvider(name = "concatAnyTypeArraysData")
+    public Object[][] concatAnyTypeArraysData() {
+        return new Object[][]{
+                // arr1, arr2, constructor, expected
+                new Object[]{ new Integer[] { }, new Integer[] { }, (IntFunction<Integer[]>)Integer[]::new,
+                        new Integer[] { } },
+                new Object[]{ new Integer[] { }, new Integer[] {1, 2, 3}, (IntFunction<Integer[]>)Integer[]::new,
+                        new Integer[] {1, 2, 3} },
+                new Object[]{ new Integer[] { }, new Integer[] {4, 5, 6}, (IntFunction<Integer[]>)Integer[]::new,
+                        new Integer[] {4, 5, 6} },
+                new Object[]{ new Integer[] {1, 2, 3}, new Integer[] {4, 5, 6}, (IntFunction<Integer[]>)Integer[]::new,
+                        new Integer[] {1, 2, 3, 4, 5, 6} },
+        };
+    }
+
+    @Test(dataProvider = "concatAnyTypeArraysData")
+    public void testConcatAnyTypeArrays(Integer[] arr1, Integer[] arr2, IntFunction<Integer[]> constructor, Integer[] expected) {
+        Assert.assertEquals(Utils.concat(arr1, arr2, constructor), expected);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -1022,7 +1022,7 @@ UtilsUnitTest extends GATKBaseTest {
                 // arr1, arr2, constructor, expected
                 new Object[]{ new Integer[] { }, new Integer[] { }, (IntFunction<Integer[]>)Integer[]::new,
                         new Integer[] { } },
-                new Object[]{ new Integer[] { }, new Integer[] {1, 2, 3}, (IntFunction<Integer[]>)Integer[]::new,
+                new Object[]{ new Integer[] {1, 2, 3}, new Integer[] { }, (IntFunction<Integer[]>)Integer[]::new,
                         new Integer[] {1, 2, 3} },
                 new Object[]{ new Integer[] { }, new Integer[] {4, 5, 6}, (IntFunction<Integer[]>)Integer[]::new,
                         new Integer[] {4, 5, 6} },

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -989,7 +989,7 @@ public final class UtilsUnitTest extends GATKBaseTest {
                 new Object[]{ new byte[] {100, 100}, new byte[] {100, 100} },
                 new Object[]{ new byte[] {100, 100, 10, 10}, new byte[] {100, 100}, new byte[] { }, new byte[] {10,10} },
                 new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { }, new byte[] { }, new byte[] { } },
-                new Object[]{ new byte[] {10, 10, 15, 15, 20, 20}, new byte[] {10, 10}, new byte[] {15, 15}, new byte[] {20, 20} },
+                new Object[]{ new byte[] {12, 10, 15, 15, 20, 20}, new byte[] {12, 10}, new byte[] {15, 15}, new byte[] {20, 20} },
         };
     }
 
@@ -1012,7 +1012,7 @@ public final class UtilsUnitTest extends GATKBaseTest {
                 new Object[]{ new byte[] {10, 10}, new byte[] { }, new byte[] {10, 10} },
                 new Object[]{ new byte[] { }, new byte[] {10, 10}, new byte[] {10, 10} },
                 new Object[]{ new byte[] {10}, new byte[] {15, 15}, new byte[] {10, 15, 15} },
-                new Object[]{ new byte[] {10, 10}, new byte[] {15, 15}, new byte[] {10, 10, 15, 15} },
+                new Object[]{ new byte[] {12, 10}, new byte[] {15, 15}, new byte[] {12, 10, 15, 15} },
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -30,8 +30,7 @@ import static org.testng.Assert.assertEquals;
  * Testing framework for general purpose utilities class.
  *
  */
-public final class
-UtilsUnitTest extends GATKBaseTest {
+public final class UtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testForceJVMLocaleToUSEnglish() {
@@ -988,9 +987,9 @@ UtilsUnitTest extends GATKBaseTest {
                 // expected, arrays
                 new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { } },
                 new Object[]{ new byte[] {100, 100}, new byte[] {100, 100} },
-                new Object[]{ new byte[] {100, 100}, new byte[] {100, 100}, new byte[] { } },
-                new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { }, new byte[] { } },
-                new Object[]{ new byte[] {100, 100, 100, 100}, new byte[] {100, 100}, new byte[] {100, 100} },
+                new Object[]{ new byte[] {100, 100, 10, 10}, new byte[] {100, 100}, new byte[] { }, new byte[] {10,10} },
+                new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { }, new byte[] { }, new byte[] { } },
+                new Object[]{ new byte[] {10, 10, 15, 15, 20, 20}, new byte[] {10, 10}, new byte[] {15, 15}, new byte[] {20, 20} },
         };
     }
 
@@ -1010,9 +1009,10 @@ UtilsUnitTest extends GATKBaseTest {
         return new Object[][]{
                 // arr1, arr2, expected
                 new Object[]{ new byte[] { }, new byte[] { }, ArrayUtils.EMPTY_BYTE_ARRAY },
-                new Object[]{ new byte[] {100, 100}, new byte[] { }, new byte[] {100, 100} },
-                new Object[]{ new byte[] { }, new byte[] {100, 100}, new byte[] {100, 100} },
-                new Object[]{ new byte[] {100, 100}, new byte[] {100, 100}, new byte[] {100, 100, 100, 100} },
+                new Object[]{ new byte[] {10, 10}, new byte[] { }, new byte[] {10, 10} },
+                new Object[]{ new byte[] { }, new byte[] {10, 10}, new byte[] {10, 10} },
+                new Object[]{ new byte[] {10}, new byte[] {15, 15}, new byte[] {10, 15, 15} },
+                new Object[]{ new byte[] {10, 10}, new byte[] {15, 15}, new byte[] {10, 10, 15, 15} },
         };
     }
 
@@ -1033,6 +1033,8 @@ UtilsUnitTest extends GATKBaseTest {
                         new Integer[] {4, 5, 6} },
                 new Object[]{ new Integer[] {1, 2, 3}, new Integer[] {4, 5, 6}, (IntFunction<Integer[]>)Integer[]::new,
                         new Integer[] {1, 2, 3, 4, 5, 6} },
+                new Object[]{ new Integer[] {4, 5, 6}, new Integer[] {1, 2, 3}, (IntFunction<Integer[]>)Integer[]::new,
+                        new Integer[] {4, 5, 6, 1, 2, 3} },
         };
     }
 
@@ -1044,7 +1046,7 @@ UtilsUnitTest extends GATKBaseTest {
    @DataProvider(name = "concatAnyTypeWithNullArrayData")
    public Object[][] concatAnyTypeWithNullArrayData(){
        return new Object[][]{
-               new Object[]{null, new Integer[]{1, 2, 3}, (IntFunction<Integer[]>) Integer[]::new},
+               new Object[]{null, new Integer[] {1, 2, 3}, (IntFunction<Integer[]>) Integer[]::new},
                new Object[]{new Integer[] {1, 2, 3}, null, (IntFunction<Integer[]>) Integer[]::new},
                new Object[]{null, null, (IntFunction<Integer[]>) Integer[]::new}
        };

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -1000,6 +1000,11 @@ UtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(Utils.concat(arrays), expected);
     }
 
+    @Test
+    public void testConcatMultipleWithNoArrays(){
+        Assert.assertEquals(Utils.concat(), ArrayUtils.EMPTY_BYTE_ARRAY);
+    }
+
     @DataProvider(name = "concatTwoByteArraysData")
     public Object[][] concatTwoByteArraysData() {
         return new Object[][]{
@@ -1034,6 +1039,20 @@ UtilsUnitTest extends GATKBaseTest {
     @Test(dataProvider = "concatAnyTypeArraysData")
     public void testConcatAnyTypeArrays(Integer[] arr1, Integer[] arr2, IntFunction<Integer[]> constructor, Integer[] expected) {
         Assert.assertEquals(Utils.concat(arr1, arr2, constructor), expected);
+    }
+
+   @DataProvider(name = "concatAnyTypeWithNullArrayData")
+   public Object[][] concatAnyTypeWithNullArrayData(){
+       return new Object[][]{
+               new Object[]{null, new Integer[]{1, 2, 3}, (IntFunction<Integer[]>) Integer[]::new},
+               new Object[]{new Integer[] {1, 2, 3}, null, (IntFunction<Integer[]>) Integer[]::new},
+               new Object[]{null, null, (IntFunction<Integer[]>) Integer[]::new}
+       };
+   }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "concatAnyTypeWithNullArrayData")
+    public void testConcatAnyTypeWithNullArray(Integer[] arr1, Integer[] arr2, IntFunction<Integer[]> constructor){
+        Utils.concat(arr1, arr2, constructor);
     }
 
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import htsjdk.samtools.util.Log.LogLevel;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Level;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
@@ -28,7 +29,8 @@ import static org.testng.Assert.assertEquals;
  * Testing framework for general purpose utilities class.
  *
  */
-public final class UtilsUnitTest extends GATKBaseTest {
+public final class
+UtilsUnitTest extends GATKBaseTest {
 
     @Test
     public void testForceJVMLocaleToUSEnglish() {
@@ -977,5 +979,37 @@ public final class UtilsUnitTest extends GATKBaseTest {
     public void testTestFilterCollectionByExpressions(Set<String> values, Collection<String> filters, boolean exactMatch, Set<String> expected) {
         Set<String> actual = Utils.filterCollectionByExpressions(values, filters, exactMatch);
         Assert.assertEquals(actual, expected);
+    }
+
+    @DataProvider(name = "concatMultipleArraysData")
+    public Object[][] concatMultipleArraysData() {
+        return new Object[][]{
+                //new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, },
+                new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { } },
+                new Object[]{ new byte[] {100, 100}, new byte[] {100, 100} },
+                new Object[]{ new byte[] {100, 100}, new byte[] {100, 100}, new byte[] { } },
+                new Object[]{ ArrayUtils.EMPTY_BYTE_ARRAY, new byte[] { }, new byte[] { } },
+                new Object[]{ new byte[] {100, 100, 100, 100}, new byte[] {100, 100}, new byte[] {100, 100} },
+        };
+    }
+
+    @Test(dataProvider = "concatMultipleArraysData")
+    public void testConcatMultipleArrays(byte[] expected, byte[] ... arrays) {
+        Assert.assertEquals(Utils.concat(arrays), expected);
+    }
+
+    @DataProvider(name = "concatTwoArraysData")
+    public Object[][] concatTwoArraysData() {
+        return new Object[][]{
+                new Object[]{ new byte[] { }, new byte[] { }, ArrayUtils.EMPTY_BYTE_ARRAY },
+                new Object[]{ new byte[] {100, 100}, new byte[] { }, new byte[] {100, 100} },
+                new Object[]{ new byte[] { }, new byte[] {100, 100}, new byte[] {100, 100} },
+                new Object[]{ new byte[] {100, 100}, new byte[] {100, 100}, new byte[] {100, 100, 100, 100} },
+        };
+    }
+
+    @Test(dataProvider = "concatTwoArraysData")
+    public void testConcatTwoArrays(byte[] arr1, byte[] arr2, byte[] expected) {
+        Assert.assertEquals(Utils.concat(arr1, arr2), expected);
     }
 }


### PR DESCRIPTION
Fixes #7916. Data providers and unit tests for the various overloads of Utils.concat() 