### PR TITLE
Fix minor documentation mistake in VariantAnnotator

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/annotator/VariantAnnotator.java
@@ -75,7 +75,7 @@ import java.util.stream.IntStream;
  *   -V input.vcf \
  *   -o output.vcf \
  *   -L anotherInput.vcf \
- *   --resource foo:resource.vcf \
+ *   --resource:foo resource.vcf \
  *   -E foo.AF \
  *   --resource-allele-concordance
  * </pre>
@@ -86,7 +86,7 @@ import java.util.stream.IntStream;
  *   -R reference.fasta \
  *   -V input.vcf \
  *   -o output.vcf \
- *   --resource foo:resource.vcf \
+ *   --resource:foo resource.vcf \
  *   --expression foo.AF \
  *   --expression foo.FILTER
  * </pre>


### PR DESCRIPTION
I did a regex-search for other instances where we got this wrong in documentation and couldn't find any other obvious examples of this mistake anywhere else in our documentation. 

Fixes #8143