### PR TITLE
SelectVariants JEXL filter fixes and refactor

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -403,7 +403,7 @@ public final class VariantFiltration extends VariantWalker {
         }
 
         for ( final JexlVCMatchExp exp : filterExps ) {
-            if ( matchesFilter(vc, null, exp, invertFilterExpression) ) {
+            if ( matchesFilter(vc, null, exp, invertFilterExpression) ) { // tsato: again g is null...like selectVariants
                 filters.add(exp.name);
             }
         }
@@ -438,7 +438,7 @@ public final class VariantFiltration extends VariantWalker {
         // Add if expression filters the variant context
         for (final JexlVCMatchExp exp : genotypeFilterExps) {
             if (matchesFilter(vc, g, exp, invertGenotypeFilterExpression)) {
-                filters.add(exp.name);
+                filters.add(exp.name); // tsato: this is where filtering happens, still not fully decoding?
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/filters/VariantFiltration.java
@@ -403,7 +403,8 @@ public final class VariantFiltration extends VariantWalker {
         }
 
         for ( final JexlVCMatchExp exp : filterExps ) {
-            if ( matchesFilter(vc, null, exp, invertFilterExpression) ) { // tsato: again g is null...like selectVariants
+            // Note that g is set to null since filterExps contains INFO-level filters
+            if ( matchesFilter(vc, null, exp, invertFilterExpression) ) {
                 filters.add(exp.name);
             }
         }
@@ -437,8 +438,9 @@ public final class VariantFiltration extends VariantWalker {
 
         // Add if expression filters the variant context
         for (final JexlVCMatchExp exp : genotypeFilterExps) {
+            // Give the genotype g to mathchesFilter enables JEXL matching on genotype fields
             if (matchesFilter(vc, g, exp, invertGenotypeFilterExpression)) {
-                filters.add(exp.name); // tsato: this is where filtering happens, still not fully decoding?
+                filters.add(exp.name);
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -692,6 +692,10 @@ public final class SelectVariants extends VariantWalker {
      *
      */
     private boolean matchesJexlFilters(final VariantContext vc){
+        if (jexls.isEmpty()){
+            return true;
+        }
+
         try {
             for (VariantContextUtils.JexlVCMatchExp jexl : jexls) {
                 // If invert-select is set to true, we take the complement (i.e. "not") of each jexl expression,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -682,7 +682,7 @@ public final class SelectVariants extends VariantWalker {
     }
 
     /**
-     *  Applies the JEXL filters
+     *  Applies     JEXL filters
      *
      *  Notes:
      *  - Expressions that contain logical-and (&&) should appear in a single -select argument.
@@ -703,8 +703,8 @@ public final class SelectVariants extends VariantWalker {
                 // e.g. -select AF > 0.01, -select ReadPosRankSum < -20.0
                 // If invert-select is false, we have "AF > 0.01 || ReadPosRankSum < -20.0"
                 // If invert-select is true, we have "not (AF > 0.01) || not (ReadPosRankSum < -20.0)"
-                if (invertLogic(VariantContextUtils.match(vc, jexl), invertSelect)){
-                    return true;
+                if (invertLogic(VariantContextUtils.match(vc, jexl), invertSelect)){ // tsato: this match method sets the vc genotype to null
+                    return true; // we have to give it the genotype if we want to enable genotype filtering.
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -545,7 +545,7 @@ public final class SelectVariants extends VariantWalker {
         return genomicsDBOptions;
     }
     // We do not output the vcf entries in the order they arrive, as trimming alleles may change the start position
-    // (e.g. in an multiallelic site, see #6444).
+    // (e.g. at a multiallelic site, see #6444).
     final private PriorityQueue<VariantContext> pendingVariants = new PriorityQueue<>(Comparator.comparingInt(VariantContext::getStart));
     /**
      * Set up the VCF writer, the sample expressions and regexs, filters inputs, and the JEXL matcher
@@ -578,7 +578,7 @@ public final class SelectVariants extends VariantWalker {
         IntStream.range(0, selectGenotypeExpressions.size()).forEach(i -> selectGenotypeNames.add(String.format("genotype-select-%d", i)));
 
         // These are maps of type (name, JEXL expression class)
-        // Note that infoJexls could also contain JEXL expressions that access genotype fields via the VariantContext object vc
+        // Note that infoJexls could also contain JEXL expressions that access genotype fields via the VariantContext object
         infoJexls = VariantContextUtils.initializeMatchExps(selectNames, selectExpressions);
         genotypeJexls = VariantContextUtils.initializeMatchExps(selectGenotypeNames, selectGenotypeExpressions);
 
@@ -689,7 +689,7 @@ public final class SelectVariants extends VariantWalker {
         //     2. the only remaining alternate allele is spanning deletion (*)
         // If this is the case, we call it a non-variant and remove it from the output based on {@code excludeNonVariants}
         if (excludeNonVariants) {
-            // It would be cleaner to write "if (excludeNonVariants && nonVariant) {...}", but isPolymorphicInSamples() could be relatively expensive,
+            // It would be cleaner to say "if (excludeNonVariants && nonVariant) {...}", but isPolymorphicInSamples() could be relatively expensive,
             // when we have many samples, so we call it only when excludeNonVariants is set to true.
             final boolean nonVariant = ! result.isPolymorphicInSamples() || GATKVariantContextUtils.isSpanningDeletionOnly(result);
             if (nonVariant) {
@@ -782,8 +782,7 @@ public final class SelectVariants extends VariantWalker {
                 // Note that this is not equivalent to "!(AF > 0.01 || ReadPosRankSum < -20.0)"
 
                 // Notice here that calling the match method without the genotype g leads to genotype g being set to null,
-                // which is fine since infoJexls should not refer to genotype fields (unless using vc.getGenotype(), in which case
-                // JEXL can access genotype     fields via vc)
+                // which is fine since infoJexls should not refer to genotype fields (except via vc.getGenotype())
                 if (invertLogic(VariantContextUtils.match(vc, jexl), invertSelect)){
                     return true;
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -178,7 +178,7 @@ public final class SelectVariants extends VariantWalker {
      * See example commands above for detailed usage examples. Note that these expressions are evaluated *after* the
      * specified samples are extracted and the INFO field annotations are updated.
      */
-    @Argument(shortName="select", doc="One or more criteria to use when selecting the data", optional=true)
+    @Argument(fullName="select", doc="One or more criteria to use when selecting the data", optional=true)
     private ArrayList<String> selectExpressions = new ArrayList<>();
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -792,9 +792,9 @@ public final class SelectVariants extends VariantWalker {
         final SortedSet<String> vcfSamples = VcfUtils.getSortedSampleSet(vcfHeaders, GATKVariantContextUtils.GenotypeMergeType.REQUIRE_UNIQUE);
         final Collection<String> samplesFromExpressions = Utils.filterCollectionByExpressions(vcfSamples, sampleExpressions, false);
 
-        // first, find any samples that were listed on the command line but which don't exist in in the header
+        // first, find any samples that were listed on the command line but don't exist in the header
         final Set<String> samplesNotInHeader = new LinkedHashSet<>(samplesFromExpressions.size()+sampleNames.size());
-        samplesNotInHeader.addAll(samplesFromExpressions);
+        // samplesNotInHeader.addAll(samplesFromExpressions); // tsato: samplesFromExpressions is a subset of vcfsamples, so this should be unnecessary
         samplesNotInHeader.addAll(sampleNames);
         samplesNotInHeader.removeAll(vcfSamples);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants.java
@@ -656,7 +656,7 @@ public final class SelectVariants extends VariantWalker {
             vc = vc.fullyDecode(getHeaderForVariants(), lenientVCFProcessing);
         }
 
-        if (skipVariant(vc, featureContext)){
+        if (applyFirstRoundOfFiltering(vc, featureContext)){
             return;
         }
 
@@ -709,7 +709,7 @@ public final class SelectVariants extends VariantWalker {
      * If any of these predicates evaluates to true we are safe to remove the present variant from the output,
      * return (i.e. short-circuit) out of apply(), and skip to the next variant.
      */
-    private boolean skipVariant(final VariantContext vc, final FeatureContext featureContext){
+    private boolean applyFirstRoundOfFiltering(final VariantContext vc, final FeatureContext featureContext){
         // Since SelectVariants does not modify the filter field,
         // we can check this before doing expensive operations
         if (excludeFiltered && vc.isFiltered()){

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -502,7 +502,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         htsjdk.variant.variantcontext.VariantContextUtils.engine.get().setSilent(false);
     }
 
-    @Test // tsato: this test fails for teh wrongs reason; ac0.vcf does not exist
+    @Test // tsato: this test fails for the wrong reason; ac0.vcf does not exist
     public void testInvalidJexl() throws IOException {
         final GATKPath testFile = new GATKPath(getToolTestDataDir() + "ac0.vcf");
         beforeJexlTest();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -695,9 +695,9 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void testSelectRandomFraction() {
-        final File testOutput = createTempFile("jexl_genotype_info_test", "vcf");
         beforeJexlTest();
-
+        final File testOutput = createTempFile("jexl_genotype_info_test", "vcf");
+        // There are 80 variants in this vcf
         final File inputVcf = getTestFile("tetraploid-multisample-sac.g.vcf");
         final int numInputVariants = VariantContextTestUtils.readEntireVCFIntoMemory(inputVcf.getAbsolutePath()).getRight().size();
         final double fractionToKeep = 0.5;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -185,7 +185,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_NonExistingSelection.vcf")
         );
 
-        spec.executeTest("testNonExistingSelection--" + testFile, this); // tsato: failing
+        spec.executeTest("testNonExistingSelection--" + testFile, this);
     }
 
     /**
@@ -393,7 +393,7 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final String testFile = getToolTestDataDir() + "selectVariants.onePosition.vcf";
 
         final IntegrationTestSpec spec = new IntegrationTestSpec(
-                baseTestString(" -select 'KG_FREQ < 0.5' ", testFile), // tsato: another jexl test
+                baseTestString(" -select 'KG_FREQ < 0.5' ", testFile),
                 Collections.singletonList(getToolTestDataDir() + "expected/" + "testSelectVariants_MultipleRecordsAtOnePosition.vcf")
         );
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -662,6 +662,9 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         spec.executeTest("testInvertSelection--" + testFile, this);
     }
 
+    // tsato: add multiple jexl test here, should be
+    // Also: deprecate the invertlogic argument?
+
     /**
      * Test inverting the variant selection criteria by inverting the JEXL expression logic following -select
      */

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -665,6 +665,13 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
     // tsato: add multiple jexl test here, should be
     // Also: deprecate the invertlogic argument?
 
+    // Tests needed:
+    // * Filter by genotypes; what does that even mean? VariantFiltration goes through the genotypes and adds a flag, rather than subsetting
+    // * Multiple select expression as logical-or
+    // * Jexl with logical-and
+    // * 
+
+
     /**
      * Test inverting the variant selection criteria by inverting the JEXL expression logic following -select
      */

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariantsIntegrationTest.java
@@ -520,24 +520,17 @@ public class SelectVariantsIntegrationTest extends CommandLineProgramTest {
         final File testOutput = createTempFile("jexl_genotype_test", "vcf");
         beforeJexlTest();
 
-        // Parsing 'GQ > 0' is a struggle
+        // Parsing 'GQ > 0' is a struggle. So I abandoned the ArgumentsBuilder approach and put the string directly, as below.
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .add("V", testVcf.toString())
                 .add("O", testOutput.getAbsolutePath())
-                .addRaw("--select 'GQ > 0'"); // tsato: there cannot be spaces between GQ>0
+                .addRaw("--select 'GQ > 0'");
                 // .add("select", "'GQ > 0'"); // tsato: this does not work for some reason...
 
-        String test = args.toString();
+        // tsato: if it were really a commandline I would do "'GQ > 0'" but the parser did not like that. Functionally, "GQ > 0" does the right thing.
         runCommandLine(Arrays.asList("-V", testVcf.toString(), "-O", testOutput.getAbsolutePath(), "--select","GQ > 0"),
                 SelectVariants.class.getSimpleName());
         int d = 3;
-
-//        final IntegrationTestSpec spec = new IntegrationTestSpec(
-//                baseTestString("-select 'GQ > 0' ", testVcf.toString()),
-//                Collections.singletonList(testVcf.toString())
-//        );
-
-//        spec.executeTest("yo", this);
 
         // see Mutect integration test
         final Pair<VCFHeader, List<VariantContext>> result = VariantContextTestUtils.readEntireVCFIntoMemory(testOutput.getAbsolutePath());

--- a/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/hgdb_sv_multi_sample_mini.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/walkers/variantutils/SelectVariants/hgdb_sv_multi_sample_mini.vcf
@@ -1,0 +1,95 @@
+##fileformat=VCFv4.2
+##ALT=<ID=BND,Description="Translocation">
+##ALT=<ID=CNV,Description="Copy Number Polymorphism">
+##ALT=<ID=CPX,Description="Complex SV">
+##ALT=<ID=CTX,Description="Reciprocal chromosomal translocation">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=INS,Description="Insertion">
+##ALT=<ID=INS:ME,Description="Mobile element insertion of unspecified ME class">
+##ALT=<ID=INS:ME:ALU,Description="Alu element insertion">
+##ALT=<ID=INS:ME:LINE1,Description="LINE1 element insertion">
+##ALT=<ID=INS:ME:SVA,Description="SVA element insertion">
+##ALT=<ID=INS:UNK,Description="Sequence insertion of unspecified origin">
+##ALT=<ID=INV,Description="Inversion">
+##CPX_TYPE_INS_iDEL="Insertion with deletion at insertion site."
+##CPX_TYPE_INVdel="Complex inversion with 3' flanking deletion."
+##CPX_TYPE_INVdup="Complex inversion with 3' flanking duplication."
+##CPX_TYPE_dDUP="Dispersed duplication."
+##CPX_TYPE_dDUP_iDEL="Dispersed duplication with deletion at insertion site."
+##CPX_TYPE_delINV="Complex inversion with 5' flanking deletion."
+##CPX_TYPE_delINVdel="Complex inversion with 5' and 3' flanking deletions."
+##CPX_TYPE_delINVdup="Complex inversion with 5' flanking deletion and 3' flanking duplication."
+##CPX_TYPE_dupINV="Complex inversion with 5' flanking duplication."
+##CPX_TYPE_dupINVdel="Complex inversion with 5' flanking duplication and 3' flanking deletion."
+##CPX_TYPE_dupINVdup="Complex inversion with 5' and 3' flanking duplications."
+##CPX_TYPE_piDUP_FR="Palindromic inverted tandem duplication, forward-reverse orientation."
+##CPX_TYPE_piDUP_RF="Palindromic inverted tandem duplication, reverse-forward orientation."
+##FILTER=<ID=BOTHSIDES_SUPPORT,Description="Variant has read-level support for both sides of breakpoint">
+##FILTER=<ID=HIGH_SR_BACKGROUND,Description="High number of SR splits in background samples indicating messy region">
+##FILTER=<ID=MULTIALLELIC,Description="Multiallelic site">
+##FILTER=<ID=PASS,Description="All filters passed">
+##FILTER=<ID=PESR_GT_OVERDISPERSION,Description="High PESR dispersion count">
+##FILTER=<ID=UNRESOLVED,Description="Variant is unresolved">
+##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Predicted copy state">
+##FORMAT=<ID=CNQ,Number=1,Type=Integer,Description="Read-depth genotype quality">
+##FORMAT=<ID=EV,Number=1,Type=String,Description="Classes of evidence supporting final genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PE_GQ,Number=1,Type=Integer,Description="Paired-end genotype quality">
+##FORMAT=<ID=PE_GT,Number=1,Type=Integer,Description="Paired-end genotype">
+##FORMAT=<ID=RD_CN,Number=1,Type=Integer,Description="Predicted copy state">
+##FORMAT=<ID=RD_GQ,Number=1,Type=Integer,Description="Read-depth genotype quality">
+##FORMAT=<ID=SR_GQ,Number=1,Type=Integer,Description="Split read genotype quality">
+##FORMAT=<ID=SR_GT,Number=1,Type=Integer,Description="Split-read genotype">
+##GATKCommandLine=<ID=SelectVariants,CommandLine="SelectVariants --output hgdb_sv_multi_sample_mini.vcf --variant hgdb_sv_multi_sample.vcf --intervals chr1:1-50000 --jexl-first false --invertSelect false --exclude-non-variants false --exclude-filtered false --preserve-alleles false --remove-unused-alternates false --restrict-alleles-to ALL --keep-original-ac false --keep-original-dp false --mendelian-violation false --invert-mendelian-violation false --mendelian-violation-qual-threshold 0.0 --select-random-fraction 0.0 --remove-fraction-genotypes 0.0 --fully-decode false --max-indel-size 2147483647 --min-indel-size 0 --max-filtered-genotypes 2147483647 --min-filtered-genotypes 0 --max-fraction-filtered-genotypes 1.0 --min-fraction-filtered-genotypes 0.0 --max-nocall-number 2147483647 --max-nocall-fraction 1.0 --set-filtered-gt-to-nocall false --allow-nonoverlapping-command-line-samples false --suppress-reference-path false --fail-on-unsorted-genotype false --genomicsdb-max-alternate-alleles 50 --call-genotypes false --genomicsdb-use-bcf-codec false --genomicsdb-shared-posixfs-optimizations false --genomicsdb-use-gcs-hdfs-connector false --interval-set-rule UNION --interval-padding 0 --interval-exclusion-padding 0 --interval-merging-rule ALL --read-validation-stringency SILENT --seconds-between-progress-updates 10.0 --disable-sequence-dictionary-validation false --create-output-bam-index true --create-output-bam-md5 false --create-output-variant-index true --create-output-variant-md5 false --max-variants-per-shard 0 --lenient false --add-output-sam-program-record true --add-output-vcf-command-line true --cloud-prefetch-buffer 40 --cloud-index-prefetch-buffer -1 --disable-bam-index-caching false --sites-only-vcf-output false --help false --version false --showHidden false --verbosity INFO --QUIET false --use-jdk-deflater false --use-jdk-inflater false --gcs-max-retries 20 --gcs-project-for-requester-pays  --disable-tool-default-read-filters false",Version="4.2.6.1-52-gbbdfb01-SNAPSHOT",Date="October 24, 2022 7:07:48 PM EDT">
+##GATKCommandLine=<ID=SelectVariants,CommandLine="SelectVariants --output test1_small.vcf --sample-name __HGDP00007__ --sample-name __HGDP00013__ --sample-name __HGDP00029__ --sample-name __HGDP01347__ --variant /dsde/working/tsato/sv/hgdp_and_hgsv.cleaned_fixed.vcf.gz --intervals chr1:1-130000 --jexl-first false --invertSelect false --exclude-non-variants false --exclude-filtered false --preserve-alleles false --remove-unused-alternates false --restrict-alleles-to ALL --keep-original-ac false --keep-original-dp false --mendelian-violation false --invert-mendelian-violation false --mendelian-violation-qual-threshold 0.0 --select-random-fraction 0.0 --remove-fraction-genotypes 0.0 --fully-decode false --max-indel-size 2147483647 --min-indel-size 0 --max-filtered-genotypes 2147483647 --min-filtered-genotypes 0 --max-fraction-filtered-genotypes 1.0 --min-fraction-filtered-genotypes 0.0 --max-nocall-number 2147483647 --max-nocall-fraction 1.0 --set-filtered-gt-to-nocall false --allow-nonoverlapping-command-line-samples false --suppress-reference-path false --fail-on-unsorted-genotype false --genomicsdb-max-alternate-alleles 50 --call-genotypes false --genomicsdb-use-bcf-codec false --genomicsdb-shared-posixfs-optimizations false --genomicsdb-use-gcs-hdfs-connector false --interval-set-rule UNION --interval-padding 0 --interval-exclusion-padding 0 --interval-merging-rule ALL --read-validation-stringency SILENT --seconds-between-progress-updates 10.0 --disable-sequence-dictionary-validation false --create-output-bam-index true --create-output-bam-md5 false --create-output-variant-index true --create-output-variant-md5 false --max-variants-per-shard 0 --lenient false --add-output-sam-program-record true --add-output-vcf-command-line true --cloud-prefetch-buffer 40 --cloud-index-prefetch-buffer -1 --disable-bam-index-caching false --sites-only-vcf-output false --help false --version false --showHidden false --verbosity INFO --QUIET false --use-jdk-deflater false --use-jdk-inflater false --gcs-max-retries 20 --gcs-project-for-requester-pays  --disable-tool-default-read-filters false",Version="4.2.6.1-55-g724df13-SNAPSHOT",Date="October 22, 2022 11:04:42 AM EDT">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=ALGORITHMS,Number=.,Type=String,Description="Source algorithms">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate">
+##INFO=<ID=CPX_INTERVALS,Number=.,Type=String,Description="Genomic intervals constituting complex variant.">
+##INFO=<ID=CPX_TYPE,Number=1,Type=String,Description="Class of complex variant.">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the structural variant">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="Position of breakpoint on CHR2">
+##INFO=<ID=EVIDENCE,Number=.,Type=String,Description="Classes of random forest support.">
+##INFO=<ID=SOURCE,Number=1,Type=String,Description="Source of inserted sequence.">
+##INFO=<ID=STRANDS,Number=1,Type=String,Description="Breakpoint strandedness [++,+-,-+,--]">
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="SV length">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=UNRESOLVED_TYPE,Number=1,Type=String,Description="Class of unresolved variant.">
+##bcftools_concatCommand=concat -a --allow-overlaps --output-type z --file-list /cromwell_root/fc-4f7d6060-18d4-47ce-9f00-d83a04c1e312/547bf530-6a24-49fc-9d37-4ab0430f28b6/Module0506/5ee557ba-571a-4799-92de-639f2d857537/call-Module0506Clean/Module0506Clean/4d33714f-5e35-4b61-a9c3-6a0c915f6ff6/call-ConcatCleanedVcfs/write_lines_75d54427c5d0a6a1ccab213d2f2c72a7.tmp --output hgdp_and_hgsv.cleaned.vcf.gz; Date=Wed Jun 30 20:21:50 2021
+##bcftools_concatVersion=1.9+htslib-1.9
+##contig=<ID=chr1,length=248956422>
+##contig=<ID=chr10,length=133797422>
+##contig=<ID=chr11,length=135086622>
+##contig=<ID=chr12,length=133275309>
+##contig=<ID=chr13,length=114364328>
+##contig=<ID=chr14,length=107043718>
+##contig=<ID=chr15,length=101991189>
+##contig=<ID=chr16,length=90338345>
+##contig=<ID=chr17,length=83257441>
+##contig=<ID=chr18,length=80373285>
+##contig=<ID=chr19,length=58617616>
+##contig=<ID=chr2,length=242193529>
+##contig=<ID=chr20,length=64444167>
+##contig=<ID=chr21,length=46709983>
+##contig=<ID=chr22,length=50818468>
+##contig=<ID=chr3,length=198295559>
+##contig=<ID=chr4,length=190214555>
+##contig=<ID=chr5,length=181538259>
+##contig=<ID=chr6,length=170805979>
+##contig=<ID=chr7,length=159345973>
+##contig=<ID=chr8,length=145138636>
+##contig=<ID=chr9,length=138394717>
+##contig=<ID=chrX,length=156040895>
+##contig=<ID=chrY,length=57227415>
+##source=SelectVariants
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	__HGDP00007__	__HGDP00013__	__HGDP00029__	__HGDP01347__
+chr1	10639	hgdp_and_hgsv_BND_chr1_1	N	<BND>	328	HIGH_SR_BACKGROUND;UNRESOLVED	AC=2;AF=0.250;ALGORITHMS=manta;AN=8;CHR2=chr15;END=10640;END2=101980265;EVIDENCE=SR;STRANDS=--;SVLEN=-1;SVTYPE=BND;UNRESOLVED_TYPE=SINGLE_ENDER_--	GT:EV:GQ:PE_GQ:PE_GT:SR_GQ:SR_GT	0/0:PE,SR:99:9:0:999:0	0/1:PE:0:1:1:999:0	0/0:PE,SR:2:25:0:4:0	0/1:PE:0:1:1:999:0
+chr1	11000	hgdp_and_hgsv_DUP_chr1_1	N	<DUP>	143	PASS	AC=1;AF=0.125;ALGORITHMS=depth;AN=8;END=51000;EVIDENCE=RD;SVLEN=40000;SVTYPE=DUP	GT:EV:GQ:RD_CN:RD_GQ	0/0:RD:11:2:113	0/1:RD:13:3:131	0/0:RD:1:2:11	0/0:RD:7:2:73
+chr1	29000	hgdp_and_hgsv_DUP_chr1_2	N	<DUP>	999	PASS	AC=2;AF=0.250;ALGORITHMS=depth;AN=8;END=140000;EVIDENCE=BAF,RD;SVLEN=111000;SVTYPE=DUP	GT:EV:GQ:RD_CN:RD_GQ	0/0:RD:12:1:117	0/1:RD:10:3:103	0/0:RD:1:2:11	0/1:RD:6:3:58
+chr1	40000	hgdp_and_hgsv_DEL_chr1_1	N	<DEL>	133	PASS	AC=1;AF=0.125;ALGORITHMS=depth;AN=8;END=46000;EVIDENCE=RD;SVLEN=6000;SVTYPE=DEL	GT:EV:GQ:RD_CN:RD_GQ	0/0:RD:5:2:50	0/0:RD:1:2:6	0/1:RD:9:1:87	0/0:RD:2:2:21
+chr1	40000	hgdp_and_hgsv_CNV_chr1_1	N	<CNV>	999	MULTIALLELIC	AC=0;AF=0.00;ALGORITHMS=depth;AN=0;END=107150;EVIDENCE=BAF,RD;SVLEN=67150;SVTYPE=CNV	GT:CN:CNQ:EV:RD_CN:RD_GQ	.:1:1:RD:1:1	.:3:83:RD:3:83	.:2:1:RD:2:1	.:2:142:RD:2:142


### PR DESCRIPTION
This PR is an attempt at improving SelectVariants by

- Rewriting unclear code;
- Adding documentation where needed; and
- Adding tests.

The initial motivation for this code change (#7497) was to improve performance of SelectVariants by adding an option to do the "INFO-level filtering" before doing "genotype filtering." Our assumption was that this would improve performance because  then we would avoid the expensive genotype "fully-decode" operation, which turns string format fields into appropriate object/types (int, array, etc.). This is (we think) done in `VariantContext.fullyDecode().`

This turned out not to be possible for the following reasons. First, there are roughly four types of genotype subsetting you could do:

a) By the sample names (`--sample-name NA12878`)
b) JEXL (`--select GQ > 0`)
c) JEXL by accessing the variant context object (`--select vc.getGenotype('NA12878').getGQ() > 1`)
d) Others (e.g. `--remove-fraction-genotype`)

a) does not need "fully-decode." It turns out b) was never supported (GATK currently removes all variants and succeed.) And from my experiments, c) does not seem to ever trigger calling `VariantContext.fullyDecode().` In fact the only code path I can see that calls fullyDecode() is by setting the `fully-decode` SelectVariants argument, which seems to just call fullyDecode at the beginning just for the sake of calling it (or so it appears to me. The utility of this command line argument is highly dubious.) 

It's possible that apache code does something similar to fully decoding that could affect performance.

All that is to say that we cannot achieve performance improvement with our original blueprint simply because this expensive "fullyDecode" operation seems to be a mythical operation that is never used in reality.

So while I could not speed up SelectVariants, I cleaned up the code and added the following new arguments:

* `--select-genotype`: with this new genotype-specific JEXL argument, we support filtering by genotype fields like 'GQ > 0', where the behavior in the multi-sample case is 'GQ > 0' in at least one sample. I have not added the ability to do 'GQ > 0 for all samples' but it should be a simple (but not easy…) exercise in boolean operations.
* `applyJexlFiltersBeforeFilteringGenotypes`: if set to true, we do the JEXL checking before we subset by samples. In my tests, performance improvement from this option was very modest. Subsetting a ~3k 1kg SV vcf to a single sample was about 30 seconds faster (out of ~20 min total run time) than the default. I kept it in the PR because I thought some user might find it useful, but I wouldn't be opposed to removing it.


Tests needed:
- [x] Filter by genotypes with a new flag --genotype-select, with the default behavior being 'passes if at least one sample passes' 
- [x] Multiple --select expressions should be combined with logical-or
- [x] Test string annotations (e.g. ALGORITHM == 'depth')
- [x] Jexl involving with logical-and (e.g. AC > 0 && AF > 0.01)
- [x] Access genotypes directly e.g. vc.getsample('NA12878')
- [x] DP > 0 as --genotype-select and as --select
- [x] Combine --select and --select-genotypes
- [x] Code path that uses "fully-decode"
- [x] Failing cases (reference genotype fields in --select and vice versa)
- [x] `--applyJexlFiltersBeforeFilteringGenotypes.` Does this actually give us performance advantage? 
- [x] Add a test for `select-random-fraction`