### PR TITLE
Allow for incremental addition of data to alt_allele [VS-52]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,11 +95,9 @@ workflows:
        branches:
          - master
          - ah_var_store
-   - name: GvsCreateAltAllele
+   - name: GvsPopulateAltAllele
      subclass: WDL
-     primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateAltAllele.wdl
-     testParameterFiles:
-       - /scripts/variantstore/wdl/GvsCreateAltAllele.example.inputs.json
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
      filters:
        branches:
          - master

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -97,6 +97,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_vs_52_incremental_alt_allele
    - name: GvsCreateTables
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateTables.wdl

--- a/scripts/variantstore/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/AOU_DELIVERABLES.md
@@ -11,7 +11,7 @@
   - [GvsAssignIds](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsAssignIds) workflow
   - [GvsImportGenomes](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsImportGenomes) workflow
   - [GvsWithdrawSamples](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsWithdrawSamples) workflow
-  - [GvsCreateAltAllele](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsCreateAltAllele) workflow
+  - [GvsPopulateAltAllele](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsPopulateAltAllele) workflow
   - [GvsCreateFilterSet](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsCreateFilterSet) workflow
   - [GvsPrepareRangesCallset](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsPrepareRangesCallset) workflow (VCF output)
   - [GvsExtractCallset](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsExtractCallset) workflow (VCF output)
@@ -42,7 +42,7 @@
 3. `GvsWithdrawSamples` workflow
    - Run if there are any samples to withdraw from the last callset.
 4. **TBD Workflow to soft delete samples**
