### PR TITLE
 Rightsize import batches [VS-486]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -198,6 +198,7 @@ workflows:
          - master
          - ah_var_store
          - rc-vs-483-beta-user-wdl
+         - vs_486_rightsize_import_batches
    - name: GvsCalculatePrecisionAndSensitivity
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -38,6 +38,9 @@ workflow GvsImportGenomes {
                                        else if num_samples < 1000 then 1
                                             else num_samples / 1000
 
+  # Both preemptible and maxretries should be scaled up alongside import batch size since the likelihood of preemptions
+  # and retryable random BQ import errors increases with import batch size / job run time.
+
   # At least 3, per limits above not more than 5.
   Int effective_load_data_preemptible = if (defined(load_data_preemptible_override)) then select_first([load_data_preemptible_override])
                                         else if effective_load_data_batch_size < 12 then 3

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -22,6 +22,7 @@ workflow GvsJointVariantCalling {
       Int extract_maxretries_override = ""
       Int extract_preemptible_override = ""
       Int extract_scatter_count = ""
+      Int load_data_batch_size = ""
       Int load_data_preemptible_override = ""
       Int load_data_maxretries_override = ""
       Array[String] query_labels = []
@@ -64,7 +65,7 @@ workflow GvsJointVariantCalling {
             indel_recalibration_annotation_values = indel_recalibration_annotation_values,
             interval_list = interval_list,
             interval_weights_bed = interval_weights_bed,
-            load_data_batch_size = 5,
+            load_data_batch_size = load_data_batch_size,
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_preemptible_override = load_data_preemptible_override,
             query_labels = query_labels,

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -49,8 +49,6 @@ workflow GvsQuickstartIntegration {
                                         ]
 
         Int? extract_scatter_count
-
-        Int load_data_batch_size = 1
     }
     String project_id = "gvs-internal"
 
@@ -75,7 +73,6 @@ workflow GvsQuickstartIntegration {
             # Force filtering off as it is not deterministic and the initial version of this integration test does not
             # allow for inexact matching of actual and expected results.
             extract_do_not_filter_override = true,
-            load_data_batch_size = load_data_batch_size,
     }
 
     call AssertIdenticalOutputs {

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -26,9 +26,11 @@ workflow GvsUnified {
         Array[File] input_vcf_indexes
         File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
 
+
         # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
-        # BigQuery errors. So if increasing the batch size, then preemptible and maxretries should also be increased.
-        Int load_data_batch_size = 5
+        # BigQuery errors so if specifying this adjust preemptible and maxretries accordingly. Or just take the defaults,
+        # those should work fine in most cases.
+        Int? load_data_batch_size
         Int? load_data_preemptible_override
         Int? load_data_maxretries_override
         # End GvsImportGenomes


### PR DESCRIPTION
Automatically choose appropriate import batch, preemptible, and max retry values for sample sets up to 20K. This makes 20K samples our effective threshold for where we feel comfortable with the current stability / performance of our import code.