### PR TITLE
Updated carrot publish github action version

### DIFF
--- a/.github/workflows/carrot_run_test_from_pr_comment.yml
+++ b/.github/workflows/carrot_run_test_from_pr_comment.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Parse comment
-        uses: broadinstitute/carrot-publish-github-action@v0.3.1-beta
+        uses: broadinstitute/carrot-publish-github-action@0.6.0
         with:
           software-name: gatk
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated the carrot github action workflow to the most recent version, which supports using #carrot_pr to trigger branch vs master comparison runs