### PR TITLE
Cost WDL should throw on FISS API errors [VS-518]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -232,6 +232,7 @@ workflows:
          - master
          - ah_var_store
          - vs_475_read_cost_observability
+         - vs_518_throw_on_fiss_api_error
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -214,7 +214,7 @@ task CreateCostObservabilityTable {
     fi
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
   }
   output {
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -59,7 +59,7 @@ task WorkflowComputeCosts {
             --workspace_namespace '~{workspace_namespace}' \
             --workspace_name '~{workspace_name}' \
             ~{sep=' ' excluded_ids} \
-            > costs_by_workflow.json 2> workflow_compute_costs.log
+            > costs_by_workflow.json
     >>>
 
     runtime {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -32,7 +32,6 @@ workflow GvsCallsetCost {
 
     output {
         File workflow_compute_costs = WorkflowComputeCosts.costs
-        File workflow_compute_costs_log = WorkflowComputeCosts.log
         String vet_gib = CoreStorageModelSizes.vet_gib
         String ref_ranges_gib = CoreStorageModelSizes.ref_ranges_gib
         String alt_allele_gib = CoreStorageModelSizes.alt_allele_gib
@@ -68,7 +67,6 @@ task WorkflowComputeCosts {
 
     output {
         File costs = "costs_by_workflow.json"
-        File log = "workflow_compute_costs.log"
     }
 }
 

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -63,7 +63,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -204,7 +204,7 @@ task PopulateAltAlleleTable {
       $SERVICE_ACCOUNT_STANZA
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -155,7 +155,7 @@ task MakeSubpopulationFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -186,7 +186,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -317,7 +317,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
@@ -92,7 +92,7 @@ task GetAnnotations {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -151,7 +151,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -426,7 +426,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -116,7 +116,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -367,7 +367,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_08"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_13"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/extract/workflow_compute_costs.py
+++ b/scripts/variantstore/wdl/extract/workflow_compute_costs.py
@@ -2,19 +2,26 @@ from logging import info, warning
 import urllib.parse
 
 
+def fapi_error_check(result):
+    j = result.json()
+    if result.status_code >= 400 and j and type(j == 'dict') and 'message' in j:
+        raise Exception(j['message'])
+    return j
+
+
 def fapi_list_submissions(workspace_namespace: str, workspace_name: str):
     from firecloud import api as fapi
-    return fapi.list_submissions(workspace_namespace, workspace_name).json()
+    return fapi_error_check(fapi.list_submissions(workspace_namespace, workspace_name))
 
 
 def fapi_get_submission(workspace_namespace: str, workspace_name: str, submission_id: str):
     from firecloud import api as fapi
-    return fapi.get_submission(workspace_namespace, workspace_name, submission_id).json()
+    return fapi_error_check(fapi.get_submission(workspace_namespace, workspace_name, submission_id))
 
 
 def fapi_get_workflow_metadata(workspace_namespace: str, workspace_name: str, submission_id: str, workflow_id: str):
     from firecloud import api as fapi
-    return fapi.get_workflow_metadata(workspace_namespace, workspace_name, submission_id, workflow_id).json()
+    return fapi_error_check(fapi.get_workflow_metadata(workspace_namespace, workspace_name, submission_id, workflow_id))
 
 
 def compute_costs(workspace_namespace, workspace_name, excluded_submission_ids,


### PR DESCRIPTION
```
% python3 workflow_compute_costs.py \
    --workspace_namespace 'not' \                            
    --workspace_name 'there'                
Traceback (most recent call last):
  File "workflow_compute_costs.py", line 135, in <module>
    costs = compute_costs(args.workspace_namespace, args.workspace_name, args.exclude)
  File "workflow_compute_costs.py", line 32, in compute_costs
    submissions = list_submissions(workspace_namespace, workspace_name)
  File "workflow_compute_costs.py", line 14, in fapi_list_submissions
    return fapi_error_check(fapi.list_submissions(workspace_namespace, workspace_name))
  File "workflow_compute_costs.py", line 8, in fapi_error_check
    raise Exception(j['message'])
Exception: workspace not/there does not exist or you do not have permission to use it
```