### PR TITLE
Vs 741 fix indefinite freeze in split intervals task when using exome data

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -166,6 +166,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - ah_exome_changes
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -118,6 +118,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - VS-741-fix-indefinite-freeze-in-split-intervals-task-when-using-exome-data
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -166,7 +167,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ah_exome_changes
    - name: GvsWithdrawSamples
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsWithdrawSamples.wdl

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -24,6 +24,7 @@ workflow GvsExtractCallset {
     String drop_state = "NONE"
 
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
+    Boolean use_interval_weights = true
     File interval_weights_bed = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"
     File? gatk_override
 

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -105,7 +105,8 @@ workflow GvsExtractCallset {
       output_gcs_dir = output_gcs_dir,
       split_intervals_disk_size_override = split_intervals_disk_size_override,
       split_intervals_mem_override = split_intervals_mem_override,
-      gatk_override = gatk_override
+      gatk_override = gatk_override,
+      use_interval_weights = use_interval_weights
   }
 
   call Utils.GetBQTableLastModifiedDatetime as FilterSetInfoTimestamp {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -75,7 +75,7 @@ task SplitIntervals {
 
   String gatkTool = if (use_interval_weights && defined(interval_weights_bed)) then 'WeightedSplitIntervals' else 'SplitIntervals'
   # This is hacky but it only has to work for now
-  String weight_bed_java_arg =  if (use_interval_weights) then "--weight-bed-file" else ""
+  String using_weighted_beds =  if (use_interval_weights) then "using them!" else ""
 
   parameter_meta {
     intervals: {
@@ -96,7 +96,7 @@ task SplitIntervals {
     set -e
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
-    WEIGHT_BED_JAVE_ARG="~{weight_bed_java_arg}"
+    WEIGHT_BED_JAVE_ARG="~{using_weighted_beds}"
     if [ -z "$WEIGHT_BED_FILE" ]
     then
       WEIGHT_BED_ARG=""

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,6 +74,8 @@ task SplitIntervals {
   Int java_memory = disk_memory - 4
 
   String gatkTool = if (use_interval_weights && defined(interval_weights_bed)) then 'WeightedSplitIntervals' else 'SplitIntervals'
+  # This is hacky but it only has to work for now
+  String weight_bed_java_arg =  if (use_interval_weights) then "--weight-bed-file" else ""
 
   parameter_meta {
     intervals: {
@@ -94,12 +96,12 @@ task SplitIntervals {
     set -e
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
-    WEIGHT_BED_FILE="~{interval_weights_bed}"
+    WEIGHT_BED_JAVE_ARG="~{weight_bed_java_arg}"
     if [ -z "$WEIGHT_BED_FILE" ]
     then
       WEIGHT_BED_ARG=""
     else
-      WEIGHT_BED_ARG="--weight-bed-file $WEIGHT_BED_FILE"
+      WEIGHT_BED_ARG="~{"--weight-bed-file " + interval_weights_bed}"
     fi
 
     mkdir interval-files

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -56,6 +56,7 @@ task SplitIntervals {
     File ref_fai
     File ref_dict
     Int scatter_count
+    Boolean use_interval_weights = true
     File? interval_weights_bed
     String? intervals_file_extension
     String? split_intervals_extra_args
@@ -72,7 +73,7 @@ task SplitIntervals {
   Int disk_memory = if (defined(split_intervals_mem_override)) then split_intervals_mem_override else 16
   Int java_memory = disk_memory - 4
 
-  String gatkTool = if (defined(interval_weights_bed)) then 'WeightedSplitIntervals' else 'SplitIntervals'
+  String gatkTool = if (use_interval_weights && defined(interval_weights_bed)) then 'WeightedSplitIntervals' else 'SplitIntervals'
 
   parameter_meta {
     intervals: {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -94,12 +94,20 @@ task SplitIntervals {
     set -e
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
+    WEIGHT_BED_FILE="~{interval_weights_bed}"
+    if [ -z "$WEIGHT_BED_FILE" ]
+    then
+      WEIGHT_BED_ARG=""
+    else
+      WEIGHT_BED_ARG="--weight-bed-file $WEIGHT_BED_FILE"
+    fi
+
     mkdir interval-files
     gatk --java-options "-Xmx~{java_memory}g" ~{gatkTool} \
       --dont-mix-contigs \
       -R ~{ref_fasta} \
       ~{"-L " + intervals} \
-      ~{"--weight-bed-file " + interval_weights_bed} \
+      $WEIGHT_BED_ARG \
       -scatter ~{scatter_count} \
       -O interval-files \
       ~{"--extension " + intervals_file_extension} \

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -306,8 +306,8 @@ public class ExtractCohortEngine {
         // Related to the problem in createSortedVetCollectionFromExtractTableBigQuery with having a minLocation within
         // IngestConstants.MAX_DELETION_SIZE of the start of a chromosome
         int adjustedStartingLocation = (SchemaUtils.decodePosition(minLocation) - IngestConstants.MAX_DELETION_SIZE + 1);
-        if (adjustedStartingLocation < 0) {
-            adjustedStartingLocation = 0;
+        if (adjustedStartingLocation < 1) {
+            adjustedStartingLocation = 1;
         }
 
         overlapIntervals.add(new SimpleInterval(SchemaUtils.decodeContig(minLocation),

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -307,6 +307,7 @@ public class ExtractCohortEngine {
         // IngestConstants.MAX_DELETION_SIZE of the start of a chromosome
         int adjustedStartingLocation = (SchemaUtils.decodePosition(minLocation) - IngestConstants.MAX_DELETION_SIZE + 1);
         if (adjustedStartingLocation < 1) {
+            // These are 1 indexed, not 0 indexed.  This is the first valid location
             adjustedStartingLocation = 1;
         }
 


### PR DESCRIPTION
This PR fixes two bugs.

First, the SplitIntervals task would enter WeightedSplitIntervals and hang.  I added an extra boolean argument to extract so you can specify that no, you really don't want to use a weighted bed.  Relatedly, the code branch for running the original GATK SplitIntervals code wasn't correct, as passing weight-bed-file to it as an argument caused a failure.  It uses a slightly hacky method of defining a string in WDL to be empty or not depending on if we use weighted beds, interpolating that string into the bash, then checking to see if it's empty there to transmit that state.  There is likely a cleaner way to do this, and in the next revision I will likely rewrite this part cleaner.

Second, after SplitIntervals passed we hit an error during ExtractTask.  The way it expanded intervals to handle large deletions could sometimes subtract past the start of a chromosome, so that logic needed to be patched in a few separate places to handle the interval for the mitochondrial dna that started much closer to the beginning (instead of having a 10k base pair buffer).  This PR has those changes too.

Successful run here: https://app.terra.bio/#workspaces/gvs-dev/GVS%20Exome%20Test/job_history/a006a959-9300-42cf-84a7-38c70a35ee21