### PR TITLE
Fix Mutect2 IndexOutOfBoundException with germline resource

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2Engine.java
@@ -490,10 +490,9 @@ public final class Mutect2Engine implements AssemblyRegionEvaluator, AutoCloseab
 
             for (final VariantContext germlineVC : germline) {
                 final List<Double> germlineAlleleFrequencies = getAttributeAsDoubleList(germlineVC, VCFConstants.ALLELE_FREQUENCY_KEY, 0.0);
-                final List<Allele> germlineAlts = germlineVC.getAlternateAlleles();
                 final Allele germlineRef = germlineVC.getReference();
 
-                for (int germlineAltIdx = 0; germlineAltIdx < germlineAlts.size(); germlineAltIdx++) {
+                for (int germlineAltIdx = 0; germlineAltIdx < germlineAlleleFrequencies.size(); germlineAltIdx++) {
                     if (germlineAlleleFrequencies.get(germlineAltIdx) < MTAC.maxPopulationAlleleFrequency) {
                         continue;
                     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class SomaticGenotypingEngine implements AutoCloseable {
-    protected final Logger logger = LogManager.getLogger(this.getClass());
+    protected static final Logger logger = LogManager.getLogger(SomaticGenotypingEngine.class);
 
     private final M2ArgumentCollection MTAC;
     private final Set<String> normalSamples;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -371,7 +371,7 @@ public class SomaticGenotypingEngine implements AutoCloseable {
     @VisibleForTesting
     static double[] getGermlineAltAlleleFrequencies(final List<Allele> allAlleles, final Optional<VariantContext> germlineVC, final double afOfAllelesNotInGermlineResource) {
         Utils.validateArg(!allAlleles.isEmpty(), "allAlleles are empty -- there is not even a reference allele.");
-        if (germlineVC.isPresent())  {
+        if (germlineVC.isPresent() && germlineVC.get().hasAttribute(VCFConstants.ALLELE_FREQUENCY_KEY))  {
             List<OptionalInt> germlineIndices = GATKVariantContextUtils.alleleIndices(allAlleles, germlineVC.get().getAlleles());
             final List<Double> germlineAltAFs = Mutect2Engine.getAttributeAsDoubleList(germlineVC.get(), VCFConstants.ALLELE_FREQUENCY_KEY, afOfAllelesNotInGermlineResource);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
@@ -42,8 +42,7 @@ public class SomaticGenotypingEngineUnitTest {
 
                 //biallelic, same alt allele in different representations
                 { Arrays.asList(Allele.REF_A, Allele.ALT_G), Arrays.asList(ATref, GT), new double[] {0.1}, new double[] {0.1}},
-                { Arrays.asList(ATref, GT), Arrays.asList(Allele.REF_A, Allele.ALT_G), new double[] {0.1}, new double[] {0.1}},
-
+                { Arrays.asList(ATref, GT), Arrays.asList(Allele.REF_A, Allele.ALT_G), new double[] {0.1}, new double[] {0.1}}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
@@ -43,6 +43,7 @@ public class SomaticGenotypingEngineUnitTest {
                 //biallelic, same alt allele in different representations
                 { Arrays.asList(Allele.REF_A, Allele.ALT_G), Arrays.asList(ATref, GT), new double[] {0.1}, new double[] {0.1}},
                 { Arrays.asList(ATref, GT), Arrays.asList(Allele.REF_A, Allele.ALT_G), new double[] {0.1}, new double[] {0.1}},
+
         };
     }
 
@@ -55,5 +56,21 @@ public class SomaticGenotypingEngineUnitTest {
                 .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, germlineAltAFs).make();
         final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(calledAlleles, Optional.of(vc1), DEFAULT_AF);
         Assert.assertEquals(result, expected, 1.0e-10);
+    }
+
+    @DataProvider(name = "missingAFData")
+    Object[][] missingAFData() {
+        return new Object[][]{
+                {new VariantContextBuilder("SOURCE", "1", 1, 1, Arrays.asList(Allele.REF_A, Allele.ALT_C))
+                        .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, VCFConstants.MISSING_VALUE_v4).make()},
+                {new VariantContextBuilder("SOURCE", "1", 1, 1, Arrays.asList(Allele.REF_A, Allele.ALT_C))
+                        .make()}
+        };
+    }
+
+    @Test(dataProvider = "missingAFData")
+    public void testGetGermlineAltAlleleFrequenciesWithMissingAF(final VariantContext vc) {
+        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(vc.getAlleles(), Optional.of(vc), DEFAULT_AF);
+        Assert.assertEquals(result, new double[] {DEFAULT_AF}, 1.0e-10);
     }
 }


### PR DESCRIPTION
Fixes issue reported in #6605

If a germline resource vcf (such as gnomad) used when running Mutect2 includes a variant record without the AF attribute in  its info field, this can lead to an IndexOutOfBoundsException.  This PR fixing this, and adds a warning when this is the case.