### PR TITLE
VS-665 updating beta workflow to use changes tested in quickstart

### DIFF
--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -35,7 +35,8 @@ workflow GvsJointVariantCalling {
       Int SNP_VQSR_max_gaussians_override = 6
       Int SNP_VQSR_mem_gb_override = ""
     }
-    File gatk_override = "gs://gvs_quickstart_storage/jars/gatk-package-4.2.0.0-613-g1219576-SNAPSHOT-local.jar"
+    # This is the most updated snapshot of the code as of Oct 18, 2022
+    File gatk_override = "gs://gvs_quickstart_storage/jars/gatk-package-4.2.0.0-625-g950122c-SNAPSHOT-local.jar"
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     Array[String] indel_recalibration_annotation_values = ["AS_FS", "AS_ReadPosRankSum", "AS_MQRankSum", "AS_QD", "AS_SOR"]
     Array[String] snp_recalibration_annotation_values = ["AS_QD", "AS_MQRankSum", "AS_ReadPosRankSum", "AS_FS", "AS_MQ", "AS_SOR"]


### PR DESCRIPTION
Updating the beta workflow to use the latest jar, representing the version of GATK tested against the quickstart workflow