### PR TITLE
VS-517   Use standard version of GetBQTableLastModifiedDatetime in GvsValidateVat

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -159,6 +159,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - ah_vs617
    - name: GvsExtractCohortFromSampleNames
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -159,7 +159,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ah_vs617
+         - ah_vs517
    - name: GvsExtractCohortFromSampleNames
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -160,7 +160,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ah_vs517
    - name: GvsExtractCohortFromSampleNames
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl


### PR DESCRIPTION
Simply replaced a custom version of the task with a standard one we are using elsewhere

Original run:
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20hatcher/job_history/193c7c2b-2d29-4bab-8abc-6ab85a2f5270

Run from the modified branch:
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20hatcher/job_history/575121f1-07e9-4821-bb20-35b6ed430560

Both ran within my quickstart workspace, but were pointed at George's dataset.  Both failed the same two predicted tasks.