### PR TITLE
Don't require python to just instantiate tool classes.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNScoreVariants.java
@@ -205,9 +205,7 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
     @Argument(fullName = "python-profile", shortName = "python-profile", doc = "Run the tool with the Python CProfiler on and write results to this file.", optional = true)
     private File pythonProfileResults;
 
-    // Create the Python executor. This doesn't actually start the Python process, but verifies that
-    // the requestedPython executable exists and can be located.
-    final StreamingPythonScriptExecutor<String> pythonExecutor = new StreamingPythonScriptExecutor<>(true);
+    private StreamingPythonScriptExecutor<String> pythonExecutor;
 
     private List<String> batchList = new ArrayList<>(inferenceBatchSize);
 
@@ -283,6 +281,10 @@ public class CNNScoreVariants extends TwoPassVariantWalker {
                 throw new UserException.HardwareFeatureException(String.format(CNNScoreVariants.AVXREQUIRED_ERROR, DISABLE_AVX_CHECK_NAME));
             }
         }
+
+        // Create the Python executor. This doesn't actually start the Python process, but verifies that
+        // the requestedPython executable exists and can be located.
+        pythonExecutor = new StreamingPythonScriptExecutor<>(true);
 
         final VCFHeader inputHeader = getHeaderForVariants();
         if (inputHeader.getGenotypeSamples().size() > 1) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantTrain.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantTrain.java
@@ -129,8 +129,7 @@ public class CNNVariantTrain extends CommandLineProgram {
     @Argument(fullName = "annotation-set", shortName = "annotation-set", doc = "Which set of annotations to use.", optional = true)
     private String annotationSet = "best_practices";
 
-    // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
-    final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
+    private PythonScriptExecutor pythonExecutor;
 
 
     @Override
@@ -140,6 +139,9 @@ public class CNNVariantTrain extends CommandLineProgram {
 
     @Override
     protected Object doWork() {
+        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
+        pythonExecutor = new PythonScriptExecutor(true);
+
         final Resource pythonScriptResource = new Resource("training.py", CNNVariantTrain.class);
         List<String> arguments = new ArrayList<>(Arrays.asList(
                 "--data_dir", inputTensorDir,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantTrain.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantTrain.java
@@ -135,12 +135,12 @@ public class CNNVariantTrain extends CommandLineProgram {
     @Override
     protected void onStartup() {
         PythonScriptExecutor.checkPythonEnvironmentForPackage("vqsr_cnn");
+        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
+        pythonExecutor = new PythonScriptExecutor(true);
     }
 
     @Override
     protected Object doWork() {
-        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
-        pythonExecutor = new PythonScriptExecutor(true);
 
         final Resource pythonScriptResource = new Resource("training.py", CNNVariantTrain.class);
         List<String> arguments = new ArrayList<>(Arrays.asList(

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantWriteTensors.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantWriteTensors.java
@@ -117,8 +117,7 @@ public class CNNVariantWriteTensors extends CommandLineProgram {
     @Argument(fullName = "max-tensors", shortName = "max-tensors", doc = "Maximum number of tensors to write.", optional = true, minValue = 0)
     private int maxTensors = 1000000;
 
-    // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
-    final PythonScriptExecutor pythonExecutor = new PythonScriptExecutor(true);
+    private PythonScriptExecutor pythonExecutor;
 
     @Override
     protected void onStartup() {
@@ -127,6 +126,9 @@ public class CNNVariantWriteTensors extends CommandLineProgram {
 
     @Override
     protected Object doWork() {
+        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
+        pythonExecutor = new PythonScriptExecutor(true);
+
         final Resource pythonScriptResource = new Resource("training.py", CNNVariantWriteTensors.class);
         List<String> arguments = new ArrayList<>(Arrays.asList(
                 "--reference_fasta", reference,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantWriteTensors.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/CNNVariantWriteTensors.java
@@ -122,12 +122,13 @@ public class CNNVariantWriteTensors extends CommandLineProgram {
     @Override
     protected void onStartup() {
         PythonScriptExecutor.checkPythonEnvironmentForPackage("vqsr_cnn");
+
+        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
+        pythonExecutor = new PythonScriptExecutor(true);
     }
 
     @Override
     protected Object doWork() {
-        // Start the Python executor. This does not actually start the Python process, but fails if python can't be located
-        pythonExecutor = new PythonScriptExecutor(true);
 
         final Resource pythonScriptResource = new Resource("training.py", CNNVariantWriteTensors.class);
         List<String> arguments = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
The CNN tools launch python immediately even when they're just instantiated, rather than waiting until the tool actually starts executing. This can cause some build tasks (gatkDoc, gatkWDLGen, etc.) to fail if python isn't available.