### PR TITLE
Revert Alpinizing of apt dependent task [VS-688]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -209,7 +209,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_661_restore_bcftools
+         - vs_688_fix_integration_for_alpine
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -222,6 +222,8 @@ task BuildGATKJarAndCreateDataset {
 
   command <<<
     # Much of this could/should be put into a Docker image.
+    # Prepend date, time and pwd to xtrace log entries.
+    PS4='\D{+%F %T} \w $ '
     set -o errexit -o nounset -o pipefail -o xtrace
 
     # git and git-lfs
@@ -281,7 +283,7 @@ task BuildGATKJarAndCreateDataset {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:404.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:404.0.0-slim"
     disks: "local-disk 500 HDD"
   }
 }


### PR DESCRIPTION
Integration run [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/76c46310-3c0d-43a8-9fce-072ef7750651).

As written the task requires `apt-get`. Converting this to Alpine would be non-trivial and not really worthwhile as it might even take longer to build all the extra things into the `alpine` image that we simply download with the `slim` image.