### PR TITLE
Ah 617 exposing the drop_state parameter to the GvsJointVariantCalling wdl used for beta (and internal customer)

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -188,6 +188,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - ah_617
    - name: GvsJointVariantCallsetCost
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCallsetCost.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -188,7 +188,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ah_617
    - name: GvsJointVariantCallsetCost
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCallsetCost.wdl

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -11,6 +11,7 @@ workflow GvsJointVariantCalling {
         Array[File] input_vcf_indexes
         String call_set_identifier
         String? extract_output_gcs_dir
+        String drop_state = "FORTY"
     }
 
     # the call_set_identifier string is used to name many different things throughout this workflow (BQ tables, vcfs etc),
@@ -77,6 +78,7 @@ workflow GvsJointVariantCalling {
             INDEL_VQSR_mem_gb_override = INDEL_VQSR_mem_gb_override,
             SNP_VQSR_max_gaussians_override = SNP_VQSR_max_gaussians_override,
             SNP_VQSR_mem_gb_override = SNP_VQSR_mem_gb_override,
+            drop_state = drop_state,
     }
 
     output {


### PR DESCRIPTION
I made it a non-optional paramater, but also have it defaulting to "FORTY" so beta users will have the same experience they did before by default, but we can override it trivially if we ever need to use a different drop state