### PR TITLE
Added toggle for selecting resource-matching strategies and miscellaneous minor fixes to new annotation-based filtering tools.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ExtractVariantAnnotations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ExtractVariantAnnotations.java
@@ -170,11 +170,11 @@ import java.util.stream.Collectors;
  *          ...
  *          -A annotation_N \
  *          --mode SNP \
- *          --resource snp-training,training=true snp-training.vcf \
- *          --resource snp-calibration,calibration=true snp-calibration.vcf \
+ *          --resource:snp-training,training=true snp-training.vcf \
+ *          --resource:snp-calibration,calibration=true snp-calibration.vcf \
  *          --mode INDEL \
- *          --resource indel-training,training=true indel-training.vcf \
- *          --resource indel-calibration,calibration=true indel-calibration.vcf \
+ *          --resource:indel-training,training=true indel-training.vcf \
+ *          --resource:indel-calibration,calibration=true indel-calibration.vcf \
  *          -O extract
  * </pre>
  * </p>
@@ -195,11 +195,11 @@ import java.util.stream.Collectors;
  *          ...
  *          -A annotation_N \
  *          --mode SNP \
- *          --resource snp-training,training=true snp-training.vcf \
- *          --resource snp-calibration,calibration=true snp-calibration.vcf \
+ *          --resource:snp-training,training=true snp-training.vcf \
+ *          --resource:snp-calibration,calibration=true snp-calibration.vcf \
  *          --mode INDEL \
- *          --resource indel-training,training=true indel-training.vcf \
- *          --resource indel-calibration,calibration=true indel-calibration.vcf \
+ *          --resource:indel-training,training=true indel-training.vcf \
+ *          --resource:indel-calibration,calibration=true indel-calibration.vcf \
  *          --maximum-number-of-unlableled-variants 1000000
  *          -O extract
  * </pre>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ScoreVariantAnnotations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ScoreVariantAnnotations.java
@@ -190,12 +190,12 @@ import java.util.stream.IntStream;
  *          -A annotation_N \
  *          --model-prefix model_dir \
  *          --mode SNP \
- *          --resource snp-training,training=true snp-training.vcf \
- *          --resource snp-calibration,calibration=true snp-calibration.vcf \
+ *          --resource:snp-training,training=true snp-training.vcf \
+ *          --resource:snp-calibration,calibration=true snp-calibration.vcf \
  *          --mode INDEL \
- *          --resource indel-training,training=true indel-training.vcf \
- *          --resource indel-calibration,calibration=true indel-calibration.vcf \
- *          --resource extracted,extracted=true extract.vcf.gz \
+ *          --resource:indel-training,training=true indel-training.vcf \
+ *          --resource:indel-calibration,calibration=true indel-calibration.vcf \
+ *          --resource:extracted,extracted=true extract.vcf.gz \
  *          --snp-calibration-sensitivity-threshold 0.99 \
  *          --indel-calibration-sensitivity-threshold 0.99 \
  *          -O output
@@ -216,9 +216,9 @@ import java.util.stream.IntStream;
  *          -A snp_annotation_N \
  *          --model-prefix model_dir \
  *          --mode SNP \
- *          --resource snp-training,training=true snp-training.vcf \
- *          --resource snp-calibration,calibration=true snp-calibration.vcf \
- *          --resource extracted,extracted=true snp-extract.vcf.gz \
+ *          --resource:snp-training,training=true snp-training.vcf \
+ *          --resource:snp-calibration,calibration=true snp-calibration.vcf \
+ *          --resource:extracted,extracted=true snp-extract.vcf.gz \
  *          --snp-calibration-sensitivity-threshold 0.99 \
  *          -O intermediate-output
  *
@@ -229,9 +229,9 @@ import java.util.stream.IntStream;
  *          -A indel_annotation_M \
  *          --model-prefix model_dir \
  *          --mode INDEL \
- *          --resource indel-training,training=true indel-training.vcf \
- *          --resource indel-calibration,calibration=true indel-calibration.vcf \
- *          --resource extracted,extracted=true indel-extract.vcf.gz \
+ *          --resource:indel-training,training=true indel-training.vcf \
+ *          --resource:indel-calibration,calibration=true indel-calibration.vcf \
+ *          --resource:extracted,extracted=true indel-extract.vcf.gz \
  *          --indel-calibration-sensitivity-threshold 0.99 \
  *          -O output
  * </pre>


### PR DESCRIPTION
Ticks off a few straggler issues noted in #7724.

@meganshand mind reviewing? Hopefully should be quick and we can get it in before @droazen cuts the next release. Note that this shouldn't change behavior in the Ultima pipeline, as the default toggle is still the same start-position resource-matching strategy inherited from VQSR, but we might want to explore the effect of choosing another strategy there.