### PR TITLE
Rc vs 778 spike import limit

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -125,7 +125,12 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - VS-816
+   - name: GvsPrepareBulkImport
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+     filters:
+       branches:
+         - VS-778-spike-import-limit
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -131,6 +131,12 @@ workflows:
      filters:
        branches:
          - VS-778-spike-import-limit
+   - name: GvsBulkIngestGenomes
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+     filters:
+       branches:
+         - rc-VS-778-spike-import-limit
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -133,7 +133,7 @@ workflows:
          - VS-778-spike-import-limit
    - name: GvsBulkIngestGenomes
      subclass: WDL
-     primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+     primaryDescriptorPath: /scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
      filters:
        branches:
          - rc-VS-778-spike-import-limit

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -125,12 +125,13 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rc-VS-778-spike-import-limit
    - name: GvsPrepareBulkImport
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
      filters:
        branches:
-         - VS-778-spike-import-limit
+         - rc-VS-778-spike-import-limit
    - name: GvsBulkIngestGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -76,8 +76,9 @@ workflow GvsBulkIngestGenomes {
             input_vcfs = read_lines(PrepareBulkImport.vcfFOFN),
             input_vcf_indexes = read_lines(PrepareBulkImport.vcfIndexFOFN),
 
-            is_rate_limited_beta_customer = true,
-            beta_customer_max_scatter = 25,
+            ## TODO the following will be kept short term for testing
+            ## is_rate_limited_beta_customer = true,
+            ## beta_customer_max_scatter = 25,
 
             interval_list = interval_list,
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -6,6 +6,7 @@ import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
 # ugly hardcoding of file type compression
+    # oh em gee typo
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,7 +5,6 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
-# less cautious
 
 workflow GvsBulkIngestGenomes {
     input {
@@ -22,8 +21,6 @@ workflow GvsBulkIngestGenomes {
         String dataset_name
         String bq_project_id
         String call_set_identifier
-
-        ## Array[String] external_sample_names ## TODO no longer an input param?
 
         File? gatk_override
         # End GvsAssignIds
@@ -48,17 +45,11 @@ workflow GvsBulkIngestGenomes {
 
     call GetWorkspaceId
 
-    #call GetWorkspaceNameandNamespace {
-    #    input:
-    #        workspace_id = GetWorkspaceId.workspace_id
-    #}
-
 
     call PrepareBulkImport.GvsPrepareBulkImport as PrepareBulkImport {
         input:
             project_id = terra_project_id,
             workspace_name = workspace_name,
-            # workspace_name = GetWorkspaceNameandNamespace.workspace_name,
             workspace_bucket = "fc-" + GetWorkspaceId.workspace_id,
             samples_table_name = samples_table_name,
             sample_id_column_name = sample_id_column_name,
@@ -100,7 +91,6 @@ workflow GvsBulkIngestGenomes {
     }
 
     output {
-        ## Boolean done = true
         Array[File] load_data_stderrs = ImportGenomes.load_data_stderrs
     }
 }
@@ -124,41 +114,4 @@ workflow GvsBulkIngestGenomes {
             String workspace_id = read_string("workspace_id.txt")
         }
     }
-
-
-#    task GetWorkspaceNameandNamespace {
-#      input {
-#        String workspace_id
-#      }
-#        command <<<
-#            # Prepend date, time and pwd to xtrace log entries.
-#            PS4='\D{+%F %T} \w $ '
-#            set -o errexit -o nounset -o pipefail -o xtrace
-#
-#
-#            # hit api based on workspace id
-#            https://rawls.dsde-prod.broadinstitute.org/#/workspaces/getWorkspaceById
-#
-#            # python library
-#
-#            # then parse the return blob to get stuff out
-#            String workspace_name = obj.workspace.name
-#            String namespace = obj.workspace.namespace
-#
-#
-#            # curl -X 'GET' \
-#            # 'https://rawls.dsde-prod.broadinstitute.org/api/workspaces/id/65c09f83-820f-4c09-ad92-3a3e83fd5d1b' \
-#            # -H 'accept: application/json' \
-#
-#        >>>
-#
-#        runtime {
-#            docker: "ubuntu:latest"
-#        }
-#
-#        output {
-#            String workspace_name = ~{workspace_name}
-#            String terra_project_name = ~{namespace}
-#        }
-#    }
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -52,16 +52,12 @@ workflow GvsBulkIngestGenomes {
     #        workspace_id = GetWorkspaceId.workspace_id
     #}
 
-    #call GetWorkspaceName {
-    #    input:
-    #        workspace_id = GetWorkspaceId.workspace_id
-    #}
-
 
     call PrepareBulkImport.GvsPrepareBulkImport as PrepareBulkImport {
         input:
             project_id = terra_project_id,
-            workspace_name = GetWorkspaceNameandNamespace.workspace_name,
+            workspace_name = workspace_name,
+            # workspace_name = GetWorkspaceNameandNamespace.workspace_name,
             workspace_bucket = "fc-" + GetWorkspaceId.workspace_id,
             samples_table_name = samples_table_name,
             sample_id_column_name = sample_id_column_name,
@@ -164,3 +160,4 @@ workflow GvsBulkIngestGenomes {
 #            String terra_project_name = ~{namespace}
 #        }
 #    }
+

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -4,11 +4,8 @@ import "GvsUtils.wdl" as Utils
 import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-
-# swap to file
-# swap to sample_names direct
-# ok write lines of the array
-# add $NAMES_FILE
+# 1
+#2
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,7 +5,7 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
-# this should be the right GATK docker -- but does it have python?!?!?
+# ugly hardcoding of file type compression
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -6,6 +6,7 @@ import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 # 1
 # 2
+# 3
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,6 +5,7 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
+# this should be the right GATK docker -- but does it have python?!?!?
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -4,9 +4,9 @@ import "GvsUtils.wdl" as Utils
 import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 1
-# 2
-# 3
+
+# cleanup
+
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,8 +5,6 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
-# cleanup
-
 
 workflow GvsBulkIngestGenomes {
     input {
@@ -26,7 +24,7 @@ workflow GvsBulkIngestGenomes {
 
         ## Array[String] external_sample_names ## TODO no longer an input param?
 
-        File? gatk_override
+        File gatk ## No longer an override for ImportGenomes
         # End GvsAssignIds
 
         # Begin GvsImportGenomes
@@ -97,7 +95,7 @@ workflow GvsBulkIngestGenomes {
             load_data_batch_size = load_data_batch_size,
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_preemptible_override = load_data_preemptible_override,
-            load_data_gatk_override = gatk_override,
+            load_data_gatk = gatk,
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -9,6 +9,7 @@ import "GvsImportGenomes.wdl" as ImportGenomes
 # swap to sample_names direct
 # ok write lines of the array
 # add $NAMES_FILE
+
 workflow GvsBulkIngestGenomes {
     input {
         # Begin GvsPrepareBulkImport

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,8 +5,7 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
-# ugly hardcoding of file type compression
-    # oh em gee typo
+# oops not a var
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,12 +5,15 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
+# swap to file
+# swap to sample_names direct
+# ok write lines of the array
+# add $NAMES_FILE
 workflow GvsBulkIngestGenomes {
     input {
         # Begin GvsPrepareBulkImport
         String terra_project_id # env vars
         String workspace_name # env vars
-        String workspace_bucket # env vars -- this is just workspace_id + fc
         String samples_table_name
         String sample_id_column_name # is this just <samples_table_name>_id ?
         String vcf_files_column_name

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -24,7 +24,7 @@ workflow GvsBulkIngestGenomes {
 
         ## Array[String] external_sample_names ## TODO no longer an input param?
 
-        File gatk ## No longer an override for ImportGenomes
+        File? gatk_override
         # End GvsAssignIds
 
         # Begin GvsImportGenomes
@@ -95,7 +95,7 @@ workflow GvsBulkIngestGenomes {
             load_data_batch_size = load_data_batch_size,
             load_data_maxretries_override = load_data_maxretries_override,
             load_data_preemptible_override = load_data_preemptible_override,
-            load_data_gatk = gatk,
+            load_data_gatk_override = gatk_override,
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -46,7 +46,7 @@ workflow GvsBulkIngestGenomes {
         ## TODO do we want to add Alt Allele Table creation?
     }
 
-    call PrepareBulkImport {
+    call PrepareBulkImport.GvsPrepareBulkImport as PrepareBulkImport {
         input:
             project_id = project_id,
             workspace_name = workspace_name,
@@ -57,7 +57,7 @@ workflow GvsBulkIngestGenomes {
             vcf_index_files_column_name = vcf_index_files_column_name
     }
 
-    call AssignIds {
+    call AssignIds.GvsAssignIds as AssignIds {
         input:
             ## go = PrepareBulkImport.done, ## TODO we're gonna want to add this, right?
             dataset_name = dataset_name,
@@ -66,7 +66,7 @@ workflow GvsBulkIngestGenomes {
             samples_are_controls = false ## TODO this shouldn't always be false tho
     }
 
-    call ImportGenomes {
+    call ImportGenomes.GvsImportGenomes as ImportGenomes {
         input:
             go = AssignIds.done,
             dataset_name = dataset_name,
@@ -75,11 +75,6 @@ workflow GvsBulkIngestGenomes {
             external_sample_names = read_lines(PrepareBulkImport.sampleFOFN),
             input_vcfs = read_lines(PrepareBulkImport.vcfFOFN),
             input_vcf_indexes = read_lines(PrepareBulkImport.vcfIndexFOFN),
-
-            skip_loading_vqsr_fields = false
-
-            # set to "NONE" to ingest all the reference data into GVS for VDS (instead of VCF) output
-            drop_state = "NONE"
 
             interval_list = interval_list,
 
@@ -94,7 +89,6 @@ workflow GvsBulkIngestGenomes {
 
     output {
         ## Boolean done = true
-        Array[File] load_data_stderrs = ImportGenomes.stderr
-        File errorRows = PrepareBulkImport.errors
+        Array[File] load_data_stderrs = ImportGenomes.load_data_stderrs
     }
 }

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -75,6 +75,7 @@ workflow GvsBulkIngestGenomes {
             input_vcf_indexes = read_lines(PrepareBulkImport.vcfIndexFOFN),
 
             is_rate_limited_beta_customer = true,
+            beta_customer_max_scatter = 25,
 
             interval_list = interval_list,
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,7 +5,7 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 # 1
-#2
+# 2
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -45,14 +45,14 @@ workflow GvsBulkIngestGenomes {
     }
 
 
-    call WorkspaceIdTask
+    call GetWorkspaceId
 
 
     call PrepareBulkImport.GvsPrepareBulkImport as PrepareBulkImport {
         input:
             project_id = terra_project_id,
             workspace_name = workspace_name,
-            workspace_bucket = "fc-" + WorkspaceId.workspace_id,
+            workspace_bucket = "fc-" + GetWorkspaceId.workspace_id,
             samples_table_name = samples_table_name,
             sample_id_column_name = sample_id_column_name,
             vcf_files_column_name = vcf_files_column_name,
@@ -99,7 +99,7 @@ workflow GvsBulkIngestGenomes {
 }
 
 
-    task WorkspaceIdTask {
+    task GetWorkspaceId {
         command <<<
             # Prepend date, time and pwd to xtrace log entries.
             PS4='\D{+%F %T} \w $ '

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -1,0 +1,128 @@
+version 1.0
+
+import "GvsUtils.wdl" as Utils
+import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
+import "GvsAssignIds.wdl" as AssignIds
+import "GvsImportGenomes.wdl" as ImportGenomes
+
+workflow GvsBulkIngestGenomes {
+    input {
+        # Begin GvsPrepareBulkImport
+        String project_id
+        String workspace_name
+        String workspace_bucket
+        String samples_table_name = "sample"
+        String sample_id_column_name = "sample_id"
+        String vcf_files_column_name = "hg38_reblocked_v2_vcf" ## TODO should these stay hardcoded!?!?!
+        String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
+        # End GvsPrepareBulkImport
+
+        # Begin GvsAssignIds
+        String dataset_name
+        String project_id
+        String call_set_identifier
+
+        ## Array[String] external_sample_names TODO no longer an input param?
+
+        File? gatk_override
+        # End GvsAssignIds
+
+        # Begin GvsImportGenomes
+        Array[File] input_vcfs
+        Array[File] input_vcf_indexes
+        File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
+
+        # set to "NONE" to ingest all the reference data into GVS for VDS (instead of VCF) output
+        String drop_state = "NONE"
+
+        # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
+        # BigQuery errors so if specifying this adjust preemptible and maxretries accordingly. Or just take the defaults,
+        # those should work fine in most cases.
+        Int? load_data_batch_size
+        Int? load_data_preemptible_override
+        Int? load_data_maxretries_override
+        # End GvsImportGenomes
+    }
+
+    call PrepareBulkImport {
+        input:
+            project_id = project_id,
+            workspace_name = workspace_name,
+            workspace_bucket  = workspace_bucket,
+            samples_table_name = samples_table_name,
+            sample_id_column_name = sample_id_column_name,
+            vcf_files_column_name = vcf_files_column_name,
+            vcf_index_files_column_name = vcf_index_files_column_name
+    }
+
+    call ArrayStringify {
+
+    }
+
+    call AssignIds {
+        input:
+            go = ArrayStringify.done,
+            dataset_name = dataset_name,
+            project_id = project_id,
+            external_sample_names = ArrayStringify.external_sample_names, ## Do I need the array string format here?
+            samples_are_controls = false ## interesting that this isn't the DEFAULT default
+    }
+
+    call ImportGenomes {
+        input:
+            go = AssignIds.done,
+            dataset_name = dataset_name,
+            project_id = project_id,
+
+            external_sample_names = ArrayStringify.external_sample_names, ## Do I need the array string format here?
+            input_vcfs = input_vcfs,
+            input_vcf_indexes = input_vcf_indexes,
+
+            skip_loading_vqsr_fields = false
+
+            # set to "NONE" to ingest all the reference data into GVS for VDS (instead of VCF) output
+            drop_state = "NONE"
+
+            interval_list = interval_list,
+
+            # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
+            # BigQuery errors so if specifying this adjust preemptible and maxretries accordingly. Or just take the defaults,
+            # those should work fine in most cases.
+            load_data_batch_size = load_data_batch_size,
+            load_data_maxretries_override = load_data_maxretries_override,
+            load_data_preemptible_override = load_data_preemptible_override,
+            load_data_gatk_override = gatk_override,
+
+    }
+
+    output {
+        Boolean done = true
+        Array[File] load_data_stderrs = LoadData.stderr
+    }
+}
+
+task ArrayStringify {
+    input {
+        String project_id
+        String workspace_name
+        String workspace_bucket
+    }
+
+
+    command <<<
+        set -o errexit -o nounset -o xtrace -o pipefail
+
+        ## stuff
+
+    >>>
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-20-FOFN"
+        memory: "3 GB"
+        disks: "local-disk 200 HDD"
+        cpu: 1
+    }
+
+    output {
+         Array[String] external_sample_names = external_sample_names
+    }
+}

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -74,6 +74,8 @@ workflow GvsBulkIngestGenomes {
             input_vcfs = read_lines(PrepareBulkImport.vcfFOFN),
             input_vcf_indexes = read_lines(PrepareBulkImport.vcfIndexFOFN),
 
+            is_rate_limited_beta_customer = true,
+
             interval_list = interval_list,
 
             # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -5,7 +5,7 @@ import "GvsPrepareBulkImport.wdl" as PrepareBulkImport
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
 
-# oops not a var
+# less cautious
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -47,11 +47,21 @@ workflow GvsBulkIngestGenomes {
 
     call GetWorkspaceId
 
+    #call GetWorkspaceNameandNamespace {
+    #    input:
+    #        workspace_id = GetWorkspaceId.workspace_id
+    #}
+
+    #call GetWorkspaceName {
+    #    input:
+    #        workspace_id = GetWorkspaceId.workspace_id
+    #}
+
 
     call PrepareBulkImport.GvsPrepareBulkImport as PrepareBulkImport {
         input:
             project_id = terra_project_id,
-            workspace_name = workspace_name,
+            workspace_name = GetWorkspaceNameandNamespace.workspace_name,
             workspace_bucket = "fc-" + GetWorkspaceId.workspace_id,
             samples_table_name = samples_table_name,
             sample_id_column_name = sample_id_column_name,
@@ -117,3 +127,40 @@ workflow GvsBulkIngestGenomes {
             String workspace_id = read_string("workspace_id.txt")
         }
     }
+
+
+#    task GetWorkspaceNameandNamespace {
+#      input {
+#        String workspace_id
+#      }
+#        command <<<
+#            # Prepend date, time and pwd to xtrace log entries.
+#            PS4='\D{+%F %T} \w $ '
+#            set -o errexit -o nounset -o pipefail -o xtrace
+#
+#
+#            # hit api based on workspace id
+#            https://rawls.dsde-prod.broadinstitute.org/#/workspaces/getWorkspaceById
+#
+#            # python library
+#
+#            # then parse the return blob to get stuff out
+#            String workspace_name = obj.workspace.name
+#            String namespace = obj.workspace.namespace
+#
+#
+#            # curl -X 'GET' \
+#            # 'https://rawls.dsde-prod.broadinstitute.org/api/workspaces/id/65c09f83-820f-4c09-ad92-3a3e83fd5d1b' \
+#            # -H 'accept: application/json' \
+#
+#        >>>
+#
+#        runtime {
+#            docker: "ubuntu:latest"
+#        }
+#
+#        output {
+#            String workspace_name = ~{workspace_name}
+#            String terra_project_name = ~{namespace}
+#        }
+#    }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -315,7 +315,7 @@ task LoadData {
       # we always do our own localization
       gsutil cp $gs_input_vcf input_vcf_$i.vcf.gz
       gsutil cp $gs_input_vcf_index input_vcf_index_$i.vcf.gz.tbi
-      updated_input_vcf=input_vcf_$i
+      updated_input_vcf=input_vcf_$i.vcf.gz
 
       gatk --java-options "-Xmx2g" CreateVariantIngestFiles \
         -V ${updated_input_vcf} \
@@ -333,8 +333,8 @@ task LoadData {
         --ref-version 38 \
         --skip-loading-vqsr-fields ~{skip_loading_vqsr_fields}
 
-      rm $input_vcf_$i
-      rm $input_vcf_index_$i
+      rm $input_vcf_$i.vcf.gz
+      rm $input_vcf_index_$i.vcf.gz.tbi
 
     done
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-21-bulk-ingest"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-bulk-ingest"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -280,7 +280,7 @@ task LoadData {
     cut -d, -f1 sample_map.csv > gvs_ids.csv ## TODO do we need this?!?!
 
     ## delete the table that was only needed for this ingest test
-    ## bq --project_id=~{project_id} rm -f=true ~{temp_table}
+    bq --project_id=~{project_id} rm -f=true ~{temp_table}
 
     ## now we want to create a sub list of these samples (without the ones that have already been loaded)
     curl https://raw.githubusercontent.com/broadinstitute/gatk/ah_var_store/scripts/variantstore/wdl/extract/curate_input_array_files.py -o curate_input_array_files.py

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -282,15 +282,16 @@ task LoadData {
     cut -d, -f1 sample_map.csv > gvs_ids.csv ## TODO do we need this?!?!
 
     ## delete the table that was only needed for this ingest test
-    bq --project_id=~{project_id} rm -f=true ~{temp_table}
-## We are good up to here!
+    ## bq --project_id=~{project_id} rm -f=true ~{temp_table}
+
+    ## OK UP TO HERE WORKED
 
     ## now we want to create a sub list of these samples (without the ones that have already been loaded)
 
     python3 /app/curate_input_array_files.py --sample_map_to_be_loaded_file_name sample_map.csv \
       --sample_name_list_file_name $NAMES_FILE \
-      --vcf_list_file_name ~{input_vcfs} \
-      --vcf_index_list_file_name  ~{input_vcf_indexes} \
+      --vcf_list_file_name ~{write_lines(input_vcfs)} \
+      --vcf_index_list_file_name  ~{write_lines(input_vcf_indexes)} \
       --output_files True
 
 
@@ -298,49 +299,6 @@ task LoadData {
     # output_vcf_index_list_file
     # output_vcf_list_file
     # output_sample_name_list_file
-
-
-    command <<<
-    # translate python files into BASH arrays---but only of the samples that aren't there already
-    VCFS_ARRAY=$(cat output_vcf_list_file |tr "\n" " ")
-    VCF_INDEXES_ARRAY=$(cat output_vcf_index_list_file |tr "\n" " ")
-    SAMPLE_NAMES_ARRAY=$(cat output_sample_name_list_file |tr "\n" " ")
-
-
-
-    # loop over the BASH arrays (See https://stackoverflow.com/questions/6723426/looping-over-arrays-printing-both-index-and-value)
-    for i in "${!VCFS_ARRAY[@]}"; do
-      input_vcf="${VCFS_ARRAY[$i]}"
-      input_vcf_basename=$(basename $input_vcf)
-      updated_input_vcf=$input_vcf
-      input_vcf_index="${VCF_INDEXES_ARRAY[$i]}"
-      sample_name="${SAMPLE_NAMES_ARRAY[$i]}"
-
-      # we always do our own localization
-      gsutil cp $input_vcf .
-      gsutil cp $input_vcf_index .
-      updated_input_vcf=$input_vcf_basename
-
-      gatk --java-options "-Xmx2g" CreateVariantIngestFiles \
-        -V ${updated_input_vcf} \
-        -L ~{interval_list} \
-        ~{"-IG " + drop_state} \
-        --force-loading-from-non-allele-specific ~{force_loading_from_non_allele_specific} \
-        --ignore-above-gq-threshold ~{drop_state_includes_greater_than} \
-        --project-id ~{project_id} \
-        --dataset-name ~{dataset_name} \
-        --output-type BQ \
-        --enable-reference-ranges ~{load_ref_ranges} \
-        --enable-vet ~{load_vet} \
-        -SN ${sample_name} \
-        -SNM ~{sample_map} \
-        --ref-version 38 \
-        --skip-loading-vqsr-fields ~{skip_loading_vqsr_fields}
-
-      rm $input_vcf
-      rm $input_vcf_index
-
-    done
 
   >>>
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -254,6 +254,10 @@ task LoadData {
         -SNM ~{sample_map} \
         --ref-version 38 \
         --skip-loading-vqsr-fields ~{skip_loading_vqsr_fields}
+
+      rm $input_vcf
+      rm $input_vcf_index
+
     done
   >>>
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -230,7 +230,7 @@ task LoadData {
     Int num_samples = length(sample_names)
     # add labels for DSP Cloud Cost Control Labeling and Reporting
     String bq_labels = "--label service:gvs --label team:variants --label managedby:import_genomes"
-    String temp_table="~{dataset_name}.sample_names_to_load"
+    String temp_table="~{dataset_name}.sample_names_to_load_rori" # TODO track a second table for now---should this get its own name in the future?
 
     ## TODO check if samples even need loading?!? hit the BQ database and get the loaded status for these samples
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -313,8 +313,8 @@ task LoadData {
       sample_name="${SAMPLE_NAMES_ARRAY[$i]}"
 
       # we always do our own localization
-      gsutil cp $gs_input_vcf input_vcf_$i
-      gsutil cp $gs_input_vcf_index input_vcf_index_$i
+      gsutil cp $gs_input_vcf input_vcf_$i.vcf.gz
+      gsutil cp $gs_input_vcf_index input_vcf_index_$i.vcf.gz.tbi
       updated_input_vcf=input_vcf_$i
 
       gatk --java-options "-Xmx2g" CreateVariantIngestFiles \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-14"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-21-bulk-ingest"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -314,7 +314,7 @@ task LoadData {
 
       # we always do our own localization
       gsutil cp $gs_input_vcf input_vcf_$i.vcf.gz
-      gsutil cp $gs_input_vcf_index input_vcf_index_$i.vcf.gz.tbi
+      gsutil cp $gs_input_vcf_index input_vcf_$i.vcf.gz.tbi
       updated_input_vcf=input_vcf_$i.vcf.gz
 
       gatk --java-options "-Xmx2g" CreateVariantIngestFiles \
@@ -333,8 +333,8 @@ task LoadData {
         --ref-version 38 \
         --skip-loading-vqsr-fields ~{skip_loading_vqsr_fields}
 
-      rm $input_vcf_$i.vcf.gz
-      rm $input_vcf_index_$i.vcf.gz.tbi
+      rm input_vcf_$i.vcf.gz
+      rm input_vcf_$i.vcf.gz.tbi
 
     done
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -242,12 +242,10 @@ task LoadData {
     BQ_SHOW_RC=$?
     set -o errexit
 
-    # If there is already a table of sample names or something else is wrong, bail.
+    # If there is already a table of sample names or something else is wrong, burn it down to start fresh.
     if [ $BQ_SHOW_RC -eq 0 ]; then
-      echo "There is already a list of sample names. This may need manual cleanup. Exiting"
-      exit 1
+      bq rm -t -f --project_id=~{project_id} ~{temp_table}
     fi
-
 
     echo "Creating the external sample name list table ~{temp_table}"
     bq --project_id=~{project_id} mk ~{temp_table} "sample_name:STRING"
@@ -293,12 +291,6 @@ task LoadData {
       --vcf_list_file_name ~{write_lines(input_vcfs)} \
       --vcf_index_list_file_name  ~{write_lines(input_vcf_indexes)} \
       --output_files True
-
-
-    ## the output files from the python:
-    # output_vcf_index_list_file
-    # output_vcf_list_file
-    # output_sample_name_list_file
 
     # translate python files into BASH arrays---but only of the samples that aren't there already
     VCFS_ARRAY=($(cat output_vcf_list_file |tr "\n" " "))

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -284,7 +284,7 @@ task LoadData {
     ## delete the table that was only needed for this ingest test
     ## bq --project_id=~{project_id} rm -f=true ~{temp_table}
 
-    ## OK UP TO HERE WORKED
+    ## OK UP TO HERE WORKED -- and now we can't find curate_input_array_files.py
 
     ## now we want to create a sub list of these samples (without the ones that have already been loaded)
 
@@ -303,7 +303,7 @@ task LoadData {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_02_15"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2022-10-14"
     maxRetries: load_data_maxretries
     memory: "3.75 GB"
     disks: "local-disk 50 HDD"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -343,7 +343,7 @@ task LoadData {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.3.0.0"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2022_10_18_950122cadfbfec1ac3790f07edad4d6484a5a894"
     maxRetries: load_data_maxretries
     memory: "3.75 GB"
     disks: "local-disk 50 HDD"

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -7,10 +7,10 @@ workflow GvsPrepareBulkImport {
         String project_id
         String workspace_name
         String workspace_bucket
-        String samples_table_name = "sample"
-        String sample_id_column_name = "sample_id"
-        String vcf_files_column_name = "hg38_reblocked_v2_vcf"
-        String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
+        String samples_table_name
+        String sample_id_column_name
+        String vcf_files_column_name
+        String vcf_index_files_column_name
     }
 
     call GenerateFOFNsFromDataTables {
@@ -43,6 +43,8 @@ task GenerateFOFNsFromDataTables {
         String vcf_files_column_name = "hg38_reblocked_v2_vcf"
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
     }
+
+    ## TODO currently we can only take in samples, but we need to be able to take in sample_sets
 
     String sample_names_file_name = "sample_names.txt"
     String vcf_files_name = "vcf_files.txt"

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -47,7 +47,7 @@ task GenerateFOFNsFromDataTables {
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail
 
-        export WORKSPACE_NAME=~{workspace_name}
+        export WORKSPACE_NAME='~{workspace_name}'
         export WORKSPACE_BUCKET=~{workspace_bucket}
 
         python3 /app/generate_FOFNs_for_import.py \

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -1,0 +1,64 @@
+version 1.0
+
+import "GvsUtils.wdl" as Utils
+
+workflow GvePrepareBulkImport {
+    input {
+        Boolean go = true
+        String samples_table_name = "sample"
+        String vcf_files_column_name = "hg38_reblocked_v2_vcf"
+        String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
+    }
+
+    call GenerateFOFNsFromDataTables {
+        input:
+            samples_table_name = samples_table_name,
+            vcf_files_column_name = vcf_files_column_name,
+            vcf_index_files_column_name = vcf_index_files_column_name
+    }
+
+
+    output {
+        Boolean done = false
+    }
+}
+
+task GenerateFOFNsFromDataTables {
+    input {
+        Boolean go = true
+        String samples_table_name = "sample"
+        String vcf_files_column_name = "hg38_reblocked_v2_vcf"
+        String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
+    }
+
+    String sample_names_file_name = "sample_names.txt"
+    String vcf_files_name = "vcf_files.txt"
+    String vcf_index_files_name = "vcf_index_files.txt"
+
+    meta {
+        # because this is being used to determine the current state of the GVS database, never use call cache
+        volatile: false
+    }
+
+    command <<<
+        set -o errexit -o nounset -o xtrace -o pipefail
+
+        python3 /app/generate_FOFNs_for_import.py \
+        --data_table_name ~{samples_table_name} \
+        --vcf_files_column_name ~{vcf_files_column_name} \
+        --vcf_index_files_column_name ~{vcf_index_files_column_name}}
+
+    >>>
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-13"
+        memory: "3 GB"
+        disks: "local-disk 10 HDD"
+        cpu: 1
+    }
+
+    output {
+        File sampleFOFN = sample_names_file_name
+        File vcfFOFN = vcf_files_name
+        File vcfIndexFOFN = vcf_index_files_name
+    }
+}

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -28,6 +28,7 @@ workflow GvsPrepareBulkImport {
         File sampleFOFN = GenerateFOFNsFromDataTables.sampleFOFN
         File vcfFOFN = GenerateFOFNsFromDataTables.vcfFOFN
         File vcfIndexFOFN = GenerateFOFNsFromDataTables.vcfIndexFOFN
+        File errorRows = GenerateFOFNsFromDataTables.errors
     }
 }
 

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -44,8 +44,6 @@ task GenerateFOFNsFromDataTables {
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
     }
 
-    ## TODO currently we can only take in samples, but we need to be able to take in sample_sets
-
     String sample_names_file_name = "sample_names.txt"
     String vcf_files_name = "vcf_files.txt"
     String vcf_index_files_name = "vcf_index_files.txt"
@@ -60,10 +58,10 @@ task GenerateFOFNsFromDataTables {
         export WORKSPACE_BUCKET='~{workspace_bucket}'
 
         python3 /app/generate_FOFNs_for_import.py \
-        --data_table_name ~{samples_table_name} \
-        --sample_id_column_name ~{sample_id_column_name} \
-        --vcf_files_column_name ~{vcf_files_column_name} \
-        --vcf_index_files_column_name ~{vcf_index_files_column_name}
+            --data_table_name ~{samples_table_name} \
+            --sample_id_column_name ~{sample_id_column_name} \
+            --vcf_files_column_name ~{vcf_files_column_name} \
+            --vcf_index_files_column_name ~{vcf_index_files_column_name}
 
     >>>
     runtime {

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -23,9 +23,9 @@ workflow GvePrepareBulkImport {
     }
 
     output {
-        File sampleFOFN = GenerateFOFNsFromDataTables.sample_names_file_name
-        File vcfFOFN = GenerateFOFNsFromDataTables.vcf_files_name
-        File vcfIndexFOFN = GenerateFOFNsFromDataTables.vcf_index_files_name
+        File sampleFOFN = GenerateFOFNsFromDataTables.sampleFOFN
+        File vcfFOFN = GenerateFOFNsFromDataTables.vcfFOFN
+        File vcfIndexFOFN = GenerateFOFNsFromDataTables.vcfIndexFOFN
     }
 }
 

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -4,7 +4,7 @@ import "GvsUtils.wdl" as Utils
 
 workflow GvePrepareBulkImport {
     input {
-        String project_name
+        String project_id
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
@@ -14,7 +14,7 @@ workflow GvePrepareBulkImport {
 
     call GenerateFOFNsFromDataTables {
         input:
-            project_name = project_name,
+            project_id = project_id,
             workspace_name = workspace_name,
             workspace_bucket  = workspace_bucket,
             samples_table_name = samples_table_name,
@@ -30,7 +30,7 @@ workflow GvePrepareBulkImport {
 
 task GenerateFOFNsFromDataTables {
     input {
-        String project_name
+        String project_id
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
@@ -50,7 +50,7 @@ task GenerateFOFNsFromDataTables {
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail
 
-        export GOOGLE_PROJECT='~{project_name}'
+        export GOOGLE_PROJECT='~{project_id}'
         export WORKSPACE_NAME='~{workspace_name}'
         export WORKSPACE_BUCKET='~{workspace_bucket}'
 

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -58,7 +58,7 @@ task GenerateFOFNsFromDataTables {
         python3 /app/generate_FOFNs_for_import.py \
         --data_table_name ~{samples_table_name} \
         --vcf_files_column_name ~{vcf_files_column_name} \
-        --vcf_index_files_column_name ~{vcf_index_files_column_name}}
+        --vcf_index_files_column_name ~{vcf_index_files_column_name}
 
     >>>
     runtime {

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-workflow GvePrepareBulkImport {
+workflow GvsPrepareBulkImport {
     input {
         String project_id
         String workspace_name

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -66,7 +66,7 @@ task GenerateFOFNsFromDataTables {
     runtime {
         docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-20-FOFN"
         memory: "3 GB"
-        disks: "local-disk 10 HDD"
+        disks: "local-disk 200 HDD"
         cpu: 1
     }
 

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -8,6 +8,7 @@ workflow GvsPrepareBulkImport {
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
+        String sample_id_column_name = "sample_id"
         String vcf_files_column_name = "hg38_reblocked_v2_vcf"
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
     }
@@ -18,6 +19,7 @@ workflow GvsPrepareBulkImport {
             workspace_name = workspace_name,
             workspace_bucket  = workspace_bucket,
             samples_table_name = samples_table_name,
+            sample_id_column_name = sample_id_column_name,
             vcf_files_column_name = vcf_files_column_name,
             vcf_index_files_column_name = vcf_index_files_column_name
     }
@@ -36,6 +38,7 @@ task GenerateFOFNsFromDataTables {
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
+        String sample_id_column_name = "sample_id"
         String vcf_files_column_name = "hg38_reblocked_v2_vcf"
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
     }
@@ -43,6 +46,7 @@ task GenerateFOFNsFromDataTables {
     String sample_names_file_name = "sample_names.txt"
     String vcf_files_name = "vcf_files.txt"
     String vcf_index_files_name = "vcf_index_files.txt"
+    String error_file_name = "errors.txt"
 
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail
@@ -54,12 +58,13 @@ task GenerateFOFNsFromDataTables {
 
         python3 /app/generate_FOFNs_for_import.py \
         --data_table_name ~{samples_table_name} \
+        --sample_id_column_name ~{sample_id_column_name} \
         --vcf_files_column_name ~{vcf_files_column_name} \
         --vcf_index_files_column_name ~{vcf_index_files_column_name}
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-13-FOFN_1"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-19-FOFN"
         memory: "3 GB"
         disks: "local-disk 10 HDD"
         cpu: 1
@@ -69,5 +74,6 @@ task GenerateFOFNsFromDataTables {
         File sampleFOFN = sample_names_file_name
         File vcfFOFN = vcf_files_name
         File vcfIndexFOFN = vcf_index_files_name
+        File errors = error_file_name
     }
 }

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -4,6 +4,7 @@ import "GvsUtils.wdl" as Utils
 
 workflow GvePrepareBulkImport {
     input {
+        String project_name
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
@@ -13,6 +14,7 @@ workflow GvePrepareBulkImport {
 
     call GenerateFOFNsFromDataTables {
         input:
+            project_name = project_name,
             workspace_name = workspace_name,
             workspace_bucket  = workspace_bucket,
             samples_table_name = samples_table_name,
@@ -28,6 +30,7 @@ workflow GvePrepareBulkImport {
 
 task GenerateFOFNsFromDataTables {
     input {
+        String project_name
         String workspace_name
         String workspace_bucket
         String samples_table_name = "sample"
@@ -47,8 +50,9 @@ task GenerateFOFNsFromDataTables {
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail
 
+        export GOOGLE_PROJECT='~{project_name}'
         export WORKSPACE_NAME='~{workspace_name}'
-        export WORKSPACE_BUCKET=~{workspace_bucket}
+        export WORKSPACE_BUCKET='~{workspace_bucket}'
 
         python3 /app/generate_FOFNs_for_import.py \
         --data_table_name ~{samples_table_name} \

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -51,6 +51,7 @@ task GenerateFOFNsFromDataTables {
         set -o errexit -o nounset -o xtrace -o pipefail
 
         export GOOGLE_PROJECT='~{project_id}'
+        export WORKSPACE_NAMESPACE='~{project_id}'
         export WORKSPACE_NAME='~{workspace_name}'
         export WORKSPACE_BUCKET='~{workspace_bucket}'
 

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -64,7 +64,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-19-FOFN"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-20-FOFN"
         memory: "3 GB"
         disks: "local-disk 10 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -65,7 +65,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-20-FOFN"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-21-bulk-ingest"
         memory: "3 GB"
         disks: "local-disk 200 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -65,7 +65,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-21-bulk-ingest"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-bulk-ingest"
         memory: "3 GB"
         disks: "local-disk 200 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -50,7 +50,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-13"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-1-13-FOFN_1"
         memory: "3 GB"
         disks: "local-disk 10 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -22,12 +22,14 @@ workflow GvePrepareBulkImport {
             vcf_index_files_column_name = vcf_index_files_column_name
     }
 
-
     output {
-        Boolean done = false
+        File sampleFOFN = GenerateFOFNsFromDataTables.sample_names_file_name
+        File vcfFOFN = GenerateFOFNsFromDataTables.vcf_files_name
+        File vcfIndexFOFN = GenerateFOFNsFromDataTables.vcf_index_files_name
     }
 }
 
+# This copies the entirety of the data tables over.  We'll want a different task to make FOFNs for just a sample set
 task GenerateFOFNsFromDataTables {
     input {
         String project_id
@@ -41,11 +43,6 @@ task GenerateFOFNsFromDataTables {
     String sample_names_file_name = "sample_names.txt"
     String vcf_files_name = "vcf_files.txt"
     String vcf_index_files_name = "vcf_index_files.txt"
-
-    meta {
-        # because this is being used to determine the current state of the GVS database, never use call cache
-        volatile: false
-    }
 
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -4,7 +4,8 @@ import "GvsUtils.wdl" as Utils
 
 workflow GvePrepareBulkImport {
     input {
-        Boolean go = true
+        String workspace_name
+        String workspace_bucket
         String samples_table_name = "sample"
         String vcf_files_column_name = "hg38_reblocked_v2_vcf"
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
@@ -12,6 +13,8 @@ workflow GvePrepareBulkImport {
 
     call GenerateFOFNsFromDataTables {
         input:
+            workspace_name = workspace_name,
+            workspace_bucket  = workspace_bucket,
             samples_table_name = samples_table_name,
             vcf_files_column_name = vcf_files_column_name,
             vcf_index_files_column_name = vcf_index_files_column_name
@@ -25,7 +28,8 @@ workflow GvePrepareBulkImport {
 
 task GenerateFOFNsFromDataTables {
     input {
-        Boolean go = true
+        String workspace_name
+        String workspace_bucket
         String samples_table_name = "sample"
         String vcf_files_column_name = "hg38_reblocked_v2_vcf"
         String vcf_index_files_column_name = "hg38_reblocked_v2_vcf_index"
@@ -42,6 +46,9 @@ task GenerateFOFNsFromDataTables {
 
     command <<<
         set -o errexit -o nounset -o xtrace -o pipefail
+
+        export WORKSPACE_NAME=~{workspace_name}
+        export WORKSPACE_BUCKET=~{workspace_bucket}
 
         python3 /app/generate_FOFNs_for_import.py \
         --data_table_name ~{samples_table_name} \

--- a/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
+++ b/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
@@ -4,33 +4,48 @@ import argparse
 from terra_notebook_utils import table
 from terra_notebook_utils import workspace
 
-from google.cloud import storage
-from pathlib import Path
-
-import utils
+import time
 
 # just keep these around as constants for now
 vcf_files_name = "vcf_files.txt"
 vcf_index_files_name = "vcf_index_files.txt"
 sample_names_file_name = "sample_names.txt"
+error_file_name = "errors.txt"
 
 
-def generate_FOFNs_from_data_table(data_table_name, vcf_files_column_name, vcf_index_files_column_name):
+# make a default, but allow a user to overwrite it just in case someone wants to tweak this while tuning
+attempts_between_pauses=500
+
+def generate_FOFNs_from_data_table(data_table_name, sample_id_column_name, vcf_files_column_name, vcf_index_files_column_name):
 
     vcf_files = open(vcf_files_name, "w")
     vcf_index_files = open(vcf_index_files_name, "w")
     sample_names_file = open(sample_names_file_name, "w")
+    error_file = open(error_file_name, "w")
 
     # Replace this with the actual data in the tables later
     for row in table.list_rows(data_table_name):
-        sample_names_file.write(f"{row.name}\n")
-        vcf_files.write(f'{row.attributes[vcf_files_column_name]}\n')
-        vcf_index_files.write(f'{row.attributes[vcf_index_files_column_name]}\n')
+        try:
+            current_sample_name = row.attributes[sample_id_column_name]
+            current_vcf_file = row.attributes[vcf_files_column_name]
+            current_vcf_index_file = row.attributes[vcf_index_files_column_name]
+
+            sample_names_file.write(f'{current_sample_name}\n')
+            vcf_files.write(f'{current_vcf_file}\n')
+            vcf_index_files.write(f'{current_vcf_index_file}\n')
+        except KeyError:
+            error_file.write(f'Row "{row.name}" skipped: missing columns\n')
+
+        count += 1
+        if count >= attempts_between_pauses:
+            print("sleeping between requests...")
+            time.sleep(1)
+            count = 0
 
     vcf_files.close()
     vcf_index_files.close()
     sample_names_file.close()
-
+    error_file.close()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(allow_abbrev=False,
@@ -38,12 +53,23 @@ if __name__ == '__main__':
 
     parser.add_argument('--data_table_name', type=str,
                         help='The name of the table in your workspace that holds your sample data', default='sample')
+    parser.add_argument('--sample_id_column_name', type=str, help='name of the column that holds the external sample names',
+                            required=True)
     parser.add_argument('--vcf_files_column_name', type=str, help='name of the column that holds the paths to the vcf files',
                         required=True)
     parser.add_argument('--vcf_index_files_column_name', type=str, help='name of the column that holds the paths to the vcf index files', required=True)
 
+    parser.add_argument('--attempts_between_pauses', type=int,
+                        help='The number of rows in the db that are processed before we pause', default=500)
+
     args = parser.parse_args()
 
+    # allow this to be overridden, but default it to 500
+    if "attempts_between_pauses" in args:
+        attempts_between_pauses = args.attempts_between_pauses
+
+
     generate_FOFNs_from_data_table(args.data_table_name,
+                              args.sample_id_column_name,
                               args.vcf_files_column_name,
                               args.vcf_index_files_column_name)

--- a/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
+++ b/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
@@ -1,6 +1,9 @@
 import os
 import argparse
 
+from terra_notebook_utils import table
+from terra_notebook_utils import workspace
+
 from google.cloud import storage
 from pathlib import Path
 
@@ -19,15 +22,14 @@ def generate_FOFNs_from_data_table(data_table_name, vcf_files_column_name, vcf_i
     sample_names_file = open(sample_names_file_name, "w")
 
     # Replace this with the actual data in the tables later
-    sample_names_file.write("Writing some name stuff\n")
-    vcf_files.write("Writing some vcf paths\n")
-    vcf_index_files.write("Writing some vcf index paths\n")
+    for row in table.list_rows(data_table_name):
+        sample_names_file.write(f"{row.name}\n")
+        vcf_files.write(f'{row.attributes[vcf_files_column_name]}\n')
+        vcf_index_files.write(f'{row.attributes[vcf_index_files_column_name]}\n')
 
     vcf_files.close()
     vcf_index_files.close()
     sample_names_file.close()
-
-    return f'I did a thing and copied data from {data_table_name} to files!'
 
 
 if __name__ == '__main__':

--- a/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
+++ b/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
@@ -17,7 +17,7 @@ error_file_name = "errors.txt"
 attempts_between_pauses=500
 
 def generate_FOFNs_from_data_table(data_table_name, sample_id_column_name, vcf_files_column_name, vcf_index_files_column_name):
-    with open(vcf_files_name, "w") as vcf_files, open(vcf_index_files_name, "w") as vcf_index_files, open(sample_names_file_name, "w") as sample_names_file, open(error_file_name, "w") as error_file
+    with open(vcf_files_name, "w") as vcf_files, open(vcf_index_files_name, "w") as vcf_index_files, open(sample_names_file_name, "w") as sample_names_file, open(error_file_name, "w") as error_file:
         count = 0
         processed_entities = 0
         for row in table.list_rows(data_table_name):

--- a/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
+++ b/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
@@ -1,0 +1,47 @@
+import os
+import argparse
+
+from google.cloud import storage
+from pathlib import Path
+
+import utils
+
+# just keep these around as constants for now
+vcf_files_name = "vcf_files.txt"
+vcf_index_files_name = "vcf_index_files.txt"
+sample_names_file_name = "sample_names.txt"
+
+
+def generate_FOFNs_from_data_table(data_table_name, vcf_files_column_name, vcf_index_files_column_name):
+
+    vcf_files = open(vcf_files_name, "w")
+    vcf_index_files = open(vcf_index_files_name, "w")
+    sample_names_file = open(sample_names_file_name, "w")
+
+    # Replace this with the actual data in the tables later
+    sample_names_file.write("Writing some name stuff\n")
+    vcf_files.write("Writing some vcf paths\n")
+    vcf_index_files.write("Writing some vcf index paths\n")
+
+    vcf_files.close()
+    vcf_index_files.close()
+    sample_names_file.close()
+
+    return f'I did a thing and copied data from {data_table_name} to files!'
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Turn the data tables into 3 FOFNs, one for sample names, vcf paths, and vcf index paths')
+
+    parser.add_argument('--data_table_name', type=str,
+                        help='The name of the table in your workspace that holds your sample data', default='sample')
+    parser.add_argument('--vcf_files_column_name', type=str, help='name of the column that holds the paths to the vcf files',
+                        required=True)
+    parser.add_argument('--vcf_index_files_column_name', type=str, help='name of the column that holds the paths to the vcf index files', required=True)
+
+    args = parser.parse_args()
+
+    generate_FOFNs_from_data_table(args.data_table_name,
+                              args.vcf_files_column_name,
+                              args.vcf_index_files_column_name)

--- a/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
+++ b/scripts/variantstore/wdl/extract/generate_FOFNs_for_import.py
@@ -23,7 +23,7 @@ def generate_FOFNs_from_data_table(data_table_name, sample_id_column_name, vcf_f
     sample_names_file = open(sample_names_file_name, "w")
     error_file = open(error_file_name, "w")
 
-    # Replace this with the actual data in the tables later
+    count = 0
     for row in table.list_rows(data_table_name):
         try:
             current_sample_name = row.attributes[sample_id_column_name]

--- a/scripts/variantstore/wdl/extract/requirements.txt
+++ b/scripts/variantstore/wdl/extract/requirements.txt
@@ -3,3 +3,4 @@ ijson
 numpy
 google-cloud-storage
 firecloud
+terra-notebook-utils


### PR DESCRIPTION
The goal of this PR is to adjust the ingest in two ways:
1. To update the ingest to loop through all samples (not just the first 10k)
2. To update the ingest to be far more efficient in a few ways:
      - To remove the files that are downloaded to each vm so that they do not carry around the extra weight
      - To check that the samples in the fofns have not been ingested already so that additional work doesn't need to be done toward processing those samples.

There is still work to do around making the bulk ingest process significantly more user-friendly