### PR TITLE
Stop tests from running when only variant store scripts are touched

### DIFF
--- a/.github/workflows/gatk-tests.yml
+++ b/.github/workflows/gatk-tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'master'
   pull_request:
+    paths-ignore:
+      - 'scripts/variantstore/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This should add an exclusion for tests so they don't run when only the var store scripts are changed.