### PR TITLE
GL-548 - Update CreateVat code to handle samples that do not contain all population groups.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -140,6 +140,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsCreateVATAnnotations
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -149,6 +150,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsCreateVATFromAnnotations
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
@@ -158,6 +160,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsValidateVat
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl
@@ -167,6 +170,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsExtractCohortFromSampleNames
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -150,7 +150,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsCreateVATFromAnnotations
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
@@ -160,7 +159,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-548_HandleSubsetsOfSubpopulations
    - name: GvsValidateVat
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -214,7 +214,7 @@ task CreateCostObservabilityTable {
     fi
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
   }
   output {
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -264,7 +264,7 @@ task Add_AS_MAX_VQSLOD_ToVcf {
     File input_vcf
     String output_basename
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -204,7 +204,7 @@ task PopulateAltAlleleTable {
       $SERVICE_ACCOUNT_STANZA
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -156,7 +156,7 @@ task MakeSubpopulationFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:gg_vattest_2022_07_28"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -180,7 +180,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -311,7 +311,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:gg_vattest_2022_07_28"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
@@ -92,7 +92,7 @@ task GetAnnotations {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:gg_vattest_2022_07_28"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATFromAnnotations.wdl
@@ -92,7 +92,7 @@ task GetAnnotations {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:gg_vattest_2022_07_28"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -151,7 +151,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -426,7 +426,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -116,7 +116,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -374,7 +374,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_07_14"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
+++ b/scripts/variantstore/wdl/extract/create_variant_annotation_table.py
@@ -172,13 +172,13 @@ def get_subpopulation_calculations(subpop_annotations):
     max_af = None
     max_sc = None
     max_subpop = ""
-    for gvs_subpop in gvs_subpopulations: # note these will break if a subpopulation is missing
-        subpop_ac_val = subpop_annotations.get("_".join(["AC", gvs_subpop]))
-        subpop_an_val = subpop_annotations.get("_".join(["AN", gvs_subpop]))
-        subpop_af_val = subpop_annotations.get("_".join(["AF", gvs_subpop]))
+    for gvs_subpop in gvs_subpopulations:
+        subpop_ac_val = subpop_annotations.get("_".join(["AC", gvs_subpop]), 0)
+        subpop_an_val = subpop_annotations.get("_".join(["AN", gvs_subpop]), 0)
+        subpop_af_val = subpop_annotations.get("_".join(["AF", gvs_subpop]), None)
         # note the assumption is made that AC_Hom must be even because by it's nature it means there are two, but there could be an error
-        subpop_sc_val = int(subpop_annotations.get("_".join(["AC_Hom", gvs_subpop])) / 2 ) + subpop_annotations.get("_".join(["AC_Het", gvs_subpop])) + subpop_annotations.get("_".join(["AC_Hemi", gvs_subpop]))
-        # here we set the subpopulation ac/an/af values
+        subpop_sc_val = int(subpop_annotations.get("_".join(["AC_Hom", gvs_subpop]), 0) / 2 ) + subpop_annotations.get("_".join(["AC_Het", gvs_subpop]), 0) + subpop_annotations.get("_".join(["AC_Hemi", gvs_subpop]), 0)
+
         row["_".join(["gvs", gvs_subpop, "ac"])] = subpop_ac_val
         row["_".join(["gvs", gvs_subpop, "an"])] = subpop_an_val
         row["_".join(["gvs", gvs_subpop, "af"])] = subpop_af_val
@@ -377,9 +377,9 @@ def make_annotation_jsons(annotated_json, output_json, output_genes_json):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(allow_abbrev=False, description='Create BQ load friendly jsons for VAT creation')
-    parser.add_argument('--annotated_json',type=str, help='nirvana created annotation json', required=True)
-    parser.add_argument('--output_vt_json',type=str, help='name of the vt json', required=True)
-    parser.add_argument('--output_genes_json',type=str, help='name of the genes json', required=True)
+    parser.add_argument('--annotated_json', type=str, help='nirvana created annotation json', required=True)
+    parser.add_argument('--output_vt_json', type=str, help='name of the vt json', required=True)
+    parser.add_argument('--output_genes_json', type=str, help='name of the genes json', required=True)
 
     args = parser.parse_args()
 

--- a/scripts/variantstore/wdl/extract/extract_subpop.py
+++ b/scripts/variantstore/wdl/extract/extract_subpop.py
@@ -1,7 +1,7 @@
 import csv
 import argparse
 
-expected_subpopulations = [
+valid_subpopulations = [
  "afr",
  "amr",
  "eas",
@@ -14,19 +14,53 @@ expected_subpopulations = [
 def extract_subpopulation(input_path, output_path):
   with open(input_path, newline='') as tsvin, open(output_path, 'w', newline='') as csvout:
     tsvin = csv.reader(tsvin, delimiter='\t')
-    csvout = csv.writer(csvout, delimiter='\t')
+    csvout = csv.writer(csvout, delimiter='\t', lineterminator="\n")
     next(tsvin)  # Skip header row
 
+    observed_subpopulations = set()
     for row in tsvin:
+      if row[4] not in valid_subpopulations:
+          raise ValueError(f"Unrecognized subpopulation: {row[4]} in {args.input_path}")
+      observed_subpopulations.add(row[4])
       csvout.writerow([row[0], row[4]])
 
+    return observed_subpopulations
+
+def write_custom_annotations_files(observed_subpopulations, custom_annotations_template_path):
+
+    with open(custom_annotations_template_path, 'w', newline='') as csvout:
+        csvout = csv.writer(csvout, delimiter='\t', lineterminator="\n")
+        csvout.writerow(["#title=gvsAnnotations"])
+        csvout.writerow(["#assembly=GRCh38"])
+        csvout.writerow(["#matchVariantsBy=allele"])
+
+        chrom_line = ["#CHROM", "POS", "REF", "ALT", "AC", "AN", "AF", "AC_Hom", "AC_Het", "AC_Hemi"]
+        categories_line = ["#categories", ".", ".", ".", "AlleleCount", "AlleleNumber", "AlleleFrequency", "AlleleCount", "AlleleCount", "AlleleCount"]
+        description_line = ["#descriptions", ".", ".", ".", ".", ".", ".", ".", ".", "."]
+        type_line = ["#type", ".", ".", ".", "number", "number", "number", "number", "number", "number"]
+
+        for subpopulation in sorted(observed_subpopulations):
+            for annotation in (["AC", "AN", "AF", "AC_Hom", "AC_Het", "AC_Hemi"]):
+                chrom_line.append(f"{annotation}_{subpopulation}")
+            categories_line += ["AlleleCount", "AlleleNumber", "AlleleFrequency", "AlleleCount", "AlleleCount", "AlleleCount"]
+            for i in range(6):
+                description_line.append(".")
+                type_line.append("number")
+
+        csvout.writerow(chrom_line)
+        csvout.writerow(categories_line)
+        csvout.writerow(description_line)
+        csvout.writerow(type_line)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(allow_abbrev=False, description='Extract subpopulation per sample data out of a callset TSV')
-  parser.add_argument('--input_path',type=str, metavar='path', help='path to the original callset TSV', required=True)
-  parser.add_argument('--output_path',type=str, metavar='path', help='path for the output TSV', required=True)
+  parser.add_argument('--input_path', type=str, metavar='path', help='path to the original callset TSV', required=True)
+  parser.add_argument('--output_path', type=str, metavar='path', help='path for the output TSV', required=True)
+  parser.add_argument('--custom_annotations_template_path', type=str, metavar='path', help='path for the custom annotations template file', required=True)
 
   args = parser.parse_args()
 
-  extract_subpopulation(args.input_path,
-                        args.output_path)
+  observed_subpopulations = extract_subpopulation(args.input_path,
+                                                  args.output_path)
+  write_custom_annotations_files(observed_subpopulations,
+                                 args.custom_annotations_template_path)


### PR DESCRIPTION
Update GvsCreateVAT.wdl to build the subpopulation-specific files from the input ancestry file.
Have GvsCreateVAT.wdl only pull fields from the VCF for the selected subpopulations.
Update create_variant_annotation_table.py to set empty population-specific AC/AN/AF, etc. values if population is not present.