### PR TITLE
Allow empty input in TransferReadTags

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTags.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTags.java
@@ -94,7 +94,11 @@ public class TransferReadTags extends GATKTool {
         if (unmappedSamIterator.hasNext()){
             currentUnmappedRead = unmappedSamIterator.next();
         } else {
-            throw new UserException("unmapped sam iterator is empty.");
+            if (alignedSamIterator.hasNext()) {
+                throw new UserException("unmapped sam iterator is empty and aligned sam iterator is not.");
+            } else {
+                logger.warn("Input data contains no reads.  Output will also contain no reads.");
+            }
         }
 
         writer = createSAMWriter(new GATKPath(outSamFile.getAbsolutePath()), false);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTags.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTags.java
@@ -95,7 +95,7 @@ public class TransferReadTags extends GATKTool {
             currentUnmappedRead = unmappedSamIterator.next();
         } else {
             if (alignedSamIterator.hasNext()) {
-                throw new UserException("unmapped sam iterator is empty and aligned sam iterator is not.");
+                throw new UserException("Unmapped sam iterator is empty and aligned sam iterator is not.");
             } else {
                 logger.warn("Input data contains no reads.  Output will also contain no reads.");
             }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTagsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/TransferReadTagsIntegrationTest.java
@@ -17,86 +17,108 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class TransferReadTagsIntegrationTest extends CommandLineProgramTest {
-    @DataProvider(name = "testSAMPairs")
-    public Object[][] getTestSAMPairs(){
-        final File alignedSAMFile = createTempFile("sam1", ".bam");
-        final File alignedSAMWithExistingTagFile = createTempFile("sam2", ".bam");
-        final File unmappedSAMFile = createTempFile("sam3", ".bam");
 
-        final SAMFileHeader samHeader = M2TestingUtils.createSamHeader("sample");
-        samHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
-        // Often an unaligned bam does not have the SortOrder field populated.
-        final SAMFileHeader unalignedHeader = M2TestingUtils.createSamHeader("sample");
-
-        final List<String> umis = Arrays.asList("TCC-ATG", "CTA-GGA", "CCT-AGC", "GCA-AAA");
+    public File getSamFile(final String prefix, final boolean aligned, final SAMFileHeader.SortOrder sortOrder, final Map<String, String> readNamesAndUmis) {
         final int readLength = 30;
         final byte[] bases = new byte[readLength];
         final byte[] quals = new byte[readLength];
         Arrays.fill(bases, (byte)'A');
         Arrays.fill(quals, (byte)30);
 
-        try (final SAMFileGATKReadWriter alignedSAMWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(alignedSAMFile, null, samHeader, true, false, false));
-             final SAMFileGATKReadWriter alignedSAMWithExisingTagWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(alignedSAMWithExistingTagFile, null, samHeader, true, false, false));
-             final SAMFileGATKReadWriter unmappedWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(unmappedSAMFile, null, unalignedHeader, true, false, false))) {
+        final File samFile = createTempFile(prefix, ".bam");
+        final SAMFileHeader samHeader = M2TestingUtils.createSamHeader("sample");
+        if (sortOrder != null) {
+            samHeader.setSortOrder(sortOrder);
+        }
 
-            for (int i = 0; i < umis.size(); i++) {
-                final GATKRead unmappedRead = ArtificialReadUtils.createArtificialUnmappedRead(samHeader, bases, quals);
-                unmappedRead.setName("read" + i);
-                unmappedRead.setAttribute("RX", umis.get(i));
-                unmappedWriter.addRead(unmappedRead);
-            }
-
-            for (int i = 0; i < umis.size(); i++) {
-                final GATKRead alignedRead = ArtificialReadUtils.createArtificialRead(samHeader, bases, quals, "30M");
-                alignedRead.setName("read" + i);
-
-                // Simulate the case where an aligner drops a read
-                if (i == 1) {
-                    continue;
+        try (final SAMFileGATKReadWriter samWriter = new SAMFileGATKReadWriter(ReadUtils.createCommonSAMWriter(samFile, null, samHeader, true, false, false))) {
+            for (final Map.Entry<String, String> readNameAndUMI : readNamesAndUmis.entrySet()) {
+                final GATKRead read = aligned? ArtificialReadUtils.createArtificialRead(samHeader, bases, quals, "30M") :
+                        ArtificialReadUtils.createArtificialUnmappedRead(samHeader, bases, quals);
+                read.setName(readNameAndUMI.getKey());
+                final String umi = readNameAndUMI.getValue();
+                if (umi != null) {
+                    read.setAttribute("RX", umi);
                 }
-
-                alignedSAMWriter.addRead(alignedRead);
-
-                // When there the same tag exists in the aligned bam, it should be overwritten.
-                final GATKRead alignedReadWithExistingTag = alignedRead.copy();
-                alignedReadWithExistingTag.setAttribute("RX", "ZZZ-ZZZ");
-                alignedSAMWithExisingTagWriter.addRead(alignedReadWithExistingTag);
+                samWriter.addRead(read);
             }
-
         } catch (RuntimeIOException e){
             throw new UserException("Failed to open SAM writers", e);
         }
-        return new Object[][]{{alignedSAMFile, unmappedSAMFile, umis },
-                {alignedSAMWithExistingTagFile, unmappedSAMFile, umis }
+
+        return samFile;
+    }
+
+
+    @DataProvider(name = "testSAMPairs")
+    public Object[][] getTestSAMPairs(){
+        final List<String> umis = Arrays.asList("TCC-ATG", "CTA-GGA", "CCT-AGC", "GCA-AAA");
+        final LinkedHashMap<String, String> alignedUMIsMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> unmappedUMIsMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> alignedWithExistingTagsUMIsMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> expectedUMIsMap = new LinkedHashMap<>();
+
+        for (int i = 0; i < umis.size(); i++) {
+            if (i != 1) {
+                alignedUMIsMap.put("read" + i, null);
+                alignedWithExistingTagsUMIsMap.put("read"+ i, "ZZZ");
+                expectedUMIsMap.put("read"+ i, umis.get(i));
+            }
+            unmappedUMIsMap.put("read" + i, umis.get(i));
+
+        }
+        final File alignedSAMFile = getSamFile("aligned", true, SAMFileHeader.SortOrder.queryname, alignedUMIsMap);
+        final File alignedSAMWithExistingTagFile = getSamFile("aligned_with_existing_tag", true, SAMFileHeader.SortOrder.queryname, alignedWithExistingTagsUMIsMap);
+        final File unmappedSAMFile = getSamFile("unmapped", false, null, unmappedUMIsMap);
+        final File emptySAMFile = getSamFile("empty", false, SAMFileHeader.SortOrder.queryname, Collections.emptyMap());
+
+        return new Object[][]{{alignedSAMFile, unmappedSAMFile, expectedUMIsMap },
+                {alignedSAMWithExistingTagFile, unmappedSAMFile, expectedUMIsMap},
+                {emptySAMFile, emptySAMFile, Collections.emptyMap()},
+                {emptySAMFile, unmappedSAMFile, Collections.emptyMap()}
         };
     }
 
     @Test(dataProvider = "testSAMPairs")
-    public void test(final File alignedSAMFile, final File unmappedSAMFile, List<String> umis ) {
+    public void test(final File alignedSAMFile, final File unmappedSAMFile, final Map<String, String> expectedReadNamesAndUmis) {
         final File outputFile = createTempFile("output", ".bam");
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .add("I", alignedSAMFile.getAbsolutePath())
                 .add("unmapped-sam", unmappedSAMFile.getAbsolutePath())
                 .add("read-tags", "RX")
                 .add("O", outputFile.getAbsolutePath());
-        runCommandLine(args, TransferReadTags.class.getSimpleName());
+        runCommandLine(args);
 
         final ReadsPathDataSource outputReadSource = new ReadsPathDataSource(outputFile.toPath());
-        final Iterator<GATKRead> outputSamIterator = outputReadSource.iterator();
 
-        for (int i = 0; i < umis.size(); i++){
-            // Skip the same read we removed above
-            if (i == 1){
-                continue;
-            }
-
-            final GATKRead outputRead = outputSamIterator.next();
-            Assert.assertEquals(outputRead.getName(), "read" + i);
-            Assert.assertEquals(outputRead.getAttributeAsString("RX"), umis.get(i));
+        final Set<String> observedReadName = new HashSet<>();
+        for (GATKRead outputRead : outputReadSource) {
+            Assert.assertTrue(expectedReadNamesAndUmis.containsKey(outputRead.getName()));
+            observedReadName.add(outputRead.getName());
+            Assert.assertEquals(outputRead.getAttributeAsString("RX"), expectedReadNamesAndUmis.get(outputRead.getName()));
         }
+        Assert.assertTrue(observedReadName.containsAll(expectedReadNamesAndUmis.keySet()));
+    }
+
+    @Test(expectedExceptions = UserException.class, expectedExceptionsMessageRegExp = "Unmapped sam iterator is empty and aligned sam iterator is not.")
+    public void testEmptyUnmapped() {
+        final File alignedSAMFile = getSamFile("aligned", true, SAMFileHeader.SortOrder.queryname, Collections.singletonMap("read0", null));
+        final File emptySAMFile = getSamFile("empty", false, SAMFileHeader.SortOrder.queryname, Collections.emptyMap());
+        final File outputFile = createTempFile("output", ".bam");
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .add("I", alignedSAMFile.getAbsolutePath())
+                .add("unmapped-sam", emptySAMFile.getAbsolutePath())
+                .add("read-tags", "RX")
+                .add("O", outputFile.getAbsolutePath());
+        runCommandLine(args);
     }
 }


### PR DESCRIPTION
TransferReadTags will throw an exception if the unaligned bam has no read.  This pr will allow the unaligned bam to have 0 reads, as long as the aligned bam also has 0 reads, which will result in an output bam which is just a copy of the aligned bam, with 0 reads. 