### PR TITLE
Expose maximum-training-variants VQSR parameter [VS-634]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -103,7 +103,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsCreateTables
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateTables.wdl
@@ -120,7 +119,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -128,7 +126,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -138,7 +135,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -171,7 +167,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -186,7 +181,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsJointVariantCalling
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -194,7 +188,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsJointVariantCallsetCost
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCallsetCost.wdl
@@ -216,7 +209,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,7 +95,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_nth_variant_10
+         - sl_expose_vqsr_snp_max_training_variants
    - name: GvsPopulateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPopulateAltAllele.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,7 +95,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_581_fix_withdrawn
+         - rsa_nth_variant_10
    - name: GvsPopulateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPopulateAltAllele.wdl

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -21,6 +21,7 @@ workflow GvsCreateFilterSet {
     Int? INDEL_VQSR_mem_gb_override
     Int? SNP_VQSR_max_gaussians_override = 6
     Int? SNP_VQSR_mem_gb_override
+    Int? SNP_VQSR_sample_every_nth_variant
     # This is the minimum number of samples where the SNP model will be created and applied in separate tasks
     # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
     # For WARP classic this is done with 20k but the 10K Stroke Anderson dataset would not work unscattered (at least
@@ -156,6 +157,7 @@ workflow GvsCreateFilterSet {
         disk_size = "1000",
         machine_mem_gb = SNP_VQSR_mem_gb_override,
         max_gaussians = SNP_VQSR_max_gaussians_override,
+        sample_every_nth_variant = SNP_VQSR_sample_every_nth_variant,
     }
 
     scatter (idx in range(length(ExtractFilterTask.output_vcf))) {

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -22,6 +22,7 @@ workflow GvsCreateFilterSet {
     Int? SNP_VQSR_max_gaussians_override = 6
     Int? SNP_VQSR_mem_gb_override
     Int? SNP_VQSR_sample_every_nth_variant
+    Int? SNP_VQSR_maximum_training_variants
     # This is the minimum number of samples where the SNP model will be created and applied in separate tasks
     # (SNPsVariantRecalibratorClassic vs. SNPsVariantRecalibratorCreateModel and SNPsVariantRecalibratorScattered)
     # For WARP classic this is done with 20k but the 10K Stroke Anderson dataset would not work unscattered (at least
@@ -158,6 +159,7 @@ workflow GvsCreateFilterSet {
         machine_mem_gb = SNP_VQSR_mem_gb_override,
         max_gaussians = SNP_VQSR_max_gaussians_override,
         sample_every_nth_variant = SNP_VQSR_sample_every_nth_variant,
+        maximum_training_variants = SNP_VQSR_maximum_training_variants
     }
 
     scatter (idx in range(length(ExtractFilterTask.output_vcf))) {

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -18,6 +18,7 @@ workflow GvsCreateFilterSet {
     File gatk_override = "gs://gvs_quickstart_storage/jars/gatk-package-4.2.0.0-613-g1219576-SNAPSHOT-local.jar"
 
     Int? INDEL_VQSR_max_gaussians_override = 4
+    Int? INDEL_VQSR_maximum_training_variants
     Int? INDEL_VQSR_mem_gb_override
     Int? SNP_VQSR_max_gaussians_override = 6
     Int? SNP_VQSR_mem_gb_override
@@ -134,6 +135,7 @@ workflow GvsCreateFilterSet {
       disk_size = "1000",
       machine_mem_gb = INDEL_VQSR_mem_gb_override,
       max_gaussians = INDEL_VQSR_max_gaussians_override,
+      maximum_training_variants = INDEL_VQSR_maximum_training_variants,
   }
 
   if (GetNumSamplesLoaded.num_samples > snps_variant_recalibration_threshold) {

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -411,6 +411,7 @@ task PopulateFilterSetInfo {
 
   output {
     String status_load_filter_set_info = read_string("status_load_filter_set_info")
+    File monitoring_log = "monitoring.log"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -403,7 +403,7 @@ task PopulateFilterSetInfo {
   runtime {
     docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_d8a72b825eab2d979c8877448c0ca948fd9b34c7_change_to_hwe"
     memory: "3500 MB"
-    disks: "local-disk 500 HDD"
+    disks: "local-disk 250 HDD"
     bootDiskSizeGb: 15
     preemptible: 0
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -352,6 +352,7 @@ task PopulateFilterSetInfo {
 
     String query_project
 
+    File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
     File? gatk_override
   }
   meta {
@@ -360,6 +361,8 @@ task PopulateFilterSetInfo {
 
   command <<<
     set -eo pipefail
+
+    bash ~{monitoring_script} > monitoring.log &
 
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
@@ -400,7 +403,7 @@ task PopulateFilterSetInfo {
   runtime {
     docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_d8a72b825eab2d979c8877448c0ca948fd9b34c7_change_to_hwe"
     memory: "3500 MB"
-    disks: "local-disk 200 HDD"
+    disks: "local-disk 500 HDD"
     bootDiskSizeGb: 15
     preemptible: 0
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -161,10 +161,7 @@ workflow GvsCreateFilterSet {
         machine_mem_gb = SNP_VQSR_mem_gb_override,
         max_gaussians = SNP_VQSR_max_gaussians_override,
         sample_every_nth_variant = SNP_VQSR_sample_every_nth_variant,
-<<<<<<< HEAD
         maximum_training_variants = SNP_VQSR_maximum_training_variants
-=======
->>>>>>> ah_var_store
     }
 
     scatter (idx in range(length(ExtractFilterTask.output_vcf))) {

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -335,6 +335,7 @@ task ExtractFilterTask {
     disks: "local-disk 10 HDD"
     bootDiskSizeGb: 15
     preemptible: 3
+    maxRetries: 3
     cpu: 2
   }
 

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -23,6 +23,7 @@ task SNPsVariantRecalibratorCreateModel {
         File dbsnp_resource_vcf_index
         Boolean use_allele_specific_annotations
         Int max_gaussians = 6
+        Int sample_every_nth_variant = 1
         Int? machine_mem_gb
 
         Int disk_size
@@ -44,7 +45,7 @@ task SNPsVariantRecalibratorCreateModel {
         -an ~{sep=' -an ' recalibration_annotation_values} \
         ~{true='--use-allele-specific-annotations' false='' use_allele_specific_annotations} \
         -mode SNP \
-        --sample-every-Nth-variant 1 \
+        --sample-every-Nth-variant ~{sample_every_nth_variant} \
         --output-model ~{model_report_filename} \
         --max-gaussians ~{max_gaussians} \
         -resource:hapmap,known=false,training=true,truth=true,prior=15 ~{hapmap_resource_vcf} \

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -27,6 +27,7 @@ task SNPsVariantRecalibratorCreateModel {
         Int? machine_mem_gb
 
         Int disk_size
+        File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
     }
 
     Int machine_mem = select_first([machine_mem_gb, 100])
@@ -34,6 +35,8 @@ task SNPsVariantRecalibratorCreateModel {
 
     command <<<
         set -euo pipefail
+
+        bash ~{monitoring_script} > monitoring.log &
 
         gatk --java-options -Xms~{java_mem}g \
         VariantRecalibrator \
@@ -65,6 +68,7 @@ task SNPsVariantRecalibratorCreateModel {
 
     output {
         File model_report = "~{model_report_filename}"
+        File monitoring_log = "monitoring.log"
     }
 }
 

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -162,6 +162,7 @@ task IndelsVariantRecalibrator {
         File dbsnp_resource_vcf_index
         Boolean use_allele_specific_annotations
         Int max_gaussians = 4
+        Int maximum_training_variants = 2500000
 
         Int disk_size
         Int? machine_mem_gb
@@ -187,6 +188,7 @@ task IndelsVariantRecalibrator {
         -mode INDEL \
         ~{"--input-model " + model_report} \
         --max-gaussians ~{max_gaussians} \
+        --maximum-training-variants ~{maximum_training_variants} \
         -resource:mills,known=false,training=true,truth=true,prior=12 ~{mills_resource_vcf} \
         -resource:axiomPoly,known=false,training=true,truth=false,prior=10 ~{axiomPoly_resource_vcf} \
         -resource:dbsnp,known=true,training=false,truth=false,prior=2 ~{dbsnp_resource_vcf}

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -50,10 +50,7 @@ task SNPsVariantRecalibratorCreateModel {
         ~{true='--use-allele-specific-annotations' false='' use_allele_specific_annotations} \
         -mode SNP \
         --sample-every-Nth-variant ~{sample_every_nth_variant} \
-<<<<<<< HEAD
         --maximum-training-variants ~{maximum_training_variants} \
-=======
->>>>>>> ah_var_store
         --output-model ~{model_report_filename} \
         --max-gaussians ~{max_gaussians} \
         -resource:hapmap,known=false,training=true,truth=true,prior=15 ~{hapmap_resource_vcf} \

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -24,6 +24,7 @@ task SNPsVariantRecalibratorCreateModel {
         Boolean use_allele_specific_annotations
         Int max_gaussians = 6
         Int sample_every_nth_variant = 1
+        Int maximum_training_variants = 2500000
         Int? machine_mem_gb
 
         Int disk_size
@@ -49,6 +50,7 @@ task SNPsVariantRecalibratorCreateModel {
         ~{true='--use-allele-specific-annotations' false='' use_allele_specific_annotations} \
         -mode SNP \
         --sample-every-Nth-variant ~{sample_every_nth_variant} \
+        --maximum-training-variants ~{maximum_training_variants} \
         --output-model ~{model_report_filename} \
         --max-gaussians ~{max_gaussians} \
         -resource:hapmap,known=false,training=true,truth=true,prior=15 ~{hapmap_resource_vcf} \


### PR DESCRIPTION
Expose the maximum-training-variants parameter for both INDEL and SNP model creation in the `GvsCreateFilterSet` WDL.

Closes https://broadworkbench.atlassian.net/browse/VS-634