### PR TITLE
File of callset samples -> samples marked as 'withdrawn' in GVS [VS-436]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -179,7 +179,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - 
+         - rsa_vs_436_withdrawn_wdl
    - name: GvsUnified
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsUnified.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -179,6 +179,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - 
    - name: GvsUnified
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsUnified.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,7 +95,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsPopulateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -103,7 +102,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsCreateTables
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateTables.wdl
@@ -120,7 +118,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -128,7 +125,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -138,7 +134,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -171,7 +166,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -179,7 +173,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_vs_436_withdrawn_wdl
    - name: GvsUnified
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsUnified.wdl
@@ -187,7 +180,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsJointVariantCalling
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -195,7 +187,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsJointVariantCallsetCost
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCallsetCost.wdl
@@ -217,7 +208,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -75,8 +75,6 @@ task WithdrawSamples {
         AND NOT samples.is_control \
         AND withdrawn IS NULL)" > log_message.txt
 
-    cat log_message.txt
-
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
   >>>
   runtime {

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -66,14 +66,14 @@ task WithdrawSamples {
 
     # join on the temp table to figure out which samples should be marked as withdrawn
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
+      "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset \
+        FROM \`~{project_id}.~{dataset_name}.current_callset_samples\` AS callset \
         WHERE \
         samples.sample_name = callset.sample_name \
         AND NOT samples.is_control \
-        AND withdrawn IS NULL)' > log_message.txt
+        AND withdrawn IS NULL)" > log_message.txt
 
     cat log_message.txt
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -69,7 +69,7 @@ task WithdrawSamples {
       "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM \`gvs-internal.rsa_gvs_quickstart_dev.current_callset_samples\` AS callset \
+        FROM \`~{project_id}.~{dataset_name}.current_callset_samples\` AS callset \
         WHERE \
         samples.sample_name = callset.sample_name \
         AND NOT samples.is_control)" > log_message.txt

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -66,13 +66,14 @@ task WithdrawSamples {
 
     # join on the temp table to figure out which samples should be marked as withdrawn
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
+      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM \`~{project_id}.~{dataset_name}.current_callset_samples\` AS callset \
+        FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset \
         WHERE \
         samples.sample_name = callset.sample_name \
-        AND NOT samples.is_control)" > log_message.txt
+        AND NOT samples.is_control \
+        AND withdrawn IS NULL)' > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
   >>>

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -49,7 +49,7 @@ task WithdrawSamples {
     # get just the sample_name values from sample_names_to_include_file based on the
     # sample_name_column_name_in_file into sample_names.tsv
     col_num=$(head -n1 ~{sample_names_to_include_file} | tr '\t' '\n' | grep -Fxn ~{sample_name_column_name_in_file} | cut -f1 -d:)
-    awk "{print \$$col_num}" delta_v1_updated_wgs_available_flt_array_Aug152022_1600_35_tz0000.tsv | sed 1d > sample_names.tsv
+    awk "{print \$$col_num}" ~{sample_names_to_include_file} | sed 1d > sample_names.tsv
 
     # make sure that we end up with some samples to make the temp table, warn and exit if empty
     num_samples=$(cat sample_names.tsv | wc -l)

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -49,7 +49,7 @@ task WithdrawSamples {
 
     # get just the sample_name values from sample_names_to_include_file based on the
     # sample_name_column_name_in_file into sample_names.tsv
-    col_num=$(head -n1 ~{sample_names_to_include_file} | tr '\t' '\n' | grep -Fxn ~{sample_name_column_name_in_file} | cut -f1 -d:)
+    col_num=$(head -n1 ~{sample_names_to_include_file} | tr '\t' '\n' | grep -Fxn '~{sample_name_column_name_in_file}' | cut -f1 -d:)
     awk "{print \$$col_num}" ~{sample_names_to_include_file} | sed 1d > sample_names.tsv
 
     # make sure that we end up with some samples to make the temp table, warn and exit if empty

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -38,7 +38,7 @@ task WithdrawSamples {
   }
 
   meta {
-    description: "Given a list of samples for a callset, withdraw samples from GVS that are not includedby marking them as 'withdrawn' in the sample_info table with a passed in timestamp."
+    description: "Given a list of samples for a callset, withdraw samples from GVS that are not included by marking them as 'withdrawn' in the sample_info table with a passed in timestamp."
     # Might not be strictly necessary to make this volatile, but just in case:
     volatile: true
   }

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -75,6 +75,8 @@ task WithdrawSamples {
         AND NOT samples.is_control \
         AND withdrawn IS NULL)' > log_message.txt
 
+    cat log_message.txt
+
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
   >>>
   runtime {

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -6,14 +6,19 @@ workflow GvsWithdrawSamples {
     String dataset_name
     String project_id
 
-    Array[String] sample_names
+    String sample_name_column_name_in_file
+    File sample_names_to_include_file
+    # should be in the format "2022-01-01 00:00:00 UTC"
+    String withdrawn_timestamp
   }
 
   call WithdrawSamples {
     input:
       project_id = project_id,
       dataset_name = dataset_name,
-      sample_names = sample_names
+      sample_name_column_name_in_file = sample_name_column_name_in_file,
+      sample_names_to_include_file = sample_names_to_include_file,
+      withdrawn_timestamp = withdrawn_timestamp
   }
 
   output {
@@ -26,40 +31,49 @@ task WithdrawSamples {
     String project_id
     String dataset_name
 
-    Array[String] sample_names
+    String sample_name_column_name_in_file
+    File sample_names_to_include_file
+    # should be in the format "2022-01-01 00:00:00 UTC"
+    String withdrawn_timestamp
   }
 
   meta {
-    description: "Withdraw Samples from GVS by marking them as 'withdrawn' in the sample_info table"
+    description: "Given a list of samples for a callset, withdraw samples from GVS that are not includedby marking them as 'withdrawn' in the sample_info table with a passed in timestamp."
     # Might not be strictly necessary to make this volatile, but just in case:
     volatile: true
   }
 
   command <<<
-    set -e
-    set -x
+    set -o errexit -o nounset -o xtrace -o pipefail
 
-    # make sure that sample names were actually passed, warn and exit if empty
-    num_samples=~{length(sample_names)}
+    # get just the sample_name values from sample_names_to_include_file based on the
+    # sample_name_column_name_in_file into sample_names.tsv
+    col_num=$(head -n1 ~{sample_names_to_include_file} | tr '\t' '\n' | grep -Fxn ~{sample_name_column_name_in_file} | cut -f1 -d:)
+    awk "{print \$$col_num}" delta_v1_updated_wgs_available_flt_array_Aug152022_1600_35_tz0000.tsv | sed 1d > sample_names.tsv
+
+    # make sure that we end up with some samples to make the temp table, warn and exit if empty
+    num_samples=$(cat sample_names.tsv | wc -l)
     if [ $num_samples -eq 0 ]; then
-      echo "No sample names passed. Exiting"
+      echo "No sample names for callset produced. Exiting"
       exit 0
     fi
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
+    # create the temp table (expires in 1 day)
+    bq --project_id=~{project_id} mk --expiration=86400 ~{dataset_name}.current_callset_samples "sample_name:STRING"
+    # populate the temp table
+    bq load --project_id=~{project_id} -F "tab" ~{dataset_name}.current_callset_samples sample_names.tsv
 
-    # perform actual update
     bq --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      'UPDATE `~{dataset_name}.sample_info` SET withdrawn = CURRENT_TIMESTAMP() WHERE sample_name IN ("~{sep='\", \"' sample_names}")' > log_message.txt;
+      "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
+        WHERE NOT EXISTS \
+        (SELECT * \
+        FROM \`gvs-internal.rsa_gvs_quickstart_dev.current_callset_samples\` AS callset \
+        WHERE \
+        samples.sample_name = callset.sample_name \
+        AND NOT samples.is_control)" > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
-    typeset -i rows_updated=$(cat rows_updated.txt)
-
-    if [ $num_samples -ne $rows_updated ]; then
-      echo "Error: Expected to update $num_samples rows - but only updated $rows_updated."
-      exit 1
-    fi
-
   >>>
   runtime {
     docker: "us.gcr.io/broad-gatk/gatk:4.2.5.0"


### PR DESCRIPTION
Given a list of samples for a callset, withdraw samples from GVS that are not included by marking them as 'withdrawn' in the sample_info table with a passed in timestamp.

Test run here: https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/568919e6-3c51-4ce9-978c-75ffc5ff9997