-5. `GvsCreateAltAllele` workflow
+5. `GvsPopulateAltAllele` workflow
    - **TODO:** needs to be made cumulative so that it can add data to the existing table instead of creating it from scratch on each run (see [VS-52](https://broadworkbench.atlassian.net/browse/VS-52))
    - This step loads data into the `alt_allele` table from the `vet_*` tables in preparation for running the filtering step.
    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.

--- a/scripts/variantstore/TERRA_QUICKSTART.md
+++ b/scripts/variantstore/TERRA_QUICKSTART.md
@@ -52,7 +52,7 @@ This step loads data into the ALT_ALLELE table from the `vet_*` tables.
 
 This workflow does not use the Terra data model to run, so be sure to select `Run workflow with inputs defined by file paths`.
 
-This is done by running the `GvsCreateAltAllele` workflow with the following parameters:
+This is done by running the `GvsPopulateAltAllele` workflow with the following parameters:
 
 | Parameter         | Description |
 | ----------------- | ----------- |

--- a/scripts/variantstore/wdl/GvsBenchmarkExtractTask.wdl
+++ b/scripts/variantstore/wdl/GvsBenchmarkExtractTask.wdl
@@ -33,10 +33,10 @@ workflow GvsBenchmarkExtractTask {
 
         File? excluded_intervals
         Boolean? emit_pls = false
-        
+
         Int? extract_cpu_override = 2
         String? extract_memory_override = "12 GB"
-        
+
         Int? extract_preemptible_override
         Int? extract_maxretries_override
         Int? split_intervals_disk_size_override
@@ -206,7 +206,7 @@ task SumBytes {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -240,7 +240,7 @@ task CreateManifest {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         memory: "3 GB"
         disks: "local-disk 10 HDD"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -264,7 +264,7 @@ task Add_AS_MAX_VQSLOD_ToVcf {
     File input_vcf
     String output_basename
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     }
 
     output {
@@ -97,7 +97,7 @@ task CoreStorageModelSizes {
         get_billable_bytes_in_gib "alt_allele"   alt_allele_gib.txt
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:390.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     }
     output {
         Float vet_gib = read_float("vet_gib.txt")
@@ -125,7 +125,7 @@ task ReadCostObservabilityTable {
             > cost_observability.json
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:390.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     }
     output {
         File cost_observability = "cost_observability.json"

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -73,12 +73,15 @@ task GetMaxSampleId {
     set -o errexit -o nounset -o xtrace -o pipefail
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
-    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false --print_header=false \
-    'SELECT IFNULL(MAX(sample_id), 0) AS max_sample_id FROM `~{dataset_name}.alt_allele`'
+    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
+    'SELECT IFNULL(MAX(sample_id), 0) AS max_sample_id FROM `~{dataset_name}.alt_allele`' > num_rows.csv
+
+    # remove the header row from the CSV file
+    sed -i 1d num_rows.csv
   >>>
 
   output {
-    Int max_sample_id = read_int(stdout())
+    Int max_sample_id = read_int("num_rows.csv")
   }
 
   runtime {
@@ -117,8 +120,11 @@ task GetVetTableNames {
     fi
 
     # use the number calculated from the above math to get the vet_* table names to grab data from
-    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} --print_header=false \
+    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} \
     "SELECT table_name FROM \`~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES\` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, length('vet_') + 1) AS INT64) >= ${min_vat_table_num}" > vet_tables.csv
+
+    # remove the header row from the CSV file
+    sed -i 1d vet_tables.csv
   >>>
   runtime {
     docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -119,7 +119,7 @@ task GetVetTableNames {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} \
-    'SELECT table_name FROM `~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES` WHERE table_name LIKE "vet_%" AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)' > vet_tables.csv
+    "SELECT table_name FROM `~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)" > vet_tables.csv
 
     # remove the header row from the CSV file
     sed -i 1d vet_tables.csv

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -109,7 +109,9 @@ task GetVetTableNames {
   command <<<
     set -e
 
-    if [ $(i % 4000 == 0) -eq 0 ]; then
+    # if the maximum sample_id value is evenly divisible by 4000, then max_sample_id / 4000 will
+    # give us the right vet_* table to start with; otherwise, we need to start with the next table
+    if [ $((~{max_sample_id} % 4000)) -eq 0 ]; then
       echo $((~{max_sample_id} / 4000)) > min_vat_table_num.txt
     else
       echo $(((~{max_sample_id} / 4000) + 1)) > min_vat_table_num.txt

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -119,7 +119,7 @@ task GetVetTableNames {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} \
-    "SELECT table_name FROM `~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)" > vet_tables.csv
+    "SELECT table_name FROM \`~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES\` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)" > vet_tables.csv
 
     # remove the header row from the CSV file
     sed -i 1d vet_tables.csv

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -12,8 +12,15 @@ workflow GvsCreateAltAllele {
 
   String fq_alt_allele_table = "~{project_id}.~{dataset_name}.alt_allele"
 
+  call CreateAltAlleleTable {
+    input:
+      dataset_name = dataset_name,
+      project_id = project_id
+  }
+
   call GetMaxSampleId {
     input:
+      go = CreateAltAlleleTable.done,
       dataset_name = dataset_name,
       project_id = project_id
   }
@@ -23,12 +30,6 @@ workflow GvsCreateAltAllele {
       dataset_name = dataset_name,
       project_id = project_id,
       max_sample_id = GetMaxSampleId.max_sample_id
-  }
-
-  call CreateAltAlleleTable {
-    input:
-      dataset_name = dataset_name,
-      project_id = project_id
   }
 
   call Utils.GetBQTableLastModifiedDatetime {
@@ -59,6 +60,7 @@ workflow GvsCreateAltAllele {
 
 task GetMaxSampleId {
   input {
+    Boolean go = true
     String dataset_name
     String project_id
   }
@@ -72,7 +74,7 @@ task GetMaxSampleId {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
-    'SELECT MAX(sample_id) as max_sample_id FROM `~{dataset_name}.sample_info`' > num_rows.csv
+    'SELECT MAX(sample_id) as max_sample_id FROM `~{dataset_name}.alt_allele`' > num_rows.csv
 
     NUMROWS=$(python3 -c "csvObj=open('num_rows.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
 

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -74,7 +74,7 @@ task GetMaxSampleId {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
-    'SELECT MAX(sample_id) as max_sample_id FROM `~{dataset_name}.alt_allele`' > num_rows.csv
+    'SELECT IF(MAX(sample_id) IS NOT NULL, MAX(sample_id), 0) AS max_sample_id FROM `~{dataset_name}.alt_allele`' > num_rows.csv
 
     NUMROWS=$(python3 -c "csvObj=open('num_rows.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
 

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -259,7 +259,7 @@ task PopulateAltAlleleTable {
       $SERVICE_ACCOUNT_STANZA
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_vs_52_incremental_alt_allele_2022_08_16"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -47,7 +47,7 @@ workflow GvsCreateAltAllele {
         call_set_identifier = call_set_identifier,
         dataset_name = dataset_name,
         project_id = project_id,
-        create_table_done = select_first(skip_create_alt_allele_table, CreateAltAlleleTable.done),
+        create_table_done = select_first([skip_create_alt_allele_table, CreateAltAlleleTable.done]),
         vet_table_name = GetVetTableNames.vet_tables[idx],
         last_modified_timestamp = GetBQTableLastModifiedDatetime.last_modified_timestamp,
         max_sample_id = GetMaxSampleId.max_sample_id

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -223,7 +223,7 @@ task PopulateAltAlleleTable {
       --max_sample_id ~{max_sample_id} \
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_vs_52_incremental_alt_allele_2022_08_16_3"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_vs_52_incremental_alt_allele_2022_08_17"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -110,9 +110,9 @@ task GetVetTableNames {
     set -e
 
     if [ $(i % 4000 == 0) -eq 0 ]; then
-      echo $(~{max_sample_id} / 4000) > min_vat_table_num.txt
+      echo $((~{max_sample_id} / 4000)) > min_vat_table_num.txt
     else
-      echo $((~{max_sample_id} / 4000) + 1) > min_vat_table_num.txt
+      echo $(((~{max_sample_id} / 4000) + 1)) > min_vat_table_num.txt
     fi
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -110,6 +110,7 @@ task GetVetTableNames {
 
   command <<<
     set -e
+    echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
     # if the maximum sample_id value is evenly divisible by 4000, then max_sample_id / 4000 will
     # give us the right vet_* table to start with; otherwise, we need to start with the next table
@@ -119,7 +120,7 @@ task GetVetTableNames {
       echo $(((~{max_sample_id} / 4000) + 1)) > min_vat_table_num.txt
     fi
 
-    echo "project_id = ~{project_id}" > ~/.bigqueryrc
+    # use the number calculated from the above math to get the vet_* table names grab data from
     bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} \
     "SELECT table_name FROM \`~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES\` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)" > vet_tables.csv
 

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -70,15 +70,11 @@ task GetMaxSampleId {
   }
 
   command <<<
-    set -e
+    set -o errexit -o nounset -o xtrace -o pipefail
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
-    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false \
-    'SELECT IF(MAX(sample_id) IS NOT NULL, MAX(sample_id), 0) AS max_sample_id FROM `~{dataset_name}.alt_allele`' > num_rows.csv
-
-    NUMROWS=$(python3 -c "csvObj=open('num_rows.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
-
-    [[ $NUMROWS =~ ^[0-9]+$ ]] && echo $NUMROWS || exit 1
+    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false --print_header=false \
+    'SELECT IFNULL(MAX(sample_id), 0) AS max_sample_id FROM `~{dataset_name}.alt_allele`'
   >>>
 
   output {
@@ -86,7 +82,7 @@ task GetMaxSampleId {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -115,20 +111,17 @@ task GetVetTableNames {
     # if the maximum sample_id value is evenly divisible by 4000, then max_sample_id / 4000 will
     # give us the right vet_* table to start with; otherwise, we need to start with the next table
     if [ $((~{max_sample_id} % 4000)) -eq 0 ]; then
-      echo $((~{max_sample_id} / 4000)) > min_vat_table_num.txt
+      min_vat_table_num=$((~{max_sample_id} / 4000))
     else
-      echo $(((~{max_sample_id} / 4000) + 1)) > min_vat_table_num.txt
+      min_vat_table_num=$(((~{max_sample_id} / 4000) + 1))
     fi
 
-    # use the number calculated from the above math to get the vet_* table names grab data from
-    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} \
-    "SELECT table_name FROM \`~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES\` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, 5) AS INT64) >= $(cat min_vat_table_num.txt)" > vet_tables.csv
-
-    # remove the header row from the CSV file
-    sed -i 1d vet_tables.csv
+    # use the number calculated from the above math to get the vet_* table names to grab data from
+    bq query --location=US --project_id=~{project_id} --format=csv --use_legacy_sql=false ~{bq_labels} --print_header=false \
+    "SELECT table_name FROM \`~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES\` WHERE table_name LIKE 'vet_%' AND CAST(SUBSTRING(table_name, length('vet_') + 1) AS INT64) >= ${min_vat_table_num}" > vet_tables.csv
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -188,7 +181,7 @@ task CreateAltAlleleTable {
 
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsCreateAltAllele.wdl
@@ -36,7 +36,7 @@ workflow GvsCreateAltAllele {
 
   call Utils.GetBQTableLastModifiedDatetime {
     input:
-      go = CreateAltAlleleTable.done,
+      go = select_first([skip_create_alt_allele_table, CreateAltAlleleTable.done]),
       query_project = project_id,
       fq_table = fq_alt_allele_table
   }

--- a/scripts/variantstore/wdl/GvsCreateTables.wdl
+++ b/scripts/variantstore/wdl/GvsCreateTables.wdl
@@ -103,7 +103,7 @@ task CreateTables {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -124,7 +124,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -405,7 +405,7 @@ task BigQuerySmokeTest {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -169,7 +169,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -291,7 +291,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -85,7 +85,7 @@ task CountSamples {
         Int num_samples = read_int(stdout())
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     }
 }
 
@@ -152,7 +152,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     }
 }
 
@@ -203,6 +203,6 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -238,7 +238,7 @@ task ValidateFilterSetName {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -393,7 +393,7 @@ task SumBytes {
     print(total_mb);"
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -432,7 +432,7 @@ task CreateManifest {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -474,7 +474,7 @@ task GenerateSampleListFile {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -8,7 +8,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 workflow GvsExtractCohortFromSampleNames {
 
   input {
-    # cohort_sample_names_array will take precedence over cohort_sample_names if both are set 
+    # cohort_sample_names_array will take precedence over cohort_sample_names if both are set
     Array[String]? cohort_sample_names_array
     File? cohort_sample_names
 
@@ -43,7 +43,7 @@ workflow GvsExtractCohortFromSampleNames {
     call write_array_task {
       input:
         input_array = select_first([cohort_sample_names_array]),
-        docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     }
   }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -139,7 +139,7 @@ task CreateFOFNs {
     split -d -a 5 -l ~{batch_size} ~{sample_name_list} batched_sample_names.
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     bootDiskSizeGb: 15
     memory: "3 GB"
     disks: "local-disk 10 HDD"
@@ -275,7 +275,7 @@ task SetIsLoadedColumn {
     'UPDATE `~{dataset_name}.sample_info` SET is_loaded = true WHERE sample_id IN (SELECT CAST(partition_id AS INT64) from `~{dataset_name}.INFORMATION_SCHEMA.PARTITIONS` WHERE partition_id NOT LIKE "__%" AND total_logical_bytes > 0 AND table_name LIKE "vet_%") OR sample_id IN (SELECT sample_id FROM `~{dataset_name}.sample_load_status` GROUP BY 1 HAVING COUNT(1) = 2)'
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "1 GB"
     disks: "local-disk 10 HDD"
     cpu: 1
@@ -354,7 +354,7 @@ task GetUningestedSampleIds {
     bq --project_id=~{project_id} rm -f=true ${TEMP_TABLE}
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "1 GB"
     disks: "local-disk 10 HDD"
     preemptible: 5
@@ -391,7 +391,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsIngestTieout.wdl
+++ b/scripts/variantstore/wdl/GvsIngestTieout.wdl
@@ -143,7 +143,7 @@ task IngestTieout {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         memory: "14 GB"
         disks: "local-disk 2000 HDD"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-workflow GvsCreateAltAllele {
+workflow GvsPopulateAltAllele {
   input {
     Boolean go = true
     String dataset_name

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -225,7 +225,7 @@ task PopulateAltAlleleTable {
       --max_sample_id ~{max_sample_id} \
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:rsa_vs_52_incremental_alt_allele_2022_08_17"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -105,7 +105,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -188,7 +188,7 @@ task AssertIdenticalOutputs {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         disks: "local-disk 500 HDD"
     }
 
@@ -286,7 +286,7 @@ task AssertCostIsTrackedAndExpected {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         disks: "local-disk 10 HDD"
     }
 
@@ -335,7 +335,7 @@ task AssertTableSizesAreExpected {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
         disks: "local-disk 10 HDD"
     }
 

--- a/scripts/variantstore/wdl/GvsUnified.wdl
+++ b/scripts/variantstore/wdl/GvsUnified.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-import "GvsCreateAltAllele.wdl" as CreateAltAllele
+import "GvsPopulateAltAllele.wdl" as CreateAltAllele
 import "GvsCreateFilterSet.wdl" as CreateFilterSet
 import "GvsPrepareRangesCallset.wdl" as PrepareRangesCallset
 import "GvsExtractCallset.wdl" as ExtractCallset
@@ -96,7 +96,7 @@ workflow GvsUnified {
             load_data_batch_size = load_data_batch_size
     }
 
-    call CreateAltAllele.GvsCreateAltAllele {
+    call CreateAltAllele.GvsPopulateAltAllele {
         input:
             call_set_identifier = call_set_identifier,
             go = GvsImportGenomes.done,
@@ -106,7 +106,7 @@ workflow GvsUnified {
 
     call CreateFilterSet.GvsCreateFilterSet {
         input:
-            go = GvsCreateAltAllele.done,
+            go = GvsPopulateAltAllele.done,
             dataset_name = dataset_name,
             project_id = project_id,
             call_set_identifier = call_set_identifier,

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -164,7 +164,7 @@ task GetBQTableLastModifiedDatetime {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -202,7 +202,7 @@ task GetBQTablesMaxLastModifiedTimestamp {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -281,7 +281,7 @@ task BuildGATKJarAndCreateDataset {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     disks: "local-disk 500 HDD"
   }
 }
@@ -345,7 +345,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_16"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2022_08_22"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3
@@ -382,7 +382,7 @@ task GetNumSamplesLoaded {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3

--- a/scripts/variantstore/wdl/extract/populate_alt_allele_table.py
+++ b/scripts/variantstore/wdl/extract/populate_alt_allele_table.py
@@ -25,7 +25,7 @@ def populate_alt_allele_table(call_set_identifier, query_project, vet_table_name
     query_with = f"""INSERT INTO `{fq_dataset}.alt_allele`
                 WITH
                   position1 as (select * from `{fq_vet_table}` WHERE call_GT IN ('0/1', '1/0', '1/1', '0|1', '1|0', '1|1', '0/2', '0|2','2/0', '2|0') AND sample_id > {max_sample_id}),
-                  position2 as (select * from `{fq_vet_table}` WHERE call_GT IN ('1/2', '1|2', '2/1', '2|1') sample_id > {max_sample_id})"""
+                  position2 as (select * from `{fq_vet_table}` WHERE call_GT IN ('1/2', '1|2', '2/1', '2|1') AND sample_id > {max_sample_id})"""
 
     sql = alt_allele_temp_function + query_with + alt_allele_positions
     query_return = utils.execute_with_retry(client, f"into alt allele from {vet_table_name}", sql)

--- a/scripts/variantstore/wdl/extract/populate_alt_allele_table.py
+++ b/scripts/variantstore/wdl/extract/populate_alt_allele_table.py
@@ -11,7 +11,7 @@ import utils
 client = None
 
 
-def populate_alt_allele_table(call_set_identifier, query_project, vet_table_name, fq_dataset, sa_key_path):
+def populate_alt_allele_table(call_set_identifier, query_project, vet_table_name, fq_dataset, max_sample_id, sa_key_path):
     global client
     # add labels for DSP Cloud Cost Control Labeling and Reporting to default_config
     default_config = QueryJobConfig(priority="INTERACTIVE", use_query_cache=True, labels={'service':'gvs','team':'variants','managedby':'create_alt_allele'})
@@ -33,9 +33,9 @@ def populate_alt_allele_table(call_set_identifier, query_project, vet_table_name
     alt_allele_positions = Path('alt_allele_positions.sql').read_text()
     fq_vet_table = f"{fq_dataset}.{vet_table_name}"
     query_with = f"""INSERT INTO `{fq_dataset}.alt_allele`
-                WITH 
-                  position1 as (select * from `{fq_vet_table}` WHERE call_GT IN ('0/1', '1/0', '1/1', '0|1', '1|0', '1|1', '0/2', '0|2','2/0', '2|0')),
-                  position2 as (select * from `{fq_vet_table}` WHERE call_GT IN ('1/2', '1|2', '2/1', '2|1'))"""
+                WITH
+                  position1 as (select * from `{fq_vet_table}` WHERE call_GT IN ('0/1', '1/0', '1/1', '0|1', '1|0', '1|1', '0/2', '0|2','2/0', '2|0') AND sample_id > {max_sample_id}),
+                  position2 as (select * from `{fq_vet_table}` WHERE call_GT IN ('1/2', '1|2', '2/1', '2|1') sample_id > {max_sample_id})"""
 
     sql = alt_allele_temp_function + query_with + alt_allele_positions
     query_return = utils.execute_with_retry(client, f"into alt allele from {vet_table_name}", sql)
@@ -49,6 +49,7 @@ if __name__ == '__main__':
     parser.add_argument('--query_project',type=str, help='Google project where query should be executed', required=True)
     parser.add_argument('--vet_table_name',type=str, help='vet table name to ingest', required=True)
     parser.add_argument('--fq_dataset',type=str, help='project and dataset for data', required=True)
+    parser.add_argument('--max_sample_id',type=str, help='Maximum value of sample_id already loaded', required=True)
     parser.add_argument('--sa_key_path',type=str, help='Path to json key file for SA', required=False)
 
 
@@ -59,4 +60,5 @@ if __name__ == '__main__':
                               args.query_project,
                               args.vet_table_name,
                               args.fq_dataset,
+                              args.max_sample_id,
                               args.sa_key_path)


### PR DESCRIPTION
- changed CREATE OR REPLACE TABLE to CREATE TABLE IF NOT EXISTS for `alt_allele`
- pass around max sample id already in `alt_allele` to figure out which `vet_` table to start with and what sample IDs data to grab
- tied out by comparing `gvs-internal.rsa_gvs_quickstart_dev.alt_allele` (done with existing version) vs. `gvs-internal.rsa_gvs_quickstart_dev.alt_allele_incremental` (done in two batches with code from this branch)
- renamed WDL to GvsPopulateAltAllele

Closed https://broadworkbench.atlassian.net/browse/VS-52