### PR TITLE
Restore Temurin 11 [VS-570]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -222,7 +222,8 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - mc_debug_temurin_issues
+         - rsa_metadata_from_python
+         - gg_VS-492_BetaUserJarRelease
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -222,8 +222,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_metadata_from_python
-         - gg_VS-492_BetaUserJarRelease
+         - mc_restore_temurin
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -254,13 +254,23 @@ task BuildGATKJarAndCreateDataset {
 
   command <<<
     # Much of this could/should be put into a Docker image.
-    set -o errexit -o nounset -o pipefail
+    set -o errexit -o nounset -o pipefail -o xtrace
 
     # git and git-lfs
     apt-get -qq update
     apt-get -qq install git git-lfs
 
-    # Java
+    # The Terra microservices are currently aligned on Temurin as their JDK distribution which is why we use it here.
+    # However at least once Temurin unexpectedly became unavailable for download for several hours which broke this
+    # task and its dependents. The following block switched the JDK distribution to Amazon Corretto 11 which appeared to
+    # work just fine for our purposes during Temurin's brief absence.
+    #
+    # Corretto Java 11
+    # apt-get -qq install wget apt-transport-https gnupg software-properties-common
+    # wget -O- https://apt.corretto.aws/corretto.key | apt-key add -
+    # add-apt-repository 'deb https://apt.corretto.aws stable main'
+
+    # Temurin Java 11
     apt-get -qq install wget apt-transport-https gnupg
     wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
     echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -254,25 +254,18 @@ task BuildGATKJarAndCreateDataset {
 
   command <<<
     # Much of this could/should be put into a Docker image.
-    set -o errexit -o nounset -o pipefail -o xtrace
+    set -o errexit -o nounset -o pipefail
 
     # git and git-lfs
     apt-get -qq update
     apt-get -qq install git git-lfs
 
-    # Temurin Java 11
-    # apt-get -qq install wget apt-transport-https gnupg
-    # wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
-    # echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
-    # apt-get -qq --fix-missing update
-    # apt -qq install -y temurin-11-jdk
-
-    # Corretto Java 11
-    apt-get -qq install wget apt-transport-https gnupg software-properties-common
-    wget -O- https://apt.corretto.aws/corretto.key | apt-key add -
-    add-apt-repository 'deb https://apt.corretto.aws stable main'
+    # Java
+    apt-get -qq install wget apt-transport-https gnupg
+    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
+    echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     apt-get -qq update
-    apt-get install -y java-11-amazon-corretto-jdk
+    apt -qq install -y temurin-11-jdk
 
     # GATK
     git clone https://github.com/broadinstitute/gatk.git --depth 1 --branch ~{branch_name} --single-branch


### PR DESCRIPTION
Reverts VS-569 now that Temurin downloads are working again, leaves in the Corretto breadcrumbs and minor improvements like `-o xtrace`.