### PR TITLE
Add a --numeric-gt option to VariantsToTable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
     mavenLocal()
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version','3.0.1')
+final htsjdkVersion = System.getProperty('htsjdk.version','3.0.5')
 final picardVersion = System.getProperty('picard.version','2.27.5')
 final barclayVersion = System.getProperty('barclay.version','4.1.0')
 final sparkVersion = System.getProperty('spark.version', '2.4.5')

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/VariantsToTableIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.variantutils;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.annotations.Test;
 
@@ -272,6 +273,21 @@ public final class VariantsToTableIntegrationTest extends CommandLineProgramTest
 
         final String[] args = new String[] {"--variant", inputFile.getAbsolutePath(),
                 "-O", outputFile.getAbsolutePath()};
+        runCommandLine(args);
+
+        IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile);
+    }
+
+    @Test
+    public void testNumericGTFlag() throws IOException {
+        final File inputFile = new File(getToolTestDataDir(), "VCFWithGenotypes_1000G.phase3.snippet.vcf");
+        final File outputFile = createTempFile("numericGT", ".table");
+        final File expectedFile = new File(getToolTestDataDir(), "expected.numericGT.table");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addVCF(inputFile)
+                        .addOutput(outputFile)
+                        .addFlag(VariantsToTable.NUMERIC_GT_FULLNAME);
         runCommandLine(args);
 
         IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile);


### PR DESCRIPTION
* add an new option to VariantsToTable to allow output VCF style numeric GT fields
previously it always output the actual bases of the Allele in the GT spot
* resolves https://github.com/broadinstitute/gatk/issues/8160
* updates htsjdk to 3.0.5
