### PR TITLE
Add option to not prepare __REF_DATA table to Prepare [VS-697]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -125,7 +125,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-637_RespectSampleLoadStatusFinishedFlag
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -135,7 +134,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_vs_697
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -168,7 +166,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rsa_vs_697
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -232,7 +229,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_655_avro_extract_warn_on_bad_filter_name
    - name: GvsCallsetStatistics
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -240,7 +236,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_655_avro_extract_warn_on_bad_filter_name
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -135,6 +135,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_vs_697
    - name: GvsCreateVAT
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsCreateVAT.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -168,6 +168,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_vs_697
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -264,7 +264,7 @@ task Add_AS_MAX_VQSLOD_ToVcf {
     File input_vcf
     String output_basename
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -264,7 +264,7 @@ task Add_AS_MAX_VQSLOD_ToVcf {
     File input_vcf
     String output_basename
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -124,7 +124,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -124,7 +124,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -124,7 +124,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVAT.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVAT.wdl
@@ -124,7 +124,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -169,7 +169,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -291,7 +291,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -169,7 +169,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -291,7 +291,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -169,7 +169,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -291,7 +291,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATAnnotations.wdl
@@ -169,7 +169,7 @@ task ExtractAnAcAfFromVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -291,7 +291,7 @@ task PrepAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
         memory: "8 GB"
         preemptible: 5
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -286,7 +286,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -286,7 +286,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -286,7 +286,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -286,7 +286,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -110,7 +110,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -19,7 +19,7 @@ workflow GvsPrepareCallset {
 
     Array[String]? query_labels
     File? sample_names_to_extract
-    Boolean skip_ref_ranges_tables = false
+    Boolean only_output_vet_tables = false
   }
 
   String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
@@ -40,7 +40,7 @@ workflow GvsPrepareCallset {
       fq_destination_dataset          = fq_destination_dataset,
       temp_table_ttl_in_hours         = 72,
       control_samples                 = control_samples,
-      skip_ref_ranges_tables          = skip_ref_ranges_tables
+      only_output_vet_tables          = only_output_vet_tables
   }
 
   output {
@@ -63,7 +63,7 @@ task PrepareRangesCallsetTask {
     String fq_destination_dataset
     Array[String]? query_labels
     Int temp_table_ttl_in_hours = 24
-    Boolean skip_ref_ranges_tables
+    Boolean only_output_vet_tables
   }
   meta {
     # All kinds of BQ reading happening in the referenced Python script.
@@ -102,7 +102,7 @@ task PrepareRangesCallsetTask {
           ~{sep=" " query_label_args} \
           --fq_sample_mapping_table ~{fq_sample_mapping_table} \
           --ttl ~{temp_table_ttl_in_hours} \
-          ~{true="--skip_ref_ranges_tables True" false='' skip_ref_ranges_tables}
+          ~{true="--only_output_vet_tables True" false='' only_output_vet_tables}
 
   >>>
   output {

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -110,7 +110,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -110,7 +110,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -19,6 +19,7 @@ workflow GvsPrepareCallset {
 
     Array[String]? query_labels
     File? sample_names_to_extract
+    Boolean skip_ref_ranges_tables = false
   }
 
   String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
@@ -38,7 +39,8 @@ workflow GvsPrepareCallset {
       fq_temp_table_dataset           = fq_temp_table_dataset,
       fq_destination_dataset          = fq_destination_dataset,
       temp_table_ttl_in_hours         = 72,
-      control_samples                 = control_samples
+      control_samples                 = control_samples,
+      skip_ref_ranges_tables          = skip_ref_ranges_tables
   }
 
   output {
@@ -61,6 +63,7 @@ task PrepareRangesCallsetTask {
     String fq_destination_dataset
     Array[String]? query_labels
     Int temp_table_ttl_in_hours = 24
+    Boolean skip_ref_ranges_tables
   }
   meta {
     # All kinds of BQ reading happening in the referenced Python script.
@@ -98,7 +101,9 @@ task PrepareRangesCallsetTask {
           --query_project ~{query_project} \
           ~{sep=" " query_label_args} \
           --fq_sample_mapping_table ~{fq_sample_mapping_table} \
-          --ttl ~{temp_table_ttl_in_hours}
+          --ttl ~{temp_table_ttl_in_hours} \
+          ~{true="--skip_ref_ranges_tables True" false='' skip_ref_ranges_tables}
+
   >>>
   output {
     String fq_cohort_extract_table_prefix = "~{fq_destination_dataset}.~{destination_cohort_table_prefix}" # implementation detail of create_ranges_cohort_extract_data_table.py

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -110,7 +110,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -347,7 +347,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-v2-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -347,7 +347,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-25-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -347,7 +347,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-11-07-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -347,7 +347,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-28-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-31-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
@@ -221,8 +221,8 @@ def make_extract_table(call_set_identifier,
                        fq_destination_dataset,
                        destination_table_prefix,
                        fq_sample_mapping_table,
-                       temp_table_ttl_hours
-                       ):
+                       temp_table_ttl_hours,
+                       skip_ref_ranges_tables):
     try:
         fq_destination_table_ref_data = f"{fq_destination_dataset}.{destination_table_prefix}__REF_DATA"
         fq_destination_table_vet_data = f"{fq_destination_dataset}.{destination_table_prefix}__VET_DATA"
@@ -289,10 +289,12 @@ def make_extract_table(call_set_identifier,
         print(f"Discovered {len(sample_ids)} samples in {fq_destination_table_samples}...")
 
         # create the tables for extract data
-        create_final_extract_ref_table(fq_destination_table_ref_data)
+        if not skip_ref_ranges_tables:
+            create_final_extract_ref_table(fq_destination_table_ref_data)
         create_final_extract_vet_table(fq_destination_table_vet_data)
 
-        populate_final_extract_table_with_ref(fq_ranges_dataset, fq_destination_table_ref_data, sample_ids)
+        if not skip_ref_ranges_tables:
+            populate_final_extract_table_with_ref(fq_ranges_dataset, fq_destination_table_ref_data, sample_ids)
         populate_final_extract_table_with_vet(fq_ranges_dataset, fq_destination_table_vet_data, sample_ids)
 
     finally:
@@ -325,6 +327,8 @@ if __name__ == '__main__':
     parser.add_argument('--max_tables',type=int, help='Maximum number of vet/ref ranges tables to consider', required=False,
                         default=250)
     parser.add_argument('--ttl', type=int, help='Temp table TTL in hours', required=False, default=72)
+    parser.add_argument('--skip_ref_ranges_tables', type=bool,
+                      help='Create __VET_DATA and __SAMPLES tables but skip __REF_DATA creation and population', required=False, default=False)
 
     sample_args = parser.add_mutually_exclusive_group(required=True)
     sample_args.add_argument('--sample_names_to_extract', type=str,
@@ -348,4 +352,5 @@ if __name__ == '__main__':
                        args.fq_destination_dataset,
                        args.destination_cohort_table_prefix,
                        args.fq_sample_mapping_table,
-                       args.ttl)
+                       args.ttl,
+                       args.skip_ref_ranges_tables)

--- a/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
@@ -222,7 +222,7 @@ def make_extract_table(call_set_identifier,
                        destination_table_prefix,
                        fq_sample_mapping_table,
                        temp_table_ttl_hours,
-                       skip_ref_ranges_tables):
+                       only_output_vet_tables):
     try:
         fq_destination_table_ref_data = f"{fq_destination_dataset}.{destination_table_prefix}__REF_DATA"
         fq_destination_table_vet_data = f"{fq_destination_dataset}.{destination_table_prefix}__VET_DATA"
@@ -281,20 +281,20 @@ def make_extract_table(call_set_identifier,
         # drive the extract. If this script was explicitly given a list of sample names then it should create the
         # cohort from those samples without regard to `withdrawn` on the `sample_info` table, otherwise only include
         # samples with a null `withdrawn` date in the cohort.
-        create_extract_samples_table(control_samples, fq_destination_table_samples, fq_sample_name_table,
+        if not only_output_vet_tables:
+            create_extract_samples_table(control_samples, fq_destination_table_samples, fq_sample_name_table,
                                      fq_sample_mapping_table, honor_withdrawn=not sample_names_to_extract)
 
         # pull the sample ids back down
         sample_ids = get_all_sample_ids(fq_destination_table_samples)
         print(f"Discovered {len(sample_ids)} samples in {fq_destination_table_samples}...")
 
-        # create the tables for extract data
-        if not skip_ref_ranges_tables:
+        # create and populate the tables for extract data
+        if not only_output_vet_tables:
             create_final_extract_ref_table(fq_destination_table_ref_data)
-        create_final_extract_vet_table(fq_destination_table_vet_data)
-
-        if not skip_ref_ranges_tables:
             populate_final_extract_table_with_ref(fq_ranges_dataset, fq_destination_table_ref_data, sample_ids)
+
+        create_final_extract_vet_table(fq_destination_table_vet_data)
         populate_final_extract_table_with_vet(fq_ranges_dataset, fq_destination_table_vet_data, sample_ids)
 
     finally:
@@ -327,8 +327,8 @@ if __name__ == '__main__':
     parser.add_argument('--max_tables',type=int, help='Maximum number of vet/ref ranges tables to consider', required=False,
                         default=250)
     parser.add_argument('--ttl', type=int, help='Temp table TTL in hours', required=False, default=72)
-    parser.add_argument('--skip_ref_ranges_tables', type=bool,
-                      help='Create __VET_DATA and __SAMPLES tables but skip __REF_DATA creation and population', required=False, default=False)
+    parser.add_argument('--only_output_vet_tables', type=bool,
+                      help='Only create __VET_DATA table, skip __REF_DATA and __SAMPLES tables', required=False, default=False)
 
     sample_args = parser.add_mutually_exclusive_group(required=True)
     sample_args.add_argument('--sample_names_to_extract', type=str,
@@ -353,4 +353,4 @@ if __name__ == '__main__':
                        args.destination_cohort_table_prefix,
                        args.fq_sample_mapping_table,
                        args.ttl,
-                       args.skip_ref_ranges_tables)
+                       args.only_output_vet_tables)


### PR DESCRIPTION
Since we might need to run the GvsPrepareRangesCallset.wdl in the future just to help to get the callset stats, add an optional input to not create the __REF_DATA and __SAMPLES tables, since those won't be needed.

Test runs: 
 - [with](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/1ee2bc37-abd4-4185-a17d-e1f6b47a6914) `skip_ref_ranges_tables ` set to `true`:
 - [with](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/2849dfd1-fe41-4757-83f3-fc0f5451eaef) `skip_ref_ranges_tables ` set to `false`
 - [with](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/5e8c5c4d-6ae5-4117-a5ea-89a05d379cfd) `skip_ref_ranges_tables ` not set (default is false)
 - [GvsCallsetStatistics run](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/3e14b26f-125b-4742-b7a2-17cab2ac7f6f)
... after changes ... 
- [with](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/3560a8a6-71ef-46b4-be64-fd35ea5303c6) `only_output_vet_tables` set to `true`
 - [with](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/ac3a2126-c3f1-4241-aad5-55ece4178a56) `only_output_vet_tables` set to `false`
- [GvsCreateCohortFromSampleNames](https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/35379d1b-b54a-4f5e-990a-9650c92d1ead) run (failed because of other issue)