### PR TITLE
Add DeprecatedFeature annotation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
 
 final htsjdkVersion = System.getProperty('htsjdk.version','3.0.1')
 final picardVersion = System.getProperty('picard.version','2.27.5')
-final barclayVersion = System.getProperty('barclay.version','4.0.2')
+final barclayVersion = System.getProperty('barclay.version','4.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.5')
 final scalaVersion = System.getProperty('scala.version', '2.11')
 final hadoopVersion = System.getProperty('hadoop.version', '3.3.1')

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistry.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/DeprecatedToolsRegistry.java
@@ -6,8 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * When a tool is removed from GATK (after having been @Deprecated for a suitable period), an entry should
- * be added to this list to issue a message when the user tries to run that tool.
+ * When a tool is removed from GATK (after having been tagged with @DeprecatedFeature for a suitable period), an
+ * entry should be added to this list to issue a message when the user tries to run that tool.
  *
  * NOTE: Picard tools should be listed here as well, since by definition such tools will not be found in
  * the Picard jar.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypeCalculationArgumentCollection.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.walkers.genotyper;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.DeprecatedFeature;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.variant.HomoSapiensConstants;
@@ -61,7 +62,7 @@ public final class GenotypeCalculationArgumentCollection implements Serializable
     /**
      * As of version 4.1.0.0, this argument is no longer needed because the new qual score is now on by default. See GATK 3.3 release notes for more details.
      */
-    @Deprecated
+    @DeprecatedFeature(detail="New qual score is on by default")
     @Argument(fullName = "use-new-qual-calculator", shortName = "new-qual", doc = "Use the new AF model instead of the so-called exact model", optional = true)
     public boolean useNewAFCalculator = true;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerReadThreadingAssemblerArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.DeprecatedFeature;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.readthreading.ReadThreadingAssembler;
 
@@ -32,7 +33,7 @@ public class HaplotypeCallerReadThreadingAssemblerArgumentCollection extends Rea
     /**
      * As of version 3.3, this argument is no longer needed because dangling end recovery is now the default behavior. See GATK 3.3 release notes for more details.
      */
-    @Deprecated
+    @DeprecatedFeature
     @Argument(fullName= RECOVER_DANGLING_HEADS_LONG_NAME, doc="This argument is deprecated since version 3.3", optional = true)
     public boolean DEPRECATED_RecoverDanglingHeads = false;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.DeprecatedFeature;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureInput;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.FlowBasedAlignmentArgumentCollection;
@@ -115,7 +116,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public File f1r2TarGz;
 
     // As of GATK 4.1, any sample not specified as the normal is considered a tumor sample
-    @Deprecated
+    @DeprecatedFeature
     @Argument(fullName = TUMOR_SAMPLE_LONG_NAME, shortName = TUMOR_SAMPLE_SHORT_NAME, doc = "BAM sample name of tumor.  May be URL-encoded as output by GetSampleName with -encode argument.", optional = true)
     protected String tumorSample = null;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKGSONWorkUnit.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKGSONWorkUnit.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils.help;
 
+import org.broadinstitute.barclay.help.DocWorkUnit;
 import org.broadinstitute.barclay.help.GSONWorkUnit;
 
 /**
@@ -10,6 +11,10 @@ import org.broadinstitute.barclay.help.GSONWorkUnit;
 public class GATKGSONWorkUnit extends GSONWorkUnit {
 
     private String walkerType;
+
+    public GATKGSONWorkUnit(DocWorkUnit workUnit) {
+        super(workUnit);
+    }
 
     public void setWalkerType(final String walkerType){
         this.walkerType = walkerType;

--- a/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDoclet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/help/GATKHelpDoclet.java
@@ -79,7 +79,7 @@ public class GATKHelpDoclet extends HelpDoclet {
             final List<Map<String, String>> groupMaps,
             final List<Map<String, String>> featureMaps)
     {
-        GATKGSONWorkUnit gatkGSONWorkUnit = new GATKGSONWorkUnit();
+        GATKGSONWorkUnit gatkGSONWorkUnit = new GATKGSONWorkUnit(workUnit);
         gatkGSONWorkUnit.setWalkerType((String)workUnit.getRootMap().get(WALKER_TYPE_MAP_ENTRY));
         return gatkGSONWorkUnit;
     }

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
@@ -48,6 +48,8 @@
                                         <td>**EXPERIMENTAL** ${datum.summary} </td>
                                     <#elseif datum.beta?? && datum.beta == "true">
                                         <td>**BETA** ${datum.summary}</td>
+                                    <#elseif datum.deprecated?? && datum.deprecated == "true">
+                                        <td>**DEPRECATED** ${datum.summary}</a></td>
                                     <#else>
                                         <td>${datum.summary}</td>
                                     </#if>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -36,6 +36,21 @@
 
 	<#include "common.html"/>
 
+	<#macro flagDeprecated arg>
+		<#if arg.deprecated == true> (Deprecated)</#if>
+	</#macro>
+
+	<#macro flagDeprecatedWithReason arg>
+		<#if arg.deprecated == true>
+			<#if arg.deprecationDetail??>
+				This argument is deprecated. ${arg.deprecationDetail}</br>
+			<#else>
+				This argument is deprecated.</br>
+			</#if>
+		</#if>
+	</#macro>
+
+
 	<#macro argumentlist name myargs>
 		<#if myargs?size != 0>
 			<tr>
@@ -56,7 +71,7 @@
 					<#else>
 						<td></td>
 					</#if>
-					<td>${arg.summary}</td>
+						<td><@flagDeprecated arg=arg/>${arg.summary}</td>
 				</tr>
 			</#list>
 		</#if>
@@ -68,7 +83,7 @@
 			<#if arg.synonyms?? && arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
 		</h3>
 		<p class="args">
-			<b>${arg.summary}</b><br />
+			<b><@flagDeprecated arg=arg/>${arg.summary}</b><br />
 			${arg.fulltext}
 		</p>
 		<#if arg.otherArgumentRequired != "NA">
@@ -132,6 +147,8 @@
 			<h1>**BETA** ${name}</h1>
 		<#elseif experimental?? && experimental == true>
 			<h1>**EXPERIMENTAL** ${name}</h1>
+		<#elseif deprecated?? && deprecated == true>
+			<h1>**DEPRECATED** ${name} ${deprecationDetail}</h1>
 		<#else>
 			<h1>${name}</h1>
 		</#if>


### PR DESCRIPTION
Upgrades Barclay to 4.1.0. Adds an `@DeprecatedFeature` annotation that can be applied to any `@DocumentedFeature` or `@Argument`, and updates the handful of such features that are already tagged with the standard Java annotation `@Deprecated` to use the new annotation. Mutually exclusive with `@Beta` and `@Experimental`.

The output for `--use-new-qual-calculator`:
<img width="783" alt="Screen Shot 2022-11-21 at 5 04 44 PM" src="https://user-images.githubusercontent.com/10062863/203168110-381424c7-e0e2-4f93-b51b-41f74212b669.png">
<img width="918" alt="Screen Shot 2022-11-21 at 5 14 16 PM" src="https://user-images.githubusercontent.com/10062863/203168311-cfc7b1b1-79d8-48c8-b965-766e424135ab.png">
<img width="851" alt="Screen Shot 2022-11-21 at 6 39 03 PM" src="https://user-images.githubusercontent.com/10062863/203179466-b817bba3-312b-4718-a758-9c063f41d755.png">



