### PR TITLE
Add GCC OpenMP library to list of GATK requirements in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ releases of the toolkit.
     * Python 3.6.2, along with a set of additional Python packages, is required to run some tools and workflows.
       See [Python Dependencies](#python) for more information.
     * R 3.2.5 (needed for producing plots in certain tools)
+    * The GCC OpenMP library, `libgomp1`, is needed in order to run the accelerated PairHMM implementation in `HaplotypeCaller` / `Mutect2`. This library is installed automatically when you install `gcc`. If it's not installed, GATK will fall back to using the much slower Java PairHMM implementation.
 * To build GATK:
     * A Java 8 JDK
     * Git 2.5 or greater


### PR DESCRIPTION
The GCC OpenMP library, libgomp1, a required dependency of GCC, needs to be present in order to run the GKL accelerated PairHMM in tools like HaplotypeCaller. We now mention this requirement in the GATK README.

Resolves #6012