### PR TITLE
VS-816 Keeping ingestion under quota

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -127,6 +127,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - VS-816
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -20,6 +20,10 @@ workflow GvsImportGenomes {
     # beta customers will almost always have a naive GCP account, and as such will not be able to cross over their quotas
     # without Google shutting import down by throwing them API errors.  For them, we limit our scattering.
     Boolean beta_customer_rate_limit = false
+    # This was determined to be the point at which we come close to but don't cross over the "AppendRows throughput per
+    # project for small regions per minute per region" default quota of ~19G.  Uses up to ~90% of the quota at peaks
+    # without going over
+    Int beta_customer_max_scatter = 200
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     Int? load_data_batch_size
     Int? load_data_preemptible_override
@@ -29,9 +33,6 @@ workflow GvsImportGenomes {
 
   Int num_samples = length(external_sample_names)
   Int max_auto_batch_size = 20000
-  # This was determined to be the point at which we come close to but don't cross over the "AppendRows throughput per
-  # project for small regions per minute per region" quota
-  Int beta_customer_max_scatter = 200
 
   # If they're a beta customer, figure out the depth of their scatter
   Int beta_effective_load_data_batch_size = if num_samples < beta_customer_max_scatter then 1

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -17,7 +17,9 @@ workflow GvsImportGenomes {
 
     # set to "NONE" to ingest all the reference data into GVS for VDS (instead of VCF) output
     String drop_state = "NONE"
-
+    # beta customers will almost always have a naive GCP account, and as such will not be able to cross over their quotas
+    # without Google shutting import down by throwing them API errors.  For them, we limit our scattering.
+    Boolean beta_customer_rate_limit = false
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     Int? load_data_batch_size
     Int? load_data_preemptible_override
@@ -27,6 +29,13 @@ workflow GvsImportGenomes {
 
   Int num_samples = length(external_sample_names)
   Int max_auto_batch_size = 20000
+  # This was determined to be the point at which we come close to but don't cross over the "AppendRows throughput per
+  # project for small regions per minute per region" quota
+  Int beta_customer_max_scatter = 200
+
+  # If they're a beta customer, figure out the depth of their scatter
+  Int beta_effective_load_data_batch_size = if num_samples < beta_customer_max_scatter then 1
+                                            else num_samples / beta_customer_max_scatter
 
   if ((num_samples > max_auto_batch_size) && !(defined(load_data_batch_size))) {
     call Utils.TerminateWorkflow as DieDueToTooManySamplesWithoutExplicitLoadDataBatchSize {
@@ -35,10 +44,16 @@ workflow GvsImportGenomes {
     }
   }
 
+
   # At least 1, per limits above not more than 20.
+  # But if it's a beta customer, use the number computed above
   Int effective_load_data_batch_size = if (defined(load_data_batch_size)) then select_first([load_data_batch_size])
-                                       else if num_samples < 1000 then 1
-                                            else num_samples / 1000
+                                       else if beta_customer_rate_limit then beta_effective_load_data_batch_size
+                                            else if num_samples < 1000 then 1
+                                                 else num_samples / 1000
+
+
+
 
   # Both preemptible and maxretries should be scaled up alongside import batch size since the likelihood of preemptions
   # and retryable random BQ import errors increases with import batch size / job run time.

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -19,7 +19,7 @@ workflow GvsImportGenomes {
     String drop_state = "NONE"
     # beta customers will almost always have a naive GCP account, and as such will not be able to cross over their quotas
     # without Google shutting import down by throwing them API errors.  For them, we limit our scattering.
-    Boolean beta_customer_rate_limit = false
+    Boolean is_rate_limited_beta_customer = false
     # This was determined to be the point at which we come close to but don't cross over the "AppendRows throughput per
     # project for small regions per minute per region" default quota of ~19G.  Uses up to ~90% of the quota at peaks
     # without going over
@@ -33,10 +33,13 @@ workflow GvsImportGenomes {
 
   Int num_samples = length(external_sample_names)
   Int max_auto_batch_size = 20000
+  # Broad users enjoy higher quotas and can scatter more widely than beta users before BigQuery smacks them
+  # We don't expect this to be changed at runtime, so we can keep this as a constant defined in here
+  Int broad_user_max_scatter = 1000
 
-  # If they're a beta customer, figure out the depth of their scatter
-  Int beta_effective_load_data_batch_size = if num_samples < beta_customer_max_scatter then 1
-                                            else num_samples / beta_customer_max_scatter
+  # figure out max scatter depending on whether they're a Broad internal user or a beta customer.
+  Int max_scatter_for_user =  if is_rate_limited_beta_customer then beta_customer_max_scatter
+                              else broad_user_max_scatter
 
   if ((num_samples > max_auto_batch_size) && !(defined(load_data_batch_size))) {
     call Utils.TerminateWorkflow as DieDueToTooManySamplesWithoutExplicitLoadDataBatchSize {
@@ -49,10 +52,8 @@ workflow GvsImportGenomes {
   # At least 1, per limits above not more than 20.
   # But if it's a beta customer, use the number computed above
   Int effective_load_data_batch_size = if (defined(load_data_batch_size)) then select_first([load_data_batch_size])
-                                       else if beta_customer_rate_limit then beta_effective_load_data_batch_size
-                                            else if num_samples < 1000 then 1
-                                                 else num_samples / 1000
-
+                                       else if num_samples < max_scatter_for_user then 1
+                                            else num_samples / max_scatter_for_user
 
 
 


### PR DESCRIPTION
Limiting scattering size in ingest to keep beta customers under quota.

Successful run on NHGRI AnVIL dataset: https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K%20hatcher/job_history/a9c2a81b-d81c-4f7a-a433-4096ccc7b579

Quota behavior during successful run:
![Screenshot 2023-02-08 at 3 37 36 PM](https://user-images.githubusercontent.com/110987709/217656881-793e8a87-3e8c-40fc-90a6-6f640ff1c976.png)

Next successful run after minor refactoring: https://app.terra.bio/#workspaces/gvs-dev/GVS%20Tiny%20Quickstart%20hatcher/job_history/8a34477f-af3b-4e19-8184-862ed1c2cba3